### PR TITLE
Remove -ComputerName from example code block

### DIFF
--- a/reference/docs-conceptual/samples/Working-with-Printers.md
+++ b/reference/docs-conceptual/samples/Working-with-Printers.md
@@ -13,7 +13,7 @@ You can use Windows PowerShell to manage printers by using WMI and the WScript.N
 The simplest way to list the printers installed on a computer is to use the WMI **Win32_Printer** class:
 
 ```powershell
-Get-WmiObject -Class Win32_Printer -ComputerName
+Get-WmiObject -Class Win32_Printer
 ```
 
 You can also list the printers by using the **WScript.Network** COM object that is typically used in WSH scripts:


### PR DESCRIPTION
Parameter `-ComputerName` in example is without any parameter specified therefore copy&paste of the code block causes syntax error when pasted to PowerShell window.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
