### PR TITLE
Fix the default formatting for FileSystemInfo object

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/6/Microsoft.PowerShell.Management/Add-Content.md
@@ -138,7 +138,7 @@ Get-Content -Path .\IsReadOnlyTextFile.txt
 ```Output
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--ar---        1/28/2019     13:35              0 IsReadOnlyTextFile.txt
+-ar--         1/28/2019     13:35              0 IsReadOnlyTextFile.txt
 ```
 
 The `New-Item` cmdlet uses the **Path** and **ItemType** parameters to create the file

--- a/reference/6/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -54,7 +54,7 @@ names are displayed. For empty locations the command does not return any output 
 PowerShell prompt.
 
 By default `Get-ChildItem` lists the mode (attributes), last write time, file size (length), and the
-name of the item. The valid values for mode are `d` (directory), `a` (archive), `r` (read-only), `h`
+name of the item. The valid values for mode are `l` (link), `d` (directory), `a` (archive), `r` (read-only), `h`
 (hidden), and `s` (system).
 
 ```
@@ -64,11 +64,11 @@ PS> Get-ChildItem -Path C:\Test
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
-d-----        2/15/2019     08:29                Logs
--a----        2/13/2019     08:55             26 anotherfile.txt
--a----        2/12/2019     15:40         118014 Command.txt
--a----         2/1/2019     08:43            183 CreateTestFile.ps1
--ar---        2/12/2019     14:31             27 ReadOnlyFile.txt
+d----         2/15/2019     08:29                Logs
+-a---         2/13/2019     08:55             26 anotherfile.txt
+-a---         2/12/2019     15:40         118014 Command.txt
+-a---          2/1/2019     08:43            183 CreateTestFile.ps1
+-ar--         2/12/2019     14:31             27 ReadOnlyFile.txt
 ```
 
 The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory **C:\Test**.
@@ -103,33 +103,33 @@ PS> Get-ChildItem -Path C:\Test\*.txt -Recurse -Force
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----        2/12/2019     16:16             20 Afile4.txt
--a-h--        2/12/2019     15:52             22 hiddenfile.txt
--a----        2/13/2019     13:26             20 LogFile4.txt
+-a---         2/12/2019     16:16             20 Afile4.txt
+-a-h-         2/12/2019     15:52             22 hiddenfile.txt
+-a---         2/13/2019     13:26             20 LogFile4.txt
 
     Directory: C:\Test\Logs\Backup
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----        2/12/2019     16:16             20 ATextFile.txt
--a----        2/12/2019     15:50             20 LogFile3.txt
+-a---         2/12/2019     16:16             20 ATextFile.txt
+-a---         2/12/2019     15:50             20 LogFile3.txt
 
     Directory: C:\Test\Logs
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----        2/12/2019     16:16             20 Afile.txt
--a-h--        2/12/2019     15:52             22 hiddenfile.txt
--a----        2/13/2019     13:26             20 LogFile1.txt
+-a---         2/12/2019     16:16             20 Afile.txt
+-a-h-         2/12/2019     15:52             22 hiddenfile.txt
+-a---         2/13/2019     13:26             20 LogFile1.txt
 
     Directory: C:\Test
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----        2/13/2019     08:55             26 anotherfile.txt
--a----        2/12/2019     15:40         118014 Command.txt
--a-h--        2/12/2019     15:52             22 hiddenfile.txt
--ar---        2/12/2019     14:31             27 ReadOnlyFile.txt
+-a---         2/13/2019     08:55             26 anotherfile.txt
+-a---         2/12/2019     15:40         118014 Command.txt
+-a-h-         2/12/2019     15:52             22 hiddenfile.txt
+-ar--         2/12/2019     14:31             27 ReadOnlyFile.txt
 ```
 
 The `Get-ChildItem` cmdlet uses the **Path** parameter to specify `C:\Test\*.txt`. **Path** uses the
@@ -150,9 +150,9 @@ PS> Get-ChildItem -Path C:\Test\* -Include *.txt
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----        2/13/2019     08:55             26 anotherfile.txt
--a----        2/12/2019     15:40         118014 Command.txt
--ar---        2/12/2019     14:31             27 ReadOnlyFile.txt
+-a---         2/13/2019     08:55             26 anotherfile.txt
+-a---         2/12/2019     15:40         118014 Command.txt
+-ar--         2/12/2019     14:31             27 ReadOnlyFile.txt
 ```
 
 The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory **C:\Test**. The
@@ -182,12 +182,12 @@ PS> Get-ChildItem -Path C:\Test\Logs
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
-d-----        2/15/2019     13:21                Adirectory
-d-----        2/15/2019     08:28                AnEmptyDirectory
-d-----        2/15/2019     13:21                Backup
--a----        2/12/2019     16:16             20 Afile.txt
--a----        2/13/2019     13:26             20 LogFile1.txt
--a----        2/12/2019     16:24             23 systemlog1.log
+d----         2/15/2019     13:21                Adirectory
+d----         2/15/2019     08:28                AnEmptyDirectory
+d----         2/15/2019     13:21                Backup
+-a---         2/12/2019     16:16             20 Afile.txt
+-a---         2/13/2019     13:26             20 LogFile1.txt
+-a---         2/12/2019     16:24             23 systemlog1.log
 
 
 PS>  Get-ChildItem -Path C:\Test\Logs -Exclude A*
@@ -196,9 +196,9 @@ PS>  Get-ChildItem -Path C:\Test\Logs -Exclude A*
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
-d-----        2/15/2019     13:21                Backup
--a----        2/13/2019     13:26             20 LogFile1.txt
--a----        2/12/2019     16:24             23 systemlog1.log
+d----         2/15/2019     13:21                Backup
+-a---         2/13/2019     13:26             20 LogFile1.txt
+-a---         2/12/2019     16:24             23 systemlog1.log
 
 
 PS> Get-ChildItem -Path C:\Test\Logs\* -Exclude A*
