### PR TITLE
Updated Encoding parameter and YAML for Format-Hex

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -140,10 +140,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies an array of literal paths of items. This parameter does not accept wildcard characters. If
-the **LiteralPath** parameter includes escape characters, enclose the path in single quotation
-marks. PowerShell does not interpret any characters in a single quoted string as escape sequences.
-For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_quoting_rules).
+Specifies the complete path to a file. The value of **LiteralPath** is used exactly as it is typed.
+This parameter does not accept wildcard characters. If the **LiteralPath** parameter includes escape
+characters, enclose the path in single quotation marks. PowerShell does not interpret any characters
+in a single quoted string as escape sequences. For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_quoting_rules).
 
 ```yaml
 Type: String[]
@@ -159,9 +159,8 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path to a file. Use a dot, backslash (`.\`) to specify the current location. The
-`Format-Hex` cmdlet returns a hexadecimal representation of the file specified by the **Path**
-parameter.
+Specifies the path to a file. Use a dot (`.`) to specify the current location. If the **Path**
+parameter includes escape characters, enclose the path in single quotation marks.
 
 ```yaml
 Type: String[]
@@ -193,7 +192,7 @@ You can pipe a string to this cmdlet.
 
 This cmdlet returns a **ByteCollection**. This object represents a collection of bytes. It includes
 methods that convert the collection of bytes to a string formatted like each line of output returned
-by **Format-Hex**. If you specify the *Path* or *LiteralPath* parameter, the object also contains
+by `Format-Hex`. If you specify the **Path** or **LiteralPath** parameter, the object also contains
 the path of the file that contains each byte.
 
 ## NOTES

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  2/4/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -11,47 +11,71 @@ title:  Format-Hex
 # Format-Hex
 
 ## SYNOPSIS
-Displays a file or other input as hexadecimal.
+Displays a file or input such as a string, as hexadecimal.
 
 ## SYNTAX
 
 ### Path (Default)
+
 ```
-Format-Hex [-Path] <String[]> [<CommonParameters>]
+Format-Hex [-Path] <string[]> [<CommonParameters>]
 ```
 
 ### LiteralPath
+
 ```
-Format-Hex -LiteralPath <String[]> [<CommonParameters>]
+Format-Hex -LiteralPath <string[]> [<CommonParameters>]
 ```
 
 ### ByInputObject
+
 ```
-Format-Hex -InputObject <Object> [-Encoding <String>] [<CommonParameters>]
+Format-Hex -InputObject <Object> [-Encoding <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Format-Hex** cmdlet displays a file or other input as hexadecimal values.
-To determine the offset of a character from the output, add the number at the leftmost of the row to the number at the top of the column for that character.
 
-This cmdlet can help you determine the file type of a corrupted file or a file which may not have a file name extension.
-Run this cmdlet, and then inspect the results for file information.
+The `Format-Hex` cmdlet displays a file or other input as hexadecimal values. To determine the
+offset of a character from the output, add the number at the leftmost of the row to the number at
+the top of the column for that character.
+
+The `Format-Hex` cmdlet can help you determine the file type of a corrupted file or a file that
+might not have a file name extension. You can run this cmdlet, and then read the hexadecimal output
+to get file information.
 
 ## EXAMPLES
 
 ### Example 1: Get the hexadecimal representation of a string
+
+This command returns the hexadecimal values of a string.
+
+```powershell
+'Hello World' | Format-Hex
 ```
-PS C:\> "Hello World" | Format-Hex
+
+```Output
            00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
 
 00000000   48 65 6C 6C 6F 20 57 6F 72 6C 64                 Hello World
 ```
 
-This command returns the hexadecimal representation of the string Hello World.
+The string **Hello World** is sent down the pipeline to the `Format-Hex` cmdlet. The hexadecimal
+output from `Format-Hex` shows the values of each character in the string.
 
-### Example 2: Investigate a file type
+### Example 2: Find a file type from hexadecimal output
+
+This example uses the hexadecimal output to determine the file type.
+
+To test the following command, make a copy of an existing PDF file on your local computer and rename
+the copied file to **File.t7f**.
+
+```powershell
+Format-Hex -Path .\File.t7f
 ```
-PS C:\> Format-Hex -Path "C:\temp\temp.t7f"
+
+```Output
+           Path: C:\Test\File.t7f
+           
            00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
 
 00000000   25 50 44 46 2D 31 2E 35 0D 0A 25 B5 B5 B5 B5 0D  %PDF-1.5..%????.
