### PR TITLE
Fixed empty bullet and formatting

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/6/Microsoft.PowerShell.Utility/New-Alias.md
@@ -238,9 +238,9 @@ Otherwise, this cmdlet does not generate any output.
 
 ## NOTES
 
-* To create a new alias, use Set-Alias or New-Alias. To change an alias, use **Set-Alias**. To delete an alias, use Remove-Item.
+* To create a new alias, use **Set-Alias** or **New-Alias**. To change an alias, use **Set-Alias**. 
 
-*
+* To delete an alias, use **Remove-Item**.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
There was an empty point in the Notes section. Moved the `delete alias` to it and added some formatting to the first one.
