### PR TITLE
Fixes #4614, Fixes #4641 - Export-Clixml and Import-Clixml

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -32,9 +32,10 @@ Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-F
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores it
-in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
-contents of that file.
+The `Export-Clixml` cmdlet creates a Common Language Infrastructure (CLI) XML-based representation
+of an object or objects and stores it in a file. You can then use the `Import-Clixml` cmdlet to
+recreate the saved object based on the contents of that file.
+For more information about CLI, see [Language independence](/dotnet/standard/language-independence).
 
 This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
 file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
@@ -75,34 +76,31 @@ the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
-This example shows how to use a credential stored in a variable and save it to disk. The credential
-can then be imported into scripts.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
 
 > [!IMPORTANT]
-> The encrypted credentials only work on Windows. On non-Windows operating systems such as macOS and
-> Linux, encrypted credentials are exported in plain text.
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential | Export-Clixml $credxmlpath
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential = Import-Clixml $credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential | Export-Clixml $Credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The `Export-Clixml` cmdlet encrypts credential objects by using the
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
 The encryption ensures that only your user account on only that computer can decrypt the contents of
-the credential object. The exported `CliXml` file can't be used on a different computer or by a
+the credential object. The exported `CLIXML` file can't be used on a different computer or by a
 different user.
 
-In this example, given a credential that you've stored in the `$credential` variable by running the
-`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
-the example, the file in which the credential is stored is represented by
+In the example, the file in which the credential is stored is represented by
 `TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
-`$credxmlpath`, that you specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
 To import the credential automatically into your script, run the final two commands. Run
 `Import-Clixml` to import the secured credential object into your script. This import eliminates the
@@ -288,7 +286,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.PSObject
 
-You can pipe any object to `Export-Clixml`.
+You can pipeline any object to `Export-Clixml`.
 
 ## OUTPUTS
 
