### PR TITLE
Documentation for accessing errors in catch block

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
@@ -172,6 +172,47 @@ inherit from the **SystemException** type.
 If you specify an error class and one of its derived classes, place the `Catch`
 block for the derived class before the `Catch` block for the general class.
 
+### ACCESSING EXCEPTION INFORMATION
+
+Within a `Catch` block, the current error can be ascertained using `$_`, which
+is an alias for `$PSItem`, and the object is of type **ErrorRecord**.
+
+```powershell
+try { NonsenseString }
+catch {
+  Write-Host "An error occurred:"
+  Write-Host $_
+}
+```
+
+Running this script returns the following result:
+
+```
+An Error occurred:
+The term 'NonsenseString' is not recognized as the name of a cmdlet, function,
+script file, or operable program. Check the spelling of the name, or if a path
+was included, verify that the path is correct and try again.
+```
+
+There are additional properties that can be accessed, such as `ScriptStackTrace`,
+`Exception`, and `ErrorDetails`.  For example, if we change the script to the
+following:
+
+```powershell
+try { NonsenseString }
+catch {
+  Write-Host "An error occurred:"
+  Write-Host $_.ScriptStackTrace
+}
+```
+
+The result will be similar to:
+
+```
+An Error occurred:
+at <ScriptBlock>, <No file>: line 2
+```
+
 ### FREEING RESOURCES BY USING FINALLY
 
 To free resources used by a script, add a `Finally` block after the `Try` and

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
@@ -175,7 +175,7 @@ block for the derived class before the `Catch` block for the general class.
 ### ACCESSING EXCEPTION INFORMATION
 
 Within a `Catch` block, the current error can be ascertained using `$_`, which
-is an alias for `$PSItem`, and the object is of type **ErrorRecord**.
+is also known as `$PSItem`, and the object is of type **ErrorRecord**.
 
 ```powershell
 try { NonsenseString }
@@ -194,8 +194,8 @@ script file, or operable program. Check the spelling of the name, or if a path
 was included, verify that the path is correct and try again.
 ```
 
-There are additional properties that can be accessed, such as `ScriptStackTrace`,
-`Exception`, and `ErrorDetails`.  For example, if we change the script to the
+There are additional properties that can be accessed, such as **ScriptStackTrace**,
+**Exception**, and **ErrorDetails**.  For example, if we change the script to the
 following:
 
 ```powershell

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
@@ -187,7 +187,7 @@ catch {
 
 Running this script returns the following result:
 
-```
+```Output
 An Error occurred:
 The term 'NonsenseString' is not recognized as the name of a cmdlet, function,
 script file, or operable program. Check the spelling of the name, or if a path


### PR DESCRIPTION
Added a section on how to use `$_` and `$PSItem` within a `catch` block to access information about the error that was thrown.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
