### PR TITLE
Fixes #4545 - Added a splatting example

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -1,55 +1,56 @@
 ﻿---
-ms.date:  01/03/2018
+ms.date:  07/23/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Remote_Variables
 ---
+
 # About Remote Variables
 
-## Short Description
+## Short description
+
 Explains how to use local and remote variables in remote commands.
 
-## Long Description
+## Long description
 
-You can use variables in commands that you run on remote computers. Simply
-assign a value to the variable and then use the variable in place of the value.
+You can use variables in commands that you run on remote computers. Assign a
+value to the variable and then use the variable in place of the value.
 
 By default, the variables in remote commands are assumed to be defined in the
-session in which the command runs. You can also use variables that are defined
-in the local session, but you must identify them as local variables in the
-command.
+session that runs the command. Variables that are defined in a local session,
+must be identified as local variables in the command.
 
 ## Using remote variables
 
 PowerShell assumes that the variables used in remote commands are defined in
 the session in which the command runs.
 
-In the following example, the `$ps` variable is defined in the temporary
-session in which the `Get-WinEvent` command runs.
+In this example, the `$ps` variable is defined in the temporary session in
+which the `Get-WinEvent` command runs.
 
 ```powershell
 Invoke-Command -ComputerName S1 -ScriptBlock {
-  $ps = "Windows PowerShell"; Get-WinEvent -LogName $ps
+  $ps = "*PowerShell*"; Get-WinEvent -LogName $ps
 }
 ```
 
-Similarly, when the command runs in a persistent session (PSSession), the
-remote variable must be defined in the same PSSession.
+When the command runs in a persistent session, **PSSession**, the remote
+variable must be defined in that session.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
-Invoke-Command -Session $s -ScriptBlock {$ps = "Windows PowerShell"}
+Invoke-Command -Session $s -ScriptBlock {$ps = "*PowerShell*"}
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $ps}
 ```
 
 ## Using local variables
 
-You can also use local variables in remote commands, but you must indicate that
-the variable is defined in the local session.
+You can use local variables in remote commands, but the variable must be
+defined in the local session.
 
-Beginning in Windows PowerShell 3.0, you can use the Using scope modifier to
-identify a local variable in a remote command.
+Beginning in PowerShell 3.0, you can use the `Using` scope modifier to identify
+a local variable in a remote command.
 
 The syntax of `Using` is as follows:
 
@@ -58,64 +59,80 @@ $Using:<VariableName>
 ```
 
 In the following example, the `$ps` variable is created in the local session,
-but is used in the session in which the command runs. The Using scope modifier
-identifies `$ps` as a local variable.
+but is used in the session in which the command runs. The `Using` scope
+modifier identifies `$ps` as a local variable.
 
 ```powershell
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
   Get-WinEvent -LogName $Using:ps
 }
 ```
 
-You can also use the `Using` scope modifier in PSSessions.
+The `Using` scope modifier can be used in a **PSSession**.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-## Using local variables in Windows PowerShell 2.0
+### Using splatting
+
+PowerShell splatting passes a collection of parameter names and values to a
+command. For more information, see [about_Splatting](about_Splatting.md).
+
+In this example, the splatting variable, `$Splat` is a hash table that is set
+up on the local computer. The `Invoke-Command` connects to a remote computer
+session. The **ScriptBlock** uses the `Using` scope modifier with the At (`@`)
+symbol to represent the splatted variable.
+
+```powershell
+$Splat = @{ Name = "Win*"; Include = "WinRM" }
+Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
+```
+
+## Using local variables in PowerShell 2.0
 
 You can use local variables in a remote command by defining parameters for the
-remote command and using the ArgumentList parameter of the `Invoke-Command`
+remote command and using the **ArgumentList** parameter of the `Invoke-Command`
 cmdlet to specify the local variable as the parameter value.
 
-This command format is valid on Windows PowerShell 2.0 and later versions of
-Windows PowerShell and PowerShell Core.
+The following command format is valid on PowerShell 2.0 and later versions:
 
