### PR TITLE
Added content to empty parameters, copyedits

### DIFF
--- a/reference/5.1/PowershellGet/New-ScriptFileInfo.md
+++ b/reference/5.1/PowershellGet/New-ScriptFileInfo.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/1/2019
+ms.date: 07/01/2019
 online version: https://go.microsoft.com/fwlink/?linkid=822329
 schema: 2.0.0
 title: New-ScriptFileInfo
@@ -398,7 +398,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path to the module manifest file to update.
+Specifies the location where the script file is saved.
 
 ```yaml
 Type: String

--- a/reference/5.1/PowershellGet/Update-ModuleManifest.md
+++ b/reference/5.1/PowershellGet/Update-ModuleManifest.md
@@ -58,7 +58,7 @@ Update-ModuleManifest @Parms
 ```
 
 `$Parms` is a splat that stores the parameter values for **Path**, **Author**, **CompanyName**, and
-**Copyright**. `Update-ModuleManifest` gets the parameter values from **@Parms** and updates the
+**Copyright**. `Update-ModuleManifest` gets the parameter values from `@Parms` and updates the
 module manifest, **TestManifest.psd1**.
 
 ## PARAMETERS

--- a/reference/5.1/PowershellGet/Update-Script.md
+++ b/reference/5.1/PowershellGet/Update-Script.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 07/09/2019
 online version: https://go.microsoft.com/fwlink/?linkid=822342
 schema: 2.0.0
 title: Update-Script
@@ -16,35 +16,45 @@ Updates a script.
 
 ## SYNTAX
 
+### All
+
 ```
-Update-Script [[-Name] <String[]>] [-RequiredVersion <String>] [-MaximumVersion <String>] [-Proxy <Uri>]
- [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease] [-AcceptLicense]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Update-Script [[-Name] <String[]>] [-RequiredVersion <String>] [-MaximumVersion <String>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force]
+ [-AllowPrerelease] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Update-Script** cmdlet updates the specified script from the repository from which it was previously installed.
+
+The `Update-Script` cmdlet updates a script that is installed on the local computer. The updated
+script is downloaded from the same repository as the installed version.
 
 ## EXAMPLES
 
 ### Example 1: Update the specified script
-```
-PS C:\> Update-Script -Name "Fabrikam-Script" -RequiredVersion 1.5
-PS C:\> Get-InstalledScript -Name "Fabrikam-Script"
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-1.5        Fabrikam-Script                     Script     local1               Description for the Fabrikam-Script script
+
+This example updates an installed script and displays the updated version.
+
+```powershell
+Update-Script -Name UpdateManagement-Template -RequiredVersion 1.1
+Get-InstalledScript -Name UpdateManagement-Template
 ```
 
-The first command updates the script Fabrikam-Script to version 1.5.
+```Output
+Version   Name                       Repository   Description
+-------   ----                       ----------   -----------
+1.1       UpdateManagement-Template  PSGallery    This is a template script for Update Management...
+```
 
-The second command gets Fabrikam-Script and displays the results.
+`Update-Script` uses the **Name** parameter to specify the script to update. The **RequiredVersion**
+parameter specifies the script version. `Get-InstalledScript` displays the updated version of the
+script.
 
 ## PARAMETERS
 
 ### -AcceptLicense
-Automatically accept the license agreement during installation if the package requires it.
 
+Automatically accept the license agreement during installation if the package requires it.
 
 ```yaml
 Type: SwitchParameter
@@ -59,6 +69,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowPrerelease
+
 Allows you to update a script with the newer script marked as a prerelease.
 
 ```yaml
@@ -75,6 +86,8 @@ Accept wildcard characters: False
 
 ### -Credential
 
+Specifies a user account that has permission to update a script.
+
 ```yaml
 Type: PSCredential
 Parameter Sets: (All)
@@ -88,7 +101,8 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the command to run without asking for user confirmation.
+
+Forces `Update-Script` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -103,8 +117,9 @@ Accept wildcard characters: False
 ```
 
 ### -MaximumVersion
-Specifies the maximum, or newest, version of the script to update.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the maximum, or newest, version of the script to update. The **MaximumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -119,7 +134,8 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of names of scripts to update.
+
+Specifies one script name or an array of script names to update.
 
 ```yaml
 Type: String[]
@@ -134,7 +150,8 @@ Accept wildcard characters: False
 ```
 
 ### -Proxy
-Specifies a proxy server for the request, rather than connecting directly to the Internet resource.
+
+Specifies a proxy server for the request rather than connecting directly to an internet resource.
 
 ```yaml
 Type: Uri
@@ -149,7 +166,9 @@ Accept wildcard characters: False
 ```
 
 ### -ProxyCredential
-Specifies a user account that has permission to use the proxy server that is specified by the **Proxy** parameter.
+
+Specifies a user account that has permission to use the proxy server specified by the **Proxy**
+parameter.
 
 ```yaml
 Type: PSCredential
@@ -164,8 +183,9 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredVersion
-Specifies the exact version number of the script to update.
-The *MinimumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the exact version number of the script to update. The **MinimumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -180,7 +200,8 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.
+
+Prompts you for confirmation before running `Update-Script`.
 
 ```yaml
 Type: SwitchParameter
