### PR TITLE
Add back content for clipboard cmdlets

### DIFF
--- a/reference/7/Microsoft.PowerShell.Management/Get-Clipboard.md
+++ b/reference/7/Microsoft.PowerShell.Management/Get-Clipboard.md
@@ -13,15 +13,18 @@ title: Get-Clipboard
 ## SYNOPSIS
 Gets the contents of the clipboard.
 
+[!NOTE]
+> On Linux, this cmdlet requires the `xclip` utility to be in the path.
+
 ## SYNTAX
 
 ```
-Get-Clipboard [-Format <ClipboardFormat>] [-TextFormatType <TextDataFormat>] [-Raw] [<CommonParameters>]
+Get-Clipboard [-Raw] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Get-Clipboard` cmdlet gets the contents of the clipboard.
+The `Get-Clipboard` cmdlet gets the contents of the clipboard as text.
 
 ## EXAMPLES
 
@@ -37,57 +40,7 @@ Get-Clipboard
 hello
 ```
 
-### Example 2: Get the content of the clipboard in a specific format
-
-In this example we copied files to the clipboard in Windows Explorer by selecting them and pressing
-<kbd>Ctrl-C</kbd>. Using the following command, you can access the contents of the clipboard as a
-list of files:
-
-```powershell
-Get-Clipboard -Format FileDropList
-```
-
-```Output
-    Directory: C:\Git\PS-Docs\PowerShell-Docs\wmf
-
-Mode                LastWriteTime         Length Name
-----                -------------         ------ ----
--a----         5/7/2019   1:11 PM          10010 TOC.yml
--a----       11/18/2016  10:10 AM             53 md.style
--a----         5/6/2019   9:32 AM           4177 overview.md
--a----        6/28/2018   2:28 PM            345 README.md
-```
-
-> [!NOTE]
-> This example is only supported on Windows.
-
 ## PARAMETERS
-
-### -Format
-
-Specifies the type, or format, of the clipboard. The acceptable values for this parameter
-on Windows are:
-
-- Text
-- FileDropList
-- Image
-- Audio
-
-> [!NOTE]
-> On Linux and macOS, only the 'Text' format is supported.
-
-```yaml
-Type: ClipboardFormat
-Parameter Sets: (All)
-Aliases:
-Accepted values: Text, FileDropList, Image, Audio
-
-Required: False
-Position: Named
-Default value: Text
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### -Raw
 
