### PR TITLE
Fixes #4604 - Correction for ConfigurationPath and ModulePath

### DIFF
--- a/dsc/pull-server/publishConfigs.md
+++ b/dsc/pull-server/publishConfigs.md
@@ -6,16 +6,24 @@ title:  Publish to a Pull Server using Configuration IDs (v4/v5)
 
 # Publish to a Pull Server using Configuration IDs (v4/v5)
 
-The sections below assume that you have already set up a Pull Server. If you have not set up your Pull Server, you can use the following guides:
+The sections below assume that you have already set up a Pull Server. If you haven't set up your
+Pull Server, you can use the following guides:
 
 - [Set up a DSC SMB Pull Server](pullServerSmb.md)
 - [Set up a DSC HTTP Pull Server](pullServer.md)
 
-Each target node can be configured to download configurations, resources, and even report its status. This article will show you how to upload resources so they are available to be downloaded, and configure clients to download resources automatically. When the Node's receives an assigned Configuration, through **Pull** or **Push** (v5), it automatically downloads any resources required by the Configuration from the location specified in the LCM.
+Each target node can be configured to download configurations, resources, and even report its
+status. This article shows you how to upload resources so they're available to be downloaded, and
+configure clients to automatically download resources. When the node receives an assigned
+Configuration, through **Pull** or **Push** (v5), it automatically downloads any resources required
+by the Configuration from the location specified in the Local Configuration Manager (LCM).
 
-## Compile Configurations
+## Compile configurations
 
-The first step to storing [Configurations](../configurations/configurations.md) on a Pull Server, is to compile them into ".mof" files. To make a configuration generic, and applicable to more clients, use `localhost` in your Node block. The example below shows a Configuration shell that uses `localhost` instead of a specific client name.
+The first step to storing [Configurations](../configurations/configurations.md) on a Pull Server, is
+to compile them into `.mof` files. To make a configuration generic, and applicable to more clients,
+use `localhost` in your Node block. The example below shows a Configuration shell that uses
+`localhost` instead of a specific client name.
 
 ```powershell
 Configuration GenericConfig
@@ -28,15 +36,19 @@ Configuration GenericConfig
 GenericConfig
 ```
 
-Once you have compiled your generic configuration, you should have a "localhost.mof" file.
+Once you've compiled your generic configuration, you should have a `localhost.mof` file.
 
 ## Renaming the MOF file
 
-You can store Configuration ".mof" files on a Pull Server by **ConfigurationName** or **ConfigurationID**. Depending on how you plan to set up your pull clients, you can choose a section below to properly rename your compiled ".mof" files.
+You can store Configuration `.mof` files on a Pull Server by **ConfigurationName** or
+**ConfigurationID**. Depending on how you plan to set up your pull clients, you can choose a section
+below to properly rename your compiled `.mof` files.
 
 ### Configuration IDs (GUID)
 
-You will need to rename your "localhost.mof" file to "<GUID>.mof" file. You can create a random **Guid** using the example below, or by using the [New-Guid](/powershell/module/microsoft.powershell.utility/new-guid) cmdlet.
+You'll need to rename your `localhost.mof` file to `<GUID>.mof` file. You can create a random
+**Guid** using the example below, or by using the [New-Guid](/powershell/module/microsoft.powershell.utility/new-guid)
+cmdlet.
 
 ```powershell
 [System.Guid]::NewGuid()
@@ -44,13 +56,14 @@ You will need to rename your "localhost.mof" file to "<GUID>.mof" file. You can 
 
 Sample Output
 
-```output
+```Output
 Guid
 ----
 64856475-939e-41fb-aba5-4469f4006059
 ```
 