-- Use the param keyword to define parameters for the remote command. The
-  parameter names are placeholders that do not need to match the name of the
-  local variable.
+- Use the `param` keyword to define parameters for the remote command. The
+  parameter names are placeholders that don't need to match the local
+  variable's name.
 
-- Use the parameters defined by the param keyword in the command.
+- Use the parameters defined by the `param` keyword in the command.
 
-- Use the ArgumentList parameter of the `Invoke-Command` cmdlet to specify the
-  local variable as the parameter value.
+- Use the **ArgumentList** parameter of the `Invoke-Command` cmdlet to specify
+  the local variable as the parameter value.
 
 For example, the following commands define the `$ps` variable in the local
 session and then use it in a remote command. The command uses `$log` as the
 parameter name and the local variable, `$ps`, as its value.
 
 ```powershell
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
   param($log)
   Get-WinEvent -LogName $log
 } -ArgumentList $ps
 ```
 
-## SEE ALSO
-
-[about_Remote](about_Remote.md)
+## See also
 
 [about_PSSessions](about_PSSessions.md)
 
+[about_Remote](about_Remote.md)
+
 [about_Scopes](about_Scopes.md)
 
-[Invoke-Command](../Invoke-Command.md)
+[about_Splatting](about_Splatting.md)
 
 [Enter-PSSession](../Enter-PSSession.md)
+
+[Invoke-Command](../Invoke-Command.md)
 
 [New-PSSession](../New-PSSession.md)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -1,55 +1,56 @@
 ---
-ms.date:  01/03/2018
+ms.date:  07/23/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Remote_Variables
 ---
+
 # About Remote Variables
 
-## Short Description
+## Short description
+
 Explains how to use local and remote variables in remote commands.
 
-## Long Description
+## Long description
 
-You can use variables in commands that you run on remote computers. Simply
-assign a value to the variable and then use the variable in place of the value.
+You can use variables in commands that you run on remote computers. Assign a
+value to the variable and then use the variable in place of the value.
 
 By default, the variables in remote commands are assumed to be defined in the
-session in which the command runs. You can also use variables that are defined
-in the local session, but you must identify them as local variables in the
-command.
+session that runs the command. Variables that are defined in a local session,
+must be identified as local variables in the command.
 
 ## Using remote variables
 
 PowerShell assumes that the variables used in remote commands are defined in
 the session in which the command runs.
 
-In the following example, the `$ps` variable is defined in the temporary
-session in which the `Get-WinEvent` command runs.
+In this example, the `$ps` variable is defined in the temporary session in
+which the `Get-WinEvent` command runs.
 
 ```powershell
 Invoke-Command -ComputerName S1 -ScriptBlock {
-  $ps = "Windows PowerShell"; Get-WinEvent -LogName $ps
+  $ps = "*PowerShell*"; Get-WinEvent -LogName $ps
 }
 ```
 
-Similarly, when the command runs in a persistent session (PSSession), the
-remote variable must be defined in the same PSSession.
+When the command runs in a persistent session, **PSSession**, the remote
+variable must be defined in that session.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
-Invoke-Command -Session $s -ScriptBlock {$ps = "Windows PowerShell"}
+Invoke-Command -Session $s -ScriptBlock {$ps = "*PowerShell*"}
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $ps}
 ```
 
 ## Using local variables
 
-You can also use local variables in remote commands, but you must indicate that
-the variable is defined in the local session.
+You can use local variables in remote commands, but the variable must be
+defined in the local session.
 
-Beginning in Windows PowerShell 3.0, you can use the Using scope modifier to
-identify a local variable in a remote command.
+Beginning in PowerShell 3.0, you can use the `Using` scope modifier to identify
+a local variable in a remote command.
 
 The syntax of `Using` is as follows:
 
@@ -58,64 +59,80 @@ $Using:<VariableName>
 ```
 
 In the following example, the `$ps` variable is created in the local session,
-but is used in the session in which the command runs. The Using scope modifier
-identifies `$ps` as a local variable.
+but is used in the session in which the command runs. The `Using` scope
+modifier identifies `$ps` as a local variable.
 
 ```powershell
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
   Get-WinEvent -LogName $Using:ps
 }
 ```
 
