### PR TITLE
Update Sort-Object.md

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -540,7 +540,7 @@ Accept wildcard characters: False
 
 The sorted objects are delivered in the order they were received when the sort criteria are equal.
 
-This parameter was adding in PowerShell v6.2.0.
+This parameter was added in PowerShell v6.2.0.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
Grammar typo fixed


Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document


Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6.2.0 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
