### PR TITLE
Fixing Dead Link

### DIFF
--- a/developer/cmdlet/validatelength-attribute-declaration.md
+++ b/developer/cmdlet/validatelength-attribute-declaration.md
@@ -33,7 +33,7 @@ Required. Specifies the maximum number of characters allowed.
 
 ## Remarks
 
-- For more information about how to declare this attribute, see [How to Declare Input Validation Rules](https://docs.microsoft.com/en-us/powershell/developer/cmdlet/how-to-validate-parameter-input).
+- For more information about how to declare this attribute, see [How to Declare Input Validation Rules](./how-to-validate-parameter-input.md).
 
 - When this attribute is not used, the corresponding parameter argument can be of any length.
 

--- a/developer/cmdlet/validatelength-attribute-declaration.md
+++ b/developer/cmdlet/validatelength-attribute-declaration.md
@@ -33,7 +33,7 @@ Required. Specifies the maximum number of characters allowed.
 
 ## Remarks
 
-- For more information about how to declare this attribute, see [How to Declare Input Validation Rules](http://msdn.microsoft.com/en-us/544c2100-62ba-4be4-b2a2-cc0d4e4fc45b).
+- For more information about how to declare this attribute, see [How to Declare Input Validation Rules](https://docs.microsoft.com/en-us/powershell/developer/cmdlet/how-to-validate-parameter-input).
 
 - When this attribute is not used, the corresponding parameter argument can be of any length.
 


### PR DESCRIPTION
The link *How to Declare Input Validation Rules* under Remarks, bullet point #1 was pointing to a dead link. I have modified it to point to the most relevant reference page I could find on that topic.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document
- [X] This document appears not to be versioned?
<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
- [X] This document does not appear to be versioned; if this is not the case, please briefly let me know how to access the different versions and I will be happy to update them all :)
