### PR TITLE
PackageManagement docs - corrected parameter set spacing and YAML date format

### DIFF
--- a/reference/5.0/PackageManagement/Find-Package.md
+++ b/reference/5.0/PackageManagement/Find-Package.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 4/3/2019
+ms.date: 04/03/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -19,11 +19,11 @@ Finds software packages in available package sources.
 
 ```
 Find-Package [[-Name] <string[]>] [-IncludeDependencies] [-AllVersions] [-Source <string[]>]
-[-Credential <pscredential>] [-RequiredVersion <string>] [-MinimumVersion <string>]
-[-MaximumVersion <string>] [-Force] [-ForceBootstrap] [-ProviderName <string[]>]
-[-PackageManagementProvider <string>] [-Scope <string>] [-PublishLocation <string>]
-[-Filter <string>] [-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>]
-[-Command <string[]>] [<CommonParameters>]
+ [-Credential <pscredential>] [-RequiredVersion <string>] [-MinimumVersion <string>]
+ [-MaximumVersion <string>] [-Force] [-ForceBootstrap] [-ProviderName <string[]>]
+ [-PackageManagementProvider <string>] [-Scope <string>] [-PublishLocation <string>]
+ [-Filter <string>] [-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>]
+ [-Command <string[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.0/PackageManagement/Get-Package.md
+++ b/reference/5.0/PackageManagement/Get-Package.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 5/22/2019
+ms.date: 05/22/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -19,25 +19,25 @@ Returns a list of all software packages that were installed with **PackageManage
 
 ```
 Get-Package [[-Name] <string[]>] [-RequiredVersion <string>] [-MinimumVersion <string>]
-[-MaximumVersion <string>] [-Force] [-ForceBootstrap] [-ProviderName <string[]>]
-[-IncludeWindowsInstaller] [-IncludeSystemComponent] [<CommonParameters>]
+ [-MaximumVersion <string>] [-Force] [-ForceBootstrap] [-ProviderName <string[]>]
+ [-IncludeWindowsInstaller] [-IncludeSystemComponent] [<CommonParameters>]
 ```
 
 ### msi
 
 ```
 Get-Package [[-Name] <string[]>] [-RequiredVersion <string>] [-MinimumVersion <string>]
-[-MaximumVersion <string>] [-Force] [-ForceBootstrap] [-ProviderName <string[]>]
-[-AdditionalArguments <string[]>] [<CommonParameters>]
+ [-MaximumVersion <string>] [-Force] [-ForceBootstrap] [-ProviderName <string[]>]
+ [-AdditionalArguments <string[]>] [<CommonParameters>]
 ```
 
 ### PSModule
 
 ```
 Get-Package [[-Name] <string[]>] [-RequiredVersion <string>] [-MinimumVersion <string>]
