### PR TITLE
Fixes #4504 - Added SkipAutomaticTags parameter to PS 7 Publish-Module

### DIFF
--- a/reference/7/PowerShellGet/Publish-Module.md
+++ b/reference/7/PowerShellGet/Publish-Module.md
@@ -8,6 +8,7 @@ online version: https://go.microsoft.com/fwlink/?linkid=2096634
 schema: 2.0.0
 title: Publish-Module
 ---
+
 # Publish-Module
 
 ## SYNOPSIS
@@ -18,53 +19,62 @@ Publishes a specified module from the local computer to an online gallery.
 ### ModuleNameParameterSet (Default)
 
 ```
-Publish-Module -Name <String> [-RequiredVersion <String>] [-NuGetApiKey <String>] [-Repository <String>]
- [-Credential <PSCredential>] [-FormatVersion <Version>] [-ReleaseNotes <String[]>] [-Tags <String[]>]
- [-LicenseUri <Uri>] [-IconUri <Uri>] [-ProjectUri <Uri>] [-Force] [-AllowPrerelease] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Publish-Module -Name <String> [-RequiredVersion <String>] [-NuGetApiKey <String>]
+ [-Repository <String>] [-Credential <PSCredential>] [-FormatVersion <Version>]
+ [-ReleaseNotes <String[]>] [-Tags <String[]>] [-LicenseUri <Uri>] [-IconUri <Uri>]
+ [-ProjectUri <Uri>] [-Exclude <String[]>] [-Force] [-AllowPrerelease] [-SkipAutomaticTags]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ModulePathParameterSet
 
 ```
