### PR TITLE
Fixed typo in Encoding parameter

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/6/Microsoft.PowerShell.Management/Add-Content.md
@@ -18,19 +18,20 @@ Adds content to the specified items, such as adding words to a file.
 ### Path (Default)
 
 ```
-Add-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>] [-Include
-<string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf] [-Confirm]
-[-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>] [<CommonParameters>]
+Add-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>]
+[-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
+[-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
+[<CommonParameters>]
 ```
 
 ### LiteralPath
 
 ```
-Add-Content [-Value] <Object[]> -LiteralPath <string[]> [-PassThru] [-Filter <string>] [-Include
-<string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf] [-Confirm]
-[-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>] [<CommonParameters>]
+Add-Content [-Value] <Object[]> -LiteralPath <string[]> [-PassThru] [-Filter <string>]
+[-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
+[-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
+[<CommonParameters>]
 ```
-
 
 ## DESCRIPTION
 
@@ -217,15 +218,15 @@ The acceptable values for this parameter are as follows:
 - **UTF7**: Encodes in UTF-7 format.
 - **UTF8**: Encodes in UTF-8 format.
 - **UTF8BOM**: Encodes in UTF-8 format with Byte Order Mark (BOM)
-- **UF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
-- **UTF32**:  Encodes in UTF-32 format.
+- **UTF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
+- **UTF32**: Encodes in UTF-32 format.
 - **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
 
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UF8NoBOM, UTF32, Unknown
+Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32, Unknown
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-Content.md
@@ -538,8 +538,8 @@ The acceptable values for this parameter are as follows:
 - **UTF7**: Encodes in UTF-7 format.
 - **UTF8**: Encodes in UTF-8 format.
 - **UTF8BOM**: Encodes in UTF-8 format with Byte Order Mark (BOM)
-- **UF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
-- **UTF32**:  Encodes in UTF-32 format.
+- **UTF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
+- **UTF32**: Encodes in UTF-32 format.
 - **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
 
 Encoding is a dynamic parameter that the **FileSystem** provider adds to the `Get-Content` cmdlet.
@@ -555,7 +555,7 @@ the bytes to a file unless you use **AsByteStream** parameter.
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UF8NoBOM, UTF32, Unknown
+Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32, Unknown
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Content.md
@@ -186,15 +186,15 @@ The acceptable values for this parameter are as follows:
 - **UTF7**: Encodes in UTF-7 format.
 - **UTF8**: Encodes in UTF-8 format.
 - **UTF8BOM**: Encodes in UTF-8 format with Byte Order Mark (BOM)
-- **UF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
-- **UTF32**:  Encodes in UTF-32 format.
+- **UTF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
+- **UTF32**: Encodes in UTF-32 format.
 - **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
 
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UF8NoBOM, UTF32, Unknown
+Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32, Unknown
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -139,15 +139,15 @@ The acceptable values for this parameter are as follows:
 - **UTF7**: Encodes in UTF-7 format.
 - **UTF8**: Encodes in UTF-8 format.
 - **UTF8BOM**: Encodes in UTF-8 format with Byte Order Mark (BOM)
-- **UF8NOBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
-- **UTF32**:  Encodes in UTF-32 format.
+- **UTF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
+- **UTF32**: Encodes in UTF-32 format.
 - **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
 
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UF8NoBOM, UTF32, Unknown
+Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32, Unknown
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -404,15 +404,15 @@ The acceptable values for this parameter are as follows:
 - **UTF7**: Encodes in UTF-7 format.
 - **UTF8**: Encodes in UTF-8 format.
 - **UTF8BOM**: Encodes in UTF-8 format with Byte Order Mark (BOM)