@@ -59,41 +83,48 @@ PS C:\> Format-Hex -Path "C:\temp\temp.t7f"
 00000020   65 2F 43 61 74 61 6C 6F 67 2F 50 61 67 65 73 20  e/Catalog/Pages
 ```
 
-This command converts the file that is named temp.t7f to hexadecimal.
-In this example, a file that has the unfamiliar file name extension .t7f is actually a PDF file.
-The first few bytes of the header contain that information.
+The `Format-Hex` cmdlet uses the **Path** parameter to specify a file name in the current directory,
+**File.t7f**. This command displays the file's full path and the hexadecimal values. The file's
+extension **.t7f** is uncommon, but the hexadecimal output **%PDF** shows that it is a PDF file.
 
 ## PARAMETERS
 
 ### -Encoding
-Specifies the type of character encoding used in the file that this cmdlet formats as hexadecimal.
-The acceptable values for this parameter are:
 
-- Ascii
-- UTF32
-- UTF7
-- UTF8
-- BigEndianUnicode
-- Unicode
+Specifies the type of encoding for the target file. The default value is **ASCII**.
 
-The default value is Unicode.
+The acceptable values for this parameter are as follows:
+
+- **ASCII** Uses ASCII (7-bit) character set.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
+- **Byte** Encodes a set of characters into a sequence of bytes.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **OEM** Uses the encoding that corresponds to the system's current OEM code page.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
+- **Unknown** Same as **Unicode**.
+- **UTF7** Uses UTF-7.
+- **UTF8** Uses UTF-8.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
 
 ```yaml
 Type: String
 Parameter Sets: ByInputObject
 Aliases:
-Accepted values: Ascii, UTF32, UTF7, UTF8, BigEndianUnicode, Unicode
+Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, Byte, Default, OEM, String, Unicode, Unknown, UTF7, UTF8, UTF32
 
 Required: False
 Position: Named
-Default value: None
+Default value: ASCII
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies the objects to be formatted.
-Enter a variable that contains the objects or type a command or expression that gets the objects.
+
+Specifies the objects to be formatted. Enter a variable that contains the objects or type a command
+or expression that gets the objects.
 
 ```yaml
 Type: Object
@@ -108,13 +139,11 @@ Accept wildcard characters: False
 ```
 
 ### -LiteralPath
-Specifies an array of literal paths of items.
-This parameter does not accept wildcard characters.
-To use wildcard characters, specify the *Path* parameter instead.
 
-If this parameter includes escape characters, enclose the path in single quotation marks.
-Windows PowerShell does not interpret any characters in a single quoted string as escape sequences.
-For more information, type `Get-Help about_Quoting_Rules`.
+Specifies an array of literal paths of items. This parameter does not accept wildcard characters. If
+the **LiteralPath** parameter includes escape characters, enclose the path in single quotation
+marks. PowerShell does not interpret any characters in a single quoted string as escape sequences.
+For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_quoting_rules).
 
 ```yaml
 Type: String[]
@@ -129,11 +158,10 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies an array of paths of items.
-This cmdlet returns a hexadecimal representation of the items that this parameter specifies.
 
-Use a dot (.) to specify the current location.
-Use the wildcard character (*) to specify all the items in the current location.
+Specifies the path to a file. Use a dot, backslash (`.\`) to specify the current location. The
+`Format-Hex` cmdlet returns a hexadecimal representation of the file specified by the **Path**
+parameter.
 
 ```yaml
 Type: String[]
@@ -148,24 +176,31 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
+
 You can pipe a string to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.Commands.ByteCollection