-[-MaximumVersion <string>] [-Force] [-ForceBootstrap] [-ProviderName <string[]>]
-[-PackageManagementProvider <string>] [-Location <string>] [-InstallUpdate]
-[-InstallationPolicy <string>] [-DestinationPath <string>] [<CommonParameters>]
+ [-MaximumVersion <string>] [-Force] [-ForceBootstrap] [-ProviderName <string[]>]
+ [-PackageManagementProvider <string>] [-Location <string>] [-InstallUpdate]
+ [-InstallationPolicy <string>] [-DestinationPath <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.0/PackageManagement/Get-PackageSource.md
+++ b/reference/5.0/PackageManagement/Get-PackageSource.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 3/29/2019
+ms.date: 03/29/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -19,8 +19,8 @@ Gets a list of package sources that are registered for a package provider.
 
 ```
 Get-PackageSource [[-Name] <string>] [-Location <string>] [-Force] [-ForceBootstrap]
-[-ProviderName <string[]>] [-PackageManagementProvider <string>] [-Scope <string>]
-[-PublishLocation <string>] [<CommonParameters>]
+ [-ProviderName <string[]>] [-PackageManagementProvider <string>] [-Scope <string>]
+ [-PublishLocation <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.0/PackageManagement/Install-Package.md
+++ b/reference/5.0/PackageManagement/Install-Package.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  5/23/2019
+ms.date:  05/23/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -19,63 +19,63 @@ Installs one or more software packages.
 
 ```
 Install-Package [[-Name] <string[]>] [-RequiredVersion <string>] [-MinimumVersion <string>]
-[-MaximumVersion <string>] [-Source <string[]>] [-Credential <pscredential>] [-Force]
-[-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <string[]>] [<CommonParameters>]
+ [-MaximumVersion <string>] [-Source <string[]>] [-Credential <pscredential>] [-Force]
+ [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <string[]>] [<CommonParameters>]
 ```
 
 ### PackageByInputObject
 
 ```
 Install-Package [-InputObject] <SoftwareIdentity[]> [-Credential <pscredential>] [-Force]
-[-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### msi:PackageBySearch
 
 ```
 Install-Package [-Credential <pscredential>] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-AdditionalArguments <string[]>] [<CommonParameters>]
+ [-AdditionalArguments <string[]>] [<CommonParameters>]
 ```
 
 ### msi:PackageByInputObject
 
 ```
 Install-Package [-Credential <pscredential>] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-AdditionalArguments <string[]>] [<CommonParameters>]
+ [-AdditionalArguments <string[]>] [<CommonParameters>]
 ```
 
 ### Programs:PackageBySearch
 
 ```
 Install-Package [-Credential <pscredential>] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-IncludeWindowsInstaller] [-IncludeSystemComponent] [<CommonParameters>]
+ [-IncludeWindowsInstaller] [-IncludeSystemComponent] [<CommonParameters>]
 ```
 
 ### Programs:PackageByInputObject
 
 ```
 Install-Package [-Credential <pscredential>] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-IncludeWindowsInstaller] [-IncludeSystemComponent] [<CommonParameters>]
+ [-IncludeWindowsInstaller] [-IncludeSystemComponent] [<CommonParameters>]
 ```
 
 ### PSModule:PackageBySearch
 
 ```
 Install-Package [-Credential <pscredential>] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-PackageManagementProvider <string>] [-Scope <string>] [-PublishLocation <string>] [-AllVersions]
-[-Filter <string>] [-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>]
-[-Command <string[]>] [-Location <string>] [-InstallUpdate] [-InstallationPolicy <string>]
-[-DestinationPath <string>] [<CommonParameters>]
+ [-PackageManagementProvider <string>] [-Scope <string>] [-PublishLocation <string>] [-AllVersions]
+ [-Filter <string>] [-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>]
+ [-Command <string[]>] [-Location <string>] [-InstallUpdate] [-InstallationPolicy <string>]
+ [-DestinationPath <string>] [<CommonParameters>]
 ```
 
 ### PSModule:PackageByInputObject
 
 ```
 Install-Package [-Credential <pscredential>] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-PackageManagementProvider <string>] [-Scope <string>] [-PublishLocation <string>] [-AllVersions]
-[-Filter <string>] [-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>]
-[-Command <string[]>] [-Location <string>] [-InstallUpdate] [-InstallationPolicy <string>]
-[-DestinationPath <string>] [<CommonParameters>]
+ [-PackageManagementProvider <string>] [-Scope <string>] [-PublishLocation <string>] [-AllVersions]
+ [-Filter <string>] [-Tag <string[]>] [-Includes <string[]>] [-DscResource <string[]>]
+ [-Command <string[]>] [-Location <string>] [-InstallUpdate] [-InstallationPolicy <string>]
+ [-DestinationPath <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.0/PackageManagement/Register-PackageSource.md
+++ b/reference/5.0/PackageManagement/Register-PackageSource.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  4/1/2019
+ms.date:  04/01/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -19,16 +19,16 @@ Adds a package source for a specified package provider.
 
 ```
 Register-PackageSource [[-Name] <string>] [[-Location] <string>] [-Credential <pscredential>]
-[-Trusted] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <string>]
-[<CommonParameters>]
+ [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <string>]
+ [<CommonParameters>]
 ```
 
 ### PSModule
 
 ```
 Register-PackageSource [[-Name] <string>] [[-Location] <string>] [-Credential <pscredential>]
-[-Trusted] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-PackageManagementProvider <string>]
-[-Scope <string>] [-PublishLocation <string>] [<CommonParameters>]
+ [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-PackageManagementProvider <string>]
+ [-Scope <string>] [-PublishLocation <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/PackageManagement/Find-Package.md
+++ b/reference/5.1/PackageManagement/Find-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 4/3/2019
+ms.date: 04/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=517132
 schema: 2.0.0
 title: Find-Package
@@ -20,23 +20,23 @@ Finds software packages in available package sources.
 
 ```
 Find-Package [-IncludeDependencies] [-AllVersions] [-Source <String[]>] [-Credential <PSCredential>]
-[-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String[]>] [-RequiredVersion <String>]
-[-MinimumVersion <String>] [-MaximumVersion <String>] [-Force] [-ForceBootstrap]
-[-ProviderName <String[]>] [-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>]
-[-FilterOnTag <String[]>] [-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String[]>] [-RequiredVersion <String>]
+ [-MinimumVersion <String>] [-MaximumVersion <String>] [-Force] [-ForceBootstrap]
+ [-ProviderName <String[]>] [-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>]
+ [-FilterOnTag <String[]>] [-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Find-Package [-IncludeDependencies] [-AllVersions] [-Source <String[]>] [-Credential <PSCredential>]
-[-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String[]>] [-RequiredVersion <String>]
-[-MinimumVersion <String>] [-MaximumVersion <String>] [-Force] [-ForceBootstrap]
-[-ProviderName <String[]>] [-AllowPrereleaseVersions] [-PackageManagementProvider <String>]
-[-PublishLocation <String>] [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>]
-[-Type <String>] [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>]
-[-DscResource <String[]>] [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense]
-[<CommonParameters>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String[]>] [-RequiredVersion <String>]
+ [-MinimumVersion <String>] [-MaximumVersion <String>] [-Force] [-ForceBootstrap]
+ [-ProviderName <String[]>] [-AllowPrereleaseVersions] [-PackageManagementProvider <String>]
+ [-PublishLocation <String>] [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>]
+ [-Type <String>] [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>]
+ [-DscResource <String[]>] [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/PackageManagement/Get-Package.md
+++ b/reference/5.1/PackageManagement/Get-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 5/22/2019
+ms.date: 05/22/2019
 online version: https://go.microsoft.com/fwlink/?linkid=517135
 schema: 2.0.0
 title: Get-Package
@@ -20,34 +20,35 @@ Returns a list of all software packages that were installed with **PackageManage
 
 ```
 Get-Package [[-Name] <String[]>] [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
-[-AdditionalArguments <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
+ [-AdditionalArguments <String[]>] [<CommonParameters>]
 ```
 
 ### Programs
 
 ```
 Get-Package [[-Name] <String[]>] [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
-[-IncludeWindowsInstaller] [-IncludeSystemComponent] [<CommonParameters>]
+ [-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
+ [-IncludeWindowsInstaller] [-IncludeSystemComponent] [<CommonParameters>]
 ```
 
 ### NuGet
 
 ```
 Get-Package [[-Name] <String[]>] [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
-[-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies] [<CommonParameters>]
+ [-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
+ [-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies]
+ [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Get-Package [[-Name] <String[]>] [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
-[-Scope <String>] [-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber]
-[-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions]
-[<CommonParameters>]
+ [-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
+ [-Scope <String>] [-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber]
+ [-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/PackageManagement/Get-PackageSource.md
+++ b/reference/5.1/PackageManagement/Get-PackageSource.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 3/29/2019
+ms.date: 03/29/2019
 online version: https://go.microsoft.com/fwlink/?linkid=517137
 schema: 2.0.0
 title: Get-PackageSource
@@ -20,15 +20,15 @@ Gets a list of package sources that are registered for a package provider.
 
 ```
 Get-PackageSource [[-Name] <String>] [-Location <String>] [-Force] [-ForceBootstrap]
-[-ProviderName <String[]>] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-ProviderName <String[]>] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Get-PackageSource [[-Name] <String>] [-Location <String>] [-Force] [-ForceBootstrap]
-[-ProviderName <String[]>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-ProviderName <String[]>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/PackageManagement/Install-Package.md
+++ b/reference/5.1/PackageManagement/Install-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 5/23/2019
+ms.date: 05/23/2019
 online version: https://go.microsoft.com/fwlink/?linkid=517138
 schema: 2.0.0
 title: Install-Package
@@ -20,91 +20,93 @@ Installs one or more software packages.
 
 ```
 Install-Package [-Name] <String[]> [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-Source <String[]>] [-Credential <PSCredential>] [-Proxy <Uri>] 
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] 
-[-ProviderName <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-Source <String[]>] [-Credential <PSCredential>] [-Proxy <Uri>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ProviderName <String[]>] [<CommonParameters>]
 ```
 
 ### PackageByInputObject
 
 ```
 Install-Package [-InputObject] <SoftwareIdentity[]> [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### Programs:PackageBySearch
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-IncludeWindowsInstaller]
-[-IncludeSystemComponent] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-IncludeWindowsInstaller]
+ [-IncludeSystemComponent] [<CommonParameters>]
 ```
 
 ### Programs:PackageByInputObject
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-IncludeWindowsInstaller]
-[-IncludeSystemComponent] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-IncludeWindowsInstaller]
+ [-IncludeSystemComponent] [<CommonParameters>]
 ```
 
 ### msi:PackageBySearch
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AdditionalArguments <String[]>]
-[<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AdditionalArguments <String[]>]
+ [<CommonParameters>]
 ```
 
 ### msi:PackageByInputObject
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AdditionalArguments <String[]>]
-[<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AdditionalArguments <String[]>]
+ [<CommonParameters>]
 ```
 
 ### NuGet:PackageBySearch
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ConfigFile <String>]
-[-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>] [-Contains <String>]
-[-AllowPrereleaseVersions] [-Destination <String>] [-ExcludeVersion] [-Scope <String>]
-[-SkipDependencies] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ConfigFile <String>]
+ [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>] [-Contains <String>]
+ [-AllowPrereleaseVersions] [-Destination <String>] [-ExcludeVersion] [-Scope <String>]
+ [-SkipDependencies] [<CommonParameters>]
 ```
 
 ### NuGet:PackageByInputObject
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ConfigFile <String>]
-[-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>] [-Contains <String>]
-[-AllowPrereleaseVersions] [-Destination <String>] [-ExcludeVersion] [-Scope <String>]
-[-SkipDependencies] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ConfigFile <String>]
+ [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>] [-Contains <String>]
+ [-AllowPrereleaseVersions] [-Destination <String>] [-ExcludeVersion] [-Scope <String>]
+ [-SkipDependencies] [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageBySearch
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AllowPrereleaseVersions] [-Scope <String>]
-[-PackageManagementProvider <String>] [-PublishLocation <String>] [-ScriptSourceLocation <String>]
-[-ScriptPublishLocation <String>] [-Type <String>] [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>]
-[-DscResource <String[]>] [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense]
-[-AllowClobber] [-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AllowPrereleaseVersions]
+ [-Scope <String>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
+ [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
+ [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [-AllowClobber]
+ [-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageByInputObject
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AllowPrereleaseVersions] [-Scope <String>]
-[-PackageManagementProvider <String>] [-PublishLocation <String>] [-ScriptSourceLocation <String>]
-[-ScriptPublishLocation <String>] [-Type <String>] [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>]
-[-DscResource <String[]>] [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense]
-[-AllowClobber] [-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AllowPrereleaseVersions]
+ [-Scope <String>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
+ [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
+ [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [-AllowClobber]
+ [-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/PackageManagement/Register-PackageSource.md
+++ b/reference/5.1/PackageManagement/Register-PackageSource.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 4/1/2019
+ms.date: 04/01/2019
 online version: https://go.microsoft.com/fwlink/?linkid=517139
 schema: 2.0.0
 title: Register-PackageSource
@@ -20,25 +20,25 @@ Adds a package source for a specified package provider.
 
 ```
 Register-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String>]
-[[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ProviderName <String>] [<CommonParameters>]
+ [[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap]
+ [-WhatIf] [-Confirm] [-ProviderName <String>] [<CommonParameters>]
 ```
 
 ### NuGet
 
 ```
 Register-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String>]
-[[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Register-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String>]
-[[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/PackageManagement/Find-Package.md
+++ b/reference/6/PackageManagement/Find-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 4/3/2019
+ms.date: 04/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096430
 schema: 2.0.0
 title: Find-Package
@@ -19,23 +19,23 @@ Finds software packages in available package sources.
 
 ```
 Find-Package [-IncludeDependencies] [-AllVersions] [-Source <String[]>] [-Credential <PSCredential>]
-[-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String[]>] [-RequiredVersion <String>]
-[-MinimumVersion <String>] [-MaximumVersion <String>] [-Force] [-ForceBootstrap]
-[-ProviderName <String[]>] [-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>]
-[-FilterOnTag <String[]>] [-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String[]>] [-RequiredVersion <String>]
+ [-MinimumVersion <String>] [-MaximumVersion <String>] [-Force] [-ForceBootstrap]
+ [-ProviderName <String[]>] [-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>]
+ [-FilterOnTag <String[]>] [-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Find-Package [-IncludeDependencies] [-AllVersions] [-Source <String[]>] [-Credential <PSCredential>]
-[-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String[]>] [-RequiredVersion <String>]
-[-MinimumVersion <String>] [-MaximumVersion <String>] [-Force] [-ForceBootstrap]
-[-ProviderName <String[]>] [-AllowPrereleaseVersions] [-PackageManagementProvider <String>]
-[-PublishLocation <String>] [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>]
-[-Type <String>] [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>]
-[-DscResource <String[]>] [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense]
-[<CommonParameters>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String[]>] [-RequiredVersion <String>]
+ [-MinimumVersion <String>] [-MaximumVersion <String>] [-Force] [-ForceBootstrap]
+ [-ProviderName <String[]>] [-AllowPrereleaseVersions] [-PackageManagementProvider <String>]
+ [-PublishLocation <String>] [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>]
+ [-Type <String>] [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>]
+ [-DscResource <String[]>] [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/PackageManagement/Get-Package.md
+++ b/reference/6/PackageManagement/Get-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 5/22/2019
+ms.date: 05/22/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096428
 schema: 2.0.0
 title: Get-Package
@@ -20,18 +20,19 @@ Returns a list of all software packages that were installed with **PackageManage
 
 ```
 Get-Package [[-Name] <String[]>] [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
-[-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies] [<CommonParameters>]
+ [-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
+ [-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies]
+ [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Get-Package [[-Name] <String[]>] [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
-[-Scope <String>] [-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber]
-[-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions]
-[<CommonParameters>]
+ [-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
+ [-Scope <String>] [-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber]
+ [-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/PackageManagement/Get-PackageSource.md
+++ b/reference/6/PackageManagement/Get-PackageSource.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 3/29/2019
+ms.date: 03/29/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096540
 schema: 2.0.0
 title: Get-PackageSource
@@ -19,15 +19,15 @@ Gets a list of package sources that are registered for a package provider.
 
 ```
 Get-PackageSource [[-Name] <String>] [-Location <String>] [-Force] [-ForceBootstrap]
-[-ProviderName <String[]>] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-ProviderName <String[]>] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Get-PackageSource [[-Name] <String>] [-Location <String>] [-Force] [-ForceBootstrap]
-[-ProviderName <String[]>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-ProviderName <String[]>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/PackageManagement/Install-Package.md
+++ b/reference/6/PackageManagement/Install-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 5/23/2019
+ms.date: 05/23/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096432
 schema: 2.0.0
 title: Install-Package
@@ -20,61 +20,61 @@ Installs one or more software packages.
 
 ```
 Install-Package [-Name] <String[]> [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-Source <String[]>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-ProviderName <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-Source <String[]>] [-Credential <PSCredential>] [-Proxy <Uri>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ProviderName <String[]>] [<CommonParameters>]
 ```
 
 ### PackageByInputObject
 
 ```
 Install-Package [-InputObject] <SoftwareIdentity[]> [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### NuGet:PackageBySearch
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ConfigFile <String>]
-[-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>] [-Contains <String>]
-[-AllowPrereleaseVersions] [-Destination <String>] [-ExcludeVersion] [-Scope <String>]
-[-SkipDependencies] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ConfigFile <String>]
+ [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>] [-Contains <String>]
+ [-AllowPrereleaseVersions] [-Destination <String>] [-ExcludeVersion] [-Scope <String>]
+ [-SkipDependencies] [<CommonParameters>]
 ```
 
 ### NuGet:PackageByInputObject
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ConfigFile <String>]
-[-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>] [-Contains <String>]
-[-AllowPrereleaseVersions] [-Destination <String>] [-ExcludeVersion] [-Scope <String>]
-[-SkipDependencies] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ConfigFile <String>]
+ [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>] [-Contains <String>]
+ [-AllowPrereleaseVersions] [-Destination <String>] [-ExcludeVersion] [-Scope <String>]
+ [-SkipDependencies] [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageBySearch
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AllowPrereleaseVersions]
-[-Scope <String>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
-[-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
-[-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [-AllowClobber]
-[-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AllowPrereleaseVersions]
+ [-Scope <String>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
+ [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
+ [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [-AllowClobber]
+ [-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageByInputObject
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AllowPrereleaseVersions]
-[-Scope <String>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
-[-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
-[-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [-AllowClobber]
-[-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AllowPrereleaseVersions]
+ [-Scope <String>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
+ [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
+ [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [-AllowClobber]
+ [-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/PackageManagement/Register-PackageSource.md
+++ b/reference/6/PackageManagement/Register-PackageSource.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 4/1/2019
+ms.date: 04/01/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096436
 schema: 2.0.0
 title: Register-PackageSource
@@ -19,25 +19,25 @@ Adds a package source for a specified package provider.
 
 ```
 Register-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String>]
-[[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ProviderName <String>] [<CommonParameters>]
+ [[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-ProviderName <String>] [<CommonParameters>]
 ```
 
 ### NuGet
 
 ```
 Register-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String>]
-[[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Register-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String>]
-[[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/PackageManagement/Find-Package.md
+++ b/reference/7/PackageManagement/Find-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 4/3/2019
+ms.date: 04/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096630
 schema: 2.0.0
 title: Find-Package
@@ -19,23 +19,23 @@ Finds software packages in available package sources.
 
 ```
 Find-Package [-IncludeDependencies] [-AllVersions] [-Source <String[]>] [-Credential <PSCredential>]
-[-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String[]>] [-RequiredVersion <String>]
-[-MinimumVersion <String>] [-MaximumVersion <String>] [-Force] [-ForceBootstrap]
-[-ProviderName <String[]>] [-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>]
-[-FilterOnTag <String[]>] [-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String[]>] [-RequiredVersion <String>]
+ [-MinimumVersion <String>] [-MaximumVersion <String>] [-Force] [-ForceBootstrap]
+ [-ProviderName <String[]>] [-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>]
+ [-FilterOnTag <String[]>] [-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Find-Package [-IncludeDependencies] [-AllVersions] [-Source <String[]>] [-Credential <PSCredential>]
-[-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String[]>] [-RequiredVersion <String>]
-[-MinimumVersion <String>] [-MaximumVersion <String>] [-Force] [-ForceBootstrap]
-[-ProviderName <String[]>] [-AllowPrereleaseVersions] [-PackageManagementProvider <String>]
-[-PublishLocation <String>] [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>]
-[-Type <String>] [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>]
-[-DscResource <String[]>] [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense]
-[<CommonParameters>]
+ [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String[]>] [-RequiredVersion <String>]
+ [-MinimumVersion <String>] [-MaximumVersion <String>] [-Force] [-ForceBootstrap]
+ [-ProviderName <String[]>] [-AllowPrereleaseVersions] [-PackageManagementProvider <String>]
+ [-PublishLocation <String>] [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>]
+ [-Type <String>] [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>]
+ [-DscResource <String[]>] [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/PackageManagement/Get-Package.md
+++ b/reference/7/PackageManagement/Get-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 5/22/2019
+ms.date: 05/22/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2097116
 schema: 2.0.0
 title: Get-Package
@@ -20,18 +20,18 @@ Returns a list of all software packages that were installed with **PackageManage
 
 ```
 Get-Package [[-Name] <String[]>] [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
-[-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies] [<CommonParameters>]
+ [-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
+ [-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies] [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Get-Package [[-Name] <String[]>] [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
-[-Scope <String>] [-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber]
-[-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions]
-[<CommonParameters>]
+ [-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-ProviderName <String[]>]
+ [-Scope <String>] [-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber]
+ [-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/PackageManagement/Get-PackageSource.md
+++ b/reference/7/PackageManagement/Get-PackageSource.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 3/29/2019
+ms.date: 03/29/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096720
 schema: 2.0.0
 title: Get-PackageSource
@@ -19,15 +19,15 @@ Gets a list of package sources that are registered for a package provider.
 
 ```
 Get-PackageSource [[-Name] <String>] [-Location <String>] [-Force] [-ForceBootstrap]
-[-ProviderName <String[]>] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-ProviderName <String[]>] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Get-PackageSource [[-Name] <String>] [-Location <String>] [-Force] [-ForceBootstrap]
-[-ProviderName <String[]>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-ProviderName <String[]>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/PackageManagement/Install-Package.md
+++ b/reference/7/PackageManagement/Install-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 5/23/2019
+ms.date: 05/23/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096722
 schema: 2.0.0
 title: Install-Package
@@ -20,61 +20,61 @@ Installs one or more software packages.
 
 ```
 Install-Package [-Name] <String[]> [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-Source <String[]>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-ProviderName <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-Source <String[]>] [-Credential <PSCredential>] [-Proxy <Uri>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ProviderName <String[]>] [<CommonParameters>]
 ```
 
 ### PackageByInputObject
 
 ```
 Install-Package [-InputObject] <SoftwareIdentity[]> [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### NuGet:PackageBySearch
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ConfigFile <String>]
-[-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>] [-Contains <String>]
-[-AllowPrereleaseVersions] [-Destination <String>] [-ExcludeVersion] [-Scope <String>]
-[-SkipDependencies] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ConfigFile <String>]
+ [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>] [-Contains <String>]
+ [-AllowPrereleaseVersions] [-Destination <String>] [-ExcludeVersion] [-Scope <String>]
+ [-SkipDependencies] [<CommonParameters>]
 ```
 
 ### NuGet:PackageByInputObject
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ConfigFile <String>]
-[-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>] [-Contains <String>]
-[-AllowPrereleaseVersions] [-Destination <String>] [-ExcludeVersion] [-Scope <String>]
-[-SkipDependencies] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ConfigFile <String>]
+ [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>] [-Contains <String>]
+ [-AllowPrereleaseVersions] [-Destination <String>] [-ExcludeVersion] [-Scope <String>]
+ [-SkipDependencies] [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageBySearch
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AllowPrereleaseVersions]
-[-Scope <String>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
-[-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
-[-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [-AllowClobber]
-[-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AllowPrereleaseVersions]
+ [-Scope <String>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
+ [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
+ [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [-AllowClobber]
+ [-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageByInputObject
 
 ```
 Install-Package [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
-[-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AllowPrereleaseVersions]
-[-Scope <String>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
-[-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
-[-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [-AllowClobber]
-[-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [<CommonParameters>]
+ [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AllowPrereleaseVersions]
+ [-Scope <String>] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
+ [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
+ [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [-AllowClobber]
+ [-SkipPublisherCheck] [-InstallUpdate] [-NoPathUpdate] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/PackageManagement/Register-PackageSource.md
+++ b/reference/7/PackageManagement/Register-PackageSource.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 4/1/2019
+ms.date: 04/01/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096718
 schema: 2.0.0
 title: Register-PackageSource
@@ -19,25 +19,25 @@ Adds a package source for a specified package provider.
 
 ```
 Register-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String>]
-[[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ProviderName <String>] [<CommonParameters>]
+ [[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-ProviderName <String>] [<CommonParameters>]
 ```
 
 ### NuGet
 
 ```
 Register-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String>]
-[[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Register-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [[-Name] <String>]
-[[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [[-Location] <String>] [-Credential <PSCredential>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

- Corrected the parameter set spacing and YAML header ms.date
- Related to updates for #3740

Find-Package
Get-Package
Get-PackageSource
Install-Package
Register-PackageSource