### PR TITLE
Corrected operator precedence split, join (binary)

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -64,8 +64,8 @@ and explicitly case-insensitive variants have the same precedence.
 
 |OPERATOR                 |REFERENCE|
 |-------------------------|---------|
-|`-split` (unary)         |[about_Split](about_Split.md)|
-|`-join` (unary)          |[about_Join](about_Join.md)|
+|`-split` (binary)         |[about_Split](about_Split.md)|
+|`-join` (binary)          |[about_Join](about_Join.md)|
 |`-is -isnot -as`         |[about_Type_Operators](about_Type_Operators.md)|
 |`-eq -ne -gt -gt -lt -le`|[about_Comparison_Operators](about_Comparison_Operators.md)|
 |`-like -notlike`         |[about_comparison_operators](about_comparison_operators.md)|


### PR DESCRIPTION
#4496 Corrected operator precedence for the binary forms of -split and -join string operators, which is less than the operator precedence for the unary forms of these operators.  -split (binary) and -join (binary) would belong at the same level as type and comparison operators.  Applies to all Powershell versions.
