### PR TITLE
Fix #4105 - explain wildcard execution (globbing)

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -18,7 +18,7 @@ within a session can be hidden or replaced by commands with the same
 name. This article shows you how to run hidden commands and how to avoid
 command-name conflicts.
 
-## Command precedence
+## Command path precedence
 
 When a PowerShell session includes more than one command that has the
 same name, PowerShell determines which command to run by using the
@@ -48,8 +48,63 @@ following rules.
   .\FindDocs.ps1
   ```
 
-- If you do not specify a path, PowerShell uses the following precedence order
-  when it runs commands:
+### Using wildcards in execution
+
+You may use wildcards in command execution. Using wildcard characters is
+also known as *globbing*.
+
+PowerShell will execute a file that has a wildcard match, before a literal
+match.
+
+For example, consider a directory with the following files:
+
+```
+PS C:\temp\test> Get-ChildItem
+
+
+    Directory: C:\temp\test
+
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----        5/20/2019   2:29 PM             28 a.ps1
+-a----        5/20/2019   2:29 PM             28 [a1].ps1
+```
+
+Both script files have the same content: `$MyInvocation.MyCommand.Path`.
+This command displays the name of the script that is invoked.
+
+When you run `[a1].ps1`, the file `a.ps1` is executed even though the file
+`[a1].ps1` is a literal match.
+
+```powershell
+C:\temp\test\[a1].ps1
+```
+
+```Output
+C:\temp\test\a.ps1
+```
+
+Now lets delete the `a.ps1` file and attempt to run it again.
+
+```powershell
+Remove-Item a.ps1
+C:\temp\test\[a1].ps1
+```
+
+```Output
+C:\temp\test\[a1].ps1
+```
+
+You can see from the output that `[a1].ps1` runs this time because the literal
+match is the only file match for that wildcard pattern.
+
+For more information about how PowerShell uses wildcards, see [about_Wildcards](about_Wildcards.md).
+
+## Command precedence
+
+If you do not specify a path, PowerShell uses the following precedence order
+when it runs commands:
 
   1. Alias
   2. Function

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -100,7 +100,7 @@ For more information about how PowerShell uses wildcards, see [about_Wildcards](
 
 > [!NOTE]
 > To limit the search to a relative path, you must prefix the script name with
-> the relative folder name. This limits the search for commands to files in
+> the `.\`. This limits the search for commands to files in
 > that folder. Without this prefix, other PowerShell syntax may conflict and
 > there are few guarantees that the file will be found.
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -100,9 +100,9 @@ For more information about how PowerShell uses wildcards, see [about_Wildcards](
 
 > [!NOTE]
 > To limit the search to a relative path, you must prefix the script name with
-> the `.\`. This limits the search for commands to files in
-> that folder. Without this prefix, other PowerShell syntax may conflict and
-> there are few guarantees that the file will be found.
+> the `.\` path. This limits the search for commands to files in that relative
+> path. Without this prefix, other PowerShell syntax may conflict and there are
+> few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands:

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -7,7 +7,6 @@ title:  about_Command_Precedence
 # About Command Precedence
 
 ## Short description
-
 Describes how PowerShell determines which command to run.
 
 ## Long description
@@ -18,7 +17,7 @@ within a session can be hidden or replaced by commands with the same
 name. This article shows you how to run hidden commands and how to avoid
 command-name conflicts.
 
-## Command path precedence
+## Command precedence
 
 When a PowerShell session includes more than one command that has the
 same name, PowerShell determines which command to run by using the
@@ -40,7 +39,7 @@ following rules.
   path to the script file.
 
   To run a script that is in the current directory, specify the full path, or
-  type a dot `.` to represent the current directory.
+  type a dot `.\` to represent the current directory.
 
   For example, to run the FindDocs.ps1 file in the current directory, type:
 
@@ -59,7 +58,7 @@ match.
 For example, consider a directory with the following files:
 
 ```
-PS C:\temp\test> Get-ChildItem
+Get-ChildItem C:\temp\test
 
 
     Directory: C:\temp\test
@@ -88,7 +87,7 @@ C:\temp\test\a.ps1
 Now lets delete the `a.ps1` file and attempt to run it again.
 
 ```powershell
-Remove-Item a.ps1
+Remove-Item C:\temp\test\a.ps1
 C:\temp\test\[a1].ps1
 ```
 
@@ -101,7 +100,11 @@ match is the only file match for that wildcard pattern.
 
 For more information about how PowerShell uses wildcards, see [about_Wildcards](about_Wildcards.md).
 
-## Command precedence
+> [!NOTE]
+> To limit the search to a relative path, you must prefix the script name with
+> the relative folder name. This limits the search for commands to files in
+> that folder. Without this prefix, other PowerShell syntax may conflict and
+> there are few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands:

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  08/28/2018
+ms.date:  05/20/2019
 schema:  2.0.0
 keywords:  powershell,cmdlet
 title:  about_Command_Precedence
@@ -19,41 +19,39 @@ command-name conflicts.
 
 ## Command precedence
 