@@ -105,33 +58,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -TextFormatType
-
-Specifies the text data format type of the clipboard. The acceptable values for this parameter
-on Windows are:
-
-- Text
-- UnicodeText
-- Rtf
-- Html
-- CommaSeparatedValue
-
-> [!NOTE]
-> On Linux and macOS, only the 'UnicodeText' format type is supported.
-
-```yaml
-Type: TextDataFormat
-Parameter Sets: (All)
-Aliases:
-Accepted values: Text, UnicodeText, Rtf, Html, CommaSeparatedValue
-
-Required: False
-Position: Named
-Default value: UnicodeText
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
@@ -142,7 +68,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### System.String, System.IO.FileInfo, System.IO.Stream, System.Drawing.Image
+### System.String
 
 ## NOTES
 

--- a/reference/7/Microsoft.PowerShell.Management/Get-Clipboard.md
+++ b/reference/7/Microsoft.PowerShell.Management/Get-Clipboard.md
@@ -1,0 +1,148 @@
+---
+external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
+keywords: powershell,cmdlet
+locale: en-us
+Module Name: Microsoft.PowerShell.Management
+ms.date: 08/09/2019
+online version: https://go.microsoft.com/fwlink/?linkid=526219
+schema: 2.0.0
+title: Get-Clipboard
+---
+# Get-Clipboard
+
+## SYNOPSIS
+Gets the contents of the clipboard.
+
+## SYNTAX
+
+```
+Get-Clipboard [-Format <ClipboardFormat>] [-TextFormatType <TextDataFormat>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Get-Clipboard` cmdlet gets the contents of the clipboard.
+
+## EXAMPLES
+
+### Example 1: Get the content of the clipboard and display it to the command-line
+
+In this example we have copied the text "hello" into the clipboard.
+
+```powershell
+Get-Clipboard
+```
+
+```Output
+hello
+```
+
+### Example 2: Get the content of the clipboard in a specific format
+
+In this example we copied files to the clipboard in Windows Explorer by selecting them and pressing
+<kbd>Ctrl-C</kbd>. Using the following command, you can access the contents of the clipboard as a
+list of files:
+
+```powershell
+Get-Clipboard -Format FileDropList
+```
+
+```Output
+    Directory: C:\Git\PS-Docs\PowerShell-Docs\wmf
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----         5/7/2019   1:11 PM          10010 TOC.yml
+-a----       11/18/2016  10:10 AM             53 md.style
+-a----         5/6/2019   9:32 AM           4177 overview.md
+-a----        6/28/2018   2:28 PM            345 README.md
+```
+
+>[!NOTE] This example is only supported on Windows
+
+## PARAMETERS
+
+### -Format
+
+Specifies the type, or format, of the clipboard. The acceptable values for this parameter
+on Windows are:
+
+- Text
+- FileDropList
+- Image
+- Audio
+
+>[!NOTE] On Linux and macOS, only the 'Text' format is supported.
+
+```yaml
+Type: ClipboardFormat
+Parameter Sets: (All)
+Aliases:
+Accepted values: Text, FileDropList, Image, Audio
+
+Required: False
+Position: Named
+Default value: Text
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+
+Indicates that this cmdlet ignores newline characters and gets the entire contents of the clipboard.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TextFormatType
+
+Specifies the text data format type of the clipboard. The acceptable values for this parameter
+on Windows are:
+
+- Text
+- UnicodeText
+- Rtf
+- Html
+- CommaSeparatedValue
+
+>[!NOTE] On Linux and macOS, only the 'UnicodeText' format type is supported.
+
+```yaml
+Type: TextDataFormat
+Parameter Sets: (All)
+Aliases:
+Accepted values: Text, UnicodeText, Rtf, Html, CommaSeparatedValue
+
+Required: False
+Position: Named
+Default value: UnicodeText
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.String, System.IO.FileInfo, System.IO.Stream, System.Drawing.Image
+
+## NOTES
+
+## RELATED LINKS
+
+[Set-Clipboard](Set-Clipboard.md)

--- a/reference/7/Microsoft.PowerShell.Management/Get-Clipboard.md
+++ b/reference/7/Microsoft.PowerShell.Management/Get-Clipboard.md
@@ -58,7 +58,8 @@ Mode                LastWriteTime         Length Name
 -a----        6/28/2018   2:28 PM            345 README.md
 ```
 
->[!NOTE] This example is only supported on Windows
+> [!NOTE]
+> This example is only supported on Windows.
 
 ## PARAMETERS
 

--- a/reference/7/Microsoft.PowerShell.Management/Get-Clipboard.md
+++ b/reference/7/Microsoft.PowerShell.Management/Get-Clipboard.md
@@ -73,7 +73,8 @@ on Windows are:
 - Image
 - Audio
 
->[!NOTE] On Linux and macOS, only the 'Text' format is supported.
+> [!NOTE]
+> On Linux and macOS, only the 'Text' format is supported.
 
 ```yaml
 Type: ClipboardFormat
@@ -115,7 +116,8 @@ on Windows are:
 - Html
 - CommaSeparatedValue
 
->[!NOTE] On Linux and macOS, only the 'UnicodeText' format type is supported.
+> [!NOTE]
+> On Linux and macOS, only the 'UnicodeText' format type is supported.
 
 ```yaml
 Type: TextDataFormat

--- a/reference/7/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -15,33 +15,16 @@ Sets the contents of the clipboard.
 
 ## SYNTAX
 
-### String (Default)
-
 ```
-Set-Clipboard [-Append] [-AsHtml] [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
-### Value
-
-```
-Set-Clipboard [-Value] <String[]> [-Append] [-AsHtml] [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
-### Path
-
-```
-Set-Clipboard [-Append] -Path <String[]> [-AsHtml] [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
-### LiteralPath
-
-```
-Set-Clipboard [-Append] -LiteralPath <String[]> [-AsHtml] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-Clipboard [-Value] <string[]> [-Append] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 The `Set-Clipboard` cmdlet sets the contents of the clipboard.
+
+[!NOTE]
+> On Linux, this cmdlet requires the `xclip` utility to be in the path.
 
 ## EXAMPLES
 
@@ -50,17 +33,6 @@ The `Set-Clipboard` cmdlet sets the contents of the clipboard.
 ```powershell
 Set-Clipboard -Value "This is a test string"
 ```
-
-### Example 2: Copy the contents of a directory to the clipboard
-
-This command copies the content of the specified folder to the clipboard.
-
-```powershell
-Set-Clipboard -Path "C:\Staging\"
-```
-
-> [!NOTE]
-> Types other than text are only supported on Windows.
 
 ## PARAMETERS
 
@@ -77,82 +49,6 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -AsHtml
-
-Indicates that the cmdlet renders the content as HTML to the clipboard.
-
-> [!NOTE]
-> This switch is only supported on Windows.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -LiteralPath
-
-Specifies the path to the item that is copied to the clipboard. Unlike **Path**, the value of
-**LiteralPath** is used exactly as it is typed. No characters are interpreted as wildcards. If the
-path includes escape characters, enclose it in single quotation marks. Single quotation marks tell
-Windows PowerShell not to interpret any characters as escape sequences.
-
-> [!NOTE]
-> This switch is only supported on Windows.
-
-```yaml
-Type: String[]
-Parameter Sets: LiteralPath
-Aliases: PSPath
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -Path
-
-Specifies the path to the item that is copied to the clipboard. Wildcard characters are permitted.
-
-> [!NOTE]
-> This switch is only supported on Windows.
-
-```yaml
-Type: String[]
-Parameter Sets: Path
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: True
-```
-
-### -Value
-
-Specifies, as a string array, the content to copy to the clipboard.
-
-```yaml
-Type: String[]
-Parameter Sets: Value
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/reference/7/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -59,7 +59,8 @@ This command copies the content of the specified folder to the clipboard.
 Set-Clipboard -Path "C:\Staging\"
 ```
 
->[!NOTE] Types other than text are only supported on Windows.
+> [!NOTE]
+> Types other than text are only supported on Windows.
 
 ## PARAMETERS
 

--- a/reference/7/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -84,7 +84,8 @@ Accept wildcard characters: False
 
 Indicates that the cmdlet renders the content as HTML to the clipboard.
 
->[!NOTE] This switch is only supported on Windows.
+> [!NOTE]
+> This switch is only supported on Windows.
 
 ```yaml
 Type: SwitchParameter
@@ -105,7 +106,8 @@ Specifies the path to the item that is copied to the clipboard. Unlike **Path**,
 path includes escape characters, enclose it in single quotation marks. Single quotation marks tell
 Windows PowerShell not to interpret any characters as escape sequences.
 
->[!NOTE] This switch is only supported on Windows.
+> [!NOTE]
+> This switch is only supported on Windows.
 
 ```yaml
 Type: String[]
@@ -123,7 +125,8 @@ Accept wildcard characters: False
 
 Specifies the path to the item that is copied to the clipboard. Wildcard characters are permitted.
 
->[!NOTE] This switch is only supported on Windows.
+> [!NOTE]
+> This switch is only supported on Windows.
 
 ```yaml
 Type: String[]

--- a/reference/7/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -1,0 +1,203 @@
+---
+external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
+keywords: powershell,cmdlet
+locale: en-us
+Module Name: Microsoft.PowerShell.Management
+ms.date: 08/09/2019
+online version: https://go.microsoft.com/fwlink/?linkid=526220
+schema: 2.0.0
+title: Set-Clipboard
+---
+# Set-Clipboard
+
+## SYNOPSIS
+Sets the contents of the clipboard.
+
+## SYNTAX
+
+### String (Default)
+
+```
+Set-Clipboard [-Append] [-AsHtml] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### Value
+
+```
+Set-Clipboard [-Value] <String[]> [-Append] [-AsHtml] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### Path
+
+```
+Set-Clipboard [-Append] -Path <String[]> [-AsHtml] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### LiteralPath
+
+```
+Set-Clipboard [-Append] -LiteralPath <String[]> [-AsHtml] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Set-Clipboard` cmdlet sets the contents of the clipboard.
+
+## EXAMPLES
+
+### Example 1: Copy text to the clipboard
+
+```powershell
+Set-Clipboard -Value "This is a test string"
+```
+
+### Example 2: Copy the contents of a directory to the clipboard
+
+This command copies the content of the specified folder to the clipboard.
+
+```powershell
+Set-Clipboard -Path "C:\Staging\"
+```
+
+>[!NOTE] Types other than text are only supported on Windows.
+
+## PARAMETERS
+
+### -Append
+
+Indicates that the cmdlet does not clear the clipboard and appends content to it.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AsHtml
+
+Indicates that the cmdlet renders the content as HTML to the clipboard.
+
+>[!NOTE] This switch is only supported on Windows.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LiteralPath
+
+Specifies the path to the item that is copied to the clipboard. Unlike **Path**, the value of
+**LiteralPath** is used exactly as it is typed. No characters are interpreted as wildcards. If the
+path includes escape characters, enclose it in single quotation marks. Single quotation marks tell
+Windows PowerShell not to interpret any characters as escape sequences.
+
+>[!NOTE] This switch is only supported on Windows.
+
+```yaml
+Type: String[]
+Parameter Sets: LiteralPath
+Aliases: PSPath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Path
+
+Specifies the path to the item that is copied to the clipboard. Wildcard characters are permitted.
+
+>[!NOTE] This switch is only supported on Windows.
+
+```yaml
+Type: String[]
+Parameter Sets: Path
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: True
+```
+
+### -Value
+
+Specifies, as a string array, the content to copy to the clipboard.
+
+```yaml
+Type: String[]
+Parameter Sets: Value
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String[]
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Get-Clipboard](Get-Clipboard.md)


### PR DESCRIPTION
Wait for https://github.com/PowerShell/PowerShell/pull/10340 to be merged

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 7 document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version (7) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
