### PR TITLE
updated to reflect that SecureString is only not encrypted on non-Windows systems

### DIFF
--- a/reference/6/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
+++ b/reference/6/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
@@ -39,7 +39,7 @@ If no key is specified, the Windows Data Protection API (DPAPI) is used to encry
 
 > [!NOTE]
 > Note that per [DotNet](/dotnet/api/system.security.securestring?view=netcore-2.1#remarks), the
-> contents of a SecureString are not encrypted.
+> contents of a SecureString are not encrypted on non-Windows systems.
 
 ## EXAMPLES
 

--- a/reference/6/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
+++ b/reference/6/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
@@ -48,7 +48,7 @@ If the standard string being converted was encrypted with **ConvertFrom-SecureSt
 
 > [!NOTE]
 > Note that per [DotNet](/dotnet/api/system.security.securestring?view=netcore-2.1#remarks), the
-> contents of a SecureString are not encrypted.
+> contents of a SecureString are not encrypted on non-Windows systems.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Looking at the corefx source code, it appears that on Windows, SecureString is still encrypted so added clarification that unencrypted only applies to non-Windows systems.

Related PSCore6 PR https://github.com/PowerShell/PowerShell/pull/9199

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (6.2) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
