### PR TITLE
Fix links for "How to Write a PowerShell Module Manifest"

### DIFF
--- a/developer/module/how-to-write-a-powershell-binary-module.md
+++ b/developer/module/how-to-write-a-powershell-binary-module.md
@@ -23,7 +23,10 @@ The following procedure describes how to create and install a PowerShell binary 
 
 2. If necessary, create the rest of your solution: (additional cmdlets, XML files, and so on) and describe them with a module manifest.
 
-   In addition to describing the cmdlet assemblies in your solution, a module manifest can describe how you want your module exported and imported, what cmdlets will be exposed, and what additional files will go into the module. As stated previously however, PowerShell can treat a binary cmdlet like a module with no additional effort. As such, a module manifest is useful mainly for combining multiple files into a single package, or for explicitly controlling publication for a given assembly. For more information, see [How to Write a PowerShell Module Manifest](http://msdn.microsoft.com/en-us/abe4c24b-e64e-4a61-81d5-18c4fceba0b6).
+   In addition to describing the cmdlet assemblies in your solution, a module manifest can describe how you want your module exported and imported, what cmdlets will be exposed, and what additional files will go into the module.
+   As stated previously however, PowerShell can treat a binary cmdlet like a module with no additional effort.
+   As such, a module manifest is useful mainly for combining multiple files into a single package, or for explicitly controlling publication for a given assembly.
+   For more information, see [How to Write a PowerShell Module Manifest](how-to-write-a-powershell-module-manifest.md).
 
    The following code is an extremely simple C# code block that contains three cmdlets in the same file that can be used as a module.
 
@@ -76,7 +79,9 @@ The following procedure describes how to create and install a PowerShell binary 
 
 Cmdlets and providers that exist in snap-in assemblies can be loaded as binary modules. When the snap-in assemblies are loaded as binary modules, the cmdlets and providers in the snap-in are available to the user, but the snap-in class in the assembly is ignored, and the snap-in is not registered. As a result, the snap-in cmdlets provided by Windows PowerShell cannot detect the snap-in even though the cmdlets and providers are available to the session.
 
-In addition, any formatting or types files that are referenced by the snap-in cannot be imported as part of a binary module. To import the formatting and types files you must create a module manifest. See, [How to Write a PowerShell Module Manifest](http://msdn.microsoft.com/en-us/abe4c24b-e64e-4a61-81d5-18c4fceba0b6).
+In addition, any formatting or types files that are referenced by the snap-in cannot be imported as part of a binary module.
+To import the formatting and types files you must create a module manifest.
+See, [How to Write a PowerShell Module Manifest](how-to-write-a-powershell-module-manifest.md).
 
 ## See Also
 

--- a/developer/module/writing-a-windows-powershell-module.md
+++ b/developer/module/writing-a-windows-powershell-module.md
@@ -37,7 +37,7 @@ Cmdlet and provider developers can use modules to test and distribute their comp
 
 [How to Write a PowerShell Binary Module](./how-to-write-a-powershell-binary-module.md)
 
-[How to Write a PowerShell Module Manifest](http://msdn.microsoft.com/en-us/abe4c24b-e64e-4a61-81d5-18c4fceba0b6)
+[How to Write a PowerShell Module Manifest](how-to-write-a-powershell-module-manifest.md)
 
 [Modifying the PSModulePath Installation Path](./modifying-the-psmodulepath-installation-path.md)
 


### PR DESCRIPTION
Fix the URL in order to forward to the [new page](https://docs.microsoft.com/en-us/powershell/developer/module/how-to-write-a-powershell-module-manifest), not to the [old page](https://docs.microsoft.com/en-us/previous-versions//dd878297(v=vs.85)). 