### PR TITLE
fix typo in example

### DIFF
--- a/reference/3.0/CimCmdlets/Register-CimIndicationEvent.md
+++ b/reference/3.0/CimCmdlets/Register-CimIndicationEvent.md
@@ -91,7 +91,7 @@ from CIM.
 $action = {
   $name = $event.SourceEventArgs.NewEvent.ProcessName
   $id = $event.SourceEventArgs.NewEvent.ProcessId
- `Write-Host` -Object "New Process Started : Name = $name
+  Write-Host -Object "New Process Started : Name = $name
  ID = $id"
 }
 Register-CimIndicationEvent -ClassName 'Win32_ProcessStartTrace' -SourceIdentifier "ProcessStarted" -Action $action
@@ -120,8 +120,8 @@ The commands specified by this parameter run when an event is raised, instead of
 to the event queue. Enclose the commands in braces ( { } ) to create a script block.
 
 The script block specified with **Action** can include the `$Event`, `$EventSubscriber`, `$Sender`,
-`$SourceEventArgs`, and `$SourceArgs` automatic variables, which provide information about the event to
-the **Action** script block. For more information, see [About Automatic Variables](../microsoft.powershell.core/about/about_automatic_variables.md).
+`$SourceEventArgs`, and `$SourceArgs` automatic variables, which provide information about the event
+to the **Action** script block. For more information, see [About Automatic Variables](../microsoft.powershell.core/about/about_automatic_variables.md).
 
 ```yaml
 Type: ScriptBlock

--- a/reference/4.0/CimCmdlets/Register-CimIndicationEvent.md
+++ b/reference/4.0/CimCmdlets/Register-CimIndicationEvent.md
@@ -91,7 +91,7 @@ from CIM.
 $action = {
   $name = $event.SourceEventArgs.NewEvent.ProcessName
   $id = $event.SourceEventArgs.NewEvent.ProcessId
- `Write-Host` -Object "New Process Started : Name = $name
+  Write-Host -Object "New Process Started : Name = $name
  ID = $id"
 }
 Register-CimIndicationEvent -ClassName 'Win32_ProcessStartTrace' -SourceIdentifier "ProcessStarted" -Action $action
@@ -120,8 +120,8 @@ The commands specified by this parameter run when an event is raised, instead of
 to the event queue. Enclose the commands in braces ( { } ) to create a script block.
 
 The script block specified with **Action** can include the `$Event`, `$EventSubscriber`, `$Sender`,
-`$SourceEventArgs`, and `$SourceArgs` automatic variables, which provide information about the event to
-the **Action** script block. For more information, see [About Automatic Variables](../microsoft.powershell.core/about/about_automatic_variables.md).
+`$SourceEventArgs`, and `$SourceArgs` automatic variables, which provide information about the event
+to the **Action** script block. For more information, see [About Automatic Variables](../microsoft.powershell.core/about/about_automatic_variables.md).
 
 ```yaml
 Type: ScriptBlock

--- a/reference/5.0/CimCmdlets/Register-CimIndicationEvent.md
+++ b/reference/5.0/CimCmdlets/Register-CimIndicationEvent.md
@@ -91,7 +91,7 @@ from CIM.
 $action = {
   $name = $event.SourceEventArgs.NewEvent.ProcessName
   $id = $event.SourceEventArgs.NewEvent.ProcessId
- `Write-Host` -Object "New Process Started : Name = $name
+  Write-Host -Object "New Process Started : Name = $name
  ID = $id"
 }
 Register-CimIndicationEvent -ClassName 'Win32_ProcessStartTrace' -SourceIdentifier "ProcessStarted" -Action $action
@@ -120,8 +120,8 @@ The commands specified by this parameter run when an event is raised, instead of
 to the event queue. Enclose the commands in braces ( { } ) to create a script block.
 
 The script block specified with **Action** can include the `$Event`, `$EventSubscriber`, `$Sender`,
-`$SourceEventArgs`, and `$SourceArgs` automatic variables, which provide information about the event to
-the **Action** script block. For more information, see [About Automatic Variables](../microsoft.powershell.core/about/about_automatic_variables.md).
+`$SourceEventArgs`, and `$SourceArgs` automatic variables, which provide information about the event
+to the **Action** script block. For more information, see [About Automatic Variables](../microsoft.powershell.core/about/about_automatic_variables.md).
 
 ```yaml
 Type: ScriptBlock

--- a/reference/5.1/CimCmdlets/Register-CimIndicationEvent.md
+++ b/reference/5.1/CimCmdlets/Register-CimIndicationEvent.md
@@ -92,7 +92,7 @@ from CIM.
 $action = {
   $name = $event.SourceEventArgs.NewEvent.ProcessName
   $id = $event.SourceEventArgs.NewEvent.ProcessId
- `Write-Host` -Object "New Process Started : Name = $name
+  Write-Host -Object "New Process Started : Name = $name
  ID = $id"
 }
 Register-CimIndicationEvent -ClassName 'Win32_ProcessStartTrace' -SourceIdentifier "ProcessStarted" -Action $action
@@ -121,8 +121,8 @@ The commands specified by this parameter run when an event is raised, instead of
 to the event queue. Enclose the commands in braces ( { } ) to create a script block.
 
 The script block specified with **Action** can include the `$Event`, `$EventSubscriber`, `$Sender`,
-`$SourceEventArgs`, and `$SourceArgs` automatic variables, which provide information about the event to
-the **Action** script block. For more information, see [About Automatic Variables](../microsoft.powershell.core/about/about_automatic_variables.md).
+`$SourceEventArgs`, and `$SourceArgs` automatic variables, which provide information about the event
+to the **Action** script block. For more information, see [About Automatic Variables](../microsoft.powershell.core/about/about_automatic_variables.md).
 
 ```yaml
 Type: ScriptBlock

--- a/reference/6/CimCmdlets/Register-CimIndicationEvent.md
+++ b/reference/6/CimCmdlets/Register-CimIndicationEvent.md
@@ -91,7 +91,7 @@ from CIM.
 $action = {
   $name = $event.SourceEventArgs.NewEvent.ProcessName
   $id = $event.SourceEventArgs.NewEvent.ProcessId
- `Write-Host` -Object "New Process Started : Name = $name
+  Write-Host -Object "New Process Started : Name = $name
  ID = $id"
 }
 Register-CimIndicationEvent -ClassName 'Win32_ProcessStartTrace' -SourceIdentifier "ProcessStarted" -Action $action
@@ -120,8 +120,8 @@ The commands specified by this parameter run when an event is raised, instead of
 to the event queue. Enclose the commands in braces ( { } ) to create a script block.
 
 The script block specified with **Action** can include the `$Event`, `$EventSubscriber`, `$Sender`,
-`$SourceEventArgs`, and `$SourceArgs` automatic variables, which provide information about the event to
-the **Action** script block. For more information, see [About Automatic Variables](../microsoft.powershell.core/about/about_automatic_variables.md).
+`$SourceEventArgs`, and `$SourceArgs` automatic variables, which provide information about the event
+to the **Action** script block. For more information, see [About Automatic Variables](../microsoft.powershell.core/about/about_automatic_variables.md).
 
 ```yaml
 Type: ScriptBlock


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Removed unneeded backticks

Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
