### PR TITLE
fix example so that it copies the contents and not the folder

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Copy-Item.md
@@ -63,7 +63,7 @@ The **Container** parameter is set to "true" by default.
 This preserves the directory structure.
 
 ```powershell
-Copy-Item "C:\Logfiles" -Destination "C:\Drawings" -Recurse
+Copy-Item "C:\Logfiles\*" -Destination "C:\Drawings" -Recurse
 ```
 
 ### Example 3: Copy the contents of a directory to another directory and create the destination directory if it does not exist

--- a/reference/4.0/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Copy-Item.md
@@ -63,7 +63,7 @@ The **Container** parameter is set to "true" by default.
 This preserves the directory structure.
 
 ```powershell
-Copy-Item "C:\Logfiles" -Destination "C:\Drawings" -Recurse
+Copy-Item "C:\Logfiles\*" -Destination "C:\Drawings" -Recurse
 ```
 
 ### Example 3: Copy the contents of a directory to another directory and create the destination directory if it does not exist

--- a/reference/5.0/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Copy-Item.md
@@ -63,7 +63,7 @@ The **Container** parameter is set to "true" by default.
 This preserves the directory structure.
 
 ```powershell
-Copy-Item "C:\Logfiles" -Destination "C:\Drawings" -Recurse
+Copy-Item "C:\Logfiles\*" -Destination "C:\Drawings" -Recurse
 ```
 
 ### Example 3: Copy the contents of a directory to another directory and create the destination directory if it does not exist

--- a/reference/5.1/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Copy-Item.md
@@ -63,7 +63,7 @@ The **Container** parameter is set to "true" by default.
 This preserves the directory structure.
 
 ```powershell
-Copy-Item "C:\Logfiles" -Destination "C:\Drawings" -Recurse
+Copy-Item "C:\Logfiles\*" -Destination "C:\Drawings" -Recurse
 ```
 
 ### Example 3: Copy the contents of a directory to another directory and create the destination directory if it does not exist

--- a/reference/6/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/6/Microsoft.PowerShell.Management/Copy-Item.md
@@ -63,7 +63,7 @@ The **Container** parameter is set to "true" by default.
 This preserves the directory structure.
 
 ```powershell
-Copy-Item "C:\Logfiles" -Destination "C:\Drawings" -Recurse
+Copy-Item "C:\Logfiles\*" -Destination "C:\Drawings" -Recurse
 ```
 
 ### Example 3: Copy the contents of a directory to another directory and create the destination directory if it does not exist


### PR DESCRIPTION
Fix https://github.com/MicrosoftDocs/PowerShell-Docs/issues/3409

Correct example to copy the contents and not the folder itself

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