-You can also use the `Using` scope modifier in PSSessions.
+The `Using` scope modifier can be used in a **PSSession**.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-## Using local variables in Windows PowerShell 2.0
+### Using splatting
+
+PowerShell splatting passes a collection of parameter names and values to a
+command. For more information, see [about_Splatting](about_Splatting.md).
+
+In this example, the splatting variable, `$Splat` is a hash table that is set
+up on the local computer. The `Invoke-Command` connects to a remote computer
+session. The **ScriptBlock** uses the `Using` scope modifier with the At (`@`)
+symbol to represent the splatted variable.
+
+```powershell
+$Splat = @{ Name = "Win*"; Include = "WinRM" }
+Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
+```
+
+## Using local variables in PowerShell 2.0
 
 You can use local variables in a remote command by defining parameters for the
-remote command and using the ArgumentList parameter of the `Invoke-Command`
+remote command and using the **ArgumentList** parameter of the `Invoke-Command`
 cmdlet to specify the local variable as the parameter value.
 
-This command format is valid on Windows PowerShell 2.0 and later versions of
-Windows PowerShell and PowerShell Core.
+The following command format is valid on PowerShell 2.0 and later versions:
 
-- Use the param keyword to define parameters for the remote command. The
-  parameter names are placeholders that do not need to match the name of the
-  local variable.
+- Use the `param` keyword to define parameters for the remote command. The
+  parameter names are placeholders that don't need to match the local
+  variable's name.
 
-- Use the parameters defined by the param keyword in the command.
+- Use the parameters defined by the `param` keyword in the command.
 
-- Use the ArgumentList parameter of the `Invoke-Command` cmdlet to specify the
-  local variable as the parameter value.
+- Use the **ArgumentList** parameter of the `Invoke-Command` cmdlet to specify
+  the local variable as the parameter value.
 
 For example, the following commands define the `$ps` variable in the local
 session and then use it in a remote command. The command uses `$log` as the
 parameter name and the local variable, `$ps`, as its value.
 
 ```powershell
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
   param($log)
   Get-WinEvent -LogName $log
 } -ArgumentList $ps
 ```
 
-## SEE ALSO
-
-[about_Remote](about_Remote.md)
+## See also
 
 [about_PSSessions](about_PSSessions.md)
 
+[about_Remote](about_Remote.md)
+
 [about_Scopes](about_Scopes.md)
 
-[Invoke-Command](../Invoke-Command.md)
+[about_Splatting](about_Splatting.md)
 
 [Enter-PSSession](../Enter-PSSession.md)
+
+[Invoke-Command](../Invoke-Command.md)
 
 [New-PSSession](../New-PSSession.md)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -1,55 +1,56 @@
 ---
-ms.date:  01/03/2018
+ms.date:  07/23/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Remote_Variables
 ---
+
 # About Remote Variables
 
-## Short Description
+## Short description
+
 Explains how to use local and remote variables in remote commands.
 
-## Long Description
+## Long description
 
-You can use variables in commands that you run on remote computers. Simply
-assign a value to the variable and then use the variable in place of the value.
+You can use variables in commands that you run on remote computers. Assign a
+value to the variable and then use the variable in place of the value.
 
 By default, the variables in remote commands are assumed to be defined in the
-session in which the command runs. You can also use variables that are defined
-in the local session, but you must identify them as local variables in the
-command.
+session that runs the command. Variables that are defined in a local session,
+must be identified as local variables in the command.
 
 ## Using remote variables
 
 PowerShell assumes that the variables used in remote commands are defined in
 the session in which the command runs.
 
-In the following example, the `$ps` variable is defined in the temporary
-session in which the `Get-WinEvent` command runs.
+In this example, the `$ps` variable is defined in the temporary session in
+which the `Get-WinEvent` command runs.
 
 ```powershell
 Invoke-Command -ComputerName S1 -ScriptBlock {
-  $ps = "Windows PowerShell"; Get-WinEvent -LogName $ps
+  $ps = "*PowerShell*"; Get-WinEvent -LogName $ps
 }
 ```
 
