### PR TITLE
Add private scopes to PS6 Set-Variable docs

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -211,7 +211,7 @@ Accept wildcard characters: False
 
 ### -Scope
 Determines the scope of the variable.
-Valid values are "Global", "Local", or "Script", or a number relative to the current scope (0 through the number of scopes, where 0 is the current scope and 1 is its parent).
+Valid values are "Global", "Local", "Script", or "Private", or a number relative to the current scope (0 through the number of scopes, where 0 is the current scope and 1 is its parent).
 "Local" is the default.
 For more information, see [about_Scopes](../Microsoft.PowerShell.Core/About/about_scopes.md).
 

--- a/reference/4.0/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -217,7 +217,7 @@ Accept wildcard characters: False
 
 ### -Scope
 Determines the scope of the variable.
-Valid values are "Global", "Local", or "Script", or a number relative to the current scope (0 through the number of scopes, where 0 is the current scope and 1 is its parent).
+Valid values are "Global", "Local", "Script", or "Private" or a number relative to the current scope (0 through the number of scopes, where 0 is the current scope and 1 is its parent).
 "Local" is the default.
 For more information, see [about_Scopes](../Microsoft.PowerShell.Core/About/about_scopes.md).
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -251,6 +251,7 @@ The acceptable values for this parameter are:
 - Global
 - Local
 - Script
+- Private
 - A number relative to the current scope (0 through the number of scopes, where 0 is the current scope and 1 is its parent).
 
 Local is the default.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -223,6 +223,7 @@ Specifies the scope of the variable.The acceptable values for this parameter are
 - Global
 - Local
 - Script
+- Private
 - A number relative to the current scope (0 through the number of scopes, where 0 is the current scope and 1 is its parent).
 
 Local is the default.

--- a/reference/6/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -224,7 +224,7 @@ Specifies the scope of the variable.The acceptable values for this parameter are
 - Local
 - Script
 - Private
-- Numbered
+- A number relative to the current scope (0 through the number of scopes, where 0 is the current scope and 1 is its parent).
 
 Local is the default.
 

--- a/reference/6/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -223,7 +223,8 @@ Specifies the scope of the variable.The acceptable values for this parameter are
 - Global
 - Local
 - Script
-- A number relative to the current scope (0 through the number of scopes, where 0 is the current scope and 1 is its parent).
+- Private
+- Numbered
 
 Local is the default.
 


### PR DESCRIPTION
I also changed the formatting of the last bullet point to match the first few. Addresses issue #4004

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [x] This PR partially fixes the issue, and issue #4004 tracks the remaining work