-This cmdlet returns a **ByteCollection**.
-This object represents a collection of bytes.
-It includes methods that convert the collection of bytes to a string formatted like each line of output returned by **Format-Hex**.
-If you specify the *Path* or *LiteralPath* parameter, the object also contains the path of the file that contains each byte.
+
+This cmdlet returns a **ByteCollection**. This object represents a collection of bytes. It includes
+methods that convert the collection of bytes to a string formatted like each line of output returned
+by **Format-Hex**. If you specify the *Path* or *LiteralPath* parameter, the object also contains
+the path of the file that contains each byte.
 
 ## NOTES
 
 ## RELATED LINKS
+
+[about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_quoting_rules)
 
 [Format-Custom](Format-Custom.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Utility-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 2/4/2019
 online version: http://go.microsoft.com/fwlink/?LinkId=821773
 schema: 2.0.0
 title: Format-Hex
@@ -12,47 +12,71 @@ title: Format-Hex
 # Format-Hex
 
 ## SYNOPSIS
-Displays a file or other input as hexadecimal.
+Displays a file or input such as a string, as hexadecimal.
 
 ## SYNTAX
 
 ### Path (Default)
+
 ```
-Format-Hex [-Path] <String[]> [<CommonParameters>]
+Format-Hex [-Path] <string[]> [<CommonParameters>]
 ```
 
 ### LiteralPath
+
 ```
-Format-Hex -LiteralPath <String[]> [<CommonParameters>]
+Format-Hex -LiteralPath <string[]> [<CommonParameters>]
 ```
 
 ### ByInputObject
+
 ```
-Format-Hex -InputObject <Object> [-Encoding <String>] [-Raw] [<CommonParameters>]
+Format-Hex -InputObject <Object> [-Encoding <string>] [-Raw] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Format-Hex** cmdlet displays a file or other input as hexadecimal values.
-To determine the offset of a character from the output, add the number at the leftmost of the row to the number at the top of the column for that character.
 
-This cmdlet can help you determine the file type of a corrupted file or a file which may not have a file name extension.
-Run this cmdlet, and then inspect the results for file information.
+The `Format-Hex` cmdlet displays a file or other input as hexadecimal values. To determine the
+offset of a character from the output, add the number at the leftmost of the row to the number at
+the top of the column for that character.
+
+The `Format-Hex` cmdlet can help you determine the file type of a corrupted file or a file that
+might not have a file name extension. You can run this cmdlet, and then read the hexadecimal output
+to get file information.
 
 ## EXAMPLES
 
 ### Example 1: Get the hexadecimal representation of a string
+
+This command returns the hexadecimal values of a string.
+
+```powershell
+'Hello World' | Format-Hex
 ```
-PS C:\> "Hello World" | Format-Hex
+
+```Output
            00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
 
 00000000   48 65 6C 6C 6F 20 57 6F 72 6C 64                 Hello World
 ```
 
-This command returns the hexadecimal representation of the string Hello World.
+The string **Hello World** is sent down the pipeline to the `Format-Hex` cmdlet. The hexadecimal
+output from `Format-Hex` shows the values of each character in the string.
 
-### Example 2: Investigate a file type
+### Example 2: Find a file type from hexadecimal output
+
+This example uses the hexadecimal output to determine the file type.
+
+To test the following command, make a copy of an existing PDF file on your local computer and rename
+the copied file to **File.t7f**.
+
+```powershell
+Format-Hex -Path .\File.t7f
 ```
-PS C:\> Format-Hex -Path "C:\temp\temp.t7f"
+
+```Output
+           Path: C:\Test\File.t7f
+           
            00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
 
 00000000   25 50 44 46 2D 31 2E 35 0D 0A 25 B5 B5 B5 B5 0D  %PDF-1.5..%????.
@@ -60,41 +84,48 @@ PS C:\> Format-Hex -Path "C:\temp\temp.t7f"
 00000020   65 2F 43 61 74 61 6C 6F 67 2F 50 61 67 65 73 20  e/Catalog/Pages
 ```
 
-This command converts the file that is named temp.t7f to hexadecimal.
-In this example, a file that has the unfamiliar file name extension .t7f is actually a PDF file.
-The first few bytes of the header contain that information.
+The `Format-Hex` cmdlet uses the **Path** parameter to specify a file name in the current directory,
+**File.t7f**. This command displays the file's full path and the hexadecimal values. The file's
+extension **.t7f** is uncommon, but the hexadecimal output **%PDF** shows that it is a PDF file.
 
 ## PARAMETERS
 
 ### -Encoding
-Specifies the type of character encoding used in the file that this cmdlet formats as hexadecimal.
-The acceptable values for this parameter are:
 
-- Ascii
-- UTF32
-- UTF7
-- UTF8
-- BigEndianUnicode
-- Unicode
+Specifies the type of encoding for the target file. The default value is **ASCII**.
 
-The default value is Unicode.
+The acceptable values for this parameter are as follows:
+
+- **ASCII** Uses ASCII (7-bit) character set.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
+- **Byte** Encodes a set of characters into a sequence of bytes.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **OEM** Uses the encoding that corresponds to the system's current OEM code page.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
+- **Unknown** Same as **Unicode**.
+- **UTF7** Uses UTF-7.
+- **UTF8** Uses UTF-8.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
 
 ```yaml
 Type: String
 Parameter Sets: ByInputObject
 Aliases:
-Accepted values: Ascii, UTF32, UTF7, UTF8, BigEndianUnicode, Unicode
+Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, Byte, Default, OEM, String, Unicode, Unknown, UTF7, UTF8, UTF32
 
 Required: False
 Position: Named
-Default value: None
+Default value: ASCII
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies the objects to be formatted.
-Enter a variable that contains the objects or type a command or expression that gets the objects.
+
+Specifies the objects to be formatted. Enter a variable that contains the objects or type a command
+or expression that gets the objects.
 
 ```yaml
 Type: Object
@@ -109,13 +140,11 @@ Accept wildcard characters: False
 ```
 
 ### -LiteralPath
-Specifies an array of literal paths of items.
-This parameter does not accept wildcard characters.
-To use wildcard characters, specify the *Path* parameter instead.
 
-If this parameter includes escape characters, enclose the path in single quotation marks.
-Windows PowerShell does not interpret any characters in a single quoted string as escape sequences.
-For more information, type `Get-Help about_Quoting_Rules`.
+Specifies an array of literal paths of items. This parameter does not accept wildcard characters. If
+the **LiteralPath** parameter includes escape characters, enclose the path in single quotation
+marks. PowerShell does not interpret any characters in a single quoted string as escape sequences.
+For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_quoting_rules).
 
 ```yaml
 Type: String[]
@@ -130,11 +159,10 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies an array of paths of items.
-This cmdlet returns a hexadecimal representation of the items that this parameter specifies.
 
-Use a dot (.) to specify the current location.
-Use the wildcard character (*) to specify all the items in the current location.
+Specifies the path to a file. Use a dot, backslash (`.\`) to specify the current location. The
+`Format-Hex` cmdlet returns a hexadecimal representation of the file specified by the **Path**
+parameter.
 
 ```yaml
 Type: String[]
