### PR TITLE
Replace example with working one

### DIFF
--- a/developer/hosting/windows-powershell-host-quickstart.md
+++ b/developer/hosting/windows-powershell-host-quickstart.md
@@ -73,9 +73,9 @@ You can also add a dictionary of parameter names and values by calling the [Syst
 
 ```csharp
 IDictionary parameters = new Dictionary<String, String>();
-parameters.Add("Name", "PowerShell");
+parameters.Add("Path", @"c:\Windows");
+parameters.Add("Filter", "*.exe");
 
-parameters.Add("Id", "12768");
 PowerShell.Create().AddCommand("Get-Process")
    .AddParameters(parameters)
       .Invoke()

--- a/developer/hosting/windows-powershell-host-quickstart.md
+++ b/developer/hosting/windows-powershell-host-quickstart.md
@@ -62,10 +62,10 @@ PowerShell.Create().AddCommand("Get-Process")
 
 You can add additional parameters by calling the AddParameter method repeatedly.
 
-```csharp
-PowerShell.Create().AddCommand("Get-Process")
-                   .AddParameter("Name", "PowerShell")
-                   .AddParameter("Id", "12768")
+```csharp                   
+PowerShell.Create().AddCommand("Get-ChildItem")
+                   .AddParameter("Path", @"c:\Windows")
+                   .AddParameter("Filter", "*.exe")
                    .Invoke();
 ```
 


### PR DESCRIPTION
The following example passes both the `Name` and `Id` parameters to `Get-Process`:

```
                PowerShell.Create().AddCommand("Get-Process")
                   .AddParameter("Name", "PowerShell")
                   .AddParameter("Id", "12768")
                   .Invoke();
```

However, both of those parameters do not appear to be supported simultaneously.

I've replaced the example with the following one:

```
                PowerShell.Create().AddCommand("Get-ChildItem")
                    .AddParameter("Path", @"c:\Windows")
                    .AddParameter("Filter", "*.exe")
                    .Invoke();
```

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
