### PR TITLE
fix: Escapped markdown links

### DIFF
--- a/reference/3.0/PSWorkflow/About/about_Checkpoint-Workflow.md
+++ b/reference/3.0/PSWorkflow/About/about_Checkpoint-Workflow.md
@@ -84,4 +84,4 @@ Workflow Test-Workflow
 
 ## SEE ALSO
 
-How to Add Checkpoints to a Workflow (http:\/\/go.microsoft.com\/fwlink\/?LinkId\=261993)
+[How to Add Checkpoints to a Workflow](http://go.microsoft.com/fwlink/?LinkId=261993)

--- a/reference/4.0/PSWorkflow/About/about_Checkpoint-Workflow.md
+++ b/reference/4.0/PSWorkflow/About/about_Checkpoint-Workflow.md
@@ -79,4 +79,4 @@ Workflow Test-Workflow
 
 
 ## SEE ALSO
-How to Add Checkpoints to a Workflow (http:\/\/go.microsoft.com\/fwlink\/?LinkId\=261993)
+[How to Add Checkpoints to a Workflow](http://go.microsoft.com/fwlink/?LinkId=261993)

--- a/reference/4.0/PSWorkflow/About/about_Parallel.md
+++ b/reference/4.0/PSWorkflow/About/about_Parallel.md
@@ -59,7 +59,7 @@ To run a Parallel script block on items in a collection, use the ForEach or ForE
 
 
 ## SEE ALSO
-"Writing a Script Workflow" (http:\/\/go.microsoft.com\/fwlink\/?LinkID\=262872)
+[Writing a Script Workflow](http://go.microsoft.com/fwlink/?LinkID=262872)
 
 about_ForEach
 

--- a/reference/5.0/PSWorkflow/About/about_Checkpoint-Workflow.md
+++ b/reference/5.0/PSWorkflow/About/about_Checkpoint-Workflow.md
@@ -79,4 +79,4 @@ Workflow Test-Workflow
 
 
 ## SEE ALSO
-How to Add Checkpoints to a Workflow (http:\/\/go.microsoft.com\/fwlink\/?LinkId\=261993)
+[How to Add Checkpoints to a Workflow](http://go.microsoft.com/fwlink/?LinkId=261993)

--- a/reference/5.0/PSWorkflow/About/about_Parallel.md
+++ b/reference/5.0/PSWorkflow/About/about_Parallel.md
@@ -59,7 +59,7 @@ To run a Parallel script block on items in a collection, use the ForEach or ForE
 
 
 ## SEE ALSO
-"Writing a Script Workflow" (http:\/\/go.microsoft.com\/fwlink\/?LinkID\=262872)
+[Writing a Script Workflow](http://go.microsoft.com/fwlink/?LinkID=262872)
 
 about_ForEach
 

--- a/reference/5.1/PSWorkflow/About/about_Checkpoint-Workflow.md
+++ b/reference/5.1/PSWorkflow/About/about_Checkpoint-Workflow.md
@@ -79,4 +79,4 @@ Workflow Test-Workflow
 
 
 ## SEE ALSO
-How to Add Checkpoints to a Workflow (http:\/\/go.microsoft.com\/fwlink\/?LinkId\=261993)
+[How to Add Checkpoints to a Workflow](http://go.microsoft.com/fwlink/?LinkId=261993)

--- a/reference/5.1/PSWorkflow/About/about_Parallel.md
+++ b/reference/5.1/PSWorkflow/About/about_Parallel.md
@@ -59,7 +59,7 @@ To run a Parallel script block on items in a collection, use the ForEach or ForE
 
 
 ## SEE ALSO
-"Writing a Script Workflow" (http:\/\/go.microsoft.com\/fwlink\/?LinkID\=262872)
+[Writing a Script Workflow](http://go.microsoft.com/fwlink/?LinkID=262872)
 
 about_ForEach
 


### PR DESCRIPTION

- "How to Add Checkpoints to a Workflow" appears to be dead