-Similarly, when the command runs in a persistent session (PSSession), the
-remote variable must be defined in the same PSSession.
+When the command runs in a persistent session, **PSSession**, the remote
+variable must be defined in that session.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
-Invoke-Command -Session $s -ScriptBlock {$ps = "Windows PowerShell"}
+Invoke-Command -Session $s -ScriptBlock {$ps = "*PowerShell*"}
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $ps}
 ```
 
 ## Using local variables
 
-You can also use local variables in remote commands, but you must indicate that
-the variable is defined in the local session.
+You can use local variables in remote commands, but the variable must be
+defined in the local session.
 
-Beginning in Windows PowerShell 3.0, you can use the Using scope modifier to
-identify a local variable in a remote command.
+Beginning in PowerShell 3.0, you can use the `Using` scope modifier to identify
+a local variable in a remote command.
 
 The syntax of `Using` is as follows:
 
@@ -58,64 +59,80 @@ $Using:<VariableName>
 ```
 
 In the following example, the `$ps` variable is created in the local session,
-but is used in the session in which the command runs. The Using scope modifier
-identifies `$ps` as a local variable.
+but is used in the session in which the command runs. The `Using` scope
+modifier identifies `$ps` as a local variable.
 
 ```powershell
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
   Get-WinEvent -LogName $Using:ps
 }
 ```
 
-You can also use the `Using` scope modifier in PSSessions.
+The `Using` scope modifier can be used in a **PSSession**.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-## Using local variables in Windows PowerShell 2.0
+### Using splatting
+
+PowerShell splatting passes a collection of parameter names and values to a
+command. For more information, see [about_Splatting](about_Splatting.md).
+
+In this example, the splatting variable, `$Splat` is a hash table that is set
+up on the local computer. The `Invoke-Command` connects to a remote computer
+session. The **ScriptBlock** uses the `Using` scope modifier with the At (`@`)
+symbol to represent the splatted variable.
+
+```powershell
+$Splat = @{ Name = "Win*"; Include = "WinRM" }
+Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
+```
+
+## Using local variables in PowerShell 2.0
 
 You can use local variables in a remote command by defining parameters for the
-remote command and using the ArgumentList parameter of the `Invoke-Command`
+remote command and using the **ArgumentList** parameter of the `Invoke-Command`
 cmdlet to specify the local variable as the parameter value.
 
-This command format is valid on Windows PowerShell 2.0 and later versions of
-Windows PowerShell and PowerShell Core.
+The following command format is valid on PowerShell 2.0 and later versions:
 
-- Use the param keyword to define parameters for the remote command. The
-  parameter names are placeholders that do not need to match the name of the
-  local variable.
+- Use the `param` keyword to define parameters for the remote command. The
+  parameter names are placeholders that don't need to match the local
+  variable's name.
 
-- Use the parameters defined by the param keyword in the command.
+- Use the parameters defined by the `param` keyword in the command.
 
-- Use the ArgumentList parameter of the `Invoke-Command` cmdlet to specify the
-  local variable as the parameter value.
+- Use the **ArgumentList** parameter of the `Invoke-Command` cmdlet to specify
+  the local variable as the parameter value.
 
 For example, the following commands define the `$ps` variable in the local
 session and then use it in a remote command. The command uses `$log` as the
 parameter name and the local variable, `$ps`, as its value.
 
 ```powershell
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
   param($log)
   Get-WinEvent -LogName $log
 } -ArgumentList $ps
 ```
 
-## SEE ALSO
-
-[about_Remote](about_Remote.md)
+## See also
 
 [about_PSSessions](about_PSSessions.md)
 
+[about_Remote](about_Remote.md)
+
 [about_Scopes](about_Scopes.md)
 
-[Invoke-Command](../Invoke-Command.md)
+[about_Splatting](about_Splatting.md)
 
 [Enter-PSSession](../Enter-PSSession.md)