@@ -195,8 +216,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if `Update-Script` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -211,7 +232,10 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/5.1/PowershellGet/Update-ScriptFileInfo.md
+++ b/reference/5.1/PowershellGet/Update-ScriptFileInfo.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 07/09/2019
 online version: https://go.microsoft.com/fwlink/?linkid=822343
 schema: 2.0.0
 title: Update-ScriptFileInfo
@@ -17,71 +17,102 @@ Updates information for a script.
 ## SYNTAX
 
 ### PathParameterSet (Default)
+
 ```
 Update-ScriptFileInfo [-Path] <String> [-Version <String>] [-Author <String>] [-Guid <Guid>]
  [-Description <String>] [-CompanyName <String>] [-Copyright <String>] [-RequiredModules <Object[]>]
  [-ExternalModuleDependencies <String[]>] [-RequiredScripts <String[]>]
  [-ExternalScriptDependencies <String[]>] [-Tags <String[]>] [-ProjectUri <Uri>] [-LicenseUri <Uri>]
- [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PrivateData <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PrivateData <String>] [-PassThru] [-Force] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPathParameterSet
+
 ```
 Update-ScriptFileInfo [-LiteralPath] <String> [-Version <String>] [-Author <String>] [-Guid <Guid>]
  [-Description <String>] [-CompanyName <String>] [-Copyright <String>] [-RequiredModules <Object[]>]
  [-ExternalModuleDependencies <String[]>] [-RequiredScripts <String[]>]
  [-ExternalScriptDependencies <String[]>] [-Tags <String[]>] [-ProjectUri <Uri>] [-LicenseUri <Uri>]
- [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PrivateData <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PrivateData <String>] [-PassThru] [-Force] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Update-ScriptFileInfo** cmdlet updates information for a script.
+
+The `Update-ScriptFileInfo` cmdlet updates a script's property values. For example, the values for
+version, author, or description.
 
 ## EXAMPLES
 
 ### Example 1: Update the version of a script file
+
+In this example, an existing script file is updated with new property values.
+
+Splatting is used to pass parameters to the `Update-ScriptFileInfo` cmdlet. For more information,
+see [about_Splatting](../Microsoft.Powershell.Core/About/about_splatting.md).
+
+```powershell
+$Parms = @{
+  Path = "C:\Test\Temp-Scriptfile.ps1"
+  Version = "2.0"
+  Author = "bob@contoso.com"
+  CompanyName = "Contoso"
+  Description = "This is the updated description"
+  }
+Update-ScriptFileInfo @Parms -PassThru
 ```
-PS C:\> New-ScriptFileInfo -Path "\temp\temp-scriptfile.ps1" -Version 1.0 -Author "pattif@contoso.com" -Description "my test script file description goes here"
-PS C:\> Test-ScriptFileInfo -Path "\temp\temp-scriptfile.ps1"
-Version    Name                      Author               Description
--------    ----                      ------               -----------
-1.0        temp-scriptfile           manikb@microsoft.com my test script file description goes here PS C:\> Update-ScriptFileInfo -Path "\temp\temp-scriptfile.ps1" -Version 2.0 -PassThru
+
+```Output
 <#PSScriptInfo
 
 .VERSION 2.0
-.GUID eb246b19-17da-4392-8c89-7c280f69ad0e
-.AUTHOR manikb@microsoft.com
-.COMPANYNAME
+
+.GUID 4609f00c-e850-4d3f-9c69-3741e56e4133
+
+.AUTHOR bob@contoso.com
+
+.COMPANYNAME Contoso
+
 .COPYRIGHT
+
 .TAGS
+
 .LICENSEURI
+
 .PROJECTURI
+
 .ICONURI
+
 .EXTERNALMODULEDEPENDENCIES
 
 .REQUIREDSCRIPTS
+
 .EXTERNALSCRIPTDEPENDENCIES
+
 .RELEASENOTES
 
+.PRIVATEDATA
+
 #>
+
 <#
+
 .DESCRIPTION
- my test script file description goes here
+This is the updated description
+
 #>
 Param()
 ```
 
-The first command creates a script file and assigns it version 1.0.
-
-The second command uses the Test-ScriptFileInfo cmdlet to validate temp-scriptfile.ps1 and display the results.
-
-The third command uses **Update-ScriptFileInfo** to update the version number to 2.0.
+`$Parms` stores the parameter values for **Path**, **Version**, **Author**, **CompanyName**, and
+**Description**. `Update-ScriptFileInfo` gets the parameter values from **@Parms** and updates the
+script. The **PassThru** parameter displays the script's contents in the PowerShell console.
 
 ## PARAMETERS
 
 ### -Author
+
 Specifies the script author.
 
 ```yaml
@@ -97,6 +128,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompanyName
+
 Specifies the company or vendor who created the script.
 
 ```yaml
