### PR TITLE
Fixed bad link and duplicate text.

### DIFF
--- a/developer/cmdlet/tutorials-for-writing-cmdlets.md
+++ b/developer/cmdlet/tutorials-for-writing-cmdlets.md
@@ -18,16 +18,13 @@ This section contains tutorials for writing cmdlets. These tutorials include the
 
 ## In This Section
 
-[GetProc Tutorial](./getproc-tutorial.md)
+[GetProc Tutorial](./getproc-tutorial.md) - 
 This tutorial describes how to define a cmdlet class and add basic functionality such as adding parameters and reporting errors. The cmdlet described in this tutorial is very similar to the [Get-Process](/powershell/module/Microsoft.PowerShell.Management/Get-Process) cmdlet provided by Windows PowerShell.
-This tutorial describes how to define a cmdlet class and add basic functionality such as adding parameters and reporting errors. The cmdlet described in this tutorial is very similar to the [Get-Process](https://www.msn.com/?ocid=NEFLS000) cmdlet provided by Windows PowerShell.
 
-[StopProc Tutorial](./stopproc-tutorial.md)
-This tutorial describes how to define a cmdlet and add functionality such as user prompts, wildcard support, and the use of parameter sets. The cmdlet described here performs the same task as the [Stop-Process](/powershell/module/Microsoft.PowerShell.Management/Stop-Process) cmdlet provided by Windows PowerShell.
+[StopProc Tutorial](./stopproc-tutorial.md) - 
 This tutorial describes how to define a cmdlet and add functionality such as user prompts, wildcard support, and the use of parameter sets. The cmdlet described here performs the same task as the [Stop-Process](/powershell/module/Microsoft.PowerShell.Management/Stop-Process) cmdlet provided by Windows PowerShell.
 
-[SelectStr Tutorial](./selectstr-tutorial.md)
-This tutorial describes how to define a cmdlet that accesses a data store. The cmdlet described here performs the same task as the [Select-String](/powershell/module/microsoft.powershell.utility/select-string) cmdlet provided by Windows PowerShell.
+[SelectStr Tutorial](./selectstr-tutorial.md) - 
 This tutorial describes how to define a cmdlet that accesses a data store. The cmdlet described here performs the same task as the [Select-String](/powershell/module/microsoft.powershell.utility/select-string) cmdlet provided by Windows PowerShell.
 
 ## See Also


### PR DESCRIPTION
* The "In this section" content was all duplicated for whatever reason. Removed duplicate text.
* The 2nd "Get-Process" link pointed to an msn.com URL instead of the correct Microsoft Docs. Removed as it was part of the duplicate text.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documentation exists outside of a specific PowerShell reference version.
