### PR TITLE
Update Get-ChildItem -Filter position

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -512,7 +512,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: True


### PR DESCRIPTION
Looks like in PowerShell v6 a, docs got changed and now doesn't reflect what we see in the console `Get-Help Get-ChildItem`. `-Filter` parameter is (as it was in v5.1 and probably previously) positional on position 1.

**NOTE**: I wasn't able to find folder for v7 documentation so I only edited v6. If anything else is needed, feel free to point me the right file.

First noticed by me [on StackOverflow](https://stackoverflow.com/a/56632955/9902555).

Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
