### PR TITLE
Update Write-Output to reflect change in behavior in 6.2 to align with WinPS

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Write-Output.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 03/28/2019
 online version: http://go.microsoft.com/fwlink/?LinkId=821878
 schema: 2.0.0
 title: Write-Output
@@ -87,6 +87,12 @@ Accept wildcard characters: False
 By default, the **Write-Output** cmdlet always enumerates its output.
 The *NoEnumerate* parameter suppresses the default behavior, and prevents **Write-Output** from enumerating output.
 The *NoEnumerate* parameter has no effect on collections that were created by wrapping commands in parentheses, because the parentheses force enumeration.
+
+> [!NOTE]
+> This switch only works correctly with PowerShell Core 6.2 and newer. On older
+> versions of PowerShell Core, the collection is still enumerated even with
+> use of this switch.  The behavior in PowerShell Core 6.2 is consistent with
+> Windows PowerShell.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
Fix #3815

Version(s) of document impacted
------------------------------
- [X] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version (6.2) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
