### PR TITLE
Add UFormat specifiers table

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Date.md
@@ -485,115 +485,47 @@ Otherwise, it returns a **DateTime** object.
 
   When you pipe a date to cmdlets that expect string input, such as the Add-Content cmdlet, Windows PowerShell converts the **DateTime** object to a string before adding it to the file. The default `ToString()` format is short date and long time. To specify an alternate format, use the `-Format` or `-UFormat` parameters of `Get-Date`.
 
-  - Uformat Values:
+- Here are the valid **UFormat** specifiers, each of which must be preceded by `%`, for example, `Get-Date -UFormat %Y%m%d`
 
-    The following are the values of the `-UFormat` parameter. The format for the command is:
-
-    `Get-Date -UFormat %\<value\>`
-
-    For example,
-
-    `Get-Date -UFormat %d`
-
-
-     - Date-Time:
-
-       Date and time - full
-
-       (default) : (Friday, June 16, 2006 10:31:27 AM)
-
-       `c` : Date and time - abbreviated (Fri Jun 16 10:31:27 2006)
-
-      - Date:
-
-        `D` : Date in mm/dd/yy format (06/14/06)
-
-        `x` : Date in standard format for locale (09/12/07 for English-US)
-
-      - Year:
-
-        `C` : Century (20 for 2006)
-
-        `Y` : Year in 4-digit format (2006)
-
-        `y` : Year in 2-digit format (06)
-
-        `G` : Same as 'Y'
-
-        `g` : Same as 'y'
-
-      - Month:
-
-        `b` : Month name - abbreviated (Jan)
-
-        `B` : Month name - full (January)
-
-        `h` : Same as 'b'
-
-        `m` : Month number (06)
-
-      - Week:
-
-        `W` : Week of the year (00-52)
-
-        `V` : Week of the year (01-53)
-
-        `U` : Same as 'W'
-
-      - Day:
-
-        `a` : Day of the week - abbreviated name (Mon)
-
-        `A` : Day of the week - full name (Monday)
-
-        `u` : Day of the week - number (Monday = 1)
-
-        `d` : Day of the month - 2 digits (05)
-
-        `e` : Day of the month - digit preceded by a space ( 5)
-
-        `j` : Day of the year - (1-366)
-
-        `w` : Same as 'u'
-
-      - Time:
-
-        `p` : AM or PM
-
-        `r` : Time in 12-hour format (09:15:36 AM)
-
-        `R` : Time in 24-hour format - no seconds (17:45)
-
-        `T` : Time in 24 hour format (17:45:52)
-
-        `X` : Same as 'T'
-
-        `Z` : Time zone offset from Universal Time Coordinate (UTC) (-07)
-
-      - Hour:
-
-        `H` :  Hour in 24-hour format (17)
-
-        `I` :   Hour in 12 hour format (05)
-
-        `k` :  Same as 'H'
-
-        `l` :   Same as 'I' (Upper-case I = Lower-case L)
-
-      - Minutes & Seconds:
-
-        `M` : Minutes (35)
-
-        `S` : Seconds (05)
-
-        `s` : Seconds elapsed since January 1, 1970 00:00:00 (1150451174.95705)
-
-      - Special Characters:
-
-        `n` : newline character (\n)
-
-        `t` : Tab character (\t)
-
+| Format specifier | Meaning | Example |
+| ---------------- | ------- | ------- |
+| A | Day of the week - full name | Monday |
+| a | Day of the week - abbreviated name | Mon |
+| B | Month name - full | January |
+| b | Month name - abbreviated | Jan |
+| C | Century | 20 for 2006 |
+| c | Date and time - abbreviated | Fri Jun 16 10:31:27 2006 |
+| D | Date in mm/dd/yy format | 06/14/06 |
+| d | Day of the month - 2 digits | 05 |
+| e | Day of the month - digit preceded by a space | \<space\>5 |
+| G | Same as 'Y' | |
+| g | Same as 'y' | |
+| H | Hour in 24-hour format | 17 |
+| h | Same as 'b' | |
+| I | Hour in 12 hour format | 05 |
+| j | Day of the year | 1-366 |
+| k | Same as 'H' | |
+| l | Same as 'I' (Upper-case I) | 05 |
+| M | Minutes | 35 |
+| m | Month number | 06 |
+| n | newline character | |
+| p | AM or PM | |
+| R | Time in 24-hour format -no seconds | 17:45 |
+| r | Time in 12-hour format | 09:15:36 AM |
+| S | Seconds | 05 |
+| s | Seconds elapsed since January 1, 1970 00:00:00 | 1150451174.95705 |
+| t | Horizontal tab character | |
+| T | Time in 24 hour format | 17:45:52 |
+| U | Same as 'W' | |
+| u | Day of the week - number | Monday = 1 |
+| V | Week of the year | 01-53 |
+| w | Same as 'u' | |
+| W | Week of the year | 00-52 |
+| X | Same as 'T' |
+| x | Date in standard format for locale | 09/12/07 for English-US |
+| Y | Year in 4-digit format | 2006 |
+| y | Year in 2-digit format | 06 |
+| Z | Time zone offset from Universal Time Coordinate (UTC) | -07 |
 
 ## Related Links
 

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Date.md
@@ -461,115 +461,47 @@ Otherwise, it returns a **DateTime** object.
 
   When you pipe a date to cmdlets that expect string input, such as the Add-Content cmdlet, Windows PowerShell converts the **DateTime** object to a string before adding it to the file. The default `ToString()` format is short date and long time. To specify an alternate format, use the `-Format` or `-UFormat` parameters of `Get-Date`.
 