@@ -112,6 +144,7 @@ Accept wildcard characters: False
 ```
 
 ### -Copyright
+
 Specifies a copyright statement for the script.
 
 ```yaml
@@ -127,6 +160,7 @@ Accept wildcard characters: False
 ```
 
 ### -Description
+
 Specifies a description for the script.
 
 ```yaml
@@ -142,6 +176,7 @@ Accept wildcard characters: False
 ```
 
 ### -ExternalModuleDependencies
+
 Specifies an array of external module dependencies.
 
 ```yaml
@@ -157,6 +192,7 @@ Accept wildcard characters: False
 ```
 
 ### -ExternalScriptDependencies
+
 Specifies an array of external script dependencies.
 
 ```yaml
@@ -172,7 +208,8 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the command to run without asking for user confirmation.
+
+Forces `Update-ScriptFileInfo` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -187,6 +224,7 @@ Accept wildcard characters: False
 ```
 
 ### -Guid
+
 Specifies a unique ID for a script.
 
 ```yaml
@@ -202,8 +240,9 @@ Accept wildcard characters: False
 ```
 
 ### -IconUri
-Specifies the URL of an icon for the script.
-The specified icon is displayed on the gallery web page for the script.
+
+Specifies the URL of an icon for the script. The specified icon is displayed on the gallery web page
+for the script.
 
 ```yaml
 Type: Uri
@@ -218,6 +257,7 @@ Accept wildcard characters: False
 ```
 
 ### -LicenseUri
+
 Specifies the URL of licensing terms.
 
 ```yaml
@@ -233,11 +273,11 @@ Accept wildcard characters: False
 ```
 
 ### -LiteralPath
-Specifies a path to one or more locations.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is entered.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+
+Specifies a path to one or more locations. The **LiteralPath** parameter's value is used exactly as
+it's entered. No characters are interpreted as wildcards. If the path includes escape characters,
+enclose them in single quotation marks. Single quotation marks tell PowerShell not to interpret any
+characters as escape sequences.
 
 ```yaml
 Type: String
@@ -252,8 +292,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+
+Returns an object that represents the item with which you're working. By default,
+`Update-ScriptFileInfo` doesn't generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -268,9 +309,8 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies a path to one or more locations.
-Wildcards are permitted.
-The default location is the current directory (.).
+
+Specifies the script file's location. Wildcards are permitted.
 
 ```yaml
 Type: String
@@ -281,10 +321,11 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -PrivateData
+
 Specifies the private data for the script.
 
 ```yaml
@@ -300,6 +341,7 @@ Accept wildcard characters: False
 ```
 
 ### -ProjectUri
+
 Specifies the URL of a web page about this project.
 
 ```yaml
@@ -315,7 +357,9 @@ Accept wildcard characters: False
 ```
 
 ### -ReleaseNotes
-Specifies a string array that contains release notes or comments that you want to be available to users for this version of the script.
+
+Specifies a string array that contains release notes or comments that you want available for this
+version of the script.
 
 ```yaml
 Type: String[]
@@ -330,8 +374,9 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredModules
-Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, Windows PowerShell imports them.
+
+Specifies modules that must be in the global session state. If the required modules aren't in the
+global session state, PowerShell imports them.
 
 ```yaml
 Type: Object[]
@@ -346,6 +391,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredScripts
+
 Specifies an array of required scripts.
 
 ```yaml
@@ -361,6 +407,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tags
+
 Specifies an array of tags.
 
 ```yaml
@@ -376,7 +423,8 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version of the script.
+
+Specifies the script's version.
 
 ```yaml
 Type: String
@@ -391,7 +439,8 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.
+
+Prompts you for confirmation before running `Update-ScriptFileInfo`.
 
 ```yaml
 Type: SwitchParameter
@@ -406,8 +455,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if `Update-ScriptFileInfo` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -422,13 +471,19 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ## OUTPUTS
 
 ## NOTES
+
+Use the `Test-ScriptFileInfo` cmdlet to validate a script's metadata. Scripts must include values
+for version, GUID, description, and author.
 
 ## RELATED LINKS
 

--- a/reference/5.1/PowershellGet/Update-ScriptFileInfo.md
+++ b/reference/5.1/PowershellGet/Update-ScriptFileInfo.md
@@ -106,7 +106,7 @@ Param()
 ```
 
 `$Parms` stores the parameter values for **Path**, **Version**, **Author**, **CompanyName**, and
-**Description**. `Update-ScriptFileInfo` gets the parameter values from **@Parms** and updates the
+**Description**. `Update-ScriptFileInfo` gets the parameter values from `@Parms` and updates the
 script. The **PassThru** parameter displays the script's contents in the PowerShell console.
 
 ## PARAMETERS

--- a/reference/6/PowerShellGet/New-ScriptFileInfo.md
+++ b/reference/6/PowerShellGet/New-ScriptFileInfo.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/1/2019
+ms.date: 07/01/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096849
 schema: 2.0.0
 title: New-ScriptFileInfo
