### PR TITLE
Remove Resume-Job and Suspend-Job links in v6

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Debug-Job.md
@@ -198,12 +198,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-Job](Remove-Job.md)
 
-[Resume-Job](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Core/Resume-Job)
-
 [Start-Job](Start-Job.md)
 
 [Stop-Job](Stop-Job.md)
-
-[Suspend-Job](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Core/Suspend-Job)
 
 [Wait-Job](Wait-Job.md)

--- a/reference/6/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Job.md
@@ -644,12 +644,8 @@ Job started by using the *AsJob* common parameter of workflows.
 
 [Remove-Job](Remove-Job.md)
 
-[Resume-Job](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Core/Resume-Job)
-
 [Start-Job](Start-Job.md)
 
 [Stop-Job](Stop-Job.md)
-
-[Suspend-Job](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Core/Suspend-Job)
 
 [Wait-Job](Wait-Job.md)

--- a/reference/6/Microsoft.PowerShell.Core/Receive-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Receive-Job.md
@@ -622,12 +622,8 @@ This cmdlet returns the results of the commands in the job.
 
 [Remove-Job](Remove-Job.md)
 
-[Resume-Job](../../5.1/Microsoft.PowerShell.Core/Resume-Job.md)
-
 [Start-Job](Start-Job.md)
 
 [Stop-Job](Stop-Job.md)
-
-[Suspend-Job](../../5.1/Microsoft.PowerShell.Core/Suspend-Job.md)
 
 [Wait-Job](Wait-Job.md)

--- a/reference/6/Microsoft.PowerShell.Core/Remove-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Remove-Job.md
@@ -414,12 +414,8 @@ This cmdlet does not generate any output.
 
 [Receive-Job](Receive-Job.md)
 
-[Resume-Job](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Core/Resume-Job)
-
 [Start-Job](Start-Job.md)
 
 [Stop-Job](Stop-Job.md)
-
-[Suspend-Job](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Core/Suspend-Job)
 
 [Wait-Job](Wait-Job.md)

--- a/reference/6/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Start-Job.md
@@ -531,10 +531,6 @@ This cmdlet returns an object that represents the job that it started.
 
 [Remove-Job](Remove-Job.md)
 
-[Resume-Job](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Core/Resume-Job)
-
 [Stop-Job](Stop-Job.md)
-
-[Suspend-Job](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Core/Suspend-Job)
 
 [Wait-Job](Wait-Job.md)

--- a/reference/6/Microsoft.PowerShell.Core/Stop-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Stop-Job.md
@@ -401,10 +401,6 @@ Otherwise, this cmdlet does not generate any output.
 
 [Remove-Job](Remove-Job.md)
 
-[Resume-Job](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Core/Resume-Job)
-
 [Start-Job](Start-Job.md)
-
-[Suspend-Job](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Core/Suspend-Job)
 
 [Wait-Job](Wait-Job.md)

--- a/reference/6/Microsoft.PowerShell.Core/Wait-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Wait-Job.md
@@ -467,10 +467,6 @@ If the wait ends because the value of the *Timeout* parameter is exceeded, **Wai
 
 [Remove-Job](Remove-Job.md)
 
-[Resume-Job](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Core/Resume-Job)
-
 [Start-Job](Start-Job.md)
 
 [Stop-Job](Stop-Job.md)
-
-[Suspend-Job](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Core/Suspend-Job)


### PR DESCRIPTION
`Resume-Job` and `Suspend-Job` are not supported since v6 (see [the comment](https://github.com/PowerShell/PowerShell/issues/2122#issuecomment-332258023)).

Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6 of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