+
+[Invoke-Command](../Invoke-Command.md)
 
 [New-PSSession](../New-PSSession.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -1,55 +1,56 @@
 ---
-ms.date:  01/03/2018
+ms.date:  07/23/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Remote_Variables
 ---
+
 # About Remote Variables
 
-## Short Description
+## Short description
+
 Explains how to use local and remote variables in remote commands.
 
-## Long Description
+## Long description
 
-You can use variables in commands that you run on remote computers. Simply
-assign a value to the variable and then use the variable in place of the value.
+You can use variables in commands that you run on remote computers. Assign a
+value to the variable and then use the variable in place of the value.
 
 By default, the variables in remote commands are assumed to be defined in the
-session in which the command runs. You can also use variables that are defined
-in the local session, but you must identify them as local variables in the
-command.
+session that runs the command. Variables that are defined in a local session,
+must be identified as local variables in the command.
 
 ## Using remote variables
 
 PowerShell assumes that the variables used in remote commands are defined in
 the session in which the command runs.
 
-In the following example, the `$ps` variable is defined in the temporary
-session in which the `Get-WinEvent` command runs.
+In this example, the `$ps` variable is defined in the temporary session in
+which the `Get-WinEvent` command runs.
 
 ```powershell
 Invoke-Command -ComputerName S1 -ScriptBlock {
-  $ps = "Windows PowerShell"; Get-WinEvent -LogName $ps
+  $ps = "*PowerShell*"; Get-WinEvent -LogName $ps
 }
 ```
 
-Similarly, when the command runs in a persistent session (PSSession), the
-remote variable must be defined in the same PSSession.
+When the command runs in a persistent session, **PSSession**, the remote
+variable must be defined in that session.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
-Invoke-Command -Session $s -ScriptBlock {$ps = "Windows PowerShell"}
+Invoke-Command -Session $s -ScriptBlock {$ps = "*PowerShell*"}
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $ps}
 ```
 
 ## Using local variables
 
-You can also use local variables in remote commands, but you must indicate that
-the variable is defined in the local session.
+You can use local variables in remote commands, but the variable must be
+defined in the local session.
 
-Beginning in Windows PowerShell 3.0, you can use the Using scope modifier to
-identify a local variable in a remote command.
+Beginning in PowerShell 3.0, you can use the `Using` scope modifier to identify
+a local variable in a remote command.
 
 The syntax of `Using` is as follows:
 
@@ -58,64 +59,80 @@ $Using:<VariableName>
 ```
 
 In the following example, the `$ps` variable is created in the local session,
-but is used in the session in which the command runs. The Using scope modifier
-identifies `$ps` as a local variable.
+but is used in the session in which the command runs. The `Using` scope
+modifier identifies `$ps` as a local variable.
 
 ```powershell
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
   Get-WinEvent -LogName $Using:ps
 }
 ```
 
-You can also use the `Using` scope modifier in PSSessions.
+The `Using` scope modifier can be used in a **PSSession**.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-## Using local variables in Windows PowerShell 2.0
+### Using splatting
+
+PowerShell splatting passes a collection of parameter names and values to a
+command. For more information, see [about_Splatting](about_Splatting.md).
+
+In this example, the splatting variable, `$Splat` is a hash table that is set
+up on the local computer. The `Invoke-Command` connects to a remote computer
+session. The **ScriptBlock** uses the `Using` scope modifier with the At (`@`)
+symbol to represent the splatted variable.
+
+```powershell
+$Splat = @{ Name = "Win*"; Include = "WinRM" }
+Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
+```
+
+## Using local variables in PowerShell 2.0
 
 You can use local variables in a remote command by defining parameters for the
-remote command and using the ArgumentList parameter of the `Invoke-Command`
+remote command and using the **ArgumentList** parameter of the `Invoke-Command`
 cmdlet to specify the local variable as the parameter value.
 
-This command format is valid on Windows PowerShell 2.0 and later versions of
-Windows PowerShell and PowerShell Core.
+The following command format is valid on PowerShell 2.0 and later versions:
 
-- Use the param keyword to define parameters for the remote command. The
-  parameter names are placeholders that do not need to match the name of the
-  local variable.
+- Use the `param` keyword to define parameters for the remote command. The
+  parameter names are placeholders that don't need to match the local
+  variable's name.
 
