### PR TITLE
C62586: Escaping @ character to avoid issues in localized pages

### DIFF
--- a/dsc/configurations/configDataCredentials.md
+++ b/dsc/configurations/configDataCredentials.md
@@ -332,7 +332,7 @@ that could be used on other servers.
 
 **When using credentials with DSC resources, prefer a local account over a domain account when possible.**
 
-If there is a '\' or '\@' in the `Username` property of the credential,
+If there is a '\\' or '\@' in the `Username` property of the credential,
 then DSC will treat it as a domain account.
 There is an exception for "localhost",
 "127.0.0.1", and "::1" in the domain portion of the user name.

--- a/dsc/configurations/configDataCredentials.md
+++ b/dsc/configurations/configDataCredentials.md
@@ -332,7 +332,7 @@ that could be used on other servers.
 
 **When using credentials with DSC resources, prefer a local account over a domain account when possible.**
 
-If there is a '\' or '@' in the `Username` property of the credential,
+If there is a '\' or '\@' in the `Username` property of the credential,
 then DSC will treat it as a domain account.
 There is an exception for "localhost",
 "127.0.0.1", and "::1" in the domain portion of the user name.


### PR DESCRIPTION
Hello, @sdwheeler ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: unescaped @ is breaking localized pages content  

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
