### PR TITLE
Fixing product feedback link

### DIFF
--- a/developer/docfx.json
+++ b/developer/docfx.json
@@ -16,7 +16,7 @@
             "ms.author": "jaiello",
             "feedback_system": "GitHub",
             "feedback_github_repo": "MicrosoftDocs/PowerShell-Docs",
-            "feedback_product_url": "https://github.com/MicrosoftDocs/powershell/issues/new"
+            "feedback_product_url": "https://github.com/PowerShell/PowerShell/issues/new/choose"
         },
         "resource": [
             { "files": ["**/media/**", "**/*.png", "**/*.gif", "**/*.jpeg", "**/*.jpg", "**/*.svg"], "exclude": ["**/obj/**", "**/includes/**"] }

--- a/reference/docfx.json
+++ b/reference/docfx.json
@@ -56,7 +56,7 @@
             "ROBOTS": "INDEX, FOLLOW",
             "feedback_system": "GitHub",
             "feedback_github_repo": "MicrosoftDocs/PowerShell-Docs",
-            "feedback_product_url": "https://github.com/MicrosoftDocs/powershell/issues/new"
+            "feedback_product_url": "https://github.com/PowerShell/PowerShell/issues/new/choose"
         },
         "fileMetadata": {
             "ms.prod": { "**/**.md": "powershell" },

--- a/reference/docs-conceptual/docfx.json
+++ b/reference/docs-conceptual/docfx.json
@@ -15,7 +15,7 @@
             "ms.author": "sewhee",
             "feedback_system": "GitHub",
             "feedback_github_repo": "MicrosoftDocs/PowerShell-Docs",
-            "feedback_product_url": "https://github.com/MicrosoftDocs/powershell/issues/new"
+            "feedback_product_url": "https://github.com/PowerShell/PowerShell/issues/new/choose"
         },
         "resource": [
             { "files": ["**/images/**", "**/*.png", "**/*.jpg"], "exclude": ["**/obj/**"] }


### PR DESCRIPTION
Issue #3636 mentioned the **Product feedback** link is not working.  Looks like it needs pointing back to the PowerShell repo and the choose option after the repo migration.