### PR TITLE
Migration from MSDN missed a spot

### DIFF
--- a/developer/installing-the-windows-powershell-sdk.md
+++ b/developer/installing-the-windows-powershell-sdk.md
@@ -2,6 +2,7 @@
 title: Installing the Windows PowerShell SDK
 ms.date: 09/13/2016
 ms.topic: "article"
+ms.assetid: c3636b45-61aa-4720-85f0-58312c4fc8f9
 ---
 # Installing the Windows PowerShell SDK
 

--- a/developer/installing-the-windows-powershell-sdk.md
+++ b/developer/installing-the-windows-powershell-sdk.md
@@ -2,7 +2,6 @@
 title: Installing the Windows PowerShell SDK
 ms.date: 09/13/2016
 ms.topic: "article"
-ms.assetid: c3636b45-61aa-4720-85f0-58312c4fc8f9
 ---
 # Installing the Windows PowerShell SDK
 

--- a/developer/windows-powershell.md
+++ b/developer/windows-powershell.md
@@ -21,7 +21,7 @@ Windows PowerShell .
 
 ## Windows PowerShell Documents on MSDN
 
-- [Installing the Windows PowerShell SDK](https://msdn.microsoft.com/en-us/library/ff458115.aspx)
+- [Installing the Windows PowerShell SDK](./installing-the-windows-powershell-sdk.md)
 Provides information about how to install the Windows PowerShell SDK.
 
 - [Writing a Windows PowerShell Module](./module/writing-a-windows-powershell-module.md)


### PR DESCRIPTION
Specifically, there's a link to "Installing the Windows PowerShell SDK" that still points to MSDN instead of the local article.  Lets fix that.