-- Use the parameters defined by the param keyword in the command.
+- Use the parameters defined by the `param` keyword in the command.
 
-- Use the ArgumentList parameter of the `Invoke-Command` cmdlet to specify the
-  local variable as the parameter value.
+- Use the **ArgumentList** parameter of the `Invoke-Command` cmdlet to specify
+  the local variable as the parameter value.
 
 For example, the following commands define the `$ps` variable in the local
 session and then use it in a remote command. The command uses `$log` as the
 parameter name and the local variable, `$ps`, as its value.
 
 ```powershell
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
   param($log)
   Get-WinEvent -LogName $log
 } -ArgumentList $ps
 ```
 
-## SEE ALSO
-
-[about_Remote](about_Remote.md)
+## See also
 
 [about_PSSessions](about_PSSessions.md)
 
+[about_Remote](about_Remote.md)
+
 [about_Scopes](about_Scopes.md)
 
-[Invoke-Command](../Invoke-Command.md)
+[about_Splatting](about_Splatting.md)
 
 [Enter-PSSession](../Enter-PSSession.md)
+
+[Invoke-Command](../Invoke-Command.md)
 
 [New-PSSession](../New-PSSession.md)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -1,55 +1,56 @@
 ---
-ms.date:  01/03/2018
+ms.date:  07/23/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Remote_Variables
 ---
+
 # About Remote Variables
 
-## Short Description
+## Short description
+
 Explains how to use local and remote variables in remote commands.
 
-## Long Description
+## Long description
 
-You can use variables in commands that you run on remote computers. Simply
-assign a value to the variable and then use the variable in place of the value.
+You can use variables in commands that you run on remote computers. Assign a
+value to the variable and then use the variable in place of the value.
 
 By default, the variables in remote commands are assumed to be defined in the
-session in which the command runs. You can also use variables that are defined
-in the local session, but you must identify them as local variables in the
-command.
+session that runs the command. Variables that are defined in a local session,
+must be identified as local variables in the command.
 
 ## Using remote variables
 
 PowerShell assumes that the variables used in remote commands are defined in
 the session in which the command runs.
 
-In the following example, the `$ps` variable is defined in the temporary
-session in which the `Get-WinEvent` command runs.
+In this example, the `$ps` variable is defined in the temporary session in
+which the `Get-WinEvent` command runs.
 
 ```powershell
 Invoke-Command -ComputerName S1 -ScriptBlock {
-  $ps = "Windows PowerShell"; Get-WinEvent -LogName $ps
+  $ps = "*PowerShell*"; Get-WinEvent -LogName $ps
 }
 ```
 
-Similarly, when the command runs in a persistent session (PSSession), the
-remote variable must be defined in the same PSSession.
+When the command runs in a persistent session, **PSSession**, the remote
+variable must be defined in that session.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
-Invoke-Command -Session $s -ScriptBlock {$ps = "Windows PowerShell"}
+Invoke-Command -Session $s -ScriptBlock {$ps = "*PowerShell*"}
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $ps}
 ```
 
 ## Using local variables
 
-You can also use local variables in remote commands, but you must indicate that
-the variable is defined in the local session.
+You can use local variables in remote commands, but the variable must be
+defined in the local session.
 
-Beginning in Windows PowerShell 3.0, you can use the Using scope modifier to
-identify a local variable in a remote command.
+Beginning in PowerShell 3.0, you can use the `Using` scope modifier to identify
+a local variable in a remote command.
 
 The syntax of `Using` is as follows:
 
@@ -58,64 +59,80 @@ $Using:<VariableName>
 ```
 
 In the following example, the `$ps` variable is created in the local session,
-but is used in the session in which the command runs. The Using scope modifier
-identifies `$ps` as a local variable.
+but is used in the session in which the command runs. The `Using` scope
+modifier identifies `$ps` as a local variable.
 
 ```powershell
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
   Get-WinEvent -LogName $Using:ps
 }
 ```
 
