### PR TITLE
Added clarification on default header behaviour.

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Format-Table.md
@@ -317,8 +317,11 @@ Specifies the object properties that appear in the display and the order in whic
 one or more property names (separated by commas), or use a hash table to display a calculated
 property. Wildcards are permitted.
 
-If you omit this parameter, the properties that appear in the display depend on the object being
-displayed. The parameter name "Property" is optional. You cannot use the **Property** and
+If you omit this parameter, the properties that appear in the display depend on the first object's
+properties. For example, if the first object has "PropertyA" and "PropertyB" but subsequent objects 
+have "PropertyA", "PropertyB" and "PropertyC" only "PropertyA" and "PropertyB" headers will display.
+
+The parameter name "Property" is optional. You cannot use the **Property** and
 **View** parameters in the same command.
 
 The value of the **Property** parameter can be a new calculated property. To create a calculated


### PR DESCRIPTION
When -Properties is not used, the command uses the first object in a hash table to decide on headers to show. If this first object doesn't contain properties of subsequent objects (e.g Object1 has two properties and Object2 has three properties), only headers for the first object's properties will be shown.