### PR TITLE
Update "Writing a Windows PowerShell Cmdlet"

### DIFF
--- a/developer/cmdlet/writing-a-windows-powershell-cmdlet.md
+++ b/developer/cmdlet/writing-a-windows-powershell-cmdlet.md
@@ -24,9 +24,6 @@ This section describes what cmdlets are and how they work.
 [Examples of Cmdlet Code](./examples-of-cmdlet-code.md)
 This section contains example code that you can use to start writing your own cmdlets.
 
-[Writing Formatting Files for Cmdlet Output](../format/writing-a-powershell-formatting-file.md)
-This section describe how to create formatting files. Formatting files define how PowerShell displays objects at the command line.
-
 [Tutorials for Writing Cmdlets](./tutorials-for-writing-cmdlets.md)
 This section contains tutorials that you can use to learn about the fundamentals behind the cmdlet code.
 


### PR DESCRIPTION
Remove the link for "Writing Formatting Files for Cmdlet Output", which is not under this category.