### PR TITLE
Fixed empty parameters, copyedits

### DIFF
--- a/reference/5.0/PowershellGet/Save-Module.md
+++ b/reference/5.0/PowershellGet/Save-Module.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 7/1/2019
+ms.date: 07/01/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet

--- a/reference/5.0/PowershellGet/Save-Module.md
+++ b/reference/5.0/PowershellGet/Save-Module.md
@@ -204,8 +204,7 @@ Accept wildcard characters: False
 ### -MaximumVersion
 
 Specifies the maximum, or newest, version of the module to save. The **MaximumVersion** and
-**RequiredVersion** parameters are mutually exclusive; you cannot use both parameters in the same
-command.
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: Version
@@ -223,7 +222,7 @@ Accept wildcard characters: False
 
 Specifies the minimum version of a single module to save. You cannot add this parameter if you are
 attempting to install multiple modules. The **MinimumVersion** and **RequiredVersion** parameters
-are mutually exclusive; you cannot use both parameters in the same command.
+can't be used in the same command.
 
 ```yaml
 Type: Version
@@ -255,8 +254,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the location on the local computer to store a saved module. Accepts wildcard characters
-when the string is wrapped in double-quotes.
+Specifies the location on the local computer to store a saved module. Accepts wildcard characters.
 
 ```yaml
 Type: String
@@ -267,7 +265,7 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Repository

--- a/reference/5.0/PowershellGet/Uninstall-Module.md
+++ b/reference/5.0/PowershellGet/Uninstall-Module.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 7/2/2019
+ms.date: 07/02/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -37,22 +37,25 @@ uninstall a module if it has other modules as dependencies.
 
 ### Example 1: Uninstall a module
 
-In this example, an installed module's version is displayed and the module is uninstalled.
+This example uninstalls a module.
 
 ```powershell
-Get-InstalledModule -Name SpeculationControl
 Uninstall-Module -Name SpeculationControl
 ```
 
