### PR TITLE
Update approved-verbs-for-windows-powershell-commands.md

### DIFF
--- a/developer/cmdlet/approved-verbs-for-windows-powershell-commands.md
+++ b/developer/cmdlet/approved-verbs-for-windows-powershell-commands.md
@@ -8,7 +8,7 @@ ms.tgt_pltfrm: ""
 ms.topic: "article"
 helpviewer_keywords:
   - "action names [PowerShell SDK]"
-  - "verb names [PowerShell SDK]"
+  - "verb names [PowerShell SDK]"f
   - "cmdlets [PowerShell SDK], verb names"
 ms.assetid: 2d4e58a9-05bc-437c-86b9-d8d55cba7d48
 caps.latest.revision: 36
@@ -140,8 +140,8 @@ The following table lists most of the defined verbs.
 |[Compare](/dotnet/api/System.Management.Automation.VerbsData.Compare) (cr)|Evaluates the data from one resource against the data from another resource.|For this action, do not use a verb such as Diff.|
 |[Compress](/dotnet/api/System.Management.Automation.VerbsData.Compress) (cm)|Compacts the data of a resource. Pairs with `Expand`.|For this action, do not use a verb such as Compact.|
 |[Convert](/dotnet/api/System.Management.Automation.VerbsData.Convert) (cv)|Changes the data from one representation to another when the cmdlet supports bidirectional conversion or when the cmdlet supports conversion between multiple data types.|For this action, do not use verbs such as Change, Resize, or Resample.|
-|[Convertfrom](/dotnet/api/System.Management.Automation.VerbsData.ConvertFrom) (cf)|Converts one primary type of input (the cmdlet noun indicates the input) to one or more supported output types.|For this action, do not use verbs such as Export, Output, or Out.|
-|[Convertto](/dotnet/api/System.Management.Automation.VerbsData.ConvertTo) (ct)|Converts from one or more types of input to a primary output type (the cmdlet noun indicates the output type).|For this action, do not use verbs such as Import, Input, or In.|
+|[ConvertFrom](/dotnet/api/System.Management.Automation.VerbsData.ConvertFrom) (cf)|Converts one primary type of input (the cmdlet noun indicates the input) to one or more supported output types.|For this action, do not use verbs such as Export, Output, or Out.|
+|[ConvertTo](/dotnet/api/System.Management.Automation.VerbsData.ConvertTo) (ct)|Converts from one or more types of input to a primary output type (the cmdlet noun indicates the output type).|For this action, do not use verbs such as Import, Input, or In.|
 |[Dismount](/dotnet/api/System.Management.Automation.VerbsData.Dismount) (dm)|Detaches a named entity from a location. This verb is paired with `Mount`.|For this action, do not use verbs such as Unmount or Unlink.|
 |[Edit](/dotnet/api/System.Management.Automation.VerbsData.Edit) (ed)|Modifies existing data by adding or removing content.|For this action, do not use verbs such as Change, Update, or Modify for this action.|
 |[Expand](/dotnet/api/System.Management.Automation.VerbsData.Expand) (en)|Restores the data of a resource that has been compressed to its original state. This verb is paired with `Compress`.|For this action, do not use verbs such as Explode or Uncompress.|

--- a/developer/cmdlet/approved-verbs-for-windows-powershell-commands.md
+++ b/developer/cmdlet/approved-verbs-for-windows-powershell-commands.md
@@ -8,7 +8,7 @@ ms.tgt_pltfrm: ""
 ms.topic: "article"
 helpviewer_keywords:
   - "action names [PowerShell SDK]"
-  - "verb names [PowerShell SDK]"f
+  - "verb names [PowerShell SDK]"
   - "cmdlets [PowerShell SDK], verb names"
 ms.assetid: 2d4e58a9-05bc-437c-86b9-d8d55cba7d48
 caps.latest.revision: 36


### PR DESCRIPTION
Changed verb casing:
Convertfrom -> ConvertFrom
Convertto  -> ConvertTo

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
