### PR TITLE
Fix #4551 - added version info to parameter

### DIFF
--- a/reference/6/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/6/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -18,22 +18,22 @@ Creates a record of all or part of a PowerShell session to a text file.
 ### ByPath (Default)
 
 ```
-Start-Transcript [[-Path] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-UseMinimalHeader] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Start-Transcript [[-Path] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader]
+ [-UseMinimalHeader] [-WhatIf] [-Confirm]  [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Start-Transcript [[-LiteralPath] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-UseMinimalHeader] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Start-Transcript [[-LiteralPath] <String>] [-Append] [-Force] [-NoClobber]
+ [-IncludeInvocationHeader] [-UseMinimalHeader] [-WhatIf] [-Confirm]  [<CommonParameters>]
 ```
 
 ### ByOutputDirectory
 
 ```
-Start-Transcript [[-OutputDirectory] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-UseMinimalHeader]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Start-Transcript [[-OutputDirectory] <String>] [-Append] [-Force] [-NoClobber]
+ [-IncludeInvocationHeader] [-UseMinimalHeader] [-WhatIf] [-Confirm]  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -42,7 +42,7 @@ The `Start-Transcript` cmdlet creates a record of all or part of a PowerShell se
 file. The transcript includes all command that the user types and all output that appears on the
 console.
 
-Starting in Windows PowerShell 5.0, `Start-Transcript` includes the host name in the generated file
+Starting in Windows PowerShell 5.0, `Start-Transcript` includes the hostname in the generated file
 name of all transcripts. This is especially useful when your enterprise's logging is centralized.
 Files that are created by the `Start-Transcript` cmdlet include random characters in names to
 prevent potential overwrites or duplication when two or more transcripts are started simultaneously.
@@ -124,7 +124,8 @@ Accept wildcard characters: False
 
 ### -UseMinimalHeader
 
-Prepend a short header to the transcript, instead of the detailed header included by default.
+Prepend a short header to the transcript, instead of the detailed header included by default. This
+parameter was added in PowerShell 6.2.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/7/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/7/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -18,22 +18,22 @@ Creates a record of all or part of a PowerShell session to a text file.
 ### ByPath (Default)
 
 ```
-Start-Transcript [[-Path] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-UseMinimalHeader] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Start-Transcript [[-Path] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader]
+ [-UseMinimalHeader] [-WhatIf] [-Confirm]  [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Start-Transcript [[-LiteralPath] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-UseMinimalHeader] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Start-Transcript [[-LiteralPath] <String>] [-Append] [-Force] [-NoClobber]
+ [-IncludeInvocationHeader] [-UseMinimalHeader] [-WhatIf] [-Confirm]  [<CommonParameters>]
 ```
 
 ### ByOutputDirectory
 
 ```
-Start-Transcript [[-OutputDirectory] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-UseMinimalHeader]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Start-Transcript [[-OutputDirectory] <String>] [-Append] [-Force] [-NoClobber]
+ [-IncludeInvocationHeader] [-UseMinimalHeader] [-WhatIf] [-Confirm]  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -42,7 +42,7 @@ The `Start-Transcript` cmdlet creates a record of all or part of a PowerShell se
 file. The transcript includes all command that the user types and all output that appears on the
 console.
 
-Starting in Windows PowerShell 5.0, `Start-Transcript` includes the host name in the generated file
+Starting in Windows PowerShell 5.0, `Start-Transcript` includes the hostname in the generated file
 name of all transcripts. This is especially useful when your enterprise's logging is centralized.
 Files that are created by the `Start-Transcript` cmdlet include random characters in names to
 prevent potential overwrites or duplication when two or more transcripts are started simultaneously.
@@ -124,7 +124,8 @@ Accept wildcard characters: False
 
 ### -UseMinimalHeader
 
-Prepend a short header to the transcript, instead of the detailed header included by default.
+Prepend a short header to the transcript, instead of the detailed header included by default. This
+parameter was added in PowerShell 6.2.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->

Fixes [AB#1569991](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1569991)
Fixes #4551 

Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
