### PR TITLE
M32234: Missing word

### DIFF
--- a/gallery/concepts/publishing-guidelines.md
+++ b/gallery/concepts/publishing-guidelines.md
@@ -218,7 +218,7 @@ For that reason, we do not support the PowerShell Gallery as a testing target, a
 ## Use PowerShellGet to publish
 
 It is strongly recommended that publishers use the Publish-Module and Publish-Script cmdlets when working with the PowerShell Gallery.
-PowerShellGet has been created to help you avoid remembering important details about installing from an <!-- Missing word --> publishing to the PowerShell Gallery.
+PowerShellGet has been created to help you avoid remembering important details about installing from and publishing to the PowerShell Gallery.
 On occasion, publishers have chosen to skip PowerShellGet and use the NuGet client, or PackageManagement cmdlets, instead of Publish-Module.
 There are a number of details that are easily missed, which results in a variety of support requests.
 


### PR DESCRIPTION
Hello, @Saisang, @SydneyhSmith, @sdwheeler, 
Translator has reported possible source content issue. 
Description: Is there something missing between "an" and "publishing"? Otherwise, this sentence is ungrammatical. Please advise.
Please review the comment tag added and reply with explanation if fix is needed or not. If you make related fix in another PR then share your PR number so we can confirm and close this PR.
Many thanks in advance.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