@@ -150,6 +178,13 @@ Accept wildcard characters: False
 
 ### -Raw
 
+Ignores newline characters and returns the entire contents of a file in one string with the newlines
+preserved. By default, newline characters in a file are used as delimiters to separate the input
+into an array of strings. This parameter was introduced in PowerShell 3.0.
+
+**Raw** is a dynamic parameter that the **FileSystem** provider adds and works only in file system
+drives.
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: ByInputObject
@@ -163,24 +198,31 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
+
 You can pipe a string to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.Commands.ByteCollection
-This cmdlet returns a **ByteCollection**.
-This object represents a collection of bytes.
-It includes methods that convert the collection of bytes to a string formatted like each line of output returned by **Format-Hex**.
-If you specify the *Path* or *LiteralPath* parameter, the object also contains the path of the file that contains each byte.
+
+This cmdlet returns a **ByteCollection**. This object represents a collection of bytes. It includes
+methods that convert the collection of bytes to a string formatted like each line of output returned
+by **Format-Hex**. If you specify the *Path* or *LiteralPath* parameter, the object also contains
+the path of the file that contains each byte.
 
 ## NOTES
 
 ## RELATED LINKS
+
+[about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_quoting_rules)
 
 [Format-Custom](Format-Custom.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -141,10 +141,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies an array of literal paths of items. This parameter does not accept wildcard characters. If
-the **LiteralPath** parameter includes escape characters, enclose the path in single quotation
-marks. PowerShell does not interpret any characters in a single quoted string as escape sequences.
-For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_quoting_rules).
+Specifies the complete path to a file. The value of **LiteralPath** is used exactly as it is typed.
+This parameter does not accept wildcard characters. If the **LiteralPath** parameter includes escape
+characters, enclose the path in single quotation marks. PowerShell does not interpret any characters
+in a single quoted string as escape sequences. For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_quoting_rules).
 
 ```yaml
 Type: String[]
@@ -160,9 +160,8 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path to a file. Use a dot, backslash (`.\`) to specify the current location. The
-`Format-Hex` cmdlet returns a hexadecimal representation of the file specified by the **Path**
-parameter.
+Specifies the path to a file. Use a dot (`.`) to specify the current location. If the **Path**
+parameter includes escape characters, enclose the path in single quotation marks.
 
 ```yaml
 Type: String[]