-You can also use the `Using` scope modifier in PSSessions.
+The `Using` scope modifier can be used in a **PSSession**.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-## Using local variables in Windows PowerShell 2.0
+### Using splatting
+
+PowerShell splatting passes a collection of parameter names and values to a
+command. For more information, see [about_Splatting](about_Splatting.md).
+
+In this example, the splatting variable, `$Splat` is a hash table that is set
+up on the local computer. The `Invoke-Command` connects to a remote computer
+session. The **ScriptBlock** uses the `Using` scope modifier with the At (`@`)
+symbol to represent the splatted variable.
+
+```powershell
+$Splat = @{ Name = "Win*"; Include = "WinRM" }
+Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
+```
+
+## Using local variables in PowerShell 2.0
 
 You can use local variables in a remote command by defining parameters for the
-remote command and using the ArgumentList parameter of the `Invoke-Command`
+remote command and using the **ArgumentList** parameter of the `Invoke-Command`
 cmdlet to specify the local variable as the parameter value.
 
-This command format is valid on Windows PowerShell 2.0 and later versions of
-Windows PowerShell and PowerShell Core.
+The following command format is valid on PowerShell 2.0 and later versions:
 
-- Use the param keyword to define parameters for the remote command. The
-  parameter names are placeholders that do not need to match the name of the
-  local variable.
+- Use the `param` keyword to define parameters for the remote command. The
+  parameter names are placeholders that don't need to match the local
+  variable's name.
 
-- Use the parameters defined by the param keyword in the command.
+- Use the parameters defined by the `param` keyword in the command.
 
-- Use the ArgumentList parameter of the `Invoke-Command` cmdlet to specify the
-  local variable as the parameter value.
+- Use the **ArgumentList** parameter of the `Invoke-Command` cmdlet to specify
+  the local variable as the parameter value.
 
 For example, the following commands define the `$ps` variable in the local
 session and then use it in a remote command. The command uses `$log` as the
 parameter name and the local variable, `$ps`, as its value.
 
 ```powershell
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
   param($log)
   Get-WinEvent -LogName $log
 } -ArgumentList $ps
 ```
 
-## SEE ALSO
-
-[about_Remote](about_Remote.md)
+## See also
 
 [about_PSSessions](about_PSSessions.md)
 
+[about_Remote](about_Remote.md)
+
 [about_Scopes](about_Scopes.md)
 
-[Invoke-Command](../Invoke-Command.md)
+[about_Splatting](about_Splatting.md)
 
 [Enter-PSSession](../Enter-PSSession.md)
+
+[Invoke-Command](../Invoke-Command.md)
 
 [New-PSSession](../New-PSSession.md)

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -1,55 +1,56 @@
 ---
-ms.date:  01/03/2018
+ms.date:  07/23/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Remote_Variables
 ---
+
 # About Remote Variables
 
-## Short Description
+## Short description
+
 Explains how to use local and remote variables in remote commands.
 
-## Long Description
+## Long description
 
-You can use variables in commands that you run on remote computers. Simply
-assign a value to the variable and then use the variable in place of the value.
+You can use variables in commands that you run on remote computers. Assign a
+value to the variable and then use the variable in place of the value.
 
 By default, the variables in remote commands are assumed to be defined in the
-session in which the command runs. You can also use variables that are defined
-in the local session, but you must identify them as local variables in the
-command.
+session that runs the command. Variables that are defined in a local session,
+must be identified as local variables in the command.
 
 ## Using remote variables
 
 PowerShell assumes that the variables used in remote commands are defined in
 the session in which the command runs.
 
-In the following example, the `$ps` variable is defined in the temporary
-session in which the `Get-WinEvent` command runs.
+In this example, the `$ps` variable is defined in the temporary session in
+which the `Get-WinEvent` command runs.
 
 ```powershell
 Invoke-Command -ComputerName S1 -ScriptBlock {
-  $ps = "Windows PowerShell"; Get-WinEvent -LogName $ps
+  $ps = "*PowerShell*"; Get-WinEvent -LogName $ps
 }
 ```
 
