### PR TITLE
Rename "ampersand background operator" as "background job operator"

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Jobs.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Jobs.md
@@ -73,9 +73,9 @@ The following command is functionally equivalent to the command above.
 $job = Get-Process &
 ```
 
-The `&` is called the ampersand background operator.
-For more information on the ampersand background operator,
-see [ampersand background operator](about_Operators.md#ampersand-background-operator-).
+The `&` is called the background job operator.
+For more information on the background job operator,
+see [background job operator](about_Operators.md#background-job-operator-).
 
 You can also use the `Get-Job` cmdlet to get objects that represent the jobs
 started in the current session. `Get-Job` returns the same job object that

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -192,14 +192,13 @@ Hello World!
 
 For more about script blocks, see [about_Script_Blocks](about_Script_Blocks.md).
 
-#### Ampersand background operator `&`
+#### Background job operator `&`
 
-Runs the pipeline before it in a PowerShell job. The ampersand background
-operator acts similarly to the UNIX "ampersand operator" which famously runs
-the command before it as a background process. The ampersand background
-operator is built on top of PowerShell jobs so it shares a lot of functionality
-with `Start-Job`. The following command contains basic usage of the ampersand
-background operator.
+Runs the pipeline before it in a PowerShell job. The background job operator
+acts similarly to the UNIX control operator ampersand (`&`), which runs
+the command before it asynchronously in sub shell as a job. The background job
+operator is functionally equivalent to `Start-Job`. The following example
+demonstrates basic usage of the background job operator.
 
 ```powershell
 Get-Process -Name pwsh &
@@ -212,16 +211,9 @@ This is functionally equivalent to the following usage of
 Start-Job -ScriptBlock {Get-Process -Name pwsh}
 ```
 
-Since it's functionally equivalent to using
-`Start-Job`,
-the ampersand background operator returns a
-`Job`
-object just like
-`Start-Job` does.
-This means that you are able to use
-`Receive-Job` and `Remove-Job`
-just as you would if you had used
-`Start-Job` to start the job.
+Just like `Start-Job`, the background job operator returns a `Job` object.
+This object can be used with `Receive-Job` and `Remove-Job`, just as if you
+had used `Start-Job` to start the job.
 
 ```powershell
 $job = Get-Process -Name pwsh &


### PR DESCRIPTION
I renamed the "ampersand background operator" as "background job operator". The new name accurately reflects what the operator does, while the old name does not.

Version(s) of document impacted
------------------------------
- [X] Impacts 7 document
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version 6 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