@@ -398,7 +398,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path to the module manifest file to update.
+Specifies the location where the script file is saved.
 
 ```yaml
 Type: String

--- a/reference/6/PowerShellGet/Update-ModuleManifest.md
+++ b/reference/6/PowerShellGet/Update-ModuleManifest.md
@@ -58,7 +58,7 @@ Update-ModuleManifest @Parms
 ```
 
 `$Parms` is a splat that stores the parameter values for **Path**, **Author**, **CompanyName**, and
-**Copyright**. `Update-ModuleManifest` gets the parameter values from **@Parms** and updates the
+**Copyright**. `Update-ModuleManifest` gets the parameter values from `@Parms` and updates the
 module manifest, **TestManifest.psd1**.
 
 ## PARAMETERS

--- a/reference/6/PowerShellGet/Update-Script.md
+++ b/reference/6/PowerShellGet/Update-Script.md
@@ -3,11 +3,12 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 07/09/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096560
 schema: 2.0.0
 title: Update-Script
 ---
+
 # Update-Script
 
 ## SYNOPSIS
@@ -15,31 +16,39 @@ Updates a script.
 
 ## SYNTAX
 
+### All
+
 ```
-Update-Script [[-Name] <String[]>] [-RequiredVersion <String>] [-MaximumVersion <String>] [-Proxy <Uri>]
- [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease] [-AcceptLicense]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Update-Script [[-Name] <String[]>] [-RequiredVersion <String>] [-MaximumVersion <String>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force]
+ [-AllowPrerelease] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The **Update-Script** cmdlet updates the specified script from the repository from which it was previously installed.
+The `Update-Script` cmdlet updates a script that is installed on the local computer. The updated
+script is downloaded from the same repository as the installed version.
 
 ## EXAMPLES
 
 ### Example 1: Update the specified script
 
-```
-PS C:\> Update-Script -Name "Fabrikam-Script" -RequiredVersion 1.5
-PS C:\> Get-InstalledScript -Name "Fabrikam-Script"
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-1.5        Fabrikam-Script                     Script     local1               Description for the Fabrikam-Script script
+This example updates an installed script and displays the updated version.
+
+```powershell
+Update-Script -Name UpdateManagement-Template -RequiredVersion 1.1
+Get-InstalledScript -Name UpdateManagement-Template
 ```
 
-The first command updates the script Fabrikam-Script to version 1.5.
+```Output
+Version   Name                       Repository   Description
+-------   ----                       ----------   -----------
+1.1       UpdateManagement-Template  PSGallery    This is a template script for Update Management...
+```
 
-The second command gets Fabrikam-Script and displays the results.
+`Update-Script` uses the **Name** parameter to specify the script to update. The **RequiredVersion**
+parameter specifies the script version. `Get-InstalledScript` displays the updated version of the
+script.
 
 ## PARAMETERS
 
@@ -77,6 +86,8 @@ Accept wildcard characters: False
 
 ### -Credential
 
+Specifies a user account that has permission to update a script.
+
 ```yaml
 Type: PSCredential
 Parameter Sets: (All)
@@ -91,7 +102,7 @@ Accept wildcard characters: False
 
 ### -Force
 
-Forces the command to run without asking for user confirmation.
+Forces `Update-Script` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -107,8 +118,8 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies the maximum, or newest, version of the script to update.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the maximum, or newest, version of the script to update. The **MaximumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -124,7 +135,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies an array of names of scripts to update.
+Specifies one script name or an array of script names to update.
 
 ```yaml
 Type: String[]
@@ -140,6 +151,8 @@ Accept wildcard characters: False
 
 ### -Proxy
 
+Specifies a proxy server for the request rather than connecting directly to an internet resource.
+
 ```yaml
 Type: Uri
 Parameter Sets: (All)
@@ -153,6 +166,9 @@ Accept wildcard characters: False
 ```
 
 ### -ProxyCredential
+
+Specifies a user account that has permission to use the proxy server specified by the **Proxy**
+parameter.
 
 ```yaml
 Type: PSCredential
@@ -168,8 +184,8 @@ Accept wildcard characters: False
 
 ### -RequiredVersion
 
-Specifies the exact version number of the script to update.
-The *MinimumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the exact version number of the script to update. The **MinimumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -185,7 +201,7 @@ Accept wildcard characters: False
 
 ### -Confirm
 
-Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running `Update-Script`.
 
 ```yaml
 Type: SwitchParameter
