### PR TITLE
Updated Send-MailMessage to say that -subject is no longer required

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Send-MailMessage.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Send-MailMessage.md
@@ -324,14 +324,14 @@ Accept wildcard characters: False
 
 ### -Subject
 
-Th **Subject** parameter is required. This parameter specifies the subject of the email message.
+Th **Subject** parameter is not required. This parameter specifies the subject of the email message.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases: sub
 
-Required: True
+Required: False
 Position: 1
 Default value: None
 Accept pipeline input: False

--- a/reference/6/Microsoft.PowerShell.Utility/Send-MailMessage.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Send-MailMessage.md
@@ -324,7 +324,7 @@ Accept wildcard characters: False
 
 ### -Subject
 
-Th **Subject** parameter is not required. This parameter specifies the subject of the email message.
+The **Subject** parameter is not required. This parameter specifies the subject of the email message.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Doc updates are for https://github.com/PowerShell/PowerShell/pull/8961, which makes the -subject parameter no longer a required field of the Send-MailMessage command.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (6.2) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
