### PR TITLE
Update Invoke-Command AsJob param

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -523,18 +523,18 @@ Accept wildcard characters: False
 
 ### -AsJob
 
-Runs the command as a background job on a remote computer.
-Use this parameter to run commands that take an extensive time to complete.
+Indicates that this cmdlet runs the command as a background job on a remote computer.
+Use this parameter to run commands that take an extensive time to finish.
 
-When you use **AsJob**, the command returns an object that represents the job, and then displays the command prompt.
-You can continue to work in the session while the job completes.
-To manage the job, use the Job cmdlets.
-To get the job results, use the Receive-Job cmdlet.
+When you use the **AsJob** parameter, the command returns an object that represents the job, and then displays the command prompt.
+You can continue to work in the session while the job finishes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the `Receive-Job` cmdlet.
 
-The **AsJob** parameter is similar to using the **Invoke-Command** cmdlet to run a Start-Job command remotely.
+The **AsJob** parameter resembles using the `Invoke-Command` cmdlet to run a `Start-Job` cmdlet remotely.
 However, with **AsJob**, the job is created on the local computer, even though the job runs on a remote computer, and the results of the remote job are automatically returned to the local computer.
 
-For more information about Windows PowerShell background jobs, see [about_Jobs](About/about_Jobs.md) and [about_Remote_Jobs](About/about_Remote_Jobs.md).
+For more information about PowerShell background jobs, see [about_Jobs](About/about_Jobs.md) and [about_Remote_Jobs](About/about_Remote_Jobs.md).
 
 ```yaml
 Type: SwitchParameter

--- a/reference/4.0/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -513,18 +513,18 @@ Accept wildcard characters: False
 
 ### -AsJob
 
-Runs the command as a background job on a remote computer.
-Use this parameter to run commands that take an extensive time to complete.
+Indicates that this cmdlet runs the command as a background job on a remote computer.
+Use this parameter to run commands that take an extensive time to finish.
 
-When you use **AsJob**, the command returns an object that represents the job, and then displays the command prompt.
-You can continue to work in the session while the job completes.
-To manage the job, use the Job cmdlets.
-To get the job results, use the Receive-Job cmdlet.
+When you use the **AsJob** parameter, the command returns an object that represents the job, and then displays the command prompt.
+You can continue to work in the session while the job finishes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the `Receive-Job` cmdlet.
 
-The **AsJob** parameter is similar to using the **Invoke-Command** cmdlet to run a Start-Job command remotely.
+The **AsJob** parameter resembles using the `Invoke-Command` cmdlet to run a `Start-Job` cmdlet remotely.
 However, with **AsJob**, the job is created on the local computer, even though the job runs on a remote computer, and the results of the remote job are automatically returned to the local computer.
 
-For more information about Windows PowerShell background jobs, see [about_Jobs](About/about_Jobs.md) and [about_Remote_Jobs](About/about_Remote_Jobs.md).
+For more information about PowerShell background jobs, see [about_Jobs](About/about_Jobs.md) and [about_Remote_Jobs](About/about_Remote_Jobs.md).
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.0/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -633,18 +633,15 @@ Accept wildcard characters: False
 Indicates that this cmdlet runs the command as a background job on a remote computer.
 Use this parameter to run commands that take an extensive time to finish.
 
-When you use the *AsJob* parameter, the command returns an object that represents the job, and then
-displays the command prompt. You can continue to work in the session while the job finishes.
-To manage the job, use the **Job** cmdlets.
-To get the job results, use the Receive-Job cmdlet.
+When you use the **AsJob** parameter, the command returns an object that represents the job, and then displays the command prompt.
+You can continue to work in the session while the job finishes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the `Receive-Job` cmdlet.
 
-The *AsJob* parameter resembles using the **Invoke-Command** cmdlet to run a Start-Job command
-remotely.
-However, with *AsJob*, the job is created on the local computer, even though the job runs on a
-remote computer, and the results of the remote job are automatically returned to the local computer.
+The **AsJob** parameter resembles using the `Invoke-Command` cmdlet to run a `Start-Job` cmdlet remotely.
+However, with **AsJob**, the job is created on the local computer, even though the job runs on a remote computer, and the results of the remote job are automatically returned to the local computer.
 
-For more information about Windows PowerShell background jobs, see [about_Jobs](About/about_Jobs.md)
-and [about_Remote_Jobs](About/about_Remote_Jobs.md).
+For more information about PowerShell background jobs, see [about_Jobs](About/about_Jobs.md) and [about_Remote_Jobs](About/about_Remote_Jobs.md).
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.1/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -650,18 +650,15 @@ Accept wildcard characters: False
 Indicates that this cmdlet runs the command as a background job on a remote computer.
 Use this parameter to run commands that take an extensive time to finish.
 
-When you use the *AsJob* parameter, the command returns an object that represents the job, and then
-displays the command prompt. You can continue to work in the session while the job finishes.
-To manage the job, use the **Job** cmdlets.
-To get the job results, use the Receive-Job cmdlet.
+When you use the **AsJob** parameter, the command returns an object that represents the job, and then displays the command prompt.
+You can continue to work in the session while the job finishes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the `Receive-Job` cmdlet.
 
-The *AsJob* parameter resembles using the **Invoke-Command** cmdlet to run a Start-Job command
-remotely.
-However, with *AsJob*, the job is created on the local computer, even though the job runs on a
-remote computer, and the results of the remote job are automatically returned to the local computer.
+The **AsJob** parameter resembles using the `Invoke-Command` cmdlet to run a `Start-Job` cmdlet remotely.
+However, with **AsJob**, the job is created on the local computer, even though the job runs on a remote computer, and the results of the remote job are automatically returned to the local computer.
 
-For more information about Windows PowerShell background jobs, see [about_Jobs](About/about_Jobs.md)
-and [about_Remote_Jobs](About/about_Remote_Jobs.md).
+For more information about PowerShell background jobs, see [about_Jobs](About/about_Jobs.md) and [about_Remote_Jobs](About/about_Remote_Jobs.md).
 
 ```yaml
 Type: SwitchParameter

