### PR TITLE
add note to reflect that .Net Core doesn't encrypt contents of securestring

### DIFF
--- a/reference/6/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
+++ b/reference/6/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
@@ -35,6 +35,10 @@ If an encryption key is specified by using the *Key* or *SecureKey* parameters, 
 The specified key must have a length of 128, 192, or 256 bits, because those are the key lengths supported by the AES encryption algorithm.
 If no key is specified, the Windows Data Protection API (DPAPI) is used to encrypt the standard string representation.
 
+> [!NOTE]
+> Note that per [DotNet](https://github.com/dotnet/platform-compat/blob/master/docs/DE0001.md), the
+> contents of a SecureString are not encrypted.
+
 ## EXAMPLES
 
 ### Example 1: Create a secure string

--- a/reference/6/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
+++ b/reference/6/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
@@ -36,7 +36,7 @@ The specified key must have a length of 128, 192, or 256 bits, because those are
 If no key is specified, the Windows Data Protection API (DPAPI) is used to encrypt the standard string representation.
 
 > [!NOTE]
-> Note that per [DotNet](https://github.com/dotnet/platform-compat/blob/master/docs/DE0001.md), the
+> Note that per [DotNet](/dotnet/api/system.security.securestring?view=netcore-2.1#remarks), the
 > contents of a SecureString are not encrypted.
 
 ## EXAMPLES

--- a/reference/6/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
+++ b/reference/6/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
@@ -44,7 +44,7 @@ This enables it to be stored in a file for later use.
 If the standard string being converted was encrypted with **ConvertFrom-SecureString** using a specified key, that same key must be provided as the value of the *Key* or *SecureKey* parameter of the **ConvertTo-SecureString** cmdlet.
 
 > [!NOTE]
-> Note that per [DotNet](https://github.com/dotnet/platform-compat/blob/master/docs/DE0001.md), the
+> Note that per [DotNet](/dotnet/api/system.security.securestring?view=netcore-2.1#remarks), the
 > contents of a SecureString are not encrypted.
 
 ## EXAMPLES

--- a/reference/6/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
+++ b/reference/6/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
@@ -43,6 +43,10 @@ This enables it to be stored in a file for later use.
 
 If the standard string being converted was encrypted with **ConvertFrom-SecureString** using a specified key, that same key must be provided as the value of the *Key* or *SecureKey* parameter of the **ConvertTo-SecureString** cmdlet.
 
+> [!NOTE]
+> Note that per [DotNet](https://github.com/dotnet/platform-compat/blob/master/docs/DE0001.md), the
+> contents of a SecureString are not encrypted.
+
 ## EXAMPLES
 
 ### Example 1: Convert a secure string to an encrypted string


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (6.2) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