-When a PowerShell session includes more than one command that has the
-same name, PowerShell determines which command to run by using the
-following rules.
+When a PowerShell session includes more than one command that has the same
+name, PowerShell determines which command to run by using the following rules.
 
-- If you specify the path to a command, PowerShell runs the command at the
-  location specified by the path.
+If you specify the path to a command, PowerShell runs the command at the
+location specified by the path.
 
-  For example, the following command runs the FindDocs.ps1 script in the
-  "C:\\TechDocs" directory:
+For example, the following command runs the FindDocs.ps1 script in the
+"C:\\TechDocs" directory:
 
-  ```
-  C:\TechDocs\FindDocs.ps1
-  ```
+```
+C:\TechDocs\FindDocs.ps1
+```
 
-  As a security feature, PowerShell does not run executable (native) commands,
-  including PowerShell scripts, unless the command is located in a path that is
-  listed in the Path environment variable `$env:path` or unless you specify the
-  path to the script file.
+As a security feature, PowerShell does not run executable (native) commands,
+including PowerShell scripts, unless the command is located in a path that is
+listed in the Path environment variable `$env:path` or unless you specify the
+path to the script file.
 
-  To run a script that is in the current directory, specify the full path, or
-  type a dot `.\` to represent the current directory.
+To run a script that is in the current directory, specify the full path, or
+type a dot `.\` to represent the current directory.
 
-  For example, to run the FindDocs.ps1 file in the current directory, type:
+For example, to run the FindDocs.ps1 file in the current directory, type:
 
-  ```
-  .\FindDocs.ps1
-  ```
+```
+.\FindDocs.ps1
+```
 
 ### Using wildcards in execution
 
 You may use wildcards in command execution. Using wildcard characters is
 also known as *globbing*.
 
-PowerShell will execute a file that has a wildcard match, before a literal
-match.
+PowerShell executes a file that has a wildcard match, before a literal match.
 
 For example, consider a directory with the following files:
 
@@ -84,7 +82,7 @@ C:\temp\test\[a1].ps1
 C:\temp\test\a.ps1
 ```
 
-Now lets delete the `a.ps1` file and attempt to run it again.
+Now let's delete the `a.ps1` file and attempt to run it again.
 
 ```powershell
 Remove-Item C:\temp\test\a.ps1
@@ -114,18 +112,18 @@ when it runs commands:
   3. Cmdlet
   4. Native Windows commands
 
-  Therefore, if you type "help", PowerShell first looks for an alias named
-  `help`, then a function named `Help`, and finally a cmdlet named `Help`. It
-  runs the first `help` item that it finds.
+Therefore, if you type "help", PowerShell first looks for an alias named
+`help`, then a function named `Help`, and finally a cmdlet named `Help`. It
+runs the first `help` item that it finds.
 
-  For example, if your session contains a cmdlet and a function, both named
-  `Get-Map`, when you type `Get-Map`, PowerShell runs the function.
+For example, if your session contains a cmdlet and a function, both named
+`Get-Map`, when you type `Get-Map`, PowerShell runs the function.
 
-  When the session contains items of the same type that have the same name,
-  PowerShell runs the newer item.
+When the session contains items of the same type that have the same name,
+PowerShell runs the newer item.
 
-  For example, if you import another `Get-Date` cmdlet from a module, when you
-  type `Get-Date`, PowerShell runs the imported version over the native one.
+For example, if you import another `Get-Date` cmdlet from a module, when you
+type `Get-Date`, PowerShell runs the imported version over the native one.
 
 ## Hidden and replaced items
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -17,7 +17,7 @@ within a session can be hidden or replaced by commands with the same
 name. This article shows you how to run hidden commands and how to avoid
 command-name conflicts.
 
-## Command path precedence
+## Command precedence
 
 When a PowerShell session includes more than one command that has the
 same name, PowerShell determines which command to run by using the
@@ -39,7 +39,7 @@ following rules.
   path to the script file.
 
   To run a script that is in the current directory, specify the full path, or
-  type a dot `.` to represent the current directory.
+  type a dot `.\` to represent the current directory.
 
   For example, to run the FindDocs.ps1 file in the current directory, type:
 
@@ -58,7 +58,7 @@ match.
 For example, consider a directory with the following files:
 
 ```
-PS C:\temp\test> Get-ChildItem
+Get-ChildItem C:\temp\test
 
 
     Directory: C:\temp\test
@@ -87,7 +87,7 @@ C:\temp\test\a.ps1
 Now lets delete the `a.ps1` file and attempt to run it again.
 
 ```powershell
-Remove-Item a.ps1
+Remove-Item C:\temp\test\a.ps1
 C:\temp\test\[a1].ps1
 ```
 
@@ -100,7 +100,11 @@ match is the only file match for that wildcard pattern.
 
 For more information about how PowerShell uses wildcards, see [about_Wildcards](about_Wildcards.md).
 