-You can then rename your ".mof" file using any acceptable method. The example below, uses the [Rename-Item](/powershell/module/microsoft.powershell.management/rename-item) cmdlet.
+You can then rename your `.mof` file using any acceptable method. The example below, uses the [Rename-Item](/powershell/module/microsoft.powershell.management/rename-item)
+cmdlet.
 
 ```powershell
 Rename-Item -Path .\localhost.mof -NewName '64856475-939e-41fb-aba5-4469f4006059.mof'
@@ -58,31 +71,43 @@ Rename-Item -Path .\localhost.mof -NewName '64856475-939e-41fb-aba5-4469f4006059
 
 For more information about using **Guids** in your environment, see [Plan for Guids](/powershell/dsc/secureserver#guids).
 
-### Configuration Names
+### Configuration names
 
-You will need to rename your "localhost.mof" file to "<Configuration Name>.mof" file. In the following example, the configuration name from the previous section is used. You can then rename your ".mof" file using any acceptable method. The example below, uses the [Rename-Item](/powershell/module/microsoft.powershell.management/rename-item) cmdlet.
+You'll need to rename your `localhost.mof` file to `<Configuration Name>.mof` file. In the following
+example, the configuration name from the previous section is used. You can then rename your `.mof`
+file using any acceptable method. The example below, uses the [Rename-Item](/powershell/module/microsoft.powershell.management/rename-item)
+cmdlet.
 
 ```powershell
 Rename-Item -Path .\localhost.mof -NewName 'GenericConfig.mof'
 ```
 
-## Create the CheckSum
+## Create the checkSum
 
-Each ".mof" file stored on a Pull Server, or SMB share needs to have an associated ".checksum" file. This file lets clients know when the associated ".mof" file has changed and should be downloaded again.
+Each `.mof` file stored on a Pull Server, or SMB share needs to have an associated `.checksum` file.
+This file lets clients know when the associated `.mof` file has changed and should be downloaded
+again.
 
-You can create a **CheckSum** with the [New-DSCCheckSum](/powershell/module/psdesiredstateconfiguration/new-dscchecksum) cmdlet. You can also run `New-DSCCheckSum` against a directory of files using the `-Path` parameter. If a checksum already exists, you can force it to be re-created with the `-Force` parameter. The following example specified a directory containing the ".mof" file from the previous section, and uses the `-Force` parameter.
+You can create a **CheckSum** with the [New-DSCCheckSum](/powershell/module/psdesiredstateconfiguration/new-dscchecksum)
+cmdlet. You can also run `New-DSCCheckSum` against a directory of files using the `-Path` parameter.
+If a checksum already exists, you can force it to be re-created with the `-Force` parameter. The
+following example specified a directory containing the `.mof` file from the previous section, and
+uses the `-Force` parameter.
 
 ```powershell
 New-DscChecksum -Path '.\' -Force
 ```
 
-No output will be shown, but you should now see a "<GUID or Configuration Name>.mof.checksum" file.
+No output will be shown, but you should now see a `<GUID or Configuration Name>.mof.checksum` file.
 
-## Where to store MOF files and CheckSums
+## Where to store MOF files and checkSums
 
 ### On a DSC HTTP Pull Server
 
-When you set up your HTTP Pull Server, as explained in [Set up a DSC HTTP Pull Server](pullServer.md), you specify directories for the **ModulePath** and **ConfigurationPath** keys. The **ConfigurationPath** key indicates where any ".mof" files should be stored. The **ConfigurationPath** indicates where any ".mof" files and ".checksum" files should be stored.
+When you set up your HTTP Pull Server, as explained in [Set up a DSC HTTP Pull Server](pullServer.md),
+you specify directories for the **ModulePath** and **ConfigurationPath** keys. The **ModulePath**
+key indicates where a module's packaged `.zip` files should be stored. The **ConfigurationPath**
+indicates where any `.mof` files and `.checksum` files should be stored.
 
 ```powershell
     xDscWebService PSDSCPullServer
@@ -95,9 +120,11 @@ When you set up your HTTP Pull Server, as explained in [Set up a DSC HTTP Pull S
 
 ```
 
-### On an SMB Share
+### On an SMB share
 
-When you set up a Pull Client to use an SMB share, you specify a **ConfigurationRepositoryShare**. All ".mof" files and ".checksum" files should then be stored in the **SourcePath** directory from the **ConfigurationRepositoryShare** block.
+When you set up a Pull Client to use an SMB share, you specify a **ConfigurationRepositoryShare**.
+All `.mof` files and `.checksum` files should be stored in the **SourcePath** directory from the
+**ConfigurationRepositoryShare** block.
 
 ```powershell
 ConfigurationRepositoryShare SMBPullServer
@@ -106,9 +133,10 @@ ConfigurationRepositoryShare SMBPullServer
 }
 ```
 
-## Next Steps
+## Next steps
 
-Next, you will want to configure Pull Clients to pull the specified configuration. For more information, see one of the following guides:
+Next, you'll want to configure Pull Clients to pull the specified configuration. For more
+information, see one of the following guides:
 
 - [Set up a Pull Client using Configuration IDs (v4)](pullClientConfigId4.md)
 - [Set up a Pull Client using Configuration IDs (v5)](pullClientConfigId.md)


### PR DESCRIPTION
Publish to a Pull Server using Configuration IDs (v4/v5)

Acrolinx scores
Original version: 89
Updated version: 92

- Fixes [AB#1579117](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1579117)
- Fixes #4604
- Paragraph reflows, style, minor copyedits