### PR TITLE
Add SkipEditionCheck switch docs, update CompatiblePSEditions docs

### DIFF
--- a/developer/prog-guide/how-to-create-a-windows-powershell-provider.md
+++ b/developer/prog-guide/how-to-create-a-windows-powershell-provider.md
@@ -23,7 +23,7 @@ To the developer, the Windows PowerShell provider is the interface between the u
 
 Windows PowerShell provides several providers (such as the FileSystem provider, Registry provider, and Alias provider) that are used to access known data stores. For more information about the providers supplied by Windows PowerShell, use the following command to access online Help:
 
-**PS>get-help about_provider**
+**PS>get-help about_providers**
 
 ## Accessing the Stored Data Using Windows PowerShell Paths
 

--- a/gallery/concepts/module-psedition-support.md
+++ b/gallery/concepts/module-psedition-support.md
@@ -9,14 +9,25 @@ title:  Modules with compatible PowerShell Editions
 Starting with version 5.1, PowerShell is available in different editions which denote varying
 feature sets and platform compatibility.
 
-- **Desktop Edition:** Built on .NET Framework and provides compatibility with scripts and modules
-  targeting versions of PowerShell running on full footprint editions of Windows such as Server
-  Core and Windows Desktop.
-- **Core Edition:** Built on .NET Core and provides compatibility with scripts and modules
-  targeting versions of PowerShell running on reduced footprint editions of Windows such as Nano
-  Server and Windows IoT.
+- **Desktop Edition:** Built on .NET Framework, applies to Windows PowerShell v4.0 and below as well
+  as Windows PowerShell 5.1 on Windows Desktop, Windows Server, Windows Server Core and most other
+  Windows editions.
+- **Core Edition:** Built on .NET Core, applies to PowerShell Core 6.0 and above as well as
+  Windows PowerShell 5.1 on reduced footprint Windows Editions such as Windows IoT and Windows
+  Nanoserver.
 
-The running edition of PowerShell is shown in the PSEdition property of `$PSVersionTable`.
+In PowerShell 5.1 and above, the edition of the running PowerShell session can be retrieved from the
+`$PSEdition` automatic variable:
+
+```powershell
+$PSEdition
+```
+
+```output
+Core
+```
+
+Edition information is also present in the PSEdition property of `$PSVersionTable`:
 
 ```powershell
 $PSVersionTable
@@ -90,6 +101,143 @@ Get-Module -ListAvailable -PSEdition Core | % CompatiblePSEditions
 ```output
 Desktop
 Core
