### PR TITLE
Enable parallel runs of platyPS per version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ _site/
 Tools/NuGet/
 _site/
 maml/
-updateablehelp/
+updatablehelp/
 
 
 .openpublishing.build.mdproj

--- a/build.ps1
+++ b/build.ps1
@@ -20,6 +20,12 @@ Invoke-WebRequest -Uri $pandocSourceURL -OutFile $pandocZipPath
 Expand-Archive -Path (Join-Path $pandocDestinationPath "pandoc-$panDocVersion-windows.zip") -DestinationPath $pandocDestinationPath -Force
 $pandocExePath = Join-Path (Join-Path $pandocDestinationPath "pandoc-$panDocVersion") "pandoc.exe"
 
+# Install ThreadJob if not available
+$threadJob = Get-Module ThreadJob -ListAvailable
+if ($null -eq $threadjob) {
+    Install-Module ThreadJob -RequiredVersion 1.1.2 -Scope CurrentUser -Force
+}
+
 # Find the reference folder path w.r.t the script
 $ReferenceDocset = Join-Path $PSScriptRoot 'reference'
 


### PR DESCRIPTION
@sdwheeler requested if we can parallelize the building of maml help to reduce CI time.  Not clear to me how much benefit will be achieved as I believe the AzDevOps images are single core.  Anyways, the fix here is to run the scriptblock that produces the updatable help to run in a ThreadJob rather than serially.  Had to make some modifications as platyPS seems to use the current directory to produce temp files so having multiple instances run meant creating temp folders for each to use and setting the location to that path prior to using platyPS.

Other changes would be capturing the verbose output and seeing if the ThreadJob produced errors or failed outright.

There was also a typo in .gitignore for the folder of the result so fixed that.