-  * Uformat Values:
+* Here are the valid **UFormat** specifiers, each of which must be preceded by `%`, for example, `Get-Date -UFormat %Y%m%d`
 
-    The following are the values of the `-UFormat` parameter. The format for the command is:
-
-    `Get-Date -UFormat %\<value\>`
-
-    For example,
-
-    `Get-Date -UFormat %d`
-
-
-     * Date-Time:
-
-       Date and time - full
-
-       (default) : (Friday, June 16, 2006 10:31:27 AM)
-
-       `c` : Date and time - abbreviated (Fri Jun 16 10:31:27 2006)
-
-      * Date:
-
-        `D` : Date in mm/dd/yy format (06/14/06)
-
-        `x` : Date in standard format for locale (09/12/07 for English-US)
-
-      * Year:
-
-        `C` : Century (20 for 2006)
-
-        `Y` : Year in 4-digit format (2006)
-
-        `y` : Year in 2-digit format (06)
-
-        `G` : Same as 'Y'
-
-        `g` : Same as 'y'
-
-      * Month:
-
-        `b` : Month name - abbreviated (Jan)
-
-        `B` : Month name - full (January)
-
-        `h` : Same as 'b'
-
-        `m` : Month number (06)
-
-      * Week:
-
-        `W` : Week of the year (00-52)
-
-        `V` : Week of the year (01-53)
-
-        `U` : Same as 'W'
-
-      * Day:
-
-        `a` : Day of the week - abbreviated name (Mon)
-
-        `A` : Day of the week - full name (Monday)
-
-        `u` : Day of the week - number (Monday = 1)
-
-        `d` : Day of the month - 2 digits (05)
-
-        `e` : Day of the month - digit preceded by a space ( 5)
-
-        `j` : Day of the year - (1-366)
-
-        `w` : Same as 'u'
-
-      * Time:
-
-        `p` : AM or PM
-
-        `r` : Time in 12-hour format (09:15:36 AM)
-
-        `R` : Time in 24-hour format - no seconds (17:45)
-
-        `T` : Time in 24 hour format (17:45:52)
-
-        `X` : Same as 'T'
-
-        `Z` : Time zone offset from Universal Time Coordinate (UTC) (-07)
-
-      * Hour:
-
-        `H` :  Hour in 24-hour format (17)
-
-        `I` :   Hour in 12 hour format (05)
-
-        `k` :  Same as 'H'
-
-        `l` :   Same as 'I' (Upper-case I = Lower-case L)
-
-      * Minutes & Seconds:
-
-        `M` : Minutes (35)
-
-        `S` : Seconds (05)
-
-        `s` : Seconds elapsed since January 1, 1970 00:00:00 (1150451174.95705)
-
-      * Special Characters:
-
-        `n` : newline character (\n)
-
-        `t` : Tab character (\t)
-
+| Format specifier | Meaning | Example |
+| ---------------- | ------- | ------- |
+| A | Day of the week - full name | Monday |
+| a | Day of the week - abbreviated name | Mon |
+| B | Month name - full | January |
+| b | Month name - abbreviated | Jan |
+| C | Century | 20 for 2006 |
+| c | Date and time - abbreviated | Fri Jun 16 10:31:27 2006 |
+| D | Date in mm/dd/yy format | 06/14/06 |
+| d | Day of the month - 2 digits | 05 |
+| e | Day of the month - digit preceded by a space | \<space\>5 |
+| G | Same as 'Y' | |
+| g | Same as 'y' | |
+| H | Hour in 24-hour format | 17 |
+| h | Same as 'b' | |
+| I | Hour in 12 hour format | 05 |
+| j | Day of the year | 1-366 |
+| k | Same as 'H' | |
+| l | Same as 'I' (Upper-case I) | 05 |
+| M | Minutes | 35 |
+| m | Month number | 06 |
+| n | newline character | |
+| p | AM or PM | |
+| R | Time in 24-hour format -no seconds | 17:45 |
+| r | Time in 12-hour format | 09:15:36 AM |
+| S | Seconds | 05 |
+| s | Seconds elapsed since January 1, 1970 00:00:00 | 1150451174.95705 |
+| t | Horizontal tab character | |
+| T | Time in 24 hour format | 17:45:52 |
+| U | Same as 'W' | |
+| u | Day of the week - number | Monday = 1 |
+| V | Week of the year | 01-53 |
+| w | Same as 'u' | |
+| W | Week of the year | 00-52 |
+| X | Same as 'T' |
+| x | Date in standard format for locale | 09/12/07 for English-US |
+| Y | Year in 4-digit format | 2006 |
+| y | Year in 2-digit format | 06 |
+| Z | Time zone offset from Universal Time Coordinate (UTC) | -07 |
 
 ## Related Links
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Date.md
@@ -491,115 +491,47 @@ Otherwise, it returns a **DateTime** object.
 
   When you pipe a date to cmdlets that expect string input, such as the Add-Content cmdlet, Windows PowerShell converts the **DateTime** object to a string before adding it to the file. The default `ToString()` format is short date and long time. To specify an alternate format, use the `-Format` or `-UFormat` parameters of `Get-Date`.
 
