### PR TITLE
Update about_Foreach.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Foreach.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Foreach.md
@@ -175,19 +175,23 @@ function Get-FunctionPosition {
   process {
     try {
       $filesToProcess = if ($_ -is [System.IO.FileSystemInfo]) {
+        Write-Verbose "From pipeline"
         $_
       } else {
-        $filesToProcess = Get-Item -Path $Path
+        Write-Verbose "From parameter, $Path"
+        Get-Item -Path $Path
       }
       $parser = [System.Management.Automation.Language.Parser]
+      Write-Verbose "lets start the foreach loop on `$filesToProcess with $($filesToProcess.count) as count"
       foreach ($item in $filesToProcess) {
+        Write-Verbose "$item"
         if ($item.PSIsContainer -or
             $item.Extension -notin @('.ps1', '.psm1')) {
           continue
         }
         $tokens = $errors = $null
-        $ast = $parser::ParseFile($item.FullName, ([REF]$tokens),
-          ([REF]$errors))
+        $parser::ParseFile($item.FullName, ([REF]$tokens),
+          ([REF]$errors)) | Out-Null
         if ($errors) {
           $msg = "File '{0}' has {1} parser errors." -f $item.FullName,
             $errors.Count


### PR DESCRIPTION
The last example was not working when the parameter was used and not a pipeline to call the function.
Please see the original and the updated version with pester tests in this folder [about_foreach](https://github.com/sassdawe/PowerShell/tree/master/from-docs/about_foreach)

I also added some **write-verbose** to the script to help explain a little bit more what's happening.

