### PR TITLE
Fixes #4341 - Corrected ValidateRangeKind Enum

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -472,8 +472,8 @@ The `ValidateRangeKind` enum allows for the following values:
 
 - `Positive` A number greater than zero
 - `Negative` A number less than zero
-- `NotPositive` A number less than or equal to zero
-- `NotNegative` A number greater than or equal to zero
+- `NonPositive` A number less than or equal to zero
+- `NonNegative` A number greater than or equal to zero
 
 In the following example, the value of the
 `Attempts` parameter must be between zero and ten.


### PR DESCRIPTION
Version(s) of document impacted
------------------------------
- [ ] Impacts 7 document
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work

Reference: https://docs.microsoft.com/dotnet/api/system.management.automation.validaterangekind?view=pscore-6.2.0
