### PR TITLE
Fixes #4512 - Add line and link to about_PSReadline

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
@@ -17,13 +17,6 @@ Describes how to edit commands at the PowerShell command prompt.
 The PowerShell console has some useful keyboard shortcuts to help you edit
 commands at the PowerShell command prompt.
 
-### Add a line
-
-To add a line, press <kbd>Shift</kbd>+<kbd>Enter</kbd>.
-
-You can add multiple lines. Each additional line begins with `>>`, the
-continuation prompt. Press <kbd>Enter</kbd> to execute the command.
-
 ### Move left and right
 
 To move the cursor one character to the left, press the <kbd>Left arrow</kbd>.

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
@@ -1,5 +1,5 @@
 ﻿---
-ms.date:  06/09/2017
+ms.date:  07/10/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -8,48 +8,73 @@ title:  about_Line_Editing
 
 # About Line Editing
 
-## SHORT DESCRIPTION
+## Short description
 
-Describes how to edit commands at the Windows PowerShell command prompt.
+Describes how to edit commands at the PowerShell command prompt.
 
-## LONG DESCRIPTION
+## Long description
 
-The Windows PowerShell console has some useful features to help
-you to edit commands at the Windows PowerShell command prompt.
+The PowerShell console has some useful keyboard shortcuts to help you edit
+commands at the PowerShell command prompt.
 
-### Move Left and Right
+### Add a line
 
-To move the cursor one character to the left, press the LEFT ARROW
-key. To move the cursor one word to the left, press CTRL+LEFT ARROW.
-To move the cursor one character to the right, press the RIGHT ARROW
-key. To move the cursor one word to the right, press CTRL+RIGHT ARROW.
+To add a line, press <kbd>Shift</kbd>+<kbd>Enter</kbd>.
 
-### Line Start and End
+You can add multiple lines. Each additional line begins with `>>`, the
+continuation prompt. Press <kbd>Enter</kbd> to execute the command.
 
-To move to the beginning of a line, press the HOME key. To move to the
-end of a line, press the END key.
+### Move left and right
 
-### Delete Characters
+To move the cursor one character to the left, press the <kbd>Left arrow</kbd>.
 
-To delete the character in behind the cursor, press the BACKSPACE key.
-To delete the character in front of the cursor, press the DELETE key.
+To move the cursor one word to the left, press <kbd>Ctrl</kbd>+<kbd>Left
+arrow</kbd>.
 
-### Delete the Remainder of a Line
+To move the cursor one character to the right, press the <kbd>Right
+arrow</kbd>.
 
-To delete all the characters in the line after the cursor, press CTRL+END.
+To move the cursor one word to the right, press <kbd>Ctrl</kbd>+<kbd>Right
+arrow</kbd>.
 
-### Insert/Overstrike Mode
+### Move to a line's beginning or end
 
-To change to overstrike mode, press the INSERT key. To return to insert
-mode, press INSERT again.
+To move to the beginning of a line, press <kbd>Home</kbd>.
 
-### Tab Completion
+To move to the end of a line, press <kbd>End</kbd>.
 
-To complete a command, such as the name of a cmdlet, a cmdlet
-parameter, or a path, press the TAB key. If the first suggestion that
-is displayed is not what you want, press the TAB key again.
+If lines were added, press <kbd>Home</kbd> or <kbd>End</kbd> twice to move to
+the beginning or end of the lines.
 
