### PR TITLE
Fixes #4496 - error in operator precedence

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -5,11 +5,9 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Operator_Precedence
 ---
-
 # About Operator Precedence
 
 ## SHORT DESCRIPTION
-
 Lists the PowerShell operators in precedence order.
 
 [This topic was contributed by Kirk Munro, a PowerShell MVP
@@ -64,8 +62,8 @@ and explicitly case-insensitive variants have the same precedence.
 
 |OPERATOR                 |REFERENCE|
 |-------------------------|---------|
-|`-split` (binary)         |[about_Split](about_Split.md)|
-|`-join` (binary)          |[about_Join](about_Join.md)|
+|`-split` (binary)        |[about_Split](about_Split.md)|
+|`-join` (binary)         |[about_Join](about_Join.md)|
 |`-is -isnot -as`         |[about_Type_Operators](about_Type_Operators.md)|
 |`-eq -ne -gt -gt -lt -le`|[about_Comparison_Operators](about_Comparison_Operators.md)|
 |`-like -notlike`         |[about_comparison_operators](about_comparison_operators.md)|

--- a/reference/3.0/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -358,7 +358,7 @@ You cannot pipe objects to `Register-ObjectEvent`.
 
 ### None or System.Management.Automation.PSEventJob
 
-If you use the **Action** parameter, `Register-EngineEvent` returns a
+When you use the **Action** parameter, `Register-ObjectEvent` returns a
 **System.Management.Automation.PSEventJob** object. Otherwise, it does not generate any output.
 
 ## NOTES

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -5,11 +5,9 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Operator_Precedence
 ---
-
 # About Operator Precedence
 
 ## SHORT DESCRIPTION
-
 Lists the PowerShell operators in precedence order.
 
 [This topic was contributed by Kirk Munro, a PowerShell MVP
@@ -64,8 +62,8 @@ and explicitly case-insensitive variants have the same precedence.
 
 |OPERATOR                 |REFERENCE|
 |-------------------------|---------|
-|`-split` (unary)         |[about_Split](about_Split.md)|
-|`-join` (unary)          |[about_Join](about_Join.md)|
+|`-split` (binary)        |[about_Split](about_Split.md)|
+|`-join` (binary)         |[about_Join](about_Join.md)|
 |`-is -isnot -as`         |[about_Type_Operators](about_Type_Operators.md)|
 |`-eq -ne -gt -gt -lt -le`|[about_Comparison_Operators](about_Comparison_Operators.md)|
 |`-like -notlike`         |[about_comparison_operators](about_comparison_operators.md)|

--- a/reference/4.0/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -8,7 +8,6 @@ online version: https://go.microsoft.com/fwlink/?linkid=294002
 schema: 2.0.0
 title: Register-ObjectEvent
 ---
-
 # Register-ObjectEvent
 
 ## SYNOPSIS
@@ -359,7 +358,7 @@ You cannot pipe objects to `Register-ObjectEvent`.
 
 ### None or System.Management.Automation.PSEventJob
 
-If you use the **Action** parameter, `Register-EngineEvent` returns a
+When you use the **Action** parameter, `Register-ObjectEvent` returns a
 **System.Management.Automation.PSEventJob** object. Otherwise, it does not generate any output.
 
 ## NOTES

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -62,8 +62,8 @@ and explicitly case-insensitive variants have the same precedence.
 
 |OPERATOR                 |REFERENCE|
 |-------------------------|---------|
-|`-split` (unary)         |[about_Split](about_Split.md)|
-|`-join` (unary)          |[about_Join](about_Join.md)|
+|`-split` (binary)        |[about_Split](about_Split.md)|
+|`-join` (binary)         |[about_Join](about_Join.md)|
 |`-is -isnot -as`         |[about_Type_Operators](about_Type_Operators.md)|
 |`-eq -ne -gt -gt -lt -le`|[about_Comparison_Operators](about_Comparison_Operators.md)|
 |`-like -notlike`         |[about_comparison_operators](about_comparison_operators.md)|

--- a/reference/5.0/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -358,7 +358,7 @@ You cannot pipe objects to `Register-ObjectEvent`.
 
 ### None or System.Management.Automation.PSEventJob
 
-If you use the **Action** parameter, `Register-EngineEvent` returns a
+When you use the **Action** parameter, `Register-ObjectEvent` returns a
 **System.Management.Automation.PSEventJob** object. Otherwise, it does not generate any output.
 
 ## NOTES

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -5,11 +5,9 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Operator_Precedence
 ---
-
 # About Operator Precedence
 
 ## SHORT DESCRIPTION
-
 Lists the PowerShell operators in precedence order.
 
 [This topic was contributed by Kirk Munro, a PowerShell MVP
@@ -64,8 +62,8 @@ and explicitly case-insensitive variants have the same precedence.
 
 |OPERATOR                 |REFERENCE|
 |-------------------------|---------|
-|`-split` (unary)         |[about_Split](about_Split.md)|
-|`-join` (unary)          |[about_Join](about_Join.md)|
+|`-split` (binary)        |[about_Split](about_Split.md)|
+|`-join` (binary)         |[about_Join](about_Join.md)|
 |`-is -isnot -as`         |[about_Type_Operators](about_Type_Operators.md)|
 |`-eq -ne -gt -gt -lt -le`|[about_Comparison_Operators](about_Comparison_Operators.md)|
 |`-like -notlike`         |[about_comparison_operators](about_comparison_operators.md)|

--- a/reference/5.1/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -358,7 +358,7 @@ You cannot pipe objects to `Register-ObjectEvent`.
 
 ### None or System.Management.Automation.PSEventJob
 
-If you use the **Action** parameter, `Register-EngineEvent` returns a
+When you use the **Action** parameter, `Register-ObjectEvent` returns a
 **System.Management.Automation.PSEventJob** object. Otherwise, it does not generate any output.
 
 ## NOTES

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -62,8 +62,8 @@ and explicitly case-insensitive variants have the same precedence.
 
 |OPERATOR                 |REFERENCE|
 |-------------------------|---------|
-|`-split` (unary)         |[about_Split](about_Split.md)|
-|`-join` (unary)          |[about_Join](about_Join.md)|
+|`-split` (binary)        |[about_Split](about_Split.md)|
+|`-join` (binary)         |[about_Join](about_Join.md)|
 |`-is -isnot -as`         |[about_Type_Operators](about_Type_Operators.md)|
 |`-eq -ne -gt -gt -lt -le`|[about_Comparison_Operators](about_Comparison_Operators.md)|
 |`-like -notlike`         |[about_comparison_operators](about_comparison_operators.md)|

--- a/reference/6/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -358,7 +358,7 @@ You cannot pipe objects to `Register-ObjectEvent`.
 
 ### None or System.Management.Automation.PSEventJob
 
-If you use the **Action** parameter, `Register-EngineEvent` returns a
+When you use the **Action** parameter, `Register-ObjectEvent` returns a
 **System.Management.Automation.PSEventJob** object. Otherwise, it does not generate any output.
 
 ## NOTES

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -62,8 +62,8 @@ and explicitly case-insensitive variants have the same precedence.
 
 |OPERATOR                 |REFERENCE|
 |-------------------------|---------|
-|`-split` (unary)         |[about_Split](about_Split.md)|
-|`-join` (unary)          |[about_Join](about_Join.md)|
+|`-split` (binary)        |[about_Split](about_Split.md)|
+|`-join` (binary)         |[about_Join](about_Join.md)|
 |`-is -isnot -as`         |[about_Type_Operators](about_Type_Operators.md)|
 |`-eq -ne -gt -gt -lt -le`|[about_Comparison_Operators](about_Comparison_Operators.md)|
 |`-like -notlike`         |[about_comparison_operators](about_comparison_operators.md)|

--- a/reference/7/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -358,7 +358,7 @@ You cannot pipe objects to `Register-ObjectEvent`.
 
 ### None or System.Management.Automation.PSEventJob
 
-If you use the **Action** parameter, `Register-EngineEvent` returns a
+When you use the **Action** parameter, `Register-ObjectEvent` returns a
 **System.Management.Automation.PSEventJob** object. Otherwise, it does not generate any output.
 
 ## NOTES


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->

- Completes #4496
- Fixes [AB#1564528](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1564528)
- Cleanup copy/paste error in PR#4489

Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
