### PR TITLE
Fix typo

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -514,7 +514,7 @@ and change the current loop iteration. For more information, see
 In a script block that defines a script property or script method, the
 `$This` variable refers to the object that is being extended.
 
-### $trie
+### $true
 
 Contains **TRUE**. You can use this variable to represent **TRUE** in commands
 and scripts.


### PR DESCRIPTION
Do, or do not. There is no `$trie`.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version 6 of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
