### PR TITLE
Added dynamic ValidateSet example

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -548,17 +548,18 @@ Param(
 
 $Message = "bye"
 ```
-
 #### Dynamic ValidateSet Values
 
-You can use a `Class` to dynamically generate the values for `ValidateSet` at runtime.
-In the following example, the valid values for the variable `$Sound` are generated
-via a `Class` named `SoundNames` that checks three filesystem paths for available sound files:
+You can use a `Class` to dynamically generate the values for `ValidateSet` at
+runtime. In the following example, the valid values for the variable `$Sound`
+are generated via a `Class` named `SoundNames` that checks three filesystem
+paths for available sound files:
 
 ```powershell
 Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
     [String[]] GetValidValues() {
-        $SoundPaths = '/System/Library/Sounds/','/Library/Sounds','~/Library/Sounds'
+        $SoundPaths = '/System/Library/Sounds/',
+            '/Library/Sounds','~/Library/Sounds'
         $SoundNames = ForEach ($SoundPath in $SoundPaths) {
             If (Test-Path $SoundPath) {
                 (Get-ChildItem $SoundPath).BaseName
@@ -569,7 +570,8 @@ Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
 }
 ```
 
-The `[SoundNames]` class is then implemented as a dynamic `ValidateSet` value as follows:
+The `[SoundNames]` class is then implemented as a dynamic `ValidateSet` value
+as follows:
 
 ```powershell
 Param(


### PR DESCRIPTION
Per #2272.

Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