-Similarly, when the command runs in a persistent session (PSSession), the
-remote variable must be defined in the same PSSession.
+When the command runs in a persistent session, **PSSession**, the remote
+variable must be defined in that session.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
-Invoke-Command -Session $s -ScriptBlock {$ps = "Windows PowerShell"}
+Invoke-Command -Session $s -ScriptBlock {$ps = "*PowerShell*"}
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $ps}
 ```
 
 ## Using local variables
 
-You can also use local variables in remote commands, but you must indicate that
-the variable is defined in the local session.
+You can use local variables in remote commands, but the variable must be
+defined in the local session.
 
-Beginning in Windows PowerShell 3.0, you can use the Using scope modifier to
-identify a local variable in a remote command.
+Beginning in PowerShell 3.0, you can use the `Using` scope modifier to identify
+a local variable in a remote command.
 
 The syntax of `Using` is as follows:
 
@@ -58,64 +59,80 @@ $Using:<VariableName>
 ```
 
 In the following example, the `$ps` variable is created in the local session,
-but is used in the session in which the command runs. The Using scope modifier
-identifies `$ps` as a local variable.
+but is used in the session in which the command runs. The `Using` scope
+modifier identifies `$ps` as a local variable.
 
 ```powershell
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
   Get-WinEvent -LogName $Using:ps
 }
 ```
 
-You can also use the `Using` scope modifier in PSSessions.
+The `Using` scope modifier can be used in a **PSSession**.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-## Using local variables in Windows PowerShell 2.0
+### Using splatting
+
+PowerShell splatting passes a collection of parameter names and values to a
+command. For more information, see [about_Splatting](about_Splatting.md).
+
+In this example, the splatting variable, `$Splat` is a hash table that is set
+up on the local computer. The `Invoke-Command` connects to a remote computer
+session. The **ScriptBlock** uses the `Using` scope modifier with the At (`@`)
+symbol to represent the splatted variable.
+
+```powershell
+$Splat = @{ Name = "Win*"; Include = "WinRM" }
+Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
+```
+
+## Using local variables in PowerShell 2.0
 
 You can use local variables in a remote command by defining parameters for the
-remote command and using the ArgumentList parameter of the `Invoke-Command`
+remote command and using the **ArgumentList** parameter of the `Invoke-Command`
 cmdlet to specify the local variable as the parameter value.
 
-This command format is valid on Windows PowerShell 2.0 and later versions of
-Windows PowerShell and PowerShell Core.
+The following command format is valid on PowerShell 2.0 and later versions:
 
-- Use the param keyword to define parameters for the remote command. The
-  parameter names are placeholders that do not need to match the name of the
-  local variable.
+- Use the `param` keyword to define parameters for the remote command. The
+  parameter names are placeholders that don't need to match the local
+  variable's name.
 
-- Use the parameters defined by the param keyword in the command.
+- Use the parameters defined by the `param` keyword in the command.
 
-- Use the ArgumentList parameter of the `Invoke-Command` cmdlet to specify the
-  local variable as the parameter value.
+- Use the **ArgumentList** parameter of the `Invoke-Command` cmdlet to specify
+  the local variable as the parameter value.
 
 For example, the following commands define the `$ps` variable in the local
 session and then use it in a remote command. The command uses `$log` as the
 parameter name and the local variable, `$ps`, as its value.
 
 ```powershell
-$ps = "Windows PowerShell"
+$ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
   param($log)
   Get-WinEvent -LogName $log
 } -ArgumentList $ps
 ```
 
-## SEE ALSO
-
-[about_Remote](about_Remote.md)
+## See also
 
 [about_PSSessions](about_PSSessions.md)
 
+[about_Remote](about_Remote.md)
+
 [about_Scopes](about_Scopes.md)
 
-[Invoke-Command](../Invoke-Command.md)
+[about_Splatting](about_Splatting.md)
 
 [Enter-PSSession](../Enter-PSSession.md)
+
+[Invoke-Command](../Invoke-Command.md)
 
 [New-PSSession](../New-PSSession.md)


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

about_Remote_Variables Acrolinx scores
Original version: 90
Updated version: 91

- Fixes [AB#1574501](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1574501)
- Fixes #4545
- Copyedits, style, paragraph reflows