-## SEE ALSO
+### Delete characters
+
+To delete the character behind the cursor's position, press
+<kbd>Backspace</kbd>.
+
+To delete the character at the cursor's position, press <kbd>Delete</kbd>.
+
+### Delete characters from a line
+
+To delete all the characters from the cursor's position to the end of a line,
+press <kbd>Ctrl</kbd>+<kbd>End</kbd>.
+
+To delete all the characters from the cursor's position to the beginning of a
+line, press <kbd>Ctrl</kbd>+<kbd>Home</kbd>.
+
+If lines were added, characters are deleted from the current line and the lines
+that were added.
+
+### Insert and overstrike mode
+
+To change to overwrite mode, press <kbd>Insert</kbd>. To return to insert mode,
+press <kbd>Insert</kbd> again.
+
+### Tab completion
+
+To complete a cmdlet name, a parameter, or a path, press the <kbd>Tab</kbd>
+key. To scroll through a list of values, press the <kbd>Tab</kbd> key again.
+
+## See also
 
 [about_Command_Syntax](about_Command_Syntax.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
@@ -17,13 +17,6 @@ Describes how to edit commands at the PowerShell command prompt.
 The PowerShell console has some useful keyboard shortcuts to help you edit
 commands at the PowerShell command prompt.
 
-### Add a line
-
-To add a line, press <kbd>Shift</kbd>+<kbd>Enter</kbd>.
-
-You can add multiple lines. Each additional line begins with `>>`, the
-continuation prompt. Press <kbd>Enter</kbd> to execute the command.
-
 ### Move left and right
 
 To move the cursor one character to the left, press the <kbd>Left arrow</kbd>.

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  07/10/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -8,48 +8,73 @@ title:  about_Line_Editing
 
 # About Line Editing
 
-## SHORT DESCRIPTION
+## Short description
 
-Describes how to edit commands at the Windows PowerShell command prompt.
+Describes how to edit commands at the PowerShell command prompt.
 
-## LONG DESCRIPTION
+## Long description
 
-The Windows PowerShell console has some useful features to help
-you to edit commands at the Windows PowerShell command prompt.
+The PowerShell console has some useful keyboard shortcuts to help you edit
+commands at the PowerShell command prompt.
 
-### Move Left and Right
+### Add a line
 
-To move the cursor one character to the left, press the LEFT ARROW
-key. To move the cursor one word to the left, press CTRL+LEFT ARROW.
-To move the cursor one character to the right, press the RIGHT ARROW
-key. To move the cursor one word to the right, press CTRL+RIGHT ARROW.
+To add a line, press <kbd>Shift</kbd>+<kbd>Enter</kbd>.
 
-### Line Start and End
+You can add multiple lines. Each additional line begins with `>>`, the
+continuation prompt. Press <kbd>Enter</kbd> to execute the command.
 
-To move to the beginning of a line, press the HOME key. To move to the
-end of a line, press the END key.
+### Move left and right
 
-### Delete Characters
+To move the cursor one character to the left, press the <kbd>Left arrow</kbd>.
 
-To delete the character in behind the cursor, press the BACKSPACE key.
-To delete the character in front of the cursor, press the DELETE key.
+To move the cursor one word to the left, press <kbd>Ctrl</kbd>+<kbd>Left
+arrow</kbd>.
 
-### Delete the Remainder of a Line
+To move the cursor one character to the right, press the <kbd>Right
+arrow</kbd>.
 
-To delete all the characters in the line after the cursor, press CTRL+END.
+To move the cursor one word to the right, press <kbd>Ctrl</kbd>+<kbd>Right
+arrow</kbd>.
 
-### Insert/Overstrike Mode
+### Move to a line's beginning or end
 
-To change to overstrike mode, press the INSERT key. To return to insert
-mode, press INSERT again.
+To move to the beginning of a line, press <kbd>Home</kbd>.
 
-### Tab Completion
+To move to the end of a line, press <kbd>End</kbd>.
 
-To complete a command, such as the name of a cmdlet, a cmdlet
-parameter, or a path, press the TAB key. If the first suggestion that
-is displayed is not what you want, press the TAB key again.
+If lines were added, press <kbd>Home</kbd> or <kbd>End</kbd> twice to move to
+the beginning or end of the lines.
 
-## SEE ALSO
+### Delete characters
+
+To delete the character behind the cursor's position, press
+<kbd>Backspace</kbd>.
+
+To delete the character at the cursor's position, press <kbd>Delete</kbd>.
+
+### Delete characters from a line
+
+To delete all the characters from the cursor's position to the end of a line,
+press <kbd>Ctrl</kbd>+<kbd>End</kbd>.
+
+To delete all the characters from the cursor's position to the beginning of a
+line, press <kbd>Ctrl</kbd>+<kbd>Home</kbd>.
+
+If lines were added, characters are deleted from the current line and the lines
+that were added.
+
+### Insert and overstrike mode
+
+To change to overwrite mode, press <kbd>Insert</kbd>. To return to insert mode,
+press <kbd>Insert</kbd> again.
+
+### Tab completion
+
+To complete a cmdlet name, a parameter, or a path, press the <kbd>Tab</kbd>
+key. To scroll through a list of values, press the <kbd>Tab</kbd> key again.
+
+## See also
 
 [about_Command_Syntax](about_Command_Syntax.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
@@ -1,54 +1,83 @@
 ---
-ms.date:  06/09/2017
+ms.date:  07/10/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Line_Editing
 ---
+
 # About Line Editing
 
-## SHORT DESCRIPTION
-Describes how to edit commands at the Windows PowerShell command prompt.
+## Short description
 
-## LONG DESCRIPTION
+Describes how to edit commands at the PowerShell command prompt.
 
-The Windows PowerShell console has some useful features to help
-you to edit commands at the Windows PowerShell command prompt.
+## Long description
 
-### Move Left and Right
+The PowerShell console has some useful keyboard shortcuts to help you edit
+commands at the PowerShell command prompt.
 
-To move the cursor one character to the left, press the LEFT ARROW
-key. To move the cursor one word to the left, press CTRL+LEFT ARROW.
-To move the cursor one character to the right, press the RIGHT ARROW
-key. To move the cursor one word to the right, press CTRL+RIGHT ARROW.
+### Add a line
 
-### Line Start and End
+To add a line, press <kbd>Shift</kbd>+<kbd>Enter</kbd>.
 
-To move to the beginning of a line, press the HOME key. To move to the
-end of a line, press the END key.
+You can add multiple lines. Each additional line begins with `>>`, the
+continuation prompt. Press <kbd>Enter</kbd> to execute the command.
 
-### Delete Characters
+### Move left and right
 
-To delete the character in behind the cursor, press the BACKSPACE key.
-To delete the character in front of the cursor, press the DELETE key.
+To move the cursor one character to the left, press the <kbd>Left arrow</kbd>.
 
-### Delete the Remainder of a Line
+To move the cursor one word to the left, press <kbd>Ctrl</kbd>+<kbd>Left
+arrow</kbd>.
 
-To delete all the characters in the line after the cursor, press CTRL+END.
+To move the cursor one character to the right, press the <kbd>Right
+arrow</kbd>.
 
-### Insert/Overstrike Mode
+To move the cursor one word to the right, press <kbd>Ctrl</kbd>+<kbd>Right
+arrow</kbd>.
 
-To change to overstrike mode, press the INSERT key. To return to insert
-mode, press INSERT again.
+### Move to a line's beginning or end
 
-### Tab Completion
+To move to the beginning of a line, press <kbd>Home</kbd>.
 
-To complete a command, such as the name of a cmdlet, a cmdlet
-parameter, or a path, press the TAB key. If the first suggestion that
-is displayed is not what you want, press the TAB key again.
+To move to the end of a line, press <kbd>End</kbd>.
 
-## SEE ALSO
+If lines were added, press <kbd>Home</kbd> or <kbd>End</kbd> twice to move to
+the beginning or end of the lines.
+
+### Delete characters
+
+To delete the character behind the cursor's position, press
+<kbd>Backspace</kbd>.
+
+To delete the character at the cursor's position, press <kbd>Delete</kbd>.
+
+### Delete characters from a line
+
+To delete all the characters from the cursor's position to the end of a line,
+press <kbd>Ctrl</kbd>+<kbd>End</kbd>.
+
+To delete all the characters from the cursor's position to the beginning of a
+line, press <kbd>Ctrl</kbd>+<kbd>Home</kbd>.
+
+If lines were added, characters are deleted from the current line and the lines
+that were added.
+
+### Insert and overstrike mode
+
+To change to overwrite mode, press <kbd>Insert</kbd>. To return to insert mode,
+press <kbd>Insert</kbd> again.
+
+### Tab completion
+
+To complete a cmdlet name, a parameter, or a path, press the <kbd>Tab</kbd>
+key. To scroll through a list of values, press the <kbd>Tab</kbd> key again.
+
+## See also
 
 [about_Command_Syntax](about_Command_Syntax.md)
 
 [about_Path_Syntax](about_Path_Syntax.md)
+
+[about_PSReadline](../../PSReadline/About/about_PSReadline.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Line_Editing.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Line_Editing.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  07/10/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -8,49 +8,76 @@ title:  about_Line_Editing
 
 # About Line Editing
 
-## SHORT DESCRIPTION
+## Short description
 
-Describes how to edit commands at the Windows PowerShell command prompt.
+Describes how to edit commands at the PowerShell command prompt.
 
-## LONG DESCRIPTION
+## Long description
 
-The Windows PowerShell console has some useful features to help
-you to edit commands at the Windows PowerShell command prompt.
+The PowerShell console has some useful keyboard shortcuts to help you edit
+commands at the PowerShell command prompt.
 
-### Move Left and Right
+### Add a line
 
-To move the cursor one character to the left, press the LEFT ARROW
-key. To move the cursor one word to the left, press CTRL+LEFT ARROW.
-To move the cursor one character to the right, press the RIGHT ARROW
-key. To move the cursor one word to the right, press CTRL+RIGHT ARROW.
+To add a line, press <kbd>Shift</kbd>+<kbd>Enter</kbd>.
 
-### Line Start and End
+You can add multiple lines. Each additional line begins with `>>`, the
+continuation prompt. Press <kbd>Enter</kbd> to execute the command.
 
-To move to the beginning of a line, press the HOME key. To move to the
-end of a line, press the END key.
+### Move left and right
 
-### Delete Characters
+To move the cursor one character to the left, press the <kbd>Left arrow</kbd>.
 
-To delete the character in behind the cursor, press the BACKSPACE key.
-To delete the character in front of the cursor, press the DELETE key.
+To move the cursor one word to the left, press <kbd>Ctrl</kbd>+<kbd>Left
+arrow</kbd>.
 
-### Delete the Remainder of a Line
+To move the cursor one character to the right, press the <kbd>Right
+arrow</kbd>.
 
-To delete all the characters in the line after the cursor, press CTRL+END.
+To move the cursor one word to the right, press <kbd>Ctrl</kbd>+<kbd>Right
+arrow</kbd>.
 
-### Insert/Overstrike Mode
+### Move to a line's beginning or end
 
-To change to overstrike mode, press the INSERT key. To return to insert
-mode, press INSERT again.
+To move to the beginning of a line, press <kbd>Home</kbd>.
 
-### Tab Completion
+To move to the end of a line, press <kbd>End</kbd>.
 
-To complete a command, such as the name of a cmdlet, a cmdlet
-parameter, or a path, press the TAB key. If the first suggestion that
-is displayed is not what you want, press the TAB key again.
+If lines were added, press <kbd>Home</kbd> or <kbd>End</kbd> twice to move to
+the beginning or end of the lines.
 
-## SEE ALSO
+### Delete characters
+
+To delete the character behind the cursor's position, press
+<kbd>Backspace</kbd>.
+
+To delete the character at the cursor's position, press <kbd>Delete</kbd>.
+
+### Delete characters from a line
+
+To delete all the characters from the cursor's position to the end of a line,
+press <kbd>Ctrl</kbd>+<kbd>End</kbd>.
+
+To delete all the characters from the cursor's position to the beginning of a
+line, press <kbd>Ctrl</kbd>+<kbd>Home</kbd>.
+
+If lines were added, characters are deleted from the current line and the lines
+that were added.
+
+### Insert and overstrike mode
+
+To change to overwrite mode, press <kbd>Insert</kbd>. To return to insert mode,
+press <kbd>Insert</kbd> again.
+
+### Tab completion
+
+To complete a cmdlet name, a parameter, or a path, press the <kbd>Tab</kbd>
+key. To scroll through a list of values, press the <kbd>Tab</kbd> key again.
+
+## See also
 
 [about_Command_Syntax](about_Command_Syntax.md)
 
 [about_Path_Syntax](about_Path_Syntax.md)
+
+[about_PSReadline](../../PSReadline/About/about_PSReadline.md)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Line_Editing.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Line_Editing.md
@@ -1,54 +1,83 @@
 ---
-ms.date:  06/09/2017
+ms.date:  07/10/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Line_Editing
 ---
+
 # About Line Editing
 
-## SHORT DESCRIPTION
+## Short description
+
 Describes how to edit commands at the PowerShell command prompt.
 
-## LONG DESCRIPTION
+## Long description
 
-The PowerShell console has some useful features to help
-you to edit commands at the PowerShell command prompt.
+The PowerShell console has some useful keyboard shortcuts to help you edit
+commands at the PowerShell command prompt.
 
-### Move Left and Right
+### Add a line
 
-To move the cursor one character to the left, press the LEFT ARROW
-key. To move the cursor one word to the left, press CTRL+LEFT ARROW.
-To move the cursor one character to the right, press the RIGHT ARROW
-key. To move the cursor one word to the right, press CTRL+RIGHT ARROW.
+To add a line, press <kbd>Shift</kbd>+<kbd>Enter</kbd>.
 
-### Line Start and End
+You can add multiple lines. Each additional line begins with `>>`, the
+continuation prompt. Press <kbd>Enter</kbd> to execute the command.
 
-To move to the beginning of a line, press the HOME key. To move to the
-end of a line, press the END key.
+### Move left and right
 
-### Delete Characters
+To move the cursor one character to the left, press the <kbd>Left arrow</kbd>.
 
-To delete the character in behind the cursor, press the BACKSPACE key.
-To delete the character in front of the cursor, press the DELETE key.
+To move the cursor one word to the left, press <kbd>Ctrl</kbd>+<kbd>Left
+arrow</kbd>.
 
-### Delete the Remainder of a Line
+To move the cursor one character to the right, press the <kbd>Right
+arrow</kbd>.
 
-To delete all the characters in the line after the cursor, press CTRL+END.
+To move the cursor one word to the right, press <kbd>Ctrl</kbd>+<kbd>Right
+arrow</kbd>.
 
-### Insert/Overstrike Mode
+### Move to a line's beginning or end
 
-To change to overstrike mode, press the INSERT key. To return to insert
-mode, press INSERT again.
+To move to the beginning of a line, press <kbd>Home</kbd>.
 
-### Tab Completion
+To move to the end of a line, press <kbd>End</kbd>.
 
-To complete a command, such as the name of a cmdlet, a cmdlet
-parameter, or a path, press the TAB key. If the first suggestion that
-is displayed is not what you want, press the TAB key again.
+If lines were added, press <kbd>Home</kbd> or <kbd>End</kbd> twice to move to
+the beginning or end of the lines.
 
-## SEE ALSO
+### Delete characters
+
+To delete the character behind the cursor's position, press
+<kbd>Backspace</kbd>.
+
+To delete the character at the cursor's position, press <kbd>Delete</kbd>.
+
+### Delete characters from a line
+
+To delete all the characters from the cursor's position to the end of a line,
+press <kbd>Ctrl</kbd>+<kbd>End</kbd>.
+
+To delete all the characters from the cursor's position to the beginning of a
+line, press <kbd>Ctrl</kbd>+<kbd>Home</kbd>.
+
+If lines were added, characters are deleted from the current line and the lines
+that were added.
+
+### Insert and overstrike mode
+
+To change to overwrite mode, press <kbd>Insert</kbd>. To return to insert mode,
+press <kbd>Insert</kbd> again.
+
+### Tab completion
+
+To complete a cmdlet name, a parameter, or a path, press the <kbd>Tab</kbd>
+key. To scroll through a list of values, press the <kbd>Tab</kbd> key again.
+
+## See also
 
 [about_Command_Syntax](about_Command_Syntax.md)
 
 [about_Path_Syntax](about_Path_Syntax.md)
+
+[about_PSReadline](../../PSReadline/About/about_PSReadline.md)

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Line_Editing.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Line_Editing.md
@@ -1,54 +1,83 @@
 ---
-ms.date:  06/09/2017
+ms.date:  07/10/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Line_Editing
 ---
+
 # About Line Editing
 
-## SHORT DESCRIPTION
+## Short description
+
 Describes how to edit commands at the PowerShell command prompt.
 
-## LONG DESCRIPTION
+## Long description
 
-The PowerShell console has some useful features to help
-you to edit commands at the PowerShell command prompt.
+The PowerShell console has some useful keyboard shortcuts to help you edit
+commands at the PowerShell command prompt.
 
-### Move Left and Right
+### Add a line
 
-To move the cursor one character to the left, press the LEFT ARROW
-key. To move the cursor one word to the left, press CTRL+LEFT ARROW.
-To move the cursor one character to the right, press the RIGHT ARROW
-key. To move the cursor one word to the right, press CTRL+RIGHT ARROW.
+To add a line, press <kbd>Shift</kbd>+<kbd>Enter</kbd>.
 
-### Line Start and End
+You can add multiple lines. Each additional line begins with `>>`, the
+continuation prompt. Press <kbd>Enter</kbd> to execute the command.
 
-To move to the beginning of a line, press the HOME key. To move to the
-end of a line, press the END key.
+### Move left and right
 
-### Delete Characters
+To move the cursor one character to the left, press the <kbd>Left arrow</kbd>.
 
-To delete the character in behind the cursor, press the BACKSPACE key.
-To delete the character in front of the cursor, press the DELETE key.
+To move the cursor one word to the left, press <kbd>Ctrl</kbd>+<kbd>Left
+arrow</kbd>.
 
-### Delete the Remainder of a Line
+To move the cursor one character to the right, press the <kbd>Right
+arrow</kbd>.
 
-To delete all the characters in the line after the cursor, press CTRL+END.
+To move the cursor one word to the right, press <kbd>Ctrl</kbd>+<kbd>Right
+arrow</kbd>.
 
-### Insert/Overstrike Mode
+### Move to a line's beginning or end
 
-To change to overstrike mode, press the INSERT key. To return to insert
-mode, press INSERT again.
+To move to the beginning of a line, press <kbd>Home</kbd>.
 
-### Tab Completion
+To move to the end of a line, press <kbd>End</kbd>.
 
-To complete a command, such as the name of a cmdlet, a cmdlet
-parameter, or a path, press the TAB key. If the first suggestion that
-is displayed is not what you want, press the TAB key again.
+If lines were added, press <kbd>Home</kbd> or <kbd>End</kbd> twice to move to
+the beginning or end of the lines.
 
-## SEE ALSO
+### Delete characters
+
+To delete the character behind the cursor's position, press
+<kbd>Backspace</kbd>.
+
+To delete the character at the cursor's position, press <kbd>Delete</kbd>.
+
+### Delete characters from a line
+
+To delete all the characters from the cursor's position to the end of a line,
+press <kbd>Ctrl</kbd>+<kbd>End</kbd>.
+
+To delete all the characters from the cursor's position to the beginning of a
+line, press <kbd>Ctrl</kbd>+<kbd>Home</kbd>.
+
+If lines were added, characters are deleted from the current line and the lines
+that were added.
+
+### Insert and overstrike mode
+
+To change to overwrite mode, press <kbd>Insert</kbd>. To return to insert mode,
+press <kbd>Insert</kbd> again.
+
+### Tab completion
+
+To complete a cmdlet name, a parameter, or a path, press the <kbd>Tab</kbd>
+key. To scroll through a list of values, press the <kbd>Tab</kbd> key again.
+
+## See also
 
 [about_Command_Syntax](about_Command_Syntax.md)
 
 [about_Path_Syntax](about_Path_Syntax.md)
+
+[about_PSReadline](../../PSReadline/About/about_PSReadline.md)


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

about_Line_Editing Acrolinx score
Original version: 96
Updated version: 100

- Fixes [AB#1565857](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1565857)
- Copyedits, style
- Added about_PSReadline link to v5.0 - 7