--- a/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -735,18 +735,15 @@ Accept wildcard characters: False
 Indicates that this cmdlet runs the command as a background job on a remote computer.
 Use this parameter to run commands that take an extensive time to finish.
 
-When you use the *AsJob* parameter, the command returns an object that represents the job, and then
-displays the command prompt. You can continue to work in the session while the job finishes.
-To manage the job, use the **Job** cmdlets.
-To get the job results, use the Receive-Job cmdlet.
+When you use the **AsJob** parameter, the command returns an object that represents the job, and then displays the command prompt.
+You can continue to work in the session while the job finishes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the `Receive-Job` cmdlet.
 
-The *AsJob* parameter resembles using the **Invoke-Command** cmdlet to run a Start-Job command
-remotely.
-However, with *AsJob*, the job is created on the local computer, even though the job runs on a
-remote computer, and the results of the remote job are automatically returned to the local computer.
+The **AsJob** parameter resembles using the `Invoke-Command` cmdlet to run a `Start-Job` cmdlet remotely.
+However, with **AsJob**, the job is created on the local computer, even though the job runs on a remote computer, and the results of the remote job are automatically returned to the local computer.
 
-For more information about PowerShell background jobs, see [about_Jobs](About/about_Jobs.md) and
-[about_Remote_Jobs](About/about_Remote_Jobs.md).
+For more information about PowerShell background jobs, see [about_Jobs](About/about_Jobs.md) and [about_Remote_Jobs](About/about_Remote_Jobs.md).
 
 ```yaml
 Type: SwitchParameter

--- a/reference/7/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/7/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -735,18 +735,15 @@ Accept wildcard characters: False
 Indicates that this cmdlet runs the command as a background job on a remote computer.
 Use this parameter to run commands that take an extensive time to finish.
 
-When you use the *AsJob* parameter, the command returns an object that represents the job, and then
-displays the command prompt. You can continue to work in the session while the job finishes.
-To manage the job, use the **Job** cmdlets.
-To get the job results, use the Receive-Job cmdlet.
+When you use the **AsJob** parameter, the command returns an object that represents the job, and then displays the command prompt.
+You can continue to work in the session while the job finishes.
+To manage the job, use the `*-Job` cmdlets.
+To get the job results, use the `Receive-Job` cmdlet.
 
-The *AsJob* parameter resembles using the **Invoke-Command** cmdlet to run a Start-Job command
-remotely.
-However, with *AsJob*, the job is created on the local computer, even though the job runs on a
-remote computer, and the results of the remote job are automatically returned to the local computer.
+The **AsJob** parameter resembles using the `Invoke-Command` cmdlet to run a `Start-Job` cmdlet remotely.
+However, with **AsJob**, the job is created on the local computer, even though the job runs on a remote computer, and the results of the remote job are automatically returned to the local computer.
 
-For more information about PowerShell background jobs, see [about_Jobs](About/about_Jobs.md) and
-[about_Remote_Jobs](About/about_Remote_Jobs.md).
+For more information about PowerShell background jobs, see [about_Jobs](About/about_Jobs.md) and [about_Remote_Jobs](About/about_Remote_Jobs.md).
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
Minor fixes of **AsJob** parameter, working much like `Start-Job`.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
