### PR TITLE
update docs for -CustomPipeName

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_pwsh.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_pwsh.md
@@ -1,7 +1,6 @@
 ---
 ms.date:  06/09/2017
 schema:  2.0.0
-locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_PowerShell_exe
 ---

--- a/reference/6/Microsoft.PowerShell.Core/About/about_pwsh.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_pwsh.md
@@ -21,6 +21,7 @@ pwsh starts a PowerShell session.
 pwsh[.exe]
 [-Version]
 [-ConfigurationName]
+[-CustomPipeName <string>]
 [-EncodedCommand <Base64EncodedCommand>]
 [-ExecutionPolicy <ExecutionPolicy>]
 [-InputFormat {Text | XML}]
@@ -49,6 +50,17 @@ Displays the version of PowerShell. Additional parameters are ignored.
 Specifies a configuration endpoint in which PowerShell is run.
 This can be any endpoint registered on the local machine including the default PowerShell
 remoting endpoints or a custom endpoint having specific user role capabilities.
+
+#### -CustomPipeName <PipeName>
+
+Specifies the name to use for an additional IPC server
+(named pipe)
+used for debugging and other cross-process communication.
+This offers a predictable mechanism for connecting to other PowerShell instances.
+Typically used with the
+`CustomPipeName`
+parameter on
+`Enter-PSHostProcess`.
 
 #### -EncodedCommand <Base64EncodedCommand>
 
@@ -184,4 +196,10 @@ pwsh -SettingsFile ~/powershell.config.json
 
 # Example of specifying a configuration name
 pwsh -ConfigurationName AdminRoles
+
+# Example of specifying a custom pipe name
+# PowerShell instance 1
+pwsh -CustomPipeName mycustompipe
+# PowerShell instance 2
+Enter-PSHostProcess -CustomPipeName mycustompipe
 ```

--- a/reference/6/Microsoft.PowerShell.Core/About/about_pwsh.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_pwsh.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  03/22/2019
 schema:  2.0.0
 keywords:  powershell,cmdlet
 title:  about_PowerShell_exe

--- a/reference/6/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/6/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -11,7 +11,6 @@ title: Enter-PSHostProcess
 # Enter-PSHostProcess
 
 ## SYNOPSIS
-
 Connects to and enters into an interactive session with a local process.
 
 ## SYNTAX

--- a/reference/6/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/6/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -203,7 +203,7 @@ This is usually used in conjunction with
 
 ```yaml
 Type: String
-Parameter Sets: PipePipeNameParameterSet
+Parameter Sets: PipeNameParameterSet
 Aliases:
 
 Required: True

--- a/reference/6/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/6/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -11,6 +11,7 @@ title: Enter-PSHostProcess
 # Enter-PSHostProcess
 
 ## SYNOPSIS
+
 Connects to and enters into an interactive session with a local process.
 
 ## SYNTAX
@@ -37,6 +38,12 @@ Enter-PSHostProcess [-Name] <String> [[-AppDomainName] <String>] [<CommonParamet
 
 ```
 Enter-PSHostProcess [-HostProcessInfo] <PSHostProcessInfo> [[-AppDomainName] <String>] [<CommonParameters>]
+```
+
+### PipeNameParameterSet
+
+```
+Enter-PSHostProcess -CustomPipeName <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -112,7 +119,7 @@ PS C:\>
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ProcessIdParameterSet, ProcessParameterSet, ProcessNameParameterSet, PSHostProcessInfoParameterSet
 Aliases:
 
 Required: False
@@ -185,6 +192,24 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -CustomPipeName
+
+Gets or sets the custom named pipe name to connect to.
+This is usually used in conjunction with
+`pwsh -CustomPipeName`.
+
+```yaml
+Type: String
+Parameter Sets: PipePipeNameParameterSet
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/6/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/6/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 03/22/2019
 online version: http://go.microsoft.com/fwlink/?LinkID=403736
 schema: 2.0.0
 title: Enter-PSHostProcess
@@ -215,7 +215,10 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable,
+-Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 


### PR DESCRIPTION
fixes #3755

In https://github.com/PowerShell/PowerShell/pull/8889 we add the `-CustomPipeName` parameter on `pwsh` and `Enter-PSHostProcess`. This issue is to track documenting that feature.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6.2 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
