### PR TITLE
Remove Show-Command link in v6 doc

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -325,5 +325,3 @@ You can elect to send the trace data to a user-mode or kernel-mode debugger, to 
 [Measure-Command](Measure-Command.md)
 
 [Set-TraceSource](Set-TraceSource.md)
-
-[Show-Command](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Utility/Show-Command)


### PR DESCRIPTION
The `Show-Command` cmdlet is not supported since v6

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
