### PR TITLE
Update Set-PSReadlineOption.md

### DIFF
--- a/reference/6/PSReadLine/Set-PSReadlineOption.md
+++ b/reference/6/PSReadLine/Set-PSReadlineOption.md
@@ -18,7 +18,7 @@ Customizes the behavior of command line editing in PSReadLine.
 
 ### OptionsSet
 
-```
+```powershell
 Set-PSReadLineOption
  [-EditMode <EditMode>]
  [-ContinuationPrompt <String>]
@@ -169,7 +169,7 @@ The argument is a Hashtable where the keys specify which element and the values 
 
 Colors can be either a value from ConsoleColor, for example `[ConsoleColor]::Red`, or a valid
 escape sequence. Valid escape sequences depend on your terminal. In Windows PowerShell, an example
-escape sequence is `$([char]0x1b)[91m`. In PowerShell 6, the same escape sequence is ```e[91m`. You
+escape sequence is `$([char]0x1b)[91m`. In PowerShell 6, the same escape sequence is `e[91m`. You
 can specify other escape sequences including:
 
 - 256 color

--- a/reference/6/PSReadLine/Set-PSReadlineOption.md
+++ b/reference/6/PSReadLine/Set-PSReadlineOption.md
@@ -18,7 +18,7 @@ Customizes the behavior of command line editing in PSReadLine.
 
 ### OptionsSet
 
-```powershell
+```
 Set-PSReadLineOption
  [-EditMode <EditMode>]
  [-ContinuationPrompt <String>]


### PR DESCRIPTION
changed fencing to PowerShell, and fixed a typo.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