-## Command precedence
+> [!NOTE]
+> To limit the search to a relative path, you must prefix the script name with
+> the relative folder name. This limits the search for commands to files in
+> that folder. Without this prefix, other PowerShell syntax may conflict and
+> there are few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands:

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -100,9 +100,9 @@ For more information about how PowerShell uses wildcards, see [about_Wildcards](
 
 > [!NOTE]
 > To limit the search to a relative path, you must prefix the script name with
-> the relative folder name. This limits the search for commands to files in
-> that folder. Without this prefix, other PowerShell syntax may conflict and
-> there are few guarantees that the file will be found.
+> the `.\` path. This limits the search for commands to files in that relative
+> path. Without this prefix, other PowerShell syntax may conflict and there are
+> few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands:

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -7,7 +7,6 @@ title:  about_Command_Precedence
 # About Command Precedence
 
 ## Short description
-
 Describes how PowerShell determines which command to run.
 
 ## Long description
@@ -18,7 +17,7 @@ within a session can be hidden or replaced by commands with the same
 name. This article shows you how to run hidden commands and how to avoid
 command-name conflicts.
 
-## Command precedence
+## Command path precedence
 
 When a PowerShell session includes more than one command that has the
 same name, PowerShell determines which command to run by using the
@@ -48,8 +47,63 @@ following rules.
   .\FindDocs.ps1
   ```
 
-- If you do not specify a path, PowerShell uses the following precedence order
-  when it runs commands:
+### Using wildcards in execution
+
+You may use wildcards in command execution. Using wildcard characters is
+also known as *globbing*.
+
+PowerShell will execute a file that has a wildcard match, before a literal
+match.
+
+For example, consider a directory with the following files:
+
+```
+PS C:\temp\test> Get-ChildItem
+
+
+    Directory: C:\temp\test
+
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----        5/20/2019   2:29 PM             28 a.ps1
+-a----        5/20/2019   2:29 PM             28 [a1].ps1
+```
+
+Both script files have the same content: `$MyInvocation.MyCommand.Path`.
+This command displays the name of the script that is invoked.
+
+When you run `[a1].ps1`, the file `a.ps1` is executed even though the file
+`[a1].ps1` is a literal match.
+
+```powershell
+C:\temp\test\[a1].ps1
+```
+
+```Output
+C:\temp\test\a.ps1
+```
+
+Now lets delete the `a.ps1` file and attempt to run it again.
+
+```powershell
+Remove-Item a.ps1
+C:\temp\test\[a1].ps1
+```
+
+```Output
+C:\temp\test\[a1].ps1
+```
+
+You can see from the output that `[a1].ps1` runs this time because the literal
+match is the only file match for that wildcard pattern.
+
+For more information about how PowerShell uses wildcards, see [about_Wildcards](about_Wildcards.md).
+
+## Command precedence
+
+If you do not specify a path, PowerShell uses the following precedence order
+when it runs commands:
 
   1. Alias
   2. Function

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  08/28/2018
+ms.date:  05/20/2019
 schema:  2.0.0
 keywords:  powershell,cmdlet
 title:  about_Command_Precedence
@@ -19,41 +19,39 @@ command-name conflicts.
 
 ## Command precedence
 
-When a PowerShell session includes more than one command that has the
-same name, PowerShell determines which command to run by using the
-following rules.
+When a PowerShell session includes more than one command that has the same
+name, PowerShell determines which command to run by using the following rules.
 
-- If you specify the path to a command, PowerShell runs the command at the
-  location specified by the path.
+If you specify the path to a command, PowerShell runs the command at the
+location specified by the path.
 
-  For example, the following command runs the FindDocs.ps1 script in the
-  "C:\\TechDocs" directory:
+For example, the following command runs the FindDocs.ps1 script in the
+"C:\\TechDocs" directory:
 
-  ```
-  C:\TechDocs\FindDocs.ps1
-  ```
+```
+C:\TechDocs\FindDocs.ps1
+```
 
-  As a security feature, PowerShell does not run executable (native) commands,
-  including PowerShell scripts, unless the command is located in a path that is
-  listed in the Path environment variable `$env:path` or unless you specify the
-  path to the script file.
+As a security feature, PowerShell does not run executable (native) commands,
+including PowerShell scripts, unless the command is located in a path that is
+listed in the Path environment variable `$env:path` or unless you specify the
+path to the script file.
 
-  To run a script that is in the current directory, specify the full path, or
-  type a dot `.\` to represent the current directory.
+To run a script that is in the current directory, specify the full path, or
+type a dot `.\` to represent the current directory.
 
-  For example, to run the FindDocs.ps1 file in the current directory, type:
+For example, to run the FindDocs.ps1 file in the current directory, type:
 
-  ```
-  .\FindDocs.ps1
-  ```
+```
+.\FindDocs.ps1
+```
 
 ### Using wildcards in execution
 
 You may use wildcards in command execution. Using wildcard characters is
 also known as *globbing*.
 
-PowerShell will execute a file that has a wildcard match, before a literal
-match.
+PowerShell executes a file that has a wildcard match, before a literal match.
 
 For example, consider a directory with the following files:
 
@@ -84,7 +82,7 @@ C:\temp\test\[a1].ps1
 C:\temp\test\a.ps1
 ```
 
-Now lets delete the `a.ps1` file and attempt to run it again.
+Now let's delete the `a.ps1` file and attempt to run it again.
 
 ```powershell
 Remove-Item C:\temp\test\a.ps1
@@ -114,18 +112,18 @@ when it runs commands:
   3. Cmdlet
   4. Native Windows commands
 
-  Therefore, if you type "help", PowerShell first looks for an alias named
-  `help`, then a function named `Help`, and finally a cmdlet named `Help`. It
-  runs the first `help` item that it finds.
+Therefore, if you type "help", PowerShell first looks for an alias named
+`help`, then a function named `Help`, and finally a cmdlet named `Help`. It
+runs the first `help` item that it finds.
 
-  For example, if your session contains a cmdlet and a function, both named
-  `Get-Map`, when you type `Get-Map`, PowerShell runs the function.
+For example, if your session contains a cmdlet and a function, both named
+`Get-Map`, when you type `Get-Map`, PowerShell runs the function.
 
-  When the session contains items of the same type that have the same name,
-  PowerShell runs the newer item.
+When the session contains items of the same type that have the same name,
+PowerShell runs the newer item.
 
-  For example, if you import another `Get-Date` cmdlet from a module, when you
-  type `Get-Date`, PowerShell runs the imported version over the native one.
+For example, if you import another `Get-Date` cmdlet from a module, when you
+type `Get-Date`, PowerShell runs the imported version over the native one.
 
 ## Hidden and replaced items
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -17,7 +17,7 @@ within a session can be hidden or replaced by commands with the same
 name. This article shows you how to run hidden commands and how to avoid
 command-name conflicts.
 
-## Command path precedence
+## Command precedence
 
 When a PowerShell session includes more than one command that has the
 same name, PowerShell determines which command to run by using the
@@ -39,7 +39,7 @@ following rules.
   path to the script file.
 
   To run a script that is in the current directory, specify the full path, or
-  type a dot `.` to represent the current directory.
+  type a dot `.\` to represent the current directory.
 
   For example, to run the FindDocs.ps1 file in the current directory, type:
 
@@ -58,7 +58,7 @@ match.
 For example, consider a directory with the following files:
 
 ```
-PS C:\temp\test> Get-ChildItem
+Get-ChildItem C:\temp\test
 
 
     Directory: C:\temp\test
@@ -87,7 +87,7 @@ C:\temp\test\a.ps1
 Now lets delete the `a.ps1` file and attempt to run it again.
 
 ```powershell
-Remove-Item a.ps1
+Remove-Item C:\temp\test\a.ps1
 C:\temp\test\[a1].ps1
 ```
 
@@ -100,7 +100,11 @@ match is the only file match for that wildcard pattern.
 
 For more information about how PowerShell uses wildcards, see [about_Wildcards](about_Wildcards.md).
 
-## Command precedence
+> [!NOTE]
+> To limit the search to a relative path, you must prefix the script name with
+> the relative folder name. This limits the search for commands to files in
+> that folder. Without this prefix, other PowerShell syntax may conflict and
+> there are few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands:

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -100,9 +100,9 @@ For more information about how PowerShell uses wildcards, see [about_Wildcards](
 
 > [!NOTE]
 > To limit the search to a relative path, you must prefix the script name with
-> the relative folder name. This limits the search for commands to files in
-> that folder. Without this prefix, other PowerShell syntax may conflict and
-> there are few guarantees that the file will be found.
+> the `.\` path. This limits the search for commands to files in that relative
+> path. Without this prefix, other PowerShell syntax may conflict and there are
+> few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands:

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -7,7 +7,6 @@ title:  about_Command_Precedence
 # About Command Precedence
 
 ## Short description
-
 Describes how PowerShell determines which command to run.
 
 ## Long description
@@ -18,7 +17,7 @@ within a session can be hidden or replaced by commands with the same
 name. This article shows you how to run hidden commands and how to avoid
 command-name conflicts.
 
-## Command precedence
+## Command path precedence
 
 When a PowerShell session includes more than one command that has the
 same name, PowerShell determines which command to run by using the
@@ -48,8 +47,63 @@ following rules.
   .\FindDocs.ps1
   ```
 
-- If you do not specify a path, PowerShell uses the following precedence order
-  when it runs commands:
+### Using wildcards in execution
+
+You may use wildcards in command execution. Using wildcard characters is
+also known as *globbing*.
+
+PowerShell will execute a file that has a wildcard match, before a literal
+match.
+
+For example, consider a directory with the following files:
+
+```
+PS C:\temp\test> Get-ChildItem
+
+
+    Directory: C:\temp\test
+
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----        5/20/2019   2:29 PM             28 a.ps1
+-a----        5/20/2019   2:29 PM             28 [a1].ps1
+```
+
+Both script files have the same content: `$MyInvocation.MyCommand.Path`.
+This command displays the name of the script that is invoked.
+
+When you run `[a1].ps1`, the file `a.ps1` is executed even though the file
+`[a1].ps1` is a literal match.
+
+```powershell
+C:\temp\test\[a1].ps1
+```
+
+```Output
+C:\temp\test\a.ps1
+```
+
+Now lets delete the `a.ps1` file and attempt to run it again.
+
+```powershell
+Remove-Item a.ps1
+C:\temp\test\[a1].ps1
+```
+
+```Output
+C:\temp\test\[a1].ps1
+```
+
+You can see from the output that `[a1].ps1` runs this time because the literal
+match is the only file match for that wildcard pattern.
+
+For more information about how PowerShell uses wildcards, see [about_Wildcards](about_Wildcards.md).
+
+## Command precedence
+
+If you do not specify a path, PowerShell uses the following precedence order
+when it runs commands:
 
   1. Alias
   2. Function

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  08/28/2018
+ms.date:  05/20/2019
 schema:  2.0.0
 keywords:  powershell,cmdlet
 title:  about_Command_Precedence
@@ -19,41 +19,39 @@ command-name conflicts.
 
 ## Command precedence
 
-When a PowerShell session includes more than one command that has the
-same name, PowerShell determines which command to run by using the
-following rules.
+When a PowerShell session includes more than one command that has the same
+name, PowerShell determines which command to run by using the following rules.
 
-- If you specify the path to a command, PowerShell runs the command at the
-  location specified by the path.
+If you specify the path to a command, PowerShell runs the command at the
+location specified by the path.
 
-  For example, the following command runs the FindDocs.ps1 script in the
-  "C:\\TechDocs" directory:
+For example, the following command runs the FindDocs.ps1 script in the
+"C:\\TechDocs" directory:
 
-  ```
-  C:\TechDocs\FindDocs.ps1
-  ```
+```
+C:\TechDocs\FindDocs.ps1
+```
 
-  As a security feature, PowerShell does not run executable (native) commands,
-  including PowerShell scripts, unless the command is located in a path that is
-  listed in the Path environment variable `$env:path` or unless you specify the
-  path to the script file.
+As a security feature, PowerShell does not run executable (native) commands,
+including PowerShell scripts, unless the command is located in a path that is
+listed in the Path environment variable `$env:path` or unless you specify the
+path to the script file.
 
-  To run a script that is in the current directory, specify the full path, or
-  type a dot `.\` to represent the current directory.
+To run a script that is in the current directory, specify the full path, or
+type a dot `.\` to represent the current directory.
 
-  For example, to run the FindDocs.ps1 file in the current directory, type:
+For example, to run the FindDocs.ps1 file in the current directory, type:
 
-  ```
-  .\FindDocs.ps1
-  ```
+```
+.\FindDocs.ps1
+```
 
 ### Using wildcards in execution
 
 You may use wildcards in command execution. Using wildcard characters is
 also known as *globbing*.
 
-PowerShell will execute a file that has a wildcard match, before a literal
-match.
+PowerShell executes a file that has a wildcard match, before a literal match.
 
 For example, consider a directory with the following files:
 
@@ -84,7 +82,7 @@ C:\temp\test\[a1].ps1
 C:\temp\test\a.ps1
 ```
 
-Now lets delete the `a.ps1` file and attempt to run it again.
+Now let's delete the `a.ps1` file and attempt to run it again.
 
 ```powershell
 Remove-Item C:\temp\test\a.ps1
@@ -114,18 +112,18 @@ when it runs commands:
   3. Cmdlet
   4. Native Windows commands
 
-  Therefore, if you type "help", PowerShell first looks for an alias named
-  `help`, then a function named `Help`, and finally a cmdlet named `Help`. It
-  runs the first `help` item that it finds.
+Therefore, if you type "help", PowerShell first looks for an alias named
+`help`, then a function named `Help`, and finally a cmdlet named `Help`. It
+runs the first `help` item that it finds.
 
-  For example, if your session contains a cmdlet and a function, both named
-  `Get-Map`, when you type `Get-Map`, PowerShell runs the function.
+For example, if your session contains a cmdlet and a function, both named
+`Get-Map`, when you type `Get-Map`, PowerShell runs the function.
 
-  When the session contains items of the same type that have the same name,
-  PowerShell runs the newer item.
+When the session contains items of the same type that have the same name,
+PowerShell runs the newer item.
 
-  For example, if you import another `Get-Date` cmdlet from a module, when you
-  type `Get-Date`, PowerShell runs the imported version over the native one.
+For example, if you import another `Get-Date` cmdlet from a module, when you
+type `Get-Date`, PowerShell runs the imported version over the native one.
 
 ## Hidden and replaced items
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -17,7 +17,7 @@ within a session can be hidden or replaced by commands with the same
 name. This article shows you how to run hidden commands and how to avoid
 command-name conflicts.
 
-## Command path precedence
+## Command precedence
 
 When a PowerShell session includes more than one command that has the
 same name, PowerShell determines which command to run by using the
@@ -39,7 +39,7 @@ following rules.
   path to the script file.
 
   To run a script that is in the current directory, specify the full path, or
-  type a dot `.` to represent the current directory.
+  type a dot `.\` to represent the current directory.
 
   For example, to run the FindDocs.ps1 file in the current directory, type:
 
@@ -58,7 +58,7 @@ match.
 For example, consider a directory with the following files:
 
 ```
-PS C:\temp\test> Get-ChildItem
+Get-ChildItem C:\temp\test
 
 
     Directory: C:\temp\test
@@ -87,7 +87,7 @@ C:\temp\test\a.ps1
 Now lets delete the `a.ps1` file and attempt to run it again.
 
 ```powershell
-Remove-Item a.ps1
+Remove-Item C:\temp\test\a.ps1
 C:\temp\test\[a1].ps1
 ```
 
@@ -100,7 +100,11 @@ match is the only file match for that wildcard pattern.
 
 For more information about how PowerShell uses wildcards, see [about_Wildcards](about_Wildcards.md).
 
-## Command precedence
+> [!NOTE]
+> To limit the search to a relative path, you must prefix the script name with
+> the relative folder name. This limits the search for commands to files in
+> that folder. Without this prefix, other PowerShell syntax may conflict and
+> there are few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands:

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -100,9 +100,9 @@ For more information about how PowerShell uses wildcards, see [about_Wildcards](
 
 > [!NOTE]
 > To limit the search to a relative path, you must prefix the script name with
-> the relative folder name. This limits the search for commands to files in
-> that folder. Without this prefix, other PowerShell syntax may conflict and
-> there are few guarantees that the file will be found.
+> the `.\` path. This limits the search for commands to files in that relative
+> path. Without this prefix, other PowerShell syntax may conflict and there are
+> few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands:

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -7,7 +7,6 @@ title:  about_Command_Precedence
 # About Command Precedence
 
 ## Short description
-
 Describes how PowerShell determines which command to run.
 
 ## Long description
@@ -18,7 +17,7 @@ within a session can be hidden or replaced by commands with the same
 name. This article shows you how to run hidden commands and how to avoid
 command-name conflicts.
 
-## Command precedence
+## Command path precedence
 
 When a PowerShell session includes more than one command that has the
 same name, PowerShell determines which command to run by using the
@@ -48,8 +47,63 @@ following rules.
   .\FindDocs.ps1
   ```
 
-- If you do not specify a path, PowerShell uses the following precedence order
-  when it runs commands:
+### Using wildcards in execution
+
+You may use wildcards in command execution. Using wildcard characters is
+also known as *globbing*.
+
+PowerShell will execute a file that has a wildcard match, before a literal
+match.
+
+For example, consider a directory with the following files:
+
+```
+PS C:\temp\test> Get-ChildItem
+
+
+    Directory: C:\temp\test
+
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----        5/20/2019   2:29 PM             28 a.ps1
+-a----        5/20/2019   2:29 PM             28 [a1].ps1
+```
+
+Both script files have the same content: `$MyInvocation.MyCommand.Path`.
+This command displays the name of the script that is invoked.
+
+When you run `[a1].ps1`, the file `a.ps1` is executed even though the file
+`[a1].ps1` is a literal match.
+
+```powershell
+C:\temp\test\[a1].ps1
+```
+
+```Output
+C:\temp\test\a.ps1
+```
+
+Now lets delete the `a.ps1` file and attempt to run it again.
+
+```powershell
+Remove-Item a.ps1
+C:\temp\test\[a1].ps1
+```
+
+```Output
+C:\temp\test\[a1].ps1
+```
+
+You can see from the output that `[a1].ps1` runs this time because the literal
+match is the only file match for that wildcard pattern.
+
+For more information about how PowerShell uses wildcards, see [about_Wildcards](about_Wildcards.md).
+
+## Command precedence
+
+If you do not specify a path, PowerShell uses the following precedence order
+when it runs commands:
 
   1. Alias
   2. Function

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  08/28/2018
+ms.date:  05/20/2019
 schema:  2.0.0
 keywords:  powershell,cmdlet
 title:  about_Command_Precedence
@@ -19,41 +19,39 @@ command-name conflicts.
 
 ## Command precedence
 
-When a PowerShell session includes more than one command that has the
-same name, PowerShell determines which command to run by using the
-following rules.
+When a PowerShell session includes more than one command that has the same
+name, PowerShell determines which command to run by using the following rules.
 
-- If you specify the path to a command, PowerShell runs the command at the
-  location specified by the path.
+If you specify the path to a command, PowerShell runs the command at the
+location specified by the path.
 
-  For example, the following command runs the FindDocs.ps1 script in the
-  "C:\\TechDocs" directory:
+For example, the following command runs the FindDocs.ps1 script in the
+"C:\\TechDocs" directory:
 
-  ```
-  C:\TechDocs\FindDocs.ps1
-  ```
+```
+C:\TechDocs\FindDocs.ps1
+```
 
-  As a security feature, PowerShell does not run executable (native) commands,
-  including PowerShell scripts, unless the command is located in a path that is
-  listed in the Path environment variable `$env:path` or unless you specify the
-  path to the script file.
+As a security feature, PowerShell does not run executable (native) commands,
+including PowerShell scripts, unless the command is located in a path that is
+listed in the Path environment variable `$env:path` or unless you specify the
+path to the script file.
 
-  To run a script that is in the current directory, specify the full path, or
-  type a dot `.\` to represent the current directory.
+To run a script that is in the current directory, specify the full path, or
+type a dot `.\` to represent the current directory.
 
-  For example, to run the FindDocs.ps1 file in the current directory, type:
+For example, to run the FindDocs.ps1 file in the current directory, type:
 
-  ```
-  .\FindDocs.ps1
-  ```
+```
+.\FindDocs.ps1
+```
 
 ### Using wildcards in execution
 
 You may use wildcards in command execution. Using wildcard characters is
 also known as *globbing*.
 
-PowerShell will execute a file that has a wildcard match, before a literal
-match.
+PowerShell executes a file that has a wildcard match, before a literal match.
 
 For example, consider a directory with the following files:
 
@@ -84,7 +82,7 @@ C:\temp\test\[a1].ps1
 C:\temp\test\a.ps1
 ```
 
-Now lets delete the `a.ps1` file and attempt to run it again.
+Now let's delete the `a.ps1` file and attempt to run it again.
 
 ```powershell
 Remove-Item C:\temp\test\a.ps1
@@ -114,18 +112,18 @@ when it runs commands:
   3. Cmdlet
   4. Native Windows commands
 
-  Therefore, if you type "help", PowerShell first looks for an alias named
-  `help`, then a function named `Help`, and finally a cmdlet named `Help`. It
-  runs the first `help` item that it finds.
+Therefore, if you type "help", PowerShell first looks for an alias named
+`help`, then a function named `Help`, and finally a cmdlet named `Help`. It
+runs the first `help` item that it finds.
 
-  For example, if your session contains a cmdlet and a function, both named
-  `Get-Map`, when you type `Get-Map`, PowerShell runs the function.
+For example, if your session contains a cmdlet and a function, both named
+`Get-Map`, when you type `Get-Map`, PowerShell runs the function.
 
-  When the session contains items of the same type that have the same name,
-  PowerShell runs the newer item.
+When the session contains items of the same type that have the same name,
+PowerShell runs the newer item.
 
-  For example, if you import another `Get-Date` cmdlet from a module, when you
-  type `Get-Date`, PowerShell runs the imported version over the native one.
+For example, if you import another `Get-Date` cmdlet from a module, when you
+type `Get-Date`, PowerShell runs the imported version over the native one.
 
 ## Hidden and replaced items
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -17,7 +17,7 @@ within a session can be hidden or replaced by commands with the same
 name. This article shows you how to run hidden commands and how to avoid
 command-name conflicts.
 
-## Command path precedence
+## Command precedence
 
 When a PowerShell session includes more than one command that has the
 same name, PowerShell determines which command to run by using the
@@ -39,7 +39,7 @@ following rules.
   path to the script file.
 
   To run a script that is in the current directory, specify the full path, or
-  type a dot `.` to represent the current directory.
+  type a dot `.\` to represent the current directory.
 
   For example, to run the FindDocs.ps1 file in the current directory, type:
 
@@ -58,7 +58,7 @@ match.
 For example, consider a directory with the following files:
 
 ```
-PS C:\temp\test> Get-ChildItem
+Get-ChildItem C:\temp\test
 
 
     Directory: C:\temp\test
@@ -87,7 +87,7 @@ C:\temp\test\a.ps1
 Now lets delete the `a.ps1` file and attempt to run it again.
 
 ```powershell
-Remove-Item a.ps1
+Remove-Item C:\temp\test\a.ps1
 C:\temp\test\[a1].ps1
 ```
 
@@ -100,7 +100,11 @@ match is the only file match for that wildcard pattern.
 
 For more information about how PowerShell uses wildcards, see [about_Wildcards](about_Wildcards.md).
 
-## Command precedence
+> [!NOTE]
+> To limit the search to a relative path, you must prefix the script name with
+> the relative folder name. This limits the search for commands to files in
+> that folder. Without this prefix, other PowerShell syntax may conflict and
+> there are few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands:

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -17,7 +17,7 @@ within a session can be hidden or replaced by commands with the same
 name. This article shows you how to run hidden commands and how to avoid
 command-name conflicts.
 
-## Command precedence
+## Command path precedence
 
 When a PowerShell session includes more than one command that has the
 same name, PowerShell determines which command to run by using the
@@ -47,8 +47,63 @@ following rules.
   .\FindDocs.ps1
   ```
 
-- If you do not specify a path, PowerShell uses the following precedence order
-  when it runs commands:
+### Using wildcards in execution
+
+You may use wildcards in command execution. Using wildcard characters is
+also known as *globbing*.
+
+PowerShell will execute a file that has a wildcard match, before a literal
+match.
+
+For example, consider a directory with the following files:
+
+```
+PS C:\temp\test> Get-ChildItem
+
+
+    Directory: C:\temp\test
+
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----        5/20/2019   2:29 PM             28 a.ps1
+-a----        5/20/2019   2:29 PM             28 [a1].ps1
+```
+
+Both script files have the same content: `$MyInvocation.MyCommand.Path`.
+This command displays the name of the script that is invoked.
+
+When you run `[a1].ps1`, the file `a.ps1` is executed even though the file
+`[a1].ps1` is a literal match.
+
+```powershell
+C:\temp\test\[a1].ps1
+```
+
+```Output
+C:\temp\test\a.ps1
+```
+
+Now lets delete the `a.ps1` file and attempt to run it again.
+
+```powershell
+Remove-Item a.ps1
+C:\temp\test\[a1].ps1
+```
+
+```Output
+C:\temp\test\[a1].ps1
+```
+
+You can see from the output that `[a1].ps1` runs this time because the literal
+match is the only file match for that wildcard pattern.
+
+For more information about how PowerShell uses wildcards, see [about_Wildcards](about_Wildcards.md).
+
+## Command precedence
+
+If you do not specify a path, PowerShell uses the following precedence order
+when it runs commands:
 
   1. Alias
   2. Function

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -100,9 +100,9 @@ For more information about how PowerShell uses wildcards, see [about_Wildcards](
 
 > [!NOTE]
 > To limit the search to a relative path, you must prefix the script name with
-> the relative folder name. This limits the search for commands to files in
-> that folder. Without this prefix, other PowerShell syntax may conflict and
-> there are few guarantees that the file will be found.
+> the `.\` path. This limits the search for commands to files in that relative
+> path. Without this prefix, other PowerShell syntax may conflict and there are
+> few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands:

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  08/28/2018
+ms.date:  05/20/2019
 schema:  2.0.0
 keywords:  powershell,cmdlet
 title:  about_Command_Precedence
@@ -19,41 +19,39 @@ command-name conflicts.
 
 ## Command precedence
 
-When a PowerShell session includes more than one command that has the
-same name, PowerShell determines which command to run by using the
-following rules.
+When a PowerShell session includes more than one command that has the same
+name, PowerShell determines which command to run by using the following rules.
 
-- If you specify the path to a command, PowerShell runs the command at the
-  location specified by the path.
+If you specify the path to a command, PowerShell runs the command at the
+location specified by the path.
 
-  For example, the following command runs the FindDocs.ps1 script in the
-  "C:\\TechDocs" directory:
+For example, the following command runs the FindDocs.ps1 script in the
+"C:\\TechDocs" directory:
 
-  ```
-  C:\TechDocs\FindDocs.ps1
-  ```
+```
+C:\TechDocs\FindDocs.ps1
+```
 
-  As a security feature, PowerShell does not run executable (native) commands,
-  including PowerShell scripts, unless the command is located in a path that is
-  listed in the Path environment variable `$env:path` or unless you specify the
-  path to the script file.
+As a security feature, PowerShell does not run executable (native) commands,
+including PowerShell scripts, unless the command is located in a path that is
+listed in the Path environment variable `$env:path` or unless you specify the
+path to the script file.
 
-  To run a script that is in the current directory, specify the full path, or
-  type a dot `.\` to represent the current directory.
+To run a script that is in the current directory, specify the full path, or
+type a dot `.\` to represent the current directory.
 
-  For example, to run the FindDocs.ps1 file in the current directory, type:
+For example, to run the FindDocs.ps1 file in the current directory, type:
 
-  ```
-  .\FindDocs.ps1
-  ```
+```
+.\FindDocs.ps1
+```
 
 ### Using wildcards in execution
 
 You may use wildcards in command execution. Using wildcard characters is
 also known as *globbing*.
 
-PowerShell will execute a file that has a wildcard match, before a literal
-match.
+PowerShell executes a file that has a wildcard match, before a literal match.
 
 For example, consider a directory with the following files:
 
@@ -84,7 +82,7 @@ C:\temp\test\[a1].ps1
 C:\temp\test\a.ps1
 ```
 
-Now lets delete the `a.ps1` file and attempt to run it again.
+Now let's delete the `a.ps1` file and attempt to run it again.
 
 ```powershell
 Remove-Item C:\temp\test\a.ps1
@@ -114,18 +112,18 @@ when it runs commands:
   3. Cmdlet
   4. Native Windows commands
 
-  Therefore, if you type "help", PowerShell first looks for an alias named
-  `help`, then a function named `Help`, and finally a cmdlet named `Help`. It
-  runs the first `help` item that it finds.
+Therefore, if you type "help", PowerShell first looks for an alias named
+`help`, then a function named `Help`, and finally a cmdlet named `Help`. It
+runs the first `help` item that it finds.
 
-  For example, if your session contains a cmdlet and a function, both named
-  `Get-Map`, when you type `Get-Map`, PowerShell runs the function.
+For example, if your session contains a cmdlet and a function, both named
+`Get-Map`, when you type `Get-Map`, PowerShell runs the function.
 
-  When the session contains items of the same type that have the same name,
-  PowerShell runs the newer item.
+When the session contains items of the same type that have the same name,
+PowerShell runs the newer item.
 
-  For example, if you import another `Get-Date` cmdlet from a module, when you
-  type `Get-Date`, PowerShell runs the imported version over the native one.
+For example, if you import another `Get-Date` cmdlet from a module, when you
+type `Get-Date`, PowerShell runs the imported version over the native one.
 
 ## Hidden and replaced items
 


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Explain wildcard execution.

Version(s) of document impacted
------------------------------
- [ ] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