-  * Uformat Values:
+* Here are the valid **UFormat** specifiers, each of which must be preceded by `%`, for example, `Get-Date -UFormat %Y%m%d`
 
-    The following are the values of the `-UFormat` parameter. The format for the command is:
-
-    `Get-Date -UFormat %\<value\>`
-
-    For example,
-
-    `Get-Date -UFormat %d`
-
-
-     * Date-Time:
-
-       Date and time - full
-
-       (default) : (Friday, June 16, 2006 10:31:27 AM)
-
-       `c` : Date and time - abbreviated (Fri Jun 16 10:31:27 2006)
-
-      * Date:
-
-        `D` : Date in mm/dd/yy format (06/14/06)
-
-        `x` : Date in standard format for locale (09/12/07 for English-US)
-
-      * Year:
-
-        `C` : Century (20 for 2006)
-
-        `Y` : Year in 4-digit format (2006)
-
-        `y` : Year in 2-digit format (06)
-
-        `G` : Same as 'Y'
-
-        `g` : Same as 'y'
-
-      * Month:
-
-        `b` : Month name - abbreviated (Jan)
-
-        `B` : Month name - full (January)
-
-        `h` : Same as 'b'
-
-        `m` : Month number (06)
-
-      * Week:
-
-        `W` : Week of the year (00-52)
-
-        `V` : Week of the year (01-53)
-
-        `U` : Same as 'W'
-
-      * Day:
-
-        `a` : Day of the week - abbreviated name (Mon)
-
-        `A` : Day of the week - full name (Monday)
-
-        `u` : Day of the week - number (Monday = 1)
-
-        `d` : Day of the month - 2 digits (05)
-
-        `e` : Day of the month - digit preceded by a space ( 5)
-
-        `j` : Day of the year - (1-366)
-
-        `w` : Same as 'u'
-
-      * Time:
-
-        `p` : AM or PM
-
-        `r` : Time in 12-hour format (09:15:36 AM)
-
-        `R` : Time in 24-hour format - no seconds (17:45)
-
-        `T` : Time in 24 hour format (17:45:52)
-
-        `X` : Same as 'T'
-
-        `Z` : Time zone offset from Universal Time Coordinate (UTC) (-07)
-
-      * Hour:
-
-        `H` :  Hour in 24-hour format (17)
-
-        `I` :   Hour in 12 hour format (05)
-
-        `k` :  Same as 'H'
-
-        `l` :   Same as 'I' (Upper-case I = Lower-case L)
-
-      * Minutes & Seconds:
-
-        `M` : Minutes (35)
-
-        `S` : Seconds (05)
-
-        `s` : Seconds elapsed since January 1, 1970 00:00:00 (1150451174.95705)
-
-      * Special Characters:
-
-        `n` : newline character (\n)
-
-        `t` : Tab character (\t)
-
+| Format specifier | Meaning | Example |
+| ---------------- | ------- | ------- |
+| A | Day of the week - full name | Monday |
+| a | Day of the week - abbreviated name | Mon |
+| B | Month name - full | January |
+| b | Month name - abbreviated | Jan |
+| C | Century | 20 for 2006 |
+| c | Date and time - abbreviated | Fri Jun 16 10:31:27 2006 |
+| D | Date in mm/dd/yy format | 06/14/06 |
+| d | Day of the month - 2 digits | 05 |
+| e | Day of the month - digit preceded by a space | \<space\>5 |
+| G | Same as 'Y' | |
+| g | Same as 'y' | |
+| H | Hour in 24-hour format | 17 |
+| h | Same as 'b' | |
+| I | Hour in 12 hour format | 05 |
+| j | Day of the year | 1-366 |
+| k | Same as 'H' | |
+| l | Same as 'I' (Upper-case I) | 05 |
+| M | Minutes | 35 |
+| m | Month number | 06 |
+| n | newline character | |
+| p | AM or PM | |
+| R | Time in 24-hour format -no seconds | 17:45 |
+| r | Time in 12-hour format | 09:15:36 AM |
+| S | Seconds | 05 |
+| s | Seconds elapsed since January 1, 1970 00:00:00 | 1150451174.95705 |
+| t | Horizontal tab character | |
+| T | Time in 24 hour format | 17:45:52 |
+| U | Same as 'W' | |
+| u | Day of the week - number | Monday = 1 |
+| V | Week of the year | 01-53 |
+| w | Same as 'u' | |
+| W | Week of the year | 00-52 |
+| X | Same as 'T' |
+| x | Date in standard format for locale | 09/12/07 for English-US |
+| Y | Year in 4-digit format | 2006 |
+| y | Year in 2-digit format | 06 |
+| Z | Time zone offset from Universal Time Coordinate (UTC) | -07 |
 
 ## Related Links
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -474,114 +474,47 @@ Otherwise, it returns a **DateTime** object.
 
   When you pipe a date to cmdlets that expect string input, such as the Add-Content cmdlet, Windows PowerShell converts the **DateTime** object to a string before adding it to the file. The default `ToString()` format is short date and long time. To specify an alternate format, use the `-Format` or `-UFormat` parameters of `Get-Date`.
 