-Publish-Module -Path <String> [-NuGetApiKey <String>] [-Repository <String>] [-Credential <PSCredential>]
- [-FormatVersion <Version>] [-ReleaseNotes <String[]>] [-Tags <String[]>] [-LicenseUri <Uri>] [-IconUri <Uri>]
- [-ProjectUri <Uri>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Publish-Module -Path <String> [-NuGetApiKey <String>] [-Repository <String>]
+ [-Credential <PSCredential>] [-FormatVersion <Version>] [-ReleaseNotes <String[]>]
+ [-Tags <String[]>] [-LicenseUri <Uri>] [-IconUri <Uri>] [-ProjectUri <Uri>] [-Force]
+ [-SkipAutomaticTags] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Publish-Module` cmdlet publishes a module to an online NuGet-based gallery by using an API key, stored as part of a user's profile in the gallery.
-You can specify the module to publish either by the module's name, or by the path to the folder containing the module.
+The `Publish-Module` cmdlet publishes a module to an online NuGet-based gallery by using an API key,
+stored as part of a user's profile in the gallery. You can specify the module to publish either by
+the module's name, or by the path to the folder containing the module.
 
-When you specify a module by name, `Publish-Module` publishes the first module that would be found by running `Get-Module -ListAvailable <Name>`.
-If you specify a minimum version of a module to publish, `Publish-Module` publishes the first module with a version that is greater than or equal to the minimum version that you have specified.
+When you specify a module by name, `Publish-Module` publishes the first module that would be found
+by running `Get-Module -ListAvailable <Name>`. If you specify a minimum version of a module to
+publish, `Publish-Module` publishes the first module with a version that is greater than or equal to
+the minimum version that you have specified.
 
-Publishing a module requires metadata that is displayed on the gallery page for the module.
-Required metadata includes the module name, version, description, and author.
-Although most metadata is taken from the module manifest, some metadata must be specified in `Publish-Module` parameters, such as **Tag**, **ReleaseNote**, **IconUri**, **ProjectUri**, and **LicenseUri**, because these parameters match fields in a NuGet-based gallery.
+Publishing a module requires metadata that is displayed on the gallery page for the module. Required
+metadata includes the module name, version, description, and author. Although most metadata is taken
+from the module manifest, some metadata must be specified in `Publish-Module` parameters, such as
+**Tag**, **ReleaseNote**, **IconUri**, **ProjectUri**, and **LicenseUri**, because these parameters
+match fields in a NuGet-based gallery.
 
 ## EXAMPLES
 
 ### Example 1: Publish a module
 
+In this example, MyDscModule is published to the online gallery by using the API key to indicate the
+module owner's online gallery account. If MyDscModule is not a valid manifest module that specifies
+a name, version, description, and author, an error occurs.
+
 ```powershell
 Publish-Module -Name "MyDscModule" -NuGetApiKey "11e4b435-6cb4-4bf7-8611-5162ed75eb73"
 ```
 
-In this example, MyDscModule is published to the online gallery by using the API key to indicate the module owner's online gallery account.
-If MyDscModule is not a valid manifest module that specifies a name, version, description, and author, an error occurs.
-
 ### Example 2: Publish a module with gallery metadata
+
+In this example, MyDscModule is published to the online gallery by using the API key to indicate the
+module owner's gallery account. The additional metadata provided is displayed on the webpage for the
+module in the gallery. The owner adds two search tags for the module, relating it to Active
+Directory; a brief release note is added. If MyDscModule is not a valid manifest module that
+specifies a name, version, description, and author, an error occurs.
 
 ```powershell
 Publish-Module -Name "MyDscModule" -NuGetApiKey "11e4b435-6cb4-4bf7-8611-5162ed75eb73" -LicenseUri "http://contoso.com/license" -Tag "Active Directory","DSC" -ReleaseNote "Updated the ActiveDirectory DSC Resources to support adding users."
 ```
-
-In this example, MyDscModule is published to the online gallery by using the API key to indicate the module owner's gallery account.
-The additional metadata provided is displayed on the webpage for the module in the gallery.
-The owner adds two search tags for the module, relating it to Active Directory; a brief release note is also added.
-If MyDscModule is not a valid manifest module that specifies a name, version, description, and author, an error occurs.
 
 ## PARAMETERS
 
@@ -86,6 +96,9 @@ Accept wildcard characters: False
 
 ### -Credential
 
+Specifies a user account that has rights to publish a module for a specified package provider or
+source.
+
 ```yaml
 Type: PSCredential
 Parameter Sets: (All)
@@ -100,6 +113,8 @@ Accept wildcard characters: False
 
 ### -Force
 
+Forces the command to run without asking for user confirmation.
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
@@ -113,6 +128,11 @@ Accept wildcard characters: False
 ```
 
 ### -FormatVersion
+
+Accepts only valid values specified by the **ValidateSet** attribute.
+
+For more information, see [ValidateSet Attribute Declaration](/powershell/developer/cmdlet/validateset-attribute-declaration)
+and [ValidateSetAttribute](/dotnet/api/system.management.automation.validatesetattribute).
 
 ```yaml
 Type: Version
@@ -129,8 +149,8 @@ Accept wildcard characters: False
 
 ### -IconUri
 
-Specifies the URL of an icon for the module.
-The specified icon is displayed on the gallery webpage for the module.
+Specifies the URL of an icon for the module. The specified icon is displayed on the gallery webpage
+for the module.
 
 ```yaml
 Type: Uri
@@ -162,8 +182,8 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies the name of the module that you want to publish.
-`Publish-Module` searches for the specified module name in $Env:PSModulePath.
+Specifies the name of the module that you want to publish. `Publish-Module` searches for the
+specified module name in `$Env:PSModulePath`.
 
 ```yaml
 Type: String
@@ -179,9 +199,9 @@ Accept wildcard characters: False
 
 ### -NuGetApiKey
 
-Specifies the API key that you want to use to publish a module to the online gallery.
-The API key is part of your profile in the online gallery, and can be found on your user account page in the gallery.
-The API key is NuGet-specific functionality.
+Specifies the API key that you want to use to publish a module to the online gallery. The API key is
+part of your profile in the online gallery, and can be found on your user account page in the
+gallery. The API key is NuGet-specific functionality.
 
 ```yaml
 Type: String
@@ -197,8 +217,8 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path to the module that you want to publish.
-This parameter accepts the path to the folder that contains the module.
+Specifies the path to the module that you want to publish. This parameter accepts the path to the
+folder that contains the module.
 
 ```yaml
 Type: String
@@ -230,7 +250,8 @@ Accept wildcard characters: False
 
 ### -ReleaseNotes
 
-Specifies a string containing release notes or comments that you want to be available to users of this version of the module.
+Specifies a string containing release notes or comments that you want to be available to users of
+this version of the module.
 
 ```yaml
 Type: String[]
@@ -246,10 +267,9 @@ Accept wildcard characters: False
 
 ### -Repository
 
-Specifies the friendly name of a repository that has been registered by running `Register-PSRepository`.
-The repository must have a PublishLocation, which is a valid NuGet URI.
-The PublishLocation can be set by running `Set-PSRepository`.
-The default value of this parameter is PSGallery.
+Specifies the friendly name of a repository that has been registered by running
+`Register-PSRepository`. The repository must have a **PublishLocation**, which is a valid NuGet URI.
+The **PublishLocation** can be set by running `Set-PSRepository`.
 
 ```yaml
 Type: String
@@ -279,11 +299,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -SkipAutomaticTags
+
+Removes commands and resources from being included as tags.
+Skips automatically adding tags to a module.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Tags
 
-Adds one or more tags to the module that you are publishing.
-Example tags include DesiredStateConfiguration, DSC, DSCResourceKit, or PSModule.
-Separate multiple tags with commas.
+Adds one or more tags to the module that you are publishing. Example tags include
+DesiredStateConfiguration, DSC, DSCResourceKit, or PSModule. Separate multiple tags with commas.
 
 ```yaml
 Type: String[]
@@ -299,7 +335,7 @@ Accept wildcard characters: False
 
 ### -Confirm
 
-Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the `Publish-Module`.
 
 ```yaml
 Type: SwitchParameter
@@ -315,8 +351,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the `Publish-Module` runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -332,7 +367,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -342,15 +379,20 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-* This cmdlet runs on Windows PowerShell 3.0 or later releases of PowerShell, on Windows 7 or Windows 2008 R2 and later releases of Windows.
+`Publish-Module` runs on PowerShell 3.0 or later releases of PowerShell, on Windows 7 or Windows
+2008 R2 and later releases of Windows.
 
-  `Publish-Module` shows no output if a module is published successfully.
+`Publish-Module` shows no output if a module is published successfully.
 
 ## RELATED LINKS
 
 [Find-Module](Find-Module.md)
 
 [Install-Module](Install-Module.md)
+
+[Register-PSRepository](Register-PSRepository.md)
+
+[Set-PSRepository](Set-PSRepository.md)
 
 [Uninstall-Module](Uninstall-Module.md)
 


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 7 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work

PS 7 
- Fixes #4504
- Added SkipAutomaticTags parameter description to PS 7. Refer to PowerShell/PowerShellGet repo PR 452.
- Added content to empty parameters
- Style, paragraph reflows