@@ -201,8 +217,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if `Update-Script` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -218,7 +233,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/6/PowerShellGet/Update-ScriptFileInfo.md
+++ b/reference/6/PowerShellGet/Update-ScriptFileInfo.md
@@ -106,7 +106,7 @@ Param()
 ```
 
 `$Parms` stores the parameter values for **Path**, **Version**, **Author**, **CompanyName**, and
-**Description**. `Update-ScriptFileInfo` gets the parameter values from **@Parms** and updates the
+**Description**. `Update-ScriptFileInfo` gets the parameter values from `@Parms` and updates the
 script. The **PassThru** parameter displays the script's contents in the PowerShell console.
 
 ## PARAMETERS

--- a/reference/6/PowerShellGet/Update-ScriptFileInfo.md
+++ b/reference/6/PowerShellGet/Update-ScriptFileInfo.md
@@ -3,11 +3,12 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 07/09/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096851
 schema: 2.0.0
 title: Update-ScriptFileInfo
 ---
+
 # Update-ScriptFileInfo
 
 ## SYNOPSIS
@@ -22,8 +23,8 @@ Update-ScriptFileInfo [-Path] <String> [-Version <String>] [-Author <String>] [-
  [-Description <String>] [-CompanyName <String>] [-Copyright <String>] [-RequiredModules <Object[]>]
  [-ExternalModuleDependencies <String[]>] [-RequiredScripts <String[]>]
  [-ExternalScriptDependencies <String[]>] [-Tags <String[]>] [-ProjectUri <Uri>] [-LicenseUri <Uri>]
- [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PrivateData <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PrivateData <String>] [-PassThru] [-Force] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPathParameterSet
@@ -33,54 +34,80 @@ Update-ScriptFileInfo [-LiteralPath] <String> [-Version <String>] [-Author <Stri
  [-Description <String>] [-CompanyName <String>] [-Copyright <String>] [-RequiredModules <Object[]>]
  [-ExternalModuleDependencies <String[]>] [-RequiredScripts <String[]>]
  [-ExternalScriptDependencies <String[]>] [-Tags <String[]>] [-ProjectUri <Uri>] [-LicenseUri <Uri>]
- [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PrivateData <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PrivateData <String>] [-PassThru] [-Force] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The **Update-ScriptFileInfo** cmdlet updates information for a script.
+The `Update-ScriptFileInfo` cmdlet updates a script's property values. For example, the values for
+version, author, or description.
 
 ## EXAMPLES
 
 ### Example 1: Update the version of a script file
 
+In this example, an existing script file is updated with new property values.
+
+Splatting is used to pass parameters to the `Update-ScriptFileInfo` cmdlet. For more information,
+see [about_Splatting](../Microsoft.Powershell.Core/About/about_splatting.md).
+
+```powershell
+$Parms = @{
+  Path = "C:\Test\Temp-Scriptfile.ps1"
+  Version = "2.0"
+  Author = "bob@contoso.com"
+  CompanyName = "Contoso"
+  Description = "This is the updated description"
+  }
+Update-ScriptFileInfo @Parms -PassThru
 ```
-PS C:\> New-ScriptFileInfo -Path "\temp\temp-scriptfile.ps1" -Version 1.0 -Author "pattif@contoso.com" -Description "my test script file description goes here"
-PS C:\> Test-ScriptFileInfo -Path "\temp\temp-scriptfile.ps1"
-Version    Name                      Author               Description
--------    ----                      ------               -----------
-1.0        temp-scriptfile           manikb@microsoft.com my test script file description goes here PS C:\> Update-ScriptFileInfo -Path "\temp\temp-scriptfile.ps1" -Version 2.0 -PassThru
+
+```Output
 <#PSScriptInfo
 
 .VERSION 2.0
-.GUID eb246b19-17da-4392-8c89-7c280f69ad0e
-.AUTHOR manikb@microsoft.com
-.COMPANYNAME
+
+.GUID 4609f00c-e850-4d3f-9c69-3741e56e4133
+
+.AUTHOR bob@contoso.com
+
+.COMPANYNAME Contoso
+
 .COPYRIGHT
+
 .TAGS
+
 .LICENSEURI
+
 .PROJECTURI
+
 .ICONURI
+
 .EXTERNALMODULEDEPENDENCIES
 
 .REQUIREDSCRIPTS
+
 .EXTERNALSCRIPTDEPENDENCIES
+
 .RELEASENOTES
 
+.PRIVATEDATA
+
 #>
+
 <#
+
 .DESCRIPTION
- my test script file description goes here
+This is the updated description
+
 #>
 Param()
 ```
 
-The first command creates a script file and assigns it version 1.0.
-
-The second command uses the Test-ScriptFileInfo cmdlet to validate temp-scriptfile.ps1 and display the results.
-
-The third command uses **Update-ScriptFileInfo** to update the version number to 2.0.
+`$Parms` stores the parameter values for **Path**, **Version**, **Author**, **CompanyName**, and
+**Description**. `Update-ScriptFileInfo` gets the parameter values from **@Parms** and updates the
+script. The **PassThru** parameter displays the script's contents in the PowerShell console.
 
 ## PARAMETERS
 
@@ -182,7 +209,7 @@ Accept wildcard characters: False
 
 ### -Force
 
-Forces the command to run without asking for user confirmation.
+Forces `Update-ScriptFileInfo` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -214,8 +241,8 @@ Accept wildcard characters: False
 
 ### -IconUri
 
-Specifies the URL of an icon for the script.
-The specified icon is displayed on the gallery web page for the script.
+Specifies the URL of an icon for the script. The specified icon is displayed on the gallery web page
+for the script.
 
 ```yaml
 Type: Uri
