### PR TITLE
Fix example: "Controlling Format-Wide Display with Column"

### DIFF
--- a/reference/docs-conceptual/samples/Using-Format-Commands-to-Change-Output-View.md
+++ b/reference/docs-conceptual/samples/Using-Format-Commands-to-Change-Output-View.md
@@ -43,10 +43,20 @@ PS> Get-Process -Name powershell | Format-Wide -Property Id
 
 #### Controlling Format-Wide Display with Column
 
-With the **Format-Wide** cmdlet, you can only display a single property at a time. This makes it useful for displaying simple lists that show only one element per line. To get a simple listing, set the value of the **Column** parameter to 1 by typing:
+With the `Format-Wide` cmdlet, you can only display a single property at a time.
+This makes it useful for displaying simple lists that show only one element per line.
+To get a simple listing, set the value of the **Column** parameter to 1 by typing:
 
 ```powershell
-Get-Command Format-Wide -Property Name -Column 1
+Get-Command -Verb Format | Format-Wide -Property Noun -Column 1
+```
+
+```output
+Custom
+Hex
+List
+Table
+Wide
 ```
 
 ### Using Format-List for a List View


### PR DESCRIPTION
* Add missing pipeline `|`
* Add output
* Filter cmdlets by `-Verb`
* Fix formatting
