### PR TITLE
Update about_splatting.md to clarify parameter types supported by hash tables

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -54,8 +54,7 @@ single command just so you pass no more than one value for each parameter.
 ## SPLATTING WITH HASH TABLES
 
 Use a hash table to splat parameter name and value pairs. You can use this
-format for all parameter types, including positional and named parameters and
-switch parameters.
+format for all named parameter types, including switch parameters. 
 
 The following examples compare two `Copy-Item` commands that copy the Test.txt
 file to the Test2.txt file in the same directory.

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -54,7 +54,8 @@ single command just so you pass no more than one value for each parameter.
 ## SPLATTING WITH HASH TABLES
 
 Use a hash table to splat parameter name and value pairs. You can use this
-format for all named parameter types, including switch parameters. 
+format for all parameter types, including positional and switch parameters. 
+Positional parameters must be assigned by name.
 
 The following examples compare two `Copy-Item` commands that copy the Test.txt
 file to the Test2.txt file in the same directory.

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -54,8 +54,7 @@ single command just so you pass no more than one value for each parameter.
 ## SPLATTING WITH HASH TABLES
 
 Use a hash table to splat parameter name and value pairs. You can use this
-format for all parameter types, including positional and named parameters and
-switch parameters.
+format for all named parameter types, including switch parameters. 
 
 The following examples compare two `Copy-Item` commands that copy the Test.txt
 file to the Test2.txt file in the same directory.

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -54,7 +54,8 @@ single command just so you pass no more than one value for each parameter.
 ## SPLATTING WITH HASH TABLES
 
 Use a hash table to splat parameter name and value pairs. You can use this
-format for all named parameter types, including switch parameters. 
+format for all parameter types, including positional and switch parameters. 
+Positional parameters must be assigned by name.
 
 The following examples compare two `Copy-Item` commands that copy the Test.txt
 file to the Test2.txt file in the same directory.

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -52,8 +52,7 @@ single command just so you pass no more than one value for each parameter.
 ## SPLATTING WITH HASH TABLES
 
 Use a hash table to splat parameter name and value pairs. You can use this
-format for all parameter types, including positional and named parameters and
-switch parameters.
+format for all named parameter types, including switch parameters. 
 
 The following examples compare two `Copy-Item` commands that copy the Test.txt
 file to the Test2.txt file in the same directory.

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -52,7 +52,8 @@ single command just so you pass no more than one value for each parameter.
 ## SPLATTING WITH HASH TABLES
 
 Use a hash table to splat parameter name and value pairs. You can use this
-format for all named parameter types, including switch parameters. 
+format for all parameter types, including positional and switch parameters. 
+Positional parameters must be assigned by name.
 
 The following examples compare two `Copy-Item` commands that copy the Test.txt
 file to the Test2.txt file in the same directory.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -54,8 +54,7 @@ single command just so you pass no more than one value for each parameter.
 ## SPLATTING WITH HASH TABLES
 
 Use a hash table to splat parameter name and value pairs. You can use this
-format for all parameter types, including positional and named parameters and
-switch parameters.
+format for all named parameter types, including switch parameters. 
 
 The following examples compare two `Copy-Item` commands that copy the Test.txt
 file to the Test2.txt file in the same directory.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -54,7 +54,8 @@ single command just so you pass no more than one value for each parameter.
 ## SPLATTING WITH HASH TABLES
 
 Use a hash table to splat parameter name and value pairs. You can use this
-format for all named parameter types, including switch parameters. 
+format for all parameter types, including positional and switch parameters. 
+Positional parameters must be assigned by name. 
 
 The following examples compare two `Copy-Item` commands that copy the Test.txt
 file to the Test2.txt file in the same directory.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -54,8 +54,7 @@ single command just so you pass no more than one value for each parameter.
 ## SPLATTING WITH HASH TABLES
 
 Use a hash table to splat parameter name and value pairs. You can use this
-format for all parameter types, including positional and named parameters and
-switch parameters.
+format for all named parameter types, including switch parameters. 
 
 The following examples compare two `Copy-Item` commands that copy the Test.txt
 file to the Test2.txt file in the same directory.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -54,7 +54,8 @@ single command just so you pass no more than one value for each parameter.
 ## SPLATTING WITH HASH TABLES
 
 Use a hash table to splat parameter name and value pairs. You can use this
-format for all named parameter types, including switch parameters. 
+format for all parameter types, including positional and switch parameters. 
+Positional parameters must be assigned by name.
 
 The following examples compare two `Copy-Item` commands that copy the Test.txt
 file to the Test2.txt file in the same directory.


### PR DESCRIPTION
Clarify that hash tables can only address parameters by name, even if they are positional parameters.

Addresses #3713 

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