@@ -247,11 +274,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies a path to one or more locations.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is entered.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies a path to one or more locations. The **LiteralPath** parameter's value is used exactly as
+it's entered. No characters are interpreted as wildcards. If the path includes escape characters,
+enclose them in single quotation marks. Single quotation marks tell PowerShell not to interpret any
+characters as escape sequences.
 
 ```yaml
 Type: String
@@ -267,8 +293,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+Returns an object that represents the item with which you're working. By default,
+`Update-ScriptFileInfo` doesn't generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -284,9 +310,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies a path to one or more locations.
-Wildcards are permitted.
-The default location is the current directory (.).
+Specifies the script file's location. Wildcards are permitted.
 
 ```yaml
 Type: String
@@ -297,12 +321,12 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -PrivateData
 
-Specifies private data for the script.
+Specifies the private data for the script.
 
 ```yaml
 Type: String
@@ -334,7 +358,8 @@ Accept wildcard characters: False
 
 ### -ReleaseNotes
 
-Specifies a string array that contains release notes or comments that you want to be available to users for this version of the script.
+Specifies a string array that contains release notes or comments that you want available for this
+version of the script.
 
 ```yaml
 Type: String[]
@@ -350,8 +375,8 @@ Accept wildcard characters: False
 
 ### -RequiredModules
 
-Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, PowerShell imports them.
+Specifies modules that must be in the global session state. If the required modules aren't in the
+global session state, PowerShell imports them.
 
 ```yaml
 Type: Object[]
@@ -399,7 +424,7 @@ Accept wildcard characters: False
 
 ### -Version
 
-Specifies the version of the script.
+Specifies the script's version.
 
 ```yaml
 Type: String
@@ -415,7 +440,7 @@ Accept wildcard characters: False
 
 ### -Confirm
 
-Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running `Update-ScriptFileInfo`.
 
 ```yaml
 Type: SwitchParameter
@@ -431,8 +456,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if `Update-ScriptFileInfo` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -448,13 +472,18 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ## OUTPUTS
 
 ## NOTES
+
+Use the `Test-ScriptFileInfo` cmdlet to validate a script's metadata. Scripts must include values
+for version, GUID, description, and author.
 
 ## RELATED LINKS
 

--- a/reference/7/PowerShellGet/New-ScriptFileInfo.md
+++ b/reference/7/PowerShellGet/New-ScriptFileInfo.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 7/1/2019
+ms.date: 07/01/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2097019
 schema: 2.0.0
 title: New-ScriptFileInfo
@@ -398,7 +398,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path to the module manifest file to update.
+Specifies the location where the script file is saved.
 
 ```yaml
 Type: String

--- a/reference/7/PowerShellGet/Update-ModuleManifest.md
+++ b/reference/7/PowerShellGet/Update-ModuleManifest.md
@@ -58,7 +58,7 @@ Update-ModuleManifest @Parms
 ```
 
 `$Parms` is a splat that stores the parameter values for **Path**, **Author**, **CompanyName**, and
-**Copyright**. `Update-ModuleManifest` gets the parameter values from **@Parms** and updates the
+**Copyright**. `Update-ModuleManifest` gets the parameter values from `@Parms` and updates the
 module manifest, **TestManifest.psd1**.
 
 ## PARAMETERS

--- a/reference/7/PowerShellGet/Update-Script.md
+++ b/reference/7/PowerShellGet/Update-Script.md
@@ -3,11 +3,12 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 07/09/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096727
 schema: 2.0.0
 title: Update-Script
 ---
+
 # Update-Script
 
 ## SYNOPSIS
@@ -15,31 +16,39 @@ Updates a script.
 
 ## SYNTAX
 
+### All
+
 ```
-Update-Script [[-Name] <String[]>] [-RequiredVersion <String>] [-MaximumVersion <String>] [-Proxy <Uri>]
- [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease] [-AcceptLicense]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Update-Script [[-Name] <String[]>] [-RequiredVersion <String>] [-MaximumVersion <String>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force]
+ [-AllowPrerelease] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The **Update-Script** cmdlet updates the specified script from the repository from which it was previously installed.
+The `Update-Script` cmdlet updates a script that is installed on the local computer. The updated
+script is downloaded from the same repository as the installed version.
 
 ## EXAMPLES
 
 ### Example 1: Update the specified script
 
-```
-PS C:\> Update-Script -Name "Fabrikam-Script" -RequiredVersion 1.5
-PS C:\> Get-InstalledScript -Name "Fabrikam-Script"
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-1.5        Fabrikam-Script                     Script     local1               Description for the Fabrikam-Script script
+This example updates an installed script and displays the updated version.
+
+```powershell
+Update-Script -Name UpdateManagement-Template -RequiredVersion 1.1
+Get-InstalledScript -Name UpdateManagement-Template
 ```
 
-The first command updates the script Fabrikam-Script to version 1.5.
+```Output
+Version   Name                       Repository   Description
+-------   ----                       ----------   -----------
+1.1       UpdateManagement-Template  PSGallery    This is a template script for Update Management...
+```
 
-The second command gets Fabrikam-Script and displays the results.
+`Update-Script` uses the **Name** parameter to specify the script to update. The **RequiredVersion**
+parameter specifies the script version. `Get-InstalledScript` displays the updated version of the
+script.
 
 ## PARAMETERS
 
@@ -77,6 +86,8 @@ Accept wildcard characters: False
 
 ### -Credential
 
+Specifies a user account that has permission to update a script.
+
 ```yaml
 Type: PSCredential
 Parameter Sets: (All)