-- **UF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
-- **UTF32**:  Encodes in UTF-32 format.
+- **UTF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
+- **UTF32**: Encodes in UTF-32 format.
 - **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
 
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UF8NoBOM, UTF32, Unknown
+Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32, Unknown
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -18,9 +18,10 @@ Exports commands from another session and saves them in a PowerShell module.
 
 ```
 Export-PSSession [-Session] <PSSession> [-OutputModule] <string> [[-CommandName] <string[]>]
-[[-FormatTypeName] <string[]>] [-Force] [-Encoding <Encoding>] [-AllowClobber] [-ArgumentList
-<Object[]>] [-CommandType <CommandTypes>] [-Module <string[]>] [-FullyQualifiedModule
-<ModuleSpecification[]>] [-Certificate <X509Certificate2>] [<CommonParameters>]
+[[-FormatTypeName] <string[]>] [-Force] [-Encoding <Encoding>] [-AllowClobber]
+[-ArgumentList <Object[]>] [-CommandType <CommandTypes>] [-Module <string[]>]
+[-FullyQualifiedModule <ModuleSpecification[]>] [-Certificate <X509Certificate2>]
+[<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -292,15 +293,15 @@ The acceptable values for this parameter are as follows:
 - **UTF7**: Encodes in UTF-7 format.
 - **UTF8**: Encodes in UTF-8 format.
 - **UTF8BOM**: Encodes in UTF-8 format with Byte Order Mark (BOM)
-- **UF8NOBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
-- **UTF32**:  Encodes in UTF-32 format.
+- **UTF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
+- **UTF32**: Encodes in UTF-32 format.
 - **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
 
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UF8NoBOM, UTF32, Unknown
+Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32, Unknown
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -107,15 +107,15 @@ The acceptable values for this parameter are as follows:
 - **UTF7**: Encodes in UTF-7 format.
 - **UTF8**: Encodes in UTF-8 format.
 - **UTF8BOM**: Encodes in UTF-8 format with Byte Order Mark (BOM)
-- **UF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
-- **UTF32**:  Encodes in UTF-32 format.
+- **UTF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
+- **UTF32**: Encodes in UTF-32 format.
 - **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
 
 ```yaml
 Type: Encoding
 Parameter Sets: ByInputObject
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UF8NoBOM, UTF32, Unknown
+Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32, Unknown
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.PowerShell.Utility/Import-Csv.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Import-Csv.md
@@ -19,8 +19,8 @@ Creates table-like custom objects from the items in a comma-separated value (CSV
 ### Delimiter (Default)
 
 ```
-Import-Csv [[-Path] <string[]>] [[-Delimiter] <char>] [-LiteralPath <string[]>] [-Header
-<string[]>] [-Encoding <Encoding>] [<CommonParameters>]
+Import-Csv [[-Path] <string[]>] [[-Delimiter] <char>] [-LiteralPath <string[]>] [-Header <string[]>]
+[-Encoding <Encoding>] [<CommonParameters>]
 ```
 
 ### UseCulture
@@ -333,15 +333,15 @@ The acceptable values for this parameter are as follows:
 - **UTF7**: Encodes in UTF-7 format.
 - **UTF8**: Encodes in UTF-8 format.
 - **UTF8BOM**: Encodes in UTF-8 format with Byte Order Mark (BOM)
-- **UF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
-- **UTF32**:  Encodes in UTF-32 format.
+- **UTF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
+- **UTF32**: Encodes in UTF-32 format.
 - **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
 
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UF8NoBOM, UTF32, Unknown
+Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32, Unknown
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Out-File.md
@@ -167,14 +167,14 @@ The acceptable values for this parameter are as follows:
 - **UTF8**: Encodes in UTF-8 format.
 - **UTF8BOM**: Encodes in UTF-8 format with Byte Order Mark (BOM)
 - **UTF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
-- **UTF32**:  Encodes in UTF-32 format.
+- **UTF32**: Encodes in UTF-32 format.
 - **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
 
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UF8NoBOM, UTF32, Unknown
+Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32, Unknown
 
 Required: False
 Position: 1

--- a/reference/6/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Select-String.md
@@ -391,15 +391,15 @@ The acceptable values for this parameter are as follows:
 - **UTF7**: Encodes in UTF-7 format.
 - **UTF8**: Encodes in UTF-8 format.
 - **UTF8BOM**: Encodes in UTF-8 format with Byte Order Mark (BOM)
-- **UF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
-- **UTF32**:  Encodes in UTF-32 format.
+- **UTF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
+- **UTF32**: Encodes in UTF-32 format.
 - **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
 
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UF8NoBOM, UTF32, Unknown
+Accepted values: ASCII, BigEndianUnicode, Byte, Default, OEM, String, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32, Unknown
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.PowerShell.Utility/Send-MailMessage.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Send-MailMessage.md
@@ -235,7 +235,7 @@ The acceptable values for this parameter are as follows:
 - **UTF8**: Encodes in UTF-8 format.
 - **UTF8BOM**: Encodes in UTF-8 format with Byte Order Mark (BOM)
 - **UTF8NoBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
-- **UTF32**:  Encodes in UTF-32 format.
+- **UTF32**: Encodes in UTF-32 format.
 - **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
 
 ```yaml


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version 6 of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work

Corrected a typo and spacing in Encoding parameter (UTF8NoBOM rather than UF8NoBOM)
Fixed parameter reflows