### PR TITLE
Fix $OutputEncoding default value v6

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -43,7 +43,7 @@ Variable                      = Default Value
 - \$MaximumHistoryCount          = 4096
 - \$MaximumVariableCount         = 4096
 - \$OFS                          = (Space character (" "))
-- \$OutputEncoding               = ASCIIEncoding object
+- \$OutputEncoding               = UTF8Encoding object
 - \$ProgressPreference           = Continue
 - \$PSDefaultParameterValues     = (None - empty hash table)
 - \$PSEmailServer                = (None)
@@ -922,7 +922,7 @@ Valid values: Objects derived from an Encoding class, such as ASCIIEncoding,
 SBCSCodePageEncoding, UTF7Encoding, UTF8Encoding, UTF32Encoding, and
 UnicodeEncoding.
 
-Default: ASCIIEncoding object (System.Text.ASCIIEncoding)
+Default: UTF8Encoding object (System.Text.UTF8Encoding)
 
 ##### EXAMPLES
 


### PR DESCRIPTION
ASCIIEncoding -> UTF8Encoding since v6

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
