### PR TITLE
Fix links: not Update-Help

### DIFF
--- a/developer/module/how-to-set-helpinfo-xml-version-numbers.md
+++ b/developer/module/how-to-set-helpinfo-xml-version-numbers.md
@@ -15,7 +15,8 @@ This topic explains how to set and increase the version numbers in an Updatable 
 
 ## How to Set HelpInfo XML Version Numbers
 
-The version numbers in a HelpInfo XML file are critical to the operation of Updatable Help. The [Update-Help](/powershell/module/Microsoft.PowerShell.Core/Update-Help) and [Save-Help](/powershell/module/Microsoft.PowerShell.Core/Update-Help) cmdlets download new help files only when the version number for a UI culture in the remote HelpInfo XML file is greater than the version number for that UI culture in the local HelpInfo XML, or there is no local HelpInfo XML file.
+The version numbers in a HelpInfo XML file are critical to the operation of Updatable Help.
+The [Update-Help](/powershell/module/Microsoft.PowerShell.Core/Update-Help) and [Save-Help](/powershell/module/Microsoft.PowerShell.Core/Save-Help) cmdlets download new help files only when the version number for a UI culture in the remote HelpInfo XML file is greater than the version number for that UI culture in the local HelpInfo XML, or there is no local HelpInfo XML file.
 
 The HelpInfo XML file uses the 4-part version number that is defined in the **System.Version** class of the Microsoft .NET Framework. The format is `N1.N2.N3.N4`. Module authors can use any version numbering scheme that is permitted by the **System.Version** class. Updatable Help requires only that the version number for a UI culture increase when a new version of the CAB file for that UI culture is uploaded to the location that is specified by the **HelpContentURI** element in the HelpInfo XML file.
 

--- a/developer/module/updatable-help-overview.md
+++ b/developer/module/updatable-help-overview.md
@@ -25,7 +25,9 @@ Updatable Help is fully supported by all Windows PowerShell modules in Windows®
 
 Updatable Help includes the following features.
 
-- The [Update-Help](/powershell/module/Microsoft.PowerShell.Core/Update-Help) cmdlet, which determines whether users have the newest help files for a module and, if not, downloads the newest help files from the Internet, unpacks them, and installs them in the correct module subdirectories on the user's computer. Users can use the [Get-Help](/powershell/module/Microsoft.PowerShell.Core/Update-Help) cmdlet to view the newly-installed help topics immediately. They do not need to restart Windows PowerShell.
+- The [Update-Help](/powershell/module/Microsoft.PowerShell.Core/Update-Help) cmdlet, which determines whether users have the newest help files for a module and, if not, downloads the newest help files from the Internet, unpacks them, and installs them in the correct module subdirectories on the user's computer.
+  Users can use the [Get-Help](/powershell/module/Microsoft.PowerShell.Core/Get-Help) cmdlet to view the newly-installed help topics immediately.
+  They do not need to restart PowerShell.
 
 - The [Save-Help](/powershell/module/Microsoft.PowerShell.Core/Save-Help) cmdlet, which downloads the newest help files from the Internet and saves them in a file system directory. Users can use the `Update-Help` cmdlet to get help files from the file system directory, and unpack and install them in the module subdirectories on the user's computer. The `Save-Help` cmdlet is designed for users who have limited or no Internet access and for enterprises who prefer to limit Internet access.
 


### PR DESCRIPTION
Their ulrs are `Update-Help` but texts are not.