-```Output
-Version  Name                Repository   Description
--------  ----                ----------   -----------
-1.0.14   SpeculationControl  PSGallery    This module provides the ability to query...
+`Uninstall-Module` uses the **Name** parameter to specify the module to uninstall from the local
+computer.
+
+### Example 2: Use the pipeline to uninstall a module
+
+In this example, the pipeline is used to uninstall a module.
+
+```powershell
+Get-InstalledModule -Name SpeculationControl | Uninstall-Module
 ```
 
-`Get-InstalledModule` uses the **Name** parameter to display the installed module,
-**SpeculationControl**. `Uninstall-Module` uses the **Name** parameter to specify the module to
-uninstall.
+`Get-InstalledModule` uses the **Name** parameter to specify the module. The object is sent down the
+pipeline to `Uninstall-Module` and is uninstalled.
 
 ## PARAMETERS
 
@@ -124,7 +127,7 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of the script to uninstall. The **MinimumVersion** and
+Specifies the minimum version of the module to uninstall. The **MinimumVersion** and
 **RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
@@ -194,6 +197,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
+
+`Uninstall-Module` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS
 

--- a/reference/5.0/PowershellGet/Uninstall-Module.md
+++ b/reference/5.0/PowershellGet/Uninstall-Module.md
@@ -198,6 +198,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### PSRepositoryItemInfo
+
 `Uninstall-Module` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS

--- a/reference/5.0/PowershellGet/Uninstall-Module.md
+++ b/reference/5.0/PowershellGet/Uninstall-Module.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date: 7/2/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -16,33 +16,49 @@ Uninstalls a module.
 ## SYNTAX
 
 ### NameParameterSet (Default)
+
 ```
 Uninstall-Module [-Name] <String[]> [-MinimumVersion <Version>] [-RequiredVersion <Version>]
  [-MaximumVersion <Version>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InputObject
+
 ```
 Uninstall-Module [-InputObject] <PSObject[]> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Uninstall-Module** cmdlet uninstalls the specified module from the local computer.
-You cannot uninstall a module if it has other modules as dependencies.
+
+The `Uninstall-Module` cmdlet uninstalls a specified module from the local computer. You can't
+uninstall a module if it has other modules as dependencies.
 
 ## EXAMPLES
 
-### Example 1: Get a module and uninstall it
-```
-PS C:\> Get-InstalledModule -Name "xPSDesiredStateConfiguration" -RequiredVersion 3.6.0.0 | Uninstall-Module
+### Example 1: Uninstall a module
+
+In this example, an installed module's version is displayed and the module is uninstalled.
+
+```powershell
+Get-InstalledModule -Name SpeculationControl
+Uninstall-Module -Name SpeculationControl
 ```
 
-This command gets version 3.6.0.0 of the module named xPSDesiredStateConfiguration, and then uses the pipeline operator to pass it to the **Uninstall-Module** cmdlet, which uninstalls it.
+```Output
+Version  Name                Repository   Description
+-------  ----                ----------   -----------
+1.0.14   SpeculationControl  PSGallery    This module provides the ability to query...
+```
+
+`Get-InstalledModule` uses the **Name** parameter to display the installed module,
+**SpeculationControl**. `Uninstall-Module` uses the **Name** parameter to specify the module to
+uninstall.
 
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.
+
+Prompts you for confirmation before running the `Uninstall-Module`.
 
 ```yaml
 Type: SwitchParameter
@@ -57,7 +73,8 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the command to run without asking for user confirmation.
+
+Forces `Uninstall-Module` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -72,7 +89,9 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies a package by using the module's SoftwareID object, which is shown in the results of the Find-Module cmdlet.
+
+Accepts a **PSRepositoryItemInfo** object. For example, output `Get-InstalledModule` to a variable
+and use that variable as the **InputObject** argument.
 
 ```yaml
 Type: PSObject[]
@@ -87,8 +106,9 @@ Accept wildcard characters: False
 ```
 
 ### -MaximumVersion
-Specifies the maximum, or newest, version of the module to uninstall.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the maximum, or newest, version of the module to uninstall. The **MaximumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: Version
@@ -103,8 +123,9 @@ Accept wildcard characters: False
 ```
 
 ### -MinimumVersion
-Specifies the minimum version of the script to uninstall.
-The *MinimumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the minimum version of the script to uninstall. The **MinimumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: Version
@@ -119,7 +140,8 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of names of modules to uninstall.
+
+Specifies an array of module names to uninstall.
 
 ```yaml
 Type: String[]
@@ -134,6 +156,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredVersion
+
 Specifies the exact version number of the module to uninstall.
 
 ```yaml
@@ -149,8 +172,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if `Uninstall-Module` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -165,7 +188,10 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/5.1/PowershellGet/Save-Module.md
+++ b/reference/5.1/PowershellGet/Save-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/1/2019
+ms.date: 07/01/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821669
 schema: 2.0.0
 title: Save-Module

--- a/reference/5.1/PowershellGet/Save-Module.md
+++ b/reference/5.1/PowershellGet/Save-Module.md
@@ -241,8 +241,7 @@ Accept wildcard characters: False
 ### -MaximumVersion
 
 Specifies the maximum, or newest, version of the module to save. The **MaximumVersion** and
-**RequiredVersion** parameters are mutually exclusive; you cannot use both parameters in the same
-command.
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -260,7 +259,7 @@ Accept wildcard characters: False
 
 Specifies the minimum version of a single module to save. You cannot add this parameter if you are
 attempting to install multiple modules. The **MinimumVersion** and **RequiredVersion** parameters
-are mutually exclusive; you cannot use both parameters in the same command.
+can't be used in the same command.
 
 ```yaml
 Type: String
@@ -292,8 +291,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the location on the local computer to store a saved module. Accepts wildcard characters
-when the string is wrapped in double-quotes.
+Specifies the location on the local computer to store a saved module. Accepts wildcard characters.
 
 ```yaml
 Type: String
@@ -304,12 +302,12 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Proxy
 
-Specifies a proxy server for the request, rather than connecting directly to the Internet resource.
+Specifies a proxy server for the request, rather than connecting directly to the internet resource.
 
 ```yaml
 Type: Uri

--- a/reference/5.1/PowershellGet/Save-Script.md
+++ b/reference/5.1/PowershellGet/Save-Script.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/2/2019
+ms.date: 07/02/2019
 online version: https://go.microsoft.com/fwlink/?linkid=822334
 schema: 2.0.0
 title: Save-Script

--- a/reference/5.1/PowershellGet/Save-Script.md
+++ b/reference/5.1/PowershellGet/Save-Script.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 7/2/2019
 online version: https://go.microsoft.com/fwlink/?linkid=822334
 schema: 2.0.0
 title: Save-Script
@@ -17,55 +17,70 @@ Saves a script.
 ## SYNTAX
 
 ### NameAndPathParameterSet (Default)
+
 ```
 Save-Script [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <String>]
  [-RequiredVersion <String>] [-Repository <String[]>] [-Path] <String> [-Proxy <Uri>]
- [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease] [-AcceptLicense]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease]
+ [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### NameAndLiteralPathParameterSet
+
 ```
 Save-Script [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <String>]
  [-RequiredVersion <String>] [-Repository <String[]>] -LiteralPath <String> [-Proxy <Uri>]
- [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease] [-AcceptLicense]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease]
+ [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### InputOjectAndLiteralPathParameterSet
+### InputObjectAndLiteralPathParameterSet
+
 ```
-Save-Script [-InputObject] <PSObject[]> -LiteralPath <String> [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
- [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+Save-Script [-InputObject] <PSObject[]> -LiteralPath <String> [-Proxy <Uri>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
-### InputOjectAndPathParameterSet
+### InputObjectAndPathParameterSet
+
 ```
-Save-Script [-InputObject] <PSObject[]> [-Path] <String> [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
- [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+Save-Script [-InputObject] <PSObject[]> [-Path] <String> [-Proxy <Uri>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Save-Script** cmdlet saves the specified script.
+
+The `Save-Script` cmdlet saves the specified script.
 
 ## EXAMPLES
 
-### Example 1: Save a script and validate it
-```
-PS C:\> Save-Script -Name "Fabrikam-ClientScript" -Repository "Local01" -Path "D:\ScriptSharingDemo"
-PS C:\> Test-ScriptFileInfo -Path "D:\ScriptSharingDemo\Fabrikam-ClientScript.ps1"
-Version    Name                      Author               Description
--------    ----                      ------               -----------
-2.5        Fabrikam-ClientScript     pattif               Description for the Fabrikam-ClientScript script
+### Example 1: Save a script and validate the script's metadata
+
+In this example, a script from a repository is saved to the local computer and the script's metadata
+is validated.
+
+```powershell
+Save-Script -Name Install-VSCode -Repository PSGallery -Path C:\Test\Scripts
+Test-ScriptFileInfo -Path C:\Test\Scripts\Install-VSCode.ps1
 ```
 
-The first command saves the script Fabrikam-ClientScript from the Local01 repository to the local folder D:\ScriptSharingDemo.
+```Output
+Version   Name              Author      Description
+-------   ----              ------      -----------
+1.3       Install-VSCode    Microsoft   This script can be used to easily install Visual Studio Code
+```
 
-The second command uses the Test-ScriptFileInfo cmdlet to validate the script.
+`Save-Script` uses the **Name** parameter to specify the script's name. The **Repository** parameter
+specifies where to find the script. The script is saved in the location specified by the **Path**
+parameter. `Test-ScriptFileInfo` specifies the **Path** and validates the script's metadata.
 
 ## PARAMETERS
 
 ### -AcceptLicense
-Automatically accept the license agreement during installation if the package requires it.
+
+Automatically accept the license agreement if the script requires it.
 
 ```yaml
 Type: SwitchParameter
@@ -80,6 +95,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowPrerelease
+
 Allows you to save a script marked as a prerelease.
 
 ```yaml
@@ -96,6 +112,8 @@ Accept wildcard characters: False
 
 ### -Credential
 
+Specifies a user account that has permission to save a script.
+
 ```yaml
 Type: PSCredential
 Parameter Sets: (All)
@@ -109,7 +127,8 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the command to run without asking for user confirmation.
+
+Forces `Save-Script` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -124,12 +143,13 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies a package by using the script's SoftwareID object, which is shown in the results of the Find-Script cmdlet.
 
+Accepts a **PSRepositoryItemInfo** object. For example, output `Find-Script` to a variable and use
+that variable as the **InputObject** argument.
 
 ```yaml
 Type: PSObject[]
-Parameter Sets: InputOjectAndLiteralPathParameterSet, InputOjectAndPathParameterSet
+Parameter Sets: InputObjectAndLiteralPathParameterSet, InputObjectAndPathParameterSet
 Aliases:
 
 Required: True
@@ -140,15 +160,15 @@ Accept wildcard characters: False
 ```
 
 ### -LiteralPath
-Specifies a path to one or more locations.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as entered.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+
+Specifies a path to one or more locations. The value of the **LiteralPath** parameter is used
+exactly as entered. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose the path within single quotation marks. PowerShell doesn't interpret any
+characters enclosed in single quotation marks as escape sequences.
 
 ```yaml
 Type: String
-Parameter Sets: NameAndLiteralPathParameterSet, InputOjectAndLiteralPathParameterSet
+Parameter Sets: NameAndLiteralPathParameterSet, InputObjectAndLiteralPathParameterSet
 Aliases:
 
 Required: True
@@ -159,8 +179,9 @@ Accept wildcard characters: False
 ```
 
 ### -MaximumVersion
-Specifies the maximum, or newest version of the script to save.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the maximum, or newest version of the script to save. The **MaximumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -175,8 +196,9 @@ Accept wildcard characters: False
 ```
 
 ### -MinimumVersion
-Specifies the minimum version of the script to find.
-The *MinimumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the minimum version of a script to save. The **MinimumVersion** and **RequiredVersion**
+parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -191,7 +213,8 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of names of scripts to save.
+
+Specifies an array of script names to save.
 
 ```yaml
 Type: String[]
@@ -206,24 +229,24 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies a path to one or more locations.
-Wildcards are permitted.
-The default location is the current directory (.).
+
+Specifies the location on the local computer to store a saved module. Accepts wildcard characters.
 
 ```yaml
 Type: String
-Parameter Sets: NameAndPathParameterSet, InputOjectAndPathParameterSet
+Parameter Sets: NameAndPathParameterSet, InputObjectAndPathParameterSet
 Aliases:
 
 Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Proxy
-Specifies a proxy server for the request, rather than connecting directly to the Internet resource.
+
+Specifies a proxy server for the request, rather than connecting directly to an internet resource.
 
 ```yaml
 Type: Uri
@@ -238,7 +261,9 @@ Accept wildcard characters: False
 ```
 
 ### -ProxyCredential
-Specifies a user account that has permission to use the proxy server that is specified by the **Proxy** parameter.
+
+Specifies a user account that has permission to use the proxy server specified by the **Proxy**
+parameter.
 
 ```yaml
 Type: PSCredential
@@ -253,7 +278,9 @@ Accept wildcard characters: False
 ```
 
 ### -Repository
-Specifies the friendly name of a repository that has been registered by running Register-PSRepository.
+
+Specifies the friendly name of a repository that has been registered by running
+`Register-PSRepository`. Use `Get-PSRepository` to display registered repositories.
 
 ```yaml
 Type: String[]
@@ -268,6 +295,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredVersion
+
 Specifies the exact version number of the script to save.
 
 ```yaml
@@ -283,7 +311,8 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.
+
+Prompts you for confirmation before running `Save-Script`.
 
 ```yaml
 Type: SwitchParameter
@@ -298,8 +327,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if `Save-Script` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -314,7 +343,10 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -329,6 +361,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Install-Script](Install-Script.md)
 
 [Publish-Script](Publish-Script.md)
+
+[Test-ScriptFileInfo](Test-ScriptFileInfo.md)
 
 [Uninstall-Script](Uninstall-Script.md)
 

--- a/reference/5.1/PowershellGet/Uninstall-Module.md
+++ b/reference/5.1/PowershellGet/Uninstall-Module.md
@@ -234,6 +234,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### PSRepositoryItemInfo
+
 `Uninstall-Module` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS

--- a/reference/5.1/PowershellGet/Uninstall-Module.md
+++ b/reference/5.1/PowershellGet/Uninstall-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 7/2/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821673
 schema: 2.0.0
 title: Uninstall-Module
@@ -17,6 +17,7 @@ Uninstalls a module.
 ## SYNTAX
 
 ### NameParameterSet (Default)
+
 ```
 Uninstall-Module [-Name] <String[]> [-MinimumVersion <String>] [-RequiredVersion <String>]
  [-MaximumVersion <String>] [-AllVersions] [-Force] [-AllowPrerelease] [-WhatIf] [-Confirm]
@@ -24,26 +25,41 @@ Uninstall-Module [-Name] <String[]> [-MinimumVersion <String>] [-RequiredVersion
 ```
 
 ### InputObject
+
 ```
 Uninstall-Module [-InputObject] <PSObject[]> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Uninstall-Module** cmdlet uninstalls the specified module from the local computer.
-You cannot uninstall a module if it has other modules as dependencies.
+
+The `Uninstall-Module` cmdlet uninstalls a specified module from the local computer. You can't
+uninstall a module if it has other modules as dependencies.
 
 ## EXAMPLES
 
-### Example 1: Get a module and uninstall it
-```
-PS C:\> Get-InstalledModule -Name "xPSDesiredStateConfiguration" -RequiredVersion 3.6.0.0 | Uninstall-Module
+### Example 1: Uninstall a module
+
+In this example, an installed module's version is displayed and the module is uninstalled.
+
+```powershell
+Get-InstalledModule -Name SpeculationControl
+Uninstall-Module -Name SpeculationControl
 ```
 
-This command gets version 3.6.0.0 of the module named xPSDesiredStateConfiguration, and then uses the pipeline operator to pass it to the **Uninstall-Module** cmdlet, which uninstalls it.
+```Output
+Version  Name                Repository   Description
+-------  ----                ----------   -----------
+1.0.14   SpeculationControl  PSGallery    This module provides the ability to query...
+```
+
+`Get-InstalledModule` uses the **Name** parameter to display the installed module,
+**SpeculationControl**. `Uninstall-Module` uses the **Name** parameter to specify the module to
+uninstall.
 
 ## PARAMETERS
 
 ### -AllowPrerelease
+
 Allows you to uninstall a module marked as a prerelease.
 
 ```yaml
@@ -59,8 +75,10 @@ Accept wildcard characters: False
 ```
 
 ### -AllVersions
-Specifies that you want to include all available versions of a module.
-You cannot use the *AllVersions* parameter with the *MinimumVersion*, *MaximumVersion*, or *RequiredVersion* parameters.
+
+Specifies that you want to include all available versions of a module. You can't use the
+**AllVersions** parameter with the **MinimumVersion**, **MaximumVersion**, or **RequiredVersion**
+parameters.
 
 ```yaml
 Type: SwitchParameter
@@ -75,7 +93,8 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the command to run without asking for user confirmation.
+
+Forces `Uninstall-Module` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -90,7 +109,9 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies a package by using the module's SoftwareID object, which is shown in the results of the Find-Module cmdlet.
+
+Accepts a **PSRepositoryItemInfo** object. For example, output `Get-InstalledModule` to a variable
+and use that variable as the **InputObject** argument.
 
 ```yaml
 Type: PSObject[]
@@ -105,8 +126,9 @@ Accept wildcard characters: False
 ```
 
 ### -MaximumVersion
-Specifies the maximum, or newest, version of the module to uninstall.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the maximum, or newest, version of the module to uninstall. The **MaximumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -121,8 +143,9 @@ Accept wildcard characters: False
 ```
 
 ### -MinimumVersion
-Specifies the minimum version of the script to uninstall.
-The *MinimumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the minimum version of the script to uninstall. The **MinimumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -137,7 +160,8 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of names of modules to uninstall.
+
+Specifies an array of module names to uninstall.
 
 ```yaml
 Type: String[]
@@ -152,6 +176,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredVersion
+
 Specifies the exact version number of the module to uninstall.
 
 ```yaml
@@ -167,7 +192,8 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.
+
+Prompts you for confirmation before running the `Uninstall-Module`.
 
 ```yaml
 Type: SwitchParameter
@@ -182,8 +208,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if `Uninstall-Module` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -198,7 +224,10 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/5.1/PowershellGet/Uninstall-Module.md
+++ b/reference/5.1/PowershellGet/Uninstall-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/2/2019
+ms.date: 07/02/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821673
 schema: 2.0.0
 title: Uninstall-Module
@@ -39,22 +39,25 @@ uninstall a module if it has other modules as dependencies.
 
 ### Example 1: Uninstall a module
 
-In this example, an installed module's version is displayed and the module is uninstalled.
+This example uninstalls a module.
 
 ```powershell
-Get-InstalledModule -Name SpeculationControl
 Uninstall-Module -Name SpeculationControl
 ```
 
-```Output
-Version  Name                Repository   Description
--------  ----                ----------   -----------
-1.0.14   SpeculationControl  PSGallery    This module provides the ability to query...
+`Uninstall-Module` uses the **Name** parameter to specify the module to uninstall from the local
+computer.
+
+### Example 2: Use the pipeline to uninstall a module
+
+In this example, the pipeline is used to uninstall a module.
+
+```powershell
+Get-InstalledModule -Name SpeculationControl | Uninstall-Module
 ```
 
-`Get-InstalledModule` uses the **Name** parameter to display the installed module,
-**SpeculationControl**. `Uninstall-Module` uses the **Name** parameter to specify the module to
-uninstall.
+`Get-InstalledModule` uses the **Name** parameter to specify the module. The object is sent down the
+pipeline to `Uninstall-Module` and is uninstalled.
 
 ## PARAMETERS
 
@@ -144,7 +147,7 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of the script to uninstall. The **MinimumVersion** and
+Specifies the minimum version of the module to uninstall. The **MinimumVersion** and
 **RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
@@ -230,6 +233,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
+
+`Uninstall-Module` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS
 

--- a/reference/5.1/PowershellGet/Uninstall-Script.md
+++ b/reference/5.1/PowershellGet/Uninstall-Script.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 7/3/2019
 online version: https://go.microsoft.com/fwlink/?linkid=822338
 schema: 2.0.0
 title: Uninstall-Script
@@ -12,36 +12,52 @@ title: Uninstall-Script
 # Uninstall-Script
 
 ## SYNOPSIS
-Uninstalls a script file.
+Uninstalls a script.
 
 ## SYNTAX
 
 ### NameParameterSet (Default)
+
 ```
 Uninstall-Script [-Name] <String[]> [-MinimumVersion <String>] [-RequiredVersion <String>]
  [-MaximumVersion <String>] [-Force] [-AllowPrerelease] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InputObject
+
 ```
 Uninstall-Script [-InputObject] <PSObject[]> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Uninstall-Script** cmdlet uninstalls the specified script files from the online gallery.
+
+The `Uninstall-Script` cmdlet uninstalls a specified script from the local computer.
 
 ## EXAMPLES
 
 ### Example 1: Uninstall a script file
-```
-PS C:\> Uninstall-Script -Name "MyScript" -RequiredVersion 2.5
+
+This example uninstalls a script from the local computer.
+
+```powershell
+Get-InstalledScript -Name UpdateManagement-Template
+Uninstall-Script -Name UpdateManagement-Template
 ```
 
-This command uninstalls version 2.5 of the script file named MyScript.
+```Output
+Version   Name                         Repository   Description
+-------   ----                         ----------   -----------
+1.1       UpdateManagement-Template    LocalRepo    This is a template script for Update Management
+```
+
+`Get-InstalledScript` uses the **Name** parameter to display the **UpdateManagement-Template**
+script installed from a local repository. `Uninstall-Script` uses the **Name** parameter to specify
+the script to uninstall.
 
 ## PARAMETERS
 
 ### -AllowPrerelease
+
 Allows you to uninstall a script marked as a prerelease.
 
 ```yaml
@@ -57,7 +73,8 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the command to run without asking for user confirmation.
+
+Forces `Uninstall-Script` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -72,7 +89,9 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies a package by using the module's SoftwareID object, which is shown in the results of the Find-Module cmdlet.
+
+Accepts a **PSRepositoryItemInfo** object. For example, output `Get-InstalledScript` to a variable
+and use that variable as the **InputObject** argument.
 
 ```yaml
 Type: PSObject[]
@@ -87,8 +106,9 @@ Accept wildcard characters: False
 ```
 
 ### -MaximumVersion
-Specifies the maximum, or newest, version of the script to uninstall.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the maximum, or newest, version of the script to uninstall. The **MaximumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -103,8 +123,9 @@ Accept wildcard characters: False
 ```
 
 ### -MinimumVersion
-Specifies the minimum version of the script to uninstall.
-The *MinimumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the minimum version of the script to uninstall. The **MinimumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -119,7 +140,8 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of names of scripts to uninstall.
+
+Specifies an array of script names to uninstall.
 
 ```yaml
 Type: String[]
@@ -134,6 +156,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredVersion
+
 Specifies the exact version number of the script to uninstall.
 
 ```yaml
@@ -149,7 +172,8 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.
+
+Prompts you for confirmation before running `Uninstall-Script`.
 
 ```yaml
 Type: SwitchParameter
@@ -164,8 +188,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if `Uninstall-Script` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -180,7 +204,10 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/5.1/PowershellGet/Uninstall-Script.md
+++ b/reference/5.1/PowershellGet/Uninstall-Script.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/3/2019
+ms.date: 07/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=822338
 schema: 2.0.0
 title: Uninstall-Script
@@ -35,24 +35,27 @@ The `Uninstall-Script` cmdlet uninstalls a specified script from the local compu
 
 ## EXAMPLES
 
-### Example 1: Uninstall a script file
+### Example 1: Uninstall a script
 
-This example uninstalls a script from the local computer.
+This example uninstalls a script.
 
 ```powershell
-Get-InstalledScript -Name UpdateManagement-Template
 Uninstall-Script -Name UpdateManagement-Template
 ```
 
-```Output
-Version   Name                         Repository   Description
--------   ----                         ----------   -----------
-1.1       UpdateManagement-Template    LocalRepo    This is a template script for Update Management
+`Uninstall-Script` uses the **Name** parameter to specify the script to uninstall from the local
+computer.
+
+### Example 2: Use the pipeline to uninstall a script
+
+In this example, the pipeline is used to uninstall a script.
+
+```powershell
+Get-InstalledScript -Name UpdateManagement-Template | Uninstall-Script
 ```
 
-`Get-InstalledScript` uses the **Name** parameter to display the **UpdateManagement-Template**
-script installed from a local repository. `Uninstall-Script` uses the **Name** parameter to specify
-the script to uninstall.
+`Get-InstalledScript` uses the **Name** parameter to specify the script. The object is sent down the
+pipeline to `Uninstall-Script` and the script is uninstalled.
 
 ## PARAMETERS
 
@@ -210,6 +213,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
+
+`Uninstall-Script` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS
 

--- a/reference/5.1/PowershellGet/Uninstall-Script.md
+++ b/reference/5.1/PowershellGet/Uninstall-Script.md
@@ -214,6 +214,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### PSRepositoryItemInfo
+
 `Uninstall-Script` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS

--- a/reference/6/PowerShellGet/Save-Module.md
+++ b/reference/6/PowerShellGet/Save-Module.md
@@ -241,8 +241,7 @@ Accept wildcard characters: False
 ### -MaximumVersion
 
 Specifies the maximum, or newest, version of the module to save. The **MaximumVersion** and
-**RequiredVersion** parameters are mutually exclusive; you cannot use both parameters in the same
-command.
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -260,7 +259,7 @@ Accept wildcard characters: False
 
 Specifies the minimum version of a single module to save. You cannot add this parameter if you are
 attempting to install multiple modules. The **MinimumVersion** and **RequiredVersion** parameters
-are mutually exclusive; you cannot use both parameters in the same command.
+can't be used in the same command.
 
 ```yaml
 Type: String
@@ -292,8 +291,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the location on the local computer to store a saved module. Accepts wildcard characters
-when the string is wrapped in double-quotes.
+Specifies the location on the local computer to store a saved module. Accepts wildcard characters.
 
 ```yaml
 Type: String
@@ -304,12 +302,12 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Proxy
 
-Specifies a proxy server for the request, rather than connecting directly to the Internet resource.
+Specifies a proxy server for the request, rather than connecting directly to the internet resource.
 
 ```yaml
 Type: Uri

--- a/reference/6/PowerShellGet/Save-Module.md
+++ b/reference/6/PowerShellGet/Save-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/1/2019
+ms.date: 07/01/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096949
 schema: 2.0.0
 title: Save-Module

--- a/reference/6/PowerShellGet/Save-Script.md
+++ b/reference/6/PowerShellGet/Save-Script.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/2/2019
+ms.date: 07/02/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096564
 schema: 2.0.0
 title: Save-Script

--- a/reference/6/PowerShellGet/Save-Script.md
+++ b/reference/6/PowerShellGet/Save-Script.md
@@ -3,11 +3,12 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 7/2/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096564
 schema: 2.0.0
 title: Save-Script
 ---
+
 # Save-Script
 
 ## SYNOPSIS
@@ -19,9 +20,9 @@ Saves a script.
 
 ```
 Save-Script [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <String>]
- [-RequiredVersion <String>] [-Repository <String[]>] -Path <String> [-Proxy <Uri>]
- [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease] [-AcceptLicense]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-RequiredVersion <String>] [-Repository <String[]>] [-Path] <String> [-Proxy <Uri>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease]
+ [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### NameAndLiteralPathParameterSet
@@ -29,49 +30,57 @@ Save-Script [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <Stri
 ```
 Save-Script [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <String>]
  [-RequiredVersion <String>] [-Repository <String[]>] -LiteralPath <String> [-Proxy <Uri>]
- [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease] [-AcceptLicense]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease]
+ [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### InputOjectAndLiteralPathParameterSet
+### InputObjectAndLiteralPathParameterSet
 
 ```
-Save-Script [-InputObject] <PSObject[]> -LiteralPath <String> [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
- [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+Save-Script [-InputObject] <PSObject[]> -LiteralPath <String> [-Proxy <Uri>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
-### InputOjectAndPathParameterSet
+### InputObjectAndPathParameterSet
 
 ```
-Save-Script [-InputObject] <PSObject[]> -Path <String> [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
- [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+Save-Script [-InputObject] <PSObject[]> [-Path] <String> [-Proxy <Uri>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The **Save-Script** cmdlet saves the specified script.
+The `Save-Script` cmdlet saves the specified script.
 
 ## EXAMPLES
 
-### Example 1: Save a script and validate it
+### Example 1: Save a script and validate the script's metadata
 
+In this example, a script from a repository is saved to the local computer and the script's metadata
+is validated.
+
+```powershell
+Save-Script -Name Install-VSCode -Repository PSGallery -Path C:\Test\Scripts
+Test-ScriptFileInfo -Path C:\Test\Scripts\Install-VSCode.ps1
 ```
-PS C:\> Save-Script -Name "Fabrikam-ClientScript" -Repository "Local01" -Path "D:\ScriptSharingDemo"
-PS C:\> Test-ScriptFileInfo -Path "D:\ScriptSharingDemo\Fabrikam-ClientScript.ps1"
-Version    Name                      Author               Description
--------    ----                      ------               -----------
-2.5        Fabrikam-ClientScript     pattif               Description for the Fabrikam-ClientScript script
+
+```Output
+Version   Name              Author      Description
+-------   ----              ------      -----------
+1.3       Install-VSCode    Microsoft   This script can be used to easily install Visual Studio Code
 ```
 
-The first command saves the script Fabrikam-ClientScript from the Local01 repository to the local folder D:\ScriptSharingDemo.
-
-The second command uses the Test-ScriptFileInfo cmdlet to validate the script.
+`Save-Script` uses the **Name** parameter to specify the script's name. The **Repository** parameter
+specifies where to find the script. The script is saved in the location specified by the **Path**
+parameter. `Test-ScriptFileInfo` specifies the **Path** and validates the script's metadata.
 
 ## PARAMETERS
 
 ### -AcceptLicense
 
-Automatically accept the license agreement during installation if the package requires it.
+Automatically accept the license agreement if the script requires it.
 
 ```yaml
 Type: SwitchParameter
@@ -103,6 +112,8 @@ Accept wildcard characters: False
 
 ### -Credential
 
+Specifies a user account that has permission to save a script.
+
 ```yaml
 Type: PSCredential
 Parameter Sets: (All)
@@ -117,7 +128,7 @@ Accept wildcard characters: False
 
 ### -Force
 
-Forces the command to run without asking for user confirmation.
+Forces `Save-Script` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -133,11 +144,12 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies a package by using the script's SoftwareID object, which is shown in the results of the Find-Script cmdlet.
+Accepts a **PSRepositoryItemInfo** object. For example, output `Find-Script` to a variable and use
+that variable as the **InputObject** argument.
 
 ```yaml
 Type: PSObject[]
-Parameter Sets: InputOjectAndLiteralPathParameterSet, InputOjectAndPathParameterSet
+Parameter Sets: InputObjectAndLiteralPathParameterSet, InputObjectAndPathParameterSet
 Aliases:
 
 Required: True
@@ -149,15 +161,14 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies a path to one or more locations.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as entered.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies a path to one or more locations. The value of the **LiteralPath** parameter is used
+exactly as entered. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose the path within single quotation marks. PowerShell doesn't interpret any
+characters enclosed in single quotation marks as escape sequences.
 
 ```yaml
 Type: String
-Parameter Sets: NameAndLiteralPathParameterSet, InputOjectAndLiteralPathParameterSet
+Parameter Sets: NameAndLiteralPathParameterSet, InputObjectAndLiteralPathParameterSet
 Aliases:
 
 Required: True
@@ -169,8 +180,8 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies the maximum, or newest version of the script to save.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the maximum, or newest version of the script to save. The **MaximumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -186,8 +197,8 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of the script to find.
-The *MinimumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the minimum version of a script to save. The **MinimumVersion** and **RequiredVersion**
+parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -203,7 +214,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies an array of names of scripts to save.
+Specifies an array of script names to save.
 
 ```yaml
 Type: String[]
@@ -219,23 +230,23 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies a path to one or more locations.
-Wildcards are permitted.
-The default location is the current directory (.).
+Specifies the location on the local computer to store a saved module. Accepts wildcard characters.
 
 ```yaml
 Type: String
-Parameter Sets: NameAndPathParameterSet, InputOjectAndPathParameterSet
+Parameter Sets: NameAndPathParameterSet, InputObjectAndPathParameterSet
 Aliases:
 
 Required: True
-Position: Named
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Proxy
+
+Specifies a proxy server for the request, rather than connecting directly to an internet resource.
 
 ```yaml
 Type: Uri
@@ -251,6 +262,9 @@ Accept wildcard characters: False
 
 ### -ProxyCredential
 
+Specifies a user account that has permission to use the proxy server specified by the **Proxy**
+parameter.
+
 ```yaml
 Type: PSCredential
 Parameter Sets: (All)
@@ -265,7 +279,8 @@ Accept wildcard characters: False
 
 ### -Repository
 
-Specifies the friendly name of a repository that has been registered by running Register-PSRepository.
+Specifies the friendly name of a repository that has been registered by running
+`Register-PSRepository`. Use `Get-PSRepository` to display registered repositories.
 
 ```yaml
 Type: String[]
@@ -297,7 +312,7 @@ Accept wildcard characters: False
 
 ### -Confirm
 
-Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running `Save-Script`.
 
 ```yaml
 Type: SwitchParameter
@@ -313,8 +328,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if `Save-Script` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -330,7 +344,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -345,6 +361,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Install-Script](Install-Script.md)
 
 [Publish-Script](Publish-Script.md)
+
+[Test-ScriptFileInfo](Test-ScriptFileInfo.md)
 
 [Uninstall-Script](Uninstall-Script.md)
 

--- a/reference/6/PowerShellGet/Uninstall-Module.md
+++ b/reference/6/PowerShellGet/Uninstall-Module.md
@@ -234,6 +234,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### PSRepositoryItemInfo
+
 `Uninstall-Module` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS

--- a/reference/6/PowerShellGet/Uninstall-Module.md
+++ b/reference/6/PowerShellGet/Uninstall-Module.md
@@ -3,11 +3,12 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 7/2/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2097007
 schema: 2.0.0
 title: Uninstall-Module
 ---
+
 # Uninstall-Module
 
 ## SYNOPSIS
@@ -31,18 +32,29 @@ Uninstall-Module [-InputObject] <PSObject[]> [-Force] [-WhatIf] [-Confirm] [<Com
 
 ## DESCRIPTION
 
-The **Uninstall-Module** cmdlet uninstalls the specified module from the local computer.
-You cannot uninstall a module if it has other modules as dependencies.
+The `Uninstall-Module` cmdlet uninstalls a specified module from the local computer. You can't
+uninstall a module if it has other modules as dependencies.
 
 ## EXAMPLES
 
-### Example 1: Get a module and uninstall it
+### Example 1: Uninstall a module
 
-```
-PS C:\> Get-InstalledModule -Name "xPSDesiredStateConfiguration" -RequiredVersion 3.6.0.0 | Uninstall-Module
+In this example, an installed module's version is displayed and the module is uninstalled.
+
+```powershell
+Get-InstalledModule -Name SpeculationControl
+Uninstall-Module -Name SpeculationControl
 ```
 
-This command gets version 3.6.0.0 of the module named xPSDesiredStateConfiguration, and then uses the pipeline operator to pass it to the **Uninstall-Module** cmdlet, which uninstalls it.
+```Output
+Version  Name                Repository   Description
+-------  ----                ----------   -----------
+1.0.14   SpeculationControl  PSGallery    This module provides the ability to query...
+```
+
+`Get-InstalledModule` uses the **Name** parameter to display the installed module,
+**SpeculationControl**. `Uninstall-Module` uses the **Name** parameter to specify the module to
+uninstall.
 
 ## PARAMETERS
 
@@ -64,8 +76,9 @@ Accept wildcard characters: False
 
 ### -AllVersions
 
-Specifies that you want to include all available versions of a module.
-You cannot use the *AllVersions* parameter with the *MinimumVersion*, *MaximumVersion*, or *RequiredVersion* parameters.
+Specifies that you want to include all available versions of a module. You can't use the
+**AllVersions** parameter with the **MinimumVersion**, **MaximumVersion**, or **RequiredVersion**
+parameters.
 
 ```yaml
 Type: SwitchParameter
@@ -81,7 +94,7 @@ Accept wildcard characters: False
 
 ### -Force
 
-Forces the command to run without asking for user confirmation.
+Forces `Uninstall-Module` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -97,7 +110,8 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies a package by using the module's SoftwareID object, which is shown in the results of the Find-Module cmdlet.
+Accepts a **PSRepositoryItemInfo** object. For example, output `Get-InstalledModule` to a variable
+and use that variable as the **InputObject** argument.
 
 ```yaml
 Type: PSObject[]
@@ -113,8 +127,8 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies the maximum, or newest, version of the module to uninstall.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the maximum, or newest, version of the module to uninstall. The **MaximumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -130,8 +144,8 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of the script to uninstall.
-The *MinimumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the minimum version of the script to uninstall. The **MinimumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -147,7 +161,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies an array of names of modules to uninstall.
+Specifies an array of module names to uninstall.
 
 ```yaml
 Type: String[]
@@ -179,7 +193,7 @@ Accept wildcard characters: False
 
 ### -Confirm
 
-Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the `Uninstall-Module`.
 
 ```yaml
 Type: SwitchParameter
@@ -195,8 +209,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if `Uninstall-Module` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -212,7 +225,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/6/PowerShellGet/Uninstall-Module.md
+++ b/reference/6/PowerShellGet/Uninstall-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/2/2019
+ms.date: 07/02/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2097007
 schema: 2.0.0
 title: Uninstall-Module
@@ -39,22 +39,25 @@ uninstall a module if it has other modules as dependencies.
 
 ### Example 1: Uninstall a module
 
-In this example, an installed module's version is displayed and the module is uninstalled.
+This example uninstalls a module.
 
 ```powershell
-Get-InstalledModule -Name SpeculationControl
 Uninstall-Module -Name SpeculationControl
 ```
 
-```Output
-Version  Name                Repository   Description
--------  ----                ----------   -----------
-1.0.14   SpeculationControl  PSGallery    This module provides the ability to query...
+`Uninstall-Module` uses the **Name** parameter to specify the module to uninstall from the local
+computer.
+
+### Example 2: Use the pipeline to uninstall a module
+
+In this example, the pipeline is used to uninstall a module.
+
+```powershell
+Get-InstalledModule -Name SpeculationControl | Uninstall-Module
 ```
 
-`Get-InstalledModule` uses the **Name** parameter to display the installed module,
-**SpeculationControl**. `Uninstall-Module` uses the **Name** parameter to specify the module to
-uninstall.
+`Get-InstalledModule` uses the **Name** parameter to specify the module. The object is sent down the
+pipeline to `Uninstall-Module` and is uninstalled.
 
 ## PARAMETERS
 
@@ -144,7 +147,7 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of the script to uninstall. The **MinimumVersion** and
+Specifies the minimum version of the module to uninstall. The **MinimumVersion** and
 **RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
@@ -230,6 +233,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
+
+`Uninstall-Module` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS
 

--- a/reference/6/PowerShellGet/Uninstall-Script.md
+++ b/reference/6/PowerShellGet/Uninstall-Script.md
@@ -3,15 +3,16 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 7/3/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096449
 schema: 2.0.0
 title: Uninstall-Script
 ---
+
 # Uninstall-Script
 
 ## SYNOPSIS
-Uninstalls a script file.
+Uninstalls a script.
 
 ## SYNTAX
 
@@ -30,17 +31,28 @@ Uninstall-Script [-InputObject] <PSObject[]> [-Force] [-WhatIf] [-Confirm] [<Com
 
 ## DESCRIPTION
 
-The **Uninstall-Script** cmdlet uninstalls the specified script files from the online gallery.
+The `Uninstall-Script` cmdlet uninstalls a specified script from the local computer.
 
 ## EXAMPLES
 
 ### Example 1: Uninstall a script file
 
-```
-PS C:\> Uninstall-Script -Name "MyScript" -RequiredVersion 2.5
+This example uninstalls a script from the local computer.
+
+```powershell
+Get-InstalledScript -Name UpdateManagement-Template
+Uninstall-Script -Name UpdateManagement-Template
 ```
 
-This command uninstalls version 2.5 of the script file named MyScript.
+```Output
+Version   Name                         Repository   Description
+-------   ----                         ----------   -----------
+1.1       UpdateManagement-Template    LocalRepo    This is a template script for Update Management
+```
+
+`Get-InstalledScript` uses the **Name** parameter to display the **UpdateManagement-Template**
+script installed from a local repository. `Uninstall-Script` uses the **Name** parameter to specify
+the script to uninstall.
 
 ## PARAMETERS
 
@@ -62,7 +74,7 @@ Accept wildcard characters: False
 
 ### -Force
 
-Forces the command to run without asking for user confirmation.
+Forces `Uninstall-Script` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -78,7 +90,8 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies a package by using the script's SoftwareID object, which is shown in the results of the Find-Module cmdlet.
+Accepts a **PSRepositoryItemInfo** object. For example, output `Get-InstalledScript` to a variable
+and use that variable as the **InputObject** argument.
 
 ```yaml
 Type: PSObject[]
@@ -94,8 +107,8 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies the maximum, or newest, version of the script to uninstall.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the maximum, or newest, version of the script to uninstall. The **MaximumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -111,8 +124,8 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of the script to uninstall.
-The *MinimumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the minimum version of the script to uninstall. The **MinimumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -128,7 +141,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies an array of names of scripts to uninstall.
+Specifies an array of script names to uninstall.
 
 ```yaml
 Type: String[]
@@ -160,7 +173,7 @@ Accept wildcard characters: False
 
 ### -Confirm
 
-Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running `Uninstall-Script`.
 
 ```yaml
 Type: SwitchParameter
@@ -176,8 +189,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if `Uninstall-Script` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -193,7 +205,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/6/PowerShellGet/Uninstall-Script.md
+++ b/reference/6/PowerShellGet/Uninstall-Script.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/3/2019
+ms.date: 07/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096449
 schema: 2.0.0
 title: Uninstall-Script
@@ -35,24 +35,27 @@ The `Uninstall-Script` cmdlet uninstalls a specified script from the local compu
 
 ## EXAMPLES
 
-### Example 1: Uninstall a script file
+### Example 1: Uninstall a script
 
-This example uninstalls a script from the local computer.
+This example uninstalls a script.
 
 ```powershell
-Get-InstalledScript -Name UpdateManagement-Template
 Uninstall-Script -Name UpdateManagement-Template
 ```
 
-```Output
-Version   Name                         Repository   Description
--------   ----                         ----------   -----------
-1.1       UpdateManagement-Template    LocalRepo    This is a template script for Update Management
+`Uninstall-Script` uses the **Name** parameter to specify the script to uninstall from the local
+computer.
+
+### Example 2: Use the pipeline to uninstall a script
+
+In this example, the pipeline is used to uninstall a script.
+
+```powershell
+Get-InstalledScript -Name UpdateManagement-Template | Uninstall-Script
 ```
 
-`Get-InstalledScript` uses the **Name** parameter to display the **UpdateManagement-Template**
-script installed from a local repository. `Uninstall-Script` uses the **Name** parameter to specify
-the script to uninstall.
+`Get-InstalledScript` uses the **Name** parameter to specify the script. The object is sent down the
+pipeline to `Uninstall-Script` and the script is uninstalled.
 
 ## PARAMETERS
 
@@ -210,6 +213,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
+
+`Uninstall-Script` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS
 

--- a/reference/6/PowerShellGet/Uninstall-Script.md
+++ b/reference/6/PowerShellGet/Uninstall-Script.md
@@ -214,6 +214,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### PSRepositoryItemInfo
+
 `Uninstall-Script` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS

--- a/reference/7/PowerShellGet/Save-Module.md
+++ b/reference/7/PowerShellGet/Save-Module.md
@@ -241,8 +241,7 @@ Accept wildcard characters: False
 ### -MaximumVersion
 
 Specifies the maximum, or newest, version of the module to save. The **MaximumVersion** and
-**RequiredVersion** parameters are mutually exclusive; you cannot use both parameters in the same
-command.
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -260,7 +259,7 @@ Accept wildcard characters: False
 
 Specifies the minimum version of a single module to save. You cannot add this parameter if you are
 attempting to install multiple modules. The **MinimumVersion** and **RequiredVersion** parameters
-are mutually exclusive; you cannot use both parameters in the same command.
+can't be used in the same command.
 
 ```yaml
 Type: String
@@ -292,8 +291,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the location on the local computer to store a saved module. Accepts wildcard characters
-when the string is wrapped in double-quotes.
+Specifies the location on the local computer to store a saved module. Accepts wildcard characters.
 
 ```yaml
 Type: String
@@ -304,12 +302,12 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Proxy
 
-Specifies a proxy server for the request, rather than connecting directly to the Internet resource.
+Specifies a proxy server for the request, rather than connecting directly to the internet resource.
 
 ```yaml
 Type: Uri

--- a/reference/7/PowerShellGet/Save-Module.md
+++ b/reference/7/PowerShellGet/Save-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/1/2019
+ms.date: 07/01/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2097025
 schema: 2.0.0
 title: Save-Module

--- a/reference/7/PowerShellGet/Save-Script.md
+++ b/reference/7/PowerShellGet/Save-Script.md
@@ -3,11 +3,12 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 7/2/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096638
 schema: 2.0.0
 title: Save-Script
 ---
+
 # Save-Script
 
 ## SYNOPSIS
@@ -19,9 +20,9 @@ Saves a script.
 
 ```
 Save-Script [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <String>]
- [-RequiredVersion <String>] [-Repository <String[]>] -Path <String> [-Proxy <Uri>]
- [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease] [-AcceptLicense]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-RequiredVersion <String>] [-Repository <String[]>] [-Path] <String> [-Proxy <Uri>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease]
+ [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### NameAndLiteralPathParameterSet
@@ -29,49 +30,57 @@ Save-Script [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <Stri
 ```
 Save-Script [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <String>]
  [-RequiredVersion <String>] [-Repository <String[]>] -LiteralPath <String> [-Proxy <Uri>]
- [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease] [-AcceptLicense]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease]
+ [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### InputOjectAndLiteralPathParameterSet
+### InputObjectAndLiteralPathParameterSet
 
 ```
-Save-Script [-InputObject] <PSObject[]> -LiteralPath <String> [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
- [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+Save-Script [-InputObject] <PSObject[]> -LiteralPath <String> [-Proxy <Uri>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
-### InputOjectAndPathParameterSet
+### InputObjectAndPathParameterSet
 
 ```
-Save-Script [-InputObject] <PSObject[]> -Path <String> [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
- [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+Save-Script [-InputObject] <PSObject[]> [-Path] <String> [-Proxy <Uri>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The **Save-Script** cmdlet saves the specified script.
+The `Save-Script` cmdlet saves the specified script.
 
 ## EXAMPLES
 
-### Example 1: Save a script and validate it
+### Example 1: Save a script and validate the script's metadata
 
+In this example, a script from a repository is saved to the local computer and the script's metadata
+is validated.
+
+```powershell
+Save-Script -Name Install-VSCode -Repository PSGallery -Path C:\Test\Scripts
+Test-ScriptFileInfo -Path C:\Test\Scripts\Install-VSCode.ps1
 ```
-PS C:\> Save-Script -Name "Fabrikam-ClientScript" -Repository "Local01" -Path "D:\ScriptSharingDemo"
-PS C:\> Test-ScriptFileInfo -Path "D:\ScriptSharingDemo\Fabrikam-ClientScript.ps1"
-Version    Name                      Author               Description
--------    ----                      ------               -----------
-2.5        Fabrikam-ClientScript     pattif               Description for the Fabrikam-ClientScript script
+
+```Output
+Version   Name              Author      Description
+-------   ----              ------      -----------
+1.3       Install-VSCode    Microsoft   This script can be used to easily install Visual Studio Code
 ```
 
-The first command saves the script Fabrikam-ClientScript from the Local01 repository to the local folder D:\ScriptSharingDemo.
-
-The second command uses the Test-ScriptFileInfo cmdlet to validate the script.
+`Save-Script` uses the **Name** parameter to specify the script's name. The **Repository** parameter
+specifies where to find the script. The script is saved in the location specified by the **Path**
+parameter. `Test-ScriptFileInfo` specifies the **Path** and validates the script's metadata.
 
 ## PARAMETERS
 
 ### -AcceptLicense
 
-Automatically accept the license agreement during installation if the package requires it.
+Automatically accept the license agreement if the script requires it.
 
 ```yaml
 Type: SwitchParameter
@@ -103,6 +112,8 @@ Accept wildcard characters: False
 
 ### -Credential
 
+Specifies a user account that has permission to save a script.
+
 ```yaml
 Type: PSCredential
 Parameter Sets: (All)
@@ -117,7 +128,7 @@ Accept wildcard characters: False
 
 ### -Force
 
-Forces the command to run without asking for user confirmation.
+Forces `Save-Script` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -133,11 +144,12 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies a package by using the script's SoftwareID object, which is shown in the results of the Find-Script cmdlet.
+Accepts a **PSRepositoryItemInfo** object. For example, output `Find-Script` to a variable and use
+that variable as the **InputObject** argument.
 
 ```yaml
 Type: PSObject[]
-Parameter Sets: InputOjectAndLiteralPathParameterSet, InputOjectAndPathParameterSet
+Parameter Sets: InputObjectAndLiteralPathParameterSet, InputObjectAndPathParameterSet
 Aliases:
 
 Required: True
@@ -149,15 +161,14 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies a path to one or more locations.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as entered.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies a path to one or more locations. The value of the **LiteralPath** parameter is used
+exactly as entered. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose the path within single quotation marks. PowerShell doesn't interpret any
+characters enclosed in single quotation marks as escape sequences.
 
 ```yaml
 Type: String
-Parameter Sets: NameAndLiteralPathParameterSet, InputOjectAndLiteralPathParameterSet
+Parameter Sets: NameAndLiteralPathParameterSet, InputObjectAndLiteralPathParameterSet
 Aliases:
 
 Required: True
@@ -169,8 +180,8 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies the maximum, or newest version of the script to save.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the maximum, or newest version of the script to save. The **MaximumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -186,8 +197,8 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of the script to find.
-The *MinimumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the minimum version of a script to save. The **MinimumVersion** and **RequiredVersion**
+parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -203,7 +214,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies an array of names of scripts to save.
+Specifies an array of script names to save.
 
 ```yaml
 Type: String[]
@@ -219,23 +230,23 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies a path to one or more locations.
-Wildcards are permitted.
-The default location is the current directory (.).
+Specifies the location on the local computer to store a saved module. Accepts wildcard characters.
 
 ```yaml
 Type: String
-Parameter Sets: NameAndPathParameterSet, InputOjectAndPathParameterSet
+Parameter Sets: NameAndPathParameterSet, InputObjectAndPathParameterSet
 Aliases:
 
 Required: True
-Position: Named
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Proxy
+
+Specifies a proxy server for the request, rather than connecting directly to an internet resource.
 
 ```yaml
 Type: Uri
@@ -251,6 +262,9 @@ Accept wildcard characters: False
 
 ### -ProxyCredential
 
+Specifies a user account that has permission to use the proxy server specified by the **Proxy**
+parameter.
+
 ```yaml
 Type: PSCredential
 Parameter Sets: (All)
@@ -265,7 +279,8 @@ Accept wildcard characters: False
 
 ### -Repository
 
-Specifies the friendly name of a repository that has been registered by running Register-PSRepository.
+Specifies the friendly name of a repository that has been registered by running
+`Register-PSRepository`. Use `Get-PSRepository` to display registered repositories.
 
 ```yaml
 Type: String[]
@@ -297,7 +312,7 @@ Accept wildcard characters: False
 
 ### -Confirm
 
-Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running `Save-Script`.
 
 ```yaml
 Type: SwitchParameter
@@ -313,8 +328,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if `Save-Script` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -330,7 +344,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -345,6 +361,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Install-Script](Install-Script.md)
 
 [Publish-Script](Publish-Script.md)
+
+[Test-ScriptFileInfo](Test-ScriptFileInfo.md)
 
 [Uninstall-Script](Uninstall-Script.md)
 

--- a/reference/7/PowerShellGet/Save-Script.md
+++ b/reference/7/PowerShellGet/Save-Script.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/2/2019
+ms.date: 07/02/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096638
 schema: 2.0.0
 title: Save-Script

--- a/reference/7/PowerShellGet/Uninstall-Module.md
+++ b/reference/7/PowerShellGet/Uninstall-Module.md
@@ -234,6 +234,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### PSRepositoryItemInfo
+
 `Uninstall-Module` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS

--- a/reference/7/PowerShellGet/Uninstall-Module.md
+++ b/reference/7/PowerShellGet/Uninstall-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/2/2019
+ms.date: 07/02/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2097027
 schema: 2.0.0
 title: Uninstall-Module
@@ -39,22 +39,25 @@ uninstall a module if it has other modules as dependencies.
 
 ### Example 1: Uninstall a module
 
-In this example, an installed module's version is displayed and the module is uninstalled.
+This example uninstalls a module.
 
 ```powershell
-Get-InstalledModule -Name SpeculationControl
 Uninstall-Module -Name SpeculationControl
 ```
 
-```Output
-Version  Name                Repository   Description
--------  ----                ----------   -----------
-1.0.14   SpeculationControl  PSGallery    This module provides the ability to query...
+`Uninstall-Module` uses the **Name** parameter to specify the module to uninstall from the local
+computer.
+
+### Example 2: Use the pipeline to uninstall a module
+
+In this example, the pipeline is used to uninstall a module.
+
+```powershell
+Get-InstalledModule -Name SpeculationControl | Uninstall-Module
 ```
 
-`Get-InstalledModule` uses the **Name** parameter to display the installed module,
-**SpeculationControl**. `Uninstall-Module` uses the **Name** parameter to specify the module to
-uninstall.
+`Get-InstalledModule` uses the **Name** parameter to specify the module. The object is sent down the
+pipeline to `Uninstall-Module` and is uninstalled.
 
 ## PARAMETERS
 
@@ -144,7 +147,7 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of the script to uninstall. The **MinimumVersion** and
+Specifies the minimum version of the module to uninstall. The **MinimumVersion** and
 **RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
@@ -230,6 +233,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
+
+`Uninstall-Module` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS
 

--- a/reference/7/PowerShellGet/Uninstall-Module.md
+++ b/reference/7/PowerShellGet/Uninstall-Module.md
@@ -3,11 +3,12 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 7/2/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2097027
 schema: 2.0.0
 title: Uninstall-Module
 ---
+
 # Uninstall-Module
 
 ## SYNOPSIS
@@ -31,18 +32,29 @@ Uninstall-Module [-InputObject] <PSObject[]> [-Force] [-WhatIf] [-Confirm] [<Com
 
 ## DESCRIPTION
 
-The **Uninstall-Module** cmdlet uninstalls the specified module from the local computer.
-You cannot uninstall a module if it has other modules as dependencies.
+The `Uninstall-Module` cmdlet uninstalls a specified module from the local computer. You can't
+uninstall a module if it has other modules as dependencies.
 
 ## EXAMPLES
 
-### Example 1: Get a module and uninstall it
+### Example 1: Uninstall a module
 
-```
-PS C:\> Get-InstalledModule -Name "xPSDesiredStateConfiguration" -RequiredVersion 3.6.0.0 | Uninstall-Module
+In this example, an installed module's version is displayed and the module is uninstalled.
+
+```powershell
+Get-InstalledModule -Name SpeculationControl
+Uninstall-Module -Name SpeculationControl
 ```
 
-This command gets version 3.6.0.0 of the module named xPSDesiredStateConfiguration, and then uses the pipeline operator to pass it to the **Uninstall-Module** cmdlet, which uninstalls it.
+```Output
+Version  Name                Repository   Description
+-------  ----                ----------   -----------
+1.0.14   SpeculationControl  PSGallery    This module provides the ability to query...
+```
+
+`Get-InstalledModule` uses the **Name** parameter to display the installed module,
+**SpeculationControl**. `Uninstall-Module` uses the **Name** parameter to specify the module to
+uninstall.
 
 ## PARAMETERS
 
@@ -64,8 +76,9 @@ Accept wildcard characters: False
 
 ### -AllVersions
 
-Specifies that you want to include all available versions of a module.
-You cannot use the *AllVersions* parameter with the *MinimumVersion*, *MaximumVersion*, or *RequiredVersion* parameters.
+Specifies that you want to include all available versions of a module. You can't use the
+**AllVersions** parameter with the **MinimumVersion**, **MaximumVersion**, or **RequiredVersion**
+parameters.
 
 ```yaml
 Type: SwitchParameter
@@ -81,7 +94,7 @@ Accept wildcard characters: False
 
 ### -Force
 
-Forces the command to run without asking for user confirmation.
+Forces `Uninstall-Module` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -97,7 +110,8 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies a package by using the module's SoftwareID object, which is shown in the results of the Find-Module cmdlet.
+Accepts a **PSRepositoryItemInfo** object. For example, output `Get-InstalledModule` to a variable
+and use that variable as the **InputObject** argument.
 
 ```yaml
 Type: PSObject[]
@@ -113,8 +127,8 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies the maximum, or newest, version of the module to uninstall.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the maximum, or newest, version of the module to uninstall. The **MaximumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -130,8 +144,8 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of the script to uninstall.
-The *MinimumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the minimum version of the script to uninstall. The **MinimumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -147,7 +161,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies an array of names of modules to uninstall.
+Specifies an array of module names to uninstall.
 
 ```yaml
 Type: String[]
@@ -179,7 +193,7 @@ Accept wildcard characters: False
 
 ### -Confirm
 
-Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the `Uninstall-Module`.
 
 ```yaml
 Type: SwitchParameter
@@ -195,8 +209,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if `Uninstall-Module` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -212,7 +225,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/7/PowerShellGet/Uninstall-Script.md
+++ b/reference/7/PowerShellGet/Uninstall-Script.md
@@ -3,15 +3,16 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 7/3/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096629
 schema: 2.0.0
 title: Uninstall-Script
 ---
+
 # Uninstall-Script
 
 ## SYNOPSIS
-Uninstalls a script file.
+Uninstalls a script.
 
 ## SYNTAX
 
@@ -30,17 +31,28 @@ Uninstall-Script [-InputObject] <PSObject[]> [-Force] [-WhatIf] [-Confirm] [<Com
 
 ## DESCRIPTION
 
-The **Uninstall-Script** cmdlet uninstalls the specified script files from the online gallery.
+The `Uninstall-Script` cmdlet uninstalls a specified script from the local computer.
 
 ## EXAMPLES
 
 ### Example 1: Uninstall a script file
 
-```
-PS C:\> Uninstall-Script -Name "MyScript" -RequiredVersion 2.5
+This example uninstalls a script from the local computer.
+
+```powershell
+Get-InstalledScript -Name UpdateManagement-Template
+Uninstall-Script -Name UpdateManagement-Template
 ```
 
-This command uninstalls version 2.5 of the script file named MyScript.
+```Output
+Version   Name                         Repository   Description
+-------   ----                         ----------   -----------
+1.1       UpdateManagement-Template    LocalRepo    This is a template script for Update Management
+```
+
+`Get-InstalledScript` uses the **Name** parameter to display the **UpdateManagement-Template**
+script installed from a local repository. `Uninstall-Script` uses the **Name** parameter to specify
+the script to uninstall.
 
 ## PARAMETERS
 
@@ -62,7 +74,7 @@ Accept wildcard characters: False
 
 ### -Force
 
-Forces the command to run without asking for user confirmation.
+Forces `Uninstall-Script` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -78,7 +90,8 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies a package by using the script's SoftwareID object, which is shown in the results of the Find-Module cmdlet.
+Accepts a **PSRepositoryItemInfo** object. For example, output `Get-InstalledScript` to a variable
+and use that variable as the **InputObject** argument.
 
 ```yaml
 Type: PSObject[]
@@ -94,8 +107,8 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies the maximum, or newest, version of the script to uninstall.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the maximum, or newest, version of the script to uninstall. The **MaximumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -111,8 +124,8 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of the script to uninstall.
-The *MinimumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the minimum version of the script to uninstall. The **MinimumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -128,7 +141,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies an array of names of scripts to uninstall.
+Specifies an array of script names to uninstall.
 
 ```yaml
 Type: String[]
@@ -160,7 +173,7 @@ Accept wildcard characters: False
 
 ### -Confirm
 
-Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running `Uninstall-Script`.
 
 ```yaml
 Type: SwitchParameter
@@ -176,8 +189,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if `Uninstall-Script` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -193,7 +205,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/7/PowerShellGet/Uninstall-Script.md
+++ b/reference/7/PowerShellGet/Uninstall-Script.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/3/2019
+ms.date: 07/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096629
 schema: 2.0.0
 title: Uninstall-Script
@@ -35,24 +35,27 @@ The `Uninstall-Script` cmdlet uninstalls a specified script from the local compu
 
 ## EXAMPLES
 
-### Example 1: Uninstall a script file
+### Example 1: Uninstall a script
 
-This example uninstalls a script from the local computer.
+This example uninstalls a script.
 
 ```powershell
-Get-InstalledScript -Name UpdateManagement-Template
 Uninstall-Script -Name UpdateManagement-Template
 ```
 
-```Output
-Version   Name                         Repository   Description
--------   ----                         ----------   -----------
-1.1       UpdateManagement-Template    LocalRepo    This is a template script for Update Management
+`Uninstall-Script` uses the **Name** parameter to specify the script to uninstall from the local
+computer.
+
+### Example 2: Use the pipeline to uninstall a script
+
+In this example, the pipeline is used to uninstall a script.
+
+```powershell
+Get-InstalledScript -Name UpdateManagement-Template | Uninstall-Script
 ```
 
-`Get-InstalledScript` uses the **Name** parameter to display the **UpdateManagement-Template**
-script installed from a local repository. `Uninstall-Script` uses the **Name** parameter to specify
-the script to uninstall.
+`Get-InstalledScript` uses the **Name** parameter to specify the script. The object is sent down the
+pipeline to `Uninstall-Script` and the script is uninstalled.
 
 ## PARAMETERS
 
@@ -210,6 +213,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
+
+`Uninstall-Script` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS
 

--- a/reference/7/PowerShellGet/Uninstall-Script.md
+++ b/reference/7/PowerShellGet/Uninstall-Script.md
@@ -214,6 +214,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### PSRepositoryItemInfo
+
 `Uninstall-Script` accepts **PSRepositoryItemInfo** objects from the pipeline.
 
 ## OUTPUTS


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document


Acrolinx scores
Save-Script: original version: 95, updated version: 98
Uninstall-Module: original version: 93, updated version: 97
Uninstall-Script: original version: 94, updated version: 97

- Fixes [AB#1565976](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1565976)
- Related to #3740
- Added content to empty parameter descriptions
- Copyedits, style
- Revised the Save-Module parameter descriptions: MaximumVersion, MinimumVersion, and Path