### PR TITLE
Fixes #4589 - Corrected variable name

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -5,9 +5,11 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Automatic_Variables
 ---
+
 # About Automatic Variables
 
 ## Short description
+
 Describes variables that store state information for PowerShell. These
 variables are created and maintained by PowerShell.
 
@@ -17,7 +19,7 @@ Conceptually, these variables are considered to be read-only. Even though they
 **can** be written to, for backward compatibility they **should not** be
 written to.
 
-Here is a list of the automatic variables in  PowerShell:
+Here is a list of the automatic variables in PowerShell:
 
 ### $$
 
@@ -25,8 +27,8 @@ Contains the last token in the last line received by the session.
 
 ### $?
 
-Contains the execution status of the last operation. It contains TRUE if
-the last operation succeeded and FALSE if it failed.
+Contains the execution status of the last operation. It contains **True** if
+the last operation succeeded and **False** if it failed.
 
 ### $^
 
@@ -103,16 +105,16 @@ objects that are available to cmdlets.
 
 ### $false
 
-Contains **FALSE**. You can use this variable to represent **FALSE** in commands
-and scripts instead of using the string "false". The string can be
-interpreted as **TRUE** if it is converted to a non-empty string or to a
+Contains **False**. You can use this variable to represent **False** in
+commands and scripts instead of using the string "false". The string can be
+interpreted as **True** if it's converted to a non-empty string or to a
 non-zero integer.
 
 ### $foreach
 
 Contains the enumerator (not the resulting values) of a
 [ForEach](about_ForEach.md) loop. The `$ForEach` variable exists only while
-the `ForEach` loop is running; it is deleted after the loop is completed.
+the `ForEach` loop is running; it's deleted after the loop is completed.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
@@ -171,15 +173,14 @@ were matched. The `$Matches` hash table can also be populated with captures
 when you use regular expressions with the `-match` operator.
 
 For more information about the `-match` operator, see
-[about_comparison_operators](about_comparison_operators.md). For more
+[about_Comparison_Operators](about_comparison_operators.md). For more
 information on regular expressions, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### $MyInvocation
 
-Contains an information about the current command, such as the name,
-parameters, parameter values, and information about how the command was
-started, called, or "invoked," such as the name of the script that called
-the current command.
+Contains information about the current command, such as the name, parameters,
+parameter values, and information about how the command was started, called, or
+invoked, such as the name of the script that called the current command.
 
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
@@ -224,11 +225,11 @@ the command, or type `exit`.
 
 The `$NestedPromptLevel` variable helps you track the prompt level. You can
 create an alternative PowerShell command prompt that includes this value so
-that it is always visible.
+that it's always visible.
 
-### $NULL
+### $null
 
-`$null` is an automatic variable that contains a **NULL** or empty value. You
+`$null` is an automatic variable that contains a **null** or empty value. You
 can use this variable to represent an absent or undefined value in commands and
 scripts.
 
@@ -236,7 +237,7 @@ PowerShell treats `$null` as an object with a value, that is, as an explicit
 placeholder, so you can use `$null` to represent an empty value in a series
 of values.
 
-For example, when `$null` is included in a collection, it is counted as one
+For example, when `$null` is included in a collection, it's counted as one
 of the objects.
 
 ```powershell
@@ -244,7 +245,7 @@ $a = "one", $null, "three"
 $a.count
 ```
 
-```output
+```Output
 3
 ```
 
@@ -255,17 +256,17 @@ value for `$null`, just as it does for the other objects
 "one", $null, "three" | ForEach-Object { "Hello " + $_}
 ```
 
-```output
+```Output
 Hello one
 Hello
 Hello three
 ```
 
-As a result, you cannot use `$null` to mean "no parameter value." A parameter
+As a result, you can't use `$null` to mean **no parameter value**. A parameter
 value of `$null` overrides the default parameter value.
 
 However, because PowerShell treats the `$null` variable as a placeholder, you
-can use it in scripts like the following one, which would not work if `$null`
+can use it in scripts like the following one, which wouldn't work if `$null`
 were ignored.
 
 ```powershell
@@ -284,7 +285,7 @@ foreach($day in $calendar)
 }
 ```
 
-```output
+```Output
 Appointment on Tuesday: Meeting
 Appointment on Friday: Team lunch
 ```
@@ -308,13 +309,13 @@ Test-Path $PROFILE
 Or, you can use it in a command to create a profile:
 
 ```powershell
-New-Item -ItemType file -Path $PSHOME -Force
+New-Item -ItemType file -Path $PROFILE -Force
 ```
 
-You can also use it in a command to open the profile in Notepad:
+You can use it in a command to open the profile in **notepad.exe**:
 
 ```powershell
-notepad $profile
+notepad.exe $PROFILE
 ```
 
 ### $PSBoundParameterValues
