### PR TITLE
Updating Raspbian installation for Raspbian Buster

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
@@ -614,7 +614,7 @@ sudo apt-get update
 
 # Install libunwind8 and libssl1.0
 # Regex is used to ensure that we do not install libssl1.0-dev, as it is a variant that is not required
-sudo apt-get install '^libssl1.0(.?.?.?|.*([^v]|[^e]v|[^d]ev|[^-]dev))$' libunwind8 -y
+sudo apt-get install '^libssl1.0.[0-9]$' libunwind8 -y
 
 ###################################
 # Download and extract PowerShell

--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
@@ -606,8 +606,18 @@ Download [Raspbian Stretch](https://www.raspberrypi.org/downloads/raspbian/) and
 ### Installation - Raspbian
 
 ```sh
-# Install prerequisites
-sudo apt-get install libunwind8
+###################################
+# Prerequisites
+
+# Update package lists
+sudo apt-get update
+
+# Install libunwind8 and libssl1.0
+# Regex is used to ensure that we do not install libssl1.0-dev, as it is a variant that is not required
+sudo apt-get install '^libssl1.0(.?.?.?|.*([^v]|[^e]v|[^d]ev|[^-]dev))$' libunwind8 -y
+
+###################################
+# Download and extract PowerShell
 
 # Grab the latest tar.gz
 wget https://github.com/PowerShell/PowerShell/releases/download/v6.2.0/powershell-6.2.0-linux-arm32.tar.gz


### PR DESCRIPTION
Raspbian Buster was released alongside the Raspberry Pi 4. Buster does not include libssl1.0, which is a prerequisite for .NET Core 2.x. As a result, PowerShell Core 6.x would fail. Therefore, libssl1.0 is added as a prerequisite with care to not select libssl1.0-dev. Also, a step was added to update package lists prior to package installation, and the -y flag on the apt-get install command prevents a confirmation prompt.

Note that libssl1.0 is not required for PowerShell 7 because PS7 runs on .NET Core 3.x, which does not have the dependency.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 7 document
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version 6.x of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
