### PR TITLE
PowerShellGet docs - corrected parameter set spacing and YAML date format

### DIFF
--- a/reference/5.0/PowershellGet/Find-Command.md
+++ b/reference/5.0/PowershellGet/Find-Command.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 6/3/2019
+ms.date: 06/03/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -19,9 +19,9 @@ Finds PowerShell commands in modules.
 
 ```
 Find-Command [[-Name] <String[]>] [-ModuleName <String>] [-MinimumVersion <Version>]
-[-MaximumVersion <Version>] [-RequiredVersion <Version>] [-AllVersions] [-Tag <String[]>]
-[-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Repository <String[]>]
-[<CommonParameters>]
+ [-MaximumVersion <Version>] [-RequiredVersion <Version>] [-AllVersions] [-Tag <String[]>]
+ [-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Repository <String[]>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.0/PowershellGet/Find-DscResource.md
+++ b/reference/5.0/PowershellGet/Find-DscResource.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  6/4/2019
+ms.date:  06/04/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -15,10 +15,12 @@ Finds Desired State Configuration (DSC) resources.
 
 ## SYNTAX
 
+### All
+
 ```
 Find-DscResource [[-Name] <String[]>] [-ModuleName <String>] [-MinimumVersion <Version>]
-[-RequiredVersion <Version>] [-AllVersions] [-Tag <String[]>] [-Filter <String>]
-[-Repository <String[]>] [<CommonParameters>]
+ [-RequiredVersion <Version>] [-AllVersions] [-Tag <String[]>] [-Filter <String>]
+ [-Repository <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.0/PowershellGet/Find-Module.md
+++ b/reference/5.0/PowershellGet/Find-Module.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  3/11/2019
+ms.date:  03/11/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -19,9 +19,9 @@ Finds modules in a repository that match specified criteria.
 
 ```
 Find-Module [[-Name] <string[]>] [-MinimumVersion <version>] [-MaximumVersion <version>]
-[-RequiredVersion <version>] [-AllVersions] [-IncludeDependencies] [-Filter <string>]
-[-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>] [-Command <string[]>]
-[-Repository <string[]>] [<CommonParameters>]
+ [-RequiredVersion <version>] [-AllVersions] [-IncludeDependencies] [-Filter <string>]
+ [-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>] [-Command <string[]>]
+ [-Repository <string[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.0/PowershellGet/Install-Module.md
+++ b/reference/5.0/PowershellGet/Install-Module.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  3/7/2019
+ms.date:  03/07/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -19,15 +19,15 @@ Downloads one or more modules from a repository, and installs them on the local 
 
 ```
 Install-Module [-Name] <string[]> [-MinimumVersion <version>] [-MaximumVersion <version>]
-[-RequiredVersion <version>] [-Repository <string[]>] [-Scope <string>] [-Force] [-WhatIf]
-[-Confirm] [<CommonParameters>]
+ [-RequiredVersion <version>] [-Repository <string[]>] [-Scope <string>] [-Force] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ### InputObject
 
 ```
 Install-Module [-InputObject] <psobject[]> [-Scope <string>] [-Force] [-WhatIf] [-Confirm]
-[<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.0/PowershellGet/Publish-Module.md
+++ b/reference/5.0/PowershellGet/Publish-Module.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  06/28/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet

--- a/reference/5.0/PowershellGet/Publish-Module.md
+++ b/reference/5.0/PowershellGet/Publish-Module.md
@@ -19,16 +19,16 @@ Publishes a specified module from the local computer to an online gallery.
 
 ```
 Publish-Module -Name <String> [-RequiredVersion <Version>] -NuGetApiKey <String>
- [-Repository <String>]  [-FormatVersion <Version>] [-ReleaseNotes <String[]>] [-Tags <String[]>]
- [-LicenseUri <Uri>] [-IconUri <Uri>]  [-ProjectUri <Uri>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Repository <String>] [-FormatVersion <Version>] [-ReleaseNotes <String[]>] [-Tags <String[]>]
+ [-LicenseUri <Uri>] [-IconUri <Uri>] [-ProjectUri <Uri>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ModulePathParameterSet
 
 ```
 Publish-Module -Path <String> -NuGetApiKey <String> [-Repository <String>]
- [-FormatVersion <Version>]  [-ReleaseNotes <String[]>] [-Tags <String[]>] [-LicenseUri <Uri>]
- [-IconUri <Uri>] [-ProjectUri <Uri>]  [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-FormatVersion <Version>] [-ReleaseNotes <String[]>] [-Tags <String[]>] [-LicenseUri <Uri>]
+ [-IconUri <Uri>] [-ProjectUri <Uri>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/PowershellGet/Find-Command.md
+++ b/reference/5.1/PowershellGet/Find-Command.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 6/3/2019
+ms.date: 06/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=822318
 schema: 2.0.0
 title: Find-Command
@@ -20,9 +20,9 @@ Finds PowerShell commands in modules.
 
 ```
 Find-Command [[-Name] <String[]>] [-ModuleName <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-RequiredVersion <String>] [-AllVersions] [-AllowPrerelease]
-[-Tag <String[]>] [-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-Repository <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-RequiredVersion <String>] [-AllVersions] [-AllowPrerelease]
+ [-Tag <String[]>] [-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
+ [-Repository <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/PowershellGet/Find-DscResource.md
+++ b/reference/5.1/PowershellGet/Find-DscResource.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 6/4/2019
+ms.date: 06/04/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821657
 schema: 2.0.0
 title: Find-DscResource
@@ -20,9 +20,9 @@ Finds Desired State Configuration (DSC) resources.
 
 ```
 Find-DscResource [[-Name] <String[]>] [-ModuleName <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-RequiredVersion <String>] [-AllVersions] [-AllowPrerelease]
-[-Tag <String[]>] [-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-Repository <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-RequiredVersion <String>] [-AllVersions] [-AllowPrerelease]
+ [-Tag <String[]>] [-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
+ [-Repository <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/PowershellGet/Find-Module.md
+++ b/reference/5.1/PowershellGet/Find-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 3/11/2019
+ms.date: 03/11/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821658
 schema: 2.0.0
 title: Find-Module
@@ -20,10 +20,10 @@ Finds modules in a repository that match specified criteria.
 
 ```
 Find-Module [[-Name] <string[]>] [-MinimumVersion <string>] [-MaximumVersion <string>]
-[-RequiredVersion <string>] [-AllVersions] [-IncludeDependencies] [-Filter <string>]
-[-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>] [-RoleCapability <string[]>]
-[-Command <string[]>] [-Proxy <uri>] [-ProxyCredential <pscredential>] [-Repository <string[]>]
-[-Credential <pscredential>] [-AllowPrerelease] [<CommonParameters>]
+ [-RequiredVersion <string>] [-AllVersions] [-IncludeDependencies] [-Filter <string>]
+ [-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>] [-RoleCapability <string[]>]
+ [-Command <string[]>] [-Proxy <uri>] [-ProxyCredential <pscredential>] [-Repository <string[]>]
+ [-Credential <pscredential>] [-AllowPrerelease] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/PowershellGet/Find-RoleCapability.md
+++ b/reference/5.1/PowershellGet/Find-RoleCapability.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 6/5/2019
+ms.date: 06/05/2019
 online version: https://go.microsoft.com/fwlink/?linkid=822321
 schema: 2.0.0
 title: Find-RoleCapability

--- a/reference/5.1/PowershellGet/Install-Module.md
+++ b/reference/5.1/PowershellGet/Install-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 3/7/2019
+ms.date: 03/07/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821663
 schema: 2.0.0
 title: Install-Module
@@ -20,17 +20,17 @@ Downloads one or more modules from a repository, and installs them on the local 
 
 ```
 Install-Module [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <String>]
-[-RequiredVersion <String>] [-Repository <String[]>] [-Credential <PSCredential>] [-Scope <String>]
-[-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force]
-[-AllowPrerelease] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-RequiredVersion <String>] [-Repository <String[]>] [-Credential <PSCredential>] [-Scope <String>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force]
+ [-AllowPrerelease] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InputObject
 
 ```
 Install-Module [-InputObject] <PSObject[]> [-Credential <PSCredential>] [-Scope <String>]
-[-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force]
-[-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force]
+ [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/PowershellGet/Publish-Module.md
+++ b/reference/5.1/PowershellGet/Publish-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 06/28/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821666
 schema: 2.0.0
 title: Publish-Module

--- a/reference/6/PowerShellGet/Find-Command.md
+++ b/reference/6/PowerShellGet/Find-Command.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 6/3/2019
+ms.date: 06/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096847
 schema: 2.0.0
 title: Find-Command
@@ -20,9 +20,9 @@ Finds PowerShell commands in modules.
 
 ```
 Find-Command [[-Name] <String[]>] [-ModuleName <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-RequiredVersion <String>] [-AllVersions] [-AllowPrerelease]
-[-Tag <String[]>] [-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-Repository <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-RequiredVersion <String>] [-AllVersions] [-AllowPrerelease]
+ [-Tag <String[]>] [-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
+ [-Repository <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/PowerShellGet/Find-DscResource.md
+++ b/reference/6/PowerShellGet/Find-DscResource.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 6/4/2019
+ms.date: 06/04/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096457
 schema: 2.0.0
 title: Find-DscResource
@@ -20,9 +20,9 @@ Finds Desired State Configuration (DSC) resources.
 
 ```
 Find-DscResource [[-Name] <String[]>] [-ModuleName <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-RequiredVersion <String>] [-AllVersions] [-AllowPrerelease]
-[-Tag <String[]>] [-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-Repository <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-RequiredVersion <String>] [-AllVersions] [-AllowPrerelease]
+ [-Tag <String[]>] [-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
+ [-Repository <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/PowerShellGet/Find-Module.md
+++ b/reference/6/PowerShellGet/Find-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 3/11/2019
+ms.date: 03/11/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096996
 schema: 2.0.0
 title: Find-Module
@@ -19,10 +19,10 @@ Finds modules in a repository that match specified criteria.
 
 ```
 Find-Module [[-Name] <string[]>] [-MinimumVersion <string>] [-MaximumVersion <string>]
-[-RequiredVersion <string>] [-AllVersions] [-IncludeDependencies] [-Filter <string>]
-[-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>] [-RoleCapability <string[]>]
-[-Command <string[]>] [-Proxy <uri>] [-ProxyCredential <pscredential>] [-Repository <string[]>]
-[-Credential <pscredential>] [-AllowPrerelease] [<CommonParameters>]
+ [-RequiredVersion <string>] [-AllVersions] [-IncludeDependencies] [-Filter <string>]
+ [-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>] [-RoleCapability <string[]>]
+ [-Command <string[]>] [-Proxy <uri>] [-ProxyCredential <pscredential>] [-Repository <string[]>]
+ [-Credential <pscredential>] [-AllowPrerelease] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/PowerShellGet/Find-RoleCapability.md
+++ b/reference/6/PowerShellGet/Find-RoleCapability.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 6/5/2019
+ms.date: 06/05/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096556
 schema: 2.0.0
 title: Find-RoleCapability

--- a/reference/6/PowerShellGet/Install-Module.md
+++ b/reference/6/PowerShellGet/Install-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 3/7/2019
+ms.date: 03/07/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096879
 schema: 2.0.0
 title: Install-Module
@@ -19,17 +19,17 @@ Downloads one or more modules from a repository, and installs them on the local 
 
 ```
 Install-Module [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <String>]
-[-RequiredVersion <String>] [-Repository <String[]>] [-Credential <PSCredential>] [-Scope <String>]
-[-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force]
-[-AllowPrerelease] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-RequiredVersion <String>] [-Repository <String[]>] [-Credential <PSCredential>] [-Scope <String>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force]
+ [-AllowPrerelease] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InputObject
 
 ```
 Install-Module [-InputObject] <PSObject[]> [-Credential <PSCredential>] [-Scope <String>]
-[-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force]
-[-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force]
+ [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/PowerShellGet/Publish-Module.md
+++ b/reference/6/PowerShellGet/Publish-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 06/28/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096558
 schema: 2.0.0
 title: Publish-Module

--- a/reference/7/PowerShellGet/Find-Command.md
+++ b/reference/7/PowerShellGet/Find-Command.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 6/3/2019
+ms.date: 06/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096942
 schema: 2.0.0
 title: Find-Command
@@ -20,9 +20,9 @@ Finds PowerShell commands in modules.
 
 ```
 Find-Command [[-Name] <String[]>] [-ModuleName <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-RequiredVersion <String>] [-AllVersions] [-AllowPrerelease]
-[-Tag <String[]>] [-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-Repository <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-RequiredVersion <String>] [-AllVersions] [-AllowPrerelease]
+ [-Tag <String[]>] [-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
+ [-Repository <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/PowerShellGet/Find-DscResource.md
+++ b/reference/7/PowerShellGet/Find-DscResource.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 6/4/2019
+ms.date: 06/04/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096723
 schema: 2.0.0
 title: Find-DscResource
@@ -20,9 +20,9 @@ Finds Desired State Configuration (DSC) resources.
 
 ```
 Find-DscResource [[-Name] <String[]>] [-ModuleName <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-RequiredVersion <String>] [-AllVersions] [-AllowPrerelease]
-[-Tag <String[]>] [-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-Repository <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-RequiredVersion <String>] [-AllVersions] [-AllowPrerelease]
+ [-Tag <String[]>] [-Filter <String>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
+ [-Repository <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/PowerShellGet/Find-Module.md
+++ b/reference/7/PowerShellGet/Find-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 3/11/2019
+ms.date: 03/11/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096848
 schema: 2.0.0
 title: Find-Module
@@ -19,10 +19,10 @@ Finds modules in a repository that match specified criteria.
 
 ```
 Find-Module [[-Name] <string[]>] [-MinimumVersion <string>] [-MaximumVersion <string>]
-[-RequiredVersion <string>] [-AllVersions] [-IncludeDependencies] [-Filter <string>]
-[-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>] [-RoleCapability <string[]>]
-[-Command <string[]>] [-Proxy <uri>] [-ProxyCredential <pscredential>] [-Repository <string[]>]
-[-Credential <pscredential>] [-AllowPrerelease] [<CommonParameters>]
+ [-RequiredVersion <string>] [-AllVersions] [-IncludeDependencies] [-Filter <string>]
+ [-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>] [-RoleCapability <string[]>]
+ [-Command <string[]>] [-Proxy <uri>] [-ProxyCredential <pscredential>] [-Repository <string[]>]
+ [-Credential <pscredential>] [-AllowPrerelease] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/PowerShellGet/Find-RoleCapability.md
+++ b/reference/7/PowerShellGet/Find-RoleCapability.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 6/5/2019
+ms.date: 06/05/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096854
 schema: 2.0.0
 title: Find-RoleCapability

--- a/reference/7/PowerShellGet/Install-Module.md
+++ b/reference/7/PowerShellGet/Install-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 3/7/2019
+ms.date: 03/07/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096846
 schema: 2.0.0
 title: Install-Module
@@ -19,17 +19,17 @@ Downloads one or more modules from a repository, and installs them on the local 
 
 ```
 Install-Module [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <String>]
-[-RequiredVersion <String>] [-Repository <String[]>] [-Credential <PSCredential>] [-Scope <String>]
-[-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force]
-[-AllowPrerelease] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-RequiredVersion <String>] [-Repository <String[]>] [-Credential <PSCredential>] [-Scope <String>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force]
+ [-AllowPrerelease] [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InputObject
 
 ```
 Install-Module [-InputObject] <PSObject[]> [-Credential <PSCredential>] [-Scope <String>]
-[-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force]
-[-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force]
+ [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/PowerShellGet/Publish-Module.md
+++ b/reference/7/PowerShellGet/Publish-Module.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 06/09/2017
+ms.date: 06/28/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096634
 schema: 2.0.0
 title: Publish-Module


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

- Corrected the parameter set spacing and YAML header ms.date
- Related to updates for #3740

Find-Command
Find-DscResource
Find-Module
Install-Module
Find-RoleCapability
Publish-Module