-  * Uformat Values:
+* Here are the valid **UFormat** specifiers, each of which must be preceded by `%`, for example, `Get-Date -UFormat %Y%m%d`
 
-    The following are the values of the `-UFormat` parameter. The format for the command is:
-
-    `Get-Date -UFormat %\<value\>`
-
-    For example,
-
-    `Get-Date -UFormat %d`
-
-
-     * Date-Time:
-
-       Date and time - full
-
-       (default) : (Friday, June 16, 2006 10:31:27 AM)
-
-       `c` : Date and time - abbreviated (Fri Jun 16 10:31:27 2006)
-
-      * Date:
-
-        `D` : Date in mm/dd/yy format (06/14/06)
-
-        `x` : Date in standard format for locale (09/12/07 for English-US)
-
-      * Year:
-
-        `C` : Century (20 for 2006)
-
-        `Y` : Year in 4-digit format (2006)
-
-        `y` : Year in 2-digit format (06)
-
-        `G` : Same as 'Y'
-
-        `g` : Same as 'y'
-
-      * Month:
-
-        `b` : Month name - abbreviated (Jan)
-
-        `B` : Month name - full (January)
-
-        `h` : Same as 'b'
-
-        `m` : Month number (06)
-
-      * Week:
-
-        `W` : Week of the year (00-52)
-
-        `V` : Week of the year (01-53)
-
-        `U` : Same as 'W'
-
-      * Day:
-
-        `a` : Day of the week - abbreviated name (Mon)
-
-        `A` : Day of the week - full name (Monday)
-
-        `u` : Day of the week - number (Monday = 1)
-
-        `d` : Day of the month - 2 digits (05)
-
-        `e` : Day of the month - digit preceded by a space ( 5)
-
-        `j` : Day of the year - (1-366)
-
-        `w` : Same as 'u'
-
-      * Time:
-
-        `p` : AM or PM
-
-        `r` : Time in 12-hour format (09:15:36 AM)
-
-        `R` : Time in 24-hour format - no seconds (17:45)
-
-        `T` : Time in 24 hour format (17:45:52)
-
-        `X` : Same as 'T'
-
-        `Z` : Time zone offset from Universal Time Coordinate (UTC) (-07)
-
-      * Hour:
-
-        `H` :  Hour in 24-hour format (17)
-
-        `I` :   Hour in 12 hour format (05)
-
-        `k` :  Same as 'H'
-
-        `l` :   Same as 'I' (Upper-case I = Lower-case L)
-
-      * Minutes & Seconds:
-
-        `M` : Minutes (35)
-
-        `S` : Seconds (05)
-
-        `s` : Seconds elapsed since January 1, 1970 00:00:00 (1150451174.95705)
-
-      * Special Characters:
-
-        `n` : newline character (\n)
-
-        `t` : Tab character (\t)
+| Format specifier | Meaning | Example |
+| ---------------- | ------- | ------- |
+| A | Day of the week - full name | Monday |
+| a | Day of the week - abbreviated name | Mon |
+| B | Month name - full | January |
+| b | Month name - abbreviated | Jan |
+| C | Century | 20 for 2006 |
+| c | Date and time - abbreviated | Fri Jun 16 10:31:27 2006 |
+| D | Date in mm/dd/yy format | 06/14/06 |
+| d | Day of the month - 2 digits | 05 |
+| e | Day of the month - digit preceded by a space | \<space\>5 |
+| G | Same as 'Y' | |
+| g | Same as 'y' | |
+| H | Hour in 24-hour format | 17 |
+| h | Same as 'b' | |
+| I | Hour in 12 hour format | 05 |
+| j | Day of the year | 1-366 |
+| k | Same as 'H' | |
+| l | Same as 'I' (Upper-case I) | 05 |
+| M | Minutes | 35 |
+| m | Month number | 06 |
+| n | newline character | |
+| p | AM or PM | |
+| R | Time in 24-hour format -no seconds | 17:45 |
+| r | Time in 12-hour format | 09:15:36 AM |
+| S | Seconds | 05 |
+| s | Seconds elapsed since January 1, 1970 00:00:00 | 1150451174.95705 |
+| t | Horizontal tab character | |
+| T | Time in 24 hour format | 17:45:52 |
+| U | Same as 'W' | |
+| u | Day of the week - number | Monday = 1 |
+| V | Week of the year | 01-53 |
+| w | Same as 'u' | |
+| W | Week of the year | 00-52 |
+| X | Same as 'T' |
+| x | Date in standard format for locale | 09/12/07 for English-US |
+| Y | Year in 4-digit format | 2006 |
+| y | Year in 2-digit format | 06 |
+| Z | Time zone offset from Universal Time Coordinate (UTC) | -07 |
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Date.md
@@ -473,9 +473,6 @@ Accept wildcard characters: False
 
 ### -UFormat
 
