### PR TITLE
Update Installing-PowerShell-Core-on-Windows.md

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Windows.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Windows.md
@@ -54,7 +54,7 @@ Windows IoT already comes with Windows PowerShell which we will use to deploy Po
    # change the destination to however you had partitioned it with sufficient
    # space for the zip and the unzipped contents
    # the path should be local to the device
-   Copy-Item .\PowerShell-6.1.0-win-arm32.zip -Destination u:\users\administrator\Downloads -ToSession $s
+   Copy-Item .\PowerShell-<version>-win-<os-arch>.zip -Destination u:\users\administrator\Downloads -ToSession $s
    ```
 
 3. Connect to the device and expand the archive
@@ -62,13 +62,13 @@ Windows IoT already comes with Windows PowerShell which we will use to deploy Po
    ```powershell
    Enter-PSSession $s
    Set-Location u:\users\administrator\downloads
-   Expand-Archive .\PowerShell-6.1.0-win-arm32.zip
+   Expand-Archive .\PowerShell-<version>-win-<os-arch>.zip
    ```
 
 4. Setup remoting to PowerShell Core 6
 
    ```powershell
-   Set-Location .\PowerShell-6.1.0-win-arm32
+   Set-Location .\PowerShell-<version>-win-<os-arch>
    # Be sure to use the -PowerShellHome parameter otherwise it'll try to create a new
    # endpoint with Windows PowerShell 5.1
    .\Install-PowerShellRemoting.ps1 -PowerShellHome .
@@ -79,7 +79,7 @@ Windows IoT already comes with Windows PowerShell which we will use to deploy Po
 
    ```powershell
    # Be sure to use the -Configuration parameter.  If you omit it, you will connect to Windows PowerShell 5.1
-   Enter-PSSession -ComputerName <deviceIp> -Credential Administrator -Configuration powershell.6.1.0
+   Enter-PSSession -ComputerName <deviceIp> -Credential Administrator -Configuration powershell.<version>
    ```
 
 ## Deploying on Nano Server


### PR DESCRIPTION
Remove fixed-version expression and replace to "\<version\>" and "\<os-arch\>" because ARM version of PowerShell Core now experimentaly released version 6.1.3 on both x86 and x64.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
