### PR TITLE
Attempt to automate cleanup of Windows PowerShell references

### DIFF
--- a/reference/6/CimCmdlets/Get-CimAssociatedInstance.md
+++ b/reference/6/CimCmdlets/Get-CimAssociatedInstance.md
@@ -196,7 +196,7 @@ Specifies the namespace for the CIM operation.
 The default namespace is root/cimv2.
 
 > [!NOTE]
-> You can use tab completion to browse the list of namespaces, because Windows PowerShell gets a
+> You can use tab completion to browse the list of namespaces, because PowerShell gets a
 > list of namespaces from the local WMI server to provide the list of namespaces.
 
 ```yaml

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Alias_Provider.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Alias_Provider.md
@@ -45,8 +45,10 @@ in this article.
 - [Remove-Item](../../Microsoft.PowerShell.Management/Remove-Item.md)
 - [Clear-Item](../../Microsoft.PowerShell.Management/Clear-Item.md)
 
-PowerShell includes a set of cmdlets that are designed to view and to change aliases. When you use **Alias** cmdlets, you do not need to specify the `Alias:` drive in the name. This article does not cover working with
-**Alias** cmdlets.
+PowerShell includes a set of cmdlets that are designed to view and to change
+aliases. When you use **Alias** cmdlets, you do not need to specify the
+`Alias:` drive in the name. This article does not cover working with **Alias**
+cmdlets.
 
 - [Export-Alias](../../Microsoft.PowerShell.Utility/Export-Alias.md)
 - [Get-Alias](../../Microsoft.PowerShell.Utility/Get-Alias.md)
@@ -273,7 +275,8 @@ Determines the value of the **Options** property of an alias.
 
 - `None`: No options. This value is the default.
 - `Constant`:The alias cannot be deleted and its properties cannot be changed.
-  `Constant` is available only when you create an alias. You cannot change the option of an existing alias to `Constant`.
+  `Constant` is available only when you create an alias. You cannot change the
+  option of an existing alias to `Constant`.
 - `Private`:The alias is visible only in the current scope, not in the child
    scopes.
 - `ReadOnly`:The properties of the alias cannot be changed except by using the

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -704,7 +704,7 @@ Get-Member -InputObject $a
 
 You can also get the members of an array by typing a comma (,) before the
 value that is piped to the Get-Member cmdlet. The comma makes the array the
-second item in an array of arrays. Windows PowerShell pipes the arrays one at
+second item in an array of arrays. PowerShell pipes the arrays one at
 a time and Get-Member returns the members of the array. Like the next two
 examples.
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -674,8 +674,7 @@ $a.GetType().FullName
 System.String
 ```
 
-If the first value that is assigned to the variable is a string, Windows
-PowerShell treats all operations as string operations and casts new values
+If the first value that is assigned to the variable is a string, PowerShell treats all operations as string operations and casts new values
 to strings. This occurs in the following example:
 
 ```powershell

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -136,7 +136,8 @@ PS> 7, 8, 9 -gt 8
 9
 ```
 