@@ -308,10 +306,10 @@ You can pipe any object to `Export-Clixml`.
 
 [Import-Clixml](Import-Clixml.md)
 
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
 [Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
 [Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx)
 
 [Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/14/2019
 online version: https://go.microsoft.com/fwlink/?linkid=113297
 schema: 2.0.0
 title: Export-Clixml
 ---
+
 # Export-Clixml
 
 ## SYNOPSIS
@@ -18,61 +19,68 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ### ByPath (Default)
 
 ```
-Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml [-Path] <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
-it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
+The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores it
+in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
 contents of that file.
 
-This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
-a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
+file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
 
-A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
-an example of how to do this, see Example 3.
+A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
+securely as XML. For an example, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
 
-This command creates an XML file that stores a representation of the string, "This is a test" in
-the current directory.
+This example creates an XML file that stores in the current directory, a representation of the
+string **This is a test**.
 
 ```powershell
 "This is a test" | Export-Clixml -Path .\sample.xml
 ```
 
+The string **This is a test** is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
+to create an XML file named `sample.xml` in the current directory.
+
 ### Example 2: Export an object to an XML file
 
-This example shows how to export an object to an XML file and then create an object by importing
-the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing the
+XML from the file.
 
 ```powershell
-Get-Acl C:\test.txt | Export-Clixml -Path .\fileacl.xml
-$fileacl = Import-Clixml -Path .\fileacl.xml
+Get-Acl C:\test.txt | Export-Clixml -Path .\FileACL.xml
+$fileacl = Import-Clixml -Path .\FileACL.xml
 ```
 
-The `Get-Acl` cmdlet gets the security descriptor of the Test.txt file. It sends the object down
-the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of
-the object is stored in a file named FileACL.xml.
+The `Get-Acl` cmdlet gets the security descriptor of the `Test.txt` file. It sends the object down
+the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of the
+object is stored in a file named `FileACL.xml`.
 
-The `Import-Clixml` cmdlet creates an object from the XML in the FileACL.xml file. Then, it saves
+The `Import-Clixml` cmdlet creates an object from the XML in the `FileACL.xml` file. Then, it saves
 the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
 This example shows how to use a credential stored in a variable and save it to disk. The credential
 can then be imported into scripts.
+
+> [!IMPORTANT]
+> The encrypted credentials only work on Windows. On non-Windows operating systems such as macOS and
+> Linux, encrypted credentials are exported in plain text.
 
 ```powershell
 $credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
@@ -83,29 +91,47 @@ $credential = Import-Clixml $credxmlpath
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the
 [Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account can decrypt the contents of the credential object.
+The encryption ensures that only your user account on only that computer can decrypt the contents of
+the credential object. The exported `CliXml` file can't be used on a different computer or by a
+different user.
 
 In this example, given a credential that you've stored in the `$credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
 the example, the file in which the credential is stored is represented by
-TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
 In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
 `$credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Depth
 
 Specifies how many levels of contained objects are included in the XML representation. The default
-value is 2.
+value is `2`.
 
-The default value can be overridden for the object type in the Types.ps1xml files. For more
+The default value can be overridden for the object type in the `Types.ps1xml` files. For more
 information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
@@ -184,9 +210,28 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
+### -LiteralPath
+
+Specifies the path to the file where the XML representation of the object will be stored. Unlike
+**Path**, the value of the **LiteralPath** parameter is used exactly as it's typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single quotation
+marks. Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+
+```yaml
+Type: String
+Parameter Sets: ByLiteralPath
+Aliases: PSPath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -NoClobber
 
-Ensures that the cmdlet does not overwrite the contents of an existing file. By default, if a file
+Indicates that the cmdlet doesn't overwrite the contents of an existing file. By default, if a file
 exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
@@ -211,51 +256,15 @@ Parameter Sets: ByPath
 Aliases:
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -LiteralPath
-
-Specifies the path to the file where the XML representation of the object will be stored. Unlike
-**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
-are interpreted as wildcards. If the path includes escape characters, enclose it in single
-quotation marks. Single quotation marks tell PowerShell not to interpret any characters as escape
-sequences.
-
-```yaml
-Type: String
-Parameter Sets: ByLiteralPath
-Aliases: PSPath
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -273,8 +282,7 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -292,10 +300,6 @@ You can pipe any object to `Export-Clixml`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [ConvertTo-Html](ConvertTo-Html.md)
 
 [ConvertTo-Xml](ConvertTo-Xml.md)
@@ -303,3 +307,11 @@ You can pipe any object to `Export-Clixml`.
 [Export-Csv](Export-Csv.md)
 
 [Import-Clixml](Import-Clixml.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
+
+[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx)
+
+[Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/3.0/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=113340
 schema: 2.0.0
 title: Import-Clixml
 ---
+
 # Import-Clixml
 
 ## SYNOPSIS
@@ -18,7 +19,8 @@ Imports a CLIXML file and creates corresponding objects in PowerShell.
 ### ByPath (Default)
 
 ```
-Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [<CommonParameters>]
+Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [<CommonParameters>]
 ```
 
 ### ByLiteralPath
@@ -30,10 +32,12 @@ Import-Clixml -LiteralPath <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-Fi
 
 ## DESCRIPTION
 
-The `Import-Clixml` cmdlet imports a CLIXML file with data that represents Microsoft .NET Framework
-objects and creates the objects in PowerShell. A valuable use of `Import-Clixml` is to import
-credentials and secure strings that have been exported as secure XML by running the `Export-Clixml`
-cmdlet.
+The `Import-Clixml` cmdlet imports a Common Language Infrastructure (CLI) XML file with data that
+represents Microsoft .NET Framework objects and creates the PowerShell objects. For more information
+about CLI, see [Language independence](/dotnet/standard/language-independence).
+
+A valuable use of `Import-Clixml` on Windows computers is to import credentials and secure strings
+that were exported as secure XML using `Export-Clixml`. For an example, see Example 2.
 
 `Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
 file has no BOM, it assumes the encoding is UTF8.
@@ -42,19 +46,23 @@ file has no BOM, it assumes the encoding is UTF8.
 
 ### Example 1: Import a serialized file and recreate an object
 
-This command uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
-returned by `Get-Process`. It then uses `Import-Clixml` to retrieve the contents of the serialized
-file and re-create an object that is stored in the `$Processes` variable.
+This example uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
+returned by `Get-Process`. `Import-Clixml` retrieves the serialized file's contents and recreates an
+object that is stored in the `$Processes` variable.
 
 ```powershell
-Get-Process | Export-Clixml pi.xml
-$Processes = Import-Clixml pi.xml
+Get-Process | Export-Clixml -Path .\pi.xml
+$Processes = Import-Clixml -Path .\pi.xml
 ```
 
 ### Example 2: Import a secure credential object
 
 In this example, given a credential that you've stored in the `$Credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
@@ -64,18 +72,19 @@ $Credential = Import-Clixml $Credxmlpath
 ```
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
-This ensures that only your user account can decrypt the contents of the credential object.
+The encryption ensures that only your user account can decrypt the contents of the credential
+object. The exported `CLIXML` file can't be used on a different computer or by a different user.
 
 In the example, the file in which the credential is stored is represented by
-`TestScript.ps1.credential`. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-You pipe the credential object to `Export-Clixml`, and save it to the path, `$Credxmlpath`, that you
-specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
@@ -98,10 +107,11 @@ Accept wildcard characters: False
 ### -IncludeTotalCount
 
 Reports the total number of objects in the data set followed by the selected objects. If the cmdlet
-cannot determine the total count, it displays "Unknown total count." The integer has an Accuracy
-property that indicates the reliability of the total count value. The value of Accuracy ranges from
-0.0 to 1.0 where 0.0 means that the cmdlet could not count the objects, 1.0 means that the count is
-exact, and a value between 0.0 and 1.0 indicates an increasingly reliable estimate.
+can't determine the total count, it displays **Unknown total count**. The integer has an
+**Accuracy** property that indicates the reliability of the total count value. The value of
+**Accuracy** ranges from `0.0` to `1.0` where `0.0` means that the cmdlet couldn't count the
+objects, `1.0` means that the count is exact, and a value between `0.0` and `1.0` indicates an
+increasingly reliable estimate.
 
 ```yaml
 Type: SwitchParameter
@@ -117,10 +127,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is used exactly
-as it is typed. No characters are interpreted as wildcards. If the path includes escape characters,
-enclose it in single quotation marks. Single quotation marks tell PowerShell not to interpret any
-characters as escape sequences.
+Specifies the path to the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is
+used exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -136,7 +146,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the XML files.
+Specifies the path to the XML files.
 
 ```yaml
 Type: String[]
@@ -152,8 +162,8 @@ Accept wildcard characters: False
 
 ### -Skip
 
-Ignores the specified number of objects and then gets the remaining objects.
-Enter the number of objects to skip.
+Ignores the specified number of objects and then gets the remaining objects. Enter the number of
+objects to skip.
 
 ```yaml
 Type: UInt64
@@ -171,31 +181,33 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to `Import-Clixml`.
+You can pipeline a string that contains a path to `Import-Clixml`.
 
 ## OUTPUTS
 
 ### PSObject
 
-`Import-Clixml` returns objects that have been deserialized from the stored XML files.
+`Import-Clixml` returns objects that were deserialized from the stored XML files.
 
 ## NOTES
 
-* When specifying multiple values for a parameter, use commas to separate the values. For example,
-  `<parameter-name> <value1>, <value2>`.
+When specifying multiple values for a parameter, use commas to separate the values. For example,
+`<parameter-name> <value1>, <value2>`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](http://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
-
-[Securely Store Credentials on Disk](http://www.powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [Export-Clixml](Export-Clixml.md)
 
+[Introducing XML Serialization](/dotnet/standard/serialization/introducing-xml-serialization)
+
 [Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/14/2019
 online version: https://go.microsoft.com/fwlink/?linkid=293956
 schema: 2.0.0
 title: Export-Clixml
 ---
+
 # Export-Clixml
 
 ## SYNOPSIS
@@ -18,61 +19,68 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ### ByPath (Default)
 
 ```
-Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml [-Path] <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
-it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
+The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores it
+in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
 contents of that file.
 
-This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
-a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
+file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
 
-A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
-an example of how to do this, see Example 3.
+A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
+securely as XML. For an example, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
 
-This command creates an XML file that stores a representation of the string, "This is a test" in
-the current directory.
+This example creates an XML file that stores in the current directory, a representation of the
+string **This is a test**.
 
 ```powershell
 "This is a test" | Export-Clixml -Path .\sample.xml
 ```
 
+The string **This is a test** is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
+to create an XML file named `sample.xml` in the current directory.
+
 ### Example 2: Export an object to an XML file
 
-This example shows how to export an object to an XML file and then create an object by importing
-the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing the
+XML from the file.
 
 ```powershell
-Get-Acl C:\test.txt | Export-Clixml -Path .\fileacl.xml
-$fileacl = Import-Clixml -Path .\fileacl.xml
+Get-Acl C:\test.txt | Export-Clixml -Path .\FileACL.xml
+$fileacl = Import-Clixml -Path .\FileACL.xml
 ```
 
-The `Get-Acl` cmdlet gets the security descriptor of the Test.txt file. It sends the object down
-the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of
-the object is stored in a file named FileACL.xml.
+The `Get-Acl` cmdlet gets the security descriptor of the `Test.txt` file. It sends the object down
+the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of the
+object is stored in a file named `FileACL.xml`.
 
-The `Import-Clixml` cmdlet creates an object from the XML in the FileACL.xml file. Then, it saves
+The `Import-Clixml` cmdlet creates an object from the XML in the `FileACL.xml` file. Then, it saves
 the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
 This example shows how to use a credential stored in a variable and save it to disk. The credential
 can then be imported into scripts.
+
+> [!IMPORTANT]
+> The encrypted credentials only work on Windows. On non-Windows operating systems such as macOS and
+> Linux, encrypted credentials are exported in plain text.
 
 ```powershell
 $credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
@@ -83,29 +91,47 @@ $credential = Import-Clixml $credxmlpath
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the
 [Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account can decrypt the contents of the credential object.
+The encryption ensures that only your user account on only that computer can decrypt the contents of
+the credential object. The exported `CliXml` file can't be used on a different computer or by a
+different user.
 
 In this example, given a credential that you've stored in the `$credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
 the example, the file in which the credential is stored is represented by
-TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
 In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
 `$credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Depth
 
 Specifies how many levels of contained objects are included in the XML representation. The default
-value is 2.
+value is `2`.
 
-The default value can be overridden for the object type in the Types.ps1xml files. For more
+The default value can be overridden for the object type in the `Types.ps1xml` files. For more
 information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
@@ -184,9 +210,28 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
+### -LiteralPath
+
+Specifies the path to the file where the XML representation of the object will be stored. Unlike
+**Path**, the value of the **LiteralPath** parameter is used exactly as it's typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single quotation
+marks. Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+
+```yaml
+Type: String
+Parameter Sets: ByLiteralPath
+Aliases: PSPath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -NoClobber
 
-Ensures that the cmdlet does not overwrite the contents of an existing file. By default, if a file
+Indicates that the cmdlet doesn't overwrite the contents of an existing file. By default, if a file
 exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
@@ -211,51 +256,15 @@ Parameter Sets: ByPath
 Aliases:
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -LiteralPath
-
-Specifies the path to the file where the XML representation of the object will be stored. Unlike
-**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
-are interpreted as wildcards. If the path includes escape characters, enclose it in single
-quotation marks. Single quotation marks tell PowerShell not to interpret any characters as escape
-sequences.
-
-```yaml
-Type: String
-Parameter Sets: ByLiteralPath
-Aliases: PSPath
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -273,8 +282,7 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -292,10 +300,6 @@ You can pipe any object to `Export-Clixml`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [ConvertTo-Html](ConvertTo-Html.md)
 
 [ConvertTo-Xml](ConvertTo-Xml.md)
@@ -303,3 +307,11 @@ You can pipe any object to `Export-Clixml`.
 [Export-Csv](Export-Csv.md)
 
 [Import-Clixml](Import-Clixml.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
+
+[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx)
+
+[Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -32,9 +32,10 @@ Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-F
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores it
-in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
-contents of that file.
+The `Export-Clixml` cmdlet creates a Common Language Infrastructure (CLI) XML-based representation
+of an object or objects and stores it in a file. You can then use the `Import-Clixml` cmdlet to
+recreate the saved object based on the contents of that file.
+For more information about CLI, see [Language independence](/dotnet/standard/language-independence).
 
 This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
 file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
@@ -75,34 +76,31 @@ the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
-This example shows how to use a credential stored in a variable and save it to disk. The credential
-can then be imported into scripts.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
 
 > [!IMPORTANT]
-> The encrypted credentials only work on Windows. On non-Windows operating systems such as macOS and
-> Linux, encrypted credentials are exported in plain text.
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential | Export-Clixml $credxmlpath
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential = Import-Clixml $credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential | Export-Clixml $Credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The `Export-Clixml` cmdlet encrypts credential objects by using the
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
 The encryption ensures that only your user account on only that computer can decrypt the contents of
-the credential object. The exported `CliXml` file can't be used on a different computer or by a
+the credential object. The exported `CLIXML` file can't be used on a different computer or by a
 different user.
 
-In this example, given a credential that you've stored in the `$credential` variable by running the
-`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
-the example, the file in which the credential is stored is represented by
+In the example, the file in which the credential is stored is represented by
 `TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
-`$credxmlpath`, that you specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
 To import the credential automatically into your script, run the final two commands. Run
 `Import-Clixml` to import the secured credential object into your script. This import eliminates the
@@ -288,7 +286,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.PSObject
 
-You can pipe any object to `Export-Clixml`.
+You can pipeline any object to `Export-Clixml`.
 
 ## OUTPUTS
 
@@ -308,10 +306,10 @@ You can pipe any object to `Export-Clixml`.
 
 [Import-Clixml](Import-Clixml.md)
 
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
 [Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
 [Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx)
 
 [Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/4.0/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=293982
 schema: 2.0.0
 title: Import-Clixml
 ---
+
 # Import-Clixml
 
 ## SYNOPSIS
@@ -18,7 +19,8 @@ Imports a CLIXML file and creates corresponding objects in PowerShell.
 ### ByPath (Default)
 
 ```
-Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [<CommonParameters>]
+Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [<CommonParameters>]
 ```
 
 ### ByLiteralPath
@@ -30,10 +32,12 @@ Import-Clixml -LiteralPath <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-Fi
 
 ## DESCRIPTION
 
-The `Import-Clixml` cmdlet imports a CLIXML file with data that represents Microsoft .NET Framework
-objects and creates the objects in PowerShell. A valuable use of `Import-Clixml` is to import
-credentials and secure strings that have been exported as secure XML by running the `Export-Clixml`
-cmdlet.
+The `Import-Clixml` cmdlet imports a Common Language Infrastructure (CLI) XML file with data that
+represents Microsoft .NET Framework objects and creates the PowerShell objects. For more information
+about CLI, see [Language independence](/dotnet/standard/language-independence).
+
+A valuable use of `Import-Clixml` on Windows computers is to import credentials and secure strings
+that were exported as secure XML using `Export-Clixml`. For an example, see Example 2.
 
 `Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
 file has no BOM, it assumes the encoding is UTF8.
@@ -42,19 +46,23 @@ file has no BOM, it assumes the encoding is UTF8.
 
 ### Example 1: Import a serialized file and recreate an object
 
-This command uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
-returned by `Get-Process`. It then uses `Import-Clixml` to retrieve the contents of the serialized
-file and re-create an object that is stored in the `$Processes` variable.
+This example uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
+returned by `Get-Process`. `Import-Clixml` retrieves the serialized file's contents and recreates an
+object that is stored in the `$Processes` variable.
 
 ```powershell
-Get-Process | Export-Clixml pi.xml
-$Processes = Import-Clixml pi.xml
+Get-Process | Export-Clixml -Path .\pi.xml
+$Processes = Import-Clixml -Path .\pi.xml
 ```
 
 ### Example 2: Import a secure credential object
 
 In this example, given a credential that you've stored in the `$Credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
@@ -64,18 +72,19 @@ $Credential = Import-Clixml $Credxmlpath
 ```
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
-This ensures that only your user account can decrypt the contents of the credential object.
+The encryption ensures that only your user account can decrypt the contents of the credential
+object. The exported `CLIXML` file can't be used on a different computer or by a different user.
 
 In the example, the file in which the credential is stored is represented by
-`TestScript.ps1.credential`. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-You pipe the credential object to `Export-Clixml`, and save it to the path, `$Credxmlpath`, that you
-specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
@@ -98,10 +107,11 @@ Accept wildcard characters: False
 ### -IncludeTotalCount
 
 Reports the total number of objects in the data set followed by the selected objects. If the cmdlet
-cannot determine the total count, it displays "Unknown total count." The integer has an Accuracy
-property that indicates the reliability of the total count value. The value of Accuracy ranges from
-0.0 to 1.0 where 0.0 means that the cmdlet could not count the objects, 1.0 means that the count is
-exact, and a value between 0.0 and 1.0 indicates an increasingly reliable estimate.
+can't determine the total count, it displays **Unknown total count**. The integer has an
+**Accuracy** property that indicates the reliability of the total count value. The value of
+**Accuracy** ranges from `0.0` to `1.0` where `0.0` means that the cmdlet couldn't count the
+objects, `1.0` means that the count is exact, and a value between `0.0` and `1.0` indicates an
+increasingly reliable estimate.
 
 ```yaml
 Type: SwitchParameter
@@ -117,10 +127,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is used exactly
-as it is typed. No characters are interpreted as wildcards. If the path includes escape characters,
-enclose it in single quotation marks. Single quotation marks tell PowerShell not to interpret any
-characters as escape sequences.
+Specifies the path to the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is
+used exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -136,7 +146,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the XML files.
+Specifies the path to the XML files.
 
 ```yaml
 Type: String[]
@@ -152,8 +162,8 @@ Accept wildcard characters: False
 
 ### -Skip
 
-Ignores the specified number of objects and then gets the remaining objects.
-Enter the number of objects to skip.
+Ignores the specified number of objects and then gets the remaining objects. Enter the number of
+objects to skip.
 
 ```yaml
 Type: UInt64
@@ -171,31 +181,33 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to `Import-Clixml`.
+You can pipeline a string that contains a path to `Import-Clixml`.
 
 ## OUTPUTS
 
 ### PSObject
 
-`Import-Clixml` returns objects that have been deserialized from the stored XML files.
+`Import-Clixml` returns objects that were deserialized from the stored XML files.
 
 ## NOTES
 
-* When specifying multiple values for a parameter, use commas to separate the values. For example,
-  `<parameter-name> <value1>, <value2>`.
+When specifying multiple values for a parameter, use commas to separate the values. For example,
+`<parameter-name> <value1>, <value2>`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](http://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
-
-[Securely Store Credentials on Disk](http://www.powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [Export-Clixml](Export-Clixml.md)
 
+[Introducing XML Serialization](/dotnet/standard/serialization/introducing-xml-serialization)
+
 [Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/14/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821767
 schema: 2.0.0
 title: Export-Clixml
 ---
+
 # Export-Clixml
 
 ## SYNOPSIS
@@ -18,61 +19,68 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ### ByPath (Default)
 
 ```
-Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml [-Path] <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
-it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
+The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores it
+in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
 contents of that file.
 
-This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
-a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
+file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
 
-A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
-an example of how to do this, see Example 3.
+A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
+securely as XML. For an example, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
 
-This command creates an XML file that stores a representation of the string, "This is a test" in
-the current directory.
+This example creates an XML file that stores in the current directory, a representation of the
+string **This is a test**.
 
 ```powershell
 "This is a test" | Export-Clixml -Path .\sample.xml
 ```
 
+The string **This is a test** is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
+to create an XML file named `sample.xml` in the current directory.
+
 ### Example 2: Export an object to an XML file
 
-This example shows how to export an object to an XML file and then create an object by importing
-the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing the
+XML from the file.
 
 ```powershell
-Get-Acl C:\test.txt | Export-Clixml -Path .\fileacl.xml
-$fileacl = Import-Clixml -Path .\fileacl.xml
+Get-Acl C:\test.txt | Export-Clixml -Path .\FileACL.xml
+$fileacl = Import-Clixml -Path .\FileACL.xml
 ```
 
-The `Get-Acl` cmdlet gets the security descriptor of the Test.txt file. It sends the object down
-the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of
-the object is stored in a file named FileACL.xml.
+The `Get-Acl` cmdlet gets the security descriptor of the `Test.txt` file. It sends the object down
+the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of the
+object is stored in a file named `FileACL.xml`.
 
-The `Import-Clixml` cmdlet creates an object from the XML in the FileACL.xml file. Then, it saves
+The `Import-Clixml` cmdlet creates an object from the XML in the `FileACL.xml` file. Then, it saves
 the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
 This example shows how to use a credential stored in a variable and save it to disk. The credential
 can then be imported into scripts.
+
+> [!IMPORTANT]
+> The encrypted credentials only work on Windows. On non-Windows operating systems such as macOS and
+> Linux, encrypted credentials are exported in plain text.
 
 ```powershell
 $credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
@@ -83,20 +91,22 @@ $credential = Import-Clixml $credxmlpath
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the
 [Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account can decrypt the contents of the credential object.
+The encryption ensures that only your user account on only that computer can decrypt the contents of
+the credential object. The exported `CliXml` file can't be used on a different computer or by a
+different user.
 
 In this example, given a credential that you've stored in the `$credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
 the example, the file in which the credential is stored is represented by
-TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
 In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
 `$credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
@@ -119,9 +129,9 @@ Accept wildcard characters: False
 ### -Depth
 
 Specifies how many levels of contained objects are included in the XML representation. The default
-value is 2.
+value is `2`.
 
-The default value can be overridden for the object type in the Types.ps1xml files. For more
+The default value can be overridden for the object type in the `Types.ps1xml` files. For more
 information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
@@ -178,7 +188,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -203,10 +213,9 @@ Accept wildcard characters: False
 ### -LiteralPath
 
 Specifies the path to the file where the XML representation of the object will be stored. Unlike
-**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
-are interpreted as wildcards. If the path includes escape characters, enclose it in single
-quotation marks. Single quotation marks tell PowerShell not to interpret any characters as escape
-sequences.
+**Path**, the value of the **LiteralPath** parameter is used exactly as it's typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single quotation
+marks. Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -222,8 +231,8 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Indicates that the cmdlet does not overwrite the contents of an existing file. By default, if a
-file exists in the specified path, `Export-Clixml` overwrites the file without warning.
+Indicates that the cmdlet doesn't overwrite the contents of an existing file. By default, if a file
+exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -232,7 +241,7 @@ Aliases: NoOverwrite
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -255,7 +264,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -273,8 +282,7 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -292,10 +300,6 @@ You can pipe any object to `Export-Clixml`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [ConvertTo-Html](ConvertTo-Html.md)
 
 [ConvertTo-Xml](ConvertTo-Xml.md)
@@ -303,3 +307,11 @@ You can pipe any object to `Export-Clixml`.
 [Export-Csv](Export-Csv.md)
 
 [Import-Clixml](Import-Clixml.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
+
+[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx)
+
+[Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -32,9 +32,10 @@ Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-F
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores it
-in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
-contents of that file.
+The `Export-Clixml` cmdlet creates a Common Language Infrastructure (CLI) XML-based representation
+of an object or objects and stores it in a file. You can then use the `Import-Clixml` cmdlet to
+recreate the saved object based on the contents of that file.
+For more information about CLI, see [Language independence](/dotnet/standard/language-independence).
 
 This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
 file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
@@ -75,34 +76,31 @@ the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
-This example shows how to use a credential stored in a variable and save it to disk. The credential
-can then be imported into scripts.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
 
 > [!IMPORTANT]
-> The encrypted credentials only work on Windows. On non-Windows operating systems such as macOS and
-> Linux, encrypted credentials are exported in plain text.
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential | Export-Clixml $credxmlpath
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential = Import-Clixml $credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential | Export-Clixml $Credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The `Export-Clixml` cmdlet encrypts credential objects by using the
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
 The encryption ensures that only your user account on only that computer can decrypt the contents of
-the credential object. The exported `CliXml` file can't be used on a different computer or by a
+the credential object. The exported `CLIXML` file can't be used on a different computer or by a
 different user.
 
-In this example, given a credential that you've stored in the `$credential` variable by running the
-`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
-the example, the file in which the credential is stored is represented by
+In the example, the file in which the credential is stored is represented by
 `TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
-`$credxmlpath`, that you specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
 To import the credential automatically into your script, run the final two commands. Run
 `Import-Clixml` to import the secured credential object into your script. This import eliminates the
@@ -288,7 +286,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.PSObject
 
-You can pipe any object to `Export-Clixml`.
+You can pipeline any object to `Export-Clixml`.
 
 ## OUTPUTS
 
@@ -308,10 +306,10 @@ You can pipe any object to `Export-Clixml`.
 
 [Import-Clixml](Import-Clixml.md)
 
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
 [Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
 [Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx)
 
 [Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/5.0/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821813
 schema: 2.0.0
 title: Import-Clixml
 ---
+
 # Import-Clixml
 
 ## SYNOPSIS
@@ -18,7 +19,8 @@ Imports a CLIXML file and creates corresponding objects in PowerShell.
 ### ByPath (Default)
 
 ```
-Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [<CommonParameters>]
+Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [<CommonParameters>]
 ```
 
 ### ByLiteralPath
@@ -30,10 +32,12 @@ Import-Clixml -LiteralPath <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-Fi
 
 ## DESCRIPTION
 
-The `Import-Clixml` cmdlet imports a CLIXML file with data that represents Microsoft .NET Framework
-objects and creates the objects in PowerShell. A valuable use of `Import-Clixml` is to import
-credentials and secure strings that have been exported as secure XML by running the `Export-Clixml`
-cmdlet.
+The `Import-Clixml` cmdlet imports a Common Language Infrastructure (CLI) XML file with data that
+represents Microsoft .NET Framework objects and creates the PowerShell objects. For more information
+about CLI, see [Language independence](/dotnet/standard/language-independence).
+
+A valuable use of `Import-Clixml` on Windows computers is to import credentials and secure strings
+that were exported as secure XML using `Export-Clixml`. For an example, see Example 2.
 
 `Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
 file has no BOM, it assumes the encoding is UTF8.
@@ -42,19 +46,23 @@ file has no BOM, it assumes the encoding is UTF8.
 
 ### Example 1: Import a serialized file and recreate an object
 
-This command uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
-returned by `Get-Process`. It then uses `Import-Clixml` to retrieve the contents of the serialized
-file and re-create an object that is stored in the `$Processes` variable.
+This example uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
+returned by `Get-Process`. `Import-Clixml` retrieves the serialized file's contents and recreates an
+object that is stored in the `$Processes` variable.
 
 ```powershell
-Get-Process | Export-Clixml pi.xml
-$Processes = Import-Clixml pi.xml
+Get-Process | Export-Clixml -Path .\pi.xml
+$Processes = Import-Clixml -Path .\pi.xml
 ```
 
 ### Example 2: Import a secure credential object
 
 In this example, given a credential that you've stored in the `$Credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
@@ -64,18 +72,19 @@ $Credential = Import-Clixml $Credxmlpath
 ```
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
-This ensures that only your user account can decrypt the contents of the credential object.
+The encryption ensures that only your user account can decrypt the contents of the credential
+object. The exported `CLIXML` file can't be used on a different computer or by a different user.
 
 In the example, the file in which the credential is stored is represented by
-`TestScript.ps1.credential`. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-You pipe the credential object to `Export-Clixml`, and save it to the path, `$Credxmlpath`, that you
-specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
@@ -98,10 +107,11 @@ Accept wildcard characters: False
 ### -IncludeTotalCount
 
 Reports the total number of objects in the data set followed by the selected objects. If the cmdlet
-cannot determine the total count, it displays "Unknown total count." The integer has an Accuracy
-property that indicates the reliability of the total count value. The value of Accuracy ranges from
-0.0 to 1.0 where 0.0 means that the cmdlet could not count the objects, 1.0 means that the count is
-exact, and a value between 0.0 and 1.0 indicates an increasingly reliable estimate.
+can't determine the total count, it displays **Unknown total count**. The integer has an
+**Accuracy** property that indicates the reliability of the total count value. The value of
+**Accuracy** ranges from `0.0` to `1.0` where `0.0` means that the cmdlet couldn't count the
+objects, `1.0` means that the count is exact, and a value between `0.0` and `1.0` indicates an
+increasingly reliable estimate.
 
 ```yaml
 Type: SwitchParameter
@@ -117,10 +127,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is used exactly
-as it is typed. No characters are interpreted as wildcards. If the path includes escape characters,
-enclose it in single quotation marks. Single quotation marks tell PowerShell not to interpret any
-characters as escape sequences.
+Specifies the path to the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is
+used exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -136,7 +146,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the XML files.
+Specifies the path to the XML files.
 
 ```yaml
 Type: String[]
@@ -152,8 +162,8 @@ Accept wildcard characters: False
 
 ### -Skip
 
-Ignores the specified number of objects and then gets the remaining objects.
-Enter the number of objects to skip.
+Ignores the specified number of objects and then gets the remaining objects. Enter the number of
+objects to skip.
 
 ```yaml
 Type: UInt64
@@ -171,31 +181,33 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to `Import-Clixml`.
+You can pipeline a string that contains a path to `Import-Clixml`.
 
 ## OUTPUTS
 
 ### PSObject
 
-`Import-Clixml` returns objects that have been deserialized from the stored XML files.
+`Import-Clixml` returns objects that were deserialized from the stored XML files.
 
 ## NOTES
 
-* When specifying multiple values for a parameter, use commas to separate the values. For example,
-  `<parameter-name> <value1>, <value2>`.
+When specifying multiple values for a parameter, use commas to separate the values. For example,
+`<parameter-name> <value1>, <value2>`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](http://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
-
-[Securely Store Credentials on Disk](http://www.powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [Export-Clixml](Export-Clixml.md)
 
+[Introducing XML Serialization](/dotnet/standard/serialization/introducing-xml-serialization)
+
 [Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/14/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821767
 schema: 2.0.0
 title: Export-Clixml
 ---
+
 # Export-Clixml
 
 ## SYNOPSIS
@@ -18,61 +19,68 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ### ByPath (Default)
 
 ```
-Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml [-Path] <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
-it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
+The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores it
+in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
 contents of that file.
 
-This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
-a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
+file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
 
-A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
-an example of how to do this, see Example 3.
+A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
+securely as XML. For an example, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
 
-This command creates an XML file that stores a representation of the string, "This is a test" in
-the current directory.
+This example creates an XML file that stores in the current directory, a representation of the
+string **This is a test**.
 
 ```powershell
 "This is a test" | Export-Clixml -Path .\sample.xml
 ```
 
+The string **This is a test** is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
+to create an XML file named `sample.xml` in the current directory.
+
 ### Example 2: Export an object to an XML file
 
-This example shows how to export an object to an XML file and then create an object by importing
-the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing the
+XML from the file.
 
 ```powershell
-Get-Acl C:\test.txt | Export-Clixml -Path .\fileacl.xml
-$fileacl = Import-Clixml -Path .\fileacl.xml
+Get-Acl C:\test.txt | Export-Clixml -Path .\FileACL.xml
+$fileacl = Import-Clixml -Path .\FileACL.xml
 ```
 
-The `Get-Acl` cmdlet gets the security descriptor of the Test.txt file. It sends the object down
-the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of
-the object is stored in a file named FileACL.xml.
+The `Get-Acl` cmdlet gets the security descriptor of the `Test.txt` file. It sends the object down
+the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of the
+object is stored in a file named `FileACL.xml`.
 
-The `Import-Clixml` cmdlet creates an object from the XML in the FileACL.xml file. Then, it saves
+The `Import-Clixml` cmdlet creates an object from the XML in the `FileACL.xml` file. Then, it saves
 the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
 This example shows how to use a credential stored in a variable and save it to disk. The credential
 can then be imported into scripts.
+
+> [!IMPORTANT]
+> The encrypted credentials only work on Windows. On non-Windows operating systems such as macOS and
+> Linux, encrypted credentials are exported in plain text.
 
 ```powershell
 $credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
@@ -83,29 +91,47 @@ $credential = Import-Clixml $credxmlpath
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the
 [Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account can decrypt the contents of the credential object.
+The encryption ensures that only your user account on only that computer can decrypt the contents of
+the credential object. The exported `CliXml` file can't be used on a different computer or by a
+different user.
 
 In this example, given a credential that you've stored in the `$credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
 the example, the file in which the credential is stored is represented by
-TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
 In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
 `$credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Depth
 
 Specifies how many levels of contained objects are included in the XML representation. The default
-value is 2.
+value is `2`.
 
-The default value can be overridden for the object type in the Types.ps1xml files. For more
+The default value can be overridden for the object type in the `Types.ps1xml` files. For more
 information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
@@ -162,7 +188,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -187,10 +213,9 @@ Accept wildcard characters: False
 ### -LiteralPath
 
 Specifies the path to the file where the XML representation of the object will be stored. Unlike
-**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
-are interpreted as wildcards. If the path includes escape characters, enclose it in single
-quotation marks. Single quotation marks tell PowerShell not to interpret any characters as escape
-sequences.
+**Path**, the value of the **LiteralPath** parameter is used exactly as it's typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single quotation
+marks. Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -206,8 +231,8 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Indicates that the cmdlet does not overwrite the contents of an existing file. By default, if a
-file exists in the specified path, `Export-Clixml` overwrites the file without warning.
+Indicates that the cmdlet doesn't overwrite the contents of an existing file. By default, if a file
+exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -216,7 +241,7 @@ Aliases: NoOverwrite
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -237,25 +262,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -273,8 +282,7 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -292,10 +300,6 @@ You can pipe any object to `Export-Clixml`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [ConvertTo-Html](ConvertTo-Html.md)
 
 [ConvertTo-Xml](ConvertTo-Xml.md)
@@ -303,3 +307,11 @@ You can pipe any object to `Export-Clixml`.
 [Export-Csv](Export-Csv.md)
 
 [Import-Clixml](Import-Clixml.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
+
+[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx)
+
+[Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -32,9 +32,10 @@ Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-F
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores it
-in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
-contents of that file.
+The `Export-Clixml` cmdlet creates a Common Language Infrastructure (CLI) XML-based representation
+of an object or objects and stores it in a file. You can then use the `Import-Clixml` cmdlet to
+recreate the saved object based on the contents of that file.
+For more information about CLI, see [Language independence](/dotnet/standard/language-independence).
 
 This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
 file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
@@ -75,34 +76,31 @@ the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
-This example shows how to use a credential stored in a variable and save it to disk. The credential
-can then be imported into scripts.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
 
 > [!IMPORTANT]
-> The encrypted credentials only work on Windows. On non-Windows operating systems such as macOS and
-> Linux, encrypted credentials are exported in plain text.
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential | Export-Clixml $credxmlpath
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential = Import-Clixml $credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential | Export-Clixml $Credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The `Export-Clixml` cmdlet encrypts credential objects by using the
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
 The encryption ensures that only your user account on only that computer can decrypt the contents of
-the credential object. The exported `CliXml` file can't be used on a different computer or by a
+the credential object. The exported `CLIXML` file can't be used on a different computer or by a
 different user.
 
-In this example, given a credential that you've stored in the `$credential` variable by running the
-`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
-the example, the file in which the credential is stored is represented by
+In the example, the file in which the credential is stored is represented by
 `TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
-`$credxmlpath`, that you specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
 To import the credential automatically into your script, run the final two commands. Run
 `Import-Clixml` to import the secured credential object into your script. This import eliminates the
@@ -288,7 +286,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.PSObject
 
-You can pipe any object to `Export-Clixml`.
+You can pipeline any object to `Export-Clixml`.
 
 ## OUTPUTS
 
@@ -308,10 +306,10 @@ You can pipe any object to `Export-Clixml`.
 
 [Import-Clixml](Import-Clixml.md)
 
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
 [Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
 [Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx)
 
 [Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821813
 schema: 2.0.0
 title: Import-Clixml
 ---
+
 # Import-Clixml
 
 ## SYNOPSIS
@@ -18,7 +19,8 @@ Imports a CLIXML file and creates corresponding objects in PowerShell.
 ### ByPath (Default)
 
 ```
-Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [<CommonParameters>]
+Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [<CommonParameters>]
 ```
 
 ### ByLiteralPath
@@ -30,10 +32,12 @@ Import-Clixml -LiteralPath <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-Fi
 
 ## DESCRIPTION
 
-The `Import-Clixml` cmdlet imports a CLIXML file with data that represents Microsoft .NET Framework
-objects and creates the objects in PowerShell. A valuable use of `Import-Clixml` is to import
-credentials and secure strings that have been exported as secure XML by running the `Export-Clixml`
-cmdlet.
+The `Import-Clixml` cmdlet imports a Common Language Infrastructure (CLI) XML file with data that
+represents Microsoft .NET Framework objects and creates the PowerShell objects. For more information
+about CLI, see [Language independence](/dotnet/standard/language-independence).
+
+A valuable use of `Import-Clixml` on Windows computers is to import credentials and secure strings
+that were exported as secure XML using `Export-Clixml`. For an example, see Example 2.
 
 `Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
 file has no BOM, it assumes the encoding is UTF8.
@@ -42,19 +46,23 @@ file has no BOM, it assumes the encoding is UTF8.
 
 ### Example 1: Import a serialized file and recreate an object
 
-This command uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
-returned by `Get-Process`. It then uses `Import-Clixml` to retrieve the contents of the serialized
-file and re-create an object that is stored in the `$Processes` variable.
+This example uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
+returned by `Get-Process`. `Import-Clixml` retrieves the serialized file's contents and recreates an
+object that is stored in the `$Processes` variable.
 
 ```powershell
-Get-Process | Export-Clixml pi.xml
-$Processes = Import-Clixml pi.xml
+Get-Process | Export-Clixml -Path .\pi.xml
+$Processes = Import-Clixml -Path .\pi.xml
 ```
 
 ### Example 2: Import a secure credential object
 
 In this example, given a credential that you've stored in the `$Credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
@@ -64,18 +72,19 @@ $Credential = Import-Clixml $Credxmlpath
 ```
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
-This ensures that only your user account can decrypt the contents of the credential object.
+The encryption ensures that only your user account can decrypt the contents of the credential
+object. The exported `CLIXML` file can't be used on a different computer or by a different user.
 
 In the example, the file in which the credential is stored is represented by
-`TestScript.ps1.credential`. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-You pipe the credential object to `Export-Clixml`, and save it to the path, `$Credxmlpath`, that you
-specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
@@ -98,10 +107,11 @@ Accept wildcard characters: False
 ### -IncludeTotalCount
 
 Reports the total number of objects in the data set followed by the selected objects. If the cmdlet
-cannot determine the total count, it displays "Unknown total count." The integer has an Accuracy
-property that indicates the reliability of the total count value. The value of Accuracy ranges from
-0.0 to 1.0 where 0.0 means that the cmdlet could not count the objects, 1.0 means that the count is
-exact, and a value between 0.0 and 1.0 indicates an increasingly reliable estimate.
+can't determine the total count, it displays **Unknown total count**. The integer has an
+**Accuracy** property that indicates the reliability of the total count value. The value of
+**Accuracy** ranges from `0.0` to `1.0` where `0.0` means that the cmdlet couldn't count the
+objects, `1.0` means that the count is exact, and a value between `0.0` and `1.0` indicates an
+increasingly reliable estimate.
 
 ```yaml
 Type: SwitchParameter
@@ -117,10 +127,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is used exactly
-as it is typed. No characters are interpreted as wildcards. If the path includes escape characters,
-enclose it in single quotation marks. Single quotation marks tell PowerShell not to interpret any
-characters as escape sequences.
+Specifies the path to the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is
+used exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -136,7 +146,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the XML files.
+Specifies the path to the XML files.
 
 ```yaml
 Type: String[]
@@ -152,8 +162,8 @@ Accept wildcard characters: False
 
 ### -Skip
 
-Ignores the specified number of objects and then gets the remaining objects.
-Enter the number of objects to skip.
+Ignores the specified number of objects and then gets the remaining objects. Enter the number of
+objects to skip.
 
 ```yaml
 Type: UInt64
@@ -171,31 +181,33 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to `Import-Clixml`.
+You can pipeline a string that contains a path to `Import-Clixml`.
 
 ## OUTPUTS
 
 ### PSObject
 
-`Import-Clixml` returns objects that have been deserialized from the stored XML files.
+`Import-Clixml` returns objects that were deserialized from the stored XML files.
 
 ## NOTES
 
-* When specifying multiple values for a parameter, use commas to separate the values. For example,
-  `<parameter-name> <value1>, <value2>`.
+When specifying multiple values for a parameter, use commas to separate the values. For example,
+`<parameter-name> <value1>, <value2>`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](http://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
-
-[Securely Store Credentials on Disk](http://www.powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [Export-Clixml](Export-Clixml.md)
 
+[Introducing XML Serialization](/dotnet/standard/serialization/introducing-xml-serialization)
+
 [Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)

--- a/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -32,9 +32,10 @@ Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-F
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores it
-in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
-contents of that file.
+The `Export-Clixml` cmdlet creates a Common Language Infrastructure (CLI) XML-based representation
+of an object or objects and stores it in a file. You can then use the `Import-Clixml` cmdlet to
+recreate the saved object based on the contents of that file.
+For more information about CLI, see [Language independence](/dotnet/standard/language-independence).
 
 This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
 file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
@@ -75,34 +76,31 @@ the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
-This example shows how to use a credential stored in a variable and save it to disk. The credential
-can then be imported into scripts.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
 
 > [!IMPORTANT]
-> The encrypted credentials only work on Windows. On non-Windows operating systems such as macOS and
-> Linux, encrypted credentials are exported in plain text.
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential | Export-Clixml $credxmlpath
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential = Import-Clixml $credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential | Export-Clixml $Credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The `Export-Clixml` cmdlet encrypts credential objects by using the
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
 The encryption ensures that only your user account on only that computer can decrypt the contents of
-the credential object. The exported `CliXml` file can't be used on a different computer or by a
+the credential object. The exported `CLIXML` file can't be used on a different computer or by a
 different user.
 
-In this example, given a credential that you've stored in the `$credential` variable by running the
-`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
-the example, the file in which the credential is stored is represented by
+In the example, the file in which the credential is stored is represented by
 `TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
-`$credxmlpath`, that you specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
 To import the credential automatically into your script, run the final two commands. Run
 `Import-Clixml` to import the secured credential object into your script. This import eliminates the
@@ -294,7 +292,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.PSObject
 
-You can pipe any object to `Export-Clixml`.
+You can pipeline any object to `Export-Clixml`.
 
 ## OUTPUTS
 
@@ -314,10 +312,10 @@ You can pipe any object to `Export-Clixml`.
 
 [Import-Clixml](Import-Clixml.md)
 
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
 [Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
 [Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx)
 
 [Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 1/22/2019
+ms.date: 08/14/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096977
 schema: 2.0.0
 title: Export-Clixml
 ---
+
 # Export-Clixml
 
 ## SYNOPSIS
@@ -18,61 +19,68 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ### ByPath (Default)
 
 ```
-Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml [-Path] <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
-it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
+The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores it
+in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
 contents of that file.
 
-This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
-a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
+file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
 
-A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
-an example of how to do this, see Example 3.
+A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
+securely as XML. For an example, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
 
-This command creates an XML file that stores a representation of the string, "This is a test" in
-the current directory.
+This example creates an XML file that stores in the current directory, a representation of the
+string **This is a test**.
 
 ```powershell
 "This is a test" | Export-Clixml -Path .\sample.xml
 ```
 
+The string **This is a test** is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
+to create an XML file named `sample.xml` in the current directory.
+
 ### Example 2: Export an object to an XML file
 
-This example shows how to export an object to an XML file and then create an object by importing
-the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing the
+XML from the file.
 
 ```powershell
-Get-Acl C:\test.txt | Export-Clixml -Path .\fileacl.xml
-$fileacl = Import-Clixml -Path .\fileacl.xml
+Get-Acl C:\test.txt | Export-Clixml -Path .\FileACL.xml
+$fileacl = Import-Clixml -Path .\FileACL.xml
 ```
 
-The `Get-Acl` cmdlet gets the security descriptor of the Test.txt file. It sends the object down
-the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of
-the object is stored in a file named FileACL.xml.
+The `Get-Acl` cmdlet gets the security descriptor of the `Test.txt` file. It sends the object down
+the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of the
+object is stored in a file named `FileACL.xml`.
 
-The `Import-Clixml` cmdlet creates an object from the XML in the FileACL.xml file. Then, it saves
+The `Import-Clixml` cmdlet creates an object from the XML in the `FileACL.xml` file. Then, it saves
 the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
 This example shows how to use a credential stored in a variable and save it to disk. The credential
 can then be imported into scripts.
+
+> [!IMPORTANT]
+> The encrypted credentials only work on Windows. On non-Windows operating systems such as macOS and
+> Linux, encrypted credentials are exported in plain text.
 
 ```powershell
 $credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
@@ -83,31 +91,47 @@ $credential = Import-Clixml $credxmlpath
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the
 [Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account on only that computer can decrypt the contents of the
-credential object. The exported CliXml file can neither be used on a different computer nor by a
+The encryption ensures that only your user account on only that computer can decrypt the contents of
+the credential object. The exported `CliXml` file can't be used on a different computer or by a
 different user.
 
 In this example, given a credential that you've stored in the `$credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
 the example, the file in which the credential is stored is represented by
-TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
 In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
 `$credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Depth
 
 Specifies how many levels of contained objects are included in the XML representation. The default
-value is 2.
+value is `2`.
 
-The default value can be overridden for the object type in the Types.ps1xml files. For more
+The default value can be overridden for the object type in the `Types.ps1xml` files. For more
 information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
@@ -170,7 +194,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -195,10 +219,9 @@ Accept wildcard characters: False
 ### -LiteralPath
 
 Specifies the path to the file where the XML representation of the object will be stored. Unlike
-**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
-are interpreted as wildcards. If the path includes escape characters, enclose it in single
-quotation marks. Single quotation marks tell PowerShell not to interpret any characters as
-escape sequences.
+**Path**, the value of the **LiteralPath** parameter is used exactly as it's typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single quotation
+marks. Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -214,8 +237,8 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Indicates that the cmdlet does not overwrite the contents of an existing file. By default, if a
-file exists in the specified path, `Export-Clixml` overwrites the file without warning.
+Indicates that the cmdlet doesn't overwrite the contents of an existing file. By default, if a file
+exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -224,7 +247,7 @@ Aliases: NoOverwrite
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -245,25 +268,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -281,8 +288,7 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -300,10 +306,6 @@ You can pipe any object to `Export-Clixml`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [ConvertTo-Html](ConvertTo-Html.md)
 
 [ConvertTo-Xml](ConvertTo-Xml.md)
@@ -311,3 +313,11 @@ You can pipe any object to `Export-Clixml`.
 [Export-Csv](Export-Csv.md)
 
 [Import-Clixml](Import-Clixml.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
+
+[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx)
+
+[Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/6/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096532
 schema: 2.0.0
 title: Import-Clixml
 ---
+
 # Import-Clixml
 
 ## SYNOPSIS
@@ -18,7 +19,8 @@ Imports a CLIXML file and creates corresponding objects in PowerShell.
 ### ByPath (Default)
 
 ```
-Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [<CommonParameters>]
+Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [<CommonParameters>]
 ```
 
 ### ByLiteralPath
@@ -30,52 +32,65 @@ Import-Clixml -LiteralPath <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-Fi
 
 ## DESCRIPTION
 
-The **Import-CliXml** cmdlet imports a CLIXML file with data that represents Microsoft .NET Framework objects and creates the objects in PowerShell.
+The `Import-Clixml` cmdlet imports a Common Language Infrastructure (CLI) XML file with data that
+represents Microsoft .NET Framework objects and creates the PowerShell objects. For more information
+about CLI, see [Language independence](/dotnet/standard/language-independence).
 
-A valuable use of **Import-CliXml** is to import credentials and secure strings that have been exported as secure XML by running the Export-Clixml cmdlet.
-For an example of how to do this, see Example 2.
+A valuable use of `Import-Clixml` on Windows computers is to import credentials and secure strings
+that were exported as secure XML using `Export-Clixml`. For an example, see Example 2.
+
+`Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
+file has no BOM, it assumes the encoding is UTF8.
 
 ## EXAMPLES
 
 ### Example 1: Import a serialized file and recreate an object
 
-```powershell
-Get-Process | Export-Clixml pi.xml
-$Processes = Import-Clixml pi.xml
-```
+This example uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
+returned by `Get-Process`. `Import-Clixml` retrieves the serialized file's contents and recreates an
+object that is stored in the `$Processes` variable.
 
-This command uses the Export-Clixml cmdlet to save a serialized copy of the process information returned by Get-Process.
-It then uses **Import-Clixml** to retrieve the contents of the serialized file and re-create an object that is stored in the $Processes variable.
+```powershell
+Get-Process | Export-Clixml -Path .\pi.xml
+$Processes = Import-Clixml -Path .\pi.xml
+```
 
 ### Example 2: Import a secure credential object
 
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
+
 ```powershell
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-$Credential | Export-CliXml $Credxmlpath
+$Credential | Export-Clixml $Credxmlpath
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-$Credential = Import-CliXml $Credxmlpath
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The **Export-CliXml** cmdlet encrypts credential objects by using the [Windows Data Protection API](http://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account can decrypt the contents of the credential object.
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
+The encryption ensures that only your user account can decrypt the contents of the credential
+object. The exported `CLIXML` file can't be used on a different computer or by a different user.
 
-In this example, given a credential that you've stored in the $Credential variable by running the Get-Credential cmdlet, you can run the **Export-CliXml** cmdlet to save the credential to disk.
+In the example, the file in which the credential is stored is represented by
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
+loading the credential.
 
-In the example, the file in which the credential is stored is represented by TestScript.ps1.credential.
-Replace TestScript with the name of the script with which you are loading the credential.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-In the second command, you pipe the credential object to **Export-CliXml**, and save it to the path, $Credxmlpath, that you specified in the first command.
-
-To import the credential automatically into your script, run the final two commands.
-This time, you are running Import-Clixml to import the secured credential object into your script.
-This eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
 ### -First
 
-Gets only the specified number of objects.
-Enter the number of objects to get.
+Gets only the specified number of objects. Enter the number of objects to get.
 
 ```yaml
 Type: UInt64
@@ -91,9 +106,12 @@ Accept wildcard characters: False
 
 ### -IncludeTotalCount
 
-Reports the total number of objects in the data set (an integer) followed by the selected objects.
-If the cmdlet cannot determine the total count, it displays "Unknown total count." The integer has an Accuracy property that indicates the reliability of the total count value.
-The value of Accuracy ranges from 0.0 to 1.0 where 0.0 means that the cmdlet could not count the objects, 1.0 means that the count is exact, and a value between 0.0 and 1.0 indicates an increasingly reliable estimate.
+Reports the total number of objects in the data set followed by the selected objects. If the cmdlet
+can't determine the total count, it displays **Unknown total count**. The integer has an
+**Accuracy** property that indicates the reliability of the total count value. The value of
+**Accuracy** ranges from `0.0` to `1.0` where `0.0` means that the cmdlet couldn't count the
+objects, `1.0` means that the count is exact, and a value between `0.0` and `1.0` indicates an
+increasingly reliable estimate.
 
 ```yaml
 Type: SwitchParameter
@@ -109,11 +127,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the XML files.
-Unlike *Path*, the value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies the path to the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is
+used exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -129,7 +146,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the XML files.
+Specifies the path to the XML files.
 
 ```yaml
 Type: String[]
@@ -145,8 +162,8 @@ Accept wildcard characters: False
 
 ### -Skip
 
-Ignores the specified number of objects and then gets the remaining objects.
-Enter the number of objects to skip.
+Ignores the specified number of objects and then gets the remaining objects. Enter the number of
+objects to skip.
 
 ```yaml
 Type: UInt64
@@ -162,29 +179,35 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to **Import-Clixml**.
+You can pipeline a string that contains a path to `Import-Clixml`.
 
 ## OUTPUTS
 
 ### PSObject
 
-**Import-Clixml** returns objects that have been deserialized from the stored XML files.
+`Import-Clixml` returns objects that were deserialized from the stored XML files.
 
 ## NOTES
 
 When specifying multiple values for a parameter, use commas to separate the values. For example,
-"\<parameter-name\> \<value1\>, \<value2\>".
+`<parameter-name> <value1>, <value2>`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
+[Export-Clixml](Export-Clixml.md)
+
+[Introducing XML Serialization](/dotnet/standard/serialization/introducing-xml-serialization)
+
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
 
 [Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
-[Export-Clixml](Export-Clixml.md)
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)

--- a/reference/7/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 1/22/2019
+ms.date: 08/14/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096926
 schema: 2.0.0
 title: Export-Clixml
 ---
+
 # Export-Clixml
 
 ## SYNOPSIS
@@ -18,61 +19,68 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ### ByPath (Default)
 
 ```
-Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml [-Path] <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
-it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
+The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores it
+in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
 contents of that file.
 
-This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
-a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
+file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
 
-A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
-an example of how to do this, see Example 3.
+A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
+securely as XML. For an example, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
 
-This command creates an XML file that stores a representation of the string, "This is a test" in
-the current directory.
+This example creates an XML file that stores in the current directory, a representation of the
+string **This is a test**.
 
 ```powershell
 "This is a test" | Export-Clixml -Path .\sample.xml
 ```
 
+The string **This is a test** is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
+to create an XML file named `sample.xml` in the current directory.
+
 ### Example 2: Export an object to an XML file
 
-This example shows how to export an object to an XML file and then create an object by importing
-the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing the
+XML from the file.
 
 ```powershell
-Get-Acl C:\test.txt | Export-Clixml -Path .\fileacl.xml
-$fileacl = Import-Clixml -Path .\fileacl.xml
+Get-Acl C:\test.txt | Export-Clixml -Path .\FileACL.xml
+$fileacl = Import-Clixml -Path .\FileACL.xml
 ```
 
-The `Get-Acl` cmdlet gets the security descriptor of the Test.txt file. It sends the object down
-the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of
-the object is stored in a file named FileACL.xml.
+The `Get-Acl` cmdlet gets the security descriptor of the `Test.txt` file. It sends the object down
+the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of the
+object is stored in a file named `FileACL.xml`.
 
-The `Import-Clixml` cmdlet creates an object from the XML in the FileACL.xml file. Then, it saves
+The `Import-Clixml` cmdlet creates an object from the XML in the `FileACL.xml` file. Then, it saves
 the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
 This example shows how to use a credential stored in a variable and save it to disk. The credential
 can then be imported into scripts.
+
+> [!IMPORTANT]
+> The encrypted credentials only work on Windows. On non-Windows operating systems such as macOS and
+> Linux, encrypted credentials are exported in plain text.
 
 ```powershell
 $credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
@@ -83,31 +91,47 @@ $credential = Import-Clixml $credxmlpath
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the
 [Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account on only that computer can decrypt the contents of the
-credential object. The exported CliXml file can neither be used on a different computer nor by a
+The encryption ensures that only your user account on only that computer can decrypt the contents of
+the credential object. The exported `CliXml` file can't be used on a different computer or by a
 different user.
 
 In this example, given a credential that you've stored in the `$credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
 the example, the file in which the credential is stored is represented by
-TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
 In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
 `$credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Depth
 
 Specifies how many levels of contained objects are included in the XML representation. The default
-value is 2.
+value is `2`.
 
-The default value can be overridden for the object type in the Types.ps1xml files. For more
+The default value can be overridden for the object type in the `Types.ps1xml` files. For more
 information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
@@ -170,7 +194,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -195,10 +219,9 @@ Accept wildcard characters: False
 ### -LiteralPath
 
 Specifies the path to the file where the XML representation of the object will be stored. Unlike
-**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
-are interpreted as wildcards. If the path includes escape characters, enclose it in single
-quotation marks. Single quotation marks tell PowerShell not to interpret any characters as
-escape sequences.
+**Path**, the value of the **LiteralPath** parameter is used exactly as it's typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single quotation
+marks. Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -214,8 +237,8 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Indicates that the cmdlet does not overwrite the contents of an existing file. By default, if a
-file exists in the specified path, `Export-Clixml` overwrites the file without warning.
+Indicates that the cmdlet doesn't overwrite the contents of an existing file. By default, if a file
+exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -224,7 +247,7 @@ Aliases: NoOverwrite
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -245,25 +268,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -281,8 +288,7 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -300,10 +306,6 @@ You can pipe any object to `Export-Clixml`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [ConvertTo-Html](ConvertTo-Html.md)
 
 [ConvertTo-Xml](ConvertTo-Xml.md)
@@ -311,3 +313,11 @@ You can pipe any object to `Export-Clixml`.
 [Export-Csv](Export-Csv.md)
 
 [Import-Clixml](Import-Clixml.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
+
+[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx)
+
+[Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/7/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -32,9 +32,10 @@ Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-F
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores it
-in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
-contents of that file.
+The `Export-Clixml` cmdlet creates a Common Language Infrastructure (CLI) XML-based representation
+of an object or objects and stores it in a file. You can then use the `Import-Clixml` cmdlet to
+recreate the saved object based on the contents of that file.
+For more information about CLI, see [Language independence](/dotnet/standard/language-independence).
 
 This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
 file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
@@ -75,34 +76,31 @@ the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
-This example shows how to use a credential stored in a variable and save it to disk. The credential
-can then be imported into scripts.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
 
 > [!IMPORTANT]
-> The encrypted credentials only work on Windows. On non-Windows operating systems such as macOS and
-> Linux, encrypted credentials are exported in plain text.
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential | Export-Clixml $credxmlpath
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential = Import-Clixml $credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential | Export-Clixml $Credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The `Export-Clixml` cmdlet encrypts credential objects by using the
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
 The encryption ensures that only your user account on only that computer can decrypt the contents of
-the credential object. The exported `CliXml` file can't be used on a different computer or by a
+the credential object. The exported `CLIXML` file can't be used on a different computer or by a
 different user.
 
-In this example, given a credential that you've stored in the `$credential` variable by running the
-`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
-the example, the file in which the credential is stored is represented by
+In the example, the file in which the credential is stored is represented by
 `TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
-`$credxmlpath`, that you specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
 To import the credential automatically into your script, run the final two commands. Run
 `Import-Clixml` to import the secured credential object into your script. This import eliminates the
@@ -294,7 +292,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.PSObject
 
-You can pipe any object to `Export-Clixml`.
+You can pipeline any object to `Export-Clixml`.
 
 ## OUTPUTS
 
@@ -314,10 +312,10 @@ You can pipe any object to `Export-Clixml`.
 
 [Import-Clixml](Import-Clixml.md)
 
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
 [Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
 [Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx)
 
 [Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/7/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096618
 schema: 2.0.0
 title: Import-Clixml
 ---
+
 # Import-Clixml
 
 ## SYNOPSIS
@@ -18,7 +19,8 @@ Imports a CLIXML file and creates corresponding objects in PowerShell.
 ### ByPath (Default)
 
 ```
-Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [<CommonParameters>]
+Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [<CommonParameters>]
 ```
 
 ### ByLiteralPath
@@ -30,52 +32,65 @@ Import-Clixml -LiteralPath <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-Fi
 
 ## DESCRIPTION
 
-The **Import-CliXml** cmdlet imports a CLIXML file with data that represents Microsoft .NET Framework objects and creates the objects in PowerShell.
+The `Import-Clixml` cmdlet imports a Common Language Infrastructure (CLI) XML file with data that
+represents Microsoft .NET Framework objects and creates the PowerShell objects. For more information
+about CLI, see [Language independence](/dotnet/standard/language-independence).
 
-A valuable use of **Import-CliXml** is to import credentials and secure strings that have been exported as secure XML by running the Export-Clixml cmdlet.
-For an example of how to do this, see Example 2.
+A valuable use of `Import-Clixml` on Windows computers is to import credentials and secure strings
+that were exported as secure XML using `Export-Clixml`. For an example, see Example 2.
+
+`Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
+file has no BOM, it assumes the encoding is UTF8.
 
 ## EXAMPLES
 
 ### Example 1: Import a serialized file and recreate an object
 
-```powershell
-Get-Process | Export-Clixml pi.xml
-$Processes = Import-Clixml pi.xml
-```
+This example uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
+returned by `Get-Process`. `Import-Clixml` retrieves the serialized file's contents and recreates an
+object that is stored in the `$Processes` variable.
 
-This command uses the Export-Clixml cmdlet to save a serialized copy of the process information returned by Get-Process.
-It then uses **Import-Clixml** to retrieve the contents of the serialized file and re-create an object that is stored in the $Processes variable.
+```powershell
+Get-Process | Export-Clixml -Path .\pi.xml
+$Processes = Import-Clixml -Path .\pi.xml
+```
 
 ### Example 2: Import a secure credential object
 
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
+
 ```powershell
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-$Credential | Export-CliXml $Credxmlpath
+$Credential | Export-Clixml $Credxmlpath
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-$Credential = Import-CliXml $Credxmlpath
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The **Export-CliXml** cmdlet encrypts credential objects by using the [Windows Data Protection API](http://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account can decrypt the contents of the credential object.
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
+The encryption ensures that only your user account can decrypt the contents of the credential
+object. The exported `CLIXML` file can't be used on a different computer or by a different user.
 
-In this example, given a credential that you've stored in the $Credential variable by running the Get-Credential cmdlet, you can run the **Export-CliXml** cmdlet to save the credential to disk.
+In the example, the file in which the credential is stored is represented by
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
+loading the credential.
 
-In the example, the file in which the credential is stored is represented by TestScript.ps1.credential.
-Replace TestScript with the name of the script with which you are loading the credential.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-In the second command, you pipe the credential object to **Export-CliXml**, and save it to the path, $Credxmlpath, that you specified in the first command.
-
-To import the credential automatically into your script, run the final two commands.
-This time, you are running Import-Clixml to import the secured credential object into your script.
-This eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
 ### -First
 
-Gets only the specified number of objects.
-Enter the number of objects to get.
+Gets only the specified number of objects. Enter the number of objects to get.
 
 ```yaml
 Type: UInt64
@@ -91,9 +106,12 @@ Accept wildcard characters: False
 
 ### -IncludeTotalCount
 
-Reports the total number of objects in the data set (an integer) followed by the selected objects.
-If the cmdlet cannot determine the total count, it displays "Unknown total count." The integer has an Accuracy property that indicates the reliability of the total count value.
-The value of Accuracy ranges from 0.0 to 1.0 where 0.0 means that the cmdlet could not count the objects, 1.0 means that the count is exact, and a value between 0.0 and 1.0 indicates an increasingly reliable estimate.
+Reports the total number of objects in the data set followed by the selected objects. If the cmdlet
+can't determine the total count, it displays **Unknown total count**. The integer has an
+**Accuracy** property that indicates the reliability of the total count value. The value of
+**Accuracy** ranges from `0.0` to `1.0` where `0.0` means that the cmdlet couldn't count the
+objects, `1.0` means that the count is exact, and a value between `0.0` and `1.0` indicates an
+increasingly reliable estimate.
 
 ```yaml
 Type: SwitchParameter
@@ -109,11 +127,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the XML files.
-Unlike *Path*, the value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies the path to the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is
+used exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -129,7 +146,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the XML files.
+Specifies the path to the XML files.
 
 ```yaml
 Type: String[]
@@ -145,8 +162,8 @@ Accept wildcard characters: False
 
 ### -Skip
 
-Ignores the specified number of objects and then gets the remaining objects.
-Enter the number of objects to skip.
+Ignores the specified number of objects and then gets the remaining objects. Enter the number of
+objects to skip.
 
 ```yaml
 Type: UInt64
@@ -162,29 +179,35 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to **Import-Clixml**.
+You can pipeline a string that contains a path to `Import-Clixml`.
 
 ## OUTPUTS
 
 ### PSObject
 
-**Import-Clixml** returns objects that have been deserialized from the stored XML files.
+`Import-Clixml` returns objects that were deserialized from the stored XML files.
 
 ## NOTES
 
 When specifying multiple values for a parameter, use commas to separate the values. For example,
-"\<parameter-name\> \<value1\>, \<value2\>".
+`<parameter-name> <value1>, <value2>`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
+[Export-Clixml](Export-Clixml.md)
+
+[Introducing XML Serialization](/dotnet/standard/serialization/introducing-xml-serialization)
+
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
 
 [Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
-[Export-Clixml](Export-Clixml.md)
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

Export-Clixml Acrolinx scores
Original version: 91
Updated version: 98

Import-Clixml Acrolinx scores
Original version: 90
Updated version: 99

- Fixes [AB#1584227](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1584227)
- Fixes #4614 - Added note that exported encrypted credentials is Windows only
- Fixes [AB#1584808](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1584808)
- Fixes #4641 - Added CLI definition to Description
- Fixed parameter set spacing between parameters
- Paragraph reflows, copyedits, style
