### PR TITLE
Minor update to one example

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/New-Object.md
@@ -91,86 +91,49 @@ PS C:\> $Objshell = New-Object -COMObject "Shell.Application"
 
 The second command pipes the $ObjShell variable to the **Get-Member** cmdlet, which displays the properties and methods of the COM object. Among the methods is the ToggleDesktop method.
 PS C:\> $objshell | Get-Member
-   TypeName: System.__ComObject#{866738b9-6cf2-4de8-8767-f794ebe74f4e}
 
+   TypeName: System.__ComObject#{286e6f1b-7113-4355-9562-96b7e9d64c54}
 
 Name                 MemberType Definition
-
 ----                 ---------- ----------
-
 AddToRecent          Method     void AddToRecent (Variant, string)
-
 BrowseForFolder      Method     Folder BrowseForFolder (int, string, int, Variant)
-
 CanStartStopService  Method     Variant CanStartStopService (string)
-
 CascadeWindows       Method     void CascadeWindows ()
-
 ControlPanelItem     Method     void ControlPanelItem (string)
-
 EjectPC              Method     void EjectPC ()
-
 Explore              Method     void Explore (Variant)
-
 ExplorerPolicy       Method     Variant ExplorerPolicy (string)
-
 FileRun              Method     void FileRun ()
-
 FindComputer         Method     void FindComputer ()
-
 FindFiles            Method     void FindFiles ()
-
 FindPrinter          Method     void FindPrinter (string, string, string)
-
 GetSetting           Method     bool GetSetting (int)
-
 GetSystemInformation Method     Variant GetSystemInformation (string)
-
 Help                 Method     void Help ()
-
 IsRestricted         Method     int IsRestricted (string, string)
-
 IsServiceRunning     Method     Variant IsServiceRunning (string)
-
 MinimizeAll          Method     void MinimizeAll ()
-
 NameSpace            Method     Folder NameSpace (Variant)
-
 Open                 Method     void Open (Variant)
-
 RefreshMenu          Method     void RefreshMenu ()
-
+SearchCommand        Method     void SearchCommand ()
 ServiceStart         Method     Variant ServiceStart (string, Variant)
-
 ServiceStop          Method     Variant ServiceStop (string, Variant)
-
 SetTime              Method     void SetTime ()
-
 ShellExecute         Method     void ShellExecute (string, Variant, Variant, Variant, Variant)
-
 ShowBrowserBar       Method     Variant ShowBrowserBar (string, Variant)
-
 ShutdownWindows      Method     void ShutdownWindows ()
-
 Suspend              Method     void Suspend ()
-
 TileHorizontally     Method     void TileHorizontally ()
-
 TileVertically       Method     void TileVertically ()
 ToggleDesktop        Method     void ToggleDesktop ()
-
 TrayProperties       Method     void TrayProperties ()
-
 UndoMinimizeALL      Method     void UndoMinimizeALL ()
-
 Windows              Method     IDispatch Windows ()
-
 WindowsSecurity      Method     void WindowsSecurity ()
-
 WindowSwitcher       Method     void WindowSwitcher ()
-
 Application          Property   IDispatch Application () {get}
-
 Parent               Property   IDispatch Parent () {get}
 
 The third command calls the **ToggleDesktop** method of the object to minimize the open windows on your desktop.


### PR DESCRIPTION
Updated Example 4 to bring it in line with the quality of PowerShell 6 and 7 documents. (It is not urgent to update 6 and 7 documents.) A lot of white spaces are removed from this example. The reason is **NOT** saving a few bytes. It is to improve readability. We admins actually use these documents in our PowerShell instances. Screen property isn't exactly unlimited.

Version(s) of document impacted
------------------------------
- [ ] Impacts 7 document
- [ ] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version 3, 4, 5, and 5.1 of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
