### PR TITLE
Replace 6.x version with 7

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ If this doc issue is for content UNDER /reference folder, please fill out this t
 -->
 Version(s) of document impacted
 ------------------------------
-- [ ] Impacts 6.next document
+- [ ] Impacts 7 document
 - [ ] Impacts 6 document
 - [ ] Impacts 5.1 document
 - [ ] Impacts 5.0 document


### PR DESCRIPTION
The template version list should be updated to reflect the fact that there will be no 6.x releases, and the next version of PowerShell is the 7.0 release.