@@ -207,15 +207,15 @@ PS> Get-ChildItem -Path C:\Test\Logs\* -Exclude A*
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----        2/12/2019     15:50             20 LogFile3.txt
--a----        2/12/2019     16:24             23 systemlog1.log
+-a---         2/12/2019     15:50             20 LogFile3.txt
+-a---         2/12/2019     16:24             23 systemlog1.log
 
     Directory: C:\Test\Logs
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----        2/13/2019     13:26             20 LogFile1.txt
--a----        2/12/2019     16:24             23 systemlog1.log
+-a---         2/13/2019     13:26             20 LogFile1.txt
+-a---         2/12/2019     16:24             23 systemlog1.log
 
 
 PS> Get-ChildItem -Path C:\Test\Logs\* -Exclude A* -Recurse
@@ -224,28 +224,28 @@ PS> Get-ChildItem -Path C:\Test\Logs\* -Exclude A* -Recurse
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----        2/13/2019     13:26             20 LogFile4.txt
--a----        2/12/2019     16:24             23 systemlog1.log
+-a---         2/13/2019     13:26             20 LogFile4.txt
+-a---         2/12/2019     16:24             23 systemlog1.log
 
     Directory: C:\Test\Logs
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
-d-----        2/15/2019     13:21                Backup
+d----         2/15/2019     13:21                Backup
 
     Directory: C:\Test\Logs\Backup
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----        2/12/2019     15:50             20 LogFile3.txt
--a----        2/12/2019     16:24             23 systemlog1.log
+-a---         2/12/2019     15:50             20 LogFile3.txt
+-a---         2/12/2019     16:24             23 systemlog1.log
 
     Directory: C:\Test\Logs
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----        2/13/2019     13:26             20 LogFile1.txt
--a----        2/12/2019     16:24             23 systemlog1.log
+-a---         2/13/2019     13:26             20 LogFile1.txt
+-a---         2/12/2019     16:24             23 systemlog1.log
 ```
 
 The example's output shows the contents of the directory **C:\Test\Logs**. The output is a reference
@@ -323,34 +323,34 @@ Get-ChildItem -Path C:\Parent -Depth 2
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
-d-----        2/14/2019     10:24                SubDir_Level1
--a----        2/13/2019     08:55             26 file.txt
+d----         2/14/2019     10:24                SubDir_Level1
+-a---         2/13/2019     08:55             26 file.txt
 
     Directory: C:\Parent\SubDir_Level1
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
-d-----        2/14/2019     10:24                SubDir_Level2
--a----        2/13/2019     08:55             26 file.txt
+d----         2/14/2019     10:24                SubDir_Level2
+-a---         2/13/2019     08:55             26 file.txt
 
     Directory: C:\Parent\SubDir_Level1\SubDir_Level2
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
-d-----        2/14/2019     10:22                SubDir_Level3
--a----        2/13/2019     08:55             26 file.txt
+d----         2/14/2019     10:22                SubDir_Level3
+-a---         2/13/2019     08:55             26 file.txt
 ```
 
 The `Get-ChildItem` cmdlet uses the **Path** parameter to specify **C:\Parent**. The **Depth**
 parameter specifies two levels of recursion. `Get-ChildItem` displays the contents of the directory
 specified by the **Path** parameter and the two levels of subdirectories.
 
-### Example 9: Getting hardlink information
+### Example 9: Getting hard link information
 
-In 6.2, an alternate view was added to get hardlink information.
+In 6.2, an alternate view was added to get hard link information.
 
 ```powershell
-Get-ChildItem -Path C:\PathContainingHardLink | Format-Table -View childrenWithHardlink
+Get-ChildItem -Path C:\PathContainingHardLink | Format-Table -View childrenWithHardLink
 ```
 
 ## Parameters

--- a/reference/6/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/6/Microsoft.PowerShell.Management/Remove-Item.md
@@ -106,10 +106,10 @@ Get-ChildItem
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----         6/1/2018  12:19 PM           1362 myFile.txt
--a----         6/1/2018  12:30 PM           1132 myFile[1].txt
--a----         6/1/2018  12:19 PM           1283 myFile[2].txt
--a----         6/1/2018  12:19 PM           1432 myFile[3].txt
+-a---          6/1/2018  12:19 PM           1362 myFile.txt
+-a---          6/1/2018  12:30 PM           1132 myFile[1].txt
+-a---          6/1/2018  12:19 PM           1283 myFile[2].txt
+-a---          6/1/2018  12:19 PM           1432 myFile[3].txt
 
 ```
 
@@ -122,9 +122,9 @@ Get-ChildItem | Where-Object Name -Like '*`[*'
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----         6/1/2018  12:30 PM           1132 myFile[1].txt
--a----         6/1/2018  12:19 PM           1283 myFile[2].txt
--a----         6/1/2018  12:19 PM           1432 myFile[3].txt
+-a---          6/1/2018  12:30 PM           1132 myFile[1].txt
+-a---          6/1/2018  12:19 PM           1283 myFile[2].txt
+-a---          6/1/2018  12:19 PM           1432 myFile[3].txt
 
 ```
 
@@ -138,7 +138,7 @@ Get-ChildItem
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----         6/1/2018  12:19 PM           1362 myFile.txt
+-a---          6/1/2018  12:19 PM           1362 myFile.txt
 ```
 
 ### Example 7: Remove an alternate data stream


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