@@ -341,12 +342,12 @@ function Test {
 
 ### $PSCmdlet
 
-Contains an object that represents the cmdlet or advanced function that is
+Contains an object that represents the cmdlet or advanced function that's
 being run.
 
 You can use the properties and methods of the object in your cmdlet or
 function code to respond to the conditions of use. For example, the
-**ParameterSetName** property contains the name of the parameter set that is
+**ParameterSetName** property contains the name of the parameter set that's
 being used, and the **ShouldProcess** method adds the **WhatIf** and
 **Confirm** parameters to the cmdlet dynamically.
 
@@ -355,7 +356,7 @@ For more information about the `$PSCmdlet` automatic variable, see
 
 ### $PSCommandPath
 
-Contains the full path and file name of the script that is being run. This
+Contains the full path and file name of the script that's being run. This
 variable is valid in all scripts.
 
 ### $PSCulture
@@ -370,8 +371,8 @@ use the `Get-Culture` cmdlet.
 ### $PSDebugContext
 
 While debugging, this variable contains information about the debugging
-environment. Otherwise, it contains a NULL value. As a result, you can use it
-to indicate whether the debugger has control. When populated, it contains a
+environment. Otherwise, it contains a **null** value. As a result, you can use
+it to indicate whether the debugger has control. When populated, it contains a
 **PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
 properties. The **InvocationInfo** property has several useful properties,
 including the **Location** property. The **Location** property indicates the
@@ -383,47 +384,47 @@ Contains the full path of the installation directory for PowerShell,
 typically, `$env:windir\System32\PowerShell\v1.0` in Windows systems. You can
 use this variable in the paths of PowerShell files. For example, the
 following command searches the conceptual Help topics for the word
-"variable":
+**variable**:
 
 ```powershell
 Select-String -Pattern Variable -Path $pshome\*.txt
 ```
 
-### $PSITEM
+### $PSItem
 
 Same as `$_`. Contains the current object in the pipeline object. You can use
 this variable in commands that perform an action on every object or on
 selected objects in a pipeline.
 
-### $PSSCRIPTROOT
+### $PSScriptRoot
 
 Contains the directory from which a script is being run.
 
 In PowerShell 2.0, this variable is valid only in script modules (.psm1).
-Beginning in PowerShell 3.0, it is valid in all scripts.
+Beginning in PowerShell 3.0, it's valid in all scripts.
 
-### $PSSENDERINFO
+### $PSSenderInfo
 
 Contains information about the user who started the PSSession, including
 the user identity and the time zone of the originating computer. This
 variable is available only in PSSessions.
 
 The `$PSSenderInfo` variable includes a user-configurable property,
-**ApplicationArguments**, which, by default, contains only the
-`$PSVersionTable` from the originating session. To add data to the
-**ApplicationArguments** property, use the **ApplicationArguments** parameter
-of the `New-PSSessionOption` cmdlet.
+**ApplicationArguments**, that by default, contains only the `$PSVersionTable`
+from the originating session. To add data to the **ApplicationArguments**
+property, use the **ApplicationArguments** parameter of the
+`New-PSSessionOption` cmdlet.
 
-### $PSUICULTURE
+### $PSUICulture
 
-Contains the name of the user interface (UI) culture that is currently in use
+Contains the name of the user interface (UI) culture that's currently in use
 in the operating system. The UI culture determines which text strings are used
 for user interface elements, such as menus and messages. This is the value of
 the **System.Globalization.CultureInfo.CurrentUICulture.Name** property of the
 system. To get the **System.Globalization.CultureInfo** object for the system,
 use the `Get-UICulture` cmdlet.
 
-### $PSVERSIONTABLE
+### $PSVersionTable
 
 Contains a read-only hash table that displays details about the version of
 PowerShell that is running in the current session. The table includes the
@@ -431,73 +432,66 @@ following items:
 
 | Property                  | Description                                   |
 | ------------------------- | --------------------------------------------- |
-| BuildVersion              | The build number of the current version       |
-| CLRVersion                | The version of the common language runtime    |
+| **BuildVersion**          | The build number of the current version       |
+| **CLRVersion**            | The version of the common language runtime    |
 |                           | (CLR)                                         |
-| GitCommitId               | The commit Id of the source files, in GitHub, |
-|                           | used in this version of PowerShell            |
-| PSCompatibleVersions      | Versions of PowerShell that are compatible    |
+| **PSCompatibleVersions**  | Versions of PowerShell that are compatible    |
 |                           | with the current version                      |
-| PSEdition                 | This property has the value of 'Desktop', for |
-|                           | Windows Server and Windows client versions.   |
-|                           | This property has the value of 'Core' for     |
-|                           | PowerShell running under Nano Server or       |
-|                           | Windows IOT.                                  |
-| PSRemotingProtocolVersion | The version of the PowerShell remote          |
+| **PSRemotingProtocolVersion** | The version of the PowerShell remote      |
 |                           | management protocol.                          |
-| PSVersion                 | The PowerShell version number                 |
-| SerializationVersion      | The version of the serialization method       |
-| WSManStackVersion         | The version number of the WS-Management stack |
+| **PSVersion**             | The PowerShell version number                 |
+| **SerializationVersion**  | The version of the serialization method       |
+| **WSManStackVersion**     | The version number of the WS-Management stack |
 
 ### $PWD
 
 Contains a path object that represents the full path of the current directory.
 
-### REPORTERRORSHOW VARIABLES
+### ReportErrorShow variables
 
-The **ReportErrorShow** variables are defined in PowerShell, but they are not
-implemented. `Get-Variable` gets them, but they do not contain valid data.
+The **ReportErrorShow** variables are defined in PowerShell, but they aren't
+implemented. `Get-Variable` gets them, but they don't contain valid data.
 
-- $REPORTERRORSHOWEXCEPTIONCLASS
-- $REPORTERRORSHOWINNEREXCEPTION
-- $REPORTERRORSHOWSOURCE
-- $REPORTERRORSHOWSTACKTRACE
+- `$ReportErrorShowExceptionClass`
+- `$ReportErrorShowInnerException`
+- `$ReportErrorShowSource`
+- `$ReportErrorShowStackTrace`
 
-### $SENDER
+### $Sender
 
 Contains the object that generated this event. This variable is populated
 only within the Action block of an event registration command. The value of
 this variable can also be found in the Sender property of the **PSEventArgs**
 object that `Get-Event` returns.
 
-### $SHELLID
+### $ShellId
 
 Contains the identifier of the current shell.
 
-### $STACKTRACE
+### $StackTrace
 
 Contains a stack trace for the most recent error.
 
-### $SWITCH
+### $switch
 
-Contains the enumerator (not the resulting values) of a [Switch](about_Switch.md)
-statement. The `$Switch` variable exists only while the `switch` statement is
-running; it is deleted when the `switch` statement
-completes execution.
+Contains the enumerator not the resulting values of a `Switch` statement. The
+`$switch` variable exists only while the `Switch` statement is running; it's
+deleted when the `switch` statement completes execution. For more information,
+see [about_Switch](about_Switch.md).
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
 [Using Enumerators](#using-enumerators).
 
-### $THIS
+### $this
 
 In a script block that defines a script property or script method, the
-`$This` variable refers to the object that is being extended.
+`$this` variable refers to the object that is being extended.
 
-### $TRUE
+### $true
 
-Contains TRUE. You can use this variable to represent TRUE in commands and
-scripts.
+Contains **True**. You can use this variable to represent **True** in commands
+and scripts.
 
 ## Using Enumerators
 
@@ -505,13 +499,13 @@ The `$input`, `$foreach`, and `$switch` variables are all enumerators used
 to iterate through the values processed by their containing code block.
 
 An enumerator contains properties and methods you can use to advance or reset
-iteration, or retrieve iteration values. Directly manipulating enumerators is not
-considered best practice.
+iteration, or retrieve iteration values. Directly manipulating enumerators
+isn't considered best practice.
 
 - Within loops, flow control keywords [break](about_Break.md) and [continue](about_Continue.md)
   should be preferred.
-- Within functions that accepts pipeline input, it is best practice to
-  use Parameters with the **ValueFromPipeline** or
+- Within functions that accept pipeline input, it's best practice to use
+  Parameters with the **ValueFromPipeline** or
   **ValueFromPipelineByPropertyName** attributes.
 
   For more information, see [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
@@ -520,7 +514,7 @@ considered best practice.
 
 The [MoveNext](/dotnet/api/system.collections.ienumerator.movenext) method
 advances the enumerator to the next element of the collection. **MoveNext**
-returns **True** if the enumerator was successfully advanced, **false** if
+returns **True** if the enumerator was successfully advanced, **False** if
 the enumerator has passed the end of the collection.
 
 > [!NOTE]
@@ -593,7 +587,7 @@ Iteration: 1
 ```
 
 The process block automatically advances the `$input` variable even if you
-do not access it.
+don't access it.
 
 ```powershell
 $skip = $true
@@ -638,7 +632,7 @@ piped into the function.
 - Accessing the `$input` variable clears all values.
 - The **Reset** method resets the entire collection.
 - The **Current** property is never populated.
-- The **MoveNext** method returns false because the collection cannot be
+- The **MoveNext** method returns false because the collection can't be
   advanced.
   - Calling **MoveNext** clears out the `$input` variable.
 
@@ -666,7 +660,7 @@ After MoveNext:
 ### Example 3: Using the $input.Current property
 
 By using the **Current** property, the current pipeline value can be accessed
-multiple times without using the **Reset** method. The Process block does not
+multiple times without using the **Reset** method. The process block doesn't
 automatically call the **MoveNext** method.
 
 The **Current** property will never be populated unless you explicitly call
@@ -718,10 +712,10 @@ methods to change its value.
 > method.
 
 The following loop only executes twice. In the second iteration, the collection
-is moved to the 3rd element before the iteration is complete. After the second
+is moved to the third element before the iteration is complete. After the second
 iteration, there are now no more values to iterate, and the loop terminates.
 
-The **MoveNext** property does not affect the variable chosen to iterate through
+The **MoveNext** property doesn't affect the variable chosen to iterate through
 the collection (`$Num`).
 
 ```powershell
@@ -793,10 +787,10 @@ Reset Loop: 0
 ### Example 5: Using the $switch variable
 
 The `$switch` variable has the exact same rules as the `$foreach` variable.
-The following example demonstrates all of the enumerator concepts.
+The following example demonstrates all the enumerator concepts.
 
 > [!NOTE]
-> Note how the **NotEvaluated** case is never executed, even though there is
+> Note how the **NotEvaluated** case is never executed, even though there's
 > no `break` statement after the **MoveNext** method.
 
 ```powershell

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -547,7 +547,7 @@ The **Current** property continues to return the same property until
 
 ### Examples
 
-#### Example 1: Using the Input variable
+#### Example 1: Using the $input variable
 
 In the following example, accessing the `$input` variable clears the variable
 until the next time the process block executes. Using the **Reset** method
@@ -624,7 +624,7 @@ Iteration: 1
     Input: two
 ```
 
-### Example 2: Using $input outside the Process block
+### Example 2: Using $input outside the process block
 
 Outside of the process block the `$input` variable represents all the values
 piped into the function.
@@ -834,7 +834,7 @@ Default (Current): Start
 Default (Current): End
 ```
 
-## SEE ALSO
+## See also
 
 - [about_Hash_Tables](about_Hash_Tables.md)
 - [about_Preference_Variables](about_Preference_Variables.md)

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -545,9 +545,9 @@ the enumerator.
 The **Current** property continues to return the same property until
 **MoveNext** is called.
 
-### Examples
+## Examples
 
-#### Example 1: Using the $input variable
+### Example 1: Using the $input variable
 
 In the following example, accessing the `$input` variable clears the variable
 until the next time the process block executes. Using the **Reset** method

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -5,9 +5,11 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Automatic_Variables
 ---
+
 # About Automatic Variables
 
 ## Short description
+
 Describes variables that store state information for PowerShell. These
 variables are created and maintained by PowerShell.
 
@@ -17,7 +19,7 @@ Conceptually, these variables are considered to be read-only. Even though they
 **can** be written to, for backward compatibility they **should not** be
 written to.
 
-Here is a list of the automatic variables in  PowerShell:
+Here is a list of the automatic variables in PowerShell:
 
 ### $$
 
@@ -25,8 +27,8 @@ Contains the last token in the last line received by the session.
 
 ### $?
 
-Contains the execution status of the last operation. It contains TRUE if
-the last operation succeeded and FALSE if it failed.
+Contains the execution status of the last operation. It contains **True** if
+the last operation succeeded and **False** if it failed.
 
 ### $^
 
@@ -103,16 +105,16 @@ objects that are available to cmdlets.
 
 ### $false
 
-Contains **FALSE**. You can use this variable to represent **FALSE** in commands
-and scripts instead of using the string "false". The string can be
-interpreted as **TRUE** if it is converted to a non-empty string or to a
+Contains **False**. You can use this variable to represent **False** in
+commands and scripts instead of using the string "false". The string can be
+interpreted as **True** if it's converted to a non-empty string or to a
 non-zero integer.
 
 ### $foreach
 
 Contains the enumerator (not the resulting values) of a
 [ForEach](about_ForEach.md) loop. The `$ForEach` variable exists only while
-the `ForEach` loop is running; it is deleted after the loop is completed.
+the `ForEach` loop is running; it's deleted after the loop is completed.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
@@ -171,15 +173,14 @@ were matched. The `$Matches` hash table can also be populated with captures
 when you use regular expressions with the `-match` operator.
 
 For more information about the `-match` operator, see
-[about_comparison_operators](about_comparison_operators.md). For more
+[about_Comparison_Operators](about_comparison_operators.md). For more
 information on regular expressions, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### $MyInvocation
 
-Contains an information about the current command, such as the name,
-parameters, parameter values, and information about how the command was
-started, called, or "invoked," such as the name of the script that called
-the current command.
+Contains information about the current command, such as the name, parameters,
+parameter values, and information about how the command was started, called, or
+invoked, such as the name of the script that called the current command.
 
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
@@ -224,11 +225,11 @@ the command, or type `exit`.
 
 The `$NestedPromptLevel` variable helps you track the prompt level. You can
 create an alternative PowerShell command prompt that includes this value so
-that it is always visible.
+that it's always visible.
 
-### $NULL
+### $null
 
-`$null` is an automatic variable that contains a **NULL** or empty value. You
+`$null` is an automatic variable that contains a **null** or empty value. You
 can use this variable to represent an absent or undefined value in commands and
 scripts.
 
@@ -236,7 +237,7 @@ PowerShell treats `$null` as an object with a value, that is, as an explicit
 placeholder, so you can use `$null` to represent an empty value in a series
 of values.
 
-For example, when `$null` is included in a collection, it is counted as one
+For example, when `$null` is included in a collection, it's counted as one
 of the objects.
 
 ```powershell
@@ -244,7 +245,7 @@ $a = "one", $null, "three"
 $a.count
 ```
 
-```output
+```Output
 3
 ```
 
@@ -255,17 +256,17 @@ value for `$null`, just as it does for the other objects
 "one", $null, "three" | ForEach-Object { "Hello " + $_}
 ```
 
-```output
+```Output
 Hello one
 Hello
 Hello three
 ```
 
-As a result, you cannot use `$null` to mean "no parameter value." A parameter
+As a result, you can't use `$null` to mean **no parameter value**. A parameter
 value of `$null` overrides the default parameter value.
 
 However, because PowerShell treats the `$null` variable as a placeholder, you
-can use it in scripts like the following one, which would not work if `$null`
+can use it in scripts like the following one, which wouldn't work if `$null`
 were ignored.
 
 ```powershell
@@ -284,7 +285,7 @@ foreach($day in $calendar)
 }
 ```
 
-```output
+```Output
 Appointment on Tuesday: Meeting
 Appointment on Friday: Team lunch
 ```
@@ -308,13 +309,13 @@ Test-Path $PROFILE
 Or, you can use it in a command to create a profile:
 
 ```powershell
-New-Item -ItemType file -Path $PSHOME -Force
+New-Item -ItemType file -Path $PROFILE -Force
 ```
 
-You can also use it in a command to open the profile in Notepad:
+You can use it in a command to open the profile in **notepad.exe**:
 
 ```powershell
-notepad $profile
+notepad.exe $PROFILE
 ```
 
 ### $PSBoundParameterValues
@@ -341,12 +342,12 @@ function Test {
 
 ### $PSCmdlet
 
-Contains an object that represents the cmdlet or advanced function that is
+Contains an object that represents the cmdlet or advanced function that's
 being run.
 
 You can use the properties and methods of the object in your cmdlet or
 function code to respond to the conditions of use. For example, the
-**ParameterSetName** property contains the name of the parameter set that is
+**ParameterSetName** property contains the name of the parameter set that's
 being used, and the **ShouldProcess** method adds the **WhatIf** and
 **Confirm** parameters to the cmdlet dynamically.
 
@@ -355,7 +356,7 @@ For more information about the `$PSCmdlet` automatic variable, see
 
 ### $PSCommandPath
 
-Contains the full path and file name of the script that is being run. This
+Contains the full path and file name of the script that's being run. This
 variable is valid in all scripts.
 
 ### $PSCulture
@@ -370,8 +371,8 @@ use the `Get-Culture` cmdlet.
 ### $PSDebugContext
 
 While debugging, this variable contains information about the debugging
-environment. Otherwise, it contains a NULL value. As a result, you can use it
-to indicate whether the debugger has control. When populated, it contains a
+environment. Otherwise, it contains a **null** value. As a result, you can use
+it to indicate whether the debugger has control. When populated, it contains a
 **PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
 properties. The **InvocationInfo** property has several useful properties,
 including the **Location** property. The **Location** property indicates the
@@ -383,47 +384,47 @@ Contains the full path of the installation directory for PowerShell,
 typically, `$env:windir\System32\PowerShell\v1.0` in Windows systems. You can
 use this variable in the paths of PowerShell files. For example, the
 following command searches the conceptual Help topics for the word
-"variable":
+**variable**:
 
 ```powershell
 Select-String -Pattern Variable -Path $pshome\*.txt
 ```
 
-### $PSITEM
+### $PSItem
 
 Same as `$_`. Contains the current object in the pipeline object. You can use
 this variable in commands that perform an action on every object or on
 selected objects in a pipeline.
 
-### $PSSCRIPTROOT
+### $PSScriptRoot
 
 Contains the directory from which a script is being run.
 
 In PowerShell 2.0, this variable is valid only in script modules (.psm1).
-Beginning in PowerShell 3.0, it is valid in all scripts.
+Beginning in PowerShell 3.0, it's valid in all scripts.
 
-### $PSSENDERINFO
+### $PSSenderInfo
 
 Contains information about the user who started the PSSession, including
 the user identity and the time zone of the originating computer. This
 variable is available only in PSSessions.
 
 The `$PSSenderInfo` variable includes a user-configurable property,
-**ApplicationArguments**, which, by default, contains only the
-`$PSVersionTable` from the originating session. To add data to the
-**ApplicationArguments** property, use the **ApplicationArguments** parameter
-of the `New-PSSessionOption` cmdlet.
+**ApplicationArguments**, that by default, contains only the `$PSVersionTable`
+from the originating session. To add data to the **ApplicationArguments**
+property, use the **ApplicationArguments** parameter of the
+`New-PSSessionOption` cmdlet.
 
-### $PSUICULTURE
+### $PSUICulture
 
-Contains the name of the user interface (UI) culture that is currently in use
+Contains the name of the user interface (UI) culture that's currently in use
 in the operating system. The UI culture determines which text strings are used
 for user interface elements, such as menus and messages. This is the value of
 the **System.Globalization.CultureInfo.CurrentUICulture.Name** property of the
 system. To get the **System.Globalization.CultureInfo** object for the system,
 use the `Get-UICulture` cmdlet.
 
-### $PSVERSIONTABLE
+### $PSVersionTable
 
 Contains a read-only hash table that displays details about the version of
 PowerShell that is running in the current session. The table includes the
@@ -431,73 +432,66 @@ following items:
 
 | Property                  | Description                                   |
 | ------------------------- | --------------------------------------------- |
-| BuildVersion              | The build number of the current version       |
-| CLRVersion                | The version of the common language runtime    |
+| **BuildVersion**          | The build number of the current version       |
+| **CLRVersion**            | The version of the common language runtime    |
 |                           | (CLR)                                         |
-| GitCommitId               | The commit Id of the source files, in GitHub, |
-|                           | used in this version of PowerShell            |
-| PSCompatibleVersions      | Versions of PowerShell that are compatible    |
+| **PSCompatibleVersions**  | Versions of PowerShell that are compatible    |
 |                           | with the current version                      |
-| PSEdition                 | This property has the value of 'Desktop', for |
-|                           | Windows Server and Windows client versions.   |
-|                           | This property has the value of 'Core' for     |
-|                           | PowerShell running under Nano Server or       |
-|                           | Windows IOT.                                  |
-| PSRemotingProtocolVersion | The version of the PowerShell remote          |
+| **PSRemotingProtocolVersion** | The version of the PowerShell remote      |
 |                           | management protocol.                          |
-| PSVersion                 | The PowerShell version number                 |
-| SerializationVersion      | The version of the serialization method       |
-| WSManStackVersion         | The version number of the WS-Management stack |
+| **PSVersion**             | The PowerShell version number                 |
+| **SerializationVersion**  | The version of the serialization method       |
+| **WSManStackVersion**     | The version number of the WS-Management stack |
 
 ### $PWD
 
 Contains a path object that represents the full path of the current directory.
 
-### REPORTERRORSHOW VARIABLES
+### ReportErrorShow variables
 
-The **ReportErrorShow** variables are defined in PowerShell, but they are not
-implemented. `Get-Variable` gets them, but they do not contain valid data.
+The **ReportErrorShow** variables are defined in PowerShell, but they aren't
+implemented. `Get-Variable` gets them, but they don't contain valid data.
 
-- $REPORTERRORSHOWEXCEPTIONCLASS
-- $REPORTERRORSHOWINNEREXCEPTION
-- $REPORTERRORSHOWSOURCE
-- $REPORTERRORSHOWSTACKTRACE
+- `$ReportErrorShowExceptionClass`
+- `$ReportErrorShowInnerException`
+- `$ReportErrorShowSource`
+- `$ReportErrorShowStackTrace`
 
-### $SENDER
+### $Sender
 
 Contains the object that generated this event. This variable is populated
 only within the Action block of an event registration command. The value of
 this variable can also be found in the Sender property of the **PSEventArgs**
 object that `Get-Event` returns.
 
-### $SHELLID
+### $ShellId
 
 Contains the identifier of the current shell.
 
-### $STACKTRACE
+### $StackTrace
 
 Contains a stack trace for the most recent error.
 
-### $SWITCH
+### $switch
 
-Contains the enumerator (not the resulting values) of a [Switch](about_Switch.md)
-statement. The `$Switch` variable exists only while the `switch` statement is
-running; it is deleted when the `switch` statement
-completes execution.
+Contains the enumerator not the resulting values of a `Switch` statement. The
+`$switch` variable exists only while the `Switch` statement is running; it's
+deleted when the `switch` statement completes execution. For more information,
+see [about_Switch](about_Switch.md).
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
 [Using Enumerators](#using-enumerators).
 
-### $THIS
+### $this
 
 In a script block that defines a script property or script method, the
-`$This` variable refers to the object that is being extended.
+`$this` variable refers to the object that is being extended.
 
-### $TRUE
+### $true
 
-Contains TRUE. You can use this variable to represent TRUE in commands and
-scripts.
+Contains **True**. You can use this variable to represent **True** in commands
+and scripts.
 
 ## Using Enumerators
 
@@ -505,13 +499,13 @@ The `$input`, `$foreach`, and `$switch` variables are all enumerators used
 to iterate through the values processed by their containing code block.
 
 An enumerator contains properties and methods you can use to advance or reset
-iteration, or retrieve iteration values. Directly manipulating enumerators is not
-considered best practice.
+iteration, or retrieve iteration values. Directly manipulating enumerators
+isn't considered best practice.
 
 - Within loops, flow control keywords [break](about_Break.md) and [continue](about_Continue.md)
   should be preferred.
-- Within functions that accepts pipeline input, it is best practice to
-  use Parameters with the **ValueFromPipeline** or
+- Within functions that accept pipeline input, it's best practice to use
+  Parameters with the **ValueFromPipeline** or
   **ValueFromPipelineByPropertyName** attributes.
 
   For more information, see [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
@@ -520,7 +514,7 @@ considered best practice.
 
 The [MoveNext](/dotnet/api/system.collections.ienumerator.movenext) method
 advances the enumerator to the next element of the collection. **MoveNext**
-returns **True** if the enumerator was successfully advanced, **false** if
+returns **True** if the enumerator was successfully advanced, **False** if
 the enumerator has passed the end of the collection.
 
 > [!NOTE]
@@ -593,7 +587,7 @@ Iteration: 1
 ```
 
 The process block automatically advances the `$input` variable even if you
-do not access it.
+don't access it.
 
 ```powershell
 $skip = $true
@@ -638,7 +632,7 @@ piped into the function.
 - Accessing the `$input` variable clears all values.
 - The **Reset** method resets the entire collection.
 - The **Current** property is never populated.
-- The **MoveNext** method returns false because the collection cannot be
+- The **MoveNext** method returns false because the collection can't be
   advanced.
   - Calling **MoveNext** clears out the `$input` variable.
 
@@ -666,7 +660,7 @@ After MoveNext:
 ### Example 3: Using the $input.Current property
 
 By using the **Current** property, the current pipeline value can be accessed
-multiple times without using the **Reset** method. The Process block does not
+multiple times without using the **Reset** method. The process block doesn't
 automatically call the **MoveNext** method.
 
 The **Current** property will never be populated unless you explicitly call
@@ -718,10 +712,10 @@ methods to change its value.
 > method.
 
 The following loop only executes twice. In the second iteration, the collection
-is moved to the 3rd element before the iteration is complete. After the second
+is moved to the third element before the iteration is complete. After the second
 iteration, there are now no more values to iterate, and the loop terminates.
 
-The **MoveNext** property does not affect the variable chosen to iterate through
+The **MoveNext** property doesn't affect the variable chosen to iterate through
 the collection (`$Num`).
 
 ```powershell
@@ -793,10 +787,10 @@ Reset Loop: 0
 ### Example 5: Using the $switch variable
 
 The `$switch` variable has the exact same rules as the `$foreach` variable.
-The following example demonstrates all of the enumerator concepts.
+The following example demonstrates all the enumerator concepts.
 
 > [!NOTE]
-> Note how the **NotEvaluated** case is never executed, even though there is
+> Note how the **NotEvaluated** case is never executed, even though there's
 > no `break` statement after the **MoveNext** method.
 
 ```powershell

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -547,7 +547,7 @@ The **Current** property continues to return the same property until
 
 ### Examples
 
-#### Example 1: Using the Input variable
+#### Example 1: Using the $input variable
 
 In the following example, accessing the `$input` variable clears the variable
 until the next time the process block executes. Using the **Reset** method
@@ -624,7 +624,7 @@ Iteration: 1
     Input: two
 ```
 
-### Example 2: Using $input outside the Process block
+### Example 2: Using $input outside the process block
 
 Outside of the process block the `$input` variable represents all the values
 piped into the function.
@@ -834,7 +834,7 @@ Default (Current): Start
 Default (Current): End
 ```
 
-## SEE ALSO
+## See also
 
 - [about_Hash_Tables](about_Hash_Tables.md)
 - [about_Preference_Variables](about_Preference_Variables.md)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -545,9 +545,9 @@ the enumerator.
 The **Current** property continues to return the same property until
 **MoveNext** is called.
 
-### Examples
+## Examples
 
-#### Example 1: Using the $input variable
+### Example 1: Using the $input variable
 
 In the following example, accessing the `$input` variable clears the variable
 until the next time the process block executes. Using the **Reset** method

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -5,9 +5,11 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Automatic_Variables
 ---
+
 # About Automatic Variables
 
 ## Short description
+
 Describes variables that store state information for PowerShell. These
 variables are created and maintained by PowerShell.
 
@@ -17,7 +19,7 @@ Conceptually, these variables are considered to be read-only. Even though they
 **can** be written to, for backward compatibility they **should not** be
 written to.
 
-Here is a list of the automatic variables in  PowerShell:
+Here is a list of the automatic variables in PowerShell:
 
 ### $$
 
@@ -25,8 +27,8 @@ Contains the last token in the last line received by the session.
 
 ### $?
 
-Contains the execution status of the last operation. It contains TRUE if
-the last operation succeeded and FALSE if it failed.
+Contains the execution status of the last operation. It contains **True** if
+the last operation succeeded and **False** if it failed.
 
 ### $^
 
@@ -103,16 +105,16 @@ objects that are available to cmdlets.
 
 ### $false
 
-Contains **FALSE**. You can use this variable to represent **FALSE** in commands
-and scripts instead of using the string "false". The string can be
-interpreted as **TRUE** if it is converted to a non-empty string or to a
+Contains **False**. You can use this variable to represent **False** in
+commands and scripts instead of using the string "false". The string can be
+interpreted as **True** if it's converted to a non-empty string or to a
 non-zero integer.
 
 ### $foreach
 
 Contains the enumerator (not the resulting values) of a
 [ForEach](about_ForEach.md) loop. The `$ForEach` variable exists only while
-the `ForEach` loop is running; it is deleted after the loop is completed.
+the `ForEach` loop is running; it's deleted after the loop is completed.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
@@ -171,15 +173,14 @@ were matched. The `$Matches` hash table can also be populated with captures
 when you use regular expressions with the `-match` operator.
 
 For more information about the `-match` operator, see
-[about_comparison_operators](about_comparison_operators.md). For more
+[about_Comparison_Operators](about_comparison_operators.md). For more
 information on regular expressions, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### $MyInvocation
 
-Contains an information about the current command, such as the name,
-parameters, parameter values, and information about how the command was
-started, called, or "invoked," such as the name of the script that called
-the current command.
+Contains information about the current command, such as the name, parameters,
+parameter values, and information about how the command was started, called, or
+invoked, such as the name of the script that called the current command.
 
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
@@ -224,11 +225,11 @@ the command, or type `exit`.
 
 The `$NestedPromptLevel` variable helps you track the prompt level. You can
 create an alternative PowerShell command prompt that includes this value so
-that it is always visible.
+that it's always visible.
 
-### $NULL
+### $null
 
-`$null` is an automatic variable that contains a **NULL** or empty value. You
+`$null` is an automatic variable that contains a **null** or empty value. You
 can use this variable to represent an absent or undefined value in commands and
 scripts.
 
@@ -236,7 +237,7 @@ PowerShell treats `$null` as an object with a value, that is, as an explicit
 placeholder, so you can use `$null` to represent an empty value in a series
 of values.
 
-For example, when `$null` is included in a collection, it is counted as one
+For example, when `$null` is included in a collection, it's counted as one
 of the objects.
 
 ```powershell
@@ -244,7 +245,7 @@ $a = "one", $null, "three"
 $a.count
 ```
 
-```output
+```Output
 3
 ```
 
@@ -255,17 +256,17 @@ value for `$null`, just as it does for the other objects
 "one", $null, "three" | ForEach-Object { "Hello " + $_}
 ```
 
-```output
+```Output
 Hello one
 Hello
 Hello three
 ```
 
-As a result, you cannot use `$null` to mean "no parameter value." A parameter
+As a result, you can't use `$null` to mean **no parameter value**. A parameter
 value of `$null` overrides the default parameter value.
 
 However, because PowerShell treats the `$null` variable as a placeholder, you
-can use it in scripts like the following one, which would not work if `$null`
+can use it in scripts like the following one, which wouldn't work if `$null`
 were ignored.
 
 ```powershell
@@ -284,7 +285,7 @@ foreach($day in $calendar)
 }
 ```
 
-```output
+```Output
 Appointment on Tuesday: Meeting
 Appointment on Friday: Team lunch
 ```
@@ -308,13 +309,13 @@ Test-Path $PROFILE
 Or, you can use it in a command to create a profile:
 
 ```powershell
-New-Item -ItemType file -Path $PSHOME -Force
+New-Item -ItemType file -Path $PROFILE -Force
 ```
 
-You can also use it in a command to open the profile in Notepad:
+You can use it in a command to open the profile in **notepad.exe**:
 
 ```powershell
-notepad $profile
+notepad.exe $PROFILE
 ```
 
 ### $PSBoundParameterValues
@@ -341,12 +342,12 @@ function Test {
 
 ### $PSCmdlet
 
-Contains an object that represents the cmdlet or advanced function that is
+Contains an object that represents the cmdlet or advanced function that's
 being run.
 
 You can use the properties and methods of the object in your cmdlet or
 function code to respond to the conditions of use. For example, the
-**ParameterSetName** property contains the name of the parameter set that is
+**ParameterSetName** property contains the name of the parameter set that's
 being used, and the **ShouldProcess** method adds the **WhatIf** and
 **Confirm** parameters to the cmdlet dynamically.
 
@@ -355,7 +356,7 @@ For more information about the `$PSCmdlet` automatic variable, see
 
 ### $PSCommandPath
 
-Contains the full path and file name of the script that is being run. This
+Contains the full path and file name of the script that's being run. This
 variable is valid in all scripts.
 
 ### $PSCulture
@@ -370,8 +371,8 @@ use the `Get-Culture` cmdlet.
 ### $PSDebugContext
 
 While debugging, this variable contains information about the debugging
-environment. Otherwise, it contains a NULL value. As a result, you can use it
-to indicate whether the debugger has control. When populated, it contains a
+environment. Otherwise, it contains a **null** value. As a result, you can use
+it to indicate whether the debugger has control. When populated, it contains a
 **PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
 properties. The **InvocationInfo** property has several useful properties,
 including the **Location** property. The **Location** property indicates the
@@ -383,47 +384,47 @@ Contains the full path of the installation directory for PowerShell,
 typically, `$env:windir\System32\PowerShell\v1.0` in Windows systems. You can
 use this variable in the paths of PowerShell files. For example, the
 following command searches the conceptual Help topics for the word
-"variable":
+**variable**:
 
 ```powershell
 Select-String -Pattern Variable -Path $pshome\*.txt
 ```
 
-### $PSITEM
+### $PSItem
 
 Same as `$_`. Contains the current object in the pipeline object. You can use
 this variable in commands that perform an action on every object or on
 selected objects in a pipeline.
 
-### $PSSCRIPTROOT
+### $PSScriptRoot
 
 Contains the directory from which a script is being run.
 
 In PowerShell 2.0, this variable is valid only in script modules (.psm1).
-Beginning in PowerShell 3.0, it is valid in all scripts.
+Beginning in PowerShell 3.0, it's valid in all scripts.
 
-### $PSSENDERINFO
+### $PSSenderInfo
 
 Contains information about the user who started the PSSession, including
 the user identity and the time zone of the originating computer. This
 variable is available only in PSSessions.
 
 The `$PSSenderInfo` variable includes a user-configurable property,
-**ApplicationArguments**, which, by default, contains only the
-`$PSVersionTable` from the originating session. To add data to the
-**ApplicationArguments** property, use the **ApplicationArguments** parameter
-of the `New-PSSessionOption` cmdlet.
+**ApplicationArguments**, that by default, contains only the `$PSVersionTable`
+from the originating session. To add data to the **ApplicationArguments**
+property, use the **ApplicationArguments** parameter of the
+`New-PSSessionOption` cmdlet.
 
-### $PSUICULTURE
+### $PSUICulture
 
-Contains the name of the user interface (UI) culture that is currently in use
+Contains the name of the user interface (UI) culture that's currently in use
 in the operating system. The UI culture determines which text strings are used
 for user interface elements, such as menus and messages. This is the value of
 the **System.Globalization.CultureInfo.CurrentUICulture.Name** property of the
 system. To get the **System.Globalization.CultureInfo** object for the system,
 use the `Get-UICulture` cmdlet.
 
-### $PSVERSIONTABLE
+### $PSVersionTable
 
 Contains a read-only hash table that displays details about the version of
 PowerShell that is running in the current session. The table includes the
@@ -431,73 +432,66 @@ following items:
 
 | Property                  | Description                                   |
 | ------------------------- | --------------------------------------------- |
-| BuildVersion              | The build number of the current version       |
-| CLRVersion                | The version of the common language runtime    |
+| **BuildVersion**          | The build number of the current version       |
+| **CLRVersion**            | The version of the common language runtime    |
 |                           | (CLR)                                         |
-| GitCommitId               | The commit Id of the source files, in GitHub, |
-|                           | used in this version of PowerShell            |
-| PSCompatibleVersions      | Versions of PowerShell that are compatible    |
+| **PSCompatibleVersions**  | Versions of PowerShell that are compatible    |
 |                           | with the current version                      |
-| PSEdition                 | This property has the value of 'Desktop', for |
-|                           | Windows Server and Windows client versions.   |
-|                           | This property has the value of 'Core' for     |
-|                           | PowerShell running under Nano Server or       |
-|                           | Windows IOT.                                  |
-| PSRemotingProtocolVersion | The version of the PowerShell remote          |
+| **PSRemotingProtocolVersion** | The version of the PowerShell remote      |
 |                           | management protocol.                          |
-| PSVersion                 | The PowerShell version number                 |
-| SerializationVersion      | The version of the serialization method       |
-| WSManStackVersion         | The version number of the WS-Management stack |
+| **PSVersion**             | The PowerShell version number                 |
+| **SerializationVersion**  | The version of the serialization method       |
+| **WSManStackVersion**     | The version number of the WS-Management stack |
 
 ### $PWD
 
 Contains a path object that represents the full path of the current directory.
 
-### REPORTERRORSHOW VARIABLES
+### ReportErrorShow variables
 
-The **ReportErrorShow** variables are defined in PowerShell, but they are not
-implemented. `Get-Variable` gets them, but they do not contain valid data.
+The **ReportErrorShow** variables are defined in PowerShell, but they aren't
+implemented. `Get-Variable` gets them, but they don't contain valid data.
 
-- $REPORTERRORSHOWEXCEPTIONCLASS
-- $REPORTERRORSHOWINNEREXCEPTION
-- $REPORTERRORSHOWSOURCE
-- $REPORTERRORSHOWSTACKTRACE
+- `$ReportErrorShowExceptionClass`
+- `$ReportErrorShowInnerException`
+- `$ReportErrorShowSource`
+- `$ReportErrorShowStackTrace`
 
-### $SENDER
+### $Sender
 
 Contains the object that generated this event. This variable is populated
 only within the Action block of an event registration command. The value of
 this variable can also be found in the Sender property of the **PSEventArgs**
 object that `Get-Event` returns.
 
-### $SHELLID
+### $ShellId
 
 Contains the identifier of the current shell.
 
-### $STACKTRACE
+### $StackTrace
 
 Contains a stack trace for the most recent error.
 
-### $SWITCH
+### $switch
 
-Contains the enumerator (not the resulting values) of a [Switch](about_Switch.md)
-statement. The `$Switch` variable exists only while the `switch` statement is
-running; it is deleted when the `switch` statement
-completes execution.
+Contains the enumerator not the resulting values of a `Switch` statement. The
+`$switch` variable exists only while the `Switch` statement is running; it's
+deleted when the `switch` statement completes execution. For more information,
+see [about_Switch](about_Switch.md).
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
 [Using Enumerators](#using-enumerators).
 
-### $THIS
+### $this
 
 In a script block that defines a script property or script method, the
-`$This` variable refers to the object that is being extended.
+`$this` variable refers to the object that is being extended.
 
-### $TRUE
+### $true
 
-Contains TRUE. You can use this variable to represent TRUE in commands and
-scripts.
+Contains **True**. You can use this variable to represent **True** in commands
+and scripts.
 
 ## Using Enumerators
 
@@ -505,13 +499,13 @@ The `$input`, `$foreach`, and `$switch` variables are all enumerators used
 to iterate through the values processed by their containing code block.
 
 An enumerator contains properties and methods you can use to advance or reset
-iteration, or retrieve iteration values. Directly manipulating enumerators is not
-considered best practice.
+iteration, or retrieve iteration values. Directly manipulating enumerators
+isn't considered best practice.
 
 - Within loops, flow control keywords [break](about_Break.md) and [continue](about_Continue.md)
   should be preferred.
-- Within functions that accepts pipeline input, it is best practice to
-  use Parameters with the **ValueFromPipeline** or
+- Within functions that accept pipeline input, it's best practice to use
+  Parameters with the **ValueFromPipeline** or
   **ValueFromPipelineByPropertyName** attributes.
 
   For more information, see [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
@@ -520,7 +514,7 @@ considered best practice.
 
 The [MoveNext](/dotnet/api/system.collections.ienumerator.movenext) method
 advances the enumerator to the next element of the collection. **MoveNext**
-returns **True** if the enumerator was successfully advanced, **false** if
+returns **True** if the enumerator was successfully advanced, **False** if
 the enumerator has passed the end of the collection.
 
 > [!NOTE]
@@ -593,7 +587,7 @@ Iteration: 1
 ```
 
 The process block automatically advances the `$input` variable even if you
-do not access it.
+don't access it.
 
 ```powershell
 $skip = $true
@@ -638,7 +632,7 @@ piped into the function.
 - Accessing the `$input` variable clears all values.
 - The **Reset** method resets the entire collection.
 - The **Current** property is never populated.
-- The **MoveNext** method returns false because the collection cannot be
+- The **MoveNext** method returns false because the collection can't be
   advanced.
   - Calling **MoveNext** clears out the `$input` variable.
 
@@ -666,7 +660,7 @@ After MoveNext:
 ### Example 3: Using the $input.Current property
 
 By using the **Current** property, the current pipeline value can be accessed
-multiple times without using the **Reset** method. The Process block does not
+multiple times without using the **Reset** method. The process block doesn't
 automatically call the **MoveNext** method.
 
 The **Current** property will never be populated unless you explicitly call
@@ -718,10 +712,10 @@ methods to change its value.
 > method.
 
 The following loop only executes twice. In the second iteration, the collection
-is moved to the 3rd element before the iteration is complete. After the second
+is moved to the third element before the iteration is complete. After the second
 iteration, there are now no more values to iterate, and the loop terminates.
 
-The **MoveNext** property does not affect the variable chosen to iterate through
+The **MoveNext** property doesn't affect the variable chosen to iterate through
 the collection (`$Num`).
 
 ```powershell
@@ -793,10 +787,10 @@ Reset Loop: 0
 ### Example 5: Using the $switch variable
 
 The `$switch` variable has the exact same rules as the `$foreach` variable.
-The following example demonstrates all of the enumerator concepts.
+The following example demonstrates all the enumerator concepts.
 
 > [!NOTE]
-> Note how the **NotEvaluated** case is never executed, even though there is
+> Note how the **NotEvaluated** case is never executed, even though there's
 > no `break` statement after the **MoveNext** method.
 
 ```powershell

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -547,7 +547,7 @@ The **Current** property continues to return the same property until
 
 ### Examples
 
-#### Example 1: Using the Input variable
+#### Example 1: Using the $input variable
 
 In the following example, accessing the `$input` variable clears the variable
 until the next time the process block executes. Using the **Reset** method
@@ -624,7 +624,7 @@ Iteration: 1
     Input: two
 ```
 
-### Example 2: Using $input outside the Process block
+### Example 2: Using $input outside the process block
 
 Outside of the process block the `$input` variable represents all the values
 piped into the function.
@@ -834,7 +834,7 @@ Default (Current): Start
 Default (Current): End
 ```
 
-## SEE ALSO
+## See also
 
 - [about_Hash_Tables](about_Hash_Tables.md)
 - [about_Preference_Variables](about_Preference_Variables.md)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -545,9 +545,9 @@ the enumerator.
 The **Current** property continues to return the same property until
 **MoveNext** is called.
 
-### Examples
+## Examples
 
-#### Example 1: Using the $input variable
+### Example 1: Using the $input variable
 
 In the following example, accessing the `$input` variable clears the variable
 until the next time the process block executes. Using the **Reset** method

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -5,9 +5,11 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Automatic_Variables
 ---
+
 # About Automatic Variables
 
 ## Short description
+
 Describes variables that store state information for PowerShell. These
 variables are created and maintained by PowerShell.
 
@@ -17,7 +19,7 @@ Conceptually, these variables are considered to be read-only. Even though they
 **can** be written to, for backward compatibility they **should not** be
 written to.
 
-Here is a list of the automatic variables in  PowerShell:
+Here is a list of the automatic variables in PowerShell:
 
 ### $$
 
@@ -25,8 +27,8 @@ Contains the last token in the last line received by the session.
 
 ### $?
 
-Contains the execution status of the last operation. It contains TRUE if
-the last operation succeeded and FALSE if it failed.
+Contains the execution status of the last operation. It contains **True** if
+the last operation succeeded and **False** if it failed.
 
 ### $^
 
@@ -103,16 +105,16 @@ objects that are available to cmdlets.
 
 ### $false
 
-Contains **FALSE**. You can use this variable to represent **FALSE** in commands
-and scripts instead of using the string "false". The string can be
-interpreted as **TRUE** if it is converted to a non-empty string or to a
+Contains **False**. You can use this variable to represent **False** in
+commands and scripts instead of using the string "false". The string can be
+interpreted as **True** if it's converted to a non-empty string or to a
 non-zero integer.
 
 ### $foreach
 
 Contains the enumerator (not the resulting values) of a
 [ForEach](about_ForEach.md) loop. The `$ForEach` variable exists only while
-the `ForEach` loop is running; it is deleted after the loop is completed.
+the `ForEach` loop is running; it's deleted after the loop is completed.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
@@ -171,15 +173,14 @@ were matched. The `$Matches` hash table can also be populated with captures
 when you use regular expressions with the `-match` operator.
 
 For more information about the `-match` operator, see
-[about_comparison_operators](about_comparison_operators.md). For more
+[about_Comparison_Operators](about_comparison_operators.md). For more
 information on regular expressions, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### $MyInvocation
 
-Contains an information about the current command, such as the name,
-parameters, parameter values, and information about how the command was
-started, called, or "invoked," such as the name of the script that called
-the current command.
+Contains information about the current command, such as the name, parameters,
+parameter values, and information about how the command was started, called, or
+invoked, such as the name of the script that called the current command.
 
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
@@ -224,11 +225,11 @@ the command, or type `exit`.
 
 The `$NestedPromptLevel` variable helps you track the prompt level. You can
 create an alternative PowerShell command prompt that includes this value so
-that it is always visible.
+that it's always visible.
 
-### $NULL
+### $null
 
-`$null` is an automatic variable that contains a **NULL** or empty value. You
+`$null` is an automatic variable that contains a **null** or empty value. You
 can use this variable to represent an absent or undefined value in commands and
 scripts.
 
@@ -236,7 +237,7 @@ PowerShell treats `$null` as an object with a value, that is, as an explicit
 placeholder, so you can use `$null` to represent an empty value in a series
 of values.
 
-For example, when `$null` is included in a collection, it is counted as one
+For example, when `$null` is included in a collection, it's counted as one
 of the objects.
 
 ```powershell
@@ -244,7 +245,7 @@ $a = "one", $null, "three"
 $a.count
 ```
 
-```output
+```Output
 3
 ```
 
@@ -255,17 +256,17 @@ value for `$null`, just as it does for the other objects
 "one", $null, "three" | ForEach-Object { "Hello " + $_}
 ```
 
-```output
+```Output
 Hello one
 Hello
 Hello three
 ```
 
-As a result, you cannot use `$null` to mean "no parameter value." A parameter
+As a result, you can't use `$null` to mean **no parameter value**. A parameter
 value of `$null` overrides the default parameter value.
 
 However, because PowerShell treats the `$null` variable as a placeholder, you
-can use it in scripts like the following one, which would not work if `$null`
+can use it in scripts like the following one, which wouldn't work if `$null`
 were ignored.
 
 ```powershell
@@ -284,7 +285,7 @@ foreach($day in $calendar)
 }
 ```
 
-```output
+```Output
 Appointment on Tuesday: Meeting
 Appointment on Friday: Team lunch
 ```
@@ -308,13 +309,13 @@ Test-Path $PROFILE
 Or, you can use it in a command to create a profile:
 
 ```powershell
-New-Item -ItemType file -Path $PSHOME -Force
+New-Item -ItemType file -Path $PROFILE -Force
 ```
 
-You can also use it in a command to open the profile in Notepad:
+You can use it in a command to open the profile in **notepad.exe**:
 
 ```powershell
-notepad $profile
+notepad.exe $PROFILE
 ```
 
 ### $PSBoundParameterValues
@@ -341,12 +342,12 @@ function Test {
 
 ### $PSCmdlet
 
-Contains an object that represents the cmdlet or advanced function that is
+Contains an object that represents the cmdlet or advanced function that's
 being run.
 
 You can use the properties and methods of the object in your cmdlet or
 function code to respond to the conditions of use. For example, the
-**ParameterSetName** property contains the name of the parameter set that is
+**ParameterSetName** property contains the name of the parameter set that's
 being used, and the **ShouldProcess** method adds the **WhatIf** and
 **Confirm** parameters to the cmdlet dynamically.
 
@@ -355,7 +356,7 @@ For more information about the `$PSCmdlet` automatic variable, see
 
 ### $PSCommandPath
 
-Contains the full path and file name of the script that is being run. This
+Contains the full path and file name of the script that's being run. This
 variable is valid in all scripts.
 
 ### $PSCulture
@@ -370,8 +371,8 @@ use the `Get-Culture` cmdlet.
 ### $PSDebugContext
 
 While debugging, this variable contains information about the debugging
-environment. Otherwise, it contains a NULL value. As a result, you can use it
-to indicate whether the debugger has control. When populated, it contains a
+environment. Otherwise, it contains a **null** value. As a result, you can use
+it to indicate whether the debugger has control. When populated, it contains a
 **PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
 properties. The **InvocationInfo** property has several useful properties,
 including the **Location** property. The **Location** property indicates the
@@ -383,7 +384,7 @@ Contains the full path of the installation directory for PowerShell,
 typically, `$env:windir\System32\PowerShell\v1.0` in Windows systems. You can
 use this variable in the paths of PowerShell files. For example, the
 following command searches the conceptual Help topics for the word
-"variable":
+**variable**:
 
 ```powershell
 Select-String -Pattern Variable -Path $pshome\*.txt
@@ -400,7 +401,7 @@ selected objects in a pipeline.
 Contains the directory from which a script is being run.
 
 In PowerShell 2.0, this variable is valid only in script modules (.psm1).
-Beginning in PowerShell 3.0, it is valid in all scripts.
+Beginning in PowerShell 3.0, it's valid in all scripts.
 
 ### $PSSenderInfo
 
@@ -409,14 +410,14 @@ the user identity and the time zone of the originating computer. This
 variable is available only in PSSessions.
 
 The `$PSSenderInfo` variable includes a user-configurable property,
-**ApplicationArguments**, which, by default, contains only the
-`$PSVersionTable` from the originating session. To add data to the
-**ApplicationArguments** property, use the **ApplicationArguments** parameter
-of the `New-PSSessionOption` cmdlet.
+**ApplicationArguments**, that by default, contains only the `$PSVersionTable`
+from the originating session. To add data to the **ApplicationArguments**
+property, use the **ApplicationArguments** parameter of the
+`New-PSSessionOption` cmdlet.
 
 ### $PSUICulture
 
-Contains the name of the user interface (UI) culture that is currently in use
+Contains the name of the user interface (UI) culture that's currently in use
 in the operating system. The UI culture determines which text strings are used
 for user interface elements, such as menus and messages. This is the value of
 the **System.Globalization.CultureInfo.CurrentUICulture.Name** property of the
@@ -431,43 +432,41 @@ following items:
 
 | Property                  | Description                                   |
 | ------------------------- | --------------------------------------------- |
-| BuildVersion              | The build number of the current version       |
-| CLRVersion                | The version of the common language runtime    |
+| **BuildVersion**          | The build number of the current version       |
+| **CLRVersion**            | The version of the common language runtime    |
 |                           | (CLR)                                         |
-| GitCommitId               | The commit Id of the source files, in GitHub, |
-|                           | used in this version of PowerShell            |
-| PSCompatibleVersions      | Versions of PowerShell that are compatible    |
+| **PSCompatibleVersions**  | Versions of PowerShell that are compatible    |
 |                           | with the current version                      |
-| PSEdition                 | This property has the value of 'Desktop', for |
+| **PSEdition**             | This property has the value of 'Desktop', for |
 |                           | Windows Server and Windows client versions.   |
 |                           | This property has the value of 'Core' for     |
 |                           | PowerShell running under Nano Server or       |
 |                           | Windows IOT.                                  |
-| PSRemotingProtocolVersion | The version of the PowerShell remote          |
+| **PSRemotingProtocolVersion** | The version of the PowerShell remote      |
 |                           | management protocol.                          |
-| PSVersion                 | The PowerShell version number                 |
-| SerializationVersion      | The version of the serialization method       |
-| WSManStackVersion         | The version number of the WS-Management stack |
+| **PSVersion**             | The PowerShell version number                 |
+| **SerializationVersion**  | The version of the serialization method       |
+| **WSManStackVersion**     | The version number of the WS-Management stack |
 
 ### $PWD
 
 Contains a path object that represents the full path of the current directory.
 
-### REPORTERRORSHOW VARIABLES
+### ReportErrorShow variables
 
-The **ReportErrorShow** variables are defined in PowerShell, but they are not
-implemented. `Get-Variable` gets them, but they do not contain valid data.
+The **ReportErrorShow** variables are defined in PowerShell, but they aren't
+implemented. `Get-Variable` gets them, but they don't contain valid data.
 
-- `$REPORTERRORSHOWEXCEPTIONCLASS`
-- `$REPORTERRORSHOWINNEREXCEPTION`
-- `$REPORTERRORSHOWSOURCE`
-- `$REPORTERRORSHOWSTACKTRACE`
+- `$ReportErrorShowExceptionClass`
+- `$ReportErrorShowInnerException`
+- `$ReportErrorShowSource`
+- `$ReportErrorShowStackTrace`
 
-### $SENDER
+### $Sender
 
 Contains the object that generated this event. This variable is populated
-only within the `Action` block of an event registration command. The value of
-this variable can also be found in the **Sender** property of the **PSEventArgs**
+only within the Action block of an event registration command. The value of
+this variable can also be found in the Sender property of the **PSEventArgs**
 object that `Get-Event` returns.
 
 ### $ShellId
@@ -480,10 +479,10 @@ Contains a stack trace for the most recent error.
 
 ### $switch
 
-Contains the enumerator (not the resulting values) of a [Switch](about_Switch.md)
-statement. The `$Switch` variable exists only while the `switch` statement is
-running; it is deleted when the `switch` statement
-completes execution.
+Contains the enumerator not the resulting values of a `Switch` statement. The
+`$switch` variable exists only while the `Switch` statement is running; it's
+deleted when the `switch` statement completes execution. For more information,
+see [about_Switch](about_Switch.md).
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
@@ -492,11 +491,11 @@ and change the current loop iteration. For more information, see
 ### $this
 
 In a script block that defines a script property or script method, the
-`$This` variable refers to the object that is being extended.
+`$this` variable refers to the object that is being extended.
 
 ### $true
 
-Contains **TRUE**. You can use this variable to represent **TRUE** in commands
+Contains **True**. You can use this variable to represent **True** in commands
 and scripts.
 
 ## Using Enumerators
@@ -505,13 +504,13 @@ The `$input`, `$foreach`, and `$switch` variables are all enumerators used
 to iterate through the values processed by their containing code block.
 
 An enumerator contains properties and methods you can use to advance or reset
-iteration, or retrieve iteration values. Directly manipulating enumerators is not
-considered best practice.
+iteration, or retrieve iteration values. Directly manipulating enumerators
+isn't considered best practice.
 
 - Within loops, flow control keywords [break](about_Break.md) and [continue](about_Continue.md)
   should be preferred.
-- Within functions that accepts pipeline input, it is best practice to
-  use Parameters with the **ValueFromPipeline** or
+- Within functions that accept pipeline input, it's best practice to use
+  Parameters with the **ValueFromPipeline** or
   **ValueFromPipelineByPropertyName** attributes.
 
   For more information, see [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
@@ -520,7 +519,7 @@ considered best practice.
 
 The [MoveNext](/dotnet/api/system.collections.ienumerator.movenext) method
 advances the enumerator to the next element of the collection. **MoveNext**
-returns **True** if the enumerator was successfully advanced, **false** if
+returns **True** if the enumerator was successfully advanced, **False** if
 the enumerator has passed the end of the collection.
 
 > [!NOTE]
@@ -593,7 +592,7 @@ Iteration: 1
 ```
 
 The process block automatically advances the `$input` variable even if you
-do not access it.
+don't access it.
 
 ```powershell
 $skip = $true
@@ -638,7 +637,7 @@ piped into the function.
 - Accessing the `$input` variable clears all values.
 - The **Reset** method resets the entire collection.
 - The **Current** property is never populated.
-- The **MoveNext** method returns false because the collection cannot be
+- The **MoveNext** method returns false because the collection can't be
   advanced.
   - Calling **MoveNext** clears out the `$input` variable.
 
@@ -666,7 +665,7 @@ After MoveNext:
 ### Example 3: Using the $input.Current property
 
 By using the **Current** property, the current pipeline value can be accessed
-multiple times without using the **Reset** method. The Process block does not
+multiple times without using the **Reset** method. The process block doesn't
 automatically call the **MoveNext** method.
 
 The **Current** property will never be populated unless you explicitly call
@@ -718,10 +717,10 @@ methods to change its value.
 > method.
 
 The following loop only executes twice. In the second iteration, the collection
-is moved to the 3rd element before the iteration is complete. After the second
+is moved to the third element before the iteration is complete. After the second
 iteration, there are now no more values to iterate, and the loop terminates.
 
-The **MoveNext** property does not affect the variable chosen to iterate through
+The **MoveNext** property doesn't affect the variable chosen to iterate through
 the collection (`$Num`).
 
 ```powershell
@@ -757,7 +756,7 @@ Num has not changed: two
 
 Using the **Reset** method resets the current element in the collection. The
 following example loops through the first two elements **twice** because the
-**Reset** method is called. After the first two loops, the `If` statement
+**Reset** method is called. After the first two loops, the `if` statement
 fails and the loop iterates through all three elements normally.
 
 > [!IMPORTANT]
@@ -793,10 +792,10 @@ Reset Loop: 0
 ### Example 5: Using the $switch variable
 
 The `$switch` variable has the exact same rules as the `$foreach` variable.
-The following example demonstrates all of the enumerator concepts.
+The following example demonstrates all the enumerator concepts.
 
 > [!NOTE]
-> Note how the **NotEvaluated** case is never executed, even though there is
+> Note how the **NotEvaluated** case is never executed, even though there's
 > no `break` statement after the **MoveNext** method.
 
 ```powershell

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -552,7 +552,7 @@ The **Current** property continues to return the same property until
 
 ### Examples
 
-#### Example 1: Using the Input variable
+#### Example 1: Using the $input variable
 
 In the following example, accessing the `$input` variable clears the variable
 until the next time the process block executes. Using the **Reset** method
@@ -629,7 +629,7 @@ Iteration: 1
     Input: two
 ```
 
-### Example 2: Using $input outside the Process block
+### Example 2: Using $input outside the process block
 
 Outside of the process block the `$input` variable represents all the values
 piped into the function.
@@ -839,7 +839,7 @@ Default (Current): Start
 Default (Current): End
 ```
 
-## SEE ALSO
+## See also
 
 - [about_Hash_Tables](about_Hash_Tables.md)
 - [about_Preference_Variables](about_Preference_Variables.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -550,9 +550,9 @@ the enumerator.
 The **Current** property continues to return the same property until
 **MoveNext** is called.
 
-### Examples
+## Examples
 
-#### Example 1: Using the $input variable
+### Example 1: Using the $input variable
 
 In the following example, accessing the `$input` variable clears the variable
 until the next time the process block executes. Using the **Reset** method

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -573,9 +573,9 @@ the enumerator.
 The **Current** property continues to return the same property until
 **MoveNext** is called.
 
-### Examples
+## Examples
 
-#### Example 1: Using the $input variable
+### Example 1: Using the $input variable
 
 In the following example, accessing the `$input` variable clears the variable
 until the next time the process block executes. Using the **Reset** method

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -575,7 +575,7 @@ The **Current** property continues to return the same property until
 
 ### Examples
 
-#### Example 1: Using the Input variable
+#### Example 1: Using the $input variable
 
 In the following example, accessing the `$input` variable clears the variable
 until the next time the process block executes. Using the **Reset** method
@@ -652,7 +652,7 @@ Iteration: 1
     Input: two
 ```
 
-### Example 2: Using $input outside the Process block
+### Example 2: Using $input outside the process block
 
 Outside of the process block the `$input` variable represents all the values
 piped into the function.
@@ -862,7 +862,7 @@ Default (Current): Start
 Default (Current): End
 ```
 
-## SEE ALSO
+## See also
 
 - [about_Hash_Tables](about_Hash_Tables.md)
 - [about_Preference_Variables](about_Preference_Variables.md)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -5,9 +5,11 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Automatic_Variables
 ---
+
 # About Automatic Variables
 
 ## Short description
+
 Describes variables that store state information for PowerShell. These
 variables are created and maintained by PowerShell.
 
@@ -17,7 +19,7 @@ Conceptually, these variables are considered to be read-only. Even though they
 **can** be written to, for backward compatibility they **should not** be
 written to.
 
-Here is a list of the automatic variables in  PowerShell:
+Here is a list of the automatic variables in PowerShell:
 
 ### $$
 
@@ -25,8 +27,8 @@ Contains the last token in the last line received by the session.
 
 ### $?
 
-Contains the execution status of the last operation. It contains TRUE if
-the last operation succeeded and FALSE if it failed.
+Contains the execution status of the last operation. It contains **True** if
+the last operation succeeded and **False** if it failed.
 
 ### $^
 
@@ -103,16 +105,16 @@ objects that are available to cmdlets.
 
 ### $false
 
-Contains **FALSE**. You can use this variable to represent **FALSE** in commands
-and scripts instead of using the string "false". The string can be
-interpreted as **TRUE** if it is converted to a non-empty string or to a
+Contains **False**. You can use this variable to represent **False** in
+commands and scripts instead of using the string "false". The string can be
+interpreted as **True** if it's converted to a non-empty string or to a
 non-zero integer.
 
 ### $foreach
 
 Contains the enumerator (not the resulting values) of a
 [ForEach](about_ForEach.md) loop. The `$ForEach` variable exists only while
-the `ForEach` loop is running; it is deleted after the loop is completed.
+the `ForEach` loop is running; it's deleted after the loop is completed.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
@@ -191,15 +193,14 @@ were matched. The `$Matches` hash table can also be populated with captures
 when you use regular expressions with the `-match` operator.
 
 For more information about the `-match` operator, see
-[about_comparison_operators](about_comparison_operators.md). For more
+[about_Comparison_Operators](about_comparison_operators.md). For more
 information on regular expressions, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### $MyInvocation
 
-Contains an information about the current command, such as the name,
-parameters, parameter values, and information about how the command was
-started, called, or "invoked," such as the name of the script that called
-the current command.
+Contains information about the current command, such as the name, parameters,
+parameter values, and information about how the command was started, called, or
+invoked, such as the name of the script that called the current command.
 
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
@@ -244,11 +245,11 @@ the command, or type `exit`.
 
 The `$NestedPromptLevel` variable helps you track the prompt level. You can
 create an alternative PowerShell command prompt that includes this value so
-that it is always visible.
+that it's always visible.
 
-### $NULL
+### $null
 
-`$null` is an automatic variable that contains a **NULL** or empty value. You
+`$null` is an automatic variable that contains a **null** or empty value. You
 can use this variable to represent an absent or undefined value in commands and
 scripts.
 
@@ -256,7 +257,7 @@ PowerShell treats `$null` as an object with a value, that is, as an explicit
 placeholder, so you can use `$null` to represent an empty value in a series
 of values.
 
-For example, when `$null` is included in a collection, it is counted as one
+For example, when `$null` is included in a collection, it's counted as one
 of the objects.
 
 ```powershell
@@ -264,7 +265,7 @@ $a = "one", $null, "three"
 $a.count
 ```
 
-```output
+```Output
 3
 ```
 
@@ -275,17 +276,17 @@ value for `$null`, just as it does for the other objects
 "one", $null, "three" | ForEach-Object { "Hello " + $_}
 ```
 
-```output
+```Output
 Hello one
 Hello
 Hello three
 ```
 
-As a result, you cannot use `$null` to mean "no parameter value." A parameter
+As a result, you can't use `$null` to mean **no parameter value**. A parameter
 value of `$null` overrides the default parameter value.
 
 However, because PowerShell treats the `$null` variable as a placeholder, you
-can use it in scripts like the following one, which would not work if `$null`
+can use it in scripts like the following one, which wouldn't work if `$null`
 were ignored.
 
 ```powershell
@@ -304,7 +305,7 @@ foreach($day in $calendar)
 }
 ```
 
-```output
+```Output
 Appointment on Tuesday: Meeting
 Appointment on Friday: Team lunch
 ```
@@ -328,13 +329,13 @@ Test-Path $PROFILE
 Or, you can use it in a command to create a profile:
 
 ```powershell
-New-Item -ItemType file -Path $PSHOME -Force
+New-Item -ItemType file -Path $PROFILE -Force
 ```
 
-You can also use it in a command to open the profile in Notepad:
+You can use it in a command to open the profile in **notepad.exe**:
 
 ```powershell
-notepad $profile
+notepad.exe $PROFILE
 ```
 
 ### $PSBoundParameterValues
@@ -361,12 +362,12 @@ function Test {
 
 ### $PSCmdlet
 
-Contains an object that represents the cmdlet or advanced function that is
+Contains an object that represents the cmdlet or advanced function that's
 being run.
 
 You can use the properties and methods of the object in your cmdlet or
 function code to respond to the conditions of use. For example, the
-**ParameterSetName** property contains the name of the parameter set that is
+**ParameterSetName** property contains the name of the parameter set that's
 being used, and the **ShouldProcess** method adds the **WhatIf** and
 **Confirm** parameters to the cmdlet dynamically.
 
@@ -375,7 +376,7 @@ For more information about the `$PSCmdlet` automatic variable, see
 
 ### $PSCommandPath
 
-Contains the full path and file name of the script that is being run. This
+Contains the full path and file name of the script that's being run. This
 variable is valid in all scripts.
 
 ### $PSCulture
@@ -390,8 +391,8 @@ use the `Get-Culture` cmdlet.
 ### $PSDebugContext
 
 While debugging, this variable contains information about the debugging
-environment. Otherwise, it contains a NULL value. As a result, you can use it
-to indicate whether the debugger has control. When populated, it contains a
+environment. Otherwise, it contains a **null** value. As a result, you can use
+it to indicate whether the debugger has control. When populated, it contains a
 **PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
 properties. The **InvocationInfo** property has several useful properties,
 including the **Location** property. The **Location** property indicates the
@@ -403,7 +404,7 @@ Contains the full path of the installation directory for PowerShell,
 typically, `$env:windir\System32\PowerShell\v1.0` in Windows systems. You can
 use this variable in the paths of PowerShell files. For example, the
 following command searches the conceptual Help topics for the word
-"variable":
+**variable**:
 
 ```powershell
 Select-String -Pattern Variable -Path $pshome\*.txt
@@ -420,7 +421,7 @@ selected objects in a pipeline.
 Contains the directory from which a script is being run.
 
 In PowerShell 2.0, this variable is valid only in script modules (.psm1).
-Beginning in PowerShell 3.0, it is valid in all scripts.
+Beginning in PowerShell 3.0, it's valid in all scripts.
 
 ### $PSSenderInfo
 
@@ -429,14 +430,14 @@ the user identity and the time zone of the originating computer. This
 variable is available only in PSSessions.
 
 The `$PSSenderInfo` variable includes a user-configurable property,
-**ApplicationArguments**, which, by default, contains only the
-`$PSVersionTable` from the originating session. To add data to the
-**ApplicationArguments** property, use the **ApplicationArguments** parameter
-of the `New-PSSessionOption` cmdlet.
+**ApplicationArguments**, that by default, contains only the `$PSVersionTable`
+from the originating session. To add data to the **ApplicationArguments**
+property, use the **ApplicationArguments** parameter of the
+`New-PSSessionOption` cmdlet.
 
 ### $PSUICulture
 
-Contains the name of the user interface (UI) culture that is currently in use
+Contains the name of the user interface (UI) culture that's currently in use
 in the operating system. The UI culture determines which text strings are used
 for user interface elements, such as menus and messages. This is the value of
 the **System.Globalization.CultureInfo.CurrentUICulture.Name** property of the
@@ -474,21 +475,21 @@ following items:
 
 Contains a path object that represents the full path of the current directory.
 
-### REPORTERRORSHOW VARIABLES
+### ReportErrorShow variables
 
-The **ReportErrorShow** variables are defined in PowerShell, but they are not
-implemented. `Get-Variable` gets them, but they do not contain valid data.
+The **ReportErrorShow** variables are defined in PowerShell, but they aren't
+implemented. `Get-Variable` gets them, but they don't contain valid data.
 
-- `$REPORTERRORSHOWEXCEPTIONCLASS`
-- `$REPORTERRORSHOWINNEREXCEPTION`
-- `$REPORTERRORSHOWSOURCE`
-- `$REPORTERRORSHOWSTACKTRACE`
+- `$ReportErrorShowExceptionClass`
+- `$ReportErrorShowInnerException`
+- `$ReportErrorShowSource`
+- `$ReportErrorShowStackTrace`
 
-### $SENDER
+### $Sender
 
 Contains the object that generated this event. This variable is populated
-only within the `Action` block of an event registration command. The value of
-this variable can also be found in the **Sender** property of the **PSEventArgs**
+only within the Action block of an event registration command. The value of
+this variable can also be found in the Sender property of the **PSEventArgs**
 object that `Get-Event` returns.
 
 ### $ShellId
@@ -501,10 +502,10 @@ Contains a stack trace for the most recent error.
 
 ### $switch
 
-Contains the enumerator (not the resulting values) of a [Switch](about_Switch.md)
-statement. The `$Switch` variable exists only while the `switch` statement is
-running; it is deleted when the `switch` statement
-completes execution.
+Contains the enumerator not the resulting values of a `Switch` statement. The
+`$switch` variable exists only while the `Switch` statement is running; it's
+deleted when the `switch` statement completes execution. For more information,
+see [about_Switch](about_Switch.md).
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
@@ -513,11 +514,11 @@ and change the current loop iteration. For more information, see
 ### $this
 
 In a script block that defines a script property or script method, the
-`$This` variable refers to the object that is being extended.
+`$this` variable refers to the object that is being extended.
 
 ### $true
 
-Contains **TRUE**. You can use this variable to represent **TRUE** in commands
+Contains **True**. You can use this variable to represent **True** in commands
 and scripts.
 
 ## Using Enumerators
@@ -526,13 +527,13 @@ The `$input`, `$foreach`, and `$switch` variables are all enumerators used
 to iterate through the values processed by their containing code block.
 
 An enumerator contains properties and methods you can use to advance or reset
-iteration, or retrieve iteration values. Directly manipulating enumerators is not
-considered best practice.
+iteration, or retrieve iteration values. Directly manipulating enumerators
+isn't considered best practice.
 
 - Within loops, flow control keywords [break](about_Break.md) and [continue](about_Continue.md)
   should be preferred.
-- Within functions that accepts pipeline input, it is best practice to
-  use Parameters with the **ValueFromPipeline** or
+- Within functions that accept pipeline input, it's best practice to use
+  Parameters with the **ValueFromPipeline** or
   **ValueFromPipelineByPropertyName** attributes.
 
   For more information, see [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
@@ -541,7 +542,7 @@ considered best practice.
 
 The [MoveNext](/dotnet/api/system.collections.ienumerator.movenext) method
 advances the enumerator to the next element of the collection. **MoveNext**
-returns **True** if the enumerator was successfully advanced, **false** if
+returns **True** if the enumerator was successfully advanced, **False** if
 the enumerator has passed the end of the collection.
 
 > [!NOTE]
@@ -614,7 +615,7 @@ Iteration: 1
 ```
 
 The process block automatically advances the `$input` variable even if you
-do not access it.
+don't access it.
 
 ```powershell
 $skip = $true
@@ -659,7 +660,7 @@ piped into the function.
 - Accessing the `$input` variable clears all values.
 - The **Reset** method resets the entire collection.
 - The **Current** property is never populated.
-- The **MoveNext** method returns false because the collection cannot be
+- The **MoveNext** method returns false because the collection can't be
   advanced.
   - Calling **MoveNext** clears out the `$input` variable.
 
@@ -687,7 +688,7 @@ After MoveNext:
 ### Example 3: Using the $input.Current property
 
 By using the **Current** property, the current pipeline value can be accessed
-multiple times without using the **Reset** method. The Process block does not
+multiple times without using the **Reset** method. The process block doesn't
 automatically call the **MoveNext** method.
 
 The **Current** property will never be populated unless you explicitly call
@@ -739,10 +740,10 @@ methods to change its value.
 > method.
 
 The following loop only executes twice. In the second iteration, the collection
-is moved to the 3rd element before the iteration is complete. After the second
+is moved to the third element before the iteration is complete. After the second
 iteration, there are now no more values to iterate, and the loop terminates.
 
-The **MoveNext** property does not affect the variable chosen to iterate through
+The **MoveNext** property doesn't affect the variable chosen to iterate through
 the collection (`$Num`).
 
 ```powershell
@@ -778,7 +779,7 @@ Num has not changed: two
 
 Using the **Reset** method resets the current element in the collection. The
 following example loops through the first two elements **twice** because the
-**Reset** method is called. After the first two loops, the `If` statement
+**Reset** method is called. After the first two loops, the `if` statement
 fails and the loop iterates through all three elements normally.
 
 > [!IMPORTANT]
@@ -814,10 +815,10 @@ Reset Loop: 0
 ### Example 5: Using the $switch variable
 
 The `$switch` variable has the exact same rules as the `$foreach` variable.
-The following example demonstrates all of the enumerator concepts.
+The following example demonstrates all the enumerator concepts.
 
 > [!NOTE]
-> Note how the **NotEvaluated** case is never executed, even though there is
+> Note how the **NotEvaluated** case is never executed, even though there's
 > no `break` statement after the **MoveNext** method.
 
 ```powershell

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -573,9 +573,9 @@ the enumerator.
 The **Current** property continues to return the same property until
 **MoveNext** is called.
 
-### Examples
+## Examples
 
-#### Example 1: Using the $input variable
+### Example 1: Using the $input variable
 
 In the following example, accessing the `$input` variable clears the variable
 until the next time the process block executes. Using the **Reset** method

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -575,7 +575,7 @@ The **Current** property continues to return the same property until
 
 ### Examples
 
-#### Example 1: Using the Input variable
+#### Example 1: Using the $input variable
 
 In the following example, accessing the `$input` variable clears the variable
 until the next time the process block executes. Using the **Reset** method
@@ -652,7 +652,7 @@ Iteration: 1
     Input: two
 ```
 
-### Example 2: Using $input outside the Process block
+### Example 2: Using $input outside the process block
 
 Outside of the process block the `$input` variable represents all the values
 piped into the function.
@@ -862,7 +862,7 @@ Default (Current): Start
 Default (Current): End
 ```
 
-## SEE ALSO
+## See also
 
 - [about_Hash_Tables](about_Hash_Tables.md)
 - [about_Preference_Variables](about_Preference_Variables.md)

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -5,9 +5,11 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Automatic_Variables
 ---
+
 # About Automatic Variables
 
 ## Short description
+
 Describes variables that store state information for PowerShell. These
 variables are created and maintained by PowerShell.
 
@@ -17,7 +19,7 @@ Conceptually, these variables are considered to be read-only. Even though they
 **can** be written to, for backward compatibility they **should not** be
 written to.
 
-Here is a list of the automatic variables in  PowerShell:
+Here is a list of the automatic variables in PowerShell:
 
 ### $$
 
@@ -25,8 +27,8 @@ Contains the last token in the last line received by the session.
 
 ### $?
 
-Contains the execution status of the last operation. It contains TRUE if
-the last operation succeeded and FALSE if it failed.
+Contains the execution status of the last operation. It contains **True** if
+the last operation succeeded and **False** if it failed.
 
 ### $^
 
@@ -103,16 +105,16 @@ objects that are available to cmdlets.
 
 ### $false
 
-Contains **FALSE**. You can use this variable to represent **FALSE** in commands
-and scripts instead of using the string "false". The string can be
-interpreted as **TRUE** if it is converted to a non-empty string or to a
+Contains **False**. You can use this variable to represent **False** in
+commands and scripts instead of using the string "false". The string can be
+interpreted as **True** if it's converted to a non-empty string or to a
 non-zero integer.
 
 ### $foreach
 
 Contains the enumerator (not the resulting values) of a
 [ForEach](about_ForEach.md) loop. The `$ForEach` variable exists only while
-the `ForEach` loop is running; it is deleted after the loop is completed.
+the `ForEach` loop is running; it's deleted after the loop is completed.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
@@ -191,15 +193,14 @@ were matched. The `$Matches` hash table can also be populated with captures
 when you use regular expressions with the `-match` operator.
 
 For more information about the `-match` operator, see
-[about_comparison_operators](about_comparison_operators.md). For more
+[about_Comparison_Operators](about_comparison_operators.md). For more
 information on regular expressions, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### $MyInvocation
 
-Contains an information about the current command, such as the name,
-parameters, parameter values, and information about how the command was
-started, called, or "invoked," such as the name of the script that called
-the current command.
+Contains information about the current command, such as the name, parameters,
+parameter values, and information about how the command was started, called, or
+invoked, such as the name of the script that called the current command.
 
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
@@ -244,11 +245,11 @@ the command, or type `exit`.
 
 The `$NestedPromptLevel` variable helps you track the prompt level. You can
 create an alternative PowerShell command prompt that includes this value so
-that it is always visible.
+that it's always visible.
 
-### $NULL
+### $null
 
-`$null` is an automatic variable that contains a **NULL** or empty value. You
+`$null` is an automatic variable that contains a **null** or empty value. You
 can use this variable to represent an absent or undefined value in commands and
 scripts.
 
@@ -256,7 +257,7 @@ PowerShell treats `$null` as an object with a value, that is, as an explicit
 placeholder, so you can use `$null` to represent an empty value in a series
 of values.
 
-For example, when `$null` is included in a collection, it is counted as one
+For example, when `$null` is included in a collection, it's counted as one
 of the objects.
 
 ```powershell
@@ -264,7 +265,7 @@ $a = "one", $null, "three"
 $a.count
 ```
 
-```output
+```Output
 3
 ```
 
@@ -275,17 +276,17 @@ value for `$null`, just as it does for the other objects
 "one", $null, "three" | ForEach-Object { "Hello " + $_}
 ```
 
-```output
+```Output
 Hello one
 Hello
 Hello three
 ```
 
-As a result, you cannot use `$null` to mean "no parameter value." A parameter
+As a result, you can't use `$null` to mean **no parameter value**. A parameter
 value of `$null` overrides the default parameter value.
 
 However, because PowerShell treats the `$null` variable as a placeholder, you
-can use it in scripts like the following one, which would not work if `$null`
+can use it in scripts like the following one, which wouldn't work if `$null`
 were ignored.
 
 ```powershell
@@ -304,7 +305,7 @@ foreach($day in $calendar)
 }
 ```
 
-```output
+```Output
 Appointment on Tuesday: Meeting
 Appointment on Friday: Team lunch
 ```
@@ -328,13 +329,13 @@ Test-Path $PROFILE
 Or, you can use it in a command to create a profile:
 
 ```powershell
-New-Item -ItemType file -Path $PSHOME -Force
+New-Item -ItemType file -Path $PROFILE -Force
 ```
 
-You can also use it in a command to open the profile in Notepad:
+You can use it in a command to open the profile in **notepad.exe**:
 
 ```powershell
-notepad $profile
+notepad.exe $PROFILE
 ```
 
 ### $PSBoundParameterValues
@@ -361,12 +362,12 @@ function Test {
 
 ### $PSCmdlet
 
-Contains an object that represents the cmdlet or advanced function that is
+Contains an object that represents the cmdlet or advanced function that's
 being run.
 
 You can use the properties and methods of the object in your cmdlet or
 function code to respond to the conditions of use. For example, the
-**ParameterSetName** property contains the name of the parameter set that is
+**ParameterSetName** property contains the name of the parameter set that's
 being used, and the **ShouldProcess** method adds the **WhatIf** and
 **Confirm** parameters to the cmdlet dynamically.
 
@@ -375,7 +376,7 @@ For more information about the `$PSCmdlet` automatic variable, see
 
 ### $PSCommandPath
 
-Contains the full path and file name of the script that is being run. This
+Contains the full path and file name of the script that's being run. This
 variable is valid in all scripts.
 
 ### $PSCulture
@@ -390,8 +391,8 @@ use the `Get-Culture` cmdlet.
 ### $PSDebugContext
 
 While debugging, this variable contains information about the debugging
-environment. Otherwise, it contains a NULL value. As a result, you can use it
-to indicate whether the debugger has control. When populated, it contains a
+environment. Otherwise, it contains a **null** value. As a result, you can use
+it to indicate whether the debugger has control. When populated, it contains a
 **PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
 properties. The **InvocationInfo** property has several useful properties,
 including the **Location** property. The **Location** property indicates the
@@ -403,7 +404,7 @@ Contains the full path of the installation directory for PowerShell,
 typically, `$env:windir\System32\PowerShell\v1.0` in Windows systems. You can
 use this variable in the paths of PowerShell files. For example, the
 following command searches the conceptual Help topics for the word
-"variable":
+**variable**:
 
 ```powershell
 Select-String -Pattern Variable -Path $pshome\*.txt
@@ -420,7 +421,7 @@ selected objects in a pipeline.
 Contains the directory from which a script is being run.
 
 In PowerShell 2.0, this variable is valid only in script modules (.psm1).
-Beginning in PowerShell 3.0, it is valid in all scripts.
+Beginning in PowerShell 3.0, it's valid in all scripts.
 
 ### $PSSenderInfo
 
@@ -429,14 +430,14 @@ the user identity and the time zone of the originating computer. This
 variable is available only in PSSessions.
 
 The `$PSSenderInfo` variable includes a user-configurable property,
-**ApplicationArguments**, which, by default, contains only the
-`$PSVersionTable` from the originating session. To add data to the
-**ApplicationArguments** property, use the **ApplicationArguments** parameter
-of the `New-PSSessionOption` cmdlet.
+**ApplicationArguments**, that by default, contains only the `$PSVersionTable`
+from the originating session. To add data to the **ApplicationArguments**
+property, use the **ApplicationArguments** parameter of the
+`New-PSSessionOption` cmdlet.
 
 ### $PSUICulture
 
-Contains the name of the user interface (UI) culture that is currently in use
+Contains the name of the user interface (UI) culture that's currently in use
 in the operating system. The UI culture determines which text strings are used
 for user interface elements, such as menus and messages. This is the value of
 the **System.Globalization.CultureInfo.CurrentUICulture.Name** property of the
@@ -474,21 +475,21 @@ following items:
 
 Contains a path object that represents the full path of the current directory.
 
-### REPORTERRORSHOW VARIABLES
+### ReportErrorShow variables
 
-The **ReportErrorShow** variables are defined in PowerShell, but they are not
-implemented. `Get-Variable` gets them, but they do not contain valid data.
+The **ReportErrorShow** variables are defined in PowerShell, but they aren't
+implemented. `Get-Variable` gets them, but they don't contain valid data.
 
-- `$REPORTERRORSHOWEXCEPTIONCLASS`
-- `$REPORTERRORSHOWINNEREXCEPTION`
-- `$REPORTERRORSHOWSOURCE`
-- `$REPORTERRORSHOWSTACKTRACE`
+- `$ReportErrorShowExceptionClass`
+- `$ReportErrorShowInnerException`
+- `$ReportErrorShowSource`
+- `$ReportErrorShowStackTrace`
 
-### $SENDER
+### $Sender
 
 Contains the object that generated this event. This variable is populated
-only within the `Action` block of an event registration command. The value of
-this variable can also be found in the **Sender** property of the **PSEventArgs**
+only within the Action block of an event registration command. The value of
+this variable can also be found in the Sender property of the **PSEventArgs**
 object that `Get-Event` returns.
 
 ### $ShellId
@@ -501,10 +502,10 @@ Contains a stack trace for the most recent error.
 
 ### $switch
 
-Contains the enumerator (not the resulting values) of a [Switch](about_Switch.md)
-statement. The `$Switch` variable exists only while the `switch` statement is
-running; it is deleted when the `switch` statement
-completes execution.
+Contains the enumerator not the resulting values of a `Switch` statement. The
+`$switch` variable exists only while the `Switch` statement is running; it's
+deleted when the `switch` statement completes execution. For more information,
+see [about_Switch](about_Switch.md).
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
@@ -513,11 +514,11 @@ and change the current loop iteration. For more information, see
 ### $this
 
 In a script block that defines a script property or script method, the
-`$This` variable refers to the object that is being extended.
+`$this` variable refers to the object that is being extended.
 
 ### $true
 
-Contains **TRUE**. You can use this variable to represent **TRUE** in commands
+Contains **True**. You can use this variable to represent **True** in commands
 and scripts.
 
 ## Using Enumerators
@@ -526,13 +527,13 @@ The `$input`, `$foreach`, and `$switch` variables are all enumerators used
 to iterate through the values processed by their containing code block.
 
 An enumerator contains properties and methods you can use to advance or reset
-iteration, or retrieve iteration values. Directly manipulating enumerators is not
-considered best practice.
+iteration, or retrieve iteration values. Directly manipulating enumerators
+isn't considered best practice.
 
 - Within loops, flow control keywords [break](about_Break.md) and [continue](about_Continue.md)
   should be preferred.
-- Within functions that accepts pipeline input, it is best practice to
-  use Parameters with the **ValueFromPipeline** or
+- Within functions that accept pipeline input, it's best practice to use
+  Parameters with the **ValueFromPipeline** or
   **ValueFromPipelineByPropertyName** attributes.
 
   For more information, see [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
@@ -541,7 +542,7 @@ considered best practice.
 
 The [MoveNext](/dotnet/api/system.collections.ienumerator.movenext) method
 advances the enumerator to the next element of the collection. **MoveNext**
-returns **True** if the enumerator was successfully advanced, **false** if
+returns **True** if the enumerator was successfully advanced, **False** if
 the enumerator has passed the end of the collection.
 
 > [!NOTE]
@@ -614,7 +615,7 @@ Iteration: 1
 ```
 
 The process block automatically advances the `$input` variable even if you
-do not access it.
+don't access it.
 
 ```powershell
 $skip = $true
@@ -659,7 +660,7 @@ piped into the function.
 - Accessing the `$input` variable clears all values.
 - The **Reset** method resets the entire collection.
 - The **Current** property is never populated.
-- The **MoveNext** method returns false because the collection cannot be
+- The **MoveNext** method returns false because the collection can't be
   advanced.
   - Calling **MoveNext** clears out the `$input` variable.
 
@@ -687,7 +688,7 @@ After MoveNext:
 ### Example 3: Using the $input.Current property
 
 By using the **Current** property, the current pipeline value can be accessed
-multiple times without using the **Reset** method. The Process block does not
+multiple times without using the **Reset** method. The process block doesn't
 automatically call the **MoveNext** method.
 
 The **Current** property will never be populated unless you explicitly call
@@ -739,10 +740,10 @@ methods to change its value.
 > method.
 
 The following loop only executes twice. In the second iteration, the collection
-is moved to the 3rd element before the iteration is complete. After the second
+is moved to the third element before the iteration is complete. After the second
 iteration, there are now no more values to iterate, and the loop terminates.
 
-The **MoveNext** property does not affect the variable chosen to iterate through
+The **MoveNext** property doesn't affect the variable chosen to iterate through
 the collection (`$Num`).
 
 ```powershell
@@ -778,7 +779,7 @@ Num has not changed: two
 
 Using the **Reset** method resets the current element in the collection. The
 following example loops through the first two elements **twice** because the
-**Reset** method is called. After the first two loops, the `If` statement
+**Reset** method is called. After the first two loops, the `if` statement
 fails and the loop iterates through all three elements normally.
 
 > [!IMPORTANT]
@@ -814,10 +815,10 @@ Reset Loop: 0
 ### Example 5: Using the $switch variable
 
 The `$switch` variable has the exact same rules as the `$foreach` variable.
-The following example demonstrates all of the enumerator concepts.
+The following example demonstrates all the enumerator concepts.
 
 > [!NOTE]
-> Note how the **NotEvaluated** case is never executed, even though there is
+> Note how the **NotEvaluated** case is never executed, even though there's
 > no `break` statement after the **MoveNext** method.
 
 ```powershell


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

about_Automatic_Variables Acrolinx scores
Original version: 91
Updated version: 94

- Fixes [AB#1575941](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1575941)
- Fixes #4589
- Corrected variable name in `$PROFILE` section (`$PSHOME` > `$PROFILE`)
- Corrected table for each version's output from `$PSVersionTable`
- Minor copyedits and style changes, paragraph reflows.