### PR TITLE
Change 6.next to 7 for issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,7 @@ Issue Details
 
 Version(s) of document impacted
 ------------------------------
-- [ ] Impacts 6.next document
+- [ ] Impacts 7 document
 - [ ] Impacts 6 document
 - [ ] Impacts 5.1 document
 - [ ] Impacts 5.0 document


### PR DESCRIPTION
The template version list should be updated to reflect the fact that there will be no 6.x releases, and the next version of PowerShell is the 7.0 release.