### PR TITLE
Clarifying where precisely to find the download links

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Windows.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Windows.md
@@ -9,7 +9,7 @@ ms.date: 08/06/2018
 ## MSI
 
 To install PowerShell on a Windows client or Windows Server (works on Windows 7 SP1, Server 2008 R2, and later), download the MSI package from
-our GitHub [releases][] page.  You will need to scroll down to the Assets section of the Release you want to install.  The Assets section is sometimes collapsed, so you may need to click to expand it.
+our GitHub [releases][] page.  Scroll down to the **Assets** section of the Release you want to install.  The Assets section may be collapsed, so you may need to click to expand it.
 
 The MSI file looks like this - `PowerShell-<version>-win-<os-arch>.msi`
 <!-- TODO: should be updated to point to the Download Center as well -->

--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Windows.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Windows.md
@@ -9,7 +9,7 @@ ms.date: 08/06/2018
 ## MSI
 
 To install PowerShell on a Windows client or Windows Server (works on Windows 7 SP1, Server 2008 R2, and later), download the MSI package from
-our GitHub [releases][] page.
+our GitHub [releases][] page.  You will need to scroll down to the Assets section of the Release you want to install.  The Assets section is sometimes collapsed, so you may need to click to expand it.
 
 The MSI file looks like this - `PowerShell-<version>-win-<os-arch>.msi`
 <!-- TODO: should be updated to point to the Download Center as well -->


### PR DESCRIPTION
The download links can be hard to find for newcomers, or if there are just a lot of Release Notes present to scroll though.  Since a direct link to the Assets section isn't available, I added verbiage to make it slearer where the customer shoul look.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
