### PR TITLE
Clean up documentation for the `&` background operator

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Jobs.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Jobs.md
@@ -73,9 +73,9 @@ The following command is functionally equivalent to the command above.
 $job = Get-Process &
 ```
 
-The `&` is called the ampersand background operator.
-For more information on the ampersand background operator,
-see [ampersand background operator](about_Operators.md#ampersand-background-operator-).
+The `&` is called the background job operator.
+For more information on the background job operator,
+see [background job operator](about_Operators.md#background-job-operator-).
 
 You can also use the `Get-Job` cmdlet to get objects that represent the jobs
 started in the current session. `Get-Job` returns the same job object that

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Jobs.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Jobs.md
@@ -73,9 +73,9 @@ The following command is functionally equivalent to the command above.
 $job = Get-Process &
 ```
 
-The `&` is called the background job operator.
-For more information on the background job operator,
-see [background job operator](about_Operators.md#background-job-operator-).
+The `&` is called the background operator.
+For more information on the background operator,
+see [background operator](about_Operators.md#background-operator-).
 
 You can also use the `Get-Job` cmdlet to get objects that represent the jobs
 started in the current session. `Get-Job` returns the same job object that

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -192,32 +192,32 @@ Hello World!
 
 For more about script blocks, see [about_Script_Blocks](about_Script_Blocks.md).
 
-#### Background job operator `&`
+#### Background operator `&`
 
-Runs the pipeline before it in a PowerShell job. The background job operator
-acts similarly to the UNIX control operator ampersand (`&`), which runs
-the command before it asynchronously in sub shell as a job. The background job
-operator is functionally equivalent to `Start-Job`. The following example
+Runs the pipeline before it in the background, in a PowerShell job. This
+operator acts similarly to the UNIX control operator ampersand (`&`), which
+runs the command before itasynchronously in sub shell as a job.
+
+This operator is functionally equivalent to `Start-Job`. The following example
 demonstrates basic usage of the background job operator.
 
 ```powershell
 Get-Process -Name pwsh &
 ```
 
-This is functionally equivalent to the following usage of
-`Start-Job`.
+That command is functionally equivalent to the following usage of `Start-Job`:
 
 ```powershell
 Start-Job -ScriptBlock {Get-Process -Name pwsh}
 ```
 
-Just like `Start-Job`, the background job operator returns a `Job` object.
+Just like `Start-Job`, the `&` background operator returns a `Job` object.
 This object can be used with `Receive-Job` and `Remove-Job`, just as if you
 had used `Start-Job` to start the job.
 
 ```powershell
 $job = Get-Process -Name pwsh &
-Receive-Job $job
+Receive-Job $job -Wait
 ```
 
 ```Output
@@ -234,6 +234,35 @@ Receive-Job $job
 $job = Get-Process -Name pwsh &
 Remove-Job $job
 ```
+
+The `&` background operator is also a statement terminator, just like the UNIX
+control operator ampersand (`&`). This allows you to invoke additional commands
+after the `&` background operator. The following example demonstrates the
+invocation of additional commands after the `&` background operator.
+
+```powershell
+$job = Get-Process -Name pwsh & Receive-Job $job -Wait
+```
+
+```Output
+
+ NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
+ ------    -----      -----     ------      --  -- -----------
+      0     0.00     221.16      25.90    6988 988 pwsh
+      0     0.00     140.12      29.87   14845 845 pwsh
+      0     0.00      85.51       0.91   19639 988 pwsh
+
+```
+
+This is equivalent to the following script:
+
+```powershell
+$job = Start-Job -ScriptBlock {Get-Process -Name pwsh}
+Receive-Job $job -Wait
+```
+
+If you want to run multiple commands, each in their own background process
+but all on one line, simply place `&` between and after each of the commands.
 
 For more information on PowerShell jobs, see [about_Jobs](about_Jobs.md).
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -192,14 +192,13 @@ Hello World!
 
 For more about script blocks, see [about_Script_Blocks](about_Script_Blocks.md).
 
-#### Ampersand background operator `&`
+#### Background job operator `&`
 
-Runs the pipeline before it in a PowerShell job. The ampersand background
-operator acts similarly to the UNIX "ampersand operator" which famously runs
-the command before it as a background process. The ampersand background
-operator is built on top of PowerShell jobs so it shares a lot of functionality
-with `Start-Job`. The following command contains basic usage of the ampersand
-background operator.
+Runs the pipeline before it in a PowerShell job. The background job operator
+acts similarly to the UNIX control operator ampersand (`&`), which runs
+the command before it asynchronously in sub shell as a job. The background job
+operator is functionally equivalent to `Start-Job`. The following example
+demonstrates basic usage of the background job operator.
 
 ```powershell
 Get-Process -Name pwsh &
@@ -212,16 +211,9 @@ This is functionally equivalent to the following usage of
 Start-Job -ScriptBlock {Get-Process -Name pwsh}
 ```
 
-Since it's functionally equivalent to using
-`Start-Job`,
-the ampersand background operator returns a
-`Job`
-object just like
-`Start-Job` does.
-This means that you are able to use
-`Receive-Job` and `Remove-Job`
-just as you would if you had used
-`Start-Job` to start the job.
+Just like `Start-Job`, the background job operator returns a `Job` object.
+This object can be used with `Receive-Job` and `Remove-Job`, just as if you
+had used `Start-Job` to start the job.
 
 ```powershell
 $job = Get-Process -Name pwsh &

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -196,7 +196,7 @@ For more about script blocks, see [about_Script_Blocks](about_Script_Blocks.md).
 
 Runs the pipeline before it in the background, in a PowerShell job. This
 operator acts similarly to the UNIX control operator ampersand (`&`), which
-runs the command before itasynchronously in sub shell as a job.
+runs the command before it asynchronously in sub shell as a job.
 
 This operator is functionally equivalent to `Start-Job`. The following example
 demonstrates basic usage of the background job operator.


### PR DESCRIPTION
Version(s) of document impacted
------------------------------
- [X] Impacts 7 document
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version 6 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