@@ -91,7 +102,7 @@ Accept wildcard characters: False
 
 ### -Force
 
-Forces the command to run without asking for user confirmation.
+Forces `Update-Script` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -107,8 +118,8 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies the maximum, or newest, version of the script to update.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the maximum, or newest, version of the script to update. The **MaximumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -124,7 +135,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies an array of names of scripts to update.
+Specifies one script name or an array of script names to update.
 
 ```yaml
 Type: String[]
@@ -140,6 +151,8 @@ Accept wildcard characters: False
 
 ### -Proxy
 
+Specifies a proxy server for the request rather than connecting directly to an internet resource.
+
 ```yaml
 Type: Uri
 Parameter Sets: (All)
@@ -153,6 +166,9 @@ Accept wildcard characters: False
 ```
 
 ### -ProxyCredential
+
+Specifies a user account that has permission to use the proxy server specified by the **Proxy**
+parameter.
 
 ```yaml
 Type: PSCredential
@@ -168,8 +184,8 @@ Accept wildcard characters: False
 
 ### -RequiredVersion
 
-Specifies the exact version number of the script to update.
-The *MinimumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+Specifies the exact version number of the script to update. The **MinimumVersion** and
+**RequiredVersion** parameters can't be used in the same command.
 
 ```yaml
 Type: String
@@ -185,7 +201,7 @@ Accept wildcard characters: False
 
 ### -Confirm
 
-Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running `Update-Script`.
 
 ```yaml
 Type: SwitchParameter
@@ -201,8 +217,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if `Update-Script` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -218,7 +233,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/7/PowerShellGet/Update-ScriptFileInfo.md
+++ b/reference/7/PowerShellGet/Update-ScriptFileInfo.md
@@ -106,7 +106,7 @@ Param()
 ```
 
 `$Parms` stores the parameter values for **Path**, **Version**, **Author**, **CompanyName**, and
-**Description**. `Update-ScriptFileInfo` gets the parameter values from **@Parms** and updates the
+**Description**. `Update-ScriptFileInfo` gets the parameter values from `@Parms` and updates the
 script. The **PassThru** parameter displays the script's contents in the PowerShell console.
 
 ## PARAMETERS

--- a/reference/7/PowerShellGet/Update-ScriptFileInfo.md
+++ b/reference/7/PowerShellGet/Update-ScriptFileInfo.md
@@ -3,11 +3,12 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 07/09/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2097023
 schema: 2.0.0
 title: Update-ScriptFileInfo
 ---
+
 # Update-ScriptFileInfo
 
 ## SYNOPSIS
@@ -22,8 +23,8 @@ Update-ScriptFileInfo [-Path] <String> [-Version <String>] [-Author <String>] [-
  [-Description <String>] [-CompanyName <String>] [-Copyright <String>] [-RequiredModules <Object[]>]
  [-ExternalModuleDependencies <String[]>] [-RequiredScripts <String[]>]
  [-ExternalScriptDependencies <String[]>] [-Tags <String[]>] [-ProjectUri <Uri>] [-LicenseUri <Uri>]
- [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PrivateData <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PrivateData <String>] [-PassThru] [-Force] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPathParameterSet
@@ -33,54 +34,80 @@ Update-ScriptFileInfo [-LiteralPath] <String> [-Version <String>] [-Author <Stri
  [-Description <String>] [-CompanyName <String>] [-Copyright <String>] [-RequiredModules <Object[]>]
  [-ExternalModuleDependencies <String[]>] [-RequiredScripts <String[]>]
  [-ExternalScriptDependencies <String[]>] [-Tags <String[]>] [-ProjectUri <Uri>] [-LicenseUri <Uri>]
- [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PrivateData <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PrivateData <String>] [-PassThru] [-Force] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The **Update-ScriptFileInfo** cmdlet updates information for a script.
+The `Update-ScriptFileInfo` cmdlet updates a script's property values. For example, the values for
+version, author, or description.
 
 ## EXAMPLES
 
 ### Example 1: Update the version of a script file
 
+In this example, an existing script file is updated with new property values.
+
+Splatting is used to pass parameters to the `Update-ScriptFileInfo` cmdlet. For more information,
+see [about_Splatting](../Microsoft.Powershell.Core/About/about_splatting.md).
+
+```powershell
+$Parms = @{
+  Path = "C:\Test\Temp-Scriptfile.ps1"
+  Version = "2.0"
+  Author = "bob@contoso.com"
+  CompanyName = "Contoso"
+  Description = "This is the updated description"
+  }
+Update-ScriptFileInfo @Parms -PassThru
 ```
-PS C:\> New-ScriptFileInfo -Path "\temp\temp-scriptfile.ps1" -Version 1.0 -Author "pattif@contoso.com" -Description "my test script file description goes here"
-PS C:\> Test-ScriptFileInfo -Path "\temp\temp-scriptfile.ps1"
-Version    Name                      Author               Description
--------    ----                      ------               -----------
-1.0        temp-scriptfile           manikb@microsoft.com my test script file description goes here PS C:\> Update-ScriptFileInfo -Path "\temp\temp-scriptfile.ps1" -Version 2.0 -PassThru
+
+```Output
 <#PSScriptInfo
 
 .VERSION 2.0
