### PR TITLE
Add documentation for configuring encoding with VSCode and PowerShell

### DIFF
--- a/reference/docs-conceptual/components/vscode/understanding-file-encoding.md
+++ b/reference/docs-conceptual/components/vscode/understanding-file-encoding.md
@@ -24,9 +24,11 @@ configure your VSCode and PowerShell settings properly.
 Encoding problems occur when the encoding of VSCode or your script file does not match the expected
 encoding of PowerShell. There is no way for PowerShell to automatically determine the file encoding.
 
-You're more likely to have encoding problems when you're using characters not in the [7-bit ASCII character set](https://ascii.cl/),
-such as accented latin characters (e.g. `É`, `ü`), or non-latin characters like Cyrillic (`Д`, `Ц`)
-or Han Chinese (`脚`, `本`).
+You're more likely to have encoding problems when you're using characters not in the [7-bit ASCII character set](https://ascii.cl/). For example:
+
+- Accented latin characters (`É`, `ü`)
+- Non-latin characters like Cyrillic (`Д`, `Ц`)
+- Han Chinese (`脚`, `本`)
 
 Common reasons for encoding issues are:
 
@@ -34,9 +36,9 @@ Common reasons for encoding issues are:
   5.1 and below, the default encoding is different from VSCode's.
 - Another editor has opened and overwritten the file in a new encoding. This often happens with the
   ISE.
-- The file is checked into source control (like git) in a different encoding to what VSCode or
-  PowerShell expects. This can happen when collaborators edit files with an editor with a different
-  encoding configurations.
+- The file is checked into source control in an encoding that is different from what VSCode or
+  PowerShell expects. This can happen when collaborators use editors with different encoding
+  configurations.
 
 ### How to tell when you have encoding issues
 
@@ -74,37 +76,36 @@ The PowerShell extension interacts with scripts in a number of ways:
 1. When scripts are edited in VSCode, the contents are sent by VSCode to the extension. The [Language Server Protocol][]
    mandates that this content is transferred in UTF-8. Therefore, it is not possible for the
    extension to get the wrong encoding.
-2. When scripts are executed directly in the Integrated Console, they are read off the filesystem by
-   PowerShell directly. This means that if PowerShell's encoding differs from VSCode's, something
-   may go wrong here.
+2. When scripts are executed directly in the Integrated Console, they're read from the file by
+   PowerShell directly. Tf PowerShell's encoding differs from VSCode's, something can go wrong here.
 3. When a script that is open in VSCode references another script that is not open in VSCode, the
    extension falls back to loading that script's content from the file system. VSCode defaults to
    UTF-8 encoding, but uses [byte-order mark][], or BOM, detection to select the correct encoding.
 
 The problem occurs when assuming the encoding of BOM-less formats (like [UTF-8] with no BOM and [Windows-1252]).
-In these cases, the extension defaults to UTF-8 rather than more complex logic. The PowerShell
-extension cannot change VSCode's encoding settings. For more information see [issue #824](https://github.com/Microsoft/vscode/issues/824).
+The PowerShell extension defaults to UTF-8. The extension cannot change VSCode's encoding settings.
+For more information, see [issue #824](https://github.com/Microsoft/vscode/issues/824).
 
 ## Choosing the right encoding
 
 Choosing an encoding depends on the platforms and applications you use to read and write your
 PowerShell files.
 
-On Windows, many applications have long used [Windows-1252]. Many .NET applications use [UTF-16]. In
-Windows, this is often called "Unicode", Unicode is a term that now refers to a broader [standard](https://en.wikipedia.org/wiki/Unicode).
+On Windows, many applications have long used [Windows-1252]. Many .NET applications use [UTF-16],
+often called "Unicode". Unicode is a term that now refers to a broader [standard](https://en.wikipedia.org/wiki/Unicode).
 
-In the Linux world, on the web, and .NET Standard, UTF-8 is now the dominant encoding.
+In the Linux world, on the web, and in .NET Standard, UTF-8 is now the dominant encoding.
 
 Unicode encodings also have the concept of a byte-order mark (BOM). BOMs occur at the beginning of
-text to tell a decoder which encoding the text is using. In the case of multi-byte encodings, the
-BOM also indicates [endianness](https://en.wikipedia.org/wiki/Endianness) of the encoding. BOMs are
-designed to be bytes that rarely occur in non-Unicode text, allowing a reasonable guess that text is
-Unicode when a BOM is present.
+text to tell a decoder which encoding the text is using. For multi-byte encodings, the BOM also
+indicates [endianness](https://en.wikipedia.org/wiki/Endianness) of the encoding. BOMs are designed
+to be bytes that rarely occur in non-Unicode text, allowing a reasonable guess that text is Unicode
+when a BOM is present.
 
-BOMs are optional and their adoption has not caught on in the Linux world, due to a dependable
-convention of UTF-8 being used everywhere. This means that most Linux applications presume that text
-input is encoded in UTF-8. While many Linux applications will recognize and correctly handle a BOM,
-a number do not, leading to artifacts in text manipulated with those applications.
+BOMs are optional and their adoption isn't as popular in the Linux world because a dependable
+convention of UTF-8 being used everywhere. Most Linux applications presume that text input is
+encoded in UTF-8. While many Linux applications will recognize and correctly handle a BOM, a number
+do not, leading to artifacts in text manipulated with those applications.
 
 **Therefore**:
 
@@ -138,14 +139,14 @@ Some possible values are:
 
 You should get a dropdown for this in the GUI view, or completions for it in the JSON view.
 
-You can also add the following to auto-detect encoding when possible:
+You can also add the following to autodetect encoding when possible:
 
 ```json
 "files.autoGuessEncoding": true
 ```
 
 If you don't want these settings to affect all files types, VSCode also allows per-language
-configurations. Create a language specific setting by putting settings in a `[<language-name>]`
+configurations. Create a language-specific setting by putting settings in a `[<language-name>]`
 field. For example:
 
 ```json
@@ -206,14 +207,14 @@ finally
 }
 ```
 
-If want to configure PowerShell to use a given encoding more generally, this is possible to do for
-some aspects with profile settings. See:
+It's possible to configure PowerShell to use a given encoding more generally using profile
+settings. See the following articles:
 
 - [@mklement0]'s [answer about PowerShell encoding on StackOverflow](https://stackoverflow.com/a/40098904).
 - [@rkeithhill]'s [blog post about dealing with BOM-less UTF-8 input in PowerShell](https://rkeithhill.wordpress.com/2010/05/26/handling-native-exe-output-encoding-in-utf8-with-no-bom/).
 
 It's not possible to force PowerShell to use a specific input encoding. PowerShell 5.1 and below
-default to Windows-1252 encoding when there is no BOM. For interoperability reasons, it's best to
+default to Windows-1252 encoding when there's no BOM. For interoperability reasons, it's best to
 save scripts in a Unicode format with a BOM.
 
 > [!IMPORTANT]
@@ -237,12 +238,12 @@ Get-ChildItem *.ps1 -Recurse | ForEach-Object {
 
 ### The PowerShell Integrated Scripting Environment (ISE)
 
-If you also edit scripts using the PowerShell ISE, you will need to synchronize your encoding
+If you also edit scripts using the PowerShell ISE, you need to synchronize your encoding
 settings there.
 
-The ISE should honor a BOM, but it is also possible to use reflection to
+The ISE should honor a BOM, but it's also possible to use reflection to
 [set the encoding](https://bensonxion.wordpress.com/2012/04/25/powershell-ise-default-saveas-encoding/).
-Note that this would not be persisted between startups.
+Note that this wouldn't be persisted between startups.
 
 ### Source control software
 
@@ -271,7 +272,7 @@ Some examples are:
 - Using the clipboard to copy and paste a script. This is common in scenarios like:
   - Copying a script into a VM
   - Copying a script out of an email or webpage
-  - Copying a script into or out of an Microsoft Word or PowerPoint document
+  - Copying a script into or out of a Microsoft Word or PowerPoint document
 - Other text editors, such as:
   - Notepad
   - vim
@@ -284,9 +285,9 @@ Some examples are:
   - A web browser, when downloading scripts
   - A file share
 
-Some of these deal in bytes rather than text, but others offer encoding configurations. In those
-cases where you need to configure an encoding, you need to make it the same as your editor encoding
-to prevent problems.
+Some of these tools deal in bytes rather than text, but others offer encoding configurations. In
+those cases where you need to configure an encoding, you need to make it the same as your editor
+encoding to prevent problems.
 
 ## Other resources on encoding in PowerShell
 
@@ -300,7 +301,7 @@ read:
   - [#1680](https://github.com/PowerShell/vscode-powershell/issues/1680)
   - [#1744](https://github.com/PowerShell/vscode-powershell/issues/1744)
   - [#1751](https://github.com/PowerShell/vscode-powershell/issues/1751)
-- [The classic *Joel on Software* writeup about Unicode](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/)
+- [The classic *Joel on Software* write up about Unicode](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/)
 - [Encoding in .NET Standard](https://github.com/dotnet/standard/issues/260#issuecomment-289549508)
 
 

--- a/reference/docs-conceptual/components/vscode/understanding-file-encoding.md
+++ b/reference/docs-conceptual/components/vscode/understanding-file-encoding.md
@@ -1,0 +1,314 @@
+# Understanding file encoding in VSCode and PowerShell
+
+When using VS Code to create and edit PowerShell scripts, it is important that your files are saved
+using the correct character encoding format.
+
+## What is file encoding and why is it important?
+
+VSCode manages the interface between a human entering strings of characters into a buffer and
+reading/writing blocks of bytes to the filesystem. When VSCode saves the file, it uses a text
+encoding to do this.
+
+Similarly, when PowerShell runs a script it must convert the bytes in a file to characters to
+reconstruct the file into a PowerShell program. Since VSCode writes the file and PowerShell reads
+the file, they need to use the same encoding system. This process of parsing a PowerShell script
+goes: *bytes* -> *characters* -> *tokens* -> *abstract syntax tree* -> *execution*.
+
+Both VSCode and PowerShell are installed with a sensible default encoding configuration. However,
+the default encoding used by PowerShell has changed with the release of PowerShell Core (v6.x). To
+ensure you have no problems using PowerShell or the PowerShell extension in VSCode, you need to
+configure your VSCode and PowerShell settings properly.
+
+## Common causes of encoding issues
+
+Encoding problems occur when the encoding of VSCode or your script file does not match the expected
+encoding of PowerShell. There is no way for PowerShell to automatically determine the file encoding.
+
+You're more likely to have encoding problems when you're using characters not in the [7-bit ASCII character set](https://ascii.cl/),
+such as accented latin characters (e.g. `É`, `ü`), or non-latin characters like Cyrillic (`Д`, `Ц`)
+or Han Chinese (`脚`, `本`).
+
+Common reasons for encoding issues are:
+
+- The encodings of VSCode and PowerShell have not been changed from their defaults. For PowerShell
+  5.1 and below, the default encoding is different from VSCode's.
+- Another editor has opened and overwritten the file in a new encoding. This often happens with the
+  ISE.
+- The file is checked into source control (like git) in a different encoding to what VSCode or
+  PowerShell expects. This can happen when collaborators edit files with an editor with a different
+  encoding configurations.
+
+### How to tell when you have encoding issues
+
+Often encoding errors present themselves as parse errors in scripts. If you find strange character
+sequences in your script, this can be the problem. In the example below, an en-dash (`–`) appears as
+the characters `â€“`:
+
+```Output
+Send-MailMessage : A positional parameter cannot be found that accepts argument 'Testing FuseMail SMTP...'.
+At C:\Users\<User>\<OneDrive>\Development\PowerShell\Scripts\Send-EmailUsingSmtpRelay.ps1:6 char:1
++ Send-MailMessage â€“From $from â€“To $recipient1 â€“Subject $subject  ...
++ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : InvalidArgument: (:) [Send-MailMessage], ParameterBindingException
+    + FullyQualifiedErrorId : PositionalParameterNotFound,Microsoft.PowerShell.Commands.SendMailMessage
+```
+
+This problem occurs because VSCode encodes the character `–` in UTF-8 as the bytes `0xE2 0x80 0x93`.
+When these bytes are decoded as Windows-1252, they are interpreted as the characters `â€“`.
+
+Some strange character sequences that you might see include:
+
+- `â€“` instead of `–`
+- `â€”` instead of `—`
+- `Ã„2` instead of `Ä`
+- `Â` instead of ` `  (a non-breaking space)
+- `Ã©` instead of `é`
+
+This handy [reference](https://www.i18nqa.com/debug/utf8-debug.html) lists the common patterns that
+indicate a UTF-8/Windows-1252 encoding problem.
+
+## How the PowerShell extension in VSCode interacts with encodings
+
+The PowerShell extension interacts with scripts in a number of ways:
+
+1. When scripts are edited in VSCode, the contents are sent by VSCode to the extension. The [Language Server Protocol][]
+   mandates that this content is transferred in UTF-8. Therefore, it is not possible for the
+   extension to get the wrong encoding.
+2. When scripts are executed directly in the Integrated Console, they are read off the filesystem by
+   PowerShell directly. This means that if PowerShell's encoding differs from VSCode's, something
+   may go wrong here.
+3. When a script that is open in VSCode references another script that is not open in VSCode, the
+   extension falls back to loading that script's content from the file system. VSCode defaults to
+   UTF-8 encoding, but uses [byte-order mark][], or BOM, detection to select the correct encoding.
+
+The problem occurs when assuming the encoding of BOM-less formats (like [UTF-8] with no BOM and [Windows-1252]).
+In these cases, the extension defaults to UTF-8 rather than more complex logic. The PowerShell
+extension cannot change VSCode's encoding settings. For more information see [issue #824](https://github.com/Microsoft/vscode/issues/824).
+
+## Choosing the right encoding
+
+Choosing an encoding depends on the platforms and applications you use to read and write your
+PowerShell files.
+
+On Windows, many applications have long used [Windows-1252]. Many .NET applications use [UTF-16]. In
+Windows, this is often called "Unicode", Unicode is a term that now refers to a broader [standard](https://en.wikipedia.org/wiki/Unicode).
+
+In the Linux world, on the web, and .NET Standard, UTF-8 is now the dominant encoding.
+
+Unicode encodings also have the concept of a byte-order mark (BOM). BOMs occur at the beginning of
+text to tell a decoder which encoding the text is using. In the case of multi-byte encodings, the
+BOM also indicates [endianness](https://en.wikipedia.org/wiki/Endianness) of the encoding. BOMs are
+designed to be bytes that rarely occur in non-Unicode text, allowing a reasonable guess that text is
+Unicode when a BOM is present.
+
+BOMs are optional and their adoption has not caught on in the Linux world, due to a dependable
+convention of UTF-8 being used everywhere. This means that most Linux applications presume that text
+input is encoded in UTF-8. While many Linux applications will recognize and correctly handle a BOM,
+a number do not, leading to artifacts in text manipulated with those applications.
+
+**Therefore**:
+
+- If you work primarily with Windows applications and Windows PowerShell, you should prefer an
+  encoding like UTF-8 with BOM or UTF-16.
+- If you work across platforms, you should prefer UTF-8 with BOM.
+- If you work mainly in Linux-associated contexts, you should prefer UTF-8 without BOM.
+- Windows-1252 and latin-1 are essentially legacy encodings that you should avoid if possible.
+  However, some older Windows applications may depend on them.
+- It's also worth noting that script signing is [encoding-dependent](https://github.com/PowerShell/PowerShell/issues/3466),
+  meaning a change of encoding on a signed script will require resigning.
+
+## Configuring VSCode
+
+VSCode's default encoding is UTF-8 without BOM.
+
+To set [VSCode's encoding](https://code.visualstudio.com/docs/editor/codebasics#_file-encoding-support),
+go to the VSCode settings (Ctrl+,) and set the `"files.encoding"` setting:
+
+```json
+"files.encoding": "utf8bom"
+```
+
+Some possible values are:
+
+- `utf8`: [UTF-8] without BOM
+- `utf8bom`: [UTF-8] with BOM
+- `utf16le`: Little endian [UTF-16]
+- `utf16be`: Big endian [UTF-16]
+- `windows1252`: [Windows-1252]
+
+You should get a dropdown for this in the GUI view, or completions for it in the JSON view.
+
+You can also add the following to auto-detect encoding when possible:
+
+```json
+"files.autoGuessEncoding": true
+```
+
+If you don't want these settings to affect all files types, VSCode also allows per-language
+configurations. Create a language specific setting by putting settings in a `[<language-name>]`
+field. For example:
+
+```json
+"[powershell]": {
+    "files.encoding": "utf8bom",
+    "files.autoGuessEncoding": true
+}
+```
+
+## Configuring PowerShell
+
+PowerShell's default encoding varies depending on version:
+
+- In PowerShell 6+, the default encoding is [UTF-8] without BOM on all platforms.
+- In Windows PowerShell, the default encoding is usually [Windows-1252], an extension of [latin-1],
+  also known as ISO 8859-1.
+
+In PowerShell 5+ you can find your default encoding with this:
+
+```powershell
+[psobject].Assembly.GetTypes() | Where-Object { $_.Name -eq 'ClrFacade'} |
+  ForEach-Object {
+    $_.GetMethod('GetDefaultEncoding', [System.Reflection.BindingFlags]'nonpublic,static').Invoke($null, @())
+  }
+```
+
+The following [this script](https://gist.github.com/rjmholt/3d8dd4849f718c914132ce3c5b278e0e) can be
+used to determine what encoded your PowerShell session infers for a script without a BOM.
+
+```powershell
+$badBytes = [byte[]]@(0xC3, 0x80)
+$utf8Str = [System.Text.Encoding]::UTF8.GetString($badBytes)
+$bytes = [System.Text.Encoding]::ASCII.GetBytes('Write-Output "') + [byte[]]@(0xC3, 0x80) + [byte[]]@(0x22)
+$path = Join-Path ([System.IO.Path]::GetTempPath()) 'encodingtest.ps1'
+
+try
+{
+    [System.IO.File]::WriteAllBytes($path, $bytes)
+
+    switch (& $path)
+    {
+        $utf8Str
+        {
+            return 'UTF-8'
+            break
+        }
+
+        default
+        {
+            return 'Windows-1252'
+            break
+        }
+    }
+}
+finally
+{
+    Remove-Item $path
+}
+```
+
+If want to configure PowerShell to use a given encoding more generally, this is possible to do for
+some aspects with profile settings. See:
+
+- [@mklement0]'s [answer about PowerShell encoding on StackOverflow](https://stackoverflow.com/a/40098904).
+- [@rkeithhill]'s [blog post about dealing with BOM-less UTF-8 input in PowerShell](https://rkeithhill.wordpress.com/2010/05/26/handling-native-exe-output-encoding-in-utf8-with-no-bom/).
+
+It's not possible to force PowerShell to use a specific input encoding. PowerShell 5.1 and below
+default to Windows-1252 encoding when there is no BOM. For interoperability reasons, it's best to
+save scripts in a Unicode format with a BOM.
+
+> [!IMPORTANT]
+> Any other tools you have that touch PowerShell scripts may be affected by your
+> encoding choices or re-encode your scripts to another encoding.
+
+### Scripts
+
+Scripts already on the file system may need to be re-encoded to your new chosen encoding. In the
+bottom bar of VSCode, you'll see the label UTF-8. Click it to open the action bar and select
+**Save with encoding**. You can now pick a new encoding for that file.
+
+If you need to re-encode multiple files, you can use the following script:
+
+```powershell
+Get-ChildItem *.ps1 -Recurse | ForEach-Object {
+    $content = Get-Content -Path $_
+    Set-Content -Path $_.Fullname -Value $content -Encoding UTF8 -PassThru -Force
+}
+```
+
+### The PowerShell Integrated Scripting Environment (ISE)
+
+If you also edit scripts using the PowerShell ISE, you will need to synchronize your encoding
+settings there.
+
+The ISE should honor a BOM, but it is also possible to use reflection to
+[set the encoding](https://bensonxion.wordpress.com/2012/04/25/powershell-ise-default-saveas-encoding/).
+Note that this would not be persisted between startups.
+
+### Source control software
+
+Some source control tools, such as git, ignore encodings; git just tracks the bytes.
+Others, like TFS or Mercurial, may not. Even some git-based tools rely on decoding text.
+
+When this is the case, make sure you:
+
+- Configure the text encoding in your source control to match your VSCode configuration.
+- Ensure all your files are checked into source control in the relevant encoding.
+- Be wary of changes to the encoding received through source control. A key sign of this is a diff
+  indicating changes but where nothing seems to have changed (because bytes have but characters have
+  not).
+
+### Collaborators' environments
+
+On top of configuring source control, ensure that your collaborators on any files you share don't
+have settings that override your encoding by re-encoding PowerShell files.
+
+### Other programs
+
+Any other program that reads or writes a PowerShell script may re-encode it.
+
+Some examples are:
+
+- Using the clipboard to copy and paste a script. This is common in scenarios like:
+  - Copying a script into a VM
+  - Copying a script out of an email or webpage
+  - Copying a script into or out of an Microsoft Word or PowerPoint document
+- Other text editors, such as:
+  - Notepad
+  - vim
+  - Any other PowerShell script editor
+- Text editing utilities, like:
+  - `Get-Content`/`Set-Content`/`Out-File`
+  - PowerShell redirection operators like `>` and `>>`
+  - `sed`/`awk`
+- File transfer programs, like:
+  - A web browser, when downloading scripts
+  - A file share
+
+Some of these deal in bytes rather than text, but others offer encoding configurations. In those
+cases where you need to configure an encoding, you need to make it the same as your editor encoding
+to prevent problems.
+
+## Other resources on encoding in PowerShell
+
+There are a few other nice posts on encoding and configuring encoding in PowerShell that are worth a
+read:
+
+- [@mklement0]'s [summary of PowerShell encoding on StackOverflow](https://stackoverflow.com/questions/40098771/changing-powershells-default-output-encoding-to-utf-8)
+- Previous issues opened on vscode-PowerShell for encoding problems:
+  - [#1308](https://github.com/PowerShell/vscode-powershell/issues/1308)
+  - [#1628](https://github.com/PowerShell/vscode-powershell/issues/1628)
+  - [#1680](https://github.com/PowerShell/vscode-powershell/issues/1680)
+  - [#1744](https://github.com/PowerShell/vscode-powershell/issues/1744)
+  - [#1751](https://github.com/PowerShell/vscode-powershell/issues/1751)
+- [The classic *Joel on Software* writeup about Unicode](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/)
+- [Encoding in .NET Standard](https://github.com/dotnet/standard/issues/260#issuecomment-289549508)
+
+
+[@mklement0]: https://github.com/mklement0
+[@rkeithhill]: https://github.com/rkeithhill
+[Windows-1252]: https://wikipedia.org/wiki/Windows-1252
+[latin-1]: https://wikipedia.org/wiki/ISO/IEC_8859-1
+[UTF-8]: https://wikipedia.org/wiki/UTF-8
+[byte-order mark]: https://wikipedia.org/wiki/Byte_order_mark
+[UTF-16]: https://wikipedia.org/wiki/UTF-16
+[Language Server Protocol]: https://microsoft.github.io/language-server-protocol/

--- a/reference/docs-conceptual/components/vscode/understanding-file-encoding.md
+++ b/reference/docs-conceptual/components/vscode/understanding-file-encoding.md
@@ -1,3 +1,8 @@
+---
+title: Understanding file encoding in VSCode and PowerShell
+description: Configure file encoding in VSCode and PowerShell
+ms.date: 02/28/2019
+---
 # Understanding file encoding in VSCode and PowerShell
 
 When using VS Code to create and edit PowerShell scripts, it is important that your files are saved

--- a/reference/docs-conceptual/components/vscode/understanding-file-encoding.md
+++ b/reference/docs-conceptual/components/vscode/understanding-file-encoding.md
@@ -11,7 +11,7 @@ using the correct character encoding format.
 ## What is file encoding and why is it important?
 
 VSCode manages the interface between a human entering strings of characters into a buffer and
-reading/writing blocks of bytes to the filesystem. When VSCode saves the file, it uses a text
+reading/writing blocks of bytes to the filesystem. When VSCode saves a file, it uses a text
 encoding to do this.
 
 Similarly, when PowerShell runs a script it must convert the bytes in a file to characters to
@@ -84,22 +84,23 @@ The PowerShell extension interacts with scripts in a number of ways:
 2. When scripts are executed directly in the Integrated Console, they're read from the file by
    PowerShell directly. Tf PowerShell's encoding differs from VSCode's, something can go wrong here.
 3. When a script that is open in VSCode references another script that is not open in VSCode, the
-   extension falls back to loading that script's content from the file system. VSCode defaults to
-   UTF-8 encoding, but uses [byte-order mark][], or BOM, detection to select the correct encoding.
+   extension falls back to loading that script's content from the file system. The PowerShell
+   extension defaults to UTF-8 encoding, but uses [byte-order mark][], or BOM, detection to select
+   the correct encoding.
 
-The problem occurs when assuming the encoding of BOM-less formats (like [UTF-8] with no BOM and [Windows-1252]).
+The problem occurs when assuming the encoding of BOM-less formats (like [UTF-8][] with no BOM and [Windows-1252][]).
 The PowerShell extension defaults to UTF-8. The extension cannot change VSCode's encoding settings.
 For more information, see [issue #824](https://github.com/Microsoft/vscode/issues/824).
 
 ## Choosing the right encoding
 
-Choosing an encoding depends on the platforms and applications you use to read and write your
-PowerShell files.
+Different systems and applications can use different encodings:
 
-On Windows, many applications have long used [Windows-1252]. Many .NET applications use [UTF-16],
-often called "Unicode". Unicode is a term that now refers to a broader [standard](https://en.wikipedia.org/wiki/Unicode).
-
-In the Linux world, on the web, and in .NET Standard, UTF-8 is now the dominant encoding.
+- In .NET Standard, on the web, and in the Linux world, UTF-8 is now the dominant encoding.
+- Many .NET Framework applications use [UTF-16][]. For historical reasons, this is sometimes called
+  "Unicode", a term that now refers to a broad [standard](https://en.wikipedia.org/wiki/Unicode)
+  that includes both UTF-8 and UTF-16.
+- On Windows, many native applications that predate Unicode continue to use Windows-1252 by default.
 
 Unicode encodings also have the concept of a byte-order mark (BOM). BOMs occur at the beginning of
 text to tell a decoder which encoding the text is using. For multi-byte encodings, the BOM also
@@ -108,7 +109,7 @@ to be bytes that rarely occur in non-Unicode text, allowing a reasonable guess t
 when a BOM is present.
 
 BOMs are optional and their adoption isn't as popular in the Linux world because a dependable
-convention of UTF-8 being used everywhere. Most Linux applications presume that text input is
+convention of UTF-8 is used everywhere. Most Linux applications presume that text input is
 encoded in UTF-8. While many Linux applications will recognize and correctly handle a BOM, a number
 do not, leading to artifacts in text manipulated with those applications.
 
@@ -127,8 +128,8 @@ do not, leading to artifacts in text manipulated with those applications.
 
 VSCode's default encoding is UTF-8 without BOM.
 
-To set [VSCode's encoding](https://code.visualstudio.com/docs/editor/codebasics#_file-encoding-support),
-go to the VSCode settings (Ctrl+,) and set the `"files.encoding"` setting:
+To set [VSCode's encoding][], go to the VSCode settings (<kbd>Ctrl<kbd>+</kbd>,</kbd>) and set the
+`"files.encoding"` setting:
 
 ```json
 "files.encoding": "utf8bom"
@@ -165,8 +166,8 @@ field. For example:
 
 PowerShell's default encoding varies depending on version:
 
-- In PowerShell 6+, the default encoding is [UTF-8] without BOM on all platforms.
-- In Windows PowerShell, the default encoding is usually [Windows-1252], an extension of [latin-1],
+- In PowerShell 6+, the default encoding is UTF-8 without BOM on all platforms.
+- In Windows PowerShell, the default encoding is usually Windows-1252, an extension of [latin-1][],
   also known as ISO 8859-1.
 
 In PowerShell 5+ you can find your default encoding with this:
@@ -179,7 +180,7 @@ In PowerShell 5+ you can find your default encoding with this:
 ```
 
 The following [this script](https://gist.github.com/rjmholt/3d8dd4849f718c914132ce3c5b278e0e) can be
-used to determine what encoded your PowerShell session infers for a script without a BOM.
+used to determine what encoding your PowerShell session infers for a script without a BOM.
 
 ```powershell
 $badBytes = [byte[]]@(0xC3, 0x80)
@@ -226,11 +227,12 @@ save scripts in a Unicode format with a BOM.
 > Any other tools you have that touch PowerShell scripts may be affected by your
 > encoding choices or re-encode your scripts to another encoding.
 
-### Scripts
+### Existing scripts
 
 Scripts already on the file system may need to be re-encoded to your new chosen encoding. In the
-bottom bar of VSCode, you'll see the label UTF-8. Click it to open the action bar and select
-**Save with encoding**. You can now pick a new encoding for that file.
+bottom bar of VSCode, you'll see the label UTF-8. Click it to open the action bar and select **Save
+with encoding**. You can now pick a new encoding for that file. See [VSCode's encoding][] for full
+instructions.
 
 If you need to re-encode multiple files, you can use the following script:
 
@@ -318,3 +320,4 @@ read:
 [byte-order mark]: https://wikipedia.org/wiki/Byte_order_mark
 [UTF-16]: https://wikipedia.org/wiki/UTF-16
 [Language Server Protocol]: https://microsoft.github.io/language-server-protocol/
+[VSCode's encoding]: https://code.visualstudio.com/docs/editor/codebasics#_file-encoding-support

--- a/reference/docs-conceptual/components/vscode/understanding-file-encoding.md
+++ b/reference/docs-conceptual/components/vscode/understanding-file-encoding.md
@@ -179,7 +179,7 @@ In PowerShell 5+ you can find your default encoding with this:
   }
 ```
 
-The following [this script](https://gist.github.com/rjmholt/3d8dd4849f718c914132ce3c5b278e0e) can be
+The following [script](https://gist.github.com/rjmholt/3d8dd4849f718c914132ce3c5b278e0e) can be
 used to determine what encoding your PowerShell session infers for a script without a BOM.
 
 ```powershell

--- a/reference/docs-conceptual/components/vscode/using-vscode.md
+++ b/reference/docs-conceptual/components/vscode/using-vscode.md
@@ -65,7 +65,7 @@ To exit Visual Studio Code, **File->Exit**.
 
 Some systems are set up in a way that requires all code signatures to be checked and thus requires
 PowerShell Editor Services to be manually approved to run on the system.
-A Group Policy update that changes execution policy is a likely cause if you have installed the 
+A Group Policy update that changes execution policy is a likely cause if you have installed the
 PowerShell extension but are reaching an error like:
 
 ```
@@ -117,17 +117,34 @@ We recommend the following configuration settings for Visual Studio Code:
     "editor.renderWhitespace": "all",
     "editor.renderControlCharacters": true,
     "omnisharp.projectLoadTimeout": 120,
-    "files.trimTrailingWhitespace": true
+    "files.trimTrailingWhitespace": true,
+    "files.encoding": "utf8bom",
+    "files.autoGuessEncoding": true
 }
 ```
+
+If you don't want these settings to affect all files types, VSCode also allows per-language
+configurations. Create a language specific setting by putting settings in a `[<language-name>]`
+field. For example:
+
+```json
+"[powershell]": {
+    "files.encoding": "utf8bom",
+    "files.autoGuessEncoding": true
+}
+```
+
+For more information about file encoding in VS Code, see [Understanding file encoding](understanding-file-encoding.md).
 
 ## Debugging with Visual Studio Code
 
 ### No-workspace debugging
 
-As of Visual Studio Code version 1.9 you can debug PowerShell scripts without having to open the folder containing the PowerShell script.
-Simply open the PowerShell script file with **File->Open File...**, set a breakpoint on a line (press F9) and then press F5 to start debugging.
-You should see the Debug actions pane appear which allows you to break into the debugger, step, resume and stop debugging.
+As of Visual Studio Code version 1.9 you can debug PowerShell scripts without having to open the
+folder containing the PowerShell script. Open the PowerShell script file with **File->Open
+File...**, set a breakpoint on a line (press F9) and then press F5 to start debugging. You should
+see the Debug actions pane appear which allows you to break into the debugger, step, resume and stop
+debugging.
 
 ### Workspace debugging
 

--- a/reference/docs-conceptual/toc.yml
+++ b/reference/docs-conceptual/toc.yml
@@ -138,6 +138,8 @@
           href: components/vscode/How-To-Replicate-the-ISE-Experience-In-VSCode.md
         - name: Using Visual Studio Code for remote editing and debugging
           href: components/vscode/Using-VSCode-for-Remote-Editing-and-Debugging.md
+        - name: Understanding file encoding in VSCode and PowerShell
+          href: components/vscode/understanding-file-encoding.md
     - name: Web Access
       href: ''
       items:


### PR DESCRIPTION
From https://github.com/PowerShell/vscode-powershell/pull/1761.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