-> [!NOTE] > This should not to be confused with `>`, the greater-than operator
+> [!NOTE]
+> This should not to be confused with `>`, the greater-than operator
 > in many other programming languages. In PowerShell, `>` is used for
 > redirection. For more information, see
 > [About_redirection](about_Redirection.md#potential-confusion-with-comparison-operators).

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -136,8 +136,10 @@ PS> 7, 8, 9 -gt 8
 9
 ```
 
-> [!NOTE]
-> This should not to be confused with `>`, the greater-than operator in many other programming languages. In PowerShell, `>` is used for redirection. For more information, see [About_redirection](about_Redirection.md#potential-confusion-with-comparison-operators).
+> [!NOTE] > This should not to be confused with `>`, the greater-than operator
+> in many other programming languages. In PowerShell, `>` is used for
+> redirection. For more information, see
+> [About_redirection](about_Redirection.md#potential-confusion-with-comparison-operators).
 
 #### -ge
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -252,16 +252,16 @@ files.
 
 ## Debugging Workflows
 
-The Windows PowerShell 4.0 debugger can be used to debug Windows PowerShell
-workflows, either in the Windows PowerShell console, or in Windows PowerShell
-ISE. There are some limitations with using the Windows PowerShell debugger to
+The Windows PowerShell 4.0 debugger can be used to debug PowerShell
+workflows, either in the PowerShell console, or in PowerShell
+ISE. There are some limitations with using the PowerShell debugger to
 debug workflows.
 
 - You can view workflow variables while you are in the debugger, but setting
   workflow variables from within the debugger is not supported.
 - Tab completion when stopped in the workflow debugger is not available.
 - Workflow debugging works only with synchronous running of workflows from a
-  Windows PowerShell script. You cannot debug workflows if they are running as a
+  PowerShell script. You cannot debug workflows if they are running as a
   job (with the **-AsJob** parameter).
 - Other nested debugging scenarios--such as a workflow calling another
   workflow, or a workflow calling a script--are not implemented.
@@ -814,8 +814,7 @@ DBG> k
 0: prompt: $args=[]
 ```
 
-This example demonstrates just a few of the many ways to use the Windows
-PowerShell debugger.
+This example demonstrates just a few of the many ways to use the PowerShell debugger.
 
 For more information about the debugger cmdlets, type the following command:
 
@@ -835,8 +834,8 @@ In addition to the PowerShell debugger, PowerShell includes
 several other features that you can use to debug scripts and functions.
 
 - Windows PowerShell Integrated Scripting Environment (ISE) includes an
-  interactive graphical debugger. For more information, start PowerShell ISE
-  and press F1.
+  interactive graphical debugger. For more information, start Windows
+  PowerShell ISE and press F1.
 
 - The Set-PSDebug cmdlet offers very basic script debugging features,
   including stepping and tracing.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -252,7 +252,7 @@ files.
 
 ## Debugging Workflows
 
-The Windows PowerShell 4.0 debugger can be used to debug PowerShell
+The PowerShell 4.0 debugger can be used to debug PowerShell
 workflows, either in the PowerShell console, or in Windows PowerShell
 ISE. There are some limitations with using the PowerShell debugger to
 debug workflows.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -253,7 +253,7 @@ files.
 ## Debugging Workflows
 
 The Windows PowerShell 4.0 debugger can be used to debug PowerShell
-workflows, either in the PowerShell console, or in PowerShell
+workflows, either in the PowerShell console, or in Windows PowerShell
 ISE. There are some limitations with using the PowerShell debugger to
 debug workflows.
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Environment_Provider.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Environment_Provider.md
@@ -28,10 +28,14 @@ Provides access to the Windows environment variables.
 The PowerShell **Environment** provider lets you get, add, change, clear, and delete environment
 variables and values in PowerShell.
 
-**Environment** variables are dynamically named variables that describe the environment in which your programs run. Windows and PowerShell use environment variables to store persistent information that affect system
-and process execution. Unlike PowerShell variables, environment variables are not subject to scope constraints.
+**Environment** variables are dynamically named variables that describe the
+environment in which your programs run. Windows and PowerShell use environment
+variables to store persistent information that affect system and process
+execution. Unlike PowerShell variables, environment variables are not subject
+to scope constraints.
 
-The **Environment** drive is a flat namespace containing the environment variables specific to the current user's session. The environment variables
+The **Environment** drive is a flat namespace containing the environment
+variables specific to the current user's session. The environment variables
 have no child items.
 
 The **Environment** provider supports the following cmdlets, which are covered

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -188,7 +188,8 @@ interpreted as a unit.
 
 ### Saving Changes to Environment Variables
 
-To create or change the value of an environment variable in every PowerShell session, add the change to your PowerShell profile.
+To create or change the value of an environment variable in every PowerShell
+session, add the change to your PowerShell profile.
 
 For example, to add the C:\\Temp directory to the Path environment variable in
 every PowerShell session, add the following command to your PowerShell profile.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -8,8 +8,7 @@ title:  about_Environment_Variables
 # About Environment Variables
 
 ## SHORT DESCRIPTION
-Describes how to access Windows environment variables in Windows
-PowerShell.
+Describes how to access Windows environment variables in PowerShell.
 
 ## LONG DESCRIPTION
 
@@ -189,12 +188,10 @@ interpreted as a unit.
 
 ### Saving Changes to Environment Variables
 
-To create or change the value of an environment variable in every Windows
-PowerShell session, add the change to your PowerShell profile.
+To create or change the value of an environment variable in every PowerShell session, add the change to your PowerShell profile.
 
 For example, to add the C:\\Temp directory to the Path environment variable in
-every PowerShell session, add the following command to your Windows
-PowerShell profile.
+every PowerShell session, add the following command to your PowerShell profile.
 
 ```powershell
 $Env:Path += ";C:\Temp"

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
@@ -33,7 +33,7 @@ over Group Policy settings in the Computer Configuration path.
 
 The policies are as follows:
 
-- Turn on Script Execution: Sets the Windows PowerShell execution policy.
+- Turn on Script Execution: Sets the PowerShell execution policy.
 - Turn on Module Logging: Sets the **LogPipelineExecutionDetails** property of
   modules.
 - Set the default source path for `Update-Help`: Sets the source for

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -230,7 +230,7 @@ When you import the module, you can use the new job type in your session.
 For example, the PSScheduledJob module adds scheduled jobs and the PSWorkflow
 module adds workflow jobs.
 
-Custom jobs types might differ significantly from standard Windows PowerShell
+Custom jobs types might differ significantly from standard PowerShell
 background jobs. For example, scheduled jobs are saved on disk; they do not
 exist only in a particular session. Workflow jobs can be suspended and
 resumed.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Logging_Windows.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Logging_Windows.md
@@ -50,18 +50,21 @@ Registering the event provider places a lock in the binary library used to
 decode events. To update this library, the provider must be unregistered to
 release this lock.
 
-To unregister the PowerShell provider, run the following command from an elevated PowerShell prompt.
+To unregister the PowerShell provider, run the following command from an
+elevated PowerShell prompt.
 
 ```powershell
 $PSHOME\RegisterManifest.ps1 -Unregister
 ```
 
-After updating PowerShell, run `$PSHOME\RegisterManifest.ps1` to register the updated event provider.
+After updating PowerShell, run `$PSHOME\RegisterManifest.ps1` to register the
+updated event provider.
 
 ## Enabling Script Block Logging
 
 When you enable script block logging, PowerShell records the content of all
-script blocks that it processes. Once enabled, any new PowerShell session logs this information.
+script blocks that it processes. Once enabled, any new PowerShell session logs
+this information.
 
 > [!NOTE]
 > It is recommended to enable Protected Event Logging (as described below) when

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -250,8 +250,7 @@ For more information about adding modules to your session, see
 
 ## How to Import a Module into Every Session
 
-The `Import-Module` command imports modules into your current Windows
-PowerShell session. This command affects only the current session.
+The `Import-Module` command imports modules into your current PowerShell session. This command affects only the current session.
 
 To import a module into every PowerShell session that you
 start, add the `Import-Module` command to your PowerShell

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -250,7 +250,8 @@ For more information about adding modules to your session, see
 
 ## How to Import a Module into Every Session
 
-The `Import-Module` command imports modules into your current PowerShell session. This command affects only the current session.
+The `Import-Module` command imports modules into your current PowerShell
+session. This command affects only the current session.
 
 To import a module into every PowerShell session that you
 start, add the `Import-Module` command to your PowerShell

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -149,8 +149,10 @@ At line:1 char:2
     + FullyQualifiedErrorId : CommandNotFoundException
 ```
 
-The [Invoke-Expression](../../Microsoft.PowerShell.Utility/Invoke-Expression.md) cmdlet can execute code that causes
-parsing errors when using the call operator.
+The
+[Invoke-Expression](../../Microsoft.PowerShell.Utility/Invoke-Expression.md)
+cmdlet can execute code that causes parsing errors when using the call
+operator.
 
 ```
 PS> &"1+1"
@@ -192,12 +194,12 @@ For more about script blocks, see [about_Script_Blocks](about_Script_Blocks.md).
 
 #### Ampersand background operator `&`
 
-Runs the pipeline before it in a PowerShell job.
-The ampersand background operator acts similarly to the UNIX "ampersand operator"
-which famously runs the command before it as a background process.
-The ampersand background operator is built on top of PowerShell jobs so it shares a lot of functionality with
-`Start-Job`.
-The following command contains basic usage of the ampersand background operator.
+Runs the pipeline before it in a PowerShell job. The ampersand background
+operator acts similarly to the UNIX "ampersand operator" which famously runs
+the command before it as a background process. The ampersand background
+operator is built on top of PowerShell jobs so it shares a lot of functionality
+with `Start-Job`. The following command contains basic usage of the ampersand
+background operator.
 
 ```powershell
 Get-Process -Name pwsh &

--- a/reference/6/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
@@ -61,14 +61,15 @@ However, you can also create sessions (called "PowerShell sessions"
 or "PSSessions") that you control and manage.
 
 PSSessions are critical to remote commands. If you use the **ComputerName**
-parameter of the `Invoke-Command` or `Enter-PSSession` cmdlets, PowerShell establishes a temporary session to run the command and then
-closes the session as soon as the command or the interactive session
-is complete.
+parameter of the `Invoke-Command` or `Enter-PSSession` cmdlets, PowerShell
+establishes a temporary session to run the command and then closes the session
+as soon as the command or the interactive session is complete.
 
-However, if you use the `New-PSSession` cmdlet to create a PSSession, PowerShell establishes a persistent session on the remote computer in which
-you can run multiple commands or interactive sessions. The PSSessions that
-you create remain open and available for use until you delete them or until
-you close the session in which they were created.
+However, if you use the `New-PSSession` cmdlet to create a PSSession,
+PowerShell establishes a persistent session on the remote computer in which you
+can run multiple commands or interactive sessions. The PSSessions that you
+create remain open and available for use until you delete them or until you
+close the session in which they were created.
 
 When you create a PSSession on a remote computer, the system creates a
 PowerShell process on the remote computer and establishes a connection
@@ -207,8 +208,8 @@ cmdlet with its **AsJob** parameter, or use the `Invoke-Command` cmdlet to run a
 you can use the **ComputerName** or **Session** parameters.
 
 When using `Invoke-Command` to run a `Start-Job` command, you must run the
-command in a PSSession. If you use the **ComputerName** parameter, PowerShell ends the connection when the job object returns, and the job is
-interrupted.
+command in a PSSession. If you use the **ComputerName** parameter, PowerShell
+ends the connection when the job object returns, and the job is interrupted.
 
 For more information, see [about_Jobs](about_Jobs.md).
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
@@ -33,9 +33,9 @@ can perform with sessions, see [about_PSSessions](about_PSSessions.md).
 
 ## About Sessions
 
-Technically, a session is an execution environment in which Windows
+Technically, a session is an execution environment in which
 PowerShell runs. Each session includes an instance of the
-System.Management.Automation engine and a host program in which Windows
+System.Management.Automation engine and a host program in which
 PowerShell runs. The host can be the familiar PowerShell console
 or another program that runs commands, such as Cmd.exe, or a program built
 to host PowerShell, such as Windows PowerShell Integrated Scripting
@@ -61,13 +61,11 @@ However, you can also create sessions (called "PowerShell sessions"
 or "PSSessions") that you control and manage.
 
 PSSessions are critical to remote commands. If you use the **ComputerName**
-parameter of the `Invoke-Command` or `Enter-PSSession` cmdlets, Windows
-PowerShell establishes a temporary session to run the command and then
+parameter of the `Invoke-Command` or `Enter-PSSession` cmdlets, PowerShell establishes a temporary session to run the command and then
 closes the session as soon as the command or the interactive session
 is complete.
 
-However, if you use the `New-PSSession` cmdlet to create a PSSession, Windows
-PowerShell establishes a persistent session on the remote computer in which
+However, if you use the `New-PSSession` cmdlet to create a PSSession, PowerShell establishes a persistent session on the remote computer in which
 you can run multiple commands or interactive sessions. The PSSessions that
 you create remain open and available for use until you delete them or until
 you close the session in which they were created.
@@ -209,8 +207,7 @@ cmdlet with its **AsJob** parameter, or use the `Invoke-Command` cmdlet to run a
 you can use the **ComputerName** or **Session** parameters.
 
 When using `Invoke-Command` to run a `Start-Job` command, you must run the
-command in a PSSession. If you use the **ComputerName** parameter, Windows
-PowerShell ends the connection when the job object returns, and the job is
+command in a PSSession. If you use the **ComputerName** parameter, PowerShell ends the connection when the job object returns, and the job is
 interrupted.
 
 For more information, see [about_Jobs](about_Jobs.md).

--- a/reference/6/Microsoft.PowerShell.Core/About/about_PSSessions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_PSSessions.md
@@ -65,8 +65,9 @@ PSSession. The PSSession remains available until you delete it or it times
 out.
 
 Typically, you create a PSSession to run a series of related commands on a
-remote computer. When you create a PSSession on a remote computer, PowerShell establishes a persistent connection to the remote computer to
-support the session.
+remote computer. When you create a PSSession on a remote computer, PowerShell
+establishes a persistent connection to the remote computer to support the
+session.
 
 If you use the **ComputerName** parameter of the `Invoke-Command` or
 `Enter-PSSession` cmdlet to run a remote command or to start an interactive

--- a/reference/6/Microsoft.PowerShell.Core/About/about_PSSessions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_PSSessions.md
@@ -65,8 +65,7 @@ PSSession. The PSSession remains available until you delete it or it times
 out.
 
 Typically, you create a PSSession to run a series of related commands on a
-remote computer. When you create a PSSession on a remote computer, Windows
-PowerShell establishes a persistent connection to the remote computer to
+remote computer. When you create a PSSession on a remote computer, PowerShell establishes a persistent connection to the remote computer to
 support the session.
 
 If you use the **ComputerName** parameter of the `Invoke-Command` or

--- a/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
@@ -15,7 +15,7 @@ Configuration files for PowerShell Core, replacing Registry configuration.
 The `powershell.config.json` file contains configuration settings for
 PowerShell Core. PowerShell loads this configuration at startup. The settings
 can also be modified at runtime. Previously, these settings were stored in the
-Windows Registry for Windows PowerShell, but are now contained in a file to
+Windows Registry for PowerShell, but are now contained in a file to
 enable configuration on macOS and Linux.
 
 > [!WARNING]

--- a/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -146,7 +146,7 @@ Script     1.0.0      WindowsCompatibility                Core      {Initialize-
 
 For modules that come as part of Windows (or are installed as part of a role or feature),
 PowerShell 6.1 and above treat the `CompatiblePSEditions` field differently. Such modules are found
-in the PowerShell system modules directory
+in the Windows PowerShell system modules directory
 (`%windir%\System\WindowsPowerShell\v1.0\Modules`).
 
 For modules loaded from or found in this directory, PowerShell 6.1 and above uses the

--- a/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -146,7 +146,7 @@ Script     1.0.0      WindowsCompatibility                Core      {Initialize-
 
 For modules that come as part of Windows (or are installed as part of a role or feature),
 PowerShell 6.1 and above treat the `CompatiblePSEditions` field differently. Such modules are found
-in the Windows PowerShell system modules directory
+in the PowerShell system modules directory
 (`%windir%\System\WindowsPowerShell\v1.0\Modules`).
 
 For modules loaded from or found in this directory, PowerShell 6.1 and above uses the

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -168,8 +168,7 @@ Because the contents of single-quoted strings are interpreted literally, you
 cannot use the backtick character to force a literal character interpretation
 in a single-quoted string.
 
-For example, the following command generates an error because Windows
-PowerShell does not recognize the escape character. Instead, it interprets the
+For example, the following command generates an error because PowerShell does not recognize the escape character. Instead, it interprets the
 second quotation mark as the end of the string.
 
 ```output

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -168,8 +168,9 @@ Because the contents of single-quoted strings are interpreted literally, you
 cannot use the backtick character to force a literal character interpretation
 in a single-quoted string.
 
-For example, the following command generates an error because PowerShell does not recognize the escape character. Instead, it interprets the
-second quotation mark as the end of the string.
+For example, the following command generates an error because PowerShell does
+not recognize the escape character. Instead, it interprets the second quotation
+mark as the end of the string.
 
 ```output
 PS C:\> 'Use a quotation mark (`') to begin a string.'

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -118,7 +118,9 @@ file called `script.log`
 ```
 
 This example suppresses all information stream data. To read more about
-**Information** stream cmdlets, see [Write-Host](../../microsoft.powershell.utility/Write-Host.md) and [Write-Information](../../microsoft.powershell.utility/Write-Information.md)
+**Information** stream cmdlets, see
+[Write-Host](../../microsoft.powershell.utility/Write-Host.md) and
+[Write-Information](../../microsoft.powershell.utility/Write-Information.md)
 
 ## Notes
 
@@ -139,16 +141,20 @@ with its `Encoding` parameter.
 
 ### Potential confusion with comparison operators
 
-The `>` operator is not to be confused with the [Greater-than](about_Comparison_Operators.md#-gt) comparison operator (often denoted as `>` in other programming languages).
+The `>` operator is not to be confused with the
+[Greater-than](about_Comparison_Operators.md#-gt) comparison operator (often
+denoted as `>` in other programming languages).
 
-Depending on the objects being compared, the output using `>` can appear to be correct (because 36 is not greater than 42).
+Depending on the objects being compared, the output using `>` can appear to be
+correct (because 36 is not greater than 42).
 
 ```powershell
 PS> if (36 > 42) { "true" } else { "false" }
 false
 ```
 
-However, a check of the local filesystem can see that a file called `42` was written, with the contents `36`.
+However, a check of the local filesystem can see that a file called `42` was
+written, with the contents `36`.
 
 ```powershell
 PS> dir
@@ -173,7 +179,8 @@ The '<' operator is reserved for future use.
 + FullyQualifiedErrorId : RedirectionNotSupported
 ```
 
-If numeric comparison is the required operation, `-lt` and `-gt` should be used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt)
+If numeric comparison is the required operation, `-lt` and `-gt` should be
+used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt)
 
 ## See also
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -8,7 +8,7 @@ title:  about_Regular_Expressions
 # About Regular Expressions
 
 ## Short description
-Describes regular expressions in Windows PowerShell.
+Describes regular expressions in PowerShell.
 
 ## Long description
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
@@ -19,7 +19,7 @@ continue to run while the session is disconnected.
 
 The Disconnected Sessions feature is available only when the computer at the
 remote end of a connection is running Windows PowerShell 3.0 or a later
-version of Windows PowerShell and using the WSMan transport.
+version of PowerShell and using the WSMan transport.
 
 The Disconnected Sessions feature allows you to close the session in which a
 PSSession was created, and even close PowerShell, and shut down the

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
@@ -8,8 +8,7 @@ title:  about_Remote_FAQ
 # About Remote FAQ
 
 ## SHORT DESCRIPTION
-Contains questions and answers about running remote commands in Windows
-PowerShell.
+Contains questions and answers about running remote commands in PowerShell.
 
 ## LONG DESCRIPTION
 
@@ -24,8 +23,7 @@ configured for remoting. For more information, see
 
 ### MUST BOTH COMPUTERS HAVE POWERSHELL INSTALLED?
 
-Yes. To work remotely, the local and remote computers must have Windows
-PowerShell, the Microsoft .NET Framework, and the Web Services for Management
+Yes. To work remotely, the local and remote computers must have PowerShell, the Microsoft .NET Framework, and the Web Services for Management
 (WS-Management) protocol. Any files and other resources that are needed to
 execute a particular command must be on the remote computer.
 
@@ -189,8 +187,7 @@ the connection to run only the current command, and then it closes the
 connection. This is a very efficient method for running a single command or
 several unrelated commands, even on many remote computers.
 
-When you use the New-PSSession cmdlet to create a PSSession, Windows
-PowerShell establishes a persistent connection for the PSSession. Then, you
+When you use the New-PSSession cmdlet to create a PSSession, PowerShell establishes a persistent connection for the PSSession. Then, you
 can run multiple commands in the PSSession, including commands that share
 data.
 
@@ -343,8 +340,7 @@ For example, if you run the IpConfig program on a remote computer, the command
 prompt does not return until IpConfig is completed.
 
 If you use remote commands to start a program that has a user interface, the
-program process starts, but the user interface does not appear. The Windows
-PowerShell command is not completed, and the command prompt does not return
+program process starts, but the user interface does not appear. The PowerShell command is not completed, and the command prompt does not return
 until you stop the program process or until you press CTRL\+C, which
 interrupts the command and stops the process.
 
@@ -406,8 +402,7 @@ administrator's computer) runs PowerShell commands on numerous remote
 computers. This is known as the "fan-out" scenario.
 
 However, in some enterprises, the configuration is many-to-one, where many
-client computers connect to a single remote computer that is running Windows
-PowerShell, such as a file server or a kiosk. This is known as the "fan-in"
+client computers connect to a single remote computer that is running PowerShell, such as a file server or a kiosk. This is known as the "fan-in"
 configuration.
 
 PowerShell remoting supports both fan-out and fan-in configurations.
@@ -422,10 +417,8 @@ port, an alternate session configuration, and other features to customize the
 remote connection.
 
 To support the "fan-in" configuration, PowerShell uses Internet
-Information Services (IIS) to host WS-Management, to load the Windows
-PowerShell plug-in, and to start PowerShell. In this scenario, instead
-of starting each PowerShell session in a separate process, all Windows
-PowerShell sessions run in the same host process.
+Information Services (IIS) to host WS-Management, to load the PowerShell plug-in, and to start PowerShell. In this scenario, instead
+of starting each PowerShell session in a separate process, all PowerShell sessions run in the same host process.
 
 IIS hosting and fan-in remote management is not supported in Windows XP or in
 Windows Server 2003.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
@@ -23,9 +23,10 @@ configured for remoting. For more information, see
 
 ### MUST BOTH COMPUTERS HAVE POWERSHELL INSTALLED?
 
-Yes. To work remotely, the local and remote computers must have PowerShell, the Microsoft .NET Framework, and the Web Services for Management
-(WS-Management) protocol. Any files and other resources that are needed to
-execute a particular command must be on the remote computer.
+Yes. To work remotely, the local and remote computers must have PowerShell, the
+Microsoft .NET Framework, and the Web Services for Management (WS-Management)
+protocol. Any files and other resources that are needed to execute a particular
+command must be on the remote computer.
 
 Computers running Windows PowerShell 3.0 and computers running Windows
 PowerShell 2.0 can connect to each other remotely and run remote commands.
@@ -187,9 +188,9 @@ the connection to run only the current command, and then it closes the
 connection. This is a very efficient method for running a single command or
 several unrelated commands, even on many remote computers.
 
-When you use the New-PSSession cmdlet to create a PSSession, PowerShell establishes a persistent connection for the PSSession. Then, you
-can run multiple commands in the PSSession, including commands that share
-data.
+When you use the New-PSSession cmdlet to create a PSSession, PowerShell
+establishes a persistent connection for the PSSession. Then, you can run
+multiple commands in the PSSession, including commands that share data.
 
 Typically, you create a PSSession to run a series of related commands that
 share data. Otherwise, the temporary connection created by the ComputerName
@@ -402,7 +403,8 @@ administrator's computer) runs PowerShell commands on numerous remote
 computers. This is known as the "fan-out" scenario.
 
 However, in some enterprises, the configuration is many-to-one, where many
-client computers connect to a single remote computer that is running PowerShell, such as a file server or a kiosk. This is known as the "fan-in"
+client computers connect to a single remote computer that is running
+PowerShell, such as a file server or a kiosk. This is known as the "fan-in"
 configuration.
 
 PowerShell remoting supports both fan-out and fan-in configurations.
@@ -416,9 +418,10 @@ PowerShell to start the PowerShell host process
 port, an alternate session configuration, and other features to customize the
 remote connection.
 
-To support the "fan-in" configuration, PowerShell uses Internet
-Information Services (IIS) to host WS-Management, to load the PowerShell plug-in, and to start PowerShell. In this scenario, instead
-of starting each PowerShell session in a separate process, all PowerShell sessions run in the same host process.
+To support the "fan-in" configuration, PowerShell uses Internet Information
+Services (IIS) to host WS-Management, to load the PowerShell plug-in, and to
+start PowerShell. In this scenario, instead of starting each PowerShell session
+in a separate process, all PowerShell sessions run in the same host process.
 
 IIS hosting and fan-in remote management is not supported in Windows XP or in
 Windows Server 2003.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -24,8 +24,7 @@ using Microsoft .NET Framework methods to retrieve the objects. They do not
 use the PowerShell remoting infrastructure. The requirements in this
 document do not apply to these cmdlets.
 
-To find the cmdlets that have a ComputerName parameter but do not use Windows
-PowerShell remoting, read the description of the ComputerName parameter of the
+To find the cmdlets that have a ComputerName parameter but do not use PowerShell remoting, read the description of the ComputerName parameter of the
 cmdlets.
 
 ## SYSTEM REQUIREMENTS

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -541,11 +541,11 @@ that the WS-Management service is running on the remote host and
 configured to listen for requests on the correct port and HTTP URL.
 ```
 
-Windows PowerShell remoting uses port 80 for HTTP transport by default. The
+PowerShell remoting uses port 80 for HTTP transport by default. The
 default port is used whenever the user does not specify the ConnectionURI
 or Port parameters in a remote command.
 
-To change the default port that Windows PowerShell uses, use `Set-Item` cmdlet
+To change the default port that PowerShell uses, use `Set-Item` cmdlet
 in the WSMan: drive to change the Port value in the  listener leaf node.
 
 For example, the following command changes the default port to 8080.
@@ -660,8 +660,7 @@ contains unsigned script files and formatting files.
 
 To import the modules that are created by these cmdlets, either by using
 `Import-PSSession` or `Import-Module`, the execution policy in the current
-session cannot be Restricted or AllSigned. (For information about Windows
-PowerShell execution policies, see about_Execution_Policies.
+session cannot be Restricted or AllSigned. (For information about PowerShell execution policies, see about_Execution_Policies.
 
 To import the modules without changing the execution policy for the local
 computer that is set in the registry, use the Scope parameter of
@@ -765,8 +764,7 @@ The following timeouts are available in the basic configuration.
 - You can also protect the remote computer by setting timeout values
   programmatically in the session configuration for the session.
 
-When a timeout value does not permit a operation to complete, Windows
-PowerShell terminates the operation and generates an error.
+When a timeout value does not permit a operation to complete, PowerShell terminates the operation and generates an error.
 
 To resolve the error, change the command to complete within the timeout
 interval or determine the source of the timeout limit and increase the

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -199,9 +199,9 @@ Param
 
 ### Notes
 
-In Windows PowerShell 3.0, the Windows PowerShell Core packages appear as
+In Windows PowerShell 3.0, the PowerShell Core packages appear as
 modules in sessions started by using the InitialSessionState.CreateDefault2
-method, such as sessions started in the Windows PowerShell console. Otherwise,
+method, such as sessions started in the PowerShell console. Otherwise,
 they appear as snap-ins. The exception is Microsoft.PowerShell.Core, which is
 always a snap-in.
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -145,8 +145,7 @@ Register-PSSessionConfiguration -Name NoLanguage
 -Path .\NoLanguage.pssc
 ```
 
-When a new NoLanguage session starts, users will only have access to Windows
-PowerShell commands.
+When a new NoLanguage session starts, users will only have access to PowerShell commands.
 
 To add a session configuration file to an existing session configuration, use
 the Set-PSSessionConfiguration cmdlet and the Path parameter. This affects any
@@ -178,8 +177,7 @@ $s = New-PSSession -ComputerName Srv01
 ```
 
 Because the NoLanguage constraints were added to the LockedDown session
-configuration, users in LockedDown sessions will only be able to run Windows
-PowerShell commands and cmdlets. For example, the following two commands use
+configuration, users in LockedDown sessions will only be able to run PowerShell commands and cmdlets. For example, the following two commands use
 the Invoke-Command cmdlet to run commands in the session referenced in the $s
 variable. The first command, which runs the Get-UICulture cmdlet and does not
 use any variables, succeeds. The second command, which gets the value of the
@@ -204,8 +202,7 @@ RunAsVirtualAccountGroups can be modified by editing the session configuration
 file used by the session configuration. To do this, begin by locating the
 active copy of the session configuration file.
 
-When you use a session configuration file in a session configuration, Windows
-PowerShell creates an active copy of the session configuration file and stores
+When you use a session configuration file in a session configuration, PowerShell creates an active copy of the session configuration file and stores
 it in the \$pshome\\SessionConfig directory on the local computer.
 
 The location of the active copy of a session configuration file is stored in

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -15,8 +15,7 @@ the computer remotely and the commands they can run.
 
 A session configuration, also known as an "endpoint" is a group of settings on
 the local computer that define the environment for the PowerShell
-sessions that are created when remote or local users connect to Windows
-PowerShell on the local computer.
+sessions that are created when remote or local users connect to PowerShell on the local computer.
 
 Administrators of the computer can use session configurations to protect the
 computer and to define custom environments for users who connect to the

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -50,7 +50,7 @@ For more information, see the help topic for the `Set-ExecutionPolicy` cmdlet.
 
 ## RUNNING UNSIGNED SCRIPTS (REMOTESIGNED EXECUTION POLICY)
 
-If your PowerShell execution policy is **RemoteSigned**, Windows PowerShell
+If your PowerShell execution policy is **RemoteSigned**, PowerShell
 will not run unsigned scripts that are downloaded from the Internet, including
 unsigned scripts you receive through e-mail and instant messaging programs.
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -8,8 +8,7 @@ title:  about_Splatting
 # About Splatting
 
 ## SHORT DESCRIPTION
-Describes how to use splatting to pass parameters to commands in Windows
-PowerShell.
+Describes how to use splatting to pass parameters to commands in PowerShell.
 
 ## LONG DESCRIPTION
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -46,8 +46,9 @@ You won't find the `DateTime` property in the description of the
 [`System.DateTime` structure](https://msdn.microsoft.com/library/system.datetime.aspx),
 because PowerShell adds the property and it is visible only in PowerShell.
 
-To add the `DateTime` property to all PowerShell sessions, PowerShell defines the `DateTime` property in the Types.ps1xml file in the
-PowerShell installation directory (`$PSHOME`).
+To add the `DateTime` property to all PowerShell sessions, PowerShell defines
+the `DateTime` property in the Types.ps1xml file in the PowerShell installation
+directory (`$PSHOME`).
 
 ## Adding Extended Type Data to PowerShell.
 
@@ -84,16 +85,17 @@ For more information about these cmdlets, see the help topic for each cmdlet.
 The Types.ps1xml files in the `$PSHOME` directory are added automatically to
 every session.
 
-The Types.ps1xml file in the PowerShell installation directory
-(`$PSHOME`) is an XML-based text file that lets you add properties and
-methods to the objects that are used in PowerShell. PowerShell has built-in Types.ps1xml files that add several elements
-to the .NET Framework types, but you can create additional Types.ps1xml
-files to further extend the types.
+The Types.ps1xml file in the PowerShell installation directory (`$PSHOME`) is
+an XML-based text file that lets you add properties and methods to the objects
+that are used in PowerShell. PowerShell has built-in Types.ps1xml files that
+add several elements to the .NET Framework types, but you can create additional
+Types.ps1xml files to further extend the types.
 
 For example, by default, array objects (`System.Array`) have a `Length`
-property that lists the number of objects in the array. However, because
-the name "Length" does not clearly describe the property, PowerShell adds an alias property named "Count" that displays the same
-value. The following XML adds the Count property to the `System.Array` type.
+property that lists the number of objects in the array. However, because the
+name "Length" does not clearly describe the property, PowerShell adds an alias
+property named "Count" that displays the same value. The following XML adds the
+Count property to the `System.Array` type.
 
 ```xml
 <Type>
@@ -151,11 +153,11 @@ script blocks. Therefore, to add a property or method to a .NET Framework
 type, create your own Types.ps1xml files, and then add them to your
 PowerShell session.
 
-To create a new file, start by copying an existing Types.ps1xml file. The
-new file can have any name, but it must have a .ps1xml file name
-extension. You can place the new file in any directory that is accessible
-to PowerShell, but it is useful to place the files in the PowerShell installation directory (`$PSHOME`) or in a subdirectory of the
-installation directory.
+To create a new file, start by copying an existing Types.ps1xml file. The new
+file can have any name, but it must have a .ps1xml file name extension. You can
+place the new file in any directory that is accessible to PowerShell, but it is
+useful to place the files in the PowerShell installation directory (`$PSHOME`)
+or in a subdirectory of the installation directory.
 
 When you have saved the new file, use the `Update-TypeData` cmdlet to add
 the new file to your PowerShell session. If you want your types

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -44,11 +44,9 @@ Sunday, January 29, 2012 9:43:57 AM
 
 You won't find the `DateTime` property in the description of the
 [`System.DateTime` structure](https://msdn.microsoft.com/library/system.datetime.aspx),
-because PowerShell adds the property and it is visible only in Windows
-PowerShell.
+because PowerShell adds the property and it is visible only in PowerShell.
 
-To add the `DateTime` property to all PowerShell sessions, Windows
-PowerShell defines the `DateTime` property in the Types.ps1xml file in the
+To add the `DateTime` property to all PowerShell sessions, PowerShell defines the `DateTime` property in the Types.ps1xml file in the
 PowerShell installation directory (`$PSHOME`).
 
 ## Adding Extended Type Data to PowerShell.
@@ -88,15 +86,13 @@ every session.
 
 The Types.ps1xml file in the PowerShell installation directory
 (`$PSHOME`) is an XML-based text file that lets you add properties and
-methods to the objects that are used in PowerShell. Windows
-PowerShell has built-in Types.ps1xml files that add several elements
+methods to the objects that are used in PowerShell. PowerShell has built-in Types.ps1xml files that add several elements
 to the .NET Framework types, but you can create additional Types.ps1xml
 files to further extend the types.
 
 For example, by default, array objects (`System.Array`) have a `Length`
 property that lists the number of objects in the array. However, because
-the name "Length" does not clearly describe the property, Windows
-PowerShell adds an alias property named "Count" that displays the same
+the name "Length" does not clearly describe the property, PowerShell adds an alias property named "Count" that displays the same
 value. The following XML adds the Count property to the `System.Array` type.
 
 ```xml
@@ -158,8 +154,7 @@ PowerShell session.
 To create a new file, start by copying an existing Types.ps1xml file. The
 new file can have any name, but it must have a .ps1xml file name
 extension. You can place the new file in any directory that is accessible
-to PowerShell, but it is useful to place the files in the Windows
-PowerShell installation directory (`$PSHOME`) or in a subdirectory of the
+to PowerShell, but it is useful to place the files in the PowerShell installation directory (`$PSHOME`) or in a subdirectory of the
 installation directory.
 
 When you have saved the new file, use the `Update-TypeData` cmdlet to add
@@ -562,8 +557,7 @@ the `Update-TypeData` cmdlet. If you want the types in your file to take
 precedence over types in the built-in Types.ps1xml file, add the
 PrependData parameter of `Update-TypeData`. `Update-TypeData` affects only
 the current session. To make the change to all future sessions, export
-the session, or add the `Update-TypeData` command to your Windows
-PowerShell profile.
+the session, or add the `Update-TypeData` command to your PowerShell profile.
 
 Exceptions that occur in properties, or from adding properties to an
 `Update-TypeData` command, do not report errors to `StdErr`. This is to

--- a/reference/6/Microsoft.PowerShell.Core/About/about_psconsolehostreadline.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_psconsolehostreadline.md
@@ -38,13 +38,15 @@ function PSConsoleHostReadLine
 
 ### REMARKS
 
-By default, PowerShell reads input from the console in what is known as
-"Cooked Mode" -- in which the Windows console subsystem handles all the
-keypresses, F7 menus, and other input. When you press Enter or Tab, PowerShell gets the text that you have typed up to that point. There is no way
-for it to know that you pressed Ctrl-R, Ctrl-A, Ctrl-E, or any other keys
-before pressing Enter or Tab. In Windows PowerShell 3.0, the
-PSConsoleHostReadLine function solves this issue. When you define a function
-named PSConsoleHostReadline in the PowerShell console host, PowerShell calls that function instead of the "Cooked Mode" input mechanism.
+By default, PowerShell reads input from the console in what is known as "Cooked
+Mode" -- in which the Windows console subsystem handles all the keypresses, F7
+menus, and other input. When you press Enter or Tab, PowerShell gets the text
+that you have typed up to that point. There is no way for it to know that you
+pressed Ctrl-R, Ctrl-A, Ctrl-E, or any other keys before pressing Enter or Tab.
+In Windows PowerShell 3.0, the PSConsoleHostReadLine function solves this
+issue. When you define a function named PSConsoleHostReadline in the PowerShell
+console host, PowerShell calls that function instead of the "Cooked Mode" input
+mechanism.
 
 ### SEE ALSO
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_psconsolehostreadline.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_psconsolehostreadline.md
@@ -40,13 +40,11 @@ function PSConsoleHostReadLine
 
 By default, PowerShell reads input from the console in what is known as
 "Cooked Mode" -- in which the Windows console subsystem handles all the
-keypresses, F7 menus, and other input. When you press Enter or Tab, Windows
-PowerShell gets the text that you have typed up to that point. There is no way
+keypresses, F7 menus, and other input. When you press Enter or Tab, PowerShell gets the text that you have typed up to that point. There is no way
 for it to know that you pressed Ctrl-R, Ctrl-A, Ctrl-E, or any other keys
 before pressing Enter or Tab. In Windows PowerShell 3.0, the
 PSConsoleHostReadLine function solves this issue. When you define a function
-named PSConsoleHostReadline in the PowerShell console host, Windows
-PowerShell calls that function instead of the "Cooked Mode" input mechanism.
+named PSConsoleHostReadline in the PowerShell console host, PowerShell calls that function instead of the "Cooked Mode" input mechanism.
 
 ### SEE ALSO
 

--- a/reference/6/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Debug-Job.md
@@ -12,7 +12,7 @@ title: Debug-Job
 # Debug-Job
 
 ## SYNOPSIS
-Debugs a running background, remote, or Windows PowerShell Workflow job.
+Debugs a running background, remote, or PowerShell Workflow job.
 
 ## SYNTAX
 
@@ -38,7 +38,7 @@ Debug-Job [-InstanceId] <Guid> [-WhatIf] [-Confirm] [<CommonParameters>]
 
 ## DESCRIPTION
 The **Debug-Job** cmdlet lets you debug scripts that are running within jobs.
-The cmdlet is designed to debug Windows PowerShell Workflow jobs, background jobs, and jobs running in remote sessions.
+The cmdlet is designed to debug PowerShell Workflow jobs, background jobs, and jobs running in remote sessions.
 **Debug-Job** accepts a running job object, name, ID, or instance ID as input, and starts a debugging session on the script it is running.
 The debugger **quit** command stops the job and running script.
 Starting in Windows PowerShell 5.0, the **exit** command detaches the debugger, and allows the job to continue to run.

--- a/reference/6/Microsoft.PowerShell.Core/Disable-PSRemoting.md
+++ b/reference/6/Microsoft.PowerShell.Core/Disable-PSRemoting.md
@@ -26,15 +26,14 @@ on the local computer.
 
 `Disable-PSRemoting` blocks remote access to all PowerShell session configurations on the local
 computer. This prevents remote users from creating temporary or persistent PowerShell sessions to
-the local computer. `Disable-PSRemoting` does not prevent remote users from creating Windows
-PowerShell sessions to the local computer. To disable both PowerShell and Windows PowerShell session
-configurations run `Disable-PSRemoting` in Windows PowerShell on the local computer.
+the local computer. `Disable-PSRemoting` does not prevent remote users from creating PowerShell sessions to the local computer. To disable both PowerShell and PowerShell session
+configurations run `Disable-PSRemoting` in PowerShell on the local computer.
 `Disable-PSRemoting` does not prevent users of the local computer from creating sessions
 (**PSSessions**) on the local computer or remote computers.
 
 To re-enable remote access to all PowerShell session configurations, use the `Enable-PSRemoting`
-cmdlet. To re-enable remote access to all session configurations, including Windows PowerShell
-configurations, run `Enable-PSRemoting` in Windows PowerShell on the local computer. To enable
+cmdlet. To re-enable remote access to all session configurations, including PowerShell
+configurations, run `Enable-PSRemoting` in PowerShell on the local computer. To enable
 remote access to selected session configurations, use the **AccessMode** parameter of the
 `Set-PSSessionConfiguration` cmdlet. You can also use the `Enable-PSSessionConfiguration` and
 `Disable-PSSessionConfiguration` cmdlets to enable and disable session configurations for all users.

--- a/reference/6/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -47,7 +47,7 @@ Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBuff
 
 ## DESCRIPTION
 
-The `Disconnect-PSSession` cmdlet disconnects a Windows PowerShell session ("PSSession"), such as
+The `Disconnect-PSSession` cmdlet disconnects a PowerShell session ("PSSession"), such as
 one started by using the `New-PSSession` cmdlet, from the current session. As a result, the PSSession
 is in a disconnected state. You can connect to the disconnected PSSession from the current session
 or from another session on the local computer or a different computer.
@@ -161,8 +161,7 @@ affect the ITTask sessions on the other computers.
 The third command uses the `Get-PSSession` cmdlet to get the ITTask sessions. The output shows that
 the ITTask sessions on the Srv2 and Srv30 computers were not affected by the command to disconnect.
 
-The manager logs on to his home computer, connects to his corporate network, starts Windows
-PowerShell, and uses the `Get-PSSession` cmdlet to get the ITTask session on the Srv1 computer. He
+The manager logs on to his home computer, connects to his corporate network, starts PowerShell, and uses the `Get-PSSession` cmdlet to get the ITTask session on the Srv1 computer. He
 uses the credentials of the technician to access the session.
 
 Next, the manager uses the `Connect-PSSession` cmdlet to connect to the ITTask session on the Srv1

--- a/reference/6/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -668,7 +668,7 @@ Accept wildcard characters: False
 
 ### -Session
 
-Specifies a Windows PowerShell session (**PSSession**) to use for the interactive session.
+Specifies a PowerShell session (**PSSession**) to use for the interactive session.
 This parameter takes a session object.
 You can also use the *Name*, *InstanceID*, or *ID* parameters to specify a **PSSession**.
 
@@ -805,7 +805,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet uses the Secure Sockets Layer (SSL) protocol to establish a connection to
 the remote computer. By default, SSL is not used.
 
-WS-Management encrypts all Windows PowerShell content transmitted over the network.
+WS-Management encrypts all PowerShell content transmitted over the network.
 The *UseSSL* parameter is an additional protection that sends the data across an HTTPS connection
 instead of an HTTP connection.
 
@@ -879,11 +879,10 @@ The cmdlet does not return any output.
 * To connect to a remote computer, you must be a member of the Administrators group on the remote
 computer.
 * In Windows Vista and later versions of the Windows operating system, to start an interactive
-session on the local computer, you must start Windows PowerShell with the Run as administrator
+session on the local computer, you must start PowerShell with the Run as administrator
 option.
 * When you use **Enter-PSSession**, your user profile on the remote computer is used for the
-interactive session. The commands in the remote user profile, including commands to add Windows
-PowerShell snap-ins and to change the command prompt, run before the remote prompt is displayed.
+interactive session. The commands in the remote user profile, including commands to add PowerShell snap-ins and to change the command prompt, run before the remote prompt is displayed.
 * **Enter-PSSession** uses the UI culture setting on the local computer for the interactive session.
 To find the local UI culture, use the $UICulture automatic variable.
 * **Enter-PSSession** requires the Get-Command, Out-Default, and Exit-PSSession cmdlets. If these
@@ -893,7 +892,7 @@ cmdlets are not included in the session configuration on the remote computer, th
 computer, **Enter-PSSession** sends the commands directly to the remote computer without
 interpretation.
 * If the session that you want to enter is busy processing a command, there might be a delay before
-Windows PowerShell responds to **the Enter-PSSession** command. You will be connected as soon as the
+PowerShell responds to **the Enter-PSSession** command. You will be connected as soon as the
 session is available. To cancel the **Enter-PSSession** command, press `CTRL+C`.
 * The **HostName** parameter set was included starting with PowerShell 6.0.
   It was added to provide PowerShell remoting based on Secure Shell (SSH).

--- a/reference/6/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Command.md
@@ -356,7 +356,7 @@ The acceptable values for this parameter are:
 
 - Alias. Gets the aliases of all PowerShell commands. For more information, see [about_Aliases](About/about_Aliases.md).
 - All. Gets all command types. This parameter value is the equivalent of `Get-Command *`.
-- Application. Gets non-Windows-PowerShell files in paths listed in the **Path** environment
+- Application. Gets non-PowerShell files in paths listed in the **Path** environment
   variable ($env:path), including .txt, .exe, and .dll files. For more information about the
   **Path** environment variable, see about_Environment_Variables.
 - Cmdlet. Gets all cmdlets.

--- a/reference/6/Microsoft.PowerShell.Core/Get-Help.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Help.md
@@ -266,7 +266,7 @@ SYNOPSIS
     ...
 ```
 
-This example shows how to get help that explains how to use the Get-Item cmdlet in the **DataCollection** node of the Windows PowerShellSQL Server provider.
+This example shows how to get help that explains how to use the Get-Item cmdlet in the **DataCollection** node of the PowerShellSQL Server provider.
 The example shows two ways of getting the provider-specific help for **Get-Item**.
 
 You can also get provider-specific help for cmdlets online in the section that describes the provider.

--- a/reference/6/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Module.md
@@ -624,7 +624,7 @@ Skips the check of the `CompatiblePSEditions` field.
 By default, Get-Module will omit modules in the `%windir%\System32\WindowsPowerShell\v1.0\Modules`
 directory that do not specify `Core` in the `CompatiblePSEditions` field.
 When this switch is set, modules without `Core` will be included, so that modules under the
-Windows PowerShell module path that are incompatible with PowerShell Core will be returned.
+PowerShell module path that are incompatible with PowerShell Core will be returned.
 
 On macOS and Linux, this parameter does nothing.
 

--- a/reference/6/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Module.md
@@ -115,7 +115,7 @@ current session.
 
 `Get-Module` looks for available modules in the path specified by the **$env:PSModulePath**
 environment variable.
-For more information about **PSModulePath**, see [about_Modules](About/about_Modules.md) and 
+For more information about **PSModulePath**, see [about_Modules](About/about_Modules.md) and
 [about_Environment_Variables](About/about_Environment_Variables.md).
 
 ### Example 3: Get all exported files
@@ -439,7 +439,7 @@ Accept wildcard characters: False
 ### -CimSession
 
 Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a 
+Enter a variable that contains the CIM session or a command that gets the CIM session, such as a
 [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) command.
 
 `Get-Module` uses the CIM session connection to get modules from the remote computer.
@@ -508,7 +508,7 @@ Accept wildcard characters: False
 Parameter Sets: Available, PsSession, CimSession
 Required: True (Available), False (PsSession, CimSession)
 Default value: None
-Aliases: 
+Aliases:
 Type: SwitchParameter
 ```
 
@@ -624,7 +624,7 @@ Skips the check of the `CompatiblePSEditions` field.
 By default, Get-Module will omit modules in the `%windir%\System32\WindowsPowerShell\v1.0\Modules`
 directory that do not specify `Core` in the `CompatiblePSEditions` field.
 When this switch is set, modules without `Core` will be included, so that modules under the
-PowerShell module path that are incompatible with PowerShell Core will be returned.
+Windows PowerShell module path that are incompatible with PowerShell Core will be returned.
 
 On macOS and Linux, this parameter does nothing.
 

--- a/reference/6/Microsoft.PowerShell.Core/Get-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-PSSession.md
@@ -560,7 +560,7 @@ Accept wildcard characters: False
 Parameter Sets: ComputerInstanceId, ConnectionUriInstanceId, VMNameInstanceId, ContainerIdInstanceId, VMIdInstanceId, InstanceId
 Required: True (ComputerInstanceId, ConnectionUriInstanceId, VMNameInstanceId, ContainerIdInstanceId, VMIdInstanceId), False (InstanceId)
 Default value: None
-Aliases: 
+Aliases:
 Type: Guid[]
 ```
 
@@ -579,7 +579,7 @@ Accept wildcard characters: False
 Parameter Sets: Name, ComputerName, ConnectionUri, ContainerId, VMId, VMName
 Required: False
 Default value: None
-Aliases: 
+Aliases:
 Type: String[]
 ```
 
@@ -806,10 +806,10 @@ might be connected to a different session. To determine whether you can connect 
 A value of **Busy** indicates that you cannot connect to the **PSSession** because it is connected
 to another session.
 
-  For more information about the values of the **State** property of sessions, see 
+  For more information about the values of the **State** property of sessions, see
 [RunspaceState Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspacestate) in the MSDN library.
 
-  For more information about the values of the **Availability** property of sessions, see 
+  For more information about the values of the **Availability** property of sessions, see
 [RunspaceAvailability Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspaceavailability) in the MSDN library.
 
 ## RELATED LINKS

--- a/reference/6/Microsoft.PowerShell.Core/Get-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-PSSession.md
@@ -783,34 +783,34 @@ You cannot pipe input to this cmdlet.
 
 ## NOTES
 
-* This cmdlet gets user-managed sessions **PSSession** objects" such as those that are created by
-using the New-PSSession, **Enter-PSSession**, and Invoke-Command cmdlets. It does not get the
-system-managed session that is created when you start PowerShell.
-* Starting in Windows PowerShell 3.0, **PSSession** objects are stored on the computer that is at
-the server-side or receiving end of a connection. To get the sessions that are stored on the local
-computer or a remote computer, PowerShell establishes a temporary session to the specified computer
-and runs query commands in the session.
-* To get sessions that connect to a remote computer, use the *ComputerName* or *ConnectionUri*
-parameters to specify the remote computer. To filter the sessions that **Get-PSSession** gets, use
-the *Name*, *ID*, *InstanceID*, and *State* parameters. Use the remaining parameters to configure
-the temporary session that **Get-PSSession** uses.
-* When you use the *ComputerName* or *ConnectionUri* parameters, **Get-PSSession** gets only
-sessions from computers running Windows PowerShell 3.0 and later versions of PowerShell.
-* The value of the **State** property of a **PSSession** is relative to the current session.
-Therefore, a value of **Disconnected** means that the **PSSession** is not connected to the current
-session. However, it does not mean that the **PSSession** is disconnected from all sessions. It
-might be connected to a different session. To determine whether you can connect or reconnect to the
-**PSSession** from the current session, use the **Availability** property.
+- This cmdlet gets user-managed sessions **PSSession** objects" such as those that are created by
+  using the New-PSSession, **Enter-PSSession**, and Invoke-Command cmdlets. It does not get the
+  system-managed session that is created when you start PowerShell.
+- Starting in Windows PowerShell 3.0, **PSSession** objects are stored on the computer that is at
+  the server-side or receiving end of a connection. To get the sessions that are stored on the local
+  computer or a remote computer, PowerShell establishes a temporary session to the specified computer
+  and runs query commands in the session.
+- To get sessions that connect to a remote computer, use the *ComputerName* or *ConnectionUri*
+  parameters to specify the remote computer. To filter the sessions that **Get-PSSession** gets, use
+  the *Name*, *ID*, *InstanceID*, and *State* parameters. Use the remaining parameters to configure
+  the temporary session that **Get-PSSession** uses.
+- When you use the *ComputerName* or *ConnectionUri* parameters, **Get-PSSession** gets only
+  sessions from computers running Windows PowerShell 3.0 and later versions of PowerShell.
+- The value of the **State** property of a **PSSession** is relative to the current session.
+  Therefore, a value of **Disconnected** means that the **PSSession** is not connected to the current
+  session. However, it does not mean that the **PSSession** is disconnected from all sessions. It
+  might be connected to a different session. To determine whether you can connect or reconnect to the
+  **PSSession** from the current session, use the **Availability** property.
 
-  An **Availability** value of **None** indicates that you can connect to the session.
+An **Availability** value of **None** indicates that you can connect to the session.
 A value of **Busy** indicates that you cannot connect to the **PSSession** because it is connected
 to another session.
 
-  For more information about the values of the **State** property of sessions, see
-[RunspaceState Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspacestate) in the MSDN library.
+For more information about the values of the **State** property of sessions, see
+[RunspaceState Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspacestate).
 
-  For more information about the values of the **Availability** property of sessions, see
-[RunspaceAvailability Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspaceavailability) in the MSDN library.
+For more information about the values of the **Availability** property of sessions, see
+[RunspaceAvailability Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspaceavailability).
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Import-Module.md
@@ -813,17 +813,17 @@ Accept wildcard characters: False
 
 ### -PSSession
 
-Specifies a Windows PowerShell user-managed session (**PSSession**) from which this cmdlet import modules into the current session.
+Specifies a PowerShell user-managed session (**PSSession**) from which this cmdlet import modules into the current session.
 Enter a variable that contains a **PSSession** or a command that gets a **PSSession**, such as a Get-PSSession command.
 
 When you import a module from a different session into the current session, you can use the cmdlets from the module in the current session, just as you would use cmdlets from a local module.
-Commands that use the remote cmdlets actually run in the remote session, but the remoting details are managed in the background by Windows PowerShell.
+Commands that use the remote cmdlets actually run in the remote session, but the remoting details are managed in the background by PowerShell.
 
-This parameter uses the Implicit Remoting feature of Windows PowerShell.
+This parameter uses the Implicit Remoting feature of PowerShell.
 It is equivalent to using the Import-PSSession cmdlet to import particular modules from a session.
 
-**Import-Module** cannot import Windows PowerShell Core modules from another session.
-The Windows PowerShell Core modules have names that begin with Microsoft.PowerShell.
+**Import-Module** cannot import PowerShell Core modules from another session.
+The PowerShell Core modules have names that begin with Microsoft.PowerShell.
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -314,7 +314,7 @@ The computer names are presented in a comma-separated list.
 The list of computers includes the localhost value, which represents the local computer.
 
 The command uses the *ConfigurationName* parameter to specify an alternate session configuration for
-Windows PowerShell and the *ScriptBlock* parameter to specify the command.
+PowerShell and the *ScriptBlock* parameter to specify the command.
 
 In this example, the command in the script block gets the events in the Windows PowerShell event log
 on each remote computer.
@@ -730,7 +730,7 @@ remotely.
 However, with *AsJob*, the job is created on the local computer, even though the job runs on a
 remote computer, and the results of the remote job are automatically returned to the local computer.
 
-For more information about PowerShell background jobs, see [about_Jobs](About/about_Jobs.md) and 
+For more information about PowerShell background jobs, see [about_Jobs](About/about_Jobs.md) and
 [about_Remote_Jobs](About/about_Remote_Jobs.md).
 
 ```yaml
@@ -942,7 +942,7 @@ Accept wildcard characters: False
 Parameter Sets: ComputerName, FilePathComputerName, Uri, FilePathUri, VMId, VMName, FilePathVMId, FilePathVMName
 Required: True (VMId, VMName, FilePathVMId, FilePathVMName), False (ComputerName, FilePathComputerName, Uri, FilePathUri)
 Default value: None
-Aliases: 
+Aliases:
 Type: PSCredential
 ```
 
@@ -1444,7 +1444,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet uses the Secure Sockets Layer (SSL) protocol to establish a connection to
 the remote computer. By default, SSL is not used.
 
-WS-Management encrypts all Windows PowerShell content transmitted over the network.
+WS-Management encrypts all PowerShell content transmitted over the network.
 The *UseSSL* parameter is an additional protection that sends the data across an HTTPS, instead of
 HTTP.
 
@@ -1561,10 +1561,10 @@ To determine whether you can connect or reconnect to the session, use the **Avai
 A value of Busy indicates that you cannot connect to the PSSession because it is connected to
 another session.
 
-  For more information about the values of the **State** property of sessions, see 
+  For more information about the values of the **State** property of sessions, see
 [RunspaceState Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspacestate) in the MSDN library.
 
-  For more information about the values of the **Availability** property of sessions, see 
+  For more information about the values of the **Availability** property of sessions, see
 [RunspaceAvailability Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspaceavailability) in the MSDN library.
 
 * The HostName and SSHConnection parameter sets were included starting with PowerShell 6.0.
@@ -1575,7 +1575,7 @@ remoting will work over these platforms where PowerShell and SSH are installed a
 WinRM specific features and limitations do not apply.
   For example WinRM based quotas, session options, custom endpoint configuration, and
 disconnect/reconnect features are currently not supported.
-  For more information about how to set up PowerShell SSH remoting, see 
+  For more information about how to set up PowerShell SSH remoting, see
 [PowerShell Remoting Over SSH](/powershell/scripting/core-powershell/ssh-remoting-in-powershell-core).
 
 ## RELATED LINKS

--- a/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -1520,63 +1520,61 @@ parameter.
 
 ## NOTES
 
-* On Windows Vista, and later versions of the Windows operating system, to use the *ComputerName*
-parameter of **Invoke-Command** to run a command on the local computer, you must open PowerShell by
-using the Run as administrator option.
-* When you run commands on multiple computers, PowerShell connects to the computers in the order in
-which they appear in the list. However, the command output is displayed in the order that it is
-received from the remote computers, which might be different.
-* Errors that result from the command that **Invoke-Command** runs are included in the command
-results. Errors that would be terminating errors in a local command are treated as non-terminating
-errors in a remote command. This strategy makes sure that terminating errors on one computer do not
-close the command on all computers on which it is run. This practice is used even when a remote
-command is run on a single computer.
-* If the remote computer is not in a domain that the local computer trusts, the computer might not
-be able to authenticate the credentials of the user. To add the remote computer to the list of
-trusted hosts in WS-Management, use the following command in the WSMAN provider, where
-\<Remote-Computer-Name\> is the name of the remote computer:
+- On Windows Vista, and later versions of the Windows operating system, to use the *ComputerName*
+  parameter of **Invoke-Command** to run a command on the local computer, you must open PowerShell by
+  using the Run as administrator option.
+- When you run commands on multiple computers, PowerShell connects to the computers in the order in
+  which they appear in the list. However, the command output is displayed in the order that it is
+  received from the remote computers, which might be different.
+- Errors that result from the command that **Invoke-Command** runs are included in the command
+  results. Errors that would be terminating errors in a local command are treated as non-terminating
+  errors in a remote command. This strategy makes sure that terminating errors on one computer do not
+  close the command on all computers on which it is run. This practice is used even when a remote
+  command is run on a single computer.
+- If the remote computer is not in a domain that the local computer trusts, the computer might not
+  be able to authenticate the credentials of the user. To add the remote computer to the list of
+  trusted hosts in WS-Management, use the following command in the WSMAN provider, where
+  \<Remote-Computer-Name\> is the name of the remote computer:
 
   `Set-Item -Path WSMan:\Localhost\Client\TrustedHosts -Value \<Remote-Computer-Name\>`
-
-* In Windows PowerShell 2.0, you cannot use the Select-Object cmdlet to select the
-**PSComputerName** property of the object that **Invoke-Command** returns. Instead, to display the
-value of the **PSComputerName** property, use the dot method to get the **PSComputerName** property
-value ($result.PSComputerName), use a **Format** cmdlet, such as the Format-Table cmdlet, to display
-the value of the **PSComputerName** property, or use a Select-Object command where the value of the
-property parameter is a calculated property that has a label other than PSComputerName.
+- In Windows PowerShell 2.0, you cannot use the Select-Object cmdlet to select the
+  **PSComputerName** property of the object that **Invoke-Command** returns. Instead, to display the
+  value of the **PSComputerName** property, use the dot method to get the **PSComputerName** property
+  value ($result.PSComputerName), use a **Format** cmdlet, such as the Format-Table cmdlet, to display
+  the value of the **PSComputerName** property, or use a Select-Object command where the value of the
+  property parameter is a calculated property that has a label other than PSComputerName.
 
   This limitation does not apply to Windows PowerShell 3.0 or later versions of Windows PowerShell
-or PowerShell Core.
-
-* When you disconnect a **PSSession**, such as by using *InDisconnectedSession*, the session state
-is Disconnected and the availability is None.
+  or PowerShell Core.
+- When you disconnect a **PSSession**, such as by using *InDisconnectedSession*, the session state
+  is Disconnected and the availability is None.
 
   The value of the **State** property is relative to the current session.
-Therefore, a value of Disconnected means that the *PSSession* is not connected to the current
-session. However, it does not mean that the **PSSession** is disconnected from all sessions.
-It might be connected to a different session.
-To determine whether you can connect or reconnect to the session, use the **Availability** property.
+  Therefore, a value of Disconnected means that the *PSSession* is not connected to the current
+  session. However, it does not mean that the **PSSession** is disconnected from all sessions.
+  It might be connected to a different session.
+  To determine whether you can connect or reconnect to the session, use the **Availability** property.
 
   An **Availability** value of None indicates that you can connect to the session.
-A value of Busy indicates that you cannot connect to the PSSession because it is connected to
-another session.
+  A value of Busy indicates that you cannot connect to the PSSession because it is connected to
+  another session.
 
   For more information about the values of the **State** property of sessions, see
-[RunspaceState Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspacestate) in the MSDN library.
+  [RunspaceState Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspacestate).
 
   For more information about the values of the **Availability** property of sessions, see
-[RunspaceAvailability Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspaceavailability) in the MSDN library.
+  [RunspaceAvailability Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspaceavailability).
 
-* The HostName and SSHConnection parameter sets were included starting with PowerShell 6.0.
+- The HostName and SSHConnection parameter sets were included starting with PowerShell 6.0.
   They were added to provide PowerShell remoting based on Secure Shell (SSH).
   Both SSH and PowerShell are supported on multiple platforms (Windows, Linux, macOS) and PowerShell
-remoting will work over these platforms where PowerShell and SSH are installed and configured.
+  remoting will work over these platforms where PowerShell and SSH are installed and configured.
   This is separate from the previous Windows only remoting that is based on WinRM and much of the
-WinRM specific features and limitations do not apply.
+  WinRM specific features and limitations do not apply.
   For example WinRM based quotas, session options, custom endpoint configuration, and
-disconnect/reconnect features are currently not supported.
+  disconnect/reconnect features are currently not supported.
   For more information about how to set up PowerShell SSH remoting, see
-[PowerShell Remoting Over SSH](/powershell/scripting/core-powershell/ssh-remoting-in-powershell-core).
+  [PowerShell Remoting Over SSH](/powershell/scripting/core-powershell/ssh-remoting-in-powershell-core).
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md
+++ b/reference/6/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md
@@ -32,7 +32,7 @@ Clears the display in the host program.
 Reconnects to disconnected sessions.
 
 ### [Debug-Job](Debug-Job.md)
-Debugs a running background, remote, or Windows PowerShell Workflow job.
+Debugs a running background, remote, or PowerShell Workflow job.
 
 ### [Disable-PSRemoting](Disable-PSRemoting.md)
 Prevents remote users from running commands on the local computer.

--- a/reference/6/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/6/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -497,7 +497,7 @@ Accept wildcard characters: False
 
 Specifies the formatting files (.ps1xml) that run when the module is imported.
 
-When you import a module, Windows PowerShell runs the `Update-FormatData` cmdlet with the specified
+When you import a module, PowerShell runs the `Update-FormatData` cmdlet with the specified
 files. Because formatting files are not scoped, they affect all session states in the session.
 
 ```yaml
@@ -542,7 +542,7 @@ with the same name.
 If you omit this parameter, `New-ModuleManifest` creates a **GUID** key in the manifest and
 generates a GUID for the value.
 
-To create a new GUID in Windows PowerShell, type "\[guid\]::NewGuid()".
+To create a new GUID in PowerShell, type "\[guid\]::NewGuid()".
 
 ```yaml
 Type: Guid
@@ -774,7 +774,7 @@ Accept wildcard characters: False
 
 ### -PowerShellVersion
 
-Specifies the minimum version of Windows PowerShell that works with this module.
+Specifies the minimum version of PowerShell that works with this module.
 For example, you can enter 3.0, 4.0, or 5.0 as the value of this parameter.
 
 ```yaml
@@ -881,7 +881,7 @@ Accept wildcard characters: False
 ### -RequiredModules
 
 Specifies modules that must be in the global session state. If the required modules are not in the
-global session state, Windows PowerShell imports them. If the required modules are not available,
+global session state, PowerShell imports them. If the required modules are not available,
 the `Import-Module` command fails.
 
 Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
@@ -942,7 +942,7 @@ Accept wildcard characters: False
 
 Specifies the type files (.ps1xml) that run when the module is imported.
 
-When you import the module, Windows PowerShell runs the `Update-TypeData` cmdlet with the specified
+When you import the module, PowerShell runs the `Update-TypeData` cmdlet with the specified
 files. Because type files are not scoped, they affect all session states in the session.
 
 ```yaml

--- a/reference/6/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/New-PSSession.md
@@ -882,7 +882,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet uses the SSL protocol to establish a connection to the remote computer.
 By default, SSL is not used.
 
-WS-Management encrypts all Windows PowerShell content transmitted over the network.
+WS-Management encrypts all PowerShell content transmitted over the network.
 The *UseSSL* parameter offers an additional protection that sends the data across an HTTPS
 connection instead of an HTTP connection.
 

--- a/reference/6/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -472,7 +472,7 @@ If you do not specify a connection URI, you can use the *UseSSL*, *ComputerName*
 Valid values for the Transport segment of the URI are HTTP and HTTPS.
 If you specify a connection URI with a Transport segment, but do not specify a port, the session is
 created with standards ports: 80 for HTTP and 443 for HTTPS.
-To use the default ports for Windows PowerShell remoting, specify port 5985 for HTTP or 5986 for
+To use the default ports for PowerShell remoting, specify port 5985 for HTTP or 5986 for
 HTTPS.
 
 If the destination computer redirects the connection to a different URI, PowerShell prevents the
@@ -858,7 +858,7 @@ job object. Otherwise, it returns objects that represent that command results.
 - When a session that contains a running job is disconnected and then reconnected, the original job
   object is reused only if the job is disconnected and reconnected to the same session, and the
   command to reconnect does not specify a new job name. If the session is reconnected to a different
-  client session or a new job name is specified, Windows PowerShell creates a new job object for the
+  client session or a new job name is specified, PowerShell creates a new job object for the
   new session.
 - When you disconnect a **PSSession**, the session state is Disconnected and the availability is
   None.

--- a/reference/6/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/6/Microsoft.PowerShell.Core/Save-Help.md
@@ -37,7 +37,7 @@ The **Save-Help** cmdlet downloads the newest help files for PowerShell modules 
 This feature lets you update the help files on computers that do not have access to the Internet, and makes it easier to update the help files on multiple computers.
 
 In Windows PowerShell 3.0, **Save-Help** worked only for modules that are installed on the local computer.
-Although it was possible to import a module from a remote computer, or obtain a reference to a **PSModuleInfo** object from a remote computer by using Windows PowerShell remoting, the **HelpInfoUri** property was not preserved, and **Save-Help** would not work for remote module Help.
+Although it was possible to import a module from a remote computer, or obtain a reference to a **PSModuleInfo** object from a remote computer by using PowerShell remoting, the **HelpInfoUri** property was not preserved, and **Save-Help** would not work for remote module Help.
 
 In Windows PowerShell 4.0, the **HelpInfoUri** property is preserved over PowerShell remoting, which enables **Save-Help** to work for modules that are installed on remote computers.
 It is also possible to save a **PSModuleInfo** object to disk or removable media by running Export-Clixml on a computer that does not have Internet access, import the object on a computer that does have Internet access, and then run **Save-Help** on the **PSModuleInfo** object.

--- a/reference/6/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/6/Microsoft.PowerShell.Core/Update-Help.md
@@ -573,7 +573,7 @@ specified language, it continues silently without displaying an error message. T
 progress details, use the **Verbose** parameter.
 
 The `Update-Help` cmdlet was introduced in Windows PowerShell 3.0. It doesn't work in earlier
-versions of Windows PowerShell. On computers that have both Windows PowerShell 2.0 and Windows
+versions of PowerShell. On computers that have both Windows PowerShell 2.0 and Windows
 PowerShell 3.0, use the `Update-Help` cmdlet in a Windows PowerShell 3.0 session to download and
 update help files. The help files are available to both Windows PowerShell 2.0 and Windows
 PowerShell 3.0.

--- a/reference/6/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/6/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -143,7 +143,7 @@ Accept wildcard characters: False
 Specifies a location to the transcript file. Unlike the **Path** parameter, the value of the
 **LiteralPath** parameter is used exactly as it is typed. No characters are interpreted as
 wildcards. If the path includes escape characters, enclose it in single quotation marks. Single
-quotation marks inform Windows PowerShell not to interpret any characters as escape sequences.
+quotation marks inform PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String

--- a/reference/6/Microsoft.PowerShell.Management/Clear-Content.md
+++ b/reference/6/Microsoft.PowerShell.Management/Clear-Content.md
@@ -116,7 +116,7 @@ Type a user name, such as "User01" or "Domain01\User01", or enter a **PSCredenti
 If you type a user name, you will be prompted for a password.
 
 > [!WARNING]
-> This parameter is not supported by any providers installed with Windows PowerShell.
+> This parameter is not supported by any providers installed with PowerShell.
 
 ```yaml
 Type: PSCredential

--- a/reference/6/Microsoft.PowerShell.Management/Debug-Process.md
+++ b/reference/6/Microsoft.PowerShell.Management/Debug-Process.md
@@ -49,7 +49,7 @@ Before using this cmdlet, verify that a debugger is downloaded and correctly con
 PS C:\> Debug-Process -Name "Windows Powershell"
 ```
 
-This command attaches a debugger to the Windows PowerShell process on the computer.
+This command attaches a debugger to the PowerShell process on the computer.
 
 ### Example 2: Attach a debugger to all processes that begin with the specified string
 
@@ -81,8 +81,8 @@ This command attaches a debugger to the processes that have process IDs 1132 and
 PS C:\> Get-Process "Windows PowerShell" | Debug-Process
 ```
 
-This command attaches a debugger to the Windows PowerShell processes on the computer.
-It uses the **Get-Process** cmdlet to get the Windows PowerShell processes on the computer, and it uses a pipeline operator (|) to send the processes to the **Debug-Process** cmdlet.
+This command attaches a debugger to the PowerShell processes on the computer.
+It uses the **Get-Process** cmdlet to get the PowerShell processes on the computer, and it uses a pipeline operator (|) to send the processes to the **Debug-Process** cmdlet.
 
 To specify a particular PowerShell process, use the ID parameter of **Get-Process**.
 
@@ -92,9 +92,9 @@ To specify a particular PowerShell process, use the ID parameter of **Get-Proces
 PS C:\> $PID | Debug-Process
 ```
 
-This command attaches a debugger to the current Windows PowerShell processes on the computer.
+This command attaches a debugger to the current PowerShell processes on the computer.
 
-The command uses the $PID automatic variable, which contains the process ID of the current Windows PowerShell process.
+The command uses the $PID automatic variable, which contains the process ID of the current PowerShell process.
 Then, it uses a pipeline operator (|) to send the process ID to the **Debug-Process** cmdlet.
 
 For more information about the $PID automatic variable, see about_Automatic_Variables.
@@ -106,9 +106,9 @@ PS C:\> $P = Get-Process "Windows PowerShell"
 PS C:\> Debug-Process -InputObject $P
 ```
 
-This command attaches a debugger to the Windows PowerShell processes on the local computer.
+This command attaches a debugger to the PowerShell processes on the local computer.
 
-The first command uses the **Get-Process** cmdlet to get the Windows PowerShell processes on the computer.
+The first command uses the **Get-Process** cmdlet to get the PowerShell processes on the computer.
 It saves the resulting process object in the variable named $P.
 
 The second command uses the *InputObject* parameter of the **Debug-Process** cmdlet to submit the process object in the $P variable.

--- a/reference/6/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/6/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -83,7 +83,7 @@ registry entry ("NoOfLocations"), and its value (3), to the "MyCompany" key.
 Get-Item -Path "HKLM:\Software\MyCompany" | New-ItemProperty -Name NoOfLocations -Value 3
 ```
 
-This command works because the parameter-binding feature of Windows PowerShell associates the path
+This command works because the parameter-binding feature of PowerShell associates the path
 of the `RegistryKey` object that `Get-Item` returns with the **LiteralPath** parameter of
 `New-ItemProperty`.
 For more information, see [about_Pipelines](../Microsoft.PowerShell.Core/About/about_pipelines.md).

--- a/reference/6/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Push-Location.md
@@ -97,7 +97,7 @@ For more information about location stacks, see the [Notes](#notes).
 Specifies the path to the new location. Unlike the **Path** parameter, the value of the
 **LiteralPath** parameter is used exactly as it is typed. No characters are interpreted as
 wildcards. If the path includes escape characters, enclose it in single quotation marks. Single
-quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -200,7 +200,7 @@ You add items to a stack in the order that you use them, and then retrieve them 
 reverse order. PowerShell lets you store provider locations in location stacks.
 
 PowerShell creates an unnamed default location stack and you can create multiple named location
-stacks. If you do not specify a stack name, Windows PowerShell uses the current location stack. By
+stacks. If you do not specify a stack name, PowerShell uses the current location stack. By
 default, the unnamed default location is the current location stack, but you can use the
 `Set-Location` cmdlet to change the current location stack.
 

--- a/reference/6/Microsoft.PowerShell.Management/Remove-PSDrive.md
+++ b/reference/6/Microsoft.PowerShell.Management/Remove-PSDrive.md
@@ -37,9 +37,9 @@ Beginning in Windows PowerShell 3.0, `Remove-PSDrive` also disconnects mapped ne
 
 `Remove-PSDrive` cannot delete Windows physical or logical drives.
 
-Beginning in Windows PowerShell 3.0, when an external drive is connected to the computer, Windows PowerShell automatically adds a PSDrive to the file system that represents the new drive.
+Beginning in Windows PowerShell 3.0, when an external drive is connected to the computer, PowerShell automatically adds a PSDrive to the file system that represents the new drive.
 You do not need to restart PowerShell.
-Similarly, when an external drive is disconnected from the computer, Windows PowerShell automatically deletes the PSDrive that represents the removed drive.
+Similarly, when an external drive is disconnected from the computer, PowerShell automatically deletes the PSDrive that represents the removed drive.
 
 ## EXAMPLES
 

--- a/reference/6/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/6/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -36,7 +36,7 @@ This feature makes it practical to use `Restart-Computer` in scripts and functio
 You can also use the WSMan protocol to restart the computer, in case DCOM calls are blocked, such as
 by an enterprise firewall.
 
-This cmdlet requires Windows PowerShell remoting only when you use the **AsJob** parameter in a
+This cmdlet requires PowerShell remoting only when you use the **AsJob** parameter in a
 command.
 
 ## EXAMPLES
@@ -205,8 +205,8 @@ This parameter is valid only with the **Wait** parameter.
 
 The acceptable values for this parameter are:
 
-- Default: Waits for Windows PowerShell to restart.
-- PowerShell: Can run commands in a Windows PowerShell remote session on the computer.
+- Default: Waits for PowerShell to restart.
+- PowerShell: Can run commands in a PowerShell remote session on the computer.
 - WMI: Receives a reply to a Win32_ComputerSystem query for the computer.
 - WinRM: Can establish a remote session to the computer by using WS-Management.
 
@@ -265,7 +265,7 @@ Accept wildcard characters: False
 
 ### -Wait
 
-Indicates that this cmdlet suppresses the Windows PowerShell prompt and blocks the pipeline until
+Indicates that this cmdlet suppresses the PowerShell prompt and blocks the pipeline until
 all of the computers have restarted.
 You can use this parameter in a script to restart computers and then continue to process when the
 restart is finished.

--- a/reference/6/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
+++ b/reference/6/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
@@ -28,7 +28,8 @@ Provides access to X.509 certificate stores and certificates in PowerShell.
 The PowerShell **Certificate** provider lets you get, add, change, clear, and delete
 certificates and certificate stores in PowerShell.
 
-The **Certificate** drive is a hierarchical namespace containing the cerificate stores and certificates on your computer.
+The **Certificate** drive is a hierarchical namespace containing the cerificate
+stores and certificates on your computer.
 
 The **Certificate** provider supports the following cmdlets, which are covered
 in this article.
@@ -56,7 +57,9 @@ The Certificate drive exposes the following types.
   for all users. Each system has a CurrentUser and LocalMachine (all users)
   store location.
 
-- Certificates stores (System.Security.Cryptography.X509Certificates.X509Store), which are physical stores in which certificates are saved and managed.
+- Certificates stores
+  (System.Security.Cryptography.X509Certificates.X509Store), which are physical
+  stores in which certificates are saved and managed.
 
 - X.509 **System.Security.Cryptography.X509Certificates.X509Certificate2**
   certificates, each of which represent an X.509 certificate on the computer.
@@ -92,8 +95,8 @@ Set-Location C:
 > PowerShell uses aliases to allow you a familiar way to work with provider
 > paths. Commands such as `dir` and `ls` are now aliases for
 > [Get-ChildItem](../../Microsoft.PowerShell.Management/Get-ChildItem.md),
-> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md). and `pwd` is
-> an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
+> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md).
+> and `pwd` is an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
 
 ## Displaying the Contents of the Cert: drive
 
@@ -340,8 +343,8 @@ $expired | Remove-Item -DeleteKey
 ## Creating Certificates
 
 The `New-Item` cmdlet does not create new certificates in the **Certificate**
-provider. Use the [New-SelfSignedCertificate](/powershell/module/pkiclient/new-selfsignedcertificate) cmdlet to create a certificate
-for testing purposes.
+provider. Use the [New-SelfSignedCertificate](/powershell/module/pkiclient/new-selfsignedcertificate)
+cmdlet to create a certificate for testing purposes.
 
 ## Creating Certificate Stores
 

--- a/reference/6/Microsoft.PowerShell.Security/Get-Acl.md
+++ b/reference/6/Microsoft.PowerShell.Security/Get-Acl.md
@@ -250,7 +250,7 @@ Specifies the path to a resource.
 Unlike **Path**, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 This parameter is introduced in Windows PowerShell 3.0.
 
@@ -309,19 +309,19 @@ the ACL type.
 
 ## NOTES
 
-By default, **Get-Acl** displays the Windows PowerShell path to the resource
+By default, **Get-Acl** displays the PowerShell path to the resource
 (\<provider\>::\<resource-path\>), the owner of the resource, and "Access", a list (array) of the
 access control entries in the discretionary access control list (DACL) for the resource. The DACL
 list is controlled by the resource owner.
 
 When you format the result as a list, ("`Get-Acl | Format-List`"), in addition to the path, owner,
-and access list, Windows PowerShell displays the following properties and property values:
+and access list, PowerShell displays the following properties and property values:
 
 - **Group**: The security group of the owner.
 - **Audit**:  A list (array) of entries in the system access control list (SACL). The SACL
   specifies the types of access attempts for which Windows generates audit records.
 - **Sddl**: The security descriptor of the resource displayed in a single text string in Security
-  Descriptor Definition Language format. Windows PowerShell uses the GetSddlForm method of security
+  Descriptor Definition Language format. PowerShell uses the GetSddlForm method of security
   descriptors to get this data.
 
 Because **Get-Acl** is supported by the file system and registry providers, you can use **Get-Acl**

--- a/reference/6/Microsoft.PowerShell.Security/Get-Credential.md
+++ b/reference/6/Microsoft.PowerShell.Security/Get-Credential.md
@@ -37,7 +37,7 @@ message on the dialog box that prompts the user for their name and password.
 
 The **Get-Credential** cmdlet prompts the user for a password or a user name and password. By
 default, an authentication dialog box appears to prompt the user. However, in some host programs,
-such as the Windows PowerShell console, you can prompt the user at the command line by changing a
+such as the PowerShell console, you can prompt the user at the command line by changing a
 registry entry. For more information about this registry entry, see the notes and examples.
 
 ## EXAMPLES
@@ -55,7 +55,7 @@ enter the requested information, the cmdlet creates a **PSCredential** object re
 credentials of the user and saves it in the $c variable.
 
 You can use the object as input to cmdlets that request user authentication, such as those with a
-**Credential** parameter. However, some providers that are installed with Windows PowerShell do not
+**Credential** parameter. However, some providers that are installed with PowerShell do not
 support the **Credential** parameter.
 
 ### Example 2
@@ -124,12 +124,12 @@ This example shows how to modify the registry so that the user is prompted at th
 instead of by using a dialog box.
 
 The command creates the **ConsolePrompting** registry entry and sets its value to True. To run this
-command, start Windows PowerShell with the "Run as administrator" option.
+command, start PowerShell with the "Run as administrator" option.
 
 To use a dialog box for prompting, set the value of the ConsolePrompting to false ($false) or use
 the Remove-ItemProperty cmdlet to delete it.
 
-The ConsolePrompting registry entry works in some host programs, such as the Windows PowerShell
+The ConsolePrompting registry entry works in some host programs, such as the PowerShell
 console. It might not work in all host programs.
 
 ### Example 7
@@ -302,15 +302,14 @@ at the command line, add the **ConsolePrompting** registry entry
 **ConsolePrompting** registry entry does not exist or if its value is False, the authentication
 prompt appears in a dialog box. For instructions, see the examples.
 
-The **ConsolePrompting** registry entry works in the Windows PowerShell console, but it does not
+The **ConsolePrompting** registry entry works in the PowerShell console, but it does not
 work in all host programs.
 
 For example, it has no effect in the Windows PowerShell Integrated Scripting Environment (ISE). For
 information about the effect of the **ConsolePrompting** registry entry, see the help topics for
 the host program.
 
-The **Credential** parameter is not supported by all providers that are installed with Windows
-PowerShell. Beginning in Windows PowerShell 3.0, it is supported on selected cmdlet, such as the
+The **Credential** parameter is not supported by all providers that are installed with PowerShell. Beginning in Windows PowerShell 3.0, it is supported on selected cmdlet, such as the
 Get-WmiObject and New-PSDrive cmdlets.
 
 ## RELATED LINKS

--- a/reference/6/Microsoft.PowerShell.Utility/Debug-Runspace.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Debug-Runspace.md
@@ -209,7 +209,7 @@ You can pipe the results of a **Get-Runspace** command to **Debug-Runspace.**
 
   - If it is coming from **Debug-Runspace**; that is, it has a **Debug-Runspace** GUID ID.
 
-  - If it is coming from a Windows PowerShell workflow, and its workflow job ID is the same as the current active debugger workflow job ID.
+  - If it is coming from a PowerShell workflow, and its workflow job ID is the same as the current active debugger workflow job ID.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -157,7 +157,7 @@ Specifies a location for the output file.
 Unlike the *Path* parameter, the value of *LiteralPath* is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String

--- a/reference/6/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -74,7 +74,7 @@ Specifies the path to a file that includes exported alias information.
 Unlike the **Path** parameter, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String

--- a/reference/6/Microsoft.PowerShell.Utility/Import-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Import-PSSession.md
@@ -357,7 +357,7 @@ The PowerShell aliases in the remote session.
 - All.
 The cmdlets and functions in the remote session.
 - Application.
-All the files other than Windows-PowerShell files in the paths that are listed in the Path environment variable ($env:path) in the remote session, including .txt, .exe, and .dll files.
+All the files other than PowerShell files in the paths that are listed in the Path environment variable ($env:path) in the remote session, including .txt, .exe, and .dll files.
 - Cmdlet.
 The cmdlets in the remote session.
 "Cmdlet" is the default.

--- a/reference/6/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -205,7 +205,7 @@ Specifies the paths and file names of the XML files to search.
 Unlike *Path*, the value of the *LiteralPath* parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]

--- a/reference/6/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -218,7 +218,7 @@ Accept wildcard characters: False
 ```
 
 ### -PSHost
-ndicates that this cmdlet sends the trace output to the Windows PowerShell host.
+ndicates that this cmdlet sends the trace output to the PowerShell host.
 This parameter also selects the PSHost trace listener.
 
 ```yaml

--- a/reference/6/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -138,7 +138,7 @@ Specifies a file that this cmdlet saves the object to.
 Unlike *FilePath*, the value of the *LiteralPath* parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String

--- a/reference/6/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Write-Information.md
@@ -25,7 +25,7 @@ Write-Information [-MessageData] <Object> [[-Tags] <String[]>] [<CommonParameter
 
 The `Write-Information` cmdlet specifies how PowerShell handles information stream data for a command.
 
-Windows PowerShell 5.0 introduces a new, structured information stream (number 6 in Windows PowerShell streams) that you can use to transmit structured data between a script and its callers (or hosting environment).
+Windows PowerShell 5.0 introduces a new, structured information stream (number 6 in PowerShell streams) that you can use to transmit structured data between a script and its callers (or hosting environment).
 `Write-Information` lets you add an informational message to the stream, and specify how PowerShell handles information stream data for a command. Information streams also work for `PowerShell.Streams`, jobs, scheduled jobs, and workflows.
 
 > [!NOTE]

--- a/reference/6/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -22,7 +22,7 @@ Write-Progress [-Activity] <String> [[-Status] <String>] [[-Id] <Int32>] [-Perce
 
 ## DESCRIPTION
 
-The `Write-Progress` cmdlet displays a progress bar in a Windows PowerShell command window that
+The `Write-Progress` cmdlet displays a progress bar in a PowerShell command window that
 depicts the status of a running command or script.
 You can select the indicators that the bar reflects and the text that appears above and below the
 progress bar.
@@ -290,7 +290,7 @@ You cannot pipe input to this cmdlet.
 
 If the progress bar does not appear, check the value of the `$ProgressPreference` variable. If the
 value is set to SilentlyContinue, the progress bar is not displayed. For more information about
-Windows PowerShell preferences, see [about_Preference_Variables](../Microsoft.PowerShell.Core/About/about_Preference_Variables.md).
+PowerShell preferences, see [about_Preference_Variables](../Microsoft.PowerShell.Core/About/about_Preference_Variables.md).
 
 The parameters of the cmdlet correspond to the properties of the
 **System.Management.Automation.ProgressRecord** class. For more information, see

--- a/reference/6/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
+++ b/reference/6/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
@@ -579,8 +579,10 @@ Beginning in Windows PowerShell 3.0, you can get customized help topics for
 provider cmdlets that explain how those cmdlets behave in a file system drive.
 
 To get the help topics that are customized for the file system drive, run a
-[Get-Help](../../Microsoft.PowerShell.Core/Get-Help.md) command in a file system drive or use the `-Path`
-parameter of [Get-Help](../../Microsoft.PowerShell.Core/Get-Help.md) to specify a file system drive.
+[Get-Help](../../Microsoft.PowerShell.Core/Get-Help.md) command in a file
+system drive or use the `-Path` parameter of
+[Get-Help](../../Microsoft.PowerShell.Core/Get-Help.md) to specify a file
+system drive.
 
 ```powershell
 Get-Help Get-ChildItem

--- a/reference/6/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
+++ b/reference/6/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
@@ -23,10 +23,10 @@ information.
 
 ## Detailed description
 
-The **WSMan** provider for Windows PowerShell lets you add, change, clear, and
+The **WSMan** provider for PowerShell lets you add, change, clear, and
 delete WS-Management configuration data on local or remote computers.
 
-The **WSMan** provider exposes a Windows PowerShell drive with a directory
+The **WSMan** provider exposes a PowerShell drive with a directory
 structure that corresponds to a logical grouping of WS-Management configuration
 settings. These groupings are known as containers.
 
@@ -272,7 +272,7 @@ New-Item -Path WSMan:\localhost\Plugin\TestPlugin\InitializationParameters `
 
 ## Dynamic parameters
 
-Dynamic parameters are cmdlet parameters that are added by a Windows PowerShell
+Dynamic parameters are cmdlet parameters that are added by a PowerShell
 provider and are available only when the cmdlet is being used in the
 provider-enabled drive.
 
@@ -388,7 +388,7 @@ certificate (X509) of a user account that has permission to perform this
 action. Certificates are used in client certificate-based authentication. They
 can be mapped only to local user accounts, and they do not work with domain
 accounts. To get a certificate thumbprint, use the `Get-Item` or `Get-ChildItem`
-cmdlets in the Windows PowerShell `Cert:` drive.
+cmdlets in the PowerShell `Cert:` drive.
 
 #### Cmdlets supported
 

--- a/reference/6/Microsoft.WSMan.Management/Connect-WSMan.md
+++ b/reference/6/Microsoft.WSMan.Management/Connect-WSMan.md
@@ -135,7 +135,7 @@ For example: `http://server01:8080/WSMAN`
 
 Internet Information Services (IIS), which hosts the session, forwards requests with this endpoint to the specified application.
 This default setting of WSMAN is appropriate for most uses.
-This parameter is designed to be used if many computers establish remote connections to one computer that is running Windows PowerShell.
+This parameter is designed to be used if many computers establish remote connections to one computer that is running PowerShell.
 In this case, IIS hosts Web Services for Management (WS-Management) for efficiency.
 
 ```yaml
@@ -194,7 +194,7 @@ Enter the certificate thumbprint of the certificate.
 Certificates are used in client certificate-based authentication.
 They can be mapped only to local user accounts; they do not work with domain accounts.
 
-To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the Windows PowerShell Cert: drive.
+To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the PowerShell Cert: drive.
 
 ```yaml
 Type: String
@@ -334,7 +334,7 @@ Accept wildcard characters: False
 Specifies that the Secure Sockets Layer (SSL) protocol is used to establish a connection to the remote computer.
 By default, SSL is not used.
 
-WS-Management encrypts all the Windows PowerShell content that is transmitted over the network.
+WS-Management encrypts all the PowerShell content that is transmitted over the network.
 The *UseSSL* parameter lets you specify the additional protection of HTTPS instead of HTTP.
 If SSL is not available on the port that is used for the connection, and you specify this parameter, the command fails.
 
@@ -364,7 +364,7 @@ This cmdlet does not accept any input.
 This cmdlet does not generate any output.
 
 ## NOTES
-* You can run management commands or query management data on a remote computer without creating a WS-Management session. You can do this by using the *ComputerName* parameters of Invoke-WSManAction and Get-WSManInstance. When you use the *ComputerName* parameter, Windows PowerShell creates a temporary connection that is used for the single command. After the command runs, the connection is closed.
+* You can run management commands or query management data on a remote computer without creating a WS-Management session. You can do this by using the *ComputerName* parameters of Invoke-WSManAction and Get-WSManInstance. When you use the *ComputerName* parameter, PowerShell creates a temporary connection that is used for the single command. After the command runs, the connection is closed.
 
 *
 

--- a/reference/6/Microsoft.WSMan.Management/Get-WSManInstance.md
+++ b/reference/6/Microsoft.WSMan.Management/Get-WSManInstance.md
@@ -365,7 +365,7 @@ For example: `http://server01:8080/WSMAN`
 
 Internet Information Services (IIS), which hosts the session, forwards requests with this endpoint to the specified application.
 This default setting of WSMAN is appropriate for most uses.
-This parameter is designed to be used if many computers establish remote connections to one computer that is running Windows PowerShell.
+This parameter is designed to be used if many computers establish remote connections to one computer that is running PowerShell.
 In this case, IIS hosts WS-Management for efficiency.
 
 ```yaml
@@ -456,7 +456,7 @@ Enter the certificate thumbprint of the certificate.
 Certificates are used in client certificate-based authentication.
 They can be mapped only to local user accounts; they do not work with domain accounts.
 
-To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the Windows PowerShell Cert: drive.
+To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the PowerShell Cert: drive.
 
 ```yaml
 Type: String
@@ -766,7 +766,7 @@ Accept wildcard characters: False
 Specifies that the Secure Sockets Layer (SSL) protocol is used to establish a connection to the remote computer.
 By default, SSL is not used.
 
-WS-Management encrypts all the Windows PowerShell content that is transmitted over the network.
+WS-Management encrypts all the PowerShell content that is transmitted over the network.
 The *UseSSL* parameter lets you specify the additional protection of HTTPS instead of HTTP.
 If SSL is not available on the port that is used for the connection, and you specify this parameter, the command fails.
 

--- a/reference/6/Microsoft.WSMan.Management/Invoke-WSManAction.md
+++ b/reference/6/Microsoft.WSMan.Management/Invoke-WSManAction.md
@@ -130,7 +130,7 @@ For example: `http://server01:8080/WSMAN`
 
 Internet Information Services (IIS), which hosts the session, forwards requests with this endpoint to the specified application.
 This default setting of WSMAN is appropriate for most uses.
-This parameter is designed to be used if many computers establish remote connections to one computer that is running Windows PowerShell.
+This parameter is designed to be used if many computers establish remote connections to one computer that is running PowerShell.
 In this case, IIS hosts Web Services for Management (WS-Management) for efficiency.
 
 ```yaml
@@ -189,7 +189,7 @@ Enter the certificate thumbprint of the certificate.
 Certificates are used in client certificate-based authentication.
 They can be mapped only to local user accounts; they do not work with domain accounts.
 
-To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the Windows PowerShell Cert: drive.
+To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the PowerShell Cert: drive.
 
 ```yaml
 Type: String
@@ -397,7 +397,7 @@ Accept wildcard characters: False
 Specifies that the Secure Sockets Layer (SSL) protocol is used to establish a connection to the remote computer.
 By default, SSL is not used.
 
-WS-Management encrypts all the Windows PowerShell content that is transmitted over the network.
+WS-Management encrypts all the PowerShell content that is transmitted over the network.
 The *UseSSL* parameter lets you specify the additional protection of HTTPS instead of HTTP.
 If SSL is not available on the port that is used for the connection, and you specify this parameter, the command fails.
 

--- a/reference/6/Microsoft.WSMan.Management/New-WSManInstance.md
+++ b/reference/6/Microsoft.WSMan.Management/New-WSManInstance.md
@@ -60,7 +60,7 @@ For example: `http://server01:8080/WSMAN`
 
 Internet Information Services (IIS), which hosts the session, forwards requests with this endpoint to the specified application.
 This default setting of WSMAN is appropriate for most uses.
-This parameter is designed to be used if many computers establish remote connections to one computer that is running Windows PowerShell.
+This parameter is designed to be used if many computers establish remote connections to one computer that is running PowerShell.
 In this case, IIS hosts Web Services for Management (WS-Management) for efficiency.
 
 ```yaml
@@ -119,7 +119,7 @@ Enter the certificate thumbprint of the certificate.
 Certificates are used in client certificate-based authentication.
 They can be mapped only to local user accounts; they do not work with domain accounts.
 
-To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the Windows PowerShell Cert: drive.
+To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the PowerShell Cert: drive.
 
 ```yaml
 Type: String
@@ -319,7 +319,7 @@ Accept wildcard characters: False
 Specifies that the Secure Sockets Layer (SSL) protocol is used to establish a connection to the remote computer.
 By default, SSL is not used.
 
-WS-Management encrypts all the Windows PowerShell content that is transmitted over the network.
+WS-Management encrypts all the PowerShell content that is transmitted over the network.
 The *UseSSL* parameter lets you specify the additional protection of HTTPS instead of HTTP.
 If SSL is not available on the port that is used for the connection, and you specify this parameter, the command fails.
 

--- a/reference/6/Microsoft.WSMan.Management/Remove-WSManInstance.md
+++ b/reference/6/Microsoft.WSMan.Management/Remove-WSManInstance.md
@@ -62,7 +62,7 @@ For example: `http://server01:8080/WSMAN`
 
 Internet Information Services (IIS), which hosts the session, forwards requests with this endpoint to the specified application.
 This default setting of WSMAN is appropriate for most uses.
-This parameter is designed to be used if many computers establish remote connections to one computer that is running Windows PowerShell.
+This parameter is designed to be used if many computers establish remote connections to one computer that is running PowerShell.
 In this case, IIS hosts Web Services for Management (WS-Management) for efficiency.
 
 ```yaml
@@ -123,7 +123,7 @@ Enter the certificate thumbprint of the certificate.
 Certificates are used in client certificate-based authentication.
 They can be mapped only to local user accounts; they do not work with domain accounts.
 
-To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the Windows PowerShell Cert: drive.
+To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the PowerShell Cert: drive.
 
 ```yaml
 Type: String
@@ -316,7 +316,7 @@ Accept wildcard characters: False
 Specifies that the Secure Sockets Layer (SSL) protocol is used to establish a connection to the remote computer.
 By default, SSL is not used.
 
-WS-Management encrypts all the Windows PowerShell content that is transmitted over the network.
+WS-Management encrypts all the PowerShell content that is transmitted over the network.
 The *UseSSL* parameter lets you specify the additional protection of HTTPS instead of HTTP.
 If SSL is not available on the port that is used for the connection, and you specify this parameter, the command fails.
 

--- a/reference/6/Microsoft.WSMan.Management/Set-WSManInstance.md
+++ b/reference/6/Microsoft.WSMan.Management/Set-WSManInstance.md
@@ -123,7 +123,7 @@ For example: `http://server01:8080/WSMAN`
 
 Internet Information Services (IIS), which hosts the session, forwards requests with this endpoint to the specified application.
 This default setting of WSMAN is appropriate for most uses.
-This parameter is designed to be used if many computers establish remote connections to one computer that is running Windows PowerShell.
+This parameter is designed to be used if many computers establish remote connections to one computer that is running PowerShell.
 In this case, IIS hosts Web Services for Management (WS-Management) for efficiency.
 
 ```yaml
@@ -184,7 +184,7 @@ Enter the certificate thumbprint of the certificate.
 Certificates are used in client certificate-based authentication.
 They can be mapped only to local user accounts; they do not work with domain accounts.
 
-To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the Windows PowerShell Cert: drive.
+To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the PowerShell Cert: drive.
 
 ```yaml
 Type: String
@@ -438,7 +438,7 @@ Accept wildcard characters: False
 Specifies that the Secure Sockets Layer (SSL) protocol is used to establish a connection to the remote computer.
 By default, SSL is not used.
 
-WS-Management encrypts all the Windows PowerShell content that is transmitted over the network.
+WS-Management encrypts all the PowerShell content that is transmitted over the network.
 The *UseSSL* parameter lets you specify the additional protection of HTTPS instead of HTTP.
 If SSL is not available on the port that is used for the connection, and you specify this parameter, the command fails.
 

--- a/reference/6/Microsoft.WSMan.Management/Set-WSManQuickConfig.md
+++ b/reference/6/Microsoft.WSMan.Management/Set-WSManQuickConfig.md
@@ -21,7 +21,7 @@ Set-WSManQuickConfig [-UseSSL] [-Force] [-SkipNetworkProfileCheck] [<CommonParam
 
 ## DESCRIPTION
 
-The **Set-WSManQuickConfig** cmdlet configures the computer to receive Windows PowerShell remote commands that are sent by using the Web Services for Management (WS-Management) technology.
+The **Set-WSManQuickConfig** cmdlet configures the computer to receive PowerShell remote commands that are sent by using the Web Services for Management (WS-Management) technology.
 
 This cmdlet performs the following actions:
 
@@ -32,7 +32,7 @@ If the WinRM service is not running, the service is started.
 By default, the transport is HTTP.
 - Enables a firewall exception for WinRM traffic .
 
-To run this cmdlet, start Windows PowerShell by using the Run as administrator option.
+To run this cmdlet, start PowerShell by using the Run as administrator option.
 
 ## EXAMPLES
 
@@ -101,7 +101,7 @@ Accept wildcard characters: False
 Specifies that the Secure Sockets Layer (SSL) protocol is used to establish a connection to the remote computer.
 By default, SSL is not used.
 
-WS-Management encrypts all the Windows PowerShell content that is transmitted over the network.
+WS-Management encrypts all the PowerShell content that is transmitted over the network.
 The *UseSSL* parameter lets you specify the additional protection of HTTPS instead of HTTP.
 If SSL is not available on the port that is used for the connection, and you specify this parameter, the command fails.
 

--- a/reference/6/Microsoft.WSMan.Management/Test-WSMan.md
+++ b/reference/6/Microsoft.WSMan.Management/Test-WSMan.md
@@ -106,7 +106,7 @@ For example: `http://server01:8080/WSMAN`
 
 Internet Information Services (IIS), which hosts the session, forwards requests with this endpoint to the specified application.
 This default setting of WSMAN is appropriate for most uses.
-This parameter is designed to be used if many computers establish remote connections to one computer that is running Windows PowerShell.
+This parameter is designed to be used if many computers establish remote connections to one computer that is running PowerShell.
 In this case, IIS hosts Web Services for Management (WS-Management) for efficiency.
 
 ```yaml
@@ -171,7 +171,7 @@ Enter the certificate thumbprint of the certificate.
 Certificates are used in client certificate-based authentication.
 They can be mapped only to local user accounts; they do not work with domain accounts.
 
-To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the Windows PowerShell Cert: drive.
+To get a certificate thumbprint, use the Get-Item or Get-ChildItem command in the PowerShell Cert: drive.
 
 ```yaml
 Type: String
@@ -251,7 +251,7 @@ Accept wildcard characters: False
 Specifies that the Secure Sockets Layer (SSL) protocol is used to establish a connection to the remote computer.
 By default, SSL is not used.
 
-WS-Management encrypts all the Windows PowerShell content that is transmitted over the network.
+WS-Management encrypts all the PowerShell content that is transmitted over the network.
 The *UseSSL* parameter lets you specify the additional protection of HTTPS instead of HTTP.
 If SSL is not available on the port that is used for the connection, and you specify this parameter, the command fails.
 

--- a/reference/6/PSDesiredStateConfiguration/About/about_Classes_and_DSC.md
+++ b/reference/6/PSDesiredStateConfiguration/About/about_Classes_and_DSC.md
@@ -17,7 +17,7 @@ Configuration (DSC).
 Starting in Windows PowerShell 5.0, language was added to define classes and
 other user-defined types, by using formal syntax and semantics that are
 similar to other object-oriented programming languages. The goal is to enable
-developers and IT professionals to embrace Windows PowerShell for a wider
+developers and IT professionals to embrace PowerShell for a wider
 range of use cases, simplify development of PowerShell artifacts such as DSC
 resources, and accelerate coverage of management surfaces.
 
@@ -453,7 +453,7 @@ following configuration references the MyDSCResource module. Save the
 configuration as a script, MyResource.ps1.
 
 For information about how to run a DSC configuration,
-see [Windows PowerShell Desired State Configuration Overview](/dsc/overview/overview.md).
+see [PowerShell Desired State Configuration Overview](/dsc/overview/overview.md).
 
 Before you run the configuration, create `C:\test.txt`. The configuration
 checks if the file exists at `c:\test\test.txt`. If the file does not exist,
@@ -978,4 +978,4 @@ function Html ([HTML] $doc) { return $doc }
 
 [about_Methods](../../Microsoft.PowerShell.Core/About/about_Methods.md)
 
-[Build Custom Windows PowerShell Desired State Configuration Resources](https://docs.microsoft.com/powershell/dsc/resources/authoringResource)
+[Build Custom PowerShell Desired State Configuration Resources](https://docs.microsoft.com/powershell/dsc/resources/authoringResource)

--- a/reference/6/PSDesiredStateConfiguration/Get-DscResource.md
+++ b/reference/6/PSDesiredStateConfiguration/Get-DscResource.md
@@ -21,7 +21,7 @@ Get-DscResource [[-Name] <String[]>] [[-Module] <Object>] [-Syntax] [<CommonPara
 
 ## DESCRIPTION
 
-The **Get-DscResource** cmdlet retrieves the Windows PowerShell Desired State Configuration (DSC) resources present on the computer.
+The **Get-DscResource** cmdlet retrieves the PowerShell Desired State Configuration (DSC) resources present on the computer.
 This cmdlet discovers only the resources installed in the PSModulePath.
 It shows the details about built-in and custom providers, which are created by the user.
 This cmdlet also shows details about composite resources, which are other configurations that are packaged as module or created at run time in the session.
@@ -149,6 +149,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Windows PowerShell Desired State Configuration Overview](/powershell/dsc)
+[PowerShell Desired State Configuration Overview](/powershell/dsc)
 
 [Invoke-DscResource](https://msdn.microsoft.com/en-us/powershell/reference/5.1/PSDesiredStateConfiguration/Invoke-DscResource)

--- a/reference/6/PSDesiredStateConfiguration/New-DSCCheckSum.md
+++ b/reference/6/PSDesiredStateConfiguration/New-DSCCheckSum.md
@@ -21,7 +21,7 @@ New-DscChecksum [-Path] <String[]> [[-OutPath] <String>] [-Force] [-WhatIf] [-Co
 
 ## DESCRIPTION
 
-The **New-DSCCheckSum** cmdlet generates checksum files for Windows PowerShell Desired State Configuration (DSC) documents and compressed DSC resources.
+The **New-DSCCheckSum** cmdlet generates checksum files for PowerShell Desired State Configuration (DSC) documents and compressed DSC resources.
 This cmdlet generates a checksum file for each configuration and resource to be used in pull mode.
 The DSC service uses the checksums to make sure that the correct configuration and resources exist on the target node.
 Place the checksums together with the associated DSC documents and compressed DSC resources in the DSC service store.
@@ -141,4 +141,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Windows PowerShell Desired State Configuration Overview](/powershell/dsc)
+[PowerShell Desired State Configuration Overview](/powershell/dsc)

--- a/reference/6/PSDiagnostics/PSDiagnostics.md
+++ b/reference/6/PSDiagnostics/PSDiagnostics.md
@@ -13,7 +13,7 @@ Module Name: PSDiagnostics
 
 ## Description
 
-The Windows PowerShell Diagnostics Module contains a set of cmdlets that enables the use of ETW
+The PowerShell Diagnostics Module contains a set of cmdlets that enables the use of ETW
 tracing in PowerShell on Windows.
 
 ## PSDiagnostics Cmdlets

--- a/reference/6/PSReadLine/Set-PSReadlineOption.md
+++ b/reference/6/PSReadLine/Set-PSReadlineOption.md
@@ -186,7 +186,7 @@ The Colors parameter is used to specify various colors used by PSReadLine.
 The argument is a Hashtable where the keys specify which element and the values specify the color.
 
 Colors can be either a value from ConsoleColor, for example `[ConsoleColor]::Red`, or a valid
-escape sequence. Valid escape sequences depend on your terminal. In Windows PowerShell, an example
+escape sequence. Valid escape sequences depend on your terminal. In PowerShell, an example
 escape sequence is `$([char]0x1b)[91m`. In PowerShell 6, the same escape sequence is `e[91m`. You
 can specify other escape sequences including:
 

--- a/reference/6/PowerShellGet/Find-Module.md
+++ b/reference/6/PowerShellGet/Find-Module.md
@@ -528,7 +528,7 @@ such as `Install-Module`.
 
 ## NOTES
 
-This cmdlet runs on PowerShell 5.0 or later releases of Windows PowerShell, on Windows 7, or Windows
+This cmdlet runs on PowerShell 5.0 or later releases of PowerShell, on Windows 7, or Windows
 2008 R2 and later releases of Windows.
 
 ## RELATED LINKS

--- a/reference/6/PowerShellGet/Publish-Module.md
+++ b/reference/6/PowerShellGet/Publish-Module.md
@@ -342,7 +342,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-* This cmdlet runs on Windows PowerShell 3.0 or later releases of Windows PowerShell, on Windows 7 or Windows 2008 R2 and later releases of Windows.
+* This cmdlet runs on Windows PowerShell 3.0 or later releases of PowerShell, on Windows 7 or Windows 2008 R2 and later releases of Windows.
 
   `Publish-Module` shows no output if a module is published successfully.
 

--- a/reference/6/PowerShellGet/Update-Module.md
+++ b/reference/6/PowerShellGet/Update-Module.md
@@ -269,7 +269,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-* This cmdlet runs on Windows PowerShell 3.0 or later releases of Windows PowerShell, on Windows 7 or Windows 2008 R2 and later releases of Windows.
+* This cmdlet runs on Windows PowerShell 3.0 or later releases of PowerShell, on Windows 7 or Windows 2008 R2 and later releases of Windows.
 
   If the module that you specify with the **Name** parameter was not installed by using Install-Module, an error occurs.
 You can only run **Update-Module** on modules that you installed from the online gallery by running Install-Module.


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 7 document
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