+```
+
+## Edition-compatibility for PowerShell modules that ship as part of Windows
+
+For most modules, the `CompatiblePSEditions` field is purely informational;
+PowerShell module tooling allows users to filter on this field, but does not perform
+checks on it itself.
+
+In PowerShell 6.1 and above however, for modules that ship as part of Windows in the Windows
+PowerShell system module directory (`%windir%\System32\WindowsPowerShell\v1.0\Modules`),
+the `CompatiblePSEditions` field is checked by PowerShell. This is so that Windows PowerShell modules
+that have been validated as compatible with PowerShell Core will work normally, while modules
+that are not yet compatible will be ignored or stopped from importing
+(preventing unpredictable compatibility issues later).
+
+> [!NOTE]
+> Any module you write will not have the `CompatiblePSEditions` field checked.
+> Edition-checking only occurs on Windows PowerShell modules that ship as part of Windows
+> in the `%windir%\System32\WindowsPowerShell\v1.0\Modules` directory.
+
+For `Import-Module`, the `CompatiblePSEditions` check means a Core-incompatible module will fail
+to load in PowerShell Core 6.1 and above:
+
+```powershell
+Import-Module BitsTransfer
+```
+
+```output
+Import-Module : Module 'C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\BitsTransfer\BitsTransfer.psd1' does not support current PowerShell edition 'Core'. Its supported editions are 'Desktop'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.
+At line:1 char:1
++ Import-Module BitsTransfer
++ ~~~~~~~~~~~~~~~~~~~~~~~~~~
++ CategoryInfo          : ResourceUnavailable: (C:\WINDOWS\system32\u2026r\BitsTransfer.psd1:String) [Import-Module], InvalidOperationException
++ FullyQualifiedErrorId : Modules_PSEditionNotSupported,Microsoft.PowerShell.Commands.ImportModuleCommand
+```
+
+With `Get-Module`, the `CompatiblePSEditions` check means edition-incompatible modules are not
+returned or displayed by default:
+
+```powershell
+Get-Module -ListAvailable BitsTransfer
+```
+
+```output
+```
+
+In both cases, you can bypass this with the `-SkipEditionCheck` switch parameter:
+
+```powershell
+Import-Module -SkipEditionCheck AppLocker -PassThru
+```
+
+```output
+
+ModuleType Version    Name                                ExportedCommands
+---------- -------    ----                                ----------------
+Manifest   2.0.0.0    AppLocker                           {Get-AppLockerFileInformation, Get-AppLockerPolicy, New-AppLocker…
+
+```
+
+```powershell
+Get-Module -ListAvailable BitsTransfer
+```
+
+```output
+
+
+    Directory: C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules
+
+ModuleType Version    Name                                PSEdition ExportedCommands
+---------- -------    ----                                --------- ----------------
+Manifest   2.0.0.0    BitsTransfer                        Desk      {Add-BitsFile, Complete-BitsTransfer, Get-BitsTransfer,…
+
+```
+
+However, if you import a module that is not marked as compatible with PowerShell Core,
+be aware that errors due to an incompatibility could occur at a later stage
+(the module may even import successfully and only fail while executing a command):
+
+```powershell
+Import-Module -SkipEditionCheck BitsTransfer
+```
+
+```output
+Import-Module : Could not load type 'System.Management.Automation.PSSnapIn' from assembly 'System.Management.Automation, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
+At line:1 char:1
++ Import-Module -SkipEditionCheck BitsTransfer
++ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++ CategoryInfo          : NotSpecified: (:) [Import-Module], TypeLoadException
++ FullyQualifiedErrorId : System.TypeLoadException,Microsoft.PowerShell.Commands.ImportModuleCommand
+```
+
+Changes to formatting in PowerShell Core 6.1 and above mean you will be informed about how
+PowerShell interprets the `CompatiblePSEditions` field under the `PSEdition` format table header:
+
+```powershell
+Get-Module -ListAvailable
+```
+
+```output
+
+    Directory: C:\Users\me\Documents\PowerShell\Modules
+
+ModuleType Version    Name                                PSEdition ExportedCommands
+---------- -------    ----                                --------- ----------------
+Script     1.3.1      Az.Accounts                         Core,Desk {Disable-AzDataCollection, Disable-AzContextAutosave, E…
+Script     4.4.0      Pester                              Desk      {Describe, Context, It, Should…}
+Script     1.0.0      WindowsCompatibility                Core      {Initialize-WinSession, Add-WinFunction, Invoke-WinComm…
+
+    Directory: C:\Program Files\PowerShell\Modules
+
+ModuleType Version    Name                                PSEdition ExportedCommands
+---------- -------    ----                                --------- ----------------
+Script     1.2.2      PackageManagement                   Desk      {Find-Package, Get-Package, Get-PackageProvider, Get-Pa…
+Script     2.0.1      PowerShellGet                       Desk      {Find-Command, Find-DSCResource, Find-Module, Find-Role…
+
+...
+
+    Directory: C:\program files\powershell\6-preview\Modules
+
+ModuleType Version    Name                                PSEdition ExportedCommands
+---------- -------    ----                                --------- ----------------
+Manifest   6.1.0.0    CimCmdlets                          Core      {Get-CimAssociatedInstance, Get-CimClass, Get-CimInstan…
+Manifest   1.2.2.0    Microsoft.PowerShell.Archive        Desk      {Compress-Archive, Expand-Archive}
+Manifest   6.1.0.0    Microsoft.PowerShell.Diagnostics    Core      {Get-WinEvent, New-WinEvent}
+
+...
+
+    Directory: C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules
+
+ModuleType Version    Name                                PSEdition ExportedCommands
+---------- -------    ----                                --------- ----------------
+Manifest   1.0.0.0    BitLocker                           Core,Desk {Unlock-BitLocker, Suspend-BitLocker, Resume-BitLocker,…
+Script     3.0        Dism                                Core,Desk {Add-AppxProvisionedPackage, Add-WindowsDriver, Add-Win…
+
+...
+
 ```
 
 ## Targeting multiple editions

--- a/gallery/concepts/module-psedition-support.md
+++ b/gallery/concepts/module-psedition-support.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/12/2017
+ms.date:  03/22/2019
 contributor:  manikb
 keywords:  gallery,powershell,cmdlet,psget
 title:  Modules with compatible PowerShell Editions
@@ -23,7 +23,7 @@ In PowerShell 5.1 and above, the edition of the running PowerShell session can b
 $PSEdition
 ```
 
-```output
+```Output
 Core
 ```
 
@@ -33,7 +33,7 @@ Edition information is also present in the PSEdition property of `$PSVersionTabl
 $PSVersionTable
 ```
 
-```output
+```Output
 Name                           Value
 ----                           -----
 PSVersion                      5.1.14300.1000
@@ -62,7 +62,7 @@ $ModuleInfo = Test-ModuleManifest -Path .\TestModuleWithEdition.psd1
 $ModuleInfo.CompatiblePSEditions
 ```
 
-```output
+```Output
 Desktop
 Core
 ```
@@ -71,7 +71,7 @@ Core
 $ModuleInfo | Get-Member CompatiblePSEditions
 ```
 
-```output
+```Output
    TypeName: System.Management.Automation.PSModuleInfo
 
 Name                 MemberType Definition
@@ -85,7 +85,7 @@ When getting a list of available modules, you can filter the list by PowerShell 
 Get-Module -ListAvailable -PSEdition Desktop
 ```
 
-```output
+```Output
     Directory: C:\Program Files\WindowsPowerShell\Modules
 
 
@@ -98,7 +98,7 @@ Manifest   1.0        ModuleWithPSEditions
 Get-Module -ListAvailable -PSEdition Core | % CompatiblePSEditions
 ```
 
-```output
+```Output
 Desktop
 Core
 ```
@@ -128,7 +128,7 @@ to load in PowerShell Core 6.1 and above:
 Import-Module BitsTransfer
 ```
 
-```output
+```Output
 Import-Module : Module 'C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\BitsTransfer\BitsTransfer.psd1' does not support current PowerShell edition 'Core'. Its supported editions are 'Desktop'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.
 At line:1 char:1
 + Import-Module BitsTransfer
@@ -144,7 +144,7 @@ returned or displayed by default:
 Get-Module -ListAvailable BitsTransfer
 ```
 
-```output
+```Output
 ```
 
 In both cases, you can bypass this with the `-SkipEditionCheck` switch parameter:
@@ -153,7 +153,7 @@ In both cases, you can bypass this with the `-SkipEditionCheck` switch parameter
 Import-Module -SkipEditionCheck AppLocker -PassThru
 ```
 
-```output
+```Output
 
 ModuleType Version    Name                                ExportedCommands
 ---------- -------    ----                                ----------------
@@ -165,7 +165,7 @@ Manifest   2.0.0.0    AppLocker                           {Get-AppLockerFileInfo
 Get-Module -ListAvailable BitsTransfer
 ```
 
-```output
+```Output
 
 
     Directory: C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules
@@ -184,7 +184,7 @@ be aware that errors due to an incompatibility could occur at a later stage
 Import-Module -SkipEditionCheck BitsTransfer
 ```
 
-```output
+```Output
 Import-Module : Could not load type 'System.Management.Automation.PSSnapIn' from assembly 'System.Management.Automation, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
 At line:1 char:1
 + Import-Module -SkipEditionCheck BitsTransfer
@@ -200,7 +200,7 @@ PowerShell interprets the `CompatiblePSEditions` field under the `PSEdition` for
 Get-Module -ListAvailable
 ```
 
-```output
+```Output
 
     Directory: C:\Users\me\Documents\PowerShell\Modules
 
@@ -375,7 +375,7 @@ Sample module manifest file with CompatiblePSEditions key
 dir -Recurse
 ```
 
-```output
+```Output
     Directory: C:\Users\manikb\Documents\WindowsPowerShell\Modules\ModuleWithEditions
 
 Mode           LastWriteTime   Length Name

--- a/gallery/concepts/module-psedition-support.md
+++ b/gallery/concepts/module-psedition-support.md
@@ -260,4 +260,4 @@ Find-Module -Tag PSEdition_Core
 
 [about_PowerShell_Editions][]
 
-[about_PowerShell_Editions]: ../../reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+[about_PowerShell_Editions]: /powershell/module/Microsoft.PowerShell.Core/About/about_PowerShell_Editions

--- a/gallery/concepts/module-psedition-support.md
+++ b/gallery/concepts/module-psedition-support.md
@@ -258,6 +258,6 @@ Find-Module -Tag PSEdition_Core
 
 [Update module manifest](/powershell/module/powershellget/update-modulemanifest)
 
-[about_PowerShell_Editions]
+[about_PowerShell_Editions][]
 
 [about_PowerShell_Editions]: ../../reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md

--- a/gallery/concepts/module-psedition-support.md
+++ b/gallery/concepts/module-psedition-support.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  03/22/2019
+ms.date:  03/28/2019
 contributor:  manikb
 keywords:  gallery,powershell,cmdlet,psget
 title:  Modules with compatible PowerShell Editions

--- a/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -233,10 +233,13 @@ to catch possible behavioral differences between editions. For this you must sti
 
 ## See also
 
-- [about_Automatic_Variables](about_Automatic_Variables.md)
-- [Import-Module](../Import-Module.md)
-- [Get-Module](../Get-Module.md)
-- [Modules with compatible PowerShell Editions](../../../../gallery/concepts/module-psedition-support.md)
+[about_Automatic_Variables](about_Automatic_Variables.md)
+
+[Import-Module](../Import-Module.md)
+
+[Get-Module](../Get-Module.md)
+
+[Modules with compatible PowerShell Editions](../../../../gallery/concepts/module-psedition-support.md)
 
 [Pester]: https://github.com/pester/Pester/wiki/Pester
 [PSScriptAnalyzer]: https://github.com/PowerShell/PSScriptAnalyzer

--- a/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -99,7 +99,18 @@ written for this edition.
 For modules not shipped as part of Windows (i.e. modules you write or install from the gallery),
 this field is informational only; PowerShell does not change behavior based on the
 `CompatiblePSEditions` field, but does expose it on the `PSModuleInfo` object (returned by
-`Get-Module`) for your own logic.
+`Get-Module`) for your own logic:
+
+```powershell
+New-ModuleManifest -Path .\TestModuleWithEdition.psd1 -CompatiblePSEditions Desktop,Core -PowerShellVersion '5.1'
+$ModuleInfo = Test-ModuleManifest -Path .\TestModuleWithEdition.psd1
+$ModuleInfo.CompatiblePSEditions
+```
+
+```Output
+Desktop
+Core
+```
 
 > [!NOTE]
 > The `CompatiblePSEditions` module field is only compatible with PowerShell 5.1 and above.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -1,0 +1,235 @@
+---
+ms.date:  03/28/2019
+schema:  2.0.0
+locale:  en-us
+title:  about_PowerShell_Editions
+---
+# About PowerShell Editions
+
+## Short Description
+Different editions of PowerShell run on different underlying runtimes.
+
+## Long Description
+
+From PowerShell 5.1, there are multiple *editions* of PowerShell that each run on
+a different .NET runtime. As of PowerShell 6.2 there are two editions of PowerShell:
+
+- **Desktop**, which runs on .NET Framework. PowerShell 4 and below, as well as
+  PowerShell 5.1 on full-featured Windows editions like Windows Desktop, Windows Server,
+  Windows Server Core and most other Windows operating systems are Desktop edition.
+  This is the original PowerShell edition.
+- **Core**, which runs on .NET Core. PowerShell 6.0 and above, as well as PowerShell 5.1 on
+  some reduced-footprint Windows editions such as Windows Nano Server and Windows IoT where
+  .NET Framework is unavailable.
+
+Because the edition of PowerShell corresponds to its .NET runtime, it is the primary indicator
+of .NET API and PowerShell module compatibility; some .NET APIs, types or methods are not available
+in both .NET runtimes and this affects PowerShell scripts and modules that depend on them.
+
+## The `$PSEdition` automatic variable
+
+In PowerShell 5.1 and above, you can find out what edition you are running with the `$PSEdition`
+automatic variable:
+
+```powershell
+$PSEdition
+```
+
+```Output
+Core
+```
+
+In PowerShell 4 and below, this variable does not exist. `$PSEdition` being null should be treated
+as the same as having the value `Desktop`.
+
+### Edition in `$PSVersionTable`
+
+The `$PSVersionTable` automatic variable also has edition information in PowerShell 5.1 and above:
+
+```powershell
+$PSVersionTable
+```
+
+```Output
+Name                           Value
+----                           -----
+PSVersion                      6.2.0-rc.1
+PSEdition                      Core           # <-- Edition information
+GitCommitId                    6.2.0-rc.1
+OS                             Microsoft Windows 10.0.18865
+Platform                       Win32NT
+PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}
+PSRemotingProtocolVersion      2.3
+SerializationVersion           1.1.0.1
+WSManStackVersion              3.0
+```
+
+The `PSEdition` field will have the same value as the `$PSEdition` automatic variable.
+
+## The `CompatiblePSEditions` module manifest field
+
+PowerShell modules can declare what editions of PowerShell they are compatible with using the
+`CompatiblePSEditions` field of the module manifest.
+
+For example, a module manifest declaring compatibility with both `Desktop` and `Core` editions
+of PowerShell:
+
+```powershell
+@{
+    ModuleVersion = '1.0'
+    FunctionsToExport = @('Test-MyModule')
+    CompatiblePSEditions = @('Desktop', 'Core')
+}
+```
+
+An example of a module manifest with only `Desktop` compatibility:
+
+```powershell
+@{
+    ModuleVersion = '1.0'
+    FunctionsToExport = @('Test-MyModule')
+    CompatiblePSEditions = @('Desktop')
+}
+```
+
+Omitting the `CompatiblePSEditions` field from a module manifest will have the same effect as
+setting it to `Desktop`, since modules created before this field was introduced were implicitly
+written for this edition.
+
+For modules not shipped as part of Windows (i.e. modules you write or install from the gallery),
+this field is informational only; PowerShell does not change behavior based on the
+`CompatiblePSEditions` field, but does expose it on the `PSModuleInfo` object (returned by
+`Get-Module`) for your own logic.
+
+> [!NOTE]
+> The `CompatiblePSEditions` module field is only compatible with PowerShell 5.1 and above.
+> Including this field will cause a module to be incompatible with PowerShell 4 and below.
+> Since the field is purely informational, it can be safely omitted in later PowerShell versions.
+
+In PowerShell 6.1, `Get-Module -ListAvailable` has had its formatter updated to display the
+edition-compatibility of each module:
+
+```PowerShell
+Get-Module -ListAvailable
+```
+
+```Output
+
+    Directory: C:\Users\me\Documents\PowerShell\Modules
+
+ModuleType Version    Name                                PSEdition ExportedCommands
+---------- -------    ----                                --------- ----------------
+Script     1.4.0      Az                                  Core,Desk
+Script     1.3.1      Az.Accounts                         Core,Desk {Disable-AzDataCollection, Disable-AzContextAutosave, E…
+Script     1.0.1      Az.Aks                              Core,Desk {Get-AzAks, New-AzAks, Remove-AzAks, Import-AzAksCreden…
+
+...
+
+Script     4.4.0      Pester                              Desk      {Describe, Context, It, Should…}
+Script     1.18.0     PSScriptAnalyzer                    Desk      {Get-ScriptAnalyzerRule, Invoke-ScriptAnalyzer, Invoke-…
+Script     1.0.0      WindowsCompatibility                Core      {Initialize-WinSession, Add-WinFunction, Invoke-WinComm…
+
+```
+
+## Edition-compatibility for modules that ship as part of Windows
+
+For modules that come as part of Windows (or are installed as part of a role or feature),
+PowerShell 6.1 and above treat the `CompatiblePSEditions` field differently. Such modules are found
+in the Windows PowerShell system modules directory
+(`%windir%\System\WindowsPowerShell\v1.0\Modules`).
+
+For modules loaded from or found in this directory, PowerShell 6.1 and above uses the
+`CompatiblePSEditions` field to determine whether the module will be compatible with the current
+session and behaves accordingly.
+
+When `Import-Module` is used, a module without `Core` in `CompatiblePSEditions` will not be imported
+and an error will be displayed:
+
+```powershell
+Import-Module BitsTransfer
+```
+
+```Output
+Import-Module : Module 'C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\BitsTransfer\BitsTransfer.psd1' does not support current PowerShell edition 'Core'. Its supported editions are 'Desktop'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.
+At line:1 char:1
++ Import-Module BitsTransfer
++ ~~~~~~~~~~~~~~~~~~~~~~~~~~
++ CategoryInfo          : ResourceUnavailable: (C:\WINDOWS\system32\u2026r\BitsTransfer.psd1:String) [Import-Module], InvalidOperationException
++ FullyQualifiedErrorId : Modules_PSEditionNotSupported,Microsoft.PowerShell.Commands.ImportModuleCommand
+```
+
+When `Get-Module -ListAvailable` is used, modules without `Core` in `CompatiblePSEditions` will not
+be displayed:
+
+```powershell
+Get-Module -ListAvailable BitsTransfer
+```
+
+```Output
+# No output
+```
+
+In both cases, the `-SkipEditionCheck` switch parameter can be used to override this behavior:
+
+```powershell
+Get-Module -ListAvailable -SkipEditionCheck BitsTransfer
+```
+
+```Output
+
+    Directory: C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules
+
+ModuleType Version    Name                                PSEdition ExportedCommands
+---------- -------    ----                                --------- ----------------
+Manifest   2.0.0.0    BitsTransfer                        Desk      {Add-BitsFile, Complete-BitsTransfer, Get-BitsTransfer,…
+
+```
+
+> [!WARNING]
+> `Import-Module -SkipEditionCheck` may appear to succeed for a module, but using that module
+> runs the risk of encountering an incompatibility later on; while loading the module initially
+> succeeds, a command may later call an incompatible API and fail spontaneously.
+
+## Authoring PowerShell modules for edition cross-compatibility
+
+When writing a PowerShell module to target both `Desktop` and `Core` editions of PowerShell,
+there are things you can do to ensure cross-edition compatibility.
+
+The only true way to confirm and continually validate compatibility however is to write tests for
+your script or module and run them on all versions and editions of PowerShell you need compatibility
+with. A recommended testing framework for this is [Pester][].
+
+### PowerShell script
+
+As a language, PowerShell works the same between editions; it is the cmdlets, modules and .NET APIs
+you use that are affected by edition compatibility.
+
+Generally, scripts that work in PowerShell 6.1 and above will work with Windows PowerShell 5.1,
+but there are some exceptions.
+
+Version 1.18.0 [PSScriptAnalyzer][] module has rules like [`PSUseCompatibleCommands`][] and
+[`PSUseCompatibleTypes`][] that are able to detect possibly incompatible usage of commands
+and .NET APIs in PowerShell scripts.
+
+### .NET assemblies
+
+If you are writing a binary module or a module that incorporates .NET assemblies (DLLs) generated
+from source code, you should compile against [.NET Standard][] and [PowerShell Standard][]
+for compile-time compatibility validation of .NET and PowerShell API compatibility.
+
+Although these libraries are able to check some compatibility at compile time, they won't be able
+to catch possible behavioral differences between editions. For this you must still write tests.
+
+## See also
+
+- [about_Automatic_Variables](about_Automatic_Variables.md)
+- [Import-Module](../Import-Module.md)
+- [Get-Module](../Get-Module.md)
+- [Modules with compatible PowerShell Editions](../../../../gallery/concepts/module-psedition-support.md)
+
+[Pester]: https://github.com/pester/Pester/wiki/Pester
+[PSScriptAnalyzer]: https://github.com/PowerShell/PSScriptAnalyzer
+[`PSUseCompatibleCommands`]: https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/UseCompatibleCommands.md
+[`PSUseCompatibleTypes`]: https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/UseCompatibleTypes.md
+[.NET Standard]: https://docs.microsoft.com/en-us/dotnet/standard/net-standard
+[PowerShell Standard]: https://devblogs.microsoft.com/powershell/powershell-standard-library-build-single-module-that-works-across-windows-powershell-and-powershell-core/

--- a/reference/6/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 03/22/2019
 online version: http://go.microsoft.com/fwlink/?LinkId=821486
 schema: 2.0.0
 title: Get-Module
@@ -112,7 +112,7 @@ PS> $FullyQualifedName = @{ModuleName="Microsoft.PowerShell.Management";ModuleVe
 PS> Get-Module -FullyQualifiedName | Format-Table -Property Name,Version
 ```
 
-```output
+```Output
 Name                             Version
 ----                             -------
 Microsoft.PowerShell.Management  3.1.0.0
@@ -127,7 +127,7 @@ The command then pipes the results into the `Format-Table` cmdlet to format the 
 PS> Get-Module | Get-Member -MemberType Property | Format-Table Name
 ```
 
-```output
+```Output
 Name
 ----
 AccessMode
@@ -184,7 +184,7 @@ The output includes the new properties, such as **Author** and **CompanyName**, 
 PS> Get-Module -ListAvailable -All | Format-Table -Property Name, Moduletype, Path -Groupby Name
 ```
 
-```output
+```Output
 Name: AppLocker
 
 Name      ModuleType Path
@@ -234,7 +234,7 @@ PS> $m = Get-Module -list -Name BitsTransfer
 PS> Get-Content $m.Path
 ```
 
-```output
+```Output
 @ {
     GUID               = "{8FA5064B-8479-4c5c-86EA-0D311FE48875}"
     Author             = "Microsoft Corporation"
@@ -260,7 +260,7 @@ The second command uses the `Get-Content` cmdlet to get the content of the manif
 PS> dir (Get-Module -ListAvailable FileTransfer).ModuleBase
 ```
 
-```output
+```Output
 Directory: C:\Windows\system32\WindowsPowerShell\v1.0\Modules\FileTransfer
 Mode                LastWriteTime     Length Name
 ----                -------------     ------ ----

--- a/reference/6/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Module.md
@@ -8,6 +8,7 @@ online version: http://go.microsoft.com/fwlink/?LinkId=821486
 schema: 2.0.0
 title: Get-Module
 ---
+
 # Get-Module
 
 ## SYNOPSIS
@@ -16,30 +17,27 @@ Gets the modules that have been imported or that can be imported into the curren
 ## SYNTAX
 
 ### Loaded (Default)
-
 ```
 Get-Module [[-Name] <String[]>] [-FullyQualifiedName <ModuleSpecification[]>] [-All] [<CommonParameters>]
 ```
 
 ### Available
-
 ```
 Get-Module [[-Name] <String[]>] [-FullyQualifiedName <ModuleSpecification[]>] [-All] [-ListAvailable]
- [-PSEdition <String>] [-Refresh] [<CommonParameters>]
+ [-PSEdition <String>] [-SkipEditionCheck] [-Refresh] [<CommonParameters>]
 ```
 
 ### PsSession
-
 ```
 Get-Module [[-Name] <String[]>] [-FullyQualifiedName <ModuleSpecification[]>] [-ListAvailable]
- [-PSEdition <String>] [-Refresh] -PSSession <PSSession> [<CommonParameters>]
+ [-PSEdition <String>] [-SkipEditionCheck] [-Refresh] -PSSession <PSSession> [<CommonParameters>]
 ```
 
 ### CimSession
-
 ```
-Get-Module [[-Name] <String[]>] [-FullyQualifiedName <ModuleSpecification[]>] [-ListAvailable] [-Refresh]
- -CimSession <CimSession> [-CimResourceUri <Uri>] [-CimNamespace <String>] [<CommonParameters>]
+Get-Module [[-Name] <String[]>] [-FullyQualifiedName <ModuleSpecification[]>] [-ListAvailable]
+ [-SkipEditionCheck] [-Refresh] -CimSession <CimSession> [-CimResourceUri <Uri>] [-CimNamespace <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -495,33 +493,6 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -PSEdition
-
-Gets the modules that support specified edition of PowerShell.
-
-The acceptable values for this parameter are:
-
-- Desktop
-- Core
-
-The Get-Module cmdlet checks **CompatiblePSEditions** property of **PSModuleInfo** object for the specified value and returns only those modules that have it set.
-
-> [!NOTE]
-> - **Desktop Edition:** Built on .NET Framework and provides compatibility with scripts and modules targeting versions of PowerShell running on full footprint editions of Windows such as Server Core and Windows Desktop.
-> - **Core Edition:** Built on .NET Core and provides compatibility with scripts and modules targeting versions of PowerShell running on reduced footprint editions of Windows such as Nano Server and Windows IoT.
-
-```yaml
-Type: String
-Parameter Sets: Available, PsSession
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -PSSession
 
 Gets the modules in the specified user-managed PowerShell session (**PSSession**).
@@ -569,9 +540,58 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### CommonParameters
+### -PSEdition
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+Gets the modules that support specified edition of PowerShell.
+
+The acceptable values for this parameter are:
+
+- Desktop
+- Core
+
+The Get-Module cmdlet checks **CompatiblePSEditions** property of **PSModuleInfo** object for the specified value and returns only those modules that have it set.
+
+> [!NOTE]
+> - **Desktop Edition:** Built on .NET Framework, applies to Windows PowerShell 5.1 and below on most Windows editions.
+> - **Core Edition:** Built on .NET Core, applies to PowerShell Core 6.0 and above, as well as some editions of Windows PowerShell 5.1 built for Windows IoT and Windows Nanoserver.
+>
+> The edition of the current PowerShell session can be found with the `$PSEdition` variable.
+
+```yaml
+Type: String
+Parameter Sets: Available, PsSession
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipEditionCheck
+
+Skips the check of the `CompatiblePSEditions` field.
+
+By default, Get-Module will omit modules in the `%windir%\System32\WindowsPowerShell\v1.0\Modules`
+directory that do not specify `Core` in the `CompatiblePSEditions` field.
+When this switch is set, modules without `Core` will be included, so that modules under the
+Windows PowerShell module path that are incompatible with PowerShell Core will be returned.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Available, PsSession, CimSession
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/6/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Module.md
@@ -580,7 +580,7 @@ Windows PowerShell module path that are incompatible with PowerShell Core will b
 
 On macOS and Linux, this parameter does nothing.
 
-See [about_PowerShell_Editions][] for more information.
+See [about_PowerShell_Editions](About/about_PowerShell_Editions.md) for more information.
 
 ```yaml
 Type: SwitchParameter
@@ -645,6 +645,4 @@ When you create a CIM session on the local computer, PowerShell uses DCOM, inste
 
 [Remove-Module](Remove-Module.md)
 
-[about_PowerShell_Editions][]
-
-[about_PowerShell_Editions]: About/about_PowerShell_Editions.md
+[about_PowerShell_Editions](About/about_PowerShell_Editions.md)

--- a/reference/6/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 03/22/2019
+ms.date: 03/28/2019
 online version: http://go.microsoft.com/fwlink/?LinkId=821486
 schema: 2.0.0
 title: Get-Module

--- a/reference/6/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Module.md
@@ -578,6 +578,10 @@ directory that do not specify `Core` in the `CompatiblePSEditions` field.
 When this switch is set, modules without `Core` will be included, so that modules under the
 Windows PowerShell module path that are incompatible with PowerShell Core will be returned.
 
+On macOS and Linux, this parameter does nothing.
+
+See [about_PowerShell_Editions][] for more information.
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: Available, PsSession, CimSession
@@ -640,3 +644,7 @@ When you create a CIM session on the local computer, PowerShell uses DCOM, inste
 [New-PSSession](New-PSSession.md)
 
 [Remove-Module](Remove-Module.md)
+
+[about_PowerShell_Editions][]
+
+[about_PowerShell_Editions]: About/about_PowerShell_Editions.md

--- a/reference/6/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Import-Module.md
@@ -993,6 +993,11 @@ On Linux and macOS, this switch does nothing.
 
 See [about_PowerShell_Editions] for more information.
 
+> [!WARNING]
+> `Import-Module -SkipEditionCheck` is still likely to fail to import a module. Even if it does
+> succeed, invoking a command from the module may later fail when it tries to use an
+> incompatible API.
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)

--- a/reference/6/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Import-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 03/22/2019
 online version: http://go.microsoft.com/fwlink/?LinkId=821492
 schema: 2.0.0
 title: Import-Module

--- a/reference/6/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Import-Module.md
@@ -991,30 +991,7 @@ When importing a module from another path, this switch does nothing,
 since the check is not performed.
 On Linux and macOS, this switch does nothing.
 
-> [!NOTE]
-> The `CompatiblePSEditions` field for modules not in the `%windir%\System32\WindowsPowerShell\v1.0\Modules`
-> directory is for informational purposes only.
-> It is not checked by Import-Module.
->
-> For modules that *are* in this directory, if a module does not have `Core` indicated in its
-> `CompatiblePSEditions` field, importing it will fail. If `-SkipEditionCheck` is specified,
-> this import check is bypassed.
->
-> When a module from the `%windir%\System32\WindowsPowerShell\v1.0\Modules` directory not
-> specifying `Core` in `CompatiblePSEditions` is loaded using `Import-Module -SkipEditionCheck`,
-> the initial import may succeed but problems may occur during usage due to compatibility issues
-> between .NET Framework and .NET Core.
-
-> [!NOTE]
-> The `CompatiblePSEditions` manifest field refers to the .NET runtime PowerShell is built for:
->
-> - Desktop: Runs on .NET Framework, applies to Windows PowerShell 5.1 and below,
->   on most Windows editions.
-> - Core: Runs on .NET Core, applies to PowerShell Core 6.0 and above, as well as
->   Windows PowerShell 5.1 running on reduced footprint Windows editions,
->   like Windows IoT and Windows Nanoserver.
->
-> The edition of a PowerShell session can be found with the `$PSEdition` automatic variable.
+See [about_PowerShell_Editions] for more information.
 
 ```yaml
 Type: SwitchParameter
@@ -1087,3 +1064,7 @@ When you create a CIM session on the local computer, PowerShell uses DCOM, inste
 [New-Module](New-Module.md)
 
 [Remove-Module](Remove-Module.md)
+
+[about_PowerShell_Editions]
+
+[about_PowerShell_Editions]: About/about_PowerShell_Editions.md

--- a/reference/6/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Import-Module.md
@@ -8,6 +8,7 @@ online version: http://go.microsoft.com/fwlink/?LinkId=821492
 schema: 2.0.0
 title: Import-Module
 ---
+
 # Import-Module
 
 ## SYNOPSIS
@@ -16,63 +17,57 @@ Adds modules to the current session.
 ## SYNTAX
 
 ### Name (Default)
-
 ```
 Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
- [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>]
- [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking]
- [-NoClobber] [-Scope <String>] [<CommonParameters>]
-```
-
-### PSSession
-
-```
-Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
- [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>]
- [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking]
- [-NoClobber] [-Scope <String>] -PSSession <PSSession> [<CommonParameters>]
-```
-
-### CimSession
-
-```
-Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
- [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>]
- [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking]
- [-NoClobber] [-Scope <String>] -CimSession <CimSession> [-CimResourceUri <Uri>] [-CimNamespace <String>]
- [<CommonParameters>]
-```
-
-### FullyQualifiedName
-
-```
-Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]> [-Function <String[]>]
- [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject]
- [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>] [<CommonParameters>]
-```
-
-### FullyQualifiedNameAndPSSession
-
-```
-Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]> [-Function <String[]>]
- [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject]
- [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>] -PSSession <PSSession>
- [<CommonParameters>]
-```
-
-### Assembly
-
-```
-Import-Module [-Global] [-Prefix <String>] [-Assembly] <Assembly[]> [-Function <String[]>] [-Cmdlet <String[]>]
- [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-ArgumentList <Object[]>]
+ [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject]
+ [-MinimumVersion <Version>] [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>]
  [-DisableNameChecking] [-NoClobber] [-Scope <String>] [<CommonParameters>]
 ```
 
-### ModuleInfo
+### PSSession
+```
+Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
+ [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject]
+ [-MinimumVersion <Version>] [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>]
+ [-DisableNameChecking] [-NoClobber] [-Scope <String>] -PSSession <PSSession> [<CommonParameters>]
+```
 
+### CimSession
+```
+Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
+ [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject]
+ [-MinimumVersion <Version>] [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>]
+ [-DisableNameChecking] [-NoClobber] [-Scope <String>] -CimSession <CimSession> [-CimResourceUri <Uri>]
+ [-CimNamespace <String>] [<CommonParameters>]
+```
+
+### FullyQualifiedName
+```
+Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]> [-Function <String[]>]
+ [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru]
+ [-AsCustomObject] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>]
+ [<CommonParameters>]
+```
+
+### FullyQualifiedNameAndPSSession
+```
+Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]> [-Function <String[]>]
+ [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru]
+ [-AsCustomObject] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>]
+ -PSSession <PSSession> [<CommonParameters>]
+```
+
+### Assembly
+```
+Import-Module [-Global] [-Prefix <String>] [-Assembly] <Assembly[]> [-Function <String[]>] [-Cmdlet <String[]>]
+ [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject]
+ [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>] [<CommonParameters>]
+```
+
+### ModuleInfo
 ```
 Import-Module [-Global] [-Prefix <String>] [-Function <String[]>] [-Cmdlet <String[]>] [-Variable <String[]>]
- [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-ModuleInfo] <PSModuleInfo[]>
+ [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject] [-ModuleInfo] <PSModuleInfo[]>
  [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>] [<CommonParameters>]
 ```
 
@@ -722,24 +717,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -MaximumVersion
-
-Specifies a maximum version.
-This cmdlet imports only a version of the module that is less than or equal to the specified value.
-If no version qualifies, **Import-Module** generates an error.
-
-```yaml
-Type: String
-Parameter Sets: Name, PSSession, CimSession
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -MinimumVersion
 
 Specifies a minimum version.
@@ -834,6 +811,34 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PSSession
+
+Specifies a Windows PowerShell user-managed session (**PSSession**) from which this cmdlet import modules into the current session.
+Enter a variable that contains a **PSSession** or a command that gets a **PSSession**, such as a Get-PSSession command.
+
+When you import a module from a different session into the current session, you can use the cmdlets from the module in the current session, just as you would use cmdlets from a local module.
+Commands that use the remote cmdlets actually run in the remote session, but the remoting details are managed in the background by Windows PowerShell.
+
+This parameter uses the Implicit Remoting feature of Windows PowerShell.
+It is equivalent to using the Import-PSSession cmdlet to import particular modules from a session.
+
+**Import-Module** cannot import Windows PowerShell Core modules from another session.
+The Windows PowerShell Core modules have names that begin with Microsoft.PowerShell.
+
+This parameter was introduced in Windows PowerShell 3.0.
+
+```yaml
+Type: PSSession
+Parameter Sets: PSSession, FullyQualifiedNameAndPSSession
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -PassThru
 
 Returns an object representing the item with which you are working.
@@ -870,34 +875,6 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -PSSession
-
-Specifies a Windows PowerShell user-managed session (**PSSession**) from which this cmdlet import modules into the current session.
-Enter a variable that contains a **PSSession** or a command that gets a **PSSession**, such as a Get-PSSession command.
-
-When you import a module from a different session into the current session, you can use the cmdlets from the module in the current session, just as you would use cmdlets from a local module.
-Commands that use the remote cmdlets actually run in the remote session, but the remoting details are managed in the background by Windows PowerShell.
-
-This parameter uses the Implicit Remoting feature of Windows PowerShell.
-It is equivalent to using the Import-PSSession cmdlet to import particular modules from a session.
-
-**Import-Module** cannot import Windows PowerShell Core modules from another session.
-The Windows PowerShell Core modules have names that begin with Microsoft.PowerShell.
-
-This parameter was introduced in Windows PowerShell 3.0.
-
-```yaml
-Type: PSSession
-Parameter Sets: PSSession, FullyQualifiedNameAndPSSession
-Aliases:
-
-Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -984,9 +961,75 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### CommonParameters
+### -MaximumVersion
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+Specifies a maximum version.
+This cmdlet imports only a version of the module that is less than or equal to the specified value.
+If no version qualifies, **Import-Module** generates an error.
+
+```yaml
+Type: String
+Parameter Sets: Name, PSSession, CimSession
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipEditionCheck
+
+Skips the check on the `CompatiblePSEditions` field.
+
+Allows loading a module from the `%windir%\System32\WindowsPowerShell\v1.0\Modules`
+module directory into PowerShell Core when that module does not specify `Core` in the
+`CompatiblePSEditions` manifest field.
+
+When importing a module from another path, this switch does nothing,
+since the check is not performed.
+On Linux and macOS, this switch does nothing.
+
+> [!NOTE]
+> The `CompatiblePSEditions` field for modules not in the `%windir%\System32\WindowsPowerShell\v1.0\Modules`
+> directory is for informational purposes only.
+> It is not checked by Import-Module.
+>
+> For modules that *are* in this directory, if a module does not have `Core` indicated in its
+> `CompatiblePSEditions` field, importing it will fail. If `-SkipEditionCheck` is specified,
+> this import check is bypassed.
+>
+> When a module from the `%windir%\System32\WindowsPowerShell\v1.0\Modules` directory not
+> specifying `Core` in `CompatiblePSEditions` is loaded using `Import-Module -SkipEditionCheck`,
+> the initial import may succeed but problems may occur during usage due to compatibility issues
+> between .NET Framework and .NET Core.
+
+> [!NOTE]
+> The `CompatiblePSEditions` manifest field refers to the .NET runtime PowerShell is built for:
+>
+> - Desktop: Runs on .NET Framework, applies to Windows PowerShell 5.1 and below,
+>   on most Windows editions.
+> - Core: Runs on .NET Core, applies to PowerShell Core 6.0 and above, as well as
+>   Windows PowerShell 5.1 running on reduced footprint Windows editions,
+>   like Windows IoT and Windows Nanoserver.
+>
+> The edition of a PowerShell session can be found with the `$PSEdition` automatic variable.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/6/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Import-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 03/22/2019
+ms.date: 03/28/2019
 online version: http://go.microsoft.com/fwlink/?LinkId=821492
 schema: 2.0.0
 title: Import-Module

--- a/reference/6/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Import-Module.md
@@ -991,7 +991,7 @@ When importing a module from another path, this switch does nothing,
 since the check is not performed.
 On Linux and macOS, this switch does nothing.
 
-See [about_PowerShell_Editions] for more information.
+See [about_PowerShell_Editions](About/about_PowerShell_Editions.md) for more information.
 
 > [!WARNING]
 > `Import-Module -SkipEditionCheck` is still likely to fail to import a module. Even if it does
@@ -1070,6 +1070,4 @@ When you create a CIM session on the local computer, PowerShell uses DCOM, inste
 
 [Remove-Module](Remove-Module.md)
 
-[about_PowerShell_Editions]
-
-[about_PowerShell_Editions]: About/about_PowerShell_Editions.md
+[about_PowerShell_Editions](About/about_PowerShell_Editions.md)


### PR DESCRIPTION
Resolves https://github.com/MicrosoftDocs/PowerShell-Docs/issues/3433.

Adds documentation for the `-SkipEditionCheck` parameter on `Import-Module` and `Get-Module` and updates information about the `CompatiblePSEditions` field in documentation.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (6.1) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