@@ -215,7 +214,7 @@ You can pipe a string to this cmdlet.
 
 This cmdlet returns a **ByteCollection**. This object represents a collection of bytes. It includes
 methods that convert the collection of bytes to a string formatted like each line of output returned
-by **Format-Hex**. If you specify the *Path* or *LiteralPath* parameter, the object also contains
+by `Format-Hex`. If you specify the **Path** or **LiteralPath** parameter, the object also contains
 the path of the file that contains each byte.
 
 ## NOTES

--- a/reference/6/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -143,12 +143,11 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies an array of literal paths of items. This parameter does not accept wildcard characters. To
-use wildcard characters, use the **Path** parameter.
-
-If the **LiteralPath** parameter includes escape characters, enclose the path in single quotation
-marks. PowerShell does not interpret any characters in a single quoted string as escape sequences.
-For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_quoting_rules).
+Specifies the complete path to a file. The value of **LiteralPath** is used exactly as it is typed.
+This parameter does not accept wildcard characters. To specify multiple paths to files, separate the
+paths with a comma. If the **LiteralPath** parameter includes escape characters, enclose the path in
+single quotation marks. PowerShell does not interpret any characters in a single quoted string as
+escape sequences. For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_quoting_rules).
 
 ```yaml
 Type: String[]
@@ -164,10 +163,10 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies an array of paths to files. To specify multiple files, separate the paths with a comma.
-Use a dot, backslash (`.\`) to specify the current location. Use the wildcard character (`*`) to
-specify all the items in the current location. The `Format-Hex` cmdlet returns a hexadecimal
-representation of the items specified by the **Path** parameter.
+Specifies the path to files. Use a dot (`.`) to specify the current location. The wildcard character
+(`*`) is accepted and can be used to specify all the items in a location. If the **Path** parameter
+includes escape characters, enclose the path in single quotation marks. To specify multiple paths to
+files, separate the paths with a comma.
 
 ```yaml
 Type: String[]
@@ -178,7 +177,7 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Raw
@@ -252,7 +251,7 @@ You can pipe a string to this cmdlet.
 
 This cmdlet returns a **ByteCollection**. This object represents a collection of bytes. It includes
 methods that convert the collection of bytes to a string formatted like each line of output returned
-by **Format-Hex**. If you specify the *Path* or *LiteralPath* parameter, the object also contains
+by `Format-Hex`. If you specify the **Path** or **LiteralPath** parameter, the object also contains
 the path of the file that contains each byte.
 
 ## NOTES

--- a/reference/6/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 2/4/2019
 online version: http://go.microsoft.com/fwlink/?LinkId=821773
 schema: 2.0.0
 title: Format-Hex
