### PR TITLE
Carriage return missing

### DIFF
--- a/reference/6/PowerShellGet/Publish-Script.md
+++ b/reference/6/PowerShellGet/Publish-Script.md
@@ -84,7 +84,8 @@ Demo-ScriptWorkflow
 PS C:\> Test-ScriptFileInfo -Path "D:\ScriptSharingDemo\Demo-Script.ps1"
 Version    Name                      Author               Description
 -------    ----                      ------               -----------
-1.0        Demo-Script               pattif@microsoft.com my test script file description goes here PS C:\> Publish-Script -Path "D:\ScriptSharingDemo\Demo-Script.ps1" -Repository "LocalRepo1"
+1.0        Demo-Script               pattif@microsoft.com my test script file description goes here
+PS C:\> Publish-Script -Path "D:\ScriptSharingDemo\Demo-Script.ps1" -Repository "LocalRepo1"
 PS C:\> Find-Script -Repository "LocalRepo1" -Name "Demo-Script"
 Version    Name                                Type       Repository           Description
 -------    ----                                ----       ----------           -----------


### PR DESCRIPTION
A carriage return is missing after the Test-ScriptFileInfo command output, which makes the example difficult to understand.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
