### PR TITLE
Clarify automatic variable usage in Microsoft.PowerShell.Core\Start-Job -ScriptBlock

### DIFF
--- a/reference/4.0/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Start-Job.md
@@ -167,6 +167,17 @@ This command starts a job that collects a large amount of data and saves it in a
 The command uses the InitializationScript parameter to run a script block that imports a required module.
 It also uses the RunAs32 parameter to run the job in a 32-bit process even if the computer has a 64-bit operating system.
 
+### Example 7: Pass input to a background job
+
+```
+PS C:\> Start-Job -ScriptBlock {Write-Output $Input} -InputObject 'Hello, world!'
+```
+
+This command starts a job that simply accesses and outputs its input.
+The command uses the *InputObject* parameter to pass input to the job.
+Input to a job is accessed via the $Input automatic variable.
+The $_ automatic variable (alias $PSItem) is not populated.
+
 ## PARAMETERS
 
 ### -ArgumentList

--- a/reference/4.0/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Start-Job.md
@@ -409,6 +409,7 @@ Accept wildcard characters: False
 ### -ScriptBlock
 Specifies the commands to run in the background job.
 Enclose the commands in braces ( { } ) to create a script block.
+Use the $Input automatic variable to access the value of the *InputObject* parameter.
 This parameter is required.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Start-Job.md
@@ -438,6 +438,7 @@ Accept wildcard characters: False
 ### -ScriptBlock
 Specifies the commands to run in the background job.
 Enclose the commands in braces ( { } ) to create a script block.
+Use the $Input automatic variable to access the value of the *InputObject* parameter.
 This parameter is required.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Start-Job.md
@@ -186,6 +186,17 @@ This command starts a job that collects lots of data, and then saves it in a .ti
 The command uses the *InitializationScript* parameter to run a script block that imports a required module.
 It also uses the *RunAs32* parameter to run the job in a 32-bit process even if the computer has a 64-bit operating system.
 
+### Example 7: Pass input to a background job
+
+```
+PS C:\> Start-Job -ScriptBlock {Write-Output $Input} -InputObject 'Hello, world!'
+```
+
+This command starts a job that simply accesses and outputs its input.
+The command uses the *InputObject* parameter to pass input to the job.
+Input to a job is accessed via the $Input automatic variable.
+The $_ automatic variable (alias $PSItem) is not populated.
+
 ## PARAMETERS
 
 ### -ArgumentList

--- a/reference/5.1/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Start-Job.md
@@ -419,6 +419,7 @@ Accept wildcard characters: False
 ### -ScriptBlock
 Specifies the commands to run in the background job.
 Enclose the commands in braces ( { } ) to create a script block.
+Use the $Input automatic variable to access the value of the *InputObject* parameter.
 This parameter is required.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Start-Job.md
@@ -167,6 +167,17 @@ This command starts a job that collects lots of data, and then saves it in a .ti
 The command uses the *InitializationScript* parameter to run a script block that imports a required module.
 It also uses the *RunAs32* parameter to run the job in a 32-bit process even if the computer has a 64-bit operating system.
 
+### Example 7: Pass input to a background job
+
+```
+PS C:\> Start-Job -ScriptBlock {Write-Output $Input} -InputObject 'Hello, world!'
+```
+
+This command starts a job that simply accesses and outputs its input.
+The command uses the *InputObject* parameter to pass input to the job.
+Input to a job is accessed via the $Input automatic variable.
+The $_ automatic variable (alias $PSItem) is not populated.
+
 ## PARAMETERS
 
 ### -ArgumentList

--- a/reference/6/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Start-Job.md
@@ -455,6 +455,7 @@ Accept wildcard characters: False
 
 Specifies the commands to run in the background job.
 Enclose the commands in braces ( { } ) to create a script block.
+Use the $Input automatic variable to access the value of the *InputObject* parameter.
 This parameter is required.
 
 ```yaml

--- a/reference/6/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Start-Job.md
@@ -190,6 +190,17 @@ This command starts a job that collects lots of data, and then saves it in a .ti
 The command uses the *InitializationScript* parameter to run a script block that imports a required module.
 It also uses the *RunAs32* parameter to run the job in a 32-bit process even if the computer has a 64-bit operating system.
 
+### Example 7: Pass input to a background job
+
+```
+PS C:\> Start-Job -ScriptBlock {Write-Output $Input} -InputObject 'Hello, world!'
+```
+
+This command starts a job that simply accesses and outputs its input.
+The command uses the *InputObject* parameter to pass input to the job.
+Input to a job is accessed via the $Input automatic variable.
+The $_ automatic variable (alias $PSItem) is not populated.
+
 ## PARAMETERS
 
 ### -ArgumentList


### PR DESCRIPTION
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 4.0 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue # tracks the remaining work