@@ -12,47 +12,72 @@ title: Format-Hex
 # Format-Hex
 
 ## SYNOPSIS
-Displays a file or other input as hexadecimal.
+Displays a file or input such as a string, as hexadecimal.
 
 ## SYNTAX
 
-### Path
+### Path (Default)
+
 ```
-Format-Hex [-Path] <String[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+Format-Hex [-Path] <string[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPath
+
 ```
-Format-Hex -LiteralPath <String[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+Format-Hex -LiteralPath <string[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByInputObject
+
 ```
-Format-Hex -InputObject <PSObject> [-Encoding <Encoding>] [-Raw] [-WhatIf] [-Confirm] [<CommonParameters>]
+Format-Hex -InputObject <psobject> [-Encoding <Encoding>] [-Raw] [-WhatIf] [-Confirm]
+[<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Format-Hex** cmdlet displays a file or other input as hexadecimal values.
-To determine the offset of a character from the output, add the number at the leftmost of the row to the number at the top of the column for that character.
 
-This cmdlet can help you determine the file type of a corrupted file or a file which may not have a file name extension.
-Run this cmdlet, and then inspect the results for file information.
+The `Format-Hex` cmdlet displays a file or other input as hexadecimal values. To determine the
+offset of a character from the output, add the number at the leftmost of the row to the number at
+the top of the column for that character.
+
+The `Format-Hex` cmdlet can help you determine the file type of a corrupted file or a file that
+might not have a file name extension. You can run this cmdlet, and then read the hexadecimal output
+to get file information.
 
 ## EXAMPLES
 
 ### Example 1: Get the hexadecimal representation of a string
+
+This command returns the hexadecimal values of a string.
+
+```powershell
+'Hello World' | Format-Hex
 ```
-PS C:\> "Hello World" | Format-Hex
+
+```Output
            00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
 
 00000000   48 65 6C 6C 6F 20 57 6F 72 6C 64                 Hello World
 ```
 
-This command returns the hexadecimal representation of the string Hello World.
+The string **Hello World** is sent down the pipeline to the `Format-Hex` cmdlet. The hexadecimal
+output from `Format-Hex` shows the values of each character in the string.
 
-### Example 2: Investigate a file type
+### Example 2: Find a file type from hexadecimal output
+
+This example uses the hexadecimal output to determine the file type.
+
+To test the following command, make a copy of an existing PDF file on your local computer and rename
+the copied file to **File.t7f**.
+
+```powershell
+Format-Hex -Path .\File.t7f
 ```
-PS C:\> Format-Hex -Path "C:\temp\temp.t7f"
+
+```Output
+           Path: C:\Test\File.t7f
+           
            00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
 
 00000000   25 50 44 46 2D 31 2E 35 0D 0A 25 B5 B5 B5 B5 0D  %PDF-1.5..%????.
@@ -60,40 +85,49 @@ PS C:\> Format-Hex -Path "C:\temp\temp.t7f"
 00000020   65 2F 43 61 74 61 6C 6F 67 2F 50 61 67 65 73 20  e/Catalog/Pages
 ```
 
-This command converts the file that is named temp.t7f to hexadecimal.
-In this example, a file that has the unfamiliar file name extension .t7f is actually a PDF file.
-The first few bytes of the header contain that information.
+The `Format-Hex` cmdlet uses the **Path** parameter to specify a file name in the current directory,
+**File.t7f**. This command displays the file's full path and the hexadecimal values. The file's
+extension **.t7f** is uncommon, but the hexadecimal output **%PDF** shows that it is a PDF file.
 
 ## PARAMETERS
 
 ### -Encoding
-Specifies the type of character encoding used in the file that this cmdlet formats as hexadecimal.
-The acceptable values for this parameter are:
 
-- Ascii
-- UTF32
-- UTF7
-- UTF8
-- BigEndianUnicode
-- Unicode
+Specifies the type of encoding for the target file. The default value is **UTF8NoBOM**.
 
-The default value is Unicode.
+The acceptable values for this parameter are as follows:
+
+- **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
+- **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
+- **Byte**: Encodes a set of characters into a sequence of bytes.
+- **Default**: Encodes using the default value: ASCII.
+- **OEM**: Uses the default encoding for MS-DOS and console programs.
+- **String**: Uses the encoding type for a string.
+- **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
+- **UTF7**: Encodes in UTF-7 format.
+- **UTF8**: Encodes in UTF-8 format.
+- **UTF8BOM**: Encodes in UTF-8 format with Byte Order Mark (BOM)
+- **UF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
+- **UTF32**:  Encodes in UTF-32 format.
+- **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
 
 ```yaml
 Type: Encoding
 Parameter Sets: ByInputObject
 Aliases:
+Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UF8NoBOM, UTF32, Unknown
 
 Required: False
 Position: Named
-Default value: None
+Default value: UTF8NoBOM
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies the objects to be formatted.
-Enter a variable that contains the objects or type a command or expression that gets the objects.
+
+Specifies the objects to be formatted. Enter a variable that contains the objects or type a command
+or expression that gets the objects.
 
 ```yaml
 Type: PSObject
@@ -108,13 +142,13 @@ Accept wildcard characters: False
 ```
 
 ### -LiteralPath
-Specifies an array of literal paths of items.
-This parameter does not accept wildcard characters.
-To use wildcard characters, specify the *Path* parameter instead.
 
-If this parameter includes escape characters, enclose the path in single quotation marks.
-PowerShell does not interpret any characters in a single quoted string as escape sequences.
-For more information, type `Get-Help about_Quoting_Rules`.
+Specifies an array of literal paths of items. This parameter does not accept wildcard characters. To
+use wildcard characters, use the **Path** parameter.
+
+If the **LiteralPath** parameter includes escape characters, enclose the path in single quotation
+marks. PowerShell does not interpret any characters in a single quoted string as escape sequences.
+For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_quoting_rules).
 
 ```yaml
 Type: String[]
@@ -129,11 +163,11 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies an array of paths of items.
-This cmdlet returns a hexadecimal representation of the items that this parameter specifies.
 
-Use a dot (.) to specify the current location.
-Use the wildcard character (*) to specify all the items in the current location.
+Specifies an array of paths to files. To specify multiple files, separate the paths with a comma.
+Use a dot, backslash (`.\`) to specify the current location. Use the wildcard character (`*`) to
+specify all the items in the current location. The `Format-Hex` cmdlet returns a hexadecimal
+representation of the items specified by the **Path** parameter.
 
 ```yaml
 Type: String[]
@@ -149,6 +183,13 @@ Accept wildcard characters: False
 
 ### -Raw
 
+Ignores newline characters and returns the entire contents of a file in one string with the newlines
+preserved. By default, newline characters in a file are used as delimiters to separate the input
+into an array of strings. This parameter was introduced in PowerShell 3.0.
+
+**Raw** is a dynamic parameter that the **FileSystem** provider adds and works only in file system
+drives.
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: ByInputObject
@@ -162,6 +203,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -177,6 +219,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
@@ -192,24 +235,31 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
+
 You can pipe a string to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.Commands.ByteCollection
-This cmdlet returns a **ByteCollection**.
-This object represents a collection of bytes.
-It includes methods that convert the collection of bytes to a string formatted like each line of output returned by **Format-Hex**.
-If you specify the *Path* or *LiteralPath* parameter, the object also contains the path of the file that contains each byte.
+
+This cmdlet returns a **ByteCollection**. This object represents a collection of bytes. It includes
+methods that convert the collection of bytes to a string formatted like each line of output returned
+by **Format-Hex**. If you specify the *Path* or *LiteralPath* parameter, the object also contains
+the path of the file that contains each byte.
 
 ## NOTES
 
 ## RELATED LINKS
+
+[about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_quoting_rules)
 
 [Format-Custom](Format-Custom.md)
 


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in versions 5.0, 5.1, and 6 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work

Related to Issue #2000
Updated Encoding parameter for Format-Hex
Style updates
Paragraph reflows
Fixed links

Acrolinx scores
Original version: 88
Updated version: 93