### PR TITLE
Update Test-DscConfiguration.md

### DIFF
--- a/reference/4.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -24,8 +24,8 @@ The **Test-DscConfiguration** cmdlet tests whether the actual configuration on t
 Specify computers by using Common Information Model (CIM) sessions.
 If you do not specify a target computer, the cmdlet tests configuration of the local computer.
 
-If the desired and actual configurations match, the cmdlet returns a value of $True.
-Otherwise, it returns a value of $False.
+If the desired and actual configurations match, the cmdlet returns a string value of `'True'`.
+Otherwise, it returns a string value of `'False'`.
 
 ## EXAMPLES
 

--- a/reference/4.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -24,8 +24,8 @@ The **Test-DscConfiguration** cmdlet tests whether the actual configuration on t
 Specify computers by using Common Information Model (CIM) sessions.
 If you do not specify a target computer, the cmdlet tests configuration of the local computer.
 
-If the desired and actual configurations match, the cmdlet returns a string value of `'True'`.
-Otherwise, it returns a string value of `'False'`.
+If the desired and actual configurations match, the cmdlet returns a string value of 'True'.
+Otherwise, it returns a string value of 'False'.
 
 ## EXAMPLES
 

--- a/reference/5.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -56,8 +56,8 @@ The **Test-DscConfiguration** cmdlet tests whether the actual configuration on t
 Specify which computers for which you want to test configurations by using computer names or Common Information Model (CIM) sessions.
 If you do not specify a target computer, the cmdlet tests configuration of the local computer.
 
-If the desired and actual configurations match, the cmdlet returns a string value of `'True'`.
-Otherwise, it returns a string value of `'False'`.
+If the desired and actual configurations match, the cmdlet returns a string value of 'True'.
+Otherwise, it returns a string value of 'False'.
 
 ## EXAMPLES
 

--- a/reference/5.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -56,8 +56,8 @@ The **Test-DscConfiguration** cmdlet tests whether the actual configuration on t
 Specify which computers for which you want to test configurations by using computer names or Common Information Model (CIM) sessions.
 If you do not specify a target computer, the cmdlet tests configuration of the local computer.
 
-If the desired and actual configurations match, the cmdlet returns a value of $True.
-Otherwise, it returns a value of $False.
+If the desired and actual configurations match, the cmdlet returns a string value of `'True'`.
+Otherwise, it returns a string value of `'False'`.
 
 ## EXAMPLES
 

--- a/reference/5.1/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -57,8 +57,8 @@ The **Test-DscConfiguration** cmdlet tests whether the actual configuration on t
 Specify which computers for which you want to test configurations by using computer names or Common Information Model (CIM) sessions.
 If you do not specify a target computer, the cmdlet tests configuration of the local computer.
 
-If the desired and actual configurations match, the cmdlet returns a string value value of 'True'.
-Otherwise, it returns a string value of 'False'.
+If the desired and actual configurations match, the cmdlet returns a string value of `'True'`.
+Otherwise, it returns a string value of `'False'`.
 
 ## EXAMPLES
 

--- a/reference/5.1/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -57,8 +57,8 @@ The **Test-DscConfiguration** cmdlet tests whether the actual configuration on t
 Specify which computers for which you want to test configurations by using computer names or Common Information Model (CIM) sessions.
 If you do not specify a target computer, the cmdlet tests configuration of the local computer.
 
-If the desired and actual configurations match, the cmdlet returns a value of $True.
-Otherwise, it returns a value of $False.
+If the desired and actual configurations match, the cmdlet returns a string value value of 'True'.
+Otherwise, it returns a string value of 'False'.
 
 ## EXAMPLES
 

--- a/reference/5.1/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -57,8 +57,8 @@ The **Test-DscConfiguration** cmdlet tests whether the actual configuration on t
 Specify which computers for which you want to test configurations by using computer names or Common Information Model (CIM) sessions.
 If you do not specify a target computer, the cmdlet tests configuration of the local computer.
 
-If the desired and actual configurations match, the cmdlet returns a string value of `'True'`.
-Otherwise, it returns a string value of `'False'`.
+If the desired and actual configurations match, the cmdlet returns a string value of 'True'.
+Otherwise, it returns a string value of 'False'.
 
 ## EXAMPLES
 


### PR DESCRIPTION
The cmdlet does not return the type `[System.Boolean]` but instead `[System.String]`. More information here https://github.com/PowerShell/DscResource.Template/issues/14

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (4.0) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
- [x] The documented feature does not yet exist in version (6.x) of PowerShell
- **Not sure if this is an issue in the older version (4.0 and 5.0)? I'm not able to verify that.**