### PR TITLE
PackageManagement docs part 2 - corrected parameter set spacing and YAML date format

### DIFF
--- a/reference/5.0/PackageManagement/Save-Package.md
+++ b/reference/5.0/PackageManagement/Save-Package.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  4/3/2019
+ms.date:  04/03/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -19,34 +19,34 @@ Saves packages to the local computer without installing them.
 
 ```
 Save-Package [[-Name] <string[]>] [-RequiredVersion <string>] [-MinimumVersion <string>]
-[-MaximumVersion <string>] [-Source <string[]>] [-Path <string>] [-LiteralPath <string>]
-[-Credential <pscredential>] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-ProviderName <string[]>] [<CommonParameters>]
+ [-MaximumVersion <string>] [-Source <string[]>] [-Path <string>] [-LiteralPath <string>]
+ [-Credential <pscredential>] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ProviderName <string[]>] [<CommonParameters>]
 ```
 
 ### PackageByInputObject
 
 ```
 Save-Package -InputObject <SoftwareIdentity> [-Path <string>] [-LiteralPath <string>]
-[-Credential <pscredential>] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Credential <pscredential>] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PSModule:PackageByInputObject
 
 ```
 Save-Package [-Path <string>] [-LiteralPath <string>] [-Credential <pscredential>] [-Force]
-[-ForceBootstrap] [-WhatIf] [-Confirm] [-PackageManagementProvider <string>] [-Scope <string>]
-[-PublishLocation <string>] [-AllVersions] [-Filter <string>] [-Tag <string[]>]
-[-Includes <string[]>] [-DscResource <string[]>] [-Command <string[]>] [<CommonParameters>]
+ [-ForceBootstrap] [-WhatIf] [-Confirm] [-PackageManagementProvider <string>] [-Scope <string>]
+ [-PublishLocation <string>] [-AllVersions] [-Filter <string>] [-Tag <string[]>]
+ [-Includes <string[]>] [-DscResource <string[]>] [-Command <string[]>] [<CommonParameters>]
 ```
 
 ### PSModule
 
 ```
 Save-Package [-Path <string>] [-LiteralPath <string>] [-Credential <pscredential>] [-Force]
-[-ForceBootstrap] [-WhatIf] [-Confirm] [-PackageManagementProvider <string>] [-Scope <string>]
-[-PublishLocation <string>] [-AllVersions] [-Filter <string>] [-Tag <string[]>]
-[-Includes <string[]>] [-DscResource <string[]>] [-Command <string[]>] [<CommonParameters>]
+ [-ForceBootstrap] [-WhatIf] [-Confirm] [-PackageManagementProvider <string>] [-Scope <string>]
+ [-PublishLocation <string>] [-AllVersions] [-Filter <string>] [-Tag <string[]>]
+ [-Includes <string[]>] [-DscResource <string[]>] [-Command <string[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.0/PackageManagement/Set-PackageSource.md
+++ b/reference/5.0/PackageManagement/Set-PackageSource.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 4/3/2019
+ms.date: 04/03/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -19,31 +19,31 @@ Replaces a package source for a specified package provider.
 
 ```
 Set-PackageSource [[-Name] <string>] [-Credential <pscredential>] [-Location <string>]
-[-NewLocation <string>] [-NewName <string>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ProviderName <string>] [<CommonParameters>]
+ [-NewLocation <string>] [-NewName <string>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-ProviderName <string>] [<CommonParameters>]
 ```
 
 ### SourceByInputObject
 
 ```
 Set-PackageSource -InputObject <PackageSource> [-Credential <pscredential>] [-NewLocation <string>]
-[-NewName <string>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-NewName <string>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PSModule:SourceByInputObject
 
 ```
 Set-PackageSource [-Credential <pscredential>] [-NewLocation <string>] [-NewName <string>]
-[-Trusted] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-PackageManagementProvider <string>]
-[-Scope <string>] [-PublishLocation <string>] [<CommonParameters>]
+ [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-PackageManagementProvider <string>]
+ [-Scope <string>] [-PublishLocation <string>] [<CommonParameters>]
 ```
 
 ### PSModule:SourceBySearch
 
 ```
 Set-PackageSource [-Credential <pscredential>] [-NewLocation <string>] [-NewName <string>]
-[-Trusted] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-PackageManagementProvider <string>]
-[-Scope <string>] [-PublishLocation <string>] [<CommonParameters>]
+ [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-PackageManagementProvider <string>]
+ [-Scope <string>] [-PublishLocation <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.0/PackageManagement/Uninstall-Package.md
+++ b/reference/5.0/PackageManagement/Uninstall-Package.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 5/24/2019
+ms.date: 05/24/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -19,59 +19,59 @@ Uninstalls one or more software packages.
 
 ```
 Uninstall-Package [-InputObject] <SoftwareIdentity[]> [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [<CommonParameters>]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ### PackageBySearch
 
 ```
 Uninstall-Package [-Name] <string[]> [-RequiredVersion <string>] [-MinimumVersion <string>]
-[-MaximumVersion <string>] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-ProviderName <string[]>] [<CommonParameters>]
+ [-MaximumVersion <string>] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ProviderName <string[]>] [<CommonParameters>]
 ```
 
 ### Programs:PackageByInputObject
 
 ```
 Uninstall-Package [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-IncludeWindowsInstaller]