-.GUID eb246b19-17da-4392-8c89-7c280f69ad0e
-.AUTHOR manikb@microsoft.com
-.COMPANYNAME
+
+.GUID 4609f00c-e850-4d3f-9c69-3741e56e4133
+
+.AUTHOR bob@contoso.com
+
+.COMPANYNAME Contoso
+
 .COPYRIGHT
+
 .TAGS
+
 .LICENSEURI
+
 .PROJECTURI
+
 .ICONURI
+
 .EXTERNALMODULEDEPENDENCIES
 
 .REQUIREDSCRIPTS
+
 .EXTERNALSCRIPTDEPENDENCIES
+
 .RELEASENOTES
 
+.PRIVATEDATA
+
 #>
+
 <#
+
 .DESCRIPTION
- my test script file description goes here
+This is the updated description
+
 #>
 Param()
 ```
 
-The first command creates a script file and assigns it version 1.0.
-
-The second command uses the Test-ScriptFileInfo cmdlet to validate temp-scriptfile.ps1 and display the results.
-
-The third command uses **Update-ScriptFileInfo** to update the version number to 2.0.
+`$Parms` stores the parameter values for **Path**, **Version**, **Author**, **CompanyName**, and
+**Description**. `Update-ScriptFileInfo` gets the parameter values from **@Parms** and updates the
+script. The **PassThru** parameter displays the script's contents in the PowerShell console.
 
 ## PARAMETERS
 
@@ -182,7 +209,7 @@ Accept wildcard characters: False
 
 ### -Force
 
-Forces the command to run without asking for user confirmation.
+Forces `Update-ScriptFileInfo` to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -214,8 +241,8 @@ Accept wildcard characters: False
 
 ### -IconUri
 
-Specifies the URL of an icon for the script.
-The specified icon is displayed on the gallery web page for the script.
+Specifies the URL of an icon for the script. The specified icon is displayed on the gallery web page
+for the script.
 
 ```yaml
 Type: Uri
@@ -247,11 +274,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies a path to one or more locations.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is entered.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies a path to one or more locations. The **LiteralPath** parameter's value is used exactly as
+it's entered. No characters are interpreted as wildcards. If the path includes escape characters,
+enclose them in single quotation marks. Single quotation marks tell PowerShell not to interpret any
+characters as escape sequences.
 
 ```yaml
 Type: String
@@ -267,8 +293,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+Returns an object that represents the item with which you're working. By default,
+`Update-ScriptFileInfo` doesn't generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -284,9 +310,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies a path to one or more locations.
-Wildcards are permitted.
-The default location is the current directory (.).
+Specifies the script file's location. Wildcards are permitted.
 
 ```yaml
 Type: String
@@ -297,12 +321,12 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -PrivateData
 
-Specifies private data for the script.
+Specifies the private data for the script.
 
 ```yaml
 Type: String
@@ -334,7 +358,8 @@ Accept wildcard characters: False
 
 ### -ReleaseNotes
 
-Specifies a string array that contains release notes or comments that you want to be available to users for this version of the script.
+Specifies a string array that contains release notes or comments that you want available for this
+version of the script.
 
 ```yaml
 Type: String[]
@@ -350,8 +375,8 @@ Accept wildcard characters: False
 
 ### -RequiredModules
 
-Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, PowerShell imports them.
+Specifies modules that must be in the global session state. If the required modules aren't in the
+global session state, PowerShell imports them.
 
 ```yaml
 Type: Object[]
@@ -399,7 +424,7 @@ Accept wildcard characters: False
 
 ### -Version
 
-Specifies the version of the script.
+Specifies the script's version.
 
 ```yaml
 Type: String
@@ -415,7 +440,7 @@ Accept wildcard characters: False
 
 ### -Confirm
 
-Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running `Update-ScriptFileInfo`.
 
 ```yaml
 Type: SwitchParameter
@@ -431,8 +456,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if `Update-ScriptFileInfo` runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -448,13 +472,18 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ## OUTPUTS
 
 ## NOTES
+
+Use the `Test-ScriptFileInfo` cmdlet to validate a script's metadata. Scripts must include values
+for version, GUID, description, and author.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Update-Script Acrolinx scores: original version: 93, updated version: 98
Update-ScriptFileInfo Acrolinx scores: original version: 91, updated version: 96

- Fixes [AB#1568182](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1568182)
- Related to #3740
- Added content to empty parameters
- Copyedits, style
- Fixed ms.date and Path description for New-ScriptFileInfo
- Fixed markdown style for one variable in the example description for Update-ModuleManifest