-Displays the date and time in UNIX format.
-For a list of the format specifiers, see the Notes section.
-
 Displays the date and time in UNIX format. For a list of the format specifiers, see the Notes
 section.
 

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Date.md
@@ -539,116 +539,48 @@ Otherwise, it returns a **DateTime** object.
   `ToString()` format is short date and long time. To specify an alternate format, use the `-Format`
   or `-UFormat` parameters of `Get-Date`.
 
-  * Uformat Values:
+* Here are the valid **UFormat** specifiers, each of which must be preceded by `%`, for example, `Get-Date -UFormat %Y%m%d`
 
-    The following are the values of the `-UFormat` parameter. The format for the command is:
-
-    `Get-Date -UFormat %\<value\>`
-
-    For example,
-
-    `Get-Date -UFormat %d`
-
-    * Date-Time:
-
-      Date and time - full
-
-      (default) : (Friday, June 16, 2006 10:31:27 AM)
-
-      `c` : Date and time - abbreviated (Fri Jun 16 10:31:27 2006)
-
-      * Date:
-
-        `D` : Date in mm/dd/yy format (06/14/06)
-
-        `F` : Date in YYYY-mm-dd format (2006-06-14) Equivalent to %Y-%m-%d (the ISO 8601 date
-        format).
-
-        `x` : Date in standard format for locale (09/12/07 for English-US)
-
-      * Year:
-
-        `C` : Century (20 for 2006)
-
-        `Y` : Year in 4-digit format (2006)
-
-        `y` : Year in 2-digit format (06)
-
-        `G` : Same as 'Y'
-
-        `g` : Same as 'y'
-
-      * Month:
-
-        `b` : Month name - abbreviated (Jan)
-
-        `B` : Month name - full (January)
-
-        `h` : Same as 'b'
-
-        `m` : Month number (06)
-
-      * Week:
-
-        `W` : Week of the year (00-52)
-
-        `V` : Week of the year (01-53)
-
-        `U` : Same as 'W'
-
-      * Day:
-
-        `a` : Day of the week - abbreviated name (Mon)
-
-        `A` : Day of the week - full name (Monday)
-
-        `u` : Day of the week - number (Monday = 1)
-
-        `d` : Day of the month - 2 digits (05)
-
-        `e` : Day of the month - digit preceded by a space ( 5)
-
-        `j` : Day of the year - (1-366)
-
-        `w` : Same as 'u'
-
-      * Time:
-
-        `p` : AM or PM
-
-        `r` : Time in 12-hour format (09:15:36 AM)
-
-        `R` : Time in 24-hour format - no seconds (17:45)
-
-        `T` : Time in 24 hour format (17:45:52)
-
-        `X` : Same as 'T'
-
-        `Z` : Time zone offset from Universal Time Coordinate (UTC) (-07)
-
-      * Hour:
-
-        `H` :  Hour in 24-hour format (17)
-
-        `I` :   Hour in 12 hour format (05)
-
-        `k` :  Same as 'H'
-
-        `l` :   Same as 'I' (Upper-case I = Lower-case L)
-
-      * Minutes & Seconds:
-
-        `M` : Minutes (35)
-
-        `S` : Seconds (05)
-
-        `s` : Seconds elapsed since January 1, 1970 00:00:00 (1150451174.95705)
-
-      * Special Characters:
-
-        `n` : newline character (\n)
-
-        `t` : Tab character (\t)
+| Format specifier | Meaning | Example |
+| ---------------- | ------- | ------- |
+| A | Day of the week - full name | Monday |
+| a | Day of the week - abbreviated name | Mon |
+| B | Month name - full | January |
+| b | Month name - abbreviated | Jan |
+| C | Century | 20 for 2006 |
+| c | Date and time - abbreviated | Fri Jun 16 10:31:27 2006 |
+| D | Date in mm/dd/yy format | 06/14/06 |
+| d | Day of the month - 2 digits | 05 |
+| e | Day of the month - digit preceded by a space | \<space\>5 |
+| F | Date in YYYY-mm-dd format, equivalent to %Y-%m-%d (the ISO 8601 date format) | 2006-06-14 |
+| G | Same as 'Y' | |
+| g | Same as 'y' | |
+| H | Hour in 24-hour format | 17 |
+| h | Same as 'b' | |
+| I | Hour in 12 hour format | 05 |
+| j | Day of the year | 1-366 |
+| k | Same as 'H' | |
+| l | Same as 'I' (Upper-case I) | 05 |
+| M | Minutes | 35 |
+| m | Month number | 06 |
+| n | newline character | |
+| p | AM or PM | |
+| R | Time in 24-hour format -no seconds | 17:45 |
+| r | Time in 12-hour format | 09:15:36 AM |
+| S | Seconds | 05 |
+| s | Seconds elapsed since January 1, 1970 00:00:00 | 1150451174.95705 |
+| t | Horizontal tab character | |
+| T | Time in 24 hour format | 17:45:52 |
+| U | Same as 'W' | |
+| u | Day of the week - number | Monday = 1 |
+| V | Week of the year | 01-53 |
+| w | Same as 'u' | |
+| W | Week of the year | 00-52 |
+| X | Same as 'T' |
+| x | Date in standard format for locale | 09/12/07 for English-US |
+| Y | Year in 4-digit format | 2006 |
+| y | Year in 2-digit format | 06 |
+| Z | Time zone offset from Universal Time Coordinate (UTC) | -07 |
 
 ## RELATED LINKS
 


### PR DESCRIPTION
The table is derived from the [Windows PowerShell Language Specification Version 3.0](https://www.microsoft.com/en-us/download/details.aspx?id=36389).

It seems appropriate that the table should be in the UFormat parameters section, not in the NOTES as a list.

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