-[-IncludeSystemComponent] [<CommonParameters>]
+ [-IncludeSystemComponent] [<CommonParameters>]
 ```
 
 ### Programs:PackageBySearch
 
 ```
 Uninstall-Package [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-IncludeWindowsInstaller]
-[-IncludeSystemComponent] [<CommonParameters>]
+ [-IncludeSystemComponent] [<CommonParameters>]
 ```
 
 ### msi:PackageByInputObject
 
 ```
 Uninstall-Package [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AdditionalArguments <string[]>]
-[<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### msi:PackageBySearch
 
 ```
 Uninstall-Package [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-AdditionalArguments <string[]>]
-[<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### PSModule:PackageByInputObject
 
 ```
 Uninstall-Package [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-PackageManagementProvider <string>] [-Location <string>] [-InstallUpdate]
-[-InstallationPolicy <string>] [-DestinationPath <string>] [<CommonParameters>]
+ [-PackageManagementProvider <string>] [-Location <string>] [-InstallUpdate]
+ [-InstallationPolicy <string>] [-DestinationPath <string>] [<CommonParameters>]
 ```
 
 ### PSModule:PackageBySearch
 
 ```
 Uninstall-Package [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-PackageManagementProvider <string>] [-Location <string>] [-InstallUpdate]
-[-InstallationPolicy <string>] [-DestinationPath <string>] [<CommonParameters>]
+ [-PackageManagementProvider <string>] [-Location <string>] [-InstallUpdate]
+ [-InstallationPolicy <string>] [-DestinationPath <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -276,7 +276,7 @@ Accept wildcard characters: False
 
 ### -Location
 
-Specifies a path to the input object. 
+Specifies a path to the input object.
 
 ```yaml
 Type: String

--- a/reference/5.0/PackageManagement/Unregister-PackageSource.md
+++ b/reference/5.0/PackageManagement/Unregister-PackageSource.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 5/24/2019
+ms.date: 05/24/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -19,30 +19,30 @@ Removes a registered package source.
 
 ```
 Unregister-PackageSource [[-Source] <string>] [-Location <string>] [-Credential <pscredential>]
-[-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <string>] [<CommonParameters>]
+ [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <string>] [<CommonParameters>]
 ```
 
 ### SourceByInputObject
 
 ```
 Unregister-PackageSource -InputObject <PackageSource[]> [-Credential <pscredential>] [-Force]
-[-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PSModule:SourceByInputObject
 
 ```
 Unregister-PackageSource [-Credential <pscredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <string>] [-Scope <string>] [-PublishLocation <string>]
-[<CommonParameters>]
+ [-Confirm] [-PackageManagementProvider <string>] [-Scope <string>] [-PublishLocation <string>]
+ [<CommonParameters>]
 ```
 
 ### PSModule:SourceBySearch
 
 ```
 Unregister-PackageSource [-Credential <pscredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <string>] [-Scope <string>] [-PublishLocation <string>]
-[<CommonParameters>]
+ [-Confirm] [-PackageManagementProvider <string>] [-Scope <string>] [-PublishLocation <string>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -240,7 +240,7 @@ Accept wildcard characters: False
 
 ### -Scope
 
-Specifies the scope of the Package Source. The acceptable values for this parameter are: AllUsers and CurrentUser. 
+Specifies the scope of the Package Source. The acceptable values for this parameter are: AllUsers and CurrentUser.
 
 ```yaml
 Type: String

--- a/reference/5.1/PackageManagement/Save-Package.md
+++ b/reference/5.1/PackageManagement/Save-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 4/3/2019
+ms.date: 04/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=517140
 schema: 2.0.0
 title: Save-Package
@@ -20,57 +20,57 @@ Saves packages to the local computer without installing them.
 
 ```
 Save-Package [-Name] <String[]> [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-Source <String[]>] [-Path <String>] [-LiteralPath <String>]
-[-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllVersions]
-[-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-Source <String[]>] [-Path <String>] [-LiteralPath <String>]
+ [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllVersions]
+ [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String[]>] [<CommonParameters>]
 ```
 
 ### PackageByInputObject
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] -InputObject <SoftwareIdentity>
-[-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllVersions]
-[-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllVersions]
+ [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### NuGet:PackageByInputObject
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>]
-[-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>]
+ [-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ### NuGet
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>]
-[-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>]
+ [-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageByInputObject
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-AllowPrereleaseVersions] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
-[-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
-[-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-AllowPrereleaseVersions] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
+ [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
+ [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-AllowPrereleaseVersions] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
-[-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
-[-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-AllowPrereleaseVersions] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
+ [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
+ [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/PackageManagement/Set-PackageSource.md
+++ b/reference/5.1/PackageManagement/Set-PackageSource.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 4/3/2019
+ms.date: 04/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=517141
 schema: 2.0.0
 title: Set-PackageSource
@@ -20,50 +20,50 @@ Replaces a package source for a specified package provider.
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[[-Name] <String>] [-Location <String>] [-NewLocation <String>] [-NewName <String>] [-Trusted]
-[-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String>] [<CommonParameters>]
+ [[-Name] <String>] [-Location <String>] [-NewLocation <String>] [-NewName <String>] [-Trusted]
+ [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String>] [<CommonParameters>]
 ```
 
 ### SourceByInputObject
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] -InputObject <PackageSource> [-Force]
-[-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] -InputObject <PackageSource> [-Force]
+ [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### NuGet:SourceByInputObject
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### NuGet:SourceBySearch
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### PowerShellGet:SourceByInputObject
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ### PowerShellGet:SourceBySearch
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/PackageManagement/Uninstall-Package.md
+++ b/reference/5.1/PackageManagement/Uninstall-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 5/24/2019
+ms.date: 05/24/2019
 online version: https://go.microsoft.com/fwlink/?linkid=517142
 schema: 2.0.0
 title: Uninstall-Package
@@ -20,73 +20,75 @@ Uninstalls one or more software packages.
 
 ```
 Uninstall-Package [-InputObject] <SoftwareIdentity[]> [-AllVersions] [-Force] [-ForceBootstrap]
-[-WhatIf] [-Confirm] [<CommonParameters>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PackageBySearch
 
 ```
 Uninstall-Package [-Name] <String[]> [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-ProviderName <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ProviderName <String[]>] [<CommonParameters>]
 ```
 
 ### msi:PackageByInputObject
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-AdditionalArguments <String[]>] [<CommonParameters>]
+ [-AdditionalArguments <String[]>] [<CommonParameters>]
 ```
 
 ### msi:PackageBySearch
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-AdditionalArguments <String[]>] [<CommonParameters>]
+ [-AdditionalArguments <String[]>] [<CommonParameters>]
 ```
 
 ### Programs:PackageByInputObject
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-IncludeWindowsInstaller] [-IncludeSystemComponent] [<CommonParameters>]
+ [-IncludeWindowsInstaller] [-IncludeSystemComponent] [<CommonParameters>]
 ```
 
 ### Programs:PackageBySearch
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-IncludeWindowsInstaller] [-IncludeSystemComponent] [<CommonParameters>]
+ [-IncludeWindowsInstaller] [-IncludeSystemComponent] [<CommonParameters>]
 ```
 
 ### NuGet:PackageByInputObject
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies] [<CommonParameters>]
+ [-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies]
+ [<CommonParameters>]
 ```
 
 ### NuGet:PackageBySearch
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies] [<CommonParameters>]
+ [-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies]
+ [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageByInputObject
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-Scope <String>]
-[-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber] [-SkipPublisherCheck]
-[-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber] [-SkipPublisherCheck]
+ [-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageBySearch
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-Scope <String>]
-[-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber] [-SkipPublisherCheck]
-[-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber] [-SkipPublisherCheck]
+ [-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/PackageManagement/Unregister-PackageSource.md
+++ b/reference/5.1/PackageManagement/Unregister-PackageSource.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 5/24/2019
+ms.date: 05/24/2019
 online version: https://go.microsoft.com/fwlink/?linkid=517143
 schema: 2.0.0
 title: Unregister-PackageSource
@@ -20,44 +20,44 @@ Removes a registered package source.
 
 ```
 Unregister-PackageSource [[-Source] <String>] [-Location <String>] [-Credential <PSCredential>]
-[-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String>] [<CommonParameters>]
+ [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String>] [<CommonParameters>]
 ```
 
 ### SourceByInputObject
 
 ```
 Unregister-PackageSource -InputObject <PackageSource[]> [-Credential <PSCredential>] [-Force]
-[-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### NuGet:SourceByInputObject
 
 ```
 Unregister-PackageSource [-Credential <PSCredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### NuGet:SourceBySearch
 
 ```
 Unregister-PackageSource [-Credential <PSCredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### PowerShellGet:SourceByInputObject
 
 ```
 Unregister-PackageSource [-Credential <PSCredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ### PowerShellGet:SourceBySearch
 
 ```
 Unregister-PackageSource [-Credential <PSCredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/PackageManagement/Save-Package.md
+++ b/reference/6/PackageManagement/Save-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 4/3/2019
+ms.date: 04/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096840
 schema: 2.0.0
 title: Save-Package
@@ -19,57 +19,57 @@ Saves packages to the local computer without installing them.
 
 ```
 Save-Package [-Name] <String[]> [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-Source <String[]>] [-Path <String>] [-LiteralPath <String>]
-[-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllVersions]
-[-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-Source <String[]>] [-Path <String>] [-LiteralPath <String>]
+ [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllVersions]
+ [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String[]>] [<CommonParameters>]
 ```
 
 ### PackageByInputObject
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] -InputObject <SoftwareIdentity>
-[-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllVersions]
-[-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllVersions]
+ [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### NuGet:PackageByInputObject
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>]
-[-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>]
+ [-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ### NuGet
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>]
-[-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>]
+ [-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageByInputObject
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-AllowPrereleaseVersions] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
-[-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
-[-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-AllowPrereleaseVersions] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
+ [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
+ [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-AllowPrereleaseVersions] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
-[-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
-[-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-AllowPrereleaseVersions] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
+ [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
+ [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/PackageManagement/Set-PackageSource.md
+++ b/reference/6/PackageManagement/Set-PackageSource.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 4/3/2019
+ms.date: 04/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096434
 schema: 2.0.0
 title: Set-PackageSource
@@ -19,50 +19,50 @@ Replaces a package source for a specified package provider.
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[[-Name] <String>] [-Location <String>] [-NewLocation <String>] [-NewName <String>] [-Trusted]
-[-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String>] [<CommonParameters>]
+ [[-Name] <String>] [-Location <String>] [-NewLocation <String>] [-NewName <String>] [-Trusted]
+ [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String>] [<CommonParameters>]
 ```
 
 ### SourceByInputObject
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] -InputObject <PackageSource> [-Force]
-[-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] -InputObject <PackageSource> [-Force]
+ [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### NuGet:SourceByInputObject
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### NuGet:SourceBySearch
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### PowerShellGet:SourceByInputObject
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ### PowerShellGet:SourceBySearch
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/PackageManagement/Uninstall-Package.md
+++ b/reference/6/PackageManagement/Uninstall-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 5/24/2019
+ms.date: 05/24/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096844
 schema: 2.0.0
 title: Uninstall-Package
@@ -20,45 +20,47 @@ Uninstalls one or more software packages.
 
 ```
 Uninstall-Package [-InputObject] <SoftwareIdentity[]> [-AllVersions] [-Force] [-ForceBootstrap]
-[-WhatIf] [-Confirm] [<CommonParameters>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PackageBySearch
 
 ```
 Uninstall-Package [-Name] <String[]> [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-ProviderName <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ProviderName <String[]>] [<CommonParameters>]
 ```
 
 ### NuGet:PackageByInputObject
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies] [<CommonParameters>]
+ [-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies]
+ [<CommonParameters>]
 ```
 
 ### NuGet:PackageBySearch
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies] [<CommonParameters>]
+ [-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies]
+ [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageByInputObject
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-Scope <String>]
-[-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber] [-SkipPublisherCheck]
-[-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber] [-SkipPublisherCheck]
+ [-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageBySearch
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-Scope <String>]
-[-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber] [-SkipPublisherCheck]
-[-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber] [-SkipPublisherCheck]
+ [-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/PackageManagement/Unregister-PackageSource.md
+++ b/reference/6/PackageManagement/Unregister-PackageSource.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 5/24/2019
+ms.date: 05/24/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096538
 schema: 2.0.0
 title: Unregister-PackageSource
@@ -20,44 +20,44 @@ Removes a registered package source.
 
 ```
 Unregister-PackageSource [[-Source] <String>] [-Location <String>] [-Credential <PSCredential>]
-[-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String>] [<CommonParameters>]
+ [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String>] [<CommonParameters>]
 ```
 
 ### SourceByInputObject
 
 ```
 Unregister-PackageSource -InputObject <PackageSource[]> [-Credential <PSCredential>] [-Force]
-[-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### NuGet:SourceByInputObject
 
 ```
 Unregister-PackageSource [-Credential <PSCredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### NuGet:SourceBySearch
 
 ```
 Unregister-PackageSource [-Credential <PSCredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### PowerShellGet:SourceByInputObject
 
 ```
 Unregister-PackageSource [-Credential <PSCredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ### PowerShellGet:SourceBySearch
 
 ```
 Unregister-PackageSource [-Credential <PSCredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/PackageManagement/Save-Package.md
+++ b/reference/7/PackageManagement/Save-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 4/3/2019
+ms.date: 04/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096941
 schema: 2.0.0
 title: Save-Package
@@ -19,57 +19,57 @@ Saves packages to the local computer without installing them.
 
 ```
 Save-Package [-Name] <String[]> [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-Source <String[]>] [-Path <String>] [-LiteralPath <String>]
-[-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllVersions]
-[-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-Source <String[]>] [-Path <String>] [-LiteralPath <String>]
+ [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllVersions]
+ [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String[]>] [<CommonParameters>]
 ```
 
 ### PackageByInputObject
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] -InputObject <SoftwareIdentity>
-[-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllVersions]
-[-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Credential <PSCredential>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-AllVersions]
+ [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### NuGet:PackageByInputObject
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>]
-[-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>]
+ [-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ### NuGet
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>]
-[-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ConfigFile <String>] [-SkipValidate] [-Headers <String[]>] [-FilterOnTag <String[]>]
+ [-Contains <String>] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageByInputObject
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-AllowPrereleaseVersions] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
-[-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
-[-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-AllowPrereleaseVersions] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
+ [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
+ [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [<CommonParameters>]
 ```
 
 ### PowerShellGet
 
 ```
 Save-Package [-Path <String>] [-LiteralPath <String>] [-Credential <PSCredential>] [-Proxy <Uri>]
-[-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-AllowPrereleaseVersions] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
-[-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
-[-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-AllowPrereleaseVersions] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [-Type <String>]
+ [-Filter <String>] [-Tag <String[]>] [-Includes <String[]>] [-DscResource <String[]>]
+ [-RoleCapability <String[]>] [-Command <String[]>] [-AcceptLicense] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/PackageManagement/Set-PackageSource.md
+++ b/reference/7/PackageManagement/Set-PackageSource.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 4/3/2019
+ms.date: 04/03/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096626
 schema: 2.0.0
 title: Set-PackageSource
@@ -19,50 +19,50 @@ Replaces a package source for a specified package provider.
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[[-Name] <String>] [-Location <String>] [-NewLocation <String>] [-NewName <String>] [-Trusted]
-[-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String>] [<CommonParameters>]
+ [[-Name] <String>] [-Location <String>] [-NewLocation <String>] [-NewName <String>] [-Trusted]
+ [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String>] [<CommonParameters>]
 ```
 
 ### SourceByInputObject
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] -InputObject <PackageSource> [-Force]
-[-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] -InputObject <PackageSource> [-Force]
+ [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### NuGet:SourceByInputObject
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### NuGet:SourceBySearch
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### PowerShellGet:SourceByInputObject
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ### PowerShellGet:SourceBySearch
 
 ```
 Set-PackageSource [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Credential <PSCredential>]
-[-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-NewLocation <String>] [-NewName <String>] [-Trusted] [-Force] [-ForceBootstrap] [-WhatIf]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/PackageManagement/Uninstall-Package.md
+++ b/reference/7/PackageManagement/Uninstall-Package.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 5/24/2019
+ms.date: 05/24/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096939
 schema: 2.0.0
 title: Uninstall-Package
@@ -20,45 +20,47 @@ Uninstalls one or more software packages.
 
 ```
 Uninstall-Package [-InputObject] <SoftwareIdentity[]> [-AllVersions] [-Force] [-ForceBootstrap]
-[-WhatIf] [-Confirm] [<CommonParameters>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PackageBySearch
 
 ```
 Uninstall-Package [-Name] <String[]> [-RequiredVersion <String>] [-MinimumVersion <String>]
-[-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-ProviderName <String[]>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
+ [-ProviderName <String[]>] [<CommonParameters>]
 ```
 
 ### NuGet:PackageByInputObject
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies] [<CommonParameters>]
+ [-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies]
+ [<CommonParameters>]
 ```
 
 ### NuGet:PackageBySearch
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm]
-[-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies] [<CommonParameters>]
+ [-Destination <String>] [-ExcludeVersion] [-Scope <String>] [-SkipDependencies]
+ [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageByInputObject
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-Scope <String>]
-[-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber] [-SkipPublisherCheck]
-[-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber] [-SkipPublisherCheck]
+ [-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ### PowerShellGet:PackageBySearch
 
 ```
 Uninstall-Package [-AllVersions] [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-Scope <String>]
-[-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber] [-SkipPublisherCheck]
-[-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions] [<CommonParameters>]
+ [-PackageManagementProvider <String>] [-Type <String>] [-AllowClobber] [-SkipPublisherCheck]
+ [-InstallUpdate] [-NoPathUpdate] [-AllowPrereleaseVersions] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/PackageManagement/Unregister-PackageSource.md
+++ b/reference/7/PackageManagement/Unregister-PackageSource.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PackageManagement
-ms.date: 5/24/2019
+ms.date: 05/24/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096631
 schema: 2.0.0
 title: Unregister-PackageSource
@@ -20,44 +20,44 @@ Removes a registered package source.
 
 ```
 Unregister-PackageSource [[-Source] <String>] [-Location <String>] [-Credential <PSCredential>]
-[-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String>] [<CommonParameters>]
+ [-Force] [-ForceBootstrap] [-WhatIf] [-Confirm] [-ProviderName <String>] [<CommonParameters>]
 ```
 
 ### SourceByInputObject
 
 ```
 Unregister-PackageSource -InputObject <PackageSource[]> [-Credential <PSCredential>] [-Force]
-[-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ForceBootstrap] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### NuGet:SourceByInputObject
 
 ```
 Unregister-PackageSource [-Credential <PSCredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### NuGet:SourceBySearch
 
 ```
 Unregister-PackageSource [-Credential <PSCredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
+ [-Confirm] [-ConfigFile <String>] [-SkipValidate] [<CommonParameters>]
 ```
 
 ### PowerShellGet:SourceByInputObject
 
 ```
 Unregister-PackageSource [-Credential <PSCredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ### PowerShellGet:SourceBySearch
 
 ```
 Unregister-PackageSource [-Credential <PSCredential>] [-Force] [-ForceBootstrap] [-WhatIf]
-[-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
-[-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
+ [-Confirm] [-PackageManagementProvider <String>] [-PublishLocation <String>]
+ [-ScriptSourceLocation <String>] [-ScriptPublishLocation <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

- Corrected the parameter set spacing and YAML header ms.date
- Related to updates for #3740
- Fixes [AB#1568843](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1568843)

Save-Package
Set-PackageSource
Uninstall-Package
Unregister-PackageSource