### PR TITLE
fix example text to match PowerShell example

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -537,7 +537,7 @@ Where
 The `-replace` operator replaces all or part of a value with the specified
 value using regular expressions. You can use the `-replace` operator for many
 administrative tasks, such as renaming files. For example, the following
-command changes the file name extensions of all .gif files to .jpg:
+command changes the file name extensions of all .txt files to .log:
 
 ```powershell
 Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -537,7 +537,7 @@ Where
 The `-replace` operator replaces all or part of a value with the specified
 value using regular expressions. You can use the `-replace` operator for many
 administrative tasks, such as renaming files. For example, the following
-command changes the file name extensions of all .gif files to .jpg:
+command changes the file name extensions of all .txt files to .log:
 
 ```powershell
 Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -537,7 +537,7 @@ Where
 The `-replace` operator replaces all or part of a value with the specified
 value using regular expressions. You can use the `-replace` operator for many
 administrative tasks, such as renaming files. For example, the following
-command changes the file name extensions of all .gif files to .jpg:
+command changes the file name extensions of all .txt files to .log:
 
 ```powershell
 Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -537,7 +537,7 @@ Where
 The `-replace` operator replaces all or part of a value with the specified
 value using regular expressions. You can use the `-replace` operator for many
 administrative tasks, such as renaming files. For example, the following
-command changes the file name extensions of all .gif files to .jpg:
+command changes the file name extensions of all .txt files to .log:
 
 ```powershell
 Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -536,7 +536,7 @@ Where
 The `-replace` operator replaces all or part of a value with the specified
 value using regular expressions. You can use the `-replace` operator for many
 administrative tasks, such as renaming files. For example, the following
-command changes the file name extensions of all .gif files to .jpg:
+command changes the file name extensions of all .txt files to .log:
 
 ```powershell
 Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }


### PR DESCRIPTION
Fix https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4041

Makes sense to change .txt to .log whereas .gif to .jpg wouldn't work unless they were misnamed originally.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
