### PR TITLE
delete newline after synopsis

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -12,7 +12,6 @@ title: ConvertFrom-Json
 # ConvertFrom-Json
 
 ## SYNOPSIS
-
 Converts a JSON-formatted string to a custom object or a hash table.
 
 ## SYNTAX


### PR DESCRIPTION
@sdwheeler informed me that there should not be a newline after synopsis.