### PR TITLE
 Fixes #4630 - PS classes only imported by using statement

### DIFF
--- a/dsc/pull-server/pullServer.md
+++ b/dsc/pull-server/pullServer.md
@@ -294,7 +294,7 @@ Each resource module needs to be zipped and named
 according to the following pattern `{Module Name}_{Module Version}.zip`.
 
 For example, a module named xWebAdminstration with a module version
-of 3.1.2.0 would be named `xWebAdministration_3.2.1.0.zip`.
+of 3.1.2.0 would be named `xWebAdministration_3.1.2.0.zip`.
 Each version of a module must be contained in a single zip file.
 Since there is only a single version of a resource in each zip file,
 the module format added in WMF 5.0 with support for multiple module versions

--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/14/2019
 online version: https://go.microsoft.com/fwlink/?linkid=113297
 schema: 2.0.0
 title: Export-Clixml
 ---
+
 # Export-Clixml
 
 ## SYNOPSIS
@@ -18,94 +19,117 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ### ByPath (Default)
 
 ```
-Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml [-Path] <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
-it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
-contents of that file.
+The `Export-Clixml` cmdlet creates a Common Language Infrastructure (CLI) XML-based representation
+of an object or objects and stores it in a file. You can then use the `Import-Clixml` cmdlet to
+recreate the saved object based on the contents of that file.
+For more information about CLI, see [Language independence](/dotnet/standard/language-independence).
 
-This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
-a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
+file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
 
-A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
-an example of how to do this, see Example 3.
+A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
+securely as XML. For an example, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
 
-This command creates an XML file that stores a representation of the string, "This is a test" in
-the current directory.
+This example creates an XML file that stores in the current directory, a representation of the
+string **This is a test**.
 
 ```powershell
 "This is a test" | Export-Clixml -Path .\sample.xml
 ```
 
+The string **This is a test** is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
+to create an XML file named `sample.xml` in the current directory.
+
 ### Example 2: Export an object to an XML file
 
-This example shows how to export an object to an XML file and then create an object by importing
-the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing the
+XML from the file.
 
 ```powershell
-Get-Acl C:\test.txt | Export-Clixml -Path .\fileacl.xml
-$fileacl = Import-Clixml -Path .\fileacl.xml
+Get-Acl C:\test.txt | Export-Clixml -Path .\FileACL.xml
+$fileacl = Import-Clixml -Path .\FileACL.xml
 ```
 
-The `Get-Acl` cmdlet gets the security descriptor of the Test.txt file. It sends the object down
-the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of
-the object is stored in a file named FileACL.xml.
+The `Get-Acl` cmdlet gets the security descriptor of the `Test.txt` file. It sends the object down
+the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of the
+object is stored in a file named `FileACL.xml`.
 
-The `Import-Clixml` cmdlet creates an object from the XML in the FileACL.xml file. Then, it saves
+The `Import-Clixml` cmdlet creates an object from the XML in the `FileACL.xml` file. Then, it saves
 the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
-This example shows how to use a credential stored in a variable and save it to disk. The credential
-can then be imported into scripts.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential | Export-Clixml $credxmlpath
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential = Import-Clixml $credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential | Export-Clixml $Credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The `Export-Clixml` cmdlet encrypts credential objects by using the
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account can decrypt the contents of the credential object.
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
+The encryption ensures that only your user account on only that computer can decrypt the contents of
+the credential object. The exported `CLIXML` file can't be used on a different computer or by a
+different user.
 
-In this example, given a credential that you've stored in the `$credential` variable by running the
-`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
-the example, the file in which the credential is stored is represented by
-TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+In the example, the file in which the credential is stored is represented by
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
-`$credxmlpath`, that you specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Depth
 
 Specifies how many levels of contained objects are included in the XML representation. The default
-value is 2.
+value is `2`.
 
-The default value can be overridden for the object type in the Types.ps1xml files. For more
+The default value can be overridden for the object type in the `Types.ps1xml` files. For more
 information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
@@ -184,9 +208,28 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
+### -LiteralPath
+
+Specifies the path to the file where the XML representation of the object will be stored. Unlike
+**Path**, the value of the **LiteralPath** parameter is used exactly as it's typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single quotation
+marks. Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+
+```yaml
+Type: String
+Parameter Sets: ByLiteralPath
+Aliases: PSPath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -NoClobber
 
-Ensures that the cmdlet does not overwrite the contents of an existing file. By default, if a file
+Indicates that the cmdlet doesn't overwrite the contents of an existing file. By default, if a file
 exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
@@ -211,51 +254,15 @@ Parameter Sets: ByPath
 Aliases:
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -LiteralPath
-
-Specifies the path to the file where the XML representation of the object will be stored. Unlike
-**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
-are interpreted as wildcards. If the path includes escape characters, enclose it in single
-quotation marks. Single quotation marks tell PowerShell not to interpret any characters as escape
-sequences.
-
-```yaml
-Type: String
-Parameter Sets: ByLiteralPath
-Aliases: PSPath
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -273,14 +280,13 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
 
-You can pipe any object to `Export-Clixml`.
+You can pipeline any object to `Export-Clixml`.
 
 ## OUTPUTS
 
@@ -292,10 +298,6 @@ You can pipe any object to `Export-Clixml`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [ConvertTo-Html](ConvertTo-Html.md)
 
 [ConvertTo-Xml](ConvertTo-Xml.md)
@@ -303,3 +305,11 @@ You can pipe any object to `Export-Clixml`.
 [Export-Csv](Export-Csv.md)
 
 [Import-Clixml](Import-Clixml.md)
+
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
+
+[Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/3.0/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=113340
 schema: 2.0.0
 title: Import-Clixml
 ---
+
 # Import-Clixml
 
 ## SYNOPSIS
@@ -18,7 +19,8 @@ Imports a CLIXML file and creates corresponding objects in PowerShell.
 ### ByPath (Default)
 
 ```
-Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [<CommonParameters>]
+Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [<CommonParameters>]
 ```
 
 ### ByLiteralPath
@@ -30,10 +32,12 @@ Import-Clixml -LiteralPath <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-Fi
 
 ## DESCRIPTION
 
-The `Import-Clixml` cmdlet imports a CLIXML file with data that represents Microsoft .NET Framework
-objects and creates the objects in PowerShell. A valuable use of `Import-Clixml` is to import
-credentials and secure strings that have been exported as secure XML by running the `Export-Clixml`
-cmdlet.
+The `Import-Clixml` cmdlet imports a Common Language Infrastructure (CLI) XML file with data that
+represents Microsoft .NET Framework objects and creates the PowerShell objects. For more information
+about CLI, see [Language independence](/dotnet/standard/language-independence).
+
+A valuable use of `Import-Clixml` on Windows computers is to import credentials and secure strings
+that were exported as secure XML using `Export-Clixml`. For an example, see Example 2.
 
 `Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
 file has no BOM, it assumes the encoding is UTF8.
@@ -42,19 +46,23 @@ file has no BOM, it assumes the encoding is UTF8.
 
 ### Example 1: Import a serialized file and recreate an object
 
-This command uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
-returned by `Get-Process`. It then uses `Import-Clixml` to retrieve the contents of the serialized
-file and re-create an object that is stored in the `$Processes` variable.
+This example uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
+returned by `Get-Process`. `Import-Clixml` retrieves the serialized file's contents and recreates an
+object that is stored in the `$Processes` variable.
 
 ```powershell
-Get-Process | Export-Clixml pi.xml
-$Processes = Import-Clixml pi.xml
+Get-Process | Export-Clixml -Path .\pi.xml
+$Processes = Import-Clixml -Path .\pi.xml
 ```
 
 ### Example 2: Import a secure credential object
 
 In this example, given a credential that you've stored in the `$Credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
@@ -64,18 +72,19 @@ $Credential = Import-Clixml $Credxmlpath
 ```
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
-This ensures that only your user account can decrypt the contents of the credential object.
+The encryption ensures that only your user account can decrypt the contents of the credential
+object. The exported `CLIXML` file can't be used on a different computer or by a different user.
 
 In the example, the file in which the credential is stored is represented by
-`TestScript.ps1.credential`. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-You pipe the credential object to `Export-Clixml`, and save it to the path, `$Credxmlpath`, that you
-specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
@@ -98,10 +107,11 @@ Accept wildcard characters: False
 ### -IncludeTotalCount
 
 Reports the total number of objects in the data set followed by the selected objects. If the cmdlet
-cannot determine the total count, it displays "Unknown total count." The integer has an Accuracy
-property that indicates the reliability of the total count value. The value of Accuracy ranges from
-0.0 to 1.0 where 0.0 means that the cmdlet could not count the objects, 1.0 means that the count is
-exact, and a value between 0.0 and 1.0 indicates an increasingly reliable estimate.
+can't determine the total count, it displays **Unknown total count**. The integer has an
+**Accuracy** property that indicates the reliability of the total count value. The value of
+**Accuracy** ranges from `0.0` to `1.0` where `0.0` means that the cmdlet couldn't count the
+objects, `1.0` means that the count is exact, and a value between `0.0` and `1.0` indicates an
+increasingly reliable estimate.
 
 ```yaml
 Type: SwitchParameter
@@ -117,10 +127,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is used exactly
-as it is typed. No characters are interpreted as wildcards. If the path includes escape characters,
-enclose it in single quotation marks. Single quotation marks tell PowerShell not to interpret any
-characters as escape sequences.
+Specifies the path to the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is
+used exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -136,7 +146,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the XML files.
+Specifies the path to the XML files.
 
 ```yaml
 Type: String[]
@@ -152,8 +162,8 @@ Accept wildcard characters: False
 
 ### -Skip
 
-Ignores the specified number of objects and then gets the remaining objects.
-Enter the number of objects to skip.
+Ignores the specified number of objects and then gets the remaining objects. Enter the number of
+objects to skip.
 
 ```yaml
 Type: UInt64
@@ -171,31 +181,33 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to `Import-Clixml`.
+You can pipeline a string that contains a path to `Import-Clixml`.
 
 ## OUTPUTS
 
 ### PSObject
 
-`Import-Clixml` returns objects that have been deserialized from the stored XML files.
+`Import-Clixml` returns objects that were deserialized from the stored XML files.
 
 ## NOTES
 
-* When specifying multiple values for a parameter, use commas to separate the values. For example,
-  `<parameter-name> <value1>, <value2>`.
+When specifying multiple values for a parameter, use commas to separate the values. For example,
+`<parameter-name> <value1>, <value2>`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](http://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
-
-[Securely Store Credentials on Disk](http://www.powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [Export-Clixml](Export-Clixml.md)
 
+[Introducing XML Serialization](/dotnet/standard/serialization/introducing-xml-serialization)
+
 [Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/14/2019
 online version: https://go.microsoft.com/fwlink/?linkid=293956
 schema: 2.0.0
 title: Export-Clixml
 ---
+
 # Export-Clixml
 
 ## SYNOPSIS
@@ -18,94 +19,117 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ### ByPath (Default)
 
 ```
-Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml [-Path] <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
-it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
-contents of that file.
+The `Export-Clixml` cmdlet creates a Common Language Infrastructure (CLI) XML-based representation
+of an object or objects and stores it in a file. You can then use the `Import-Clixml` cmdlet to
+recreate the saved object based on the contents of that file.
+For more information about CLI, see [Language independence](/dotnet/standard/language-independence).
 
-This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
-a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
+file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
 
-A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
-an example of how to do this, see Example 3.
+A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
+securely as XML. For an example, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
 
-This command creates an XML file that stores a representation of the string, "This is a test" in
-the current directory.
+This example creates an XML file that stores in the current directory, a representation of the
+string **This is a test**.
 
 ```powershell
 "This is a test" | Export-Clixml -Path .\sample.xml
 ```
 
+The string **This is a test** is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
+to create an XML file named `sample.xml` in the current directory.
+
 ### Example 2: Export an object to an XML file
 
-This example shows how to export an object to an XML file and then create an object by importing
-the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing the
+XML from the file.
 
 ```powershell
-Get-Acl C:\test.txt | Export-Clixml -Path .\fileacl.xml
-$fileacl = Import-Clixml -Path .\fileacl.xml
+Get-Acl C:\test.txt | Export-Clixml -Path .\FileACL.xml
+$fileacl = Import-Clixml -Path .\FileACL.xml
 ```
 
-The `Get-Acl` cmdlet gets the security descriptor of the Test.txt file. It sends the object down
-the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of
-the object is stored in a file named FileACL.xml.
+The `Get-Acl` cmdlet gets the security descriptor of the `Test.txt` file. It sends the object down
+the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of the
+object is stored in a file named `FileACL.xml`.
 
-The `Import-Clixml` cmdlet creates an object from the XML in the FileACL.xml file. Then, it saves
+The `Import-Clixml` cmdlet creates an object from the XML in the `FileACL.xml` file. Then, it saves
 the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
-This example shows how to use a credential stored in a variable and save it to disk. The credential
-can then be imported into scripts.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential | Export-Clixml $credxmlpath
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential = Import-Clixml $credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential | Export-Clixml $Credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The `Export-Clixml` cmdlet encrypts credential objects by using the
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account can decrypt the contents of the credential object.
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
+The encryption ensures that only your user account on only that computer can decrypt the contents of
+the credential object. The exported `CLIXML` file can't be used on a different computer or by a
+different user.
 
-In this example, given a credential that you've stored in the `$credential` variable by running the
-`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
-the example, the file in which the credential is stored is represented by
-TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+In the example, the file in which the credential is stored is represented by
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
-`$credxmlpath`, that you specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Depth
 
 Specifies how many levels of contained objects are included in the XML representation. The default
-value is 2.
+value is `2`.
 
-The default value can be overridden for the object type in the Types.ps1xml files. For more
+The default value can be overridden for the object type in the `Types.ps1xml` files. For more
 information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
@@ -184,9 +208,28 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
+### -LiteralPath
+
+Specifies the path to the file where the XML representation of the object will be stored. Unlike
+**Path**, the value of the **LiteralPath** parameter is used exactly as it's typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single quotation
+marks. Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+
+```yaml
+Type: String
+Parameter Sets: ByLiteralPath
+Aliases: PSPath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -NoClobber
 
-Ensures that the cmdlet does not overwrite the contents of an existing file. By default, if a file
+Indicates that the cmdlet doesn't overwrite the contents of an existing file. By default, if a file
 exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
@@ -211,51 +254,15 @@ Parameter Sets: ByPath
 Aliases:
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -LiteralPath
-
-Specifies the path to the file where the XML representation of the object will be stored. Unlike
-**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
-are interpreted as wildcards. If the path includes escape characters, enclose it in single
-quotation marks. Single quotation marks tell PowerShell not to interpret any characters as escape
-sequences.
-
-```yaml
-Type: String
-Parameter Sets: ByLiteralPath
-Aliases: PSPath
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -273,14 +280,13 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
 
-You can pipe any object to `Export-Clixml`.
+You can pipeline any object to `Export-Clixml`.
 
 ## OUTPUTS
 
@@ -292,10 +298,6 @@ You can pipe any object to `Export-Clixml`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [ConvertTo-Html](ConvertTo-Html.md)
 
 [ConvertTo-Xml](ConvertTo-Xml.md)
@@ -303,3 +305,11 @@ You can pipe any object to `Export-Clixml`.
 [Export-Csv](Export-Csv.md)
 
 [Import-Clixml](Import-Clixml.md)
+
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
+
+[Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/4.0/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=293982
 schema: 2.0.0
 title: Import-Clixml
 ---
+
 # Import-Clixml
 
 ## SYNOPSIS
@@ -18,7 +19,8 @@ Imports a CLIXML file and creates corresponding objects in PowerShell.
 ### ByPath (Default)
 
 ```
-Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [<CommonParameters>]
+Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [<CommonParameters>]
 ```
 
 ### ByLiteralPath
@@ -30,10 +32,12 @@ Import-Clixml -LiteralPath <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-Fi
 
 ## DESCRIPTION
 
-The `Import-Clixml` cmdlet imports a CLIXML file with data that represents Microsoft .NET Framework
-objects and creates the objects in PowerShell. A valuable use of `Import-Clixml` is to import
-credentials and secure strings that have been exported as secure XML by running the `Export-Clixml`
-cmdlet.
+The `Import-Clixml` cmdlet imports a Common Language Infrastructure (CLI) XML file with data that
+represents Microsoft .NET Framework objects and creates the PowerShell objects. For more information
+about CLI, see [Language independence](/dotnet/standard/language-independence).
+
+A valuable use of `Import-Clixml` on Windows computers is to import credentials and secure strings
+that were exported as secure XML using `Export-Clixml`. For an example, see Example 2.
 
 `Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
 file has no BOM, it assumes the encoding is UTF8.
@@ -42,19 +46,23 @@ file has no BOM, it assumes the encoding is UTF8.
 
 ### Example 1: Import a serialized file and recreate an object
 
-This command uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
-returned by `Get-Process`. It then uses `Import-Clixml` to retrieve the contents of the serialized
-file and re-create an object that is stored in the `$Processes` variable.
+This example uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
+returned by `Get-Process`. `Import-Clixml` retrieves the serialized file's contents and recreates an
+object that is stored in the `$Processes` variable.
 
 ```powershell
-Get-Process | Export-Clixml pi.xml
-$Processes = Import-Clixml pi.xml
+Get-Process | Export-Clixml -Path .\pi.xml
+$Processes = Import-Clixml -Path .\pi.xml
 ```
 
 ### Example 2: Import a secure credential object
 
 In this example, given a credential that you've stored in the `$Credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
@@ -64,18 +72,19 @@ $Credential = Import-Clixml $Credxmlpath
 ```
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
-This ensures that only your user account can decrypt the contents of the credential object.
+The encryption ensures that only your user account can decrypt the contents of the credential
+object. The exported `CLIXML` file can't be used on a different computer or by a different user.
 
 In the example, the file in which the credential is stored is represented by
-`TestScript.ps1.credential`. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-You pipe the credential object to `Export-Clixml`, and save it to the path, `$Credxmlpath`, that you
-specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
@@ -98,10 +107,11 @@ Accept wildcard characters: False
 ### -IncludeTotalCount
 
 Reports the total number of objects in the data set followed by the selected objects. If the cmdlet
-cannot determine the total count, it displays "Unknown total count." The integer has an Accuracy
-property that indicates the reliability of the total count value. The value of Accuracy ranges from
-0.0 to 1.0 where 0.0 means that the cmdlet could not count the objects, 1.0 means that the count is
-exact, and a value between 0.0 and 1.0 indicates an increasingly reliable estimate.
+can't determine the total count, it displays **Unknown total count**. The integer has an
+**Accuracy** property that indicates the reliability of the total count value. The value of
+**Accuracy** ranges from `0.0` to `1.0` where `0.0` means that the cmdlet couldn't count the
+objects, `1.0` means that the count is exact, and a value between `0.0` and `1.0` indicates an
+increasingly reliable estimate.
 
 ```yaml
 Type: SwitchParameter
@@ -117,10 +127,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is used exactly
-as it is typed. No characters are interpreted as wildcards. If the path includes escape characters,
-enclose it in single quotation marks. Single quotation marks tell PowerShell not to interpret any
-characters as escape sequences.
+Specifies the path to the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is
+used exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -136,7 +146,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the XML files.
+Specifies the path to the XML files.
 
 ```yaml
 Type: String[]
@@ -152,8 +162,8 @@ Accept wildcard characters: False
 
 ### -Skip
 
-Ignores the specified number of objects and then gets the remaining objects.
-Enter the number of objects to skip.
+Ignores the specified number of objects and then gets the remaining objects. Enter the number of
+objects to skip.
 
 ```yaml
 Type: UInt64
@@ -171,31 +181,33 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to `Import-Clixml`.
+You can pipeline a string that contains a path to `Import-Clixml`.
 
 ## OUTPUTS
 
 ### PSObject
 
-`Import-Clixml` returns objects that have been deserialized from the stored XML files.
+`Import-Clixml` returns objects that were deserialized from the stored XML files.
 
 ## NOTES
 
-* When specifying multiple values for a parameter, use commas to separate the values. For example,
-  `<parameter-name> <value1>, <value2>`.
+When specifying multiple values for a parameter, use commas to separate the values. For example,
+`<parameter-name> <value1>, <value2>`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](http://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
-
-[Securely Store Credentials on Disk](http://www.powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [Export-Clixml](Export-Clixml.md)
 
+[Introducing XML Serialization](/dotnet/standard/serialization/introducing-xml-serialization)
+
 [Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)

--- a/reference/4.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date: 08/19/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -11,43 +11,76 @@ title:  Stop-DscConfiguration
 # Stop-DscConfiguration
 
 ## SYNOPSIS
-Stops a configuration job that is currently running.
+Stops a configuration job that is running.
 
 ## SYNTAX
 
+### All
+
 ```
-Stop-DscConfiguration [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Stop-DscConfiguration [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The `Stop-DscConfiguration` cmdlet stops a configuration job that is currently running.
-Specify which computers this cmdlet applies to by using Common Information Model (CIM) sessions.
-If there is no configuration job running, this cmdlet returns a warning message.
 
-This cmdlet is available only as part of the [November 2014 update rollup for Windows RT 8.1, Windows 8.1, and Windows Server 2012 R2](https://support.microsoft.com/kb/3000850) from the Microsoft Support library.
-Before you use this cmdlet, review the information in What's New in Windows PowerShellhttp://technet.microsoft.com/library/hh857339.aspx (http://technet.microsoft.com/library/hh857339.aspx) in the TechNet library.
+The `Stop-DscConfiguration` cmdlet stops a configuration job that is running. Specify which
+computers this cmdlet applies to by using Common Information Model (CIM) sessions. If there's no
+configuration job running, this cmdlet returns a warning message.
+
+`Stop-DscConfiguration` is only available as part of the
+[November 2014 update rollup for Windows RT 8.1, Windows 8.1, and Windows Server 2012 R2](https://support.microsoft.com/kb/3000850)
+from the Microsoft Support library. Before you use this cmdlet, review the information in
+[What's New in Windows PowerShell 5.0](../../docs-conceptual/whats-new/What-s-New-in-Windows-PowerShell-50.md)
 
 ## EXAMPLES
 
 ### Example 1: Stop a configuration job
-```
-PS C:\> $Session = New-CimSession -ComputerName "Server01" -Credential ACCOUNTS\PattiFuller
-PS C:\> Stop-DscConfiguration -CimSession $Session
+
+In this example, a CIM session is created using the `New-CimSession` cmdlet. The **CimSession**
+object is used to stop a running configuration job.
+
+```powershell
+$Session = New-CimSession -ComputerName Server01 -Credential ACCOUNTS\User01
+Stop-DscConfiguration -CimSession $Session
 ```
 
-The first command creates a CIM session by using the **New-CimSession** cmdlet, and then stores the **CimSession** object in the **$Session** variable.
-The command prompts you for a password.
-For more information, type `Get-Help New-CimSession`.
+`New-CimSession` uses the **ComputerName** parameter to specify the Server01 computer. The
+**Credential** parameter specifies the user account. The **CimSession** object is stored in the
+`$Session` variable. When the command is run, you're prompted for the user account's password.
 
-The second command stops a currently running configuration job on the computer identified by the **CimSession** object stored in **$Session**.
+`Stop-DscConfiguration` uses the **CimSession** parameter and the object stored in `$Session` to
+stop the configuration job.
 
 ## PARAMETERS
 
+### -AsJob
+
+Indicates that this cmdlet runs the command as a background job. For more information about
+PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and
+[about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
+
+To use the **AsJob** parameter, the local and remote computers must be configured for remoting. On
+Windows Vista and later versions of the Windows operating system, you must open PowerShell with the
+**Run as administrator** option. For more information, see
+[about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
-The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output from `New-CimSession` or `Get-CimSession`.
 
 ```yaml
 Type: CimSession[]
@@ -61,7 +94,28 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Confirm
+
+`Stop-DscConfiguration` doesn't support the **Confirm** parameter. If the **Confirm** parameter is
+used, an error is displayed.
+
+For PowerShell cmdlets that support **Confirm**, using the parameter prompts you for verification
+before a command is run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Force
+
 Forces the command to run without asking for user confirmation.
 
 ```yaml
@@ -71,15 +125,18 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
+
 Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
-If this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer.
-The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+If this parameter is omitted or a value of `0` is entered, PowerShell calculates an optimum throttle
+limit based on the number of CIM cmdlets that are running on the computer. The throttle limit
+applies only to the current cmdlet, not to the session or to the computer.
 
 ```yaml
 Type: Int32
@@ -93,38 +150,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -AsJob
-Indicates that this cmdlet runs the command as a background job.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -133,13 +161,16 @@ Aliases: wi
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -153,9 +184,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Windows PowerShell Desired State Configuration Overview](http://go.microsoft.com/fwlink/?LinkID=311940)
+[Get-CimSession](../CimCmdlets/Get-CimSession.md)
 
 [Get-DscConfiguration](Get-DscConfiguration.md)
+
+[New-CimSession](../CimCmdlets/New-CimSession.md)
 
 [Restore-DscConfiguration](Restore-DscConfiguration.md)
 
@@ -164,3 +197,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Test-DscConfiguration](Test-DscConfiguration.md)
 
 [Update-DscConfiguration](Update-DscConfiguration.md)
+
+[Windows PowerShell Desired State Configuration Overview](/powershell/dsc/overview/overview)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/About_Using.md
@@ -12,19 +12,21 @@ Allows to indicate which namespaces are used in the session.
 
 ## LONG DESCRIPTION
 
-The `using` statement allows to indicate which namespaces are used in the
-session. Making easier to mention classes and members, as it requires less
-typing to mention them; also, classes from modules can be referenced too.
+The `using` statement allows you to specify which namespaces are used in the
+session. Adding namespaces simplifies usage of .NET classes and member and
+allows you to import classes from modules.
 
 The `using` statement needs to be the first statement in the script.
 
-Syntax #1, to reference .Net Framework namespaces:
+### Syntax
+
+To reference .NET Framework namespaces:
 
 ```
-using namespace <.Net-framework-namespace>
+using namespace <.NET-framework-namespace>
 ```
 
-Syntax #2, to reference PowerShell modules:
+To reference PowerShell modules:
 
 ```
 using module <module-name>
@@ -37,7 +39,7 @@ using module <module-name>
 > module. If the module isn't loaded in the current session, the `using`
 > statement fails.
 
-## Examples
+### Examples
 
 The following script gets the cryptographic hash for the "Hello World" string.
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/About_Using.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  12/01/2017
+ms.date:  08/15/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -30,16 +30,20 @@ Syntax #2, to reference PowerShell modules:
 using module <module-name>
 ```
 
-**Note**: The `using` statement, for modules, is intended to surface the
-classes in the module. If the module isn't loaded, the `using` fails.
+> [!NOTE]
+> `Import-Module` and the `#requires` statement only import the module
+> functions, aliases, and variables, as defined by the module. Classes are not
+> imported. The `using module` statement imports the classes defined in the
+> module. If the module isn't loaded in the current session, the `using`
+> statement fails.
 
 ## Examples
 
 The following script gets the cryptographic hash for the "Hello World" string.
 
 Note how the `using namespace System.Text` and `using namespace System.IO`
-simplify the references to `[UnicodeEncoding]` in *System.Text*; and, to
-`[Stream]` and to `[MemoryStream]` in *System.IO*.
+simplify the references to `[UnicodeEncoding]` in *System.Text* and `[Stream]`
+and to `[MemoryStream]` in *System.IO*.
 
 ```powershell
 using namespace System.Text
@@ -62,8 +66,8 @@ automatically.
 
 The following classes are defined in the module:
 
-- *Deck*
-- *Card*
+- **Deck**
+- **Card**
 
 ```powershell
 using module CardGames

--- a/reference/5.0/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/About_Using.md
@@ -42,8 +42,8 @@ using module <module-name>
 The following script gets the cryptographic hash for the "Hello World" string.
 
 Note how the `using namespace System.Text` and `using namespace System.IO`
-simplify the references to `[UnicodeEncoding]` in *System.Text* and `[Stream]`
-and to `[MemoryStream]` in *System.IO*.
+simplify the references to `[UnicodeEncoding]` in `System.Text` and `[Stream]`
+and to `[MemoryStream]` in `System.IO`.
 
 ```powershell
 using namespace System.Text

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_classes.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_classes.md
@@ -229,7 +229,7 @@ Devices   : {$null, $null, Microsoft|Surface Pro 4|5072641000, $null...}
 
 ## Output in class methods
 
-Methods should have a return type defined. If a method does not return output,
+Methods should have a return type defined. If a method doesn't return output,
 then the output type should be `[void]`.
 
 In class methods, no objects get sent to the pipeline except those mentioned in
@@ -340,7 +340,7 @@ Microsoft Surface Pro 4 5072641000
 In this example, the **Device** class is defined with properties, a default
 constructor, and a constructor to initialize the instance.
 
-The default constructor sets the **brand** to *Undefined*, and leaves **model**
+The default constructor sets the **brand** to **Undefined**, and leaves **model**
 and **vendor-sku** with null values.
 
 ```powershell
@@ -389,7 +389,7 @@ class definition.
 ### Example using hidden attributes
 
 When a **Rack** object is created, the number of slots for devices is a fixed
-value that should not be changed at any time. This value is known at creation
+value that shouldn't be changed at any time. This value is known at creation
 time.
 
 Using the hidden attribute allows the developer to keep the number of slots
@@ -711,7 +711,7 @@ Model               : Fbk5040
 
 ## Calling base class constructors
 
-To invoke a base class constructor from a subclass, add the "base" keyword.
+To invoke a base class constructor from a subclass, add the `base` keyword.
 
 ```powershell
 class Person {
@@ -792,7 +792,7 @@ class ChildClass1 : BaseClass
 ## Interfaces
 
 The syntax for declaring interfaces is similar to C#. You can declare
-interfaces after base types or immediately after a colon (:) when there is no
+interfaces after base types or immediately after a colon (`:`) when there is no
 base type specified. Separate all type names with commas.
 
 ```powershell

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_classes.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_classes.md
@@ -1,43 +1,40 @@
 ---
-ms.date:  08/31/2018
+ms.date:  08/15/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Classes
 description:  Describes how you can use classes to create your own custom types.
 ---
-
 # About Classes
 
-## SHORT DESCRIPTION
-
+## Short description
 Describes how you can use classes to create your own custom types.
 
-## LONG DESCRIPTION
+## Long description
 
 PowerShell 5.0 adds a formal syntax to define classes and other user-defined
 types. The addition of classes enables developers and IT professionals to
-embrace PowerShell for a wider range of use cases. It simplifies development
-of PowerShell artifacts and accelerates coverage of management surfaces.
+embrace PowerShell for a wider range of use cases. It simplifies development of
+PowerShell artifacts and accelerates coverage of management surfaces.
 
-A class declaration is like a blueprint used to create instances of objects at
-run time. When you define a class, the class name is the name of the type. For
+A class declaration is a blueprint used to create instances of objects at run
+time. When you define a class, the class name is the name of the type. For
 example, if you declare a class named **Device** and initialize a variable
 `$dev` to a new instance of **Device**, `$dev` is an object or instance of type
 **Device**. Each instance of **Device** can have different values in its
 properties.
 
-## SUPPORTED SCENARIOS
+## Supported scenarios
 
-- Define custom types in PowerShell using familiar object-oriented
-  programming semantics like classes, properties, methods, inheritance,
-  etc.
+- Define custom types in PowerShell using familiar object-oriented programming
+  semantics like classes, properties, methods, inheritance, etc.
 - Debug types using the PowerShell language.
 - Generate and handle exceptions using formal mechanisms.
 - Define DSC resources and their associated types by using the PowerShell
   language.
 
-## SYNTAX
+## Syntax
 
 Classes are declared using the following syntax:
 
@@ -62,9 +59,8 @@ Classes are instantiated using either of the following syntaxes:
 ```
 
 > [!NOTE]
-> When using the `[<class-name>]::new(` syntax,
-> brackets around the class name are mandatory!
-> The brackets signal a type definition for PowerShell.
+> When using the `[<class-name>]::new(` syntax, brackets around the class name
+> are mandatory. The brackets signal a type definition for PowerShell.
 
 ### Example syntax and usage
 
@@ -80,17 +76,17 @@ $dev.Brand = "Microsoft"
 $dev
 ```
 
-```output
+```Output
 Brand
 -----
 Microsoft
 ```
 
-## CLASS PROPERTIES
+## Class properties
 
-Properties are variables declared at class scope.
-A property may be of any built-in type or an instance of another class.
-Classes have no restriction in the number of properties they have.
+Properties are variables declared at class scope. A property may be of any
+built-in type or an instance of another class. Classes have no restriction in
+the number of properties they have.
 
 ### Example class with simple properties
 
@@ -109,20 +105,17 @@ $device.VendorSku = "5072641000"
 $device
 ```
 
-```output
-
-
+```Output
 Brand     Model         VendorSku
 -----     -----         ---------
 Microsoft Surface Pro 4 5072641000
-
 ```
 
 ### Example complex types in class properties
 
-This example defines an empty **Rack** class using the **Device** class.
-The examples, following this one, show how to add devices to the rack
-and how to start with a pre-loaded rack.
+This example defines an empty **Rack** class using the **Device** class. The
+examples, following this one, show how to add devices to the rack and how to
+start with a pre-loaded rack.
 
 ```powershell
 class Device {
@@ -145,7 +138,7 @@ $rack = [Rack]::new()
 $rack
 ```
 
-```output
+```Output
 
 Brand     :
 Model     :
@@ -156,12 +149,11 @@ Devices   : {$null, $null, $null, $null...}
 
 ```
 
-## CLASS METHODS
+## Class methods
 
-Methods define the actions that a class can perform.
-Methods may take parameters that provide input data.
-Methods can return output.
-Data returned by a method can be any defined data type.
+Methods define the actions that a class can perform. Methods may take
+parameters that provide input data. Methods can return output. Data returned by
+a method can be any defined data type.
 
 ### Example simple class with properties and methods
 
@@ -216,7 +208,7 @@ $rack
 $rack.GetAvailableSlots()
 ```
 
-```output
+```Output
 
 Slots     : 8
 Brand     :
@@ -235,23 +227,23 @@ Devices   : {$null, $null, Microsoft|Surface Pro 4|5072641000, $null...}
 
 ```
 
-## OUTPUT IN CLASS METHODS
+## Output in class methods
 
-Methods should have a return type defined. If a method does not
-return output, then the output type should be `[void]`.
+Methods should have a return type defined. If a method does not return output,
+then the output type should be `[void]`.
 
-In class methods, no objects get sent to the pipeline except those mentioned
-in the `return` statement. There's no accidental output to the pipeline
-from the code.
+In class methods, no objects get sent to the pipeline except those mentioned in
+the `return` statement. There's no accidental output to the pipeline from the
+code.
 
 > [!NOTE]
-> This is fundamentally different from how PowerShell functions
-> handle output, where everything goes to the pipeline.
+> This is fundamentally different from how PowerShell functions handle output,
+> where everything goes to the pipeline.
 
 ### Method output
 
-This example demonstrates no accidental output to the pipeline from
-class methods, except on the `return` statement.
+This example demonstrates no accidental output to the pipeline from class
+methods, except on the `return` statement.
 
 ```powershell
 class FunWithIntegers
@@ -285,7 +277,7 @@ $ints.GetEvenIntegers()
 $ints.SayHello()
 ```
 
-```output
+```Output
 1
 3
 5
@@ -295,25 +287,25 @@ Hello World
 
 ```
 
-## CONSTRUCTOR
+## Constructor
 
 Constructors enable you to set default values and validate object logic at the
 moment of creating the instance of the class. Constructors have the same name
-as the class. Constructors might have arguments, to initialize the data
-members of the new object.
+as the class. Constructors might have arguments, to initialize the data members
+of the new object.
 
 The class can have zero or more constructors defined. If no constructor is
 defined, the class is given a default parameterless constructor. This
 constructor initializes all members to their default values. Object types and
 strings are given null values. When you define constructor, no default
-parameterless constructor is created. Create a parameterless constructor if
-one is needed.
+parameterless constructor is created. Create a parameterless constructor if one
+is needed.
 
 ### Constructor basic syntax
 
-In this example, the Device class is defined with properties and a
-constructor. To use this class, the user is required to provide values for the
-parameters listed in the constructor.
+In this example, the Device class is defined with properties and a constructor.
+To use this class, the user is required to provide values for the parameters
+listed in the constructor.
 
 ```powershell
 class Device {
@@ -337,11 +329,10 @@ class Device {
 $surface
 ```
 
-```output
+```Output
 Brand     Model         VendorSku
 -----     -----         ---------
 Microsoft Surface Pro 4 5072641000
-
 ```
 
 ### Example with multiple constructors
@@ -349,8 +340,8 @@ Microsoft Surface Pro 4 5072641000
 In this example, the **Device** class is defined with properties, a default
 constructor, and a constructor to initialize the instance.
 
-The default constructor sets the **brand** to *Undefined*,
-and leaves **model** and **vendor-sku** with null values.
+The default constructor sets the **brand** to *Undefined*, and leaves **model**
+and **vendor-sku** with null values.
 
 ```powershell
 class Device {
@@ -380,26 +371,26 @@ $somedevice
 $surface
 ```
 
-```output
+```Output
 Brand       Model           VendorSku
 -----       -----           ---------
 Undefined
 Microsoft   Surface Pro 4   5072641000
 ```
 
-## HIDDEN ATTRIBUTE
+## Hidden attribute
 
-The `hidden` attribute makes a property or method less visible. The property
-or method is still accessible to the user and is available in all scopes in
-which the object is available. Hidden members are hidden from the `Get-Member`
-cmdlet and can't be displayed using tab completion or IntelliSense outside of
-the class definition.
+The `hidden` attribute makes a property or method less visible. The property or
+method is still accessible to the user and is available in all scopes in which
+the object is available. Hidden members are hidden from the `Get-Member` cmdlet
+and can't be displayed using tab completion or IntelliSense outside of the
+class definition.
 
 ### Example using hidden attributes
 
-When a **Rack** object is created, the number of slots for devices is a
-fixed value that should not be changed at any time. This value is known at
-creation time.
+When a **Rack** object is created, the number of slots for devices is a fixed
+value that should not be changed at any time. This value is known at creation
+time.
 
 Using the hidden attribute allows the developer to keep the number of slots
 hidden and prevents unintentional changes the size of the rack.
@@ -435,33 +426,30 @@ $r1.Devices.Length
 $r1.Slots
 ```
 
-```output
-
+```Output
 Brand     Model         Devices
 -----     -----         -------
 Microsoft Surface Pro 4 {$null, $null, $null, $null...}
 16
 16
-
 ```
 
-Notice **Slots** property isn't shown in `$r1` output. However, the size
-was changed by the constructor.
+Notice **Slots** property isn't shown in `$r1` output. However, the size was
+changed by the constructor.
 
-## STATIC ATTRIBUTE
+## Static attribute
 
 The `static` attribute defines a property or a method that exists in the class
 and needs no instance.
 
-A static property is always available, independent of class instantiation.
-A static property is shared across all instances of the class.
-A static method is available always.
-All static properties live for the entire session span.
+A static property is always available, independent of class instantiation. A
+static property is shared across all instances of the class. A static method is
+available always. All static properties live for the entire session span.
 
 ### Example using static attributes and methods
 
-Assume the racks instantiated here exist in your data center.
-So, you would like to keep track of the racks in your code.
+Assume the racks instantiated here exist in your data center. So, you would
+like to keep track of the racks in your code.
 
 ```powershell
 class Device {
@@ -500,7 +488,7 @@ class Rack {
 }
 ```
 
-#### Testing static property and method exist
+### Testing static property and method exist
 
 ```
 PS> [Rack]::InstalledRacks.Length
@@ -536,7 +524,7 @@ WARNING: Turning off rack: Std0010
 
 Notice that the number of racks increases each time you run this example.
 
-## PROPERTY VALIDATION ATTRIBUTES
+## Property validation attributes
 
 Validation attributes allow you to test that values given to properties meet
 defined requirements. Validation is triggered the moment that the value is
@@ -556,10 +544,9 @@ Write-Output "Testing dev"
 $dev
 
 $dev.Brand = ""
-
 ```
 
-```output
+```Output
 Testing dev
 
 Brand Model
@@ -570,24 +557,22 @@ argument that is not null or empty, and then try the command again."
 At C:\tmp\Untitled-5.ps1:11 char:1
 + $dev.Brand = ""
 + ~~~~~~~~~~~~~~~
-    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationExcep
-tion
+    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationException
     + FullyQualifiedErrorId : ExceptionWhenSetting
 ```
 
-## INHERITANCE IN POWERSHELL CLASSES
+## Inheritance in PowerShell classes
 
 You can extend a class by creating a new class that derives from an existing
-class. The derived class inherits the properties of the base class. You can
-add or override methods and properties as required.
+class. The derived class inherits the properties of the base class. You can add
+or override methods and properties as required.
 
-PowerShell does not support multiple inheritance.
-Classes cannot inherit from more than one class.
-However, you can use interfaces for that purpose.
+PowerShell does not support multiple inheritance. Classes cannot inherit from
+more than one class. However, you can use interfaces for that purpose.
 
-Inheritance implementation is defined by the `:` operator;
-which means to extend this class or implements these interfaces.
-The derived class should always be leftmost in the class declaration.
+Inheritance implementation is defined by the `:` operator; which means to
+extend this class or implements these interfaces. The derived class should
+always be leftmost in the class declaration.
 
 ### Example using simple inheritance syntax
 
@@ -606,18 +591,16 @@ Class Derived : Base.Interface {...}
 
 ### Example of simple inheritance in PowerShell classes
 
-In this example the _Rack_ and _Device_ classes used in the previous examples
-are better defined to: avoid property repetitions, better align common
+In this example the **Rack** and **Device** classes used in the previous
+examples are better defined to: avoid property repetitions, better align common
 properties, and reuse common business logic.
 
-Most objects in the data center are company assets, which makes sense to
-start tracking them as assets.
-Device types are defined by the `DeviceType` enumeration, see
-[about_Enum](about_Enum.md) for details on enumerations.
+Most objects in the data center are company assets, which makes sense to start
+tracking them as assets. Device types are defined by the `DeviceType`
+enumeration, see [about_Enum](about_Enum.md) for details on enumerations.
 
-In our example, we're only defining `Rack` and `ComputeServer`; both
-extensions to the `Device` class.
-
+In our example, we're only defining `Rack` and `ComputeServer`; both extensions
+to the `Device` class.
 
 ```powershell
 enum DeviceType {
@@ -694,12 +677,10 @@ $FirstRack.Location = "F03R02.J10"
   })
 
 $FirstRack
-
 $FirstRack.Devices
 ```
 
-```output
-
+```Output
 Datacenter : PNW
 Location   : F03R02.J10
 Devices    : {r1s000, r1s001, r1s002, r1s003...}
@@ -726,14 +707,11 @@ Hostname            : r1s015
 Status              : Installed
 Brand               : Fabrikam, Inc.
 Model               : Fbk5040
-
 ```
 
-## CALLING BASE CLASS CONSTRUCTORS
+## Calling base class constructors
 
 To invoke a base class constructor from a subclass, add the "base" keyword.
-
-### Example using the base class constructor
 
 ```powershell
 class Person {
@@ -759,12 +737,12 @@ class Child : Person
 $littleone.Age
 ```
 
-```output
+```Output
 
 10
 ```
 
-## INVOKE BASE CLASS METHODS
+## Invoke base class methods
 
 To override existing methods in subclasses, declare methods by using the same
 name and signature.
@@ -782,7 +760,7 @@ class ChildClass1 : BaseClass
 [ChildClass1]::new().days()
 ```
 
-```output
+```Output
 
 2
 ```
@@ -805,17 +783,17 @@ class ChildClass1 : BaseClass
 [ChildClass1]::new().basedays()
 ```
 
-```output
+```Output
 
 2
 1
 ```
 
-## INTERFACES
+## Interfaces
 
-The syntax for declaring interfaces is similar to C#.
-You can declare interfaces after base types or immediately after a colon (:)
-when there is no base type specified. Separate all type names with commas.
+The syntax for declaring interfaces is similar to C#. You can declare
+interfaces after base types or immediately after a colon (:) when there is no
+base type specified. Separate all type names with commas.
 
 ```powershell
 class MyComparable : system.IComparable
@@ -835,8 +813,16 @@ class MyComparableBar : bar, system.IComparable
 }
 ```
 
-## SEE ALSO
+## Importing classes from a PowerShell module
+
+`Import-Module` and the `#requires` statement only import the module functions,
+aliases, and variables, as defined by the module. Classes are not imported. The
+`using module` statement imports the classes defined in the module. If the
+module isn't loaded in the current session, the `using` statement fails.
+
+## See also
 
 - [about_Enum](about_Enum.md)
 - [about_Language_Keywords](about_language_keywords.md)
 - [about_Methods](about_methods.md)
+- [about_Using](about_using.md)

--- a/reference/5.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -82,9 +82,9 @@ Import-Module [-Global] [-Prefix <String>] [-Function <String[]>] [-Cmdlet <Stri
 The `Import-Module` cmdlet adds one or more modules to the current session. The modules that you
 import must be installed on the local computer or a remote computer.
 
-Starting in Windows PowerShell 3.0, installed modules are automatically imported to the session when
-you use any commands or providers in the module. However, you can still use the `Import-Module`
-command to import a module and you can enable and disable automatic module importing by using the
+Starting in PowerShell 3.0, installed modules are automatically imported to the session when you use
+any commands or providers in the module. However, you can still use the `Import-Module` command to
+import a module and you can enable and disable automatic module importing by using the
 `$PSModuleAutoloadingPreference` preference variable. For more information about modules, see
 [about_Modules](About/about_Modules.md). For more information about the
 `$PSModuleAutoloadingPreference` variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
@@ -119,9 +119,9 @@ parameter of `Get-Module` to get the PowerShell modules in the **PSSession**. Wh
 modules, and then use the imported commands in the current session, the commands run implicitly in
 the **PSSession** on the remote computer. You can use this strategy to manage the remote computer.
 
-You can use a similar strategy to manage computers that do not have PowerShell remoting enabled,
+You can use a similar strategy to manage computers that don't have PowerShell remoting enabled,
 including computers that are not running the Windows operating system, and Windows computers that
-have PowerShell, but do not have PowerShell remoting enabled.
+have PowerShell, but don't have PowerShell remoting enabled.
 
 Start by creating a CIM session on the remote computer, which is a connection to Windows Management
 Instrumentation (WMI) on the remote computer. Then use the **CIMSession** parameter of
@@ -154,7 +154,7 @@ Get-Module -ListAvailable | Import-Module
 
 ### Example 3: Import the members of several modules into the current session
 
-This example imports the members of the **BitsTransfer** and **Dism** modules into the
+This example imports the members of the **PSDiagnostics** and **Dism** modules into the
 current session.
 
 ```powershell
@@ -169,8 +169,8 @@ modules that are not yet imported into the session.
 The **ModuleInfo** parameter of `Import-Module` is used to import the modules into the current
 session.
 
-These commands are equivalent to using a pipeline operator (|) to send the output of a `Get-Module`
-command to `Import-Module`.
+These commands are equivalent to using a pipeline operator (`|`) to send the output of a
+`Get-Module` command to `Import-Module`.
 
 ### Example 4: Import all modules specified by a path
 
@@ -276,7 +276,7 @@ Function        Start-xTrace                           6.1.0.0    PSDiagnostics
 Function        Stop-xTrace                            6.1.0.0    PSDiagnostics
 ```
 
-It uses the **Prefix** parameter of `Import-Module` adds the "x" prefix to all members that are
+It uses the **Prefix** parameter of `Import-Module` adds the **x** prefix to all members that are
 imported from the module and the **PassThru** parameter to return a module object that represents
 the imported module.
 
@@ -332,16 +332,16 @@ $a."Show-Calendar"()
 ```
 
 The first command uses the `Get-Module` cmdlet to get the available modules. The command uses a
-pipeline operator to pass the module objects to the Format-Table cmdlet, which lists the **Name**
+pipeline operator to pass the module objects to the `Format-Table` cmdlet, which lists the **Name**
 and **ModuleType** of each module in a table.
 
 The second command uses the `Import-Module` cmdlet to import the **Show-Calendar** script module.
 The command uses the **AsCustomObject** parameter to request a custom object and the **PassThru**
 parameter to return the object. The command saves the resulting custom object in the `$a` variable.
 
-The third command uses a pipeline operator to send the $a variable to the `Get-Member` cmdlet, which
-gets the properties and methods of the **PSCustomObject** in `$a`. The output shows a
-**Show-Calendar** script method.
+The third command uses a pipeline operator to send the `$a` variable to the `Get-Member` cmdlet,
+which gets the properties and methods of the **PSCustomObject** in `$a`. The output shows a
+**Show-Calendar()** script method.
 
 The last command uses the **Show-Calendar** script method. The method name must be enclosed in
 quotation marks, because it includes a hyphen.
@@ -495,9 +495,9 @@ variable.
 The third command uses the **PSSession** parameter of the `Import-Module` cmdlet to import the
 **NetSecurity** module from the session in the `$s` variable into the current session.
 
-The fourth command uses the `Get-Command` cmdlet to get commands that begin with "Get" and include
-"Firewall" from the NetSecurity module.The output gets the commands and confirms that the module and
-its cmdlets were imported into the current session.
+The fourth command uses the `Get-Command` cmdlet to get commands that begin with **Get** and include
+**Firewall** from the **NetSecurity** module.The output gets the commands and confirms that the
+module and its cmdlets were imported into the current session.
 
 The fifth command uses the `Get-NetFirewallRule` cmdlet to get Windows Remote Management firewall
 rules on the Server01 computer. This command is equivalent to using the `Invoke-Command` cmdlet to
@@ -609,7 +609,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -692,7 +692,7 @@ current session. When you use the commands from the imported module in the curre
 commands actually run on the remote computer.
 
 You can use this parameter to import modules from computers and devices that are not running the
-Windows operating system, and Windows computers that have PowerShell, but do not have PowerShell
+Windows operating system, and Windows computers that have PowerShell, but don't have PowerShell
 remoting enabled.
 
 This parameter was introduced in Windows PowerShell 3.0.
@@ -752,7 +752,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -768,7 +768,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -832,7 +832,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -943,7 +943,7 @@ Aliases: NoOverwrite
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -960,7 +960,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -1037,7 +1037,7 @@ a script.
 This parameter was introduced in Windows PowerShell 3.0.
 
 Scripts that use **RequiredVersion** to import modules that are included with existing releases of
-the Windows operating system do not automatically run in future releases of the Windows operating
+the Windows operating system don't automatically run in future releases of the Windows operating
 system. This is because PowerShell module version numbers in future releases of the Windows
 operating system are higher than module version numbers in existing releases of the Windows
 operating system.
@@ -1068,8 +1068,8 @@ scriptblock, all the commands are imported into the global session state. You ca
 parameter with the value of **Local** to import module content into the script or scriptblock scope.
 
 When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
-commands from nested modules, into the caller's session state. Specifying **-Scope Global** or
-**-Global** indicates that this cmdlet imports modules into the global session state so they are
+commands from nested modules, into the caller's session state. Specifying `-Scope Global` or
+`-Global` indicates that this cmdlet imports modules into the global session state so they are
 available to all commands in the session.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of Global.
@@ -1112,7 +1112,7 @@ Accept wildcard characters: False
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -1147,7 +1147,7 @@ generate any output. If you specify the **PassThru** parameter, the cmdlet gener
 * To update the formatting data for commands that have been imported from a module, use the
   `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in
   the session that were imported from modules. If the formatting file for a module changes, you can
-  run an `Update-FormatData` command to update the formatting data for imported commands. You do not
+  run an `Update-FormatData` command to update the formatting data for imported commands. You don't
   need to import the module again.
 
 * Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are
@@ -1189,7 +1189,7 @@ generate any output. If you specify the **PassThru** parameter, the cmdlet gener
   alternate CIM provider that has the same basic features.
 
   You can use the CIM session feature on computers that are not running a Windows operating system
-  and on Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
+  and on Windows computers that have PowerShell, but don't have PowerShell remoting enabled.
 
   You can also use the CIM parameters to get CIM modules from computers that have PowerShell
   remoting enabled, including the local computer. When you create a CIM session on the local

--- a/reference/5.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -1,11 +1,12 @@
 ---
-ms.date:  06/09/2017
-schema:  2.0.0
-locale:  en-us
-keywords:  powershell,cmdlet
+external help file: System.Management.Automation.dll-Help.xml
+keywords: powershell,cmdlet
+locale: en-us
+Module Name: Microsoft.PowerShell.Core
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821492
-external help file:  System.Management.Automation.dll-Help.xml
-title:  Import-Module
+schema: 2.0.0
+title: Import-Module
 ---
 
 # Import-Module
@@ -16,30 +17,35 @@ Adds modules to the current session.
 ## SYNTAX
 
 ### Name (Default)
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
  [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>]
- [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>]
- [<CommonParameters>]
+ [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking]
+ [-NoClobber] [-Scope <String>] [<CommonParameters>]
 ```
 
 ### PSSession
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
  [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>]
- [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>]
- -PSSession <PSSession> [<CommonParameters>]
+ [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking]
+ [-NoClobber] [-Scope <String>] -PSSession <PSSession> [<CommonParameters>]
 ```
 
 ### CimSession
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
  [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>]
- [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>]
- -CimSession <CimSession> [-CimResourceUri <Uri>] [-CimNamespace <String>] [<CommonParameters>]
+ [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking]
+ [-NoClobber] [-Scope <String>] -CimSession <CimSession> [-CimResourceUri <Uri>] [-CimNamespace <String>]
+ [<CommonParameters>]
 ```
 
 ### FullyQualifiedName
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]> [-Function <String[]>]
  [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject]
@@ -47,6 +53,7 @@ Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecific
 ```
 
 ### FullyQualifiedNameAndPSSession
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]> [-Function <String[]>]
  [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject]
@@ -55,6 +62,7 @@ Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecific
 ```
 
 ### Assembly
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-Assembly] <Assembly[]> [-Function <String[]>] [-Cmdlet <String[]>]
  [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-ArgumentList <Object[]>]
@@ -62,6 +70,7 @@ Import-Module [-Global] [-Prefix <String>] [-Assembly] <Assembly[]> [-Function <
 ```
 
 ### ModuleInfo
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-Function <String[]>] [-Cmdlet <String[]>] [-Variable <String[]>]
  [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-ModuleInfo] <PSModuleInfo[]>
@@ -69,88 +78,109 @@ Import-Module [-Global] [-Prefix <String>] [-Function <String[]>] [-Cmdlet <Stri
 ```
 
 ## DESCRIPTION
-The **Import-Module** cmdlet adds one or more modules to the current session.
-The modules that you import must be installed on the local computer or a remote computer.
 
-Starting in Windows PowerShell 3.0, installed modules are automatically imported to the session when you use any commands or providers in the module.
-However, you can still use the `Import-Module` command to import a module and you can enable and disable automatic module importing by using the `$PSModuleAutoloadingPreference` preference variable.
-For more information about modules, see [about_Modules](About/about_Modules.md).
-For more information about the `$PSModuleAutoloadingPreference` variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
+The `Import-Module` cmdlet adds one or more modules to the current session. The modules that you
+import must be installed on the local computer or a remote computer.
 
-A module is a package that contains members that can be used in Windows PowerShell.
-Members include cmdlets, providers, scripts, functions, variables, and other tools and files.
-After a module is imported, you can use the module members in your session.
+Starting in Windows PowerShell 3.0, installed modules are automatically imported to the session when
+you use any commands or providers in the module. However, you can still use the `Import-Module`
+command to import a module and you can enable and disable automatic module importing by using the
+`$PSModuleAutoloadingPreference` preference variable. For more information about modules, see
+[about_Modules](About/about_Modules.md). For more information about the
+`$PSModuleAutoloadingPreference` variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
 
-To import a module, use the `Name`, `Assembly`,  `ModuleInfo`, `MinimumVersion` and `RequiredVersion` parameters to identify the module to import.
-By default, `Import-Module` imports all members that the module exports, but you can use the `Alias`, `Function`, `Cmdlet`, and `Variable` parameters to restrict the members that are imported.
-You can also use the `NoClobber` parameter to prevent `Import-Module` from importing members that have the same names as members in the current session.
+A module is a package that contains members that can be used in PowerShell. Members include cmdlets,
+providers, scripts, functions, variables, and other tools and files. After a module is imported, you
+can use the module members in your session.
 
-`Import-Module` imports a module only into the current session.
-To import the module into all sessions, add an `Import-Module` command to your Windows PowerShell profile.
-For more information about profiles, see [about_Profiles](/powershell/module/microsoft.powershell.core/about/about_profiles).
+To import a module, use the **Name**, **Assembly**, **ModuleInfo**, **MinimumVersion** and
+**RequiredVersion** parameters to identify the module to import. By default, `Import-Module` imports
+all members that the module exports, but you can use the **Alias**, **Function**, **Cmdlet**, and
+**Variable** parameters to restrict the members that are imported. You can also use the
+**NoClobber** parameter to prevent `Import-Module` from importing members that have the same names
+as members in the current session.
 
-Starting in Windows PowerShell 3.0, you can use `Import-Module` to import Common Information Model (CIM) modules, in which the cmdlets are defined in Cmdlet Definition XML (CDXML) files.
-This feature allows you to use cmdlets that are implemented in non-managed code assemblies, such as those written in C++.
+`Import-Module` imports a module only into the current session. To import the module into all
+sessions, add an `Import-Module` command to your PowerShell profile. For more information about
+profiles, see [about_Profiles](About/about_Profiles.md).
 
-With these new features, `Import-Module` cmdlet becomes a primary tool for managing heterogeneous enterprises that include computers that run the Windows operating system and computers that are running other operating systems.
+Starting in Windows PowerShell 3.0, you can use `Import-Module` to import Common Information Model
+(CIM) modules, in which the cmdlets are defined in Cmdlet Definition XML (CDXML) files. This feature
+allows you to use cmdlets that are implemented in non-managed code assemblies, such as those written
+in C++.
 
-To manage remote computers that run the Windows operating system that have Windows PowerShell and Windows PowerShell remoting enabled, create a **PSSession** on the remote computer and then use the *PSSession* parameter of **Get-Module** to get the Windows PowerShell modules in the **PSSession**.
-When you import the modules, and then use the imported commands in the current session, the commands run implicitly in the **PSSession** on the remote computer.
-You can use this strategy to manage the remote computer.
+With these new features, `Import-Module` cmdlet becomes a primary tool for managing heterogeneous
+enterprises that include computers that run the Windows operating system and computers that are
+running other operating systems.
 
-You can use a similar strategy to manage computers that do not have Windows PowerShell remoting enabled, including computers that are not running the Windows operating system, and Windows computers that have Windows PowerShell, but do not have Windows PowerShell remoting enabled.
+To manage remote computers that run the Windows operating system that have PowerShell and PowerShell
+remoting enabled, create a **PSSession** on the remote computer and then use the **PSSession**
+parameter of `Get-Module` to get the PowerShell modules in the **PSSession**. When you import the
+modules, and then use the imported commands in the current session, the commands run implicitly in
+the **PSSession** on the remote computer. You can use this strategy to manage the remote computer.
 
-Start by creating a CIM session on the remote computer, which is a connection to Windows Management Instrumentation (WMI) on the remote computer.
-Then use the *CIMSession* parameter of `Import-Module` to import CIM modules from the remote computer.
-When you import a CIM module and then run the imported commands, the commands run implicitly on the remote computer.
-You can use this WMI and CIM strategy to manage the remote computer.
+You can use a similar strategy to manage computers that do not have PowerShell remoting enabled,
+including computers that are not running the Windows operating system, and Windows computers that
+have PowerShell, but do not have PowerShell remoting enabled.
+
+Start by creating a CIM session on the remote computer, which is a connection to Windows Management
+Instrumentation (WMI) on the remote computer. Then use the **CIMSession** parameter of
+`Import-Module` to import CIM modules from the remote computer. When you import a CIM module and
+then run the imported commands, the commands run implicitly on the remote computer. You can use this
+WMI and CIM strategy to manage the remote computer.
 
 ## EXAMPLES
 
 ### Example 1: Import the members of a module into the current session
+
+This example imports the members of the **PSDiagnostics** module into the current session. The
+**Name** parameter name is optional and can be omitted.
+
 ```powershell
-Import-Module -Name BitsTransfer
+Import-Module -Name PSDiagnostics
 ```
 
-This command imports the members of the `BitsTransfer` module into the current session.
-
-The `Name` parameter name is optional and can be omitted.
-
-By default, `Import-Module` does not generate any output when it imports a module.
-To request output, use the `PassThru` or `AsCustomObject` parameter, or the `Verbose` common parameter.
+By default, `Import-Module` does not generate any output when it imports a module. To request
+output, use the **PassThru** or **AsCustomObject** parameter, or the **Verbose** common parameter.
 
 ### Example 2: Import all modules specified by the module path
+
+This example imports all available modules in the path specified by the `$env:PSModulePath`
+environment variable into the current session.
 
 ```powershell
 Get-Module -ListAvailable | Import-Module
 ```
 
-This command imports all available modules in the path specified by the PSModulePath environment variable (`$env:PSModulePath`) into the current session.
-
 ### Example 3: Import the members of several modules into the current session
 
+This example imports the members of the **BitsTransfer** and **Dism** modules into the
+current session.
+
 ```powershell
-$m = Get-Module -ListAvailable BitsTransfer, ServerManager
+$m = Get-Module -ListAvailable PSDiagnostics, Dism
 Import-Module -ModuleInfo $m
 ```
 
-These commands import the members of the **BitsTransfer** and **ServerManager** modules into the current session.
+The `Get-Module` cmdlet gets the **PSDiagnostics** and **Dism** modules and saves the
+objects in the `$m` variable. The **ListAvailable** parameter is required when you are getting
+modules that are not yet imported into the session.
 
-The first command uses the `Get-Module` cmdlet to get the `BitsTransfer` and `ServerManager` modules.
-It saves the objects in the `$m` variable.
-The `ListAvailable` parameter is required when you are getting modules that are not yet imported into the session.
+The **ModuleInfo** parameter of `Import-Module` is used to import the modules into the current
+session.
 
-The second command uses the `ModuleInfo` parameter of `Import-Module` to import the modules into the current session.
-
-These commands are equivalent to using a pipeline operator `|` to send the output of a `Get-Module` command to `Import-Module`.
+These commands are equivalent to using a pipeline operator (|) to send the output of a `Get-Module`
+command to `Import-Module`.
 
 ### Example 4: Import all modules specified by a path
+
+This example uses an explicit path to identify the module to import.
 
 ```powershell
 Import-Module -Name c:\ps-test\modules\test -Verbose
 ```
 
-```output
+```Output
 VERBOSE: Loading module from path 'C:\ps-test\modules\Test\Test.psm1'.
 VERBOSE: Exporting function 'my-parm'.
 VERBOSE: Exporting function 'Get-Parameter'.
@@ -158,110 +188,121 @@ VERBOSE: Exporting function 'Get-Specification'.
 VERBOSE: Exporting function 'Get-SpecDetails'.
 ```
 
-This command uses an explicit path to identify the module to import.
-
-It also uses the `Verbose` common parameter to get a list of the items imported from the module.
-Without the `Verbose`, `PassThru`, or `AsCustomObject` parameter, `Import-Module` does not generate any output when it imports a module.
+Using the **Verbose** parameter causes `Import-Module` to report progress as it loads the module.
+Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, `Import-Module` does not
+generate any output when it imports a module.
 
 ### Example 5: Restrict module members imported into a session
 
-```powershell
-Import-Module BitsTransfer -Cmdlet Add-BitsFile, Get-BitsTransfer
-(Get-Module BitsTransfer).ExportedCmdlets
-```
-
-```output
-Key                   Value
----                   -----
-Add-BitsFile          Add-BitsFile
-Complete-BitsTransfer Complete-BitsTransfer
-Get-BitsTransfer      Get-BitsTransfer
-Remove-BitsTransfer   Remove-BitsTransfer
-Resume-BitsTransfer   Resume-BitsTransfer
-Set-BitsTransfer      Set-BitsTransfer
-Start-BitsTransfer    Start-BitsTransfer
-Suspend-BitsTransfer  Suspend-BitsTransfer
-```
+This example shows how to restrict which module members are imported into the session and the effect
+of this command on the session.
 
 ```powershell
-Get-Command -Module BitsTransfer
+Import-Module PSDiagnostics -Function Disable-PSTrace, Enable-PSTrace
+(Get-Module PSDiagnostics).ExportedCommands
 ```
 
-```output
-CommandType Name             Version Source
------------ ----             ------- ------
-Cmdlet      Add-BitsFile     2.0.0.0 BitsTransfer
-Cmdlet      Get-BitsTransfer 2.0.0.0 BitsTransfer
+```Output
+Key                          Value
+---                          -----
+Disable-PSTrace              Disable-PSTrace
+Disable-PSWSManCombinedTrace Disable-PSWSManCombinedTrace
+Disable-WSManTrace           Disable-WSManTrace
+Enable-PSTrace               Enable-PSTrace
+Enable-PSWSManCombinedTrace  Enable-PSWSManCombinedTrace
+Enable-WSManTrace            Enable-WSManTrace
+Get-LogProperties            Get-LogProperties
+Set-LogProperties            Set-LogProperties
+Start-Trace                  Start-Trace
+Stop-Trace                   Stop-Trace
 ```
 
-This example shows how to restrict the module members that are imported into the session and the effect of this command on the session.
+```powershell
+Get-Command -Module PSDiagnostics
+```
 
-The first command imports only the `Add-BitsFile` and `Get-BitsTransfer` cmdlets from the `BitsTransfer` module.
-The command uses the `Cmdlet` parameter to restrict the cmdlets that the module imports.
-You can also use the `Alias`, `Variable`, and `Function` parameters to restrict other members that a module imports.
+```Output
+CommandType     Name                 Version    Source
+-----------     ----                 -------    ------
+Function        Disable-PSTrace      6.1.0.0    PSDiagnostics
+Function        Enable-PSTrace       6.1.0.0    PSDiagnostics
+```
 
-The second command uses the `Get-Module` cmdlet to get the object that represents the `BitsTransfer` module.
-The `ExportedCmdlets` property lists all of the cmdlets that the module exports, even when they were not all imported.
+The first command imports only the `Disable-PSTrace` and `Enable-PSTrace` cmdlets from the
+**PSDiagnostics** module. The **Function** parameter limits the members that are imported from the
+module. You can also use the **Alias**, **Variable**, and **Cmdlet** parameters to restrict other
+members that a module imports.
 
-The third command uses the `Module` parameter of the `Get-Command` cmdlet to get the commands that were imported from the `BitsTransfer` module.
-The results confirm that only the `Add-BitsFile` and `Get-BitsTransfer` cmdlets were imported.
+The `Get-Module` cmdlet gets the object that represents the **PSDiagnostics** module. The
+**ExportedCmdlets** property lists all the cmdlets that the module exports, even though they were
+not all imported.
+
+In the third command, the **Module** parameter of the `Get-Command` cmdlet gets the commands that
+were imported from the **PSDiagnostics** module. The results confirm that only the `Disable-PSTrace`
+and `Enable-PSTrace` cmdlets were imported.
 
 ### Example 6: Import the members of a module and add a prefix
 
-```powershell
-Import-Module BitsTransfer -Prefix PS -PassThru
-```
-
-```output
-ModuleType Name                                ExportedCommands
----------- ----                                ----------------
-Manifest   bitstransfer                        {Add-BitsFile, Complete-...
-```
+This example imports the **PSDiagnostics** module into the current session, adds a prefix to the
+member names, and then displays the prefixed member names. The prefix applies only to the members in
+the current session. It does not change the module.
 
 ```powershell
-Get-Command -Module BitsTransfer
+Import-Module PSDiagnostics -Prefix x -PassThru
 ```
 
-```output
-CommandType     Name                                               ModuleName
------------     ----                                               ----------
-Cmdlet          Add-BitsFile                                       bitstransfer
-Cmdlet          Add-PSBitsFile                                     bitstransfer
-Cmdlet          Complete-BitsTransfer                              bitstransfer
-Cmdlet          Complete-PSBitsTransfer                            bitstransfer
-Cmdlet          Get-BitsTransfer                                   bitstransfer
-Cmdlet          Get-PSBitsTransfer                                 bitstransfer
-Cmdlet          Remove-BitsTransfer                                bitstransfer
-Cmdlet          Remove-PSBitsTransfer                              bitstransfer
-Cmdlet          Resume-BitsTransfer                                bitstransfer
-Cmdlet          Resume-PSBitsTransfer                              bitstransfer
-Cmdlet          Set-BitsTransfer                                   bitstransfer
-Cmdlet          Set-PSBitsTransfer                                 bitstransfer
-Cmdlet          Start-BitsTransfer                                 bitstransfer
-Cmdlet          Start-PSBitsTransfer                               bitstransfer
-Cmdlet          Suspend-BitsTransfer                               bitstransfer
-Cmdlet          Suspend-PSBitsTransfer                             bitstransfer
+```Output
+ModuleType Version    Name               ExportedCommands
+---------- -------    ----               ----------------
+Script     6.1.0.0    PSDiagnostics      {Disable-xPSTrace, Disable-xPSWSManCombinedTrace, Disable-xW...
 ```
-
-These commands import the `BitsTransfer` module into the current session, add a prefix to the member names, and then display the prefixed member names.
-
-The first command uses the `Import-Module` cmdlet to import the `BitsTransfer` module.
-It uses the `Prefix` parameter to add the PS prefix to all members that are imported from the module and the `PassThru` parameter to return a module object that represents the imported module.
-
-The second command uses the `Get-Command` cmdlet to get the members that have been imported from the module.
-It uses the `Module` parameter to specify the module.
-The output shows that the module members were correctly prefixed.
-
-The prefix that you use applies only to the members in the current session.
-It does not change the module.
-
-### Example 7: Use the AsCustomObject parameter
 
 ```powershell
-Get-Module -ListAvailable | Format-Table -Property Name, ModuleType -AutoSize
+Get-Command -Module PSDiagnostics
 ```
 
-```output
+```Output
+CommandType     Name                                   Version    Source
+-----------     ----                                   -------    ------
+Function        Disable-xPSTrace                       6.1.0.0    PSDiagnostics
+Function        Disable-xPSWSManCombinedTrace          6.1.0.0    PSDiagnostics
+Function        Disable-xWSManTrace                    6.1.0.0    PSDiagnostics
+Function        Enable-xPSTrace                        6.1.0.0    PSDiagnostics
+Function        Enable-xPSWSManCombinedTrace           6.1.0.0    PSDiagnostics
+Function        Enable-xWSManTrace                     6.1.0.0    PSDiagnostics
+Function        Get-xLogProperties                     6.1.0.0    PSDiagnostics
+Function        Set-xLogProperties                     6.1.0.0    PSDiagnostics
+Function        Start-xTrace                           6.1.0.0    PSDiagnostics
+Function        Stop-xTrace                            6.1.0.0    PSDiagnostics
+```
+
+It uses the **Prefix** parameter of `Import-Module` adds the "x" prefix to all members that are
+imported from the module and the **PassThru** parameter to return a module object that represents
+the imported module.
+
+The `Get-Command` cmdlet to get the members that have been imported from the module. The output
+shows that the module members were correctly prefixed.
+
+### Example 7: Get and use a custom object
+
+These commands demonstrate how to get and use the custom object that **Import-Module** returns.
+
+Custom objects include synthetic members that represent each of the imported module members. For
+example, the cmdlets and functions in a module are converted to script methods of the custom object.
+
+Custom objects are very useful in scripting. They are also useful when several imported objects have
+the same names. Using the script method of an object is equivalent to specifying the fully qualified
+name of an imported member, including its module name.
+
+The **AsCustomObject** parameter can be used only when importing a script module, so the first task
+is to determine which of the available modules is a script module.
+
+
+```powershell
+Get-Module -List | Format-Table -Property Name, ModuleType -AutoSize
+```
+
+```Output
 Name          ModuleType
 ----          ----------
 Show-Calendar     Script
@@ -275,7 +316,7 @@ $a = Import-Module -Name Show-Calendar -AsCustomObject -Passthru
 $a | Get-Member
 ```
 
-```output
+```Output
     TypeName: System.Management.Automation.PSCustomObject
 Name          MemberType   Definition
 ----          ----------   ----------
@@ -290,65 +331,66 @@ Show-Calendar ScriptMethod System.Object Show-Calendar();
 $a."Show-Calendar"()
 ```
 
-These commands demonstrate how to get and use the custom object that `Import-Module` returns.
+The first command uses the `Get-Module` cmdlet to get the available modules. The command uses a
+pipeline operator to pass the module objects to the Format-Table cmdlet, which lists the **Name**
+and **ModuleType** of each module in a table.
 
-Custom objects include synthetic members that represent each of the imported module members.
-For example, the cmdlets and functions in a module are converted to script methods of the custom object.
+The second command uses the `Import-Module` cmdlet to import the **Show-Calendar** script module.
+The command uses the **AsCustomObject** parameter to request a custom object and the **PassThru**
+parameter to return the object. The command saves the resulting custom object in the `$a` variable.
 
-Custom objects are very useful in scripting.
-They are also useful when several imported objects have the same names.
-Using the script method of an object is equivalent to specifying the fully qualified name of an imported member, including its module name.
+The third command uses a pipeline operator to send the $a variable to the `Get-Member` cmdlet, which
+gets the properties and methods of the **PSCustomObject** in `$a`. The output shows a
+**Show-Calendar** script method.
 
-The `AsCustomObject` parameter can be used only when importing a script module, so the first task is to determine which of the available modules is a script module.
+The last command uses the **Show-Calendar** script method. The method name must be enclosed in
+quotation marks, because it includes a hyphen.
 
-After viewing available modules with `-ListAvailable`, the second command uses the `Import-Module` cmdlet to import the `PSDiagnostics` script module.
-The `AsCustomObject` parameter is used to request a custom object and the `PassThru` parameter to return the object and save it in the `$a` variable.
+### Example 8: Re-import a module into the same session
 
-The `$a` variable is then piped to the `Get-Member` cmdlet, which gets the properties and methods of the PSCustomObject in `$a`.
-The output shows a `Show-Calendar` script method.
-
-The last command uses the `Show-Calendar` script method.
-The method name must be enclosed in quotation marks, because it includes a hyphen.
-
-### Example 8: Use the Force parameter to re-import a module
+This example shows how to use the **Force** parameter of `Import-Module` when you are re-importing a
+module into the same session.
 
 ```powershell
-Import-Module BitsTransfer
-Import-Module BitsTransfer -Force -Prefix PS
+Import-Module PSDiagnostics
+Import-Module PSDiagnostics -Force -Prefix PS
 ```
 
-This example shows how to use the `Force` parameter of `Import-Module` when you are re-importing a module into the same session.
+The first command imports the **PSDiagnostics** module. The second command imports the module again,
+this time using the **Prefix** parameter.
 
-The first command imports the `BitsTransfer` module.
-The second command imports the module again, this time using the `Prefix` parameter.
-
-The second command also includes the `Force` parameter, which removes the module and then imports it again.
-Without this parameter, the session would include two copies of each `BitsTransfer` cmdlet, one with the standard name and one with the prefixed name.
+Using the **Force** parameter, `Import-Module` removes the module and then imports it again. Without
+this parameter, the session would include two copies of each **PSDiagnostics** cmdlet, one with the
+standard name and one with the prefixed name.
 
 ### Example 9: Run commands that have been hidden by imported commands
 
+This example shows how to run commands that have been hidden by imported commands. The
+**TestModule** module. includes a function named `Get-Date` that returns the year and day of the
+year.
+
 ```powershell
 Get-Date
 ```
 
-```output
-Thursday, March 15, 2012 6:47:04 PM
+```Output
+Thursday, August 15, 2019 2:26:12 PM
 ```
 
 ```powershell
-Import-Module TestModule -Function Get-Date
+Import-Module TestModule
 Get-Date
 ```
 
-```output
-12075
+```Output
+19227
 ```
 
 ```powershell
 Get-Command Get-Date -All | Format-Table -Property CommandType, Name, ModuleName -AutoSize
 ```
 
-```output
+```Output
 CommandType     Name         ModuleName
 -----------     ----         ----------
 Function        Get-Date     TestModule
@@ -359,43 +401,50 @@ Cmdlet          Get-Date     Microsoft.PowerShell.Utility
 Microsoft.PowerShell.Utility\Get-Date
 ```
 
-```output
-Saturday, September 12, 2009 6:33:23 PM
+```Output
+Thursday, August 15, 2019 2:28:31 PM
 ```
 
-This example shows how to run commands that have been hidden by imported commands.
+The first Get-Date` cmdlet returns a **DateTime** object with the current date. After importing the
+**TestModule** module, `Get-Date` returns the year and day of the year.
 
-The First two commands show the typical execution of the `Get-date` cmdlet.
+Using the **All** parameter of the `Get-Command` we get all of the `Get-Date` commands in the
+session. The results show that there are two `Get-Date` commands in the session, a function from the
+**TestModule** module and a cmdlet from the **Microsoft.PowerShell.Utility** module.
 
-Afterwards, a new `Get-Date` function is imported from the `TestModule` module.
-Because functions take precedence over cmdlets, when `Get-Date` is called again, the `TestModule` module version runs, instead of the `Get-Date` cmdlet.
+Because functions take precedence over cmdlets, the `Get-Date` function from the **TestModule**
+module runs, instead of the `Get-Date` cmdlet. To run the original version of `Get-Date` you must
+qualify the command name with the module name.
 
-Using the `All` parameter of `Get-Command`, it is shown that there are now two `Get-Date` commands in the session.
-A function from the `TestModule` module and a cmdlet from the `Microsoft.PowerShell.Utility` module.
+For more information about command precedence in PowerShell, see [about_Command_Precedence](about/about_Command_Precedence.md).
 
-The last command runs the hidden cmdlet by qualifying the command name with the module name.
-
-For more information about command precedence in Windows PowerShell, see [about_Command_Precedence](/powershell/module/microsoft.powershell.core/about/about_command_precedence).
-
-### Example 10: Specify a MinimumVersion for import
+### Example 10: Import a minimum version of a module
 
 ```powershell
 Import-Module -Name PSWorkflow -MinimumVersion 3.0.0.0
 ```
 
-This command imports the PSWorkflow module.
-It uses the `MinimumVersion` (alias=Version) parameter of `Import-Module` to import only version 3.0.0.0 or greater of the module.
+This command imports the **PSWorkflow** module. It uses the **MinimumVersion** parameter of
+`Import-Module` to import only version 3.0.0.0 or greater of the module.
 
-You can also use the `RequiredVersion` parameter to import a particular version of a module, or use the `Module` and `Version` parameters of the `#Requires` keyword to require a particular version of a module in a script.
+You can also use the **RequiredVersion** parameter to import a particular version of a module, or
+use the **Module** and **Version** parameters of the `#Requires` keyword to require a particular
+version of a module in a script.
 
-### Example 11: Import a Module from a remote computer
+### Example 11: Import a module from a remote computer
+
+This example shows how to use the `Import-Module` cmdlet to import a module from a remote computer.
+This command uses the Implicit Remoting feature of PowerShell.
+
+When you import modules from another session, you can use the cmdlets in the current session.
+However, commands that use the cmdlets actually run in the remote session.
 
 ```powershell
 $s = New-PSSession -ComputerName Server01
 Get-Module -PSSession $s -ListAvailable -Name NetSecurity
 ```
 
-```output
+```Output
 ModuleType Name                                ExportedCommands
 ---------- ----                                ----------------
 Manifest   NetSecurity                         {New-NetIPsecAuthProposal, New-NetIPsecMainModeCryptoProposal, New-Ne...
@@ -403,24 +452,29 @@ Manifest   NetSecurity                         {New-NetIPsecAuthProposal, New-Ne
 
 ```powershell
 Import-Module -PSSession $s -Name NetSecurity
-# Use `Get-NetFirewallRule` to get Windows Remote Management firewall rules on the Server01 computer.
-Get-NetFirewallRule -DisplayName "Windows Remote Management*" | Format-Table -Property DisplayName, Name -AutoSize
+Get-Command -Module NetSecurity -Name Get-*Firewall*
 ```
 
-```output
-DisplayName                                              Name
------------                                              ----
-Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP
-Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP-PUBLIC
-Windows Remote Management - Compatibility Mode (HTTP-In) WINRM-HTTP-Compat-In-TCP
+```Output
+CommandType     Name                                               ModuleName
+-----------     ----                                               ----------
+Function        Get-NetFirewallAddressFilter                       NetSecurity
+Function        Get-NetFirewallApplicationFilter                   NetSecurity
+Function        Get-NetFirewallInterfaceFilter                     NetSecurity
+Function        Get-NetFirewallInterfaceTypeFilter                 NetSecurity
+Function        Get-NetFirewallPortFilter                          NetSecurity
+Function        Get-NetFirewallProfile                             NetSecurity
+Function        Get-NetFirewallRule                                NetSecurity
+Function        Get-NetFirewallSecurityFilter                      NetSecurity
+Function        Get-NetFirewallServiceFilter                       NetSecurity
+Function        Get-NetFirewallSetting                             NetSecurity
 ```
 
 ```powershell
-# Perform the same operation as above using Invoke-Command.
-Invoke-Command -Session $s {Get-NetFirewallRule -DisplayName "Windows Remote Management*"} | Format-Table -Property DisplayName, Name -AutoSize
+Get-NetFirewallRule -DisplayName "Windows Remote Management*" | Format-Table -Property DisplayName, Name -AutoSize
 ```
 
-```output
+```Output
 DisplayName                                              Name
 -----------                                              ----
 Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP
@@ -428,18 +482,49 @@ Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP-PUBLI
 Windows Remote Management - Compatibility Mode (HTTP-In) WINRM-HTTP-Compat-In-TCP
 ```
 
-This example shows how to use the `Import-Module` cmdlet to import a module from a remote computer.
-This command uses the Implicit Remoting feature of Windows PowerShell.
+The first command uses the `New-PSSession` cmdlet to create a remote session (**PSSession**) to the
+Server01 computer. The command saves the **PSSession** in the `$s` variable.
 
-When you import modules from another session, you can use the cmdlets in the current session.
-However, commands that use the cmdlets actually run in the remote session.
+The second command uses the **PSSession** parameter of the `Get-Module` cmdlet to get the
+**NetSecurity** module in the session in the `$s` variable. This command is equivalent to using the
+`Invoke-Command` cmdlet to run a `Get-Module` command in the session in `$s`
+(`Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity`).The output shows that the
+**NetSecurity** module is installed on the computer and is available to the session in the `$s`
+variable.
+
+The third command uses the **PSSession** parameter of the `Import-Module` cmdlet to import the
+**NetSecurity** module from the session in the `$s` variable into the current session.
+
+The fourth command uses the `Get-Command` cmdlet to get commands that begin with "Get" and include
+"Firewall" from the NetSecurity module.The output gets the commands and confirms that the module and
+its cmdlets were imported into the current session.
+
+The fifth command uses the `Get-NetFirewallRule` cmdlet to get Windows Remote Management firewall
+rules on the Server01 computer. This command is equivalent to using the `Invoke-Command` cmdlet to
+run a `Get-NetFirewallRule` command on the session in the `$s` variable.
 
 ### Example 12: Manage storage on a remote computer without the Windows operating system
-The commands in this example enable you to manage the storage systems of a remote computer that is not running a Windows operating system.
 
-In this example, because the administrator of the computer has installed the Module Discovery WMI provider, the CIM commands can use the default values, which are designed for the provider.
+In this example, because the administrator of the computer has installed the Module Discovery WMI
+provider, the CIM commands can use the default values, which are designed for the provider.
 
-The session connects to WMI on the remote computer and saves the CIM session in the $cs variable.
+The commands in this example enable you to manage the storage systems of a remote computer that is
+not running the Windows operating system.
+
+The first command uses the `New-CimSession` cmdlet to create a session on the RSDGF03 remote
+computer. The session connects to WMI on the remote computer. The command saves the CIM session in
+the `$cs` variable.
+
+The second command uses the CIM session in the `$cs` variable to run an `Import-Module` command on
+the RSDGF03 computer. The command uses the **Name** parameter to specify the **Storage** CIM module.
+
+The third command runs the `Get-Command` command on the `Get-Disk` command in the **Storage**
+module. When you import a CIM module into the local session, PowerShell converts the CDXML files for
+each command into PowerShell scripts, which appear as functions in the local session.
+
+The fourth command runs the `Get-Disk` command. Although the command is typed in the local session,
+it runs implicitly on the remote computer from which it was imported.The command gets objects from
+the remote computer and returns them to the local session.
 
 ```powershell
 $cs = New-CimSession -ComputerName RSDGF03
@@ -449,7 +534,7 @@ Import-Module -CimSession $cs -Name Storage
 Get-Command Get-Disk
 ```
 
-```output
+```Output
 CommandType     Name                  ModuleName
 -----------     ----                  ----------
 Function        Get-Disk              Storage
@@ -460,7 +545,7 @@ Function        Get-Disk              Storage
 Get-Disk
 ```
 
-```output
+```Output
 Number Friendly Name              OperationalStatus          Total Size Partition Style
 ------ -------------              -----------------          ---------- ---------------
 0      Virtual HD ATA Device      Online                          40 GB MBR
@@ -469,9 +554,9 @@ Number Friendly Name              OperationalStatus          Total Size Partitio
 ## PARAMETERS
 
 ### -Alias
-Specifies the aliases that this cmdlet imports from the module into the current session.
-Enter a comma-separated list of aliases.
-Wildcard characters are permitted.
+
+Specifies the aliases that this cmdlet imports from the module into the current session. Enter a
+comma-separated list of aliases. Wildcard characters are permitted.
 
 Some modules automatically export selected aliases into your session when you import the module.
 This parameter lets you select from among the exported aliases.
@@ -485,15 +570,16 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -ArgumentList
-Specifies an array of arguments, or parameter values, that are passed to a script module during the **Import-Module** command.
-This parameter is valid only when you are importing a script module.
 
-You can also refer to the *ArgumentList* parameter by its alias, *args*.
-For more information, see [about_Aliases](About/about_Aliases.md).
+Specifies an array of arguments, or parameter values, that are passed to a script module during the
+`Import-Module` command. This parameter is valid only when you are importing a script module.
+
+You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information,
+see [about_Aliases](About/about_Aliases.md).
 
 ```yaml
 Type: Object[]
@@ -508,11 +594,13 @@ Accept wildcard characters: False
 ```
 
 ### -AsCustomObject
-Indicates that this cmdlet returns a custom object with members that represent the imported module members.
-This parameter is valid only for script modules.
 
-When you use the *AsCustomObject* parameter, **Import-Module** imports the module members into the session and then returns a **PSCustomObject** object instead of a **PSModuleInfo** object.
-You can save the custom object in a variable and use dot notation to invoke the members.
+Indicates that this cmdlet returns a custom object with members that represent the imported module
+members. This parameter is valid only for script modules.
+
+When you use the **AsCustomObject** parameter, `Import-Module` imports the module members into the
+session and then returns a **PSCustomObject** object instead of a **PSModuleInfo** object. You can
+save the custom object in a variable and use dot notation to invoke the members.
 
 ```yaml
 Type: SwitchParameter
@@ -527,14 +615,15 @@ Accept wildcard characters: False
 ```
 
 ### -Assembly
-Specifies an array of assembly objects.
-This cmdlet imports the cmdlets and providers implemented in the specified assembly objects.
-Enter a variable that contains assembly objects or a command that creates assembly objects.
-You can also pipe an assembly object to **Import-Module**.
 
-When you use this parameter, only the cmdlets and providers implemented by the specified assemblies are imported.
-If the module contains other files, they are not imported, and you might be missing important members of the module.
-Use this parameter for debugging and testing the module, or when you are instructed to use it by the module author.
+Specifies an array of assembly objects. This cmdlet imports the cmdlets and providers implemented in
+the specified assembly objects. Enter a variable that contains assembly objects or a command that
+creates assembly objects. You can also pipe an assembly object to `Import-Module`.
+
+When you use this parameter, only the cmdlets and providers implemented by the specified assemblies
+are imported. If the module contains other files, they are not imported, and you might be missing
+important members of the module. Use this parameter for debugging and testing the module, or when
+you are instructed to use it by the module author.
 
 ```yaml
 Type: Assembly[]
@@ -549,10 +638,12 @@ Accept wildcard characters: False
 ```
 
 ### -CimNamespace
-Specifies the namespace of an alternate CIM provider that exposes CIM modules.
-The default value is the namespace of the Module Discovery WMI provider.
 
-Use this parameter to import CIM modules from computers and devices that are not running a Windows operating system.
+Specifies the namespace of an alternate CIM provider that exposes CIM modules. The default value is
+the namespace of the Module Discovery WMI provider.
+
+Use this parameter to import CIM modules from computers and devices that are not running a Windows
+operating system.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -569,10 +660,12 @@ Accept wildcard characters: False
 ```
 
 ### -CimResourceUri
-Specifies an alternate location for CIM modules.
-The default value is the resource URI of the Module Discovery WMI provider on the remote computer.
 
-Use this parameter to import CIM modules from computers and devices that are not running a Windows operating system.
+Specifies an alternate location for CIM modules. The default value is the resource URI of the Module
+Discovery WMI provider on the remote computer.
+
+Use this parameter to import CIM modules from computers and devices that are not running a Windows
+operating system.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -589,13 +682,18 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) command.
 
-**Import-Module** uses the CIM session connection to import modules from the remote computer into the current session.
-When you use the commands from the imported module in the current session, the commands actually run on the remote computer.
+Specifies a CIM session on the remote computer. Enter a variable that contains the CIM session or a
+command that gets the CIM session, such as a [Get-CimSession](../CimCmdlets/Get-CimSession.md)
+command.
 
-You can use this parameter to import modules from computers and devices that are not running the Windows operating system, and Windows computers that have Windows PowerShell, but do not have Windows PowerShell remoting enabled.
+`Import-Module` uses the CIM session connection to import modules from the remote computer into the
+current session. When you use the commands from the imported module in the current session, the
+commands actually run on the remote computer.
+
+You can use this parameter to import modules from computers and devices that are not running the
+Windows operating system, and Windows computers that have PowerShell, but do not have PowerShell
+remoting enabled.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -612,6 +710,7 @@ Accept wildcard characters: False
 ```
 
 ### -Cmdlet
+
 Specifies an array of cmdlets that this cmdlet imports from the module into the current session.
 Wildcard characters are permitted.
 
@@ -631,16 +730,20 @@ Accept wildcard characters: False
 ```
 
 ### -DisableNameChecking
-Indicates that this cmdlet suppresses the message that warns you when you import a cmdlet or function whose name includes an unapproved verb or a prohibited character.
 
-By default, when a module that you import exports cmdlets or functions that have unapproved verbs in their names, Windows PowerShell displays the following warning message:
+Indicates that this cmdlet suppresses the message that warns you when you import a cmdlet or
+function whose name includes an unapproved verb or a prohibited character.
 
-"WARNING: Some imported command names include unapproved verbs which might make them less discoverable.
-Use the Verbose parameter for more detail or type Get-Verb to see the list of approved verbs."
+By default, when a module that you import exports cmdlets or functions that have unapproved verbs in
+their names, PowerShell displays the following warning message:
 
-This message is only a warning.
-The complete module is still imported, including the non-conforming commands.
-Although the message is displayed to module users, the naming problem should be fixed by the module author.
+> WARNING: Some imported command names include unapproved verbs which might make them less
+> discoverable. Use the Verbose parameter for more detail or type Get-Verb to see the list of
+> approved verbs.
+
+This message is only a warning. The complete module is still imported, including the non-conforming
+commands. Although the message is displayed to module users, the naming problem should be fixed by
+the module author.
 
 ```yaml
 Type: SwitchParameter
@@ -655,6 +758,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 This parameter causes a module to be loaded, or reloaded, over top of the current one
 
 ```yaml
@@ -670,6 +774,7 @@ Accept wildcard characters: False
 ```
 
 ### -FullyQualifiedName
+
 Specifies the fully qualified name of the module specification.
 
 ```yaml
@@ -685,6 +790,7 @@ Accept wildcard characters: False
 ```
 
 ### -Function
+
 Specifies an array of functions that this cmdlet imports from the module into the current session.
 Wildcard characters are permitted.
 
@@ -704,15 +810,20 @@ Accept wildcard characters: False
 ```
 
 ### -Global
-Indicates that this cmdlet imports modules into the global session state so they are available to all commands in the session.
 
-By default, when Import-Module cmdlet is called from the command prompt, script file, or scriptblock, all the commands are imported into the global session state.
+Indicates that this cmdlet imports modules into the global session state so they are available to
+all commands in the session.
 
-When invoked from another module, Import-Module cmdlet imports the commands in a module, including commands from nested modules, into the caller's session state.
+By default, when `Import-Module` cmdlet is called from the command prompt, script file, or
+scriptblock, all the commands are imported into the global session state.
+
+When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
+commands from nested modules, into the caller's session state.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of Global.
 
-To restrict the commands that a module exports, use an `Export-ModuleMember` command in the script module.
+To restrict the commands that a module exports, use an `Export-ModuleMember` command in the script
+module.
 
 ```yaml
 Type: SwitchParameter
@@ -726,17 +837,35 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -MaximumVersion
+
+Specifies a maximum version. This cmdlet imports only a version of the module that is less than or
+equal to the specified value. If no version qualifies, `Import-Module` generates an error.
+
+```yaml
+Type: String
+Parameter Sets: Name, PSSession, CimSession
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -MinimumVersion
-Specifies a minimum version.
-This cmdlet imports only a version of the module that is greater than or equal to the specified value.
-If no version qualifies, **Import-Module** generates an error.
 
-By default, **Import-Module** imports the module without checking the version number.
+Specifies a minimum version. This cmdlet imports only a version of the module that is greater than
+or equal to the specified value. If no version qualifies, `Import-Module` generates an error.
 
-Use the *MinimumVersion* parameter name or its alias, Version.
+By default, `Import-Module` imports the module without checking the version number.
 
-To specify an exact version, use the *RequiredVersion* parameter.
-You can also use the *Module* and *Version* parameters of the **#Requires** keyword to require a specific version of a module in a script.
+Use the **MinimumVersion** parameter name or its alias, Version.
+
+To specify an exact version, use the **RequiredVersion** parameter. You can also use the **Module**
+and **Version** parameters of the **#Requires** keyword to require a specific version of a module in
+a script.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -753,9 +882,10 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleInfo
-Specifies an array of module objects to import.
-Enter a variable that contains the module objects, or a command that gets the module objects, such as the following command: `Get-Module -ListAvailable`.
-You can also pipe module objects to **Import-Module**.
+
+Specifies an array of module objects to import. Enter a variable that contains the module objects,
+or a command that gets the module objects, such as the following command:
+`Get-Module -ListAvailable`. You can also pipe module objects to `Import-Module`.
 
 ```yaml
 Type: PSModuleInfo[]
@@ -770,17 +900,17 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies the names of the modules to import.
-Enter the name of the module or the name of a file in the module, such as a .psd1, .psm1, .dll, or ps1 file.
-File paths are optional.
-Wildcard characters are not permitted.
-You can also pipe module names and file names to **Import-Module**.
 
-If you omit a path, **Import-Module** looks for the module in the paths saved in the PSModulePath environment variable ($env:PSModulePath).
+Specifies the names of the modules to import. Enter the name of the module or the name of a file in
+the module, such as a .psd1, .psm1, .dll, or ps1 file. File paths are optional. Wildcard characters
+are not permitted. You can also pipe module names and file names to `Import-Module`.
 
-Specify only the module name whenever possible.
-When you specify a file name, only the members that are implemented in that file are imported.
-If the module contains other files, they are not imported, and you might be missing important members of the module.
+If you omit a path, `Import-Module` looks for the module in the paths saved in the
+`$env:PSModulePath` environment variable.
+
+Specify only the module name whenever possible. When you specify a file name, only the members that
+are implemented in that file are imported. If the module contains other files, they are not
+imported, and you might be missing important members of the module.
 
 ```yaml
 Type: String[]
@@ -795,12 +925,14 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Indicates that this cmdlet does not import commands that have the same names as existing commands in the current session.
-By default, **Import-Module** imports all exported module commands.
 
-Commands that have the same names can hide or replace commands in the session.
-To avoid command name conflicts in a session, use the *Prefix* or *NoClobber* parameters.
-For more information about name conflicts and command precedence, see "Modules and Name Conflicts" in about_Modules and about_Command_Precedence.
+Indicates that this cmdlet does not import commands that have the same names as existing commands in
+the current session. By default, `Import-Module` imports all exported module commands.
+
+Commands that have the same names can hide or replace commands in the session. To avoid command name
+conflicts in a session, use the **Prefix** or **NoClobber** parameters. For more information about
+name conflicts and command precedence, see "Modules and Name Conflicts" in [about_Modules](about/about_Modules.md)
+and [about_Command_Precedence](about/about_Command_Precedence.md).
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -816,18 +948,66 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PassThru
+
+Returns an object representing the item with which you are working. By default, this cmdlet does not
+generate any output.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Prefix
+
+Specifies a prefix that this cmdlet adds to the nouns in the names of imported module members.
+
+Use this parameter to avoid name conflicts that might occur when different members in the session
+have the same name. This parameter does not change the module, and it does not affect files that the
+module imports for its own use. These are known as nested modules. This cmdlet affects only the
+names of members in the current session.
+
+For example, if you specify the prefix UTC and then import a `Get-Date` cmdlet, the cmdlet is known
+in the session as `Get-UTCDate`, and it is not confused with the original `Get-Date` cmdlet.
+
+The value of this parameter takes precedence over the **DefaultCommandPrefix** property of the
+module, which specifies the default prefix.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -PSSession
-Specifies a Windows PowerShell user-managed session (**PSSession**) from which this cmdlet import modules into the current session.
-Enter a variable that contains a **PSSession** or a command that gets a **PSSession**, such as a Get-PSSession command.
 
-When you import a module from a different session into the current session, you can use the cmdlets from the module in the current session, just as you would use cmdlets from a local module.
-Commands that use the remote cmdlets actually run in the remote session, but the remoting details are managed in the background by Windows PowerShell.
+Specifies a PowerShell user-managed session (**PSSession**) from which this cmdlet import modules
+into the current session. Enter a variable that contains a **PSSession** or a command that gets a
+**PSSession**, such as a `Get-PSSession` command.
 
-This parameter uses the Implicit Remoting feature of Windows PowerShell.
-It is equivalent to using the Import-PSSession cmdlet to import particular modules from a session.
+When you import a module from a different session into the current session, you can use the cmdlets
+from the module in the current session, just as you would use cmdlets from a local module. Commands
+that use the remote cmdlets actually run in the remote session, but the remoting details are managed
+in the background by PowerShell.
 
-**Import-Module** cannot import Windows PowerShell Core modules from another session.
-The Windows PowerShell Core modules have names that begin with Microsoft.PowerShell.
+This parameter uses the Implicit Remoting feature of PowerShell. It is equivalent to using the
+`Import-PSSession` cmdlet to import particular modules from a session.
+
+`Import-Module` cannot import PowerShell Core modules from another session. The PowerShell Core
+modules have names that begin with Microsoft.PowerShell.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -843,59 +1023,24 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -PassThru
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Prefix
-Specifies a prefix that this cmdlet adds to the nouns in the names of imported module members.
-
-Use this parameter to avoid name conflicts that might occur when different members in the session have the same name.
-This parameter does not change the module, and it does not affect files that the module imports for its own use.
-These are known as nested modules.
-This cmdlet affects only the names of members in the current session.
-
-For example, if you specify the prefix UTC and then import a Get-Date cmdlet, the cmdlet is known in the session as **Get-UTCDate**, and it is not confused with the original **Get-Date** cmdlet.
-
-The value of this parameter takes precedence over the **DefaultCommandPrefix** property of the module, which specifies the default prefix.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -RequiredVersion
-Specifies a version of the module that this cmdlet imports.
-If the version is not installed, **Import-Module** generates an error.
 
-By default, **Import-Module** imports the module without checking the version number.
+Specifies a version of the module that this cmdlet imports. If the version is not installed,
+`Import-Module` generates an error.
 
-To specify a minimum version, use the *MinimumVersion* parameter.
-You can also use the *Module* and *Version* parameters of the **#Requires** keyword to require a specific version of a module in a script.
+By default, `Import-Module` imports the module without checking the version number.
+
+To specify a minimum version, use the **MinimumVersion** parameter. You can also use the **Module**
+and **Version** parameters of the **#Requires** keyword to require a specific version of a module in
+a script.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
-Scripts that use *RequiredVersion* to import modules that are included with existing releases of the Windows operating system do not automatically run in future releases of the Windows operating system.
-This is because Windows PowerShell module version numbers in future releases of the Windows operating system are higher than module version numbers in existing releases of the Windows operating system.
+Scripts that use **RequiredVersion** to import modules that are included with existing releases of
+the Windows operating system do not automatically run in future releases of the Windows operating
+system. This is because PowerShell module version numbers in future releases of the Windows
+operating system are higher than module version numbers in existing releases of the Windows
+operating system.
 
 ```yaml
 Type: Version
@@ -910,18 +1055,22 @@ Accept wildcard characters: False
 ```
 
 ### -Scope
+
 Specifies a scope into which this cmdlet imports the module.
 
 The acceptable values for this parameter are:
 
-- **Global**. Available to all commands in the session. Equivalent to the *Global* parameter.
+- **Global**. Available to all commands in the session. Equivalent to the **Global** parameter.
 - **Local**. Available only in the current scope.
 
-By default, when Import-Module cmdlet is called from the command prompt, script file, or scriptblock, all the commands are imported into the global session state.
-You can use the **-Scope** parameter with the value of **Local** to import module content into the script or scriptblock scope.
+By default, when `Import-Module` cmdlet is called from the command prompt, script file, or
+scriptblock, all the commands are imported into the global session state. You can use the **-Scope**
+parameter with the value of **Local** to import module content into the script or scriptblock scope.
 
-When invoked from another module, Import-Module cmdlet imports the commands in a module, including commands from nested modules, into the caller's session state.
-Specifying **-Scope Global** or **-Global** indicates that this cmdlet imports modules into the global session state so they are available to all commands in the session.
+When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
+commands from nested modules, into the caller's session state. Specifying **-Scope Global** or
+**-Global** indicates that this cmdlet imports modules into the global session state so they are
+available to all commands in the session.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of Global.
 
@@ -941,9 +1090,9 @@ Accept wildcard characters: False
 ```
 
 ### -Variable
+
 Specifies an array of variables that this cmdlet imports from the module into the current session.
-Enter a list of variables.
-Wildcard characters are permitted.
+Enter a list of variables. Wildcard characters are permitted.
 
 Some modules automatically export selected variables into your session when you import the module.
 This parameter lets you select from among the exported variables.
@@ -961,54 +1110,90 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String, System.Management.Automation.PSModuleInfo, System.Reflection.Assembly
 
-You can pipe a module name, module object, or assembly object to `Import-Module`.
+You can pipe a module name, module object, or assembly object to this cmdlet.
 
 ## OUTPUTS
 
 ### None, System.Management.Automation.PSModuleInfo, or System.Management.Automation.PSCustomObject
 
-By default, **Import-Module** does not generate any output.
-If you specify the *PassThru* parameter, the cmdlet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
-If you specify the *AsCustomObject* parameter, it generates a **PSCustomObject** object.
+This cmdlet returns a **PSModuleInfo** or **PSCustomObject**. By default, `Import-Module` does not
+generate any output. If you specify the **PassThru** parameter, the cmdlet generates a
+**System.Management.Automation.PSModuleInfo** object that represents the module. If you specify the
+**AsCustomObject** parameter, it generates a **PSCustomObject** object.
 
 ## NOTES
 
-- Before you can import a module, the module must be installed on the local computer, that is, the module directory must be copied to a directory that is accessible to your local computer. For more information, see [about_Modules](About/about_Modules.md).
+* Before you can import a module, the module must be installed on the local computer. That is, the
+  module directory must be copied to a directory that is accessible to your local computer. For more
+  information, see [about_Modules](About/about_Modules.md).
 
-  You can also use the `PSSession` and `CIMSession` parameters to import modules that are installed on remote computers.
-However, commands that use the cmdlets in these modules actually run in the remote session on the remote computer.
+  You can also use the **PSSession** and **CIMSession** parameters to import modules that are
+  installed on remote computers. However, commands that use the cmdlets in these modules actually
+  run in the remote session on the remote computer.
 
-- If you import members with the same name and the same type into your session, Windows PowerShell uses the member imported last by default. Variables and aliases are replaced, and the originals are not accessible. Functions, cmdlets and providers are merely "shadowed" by the new members, and they can be accessed by qualifying the command name with the name of its snap-in, module, or function path.
-- To update the formatting data for commands that have been imported from a module, use the `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in the session that were imported from modules. If the formatting file for a module changes, you can run an `Update-FormatData` command to update the formatting data for imported commands. You do not need to import the module again.
-- Beginning in Windows PowerShell 3.0, the core commands that are installed with Windows PowerShell are packaged in modules. In Windows PowerShell 2.0, and in host programs that create older-style sessions in later versions of Windows PowerShell, the core commands are packaged in snap-ins ("PSSnapins"). The exception is `Microsoft.PowerShell.Core`, which is always a snap-in. Also, remote sessions, such as those started by the `New-PSSession` cmdlet, are older-style sessions that include core snap-ins.
+* If you import members with the same name and the same type into your session, PowerShell uses the
+  member imported last by default. Variables and aliases are replaced, and the originals are not
+  accessible. Functions, cmdlets and providers are merely shadowed by the new members. They can be
+  accessed by qualifying the command name with the name of its snap-in, module, or function path.
 
-  For information about the `CreateDefault2` method that creates newer-style sessions with core modules, see [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2) in the MSDN library.
+* To update the formatting data for commands that have been imported from a module, use the
+  `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in
+  the session that were imported from modules. If the formatting file for a module changes, you can
+  run an `Update-FormatData` command to update the formatting data for imported commands. You do not
+  need to import the module again.
 
-- `Import-Module` cannot import Windows PowerShell Core modules from another session. The Windows PowerShell Core modules have names that begin with Microsoft.PowerShell.
-- In Windows PowerShell 2.0, some of the property values of the module object, such as the `ExportedCmdlets` and `NestedModules` property values, were not populated until the module was imported and were not available on the module object that the `PassThru` parameter returns. In Windows PowerShell 3.0, all module property values are populated.
-- If you attempt to import a module that contains mixed-mode assemblies that are not compatible with Windows PowerShell 3.0, `Import-Module` returns an error message like the following one.
+* Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are
+  packaged in modules. In Windows PowerShell 2.0, and in host programs that create older-style
+  sessions in later versions of PowerShell, the core commands are packaged in snap-ins
+  (**PSSnapins**). The exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also,
+  remote sessions, such as those started by the `New-PSSession` cmdlet, are older-style sessions
+  that include core snap-ins.
 
-  `Import-Module : Mixed mode assembly is built against version 'v2.0.50727' of the runtime and cannot be loaded in the 4.0 runtime without additional configuration information.`
+  For information about the **CreateDefault2** method that creates newer-style sessions with core
+  modules, see the [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2).
 
-  This error occurs when a module that is designed for Windows PowerShell 2.0 contains at least one mixed-module assembly, that is, an assembly that includes both managed and non-managed code, such as C++ and C#.
+* `Import-Module` cannot import PowerShell Core modules from another session. The PowerShell Core
+  modules have names that begin with Microsoft.PowerShell.
 
-  To import a module that contains mixed-mode assemblies, start Windows PowerShell 2.0 by using the following command, and then try the `Import-Module` command again.
+* In Windows PowerShell 2.0, some of the property values of the module object, such as the
+  **ExportedCmdlets** and **NestedModules** property values, were not populated until the module was
+  imported and were not available on the module object that the **PassThru** parameter returns. In
+  Windows PowerShell 3.0, all module property values are populated.
+
+* If you attempt to import a module that contains mixed-mode assemblies that are not compatible with
+  Windows PowerShell 3.0, `Import-Module` returns an error message like the following one.
+
+  > Import-Module : Mixed mode assembly is built against version 'v2.0.50727' of the runtime and
+  > cannot be loaded in the 4.0 runtime without additional configuration information.
+
+  This error occurs when a module that is designed for Windows PowerShell 2.0 contains at least one
+  mixed-module assembly, that is, an assembly that includes both managed and non-managed code, such
+  as C++ and C#.
+
+  To import a module that contains mixed-mode assemblies, start Windows PowerShell 2.0 by using the
+  following command, and then try the `Import-Module` command again.
 
   `PowerShell.exe -Version 2.0`
 
-- To use the CIM session feature, the remote computer must have WS-Management remoting and Windows Management Instrumentation (WMI), which is the Microsoft implementation of the Common Information Model (CIM) standard. The computer must also have the Module Discovery WMI provider or an alternate CIM provider that has the same basic features.
+* To use the CIM session feature, the remote computer must have WS-Management remoting and Windows
+  Management Instrumentation (WMI), which is the Microsoft implementation of the Common Information
+  Model (CIM) standard. The computer must also have the Module Discovery WMI provider or an
+  alternate CIM provider that has the same basic features.
 
-  You can use the CIM session feature on computers that are not running a Windows operating system and on Windows computers that have Windows PowerShell, but do not have Windows PowerShell remoting enabled.
+  You can use the CIM session feature on computers that are not running a Windows operating system
+  and on Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
 
-  You can also use the CIM parameters to get CIM modules from computers that have Windows PowerShell remoting enabled, including the local computer.
-When you create a CIM session on the local computer, Windows PowerShell uses DCOM, instead of WMI, to create the session.
+  You can also use the CIM parameters to get CIM modules from computers that have PowerShell
+  remoting enabled, including the local computer. When you create a CIM session on the local
+  computer, PowerShell uses DCOM, instead of WMI, to create the session.
 
 ## RELATED LINKS
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/14/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821767
 schema: 2.0.0
 title: Export-Clixml
 ---
+
 # Export-Clixml
 
 ## SYNOPSIS
@@ -18,85 +19,92 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ### ByPath (Default)
 
 ```
-Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml [-Path] <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
-it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
-contents of that file.
+The `Export-Clixml` cmdlet creates a Common Language Infrastructure (CLI) XML-based representation
+of an object or objects and stores it in a file. You can then use the `Import-Clixml` cmdlet to
+recreate the saved object based on the contents of that file.
+For more information about CLI, see [Language independence](/dotnet/standard/language-independence).
 
-This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
-a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
+file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
 
-A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
-an example of how to do this, see Example 3.
+A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
+securely as XML. For an example, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
 
-This command creates an XML file that stores a representation of the string, "This is a test" in
-the current directory.
+This example creates an XML file that stores in the current directory, a representation of the
+string **This is a test**.
 
 ```powershell
 "This is a test" | Export-Clixml -Path .\sample.xml
 ```
 
+The string **This is a test** is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
+to create an XML file named `sample.xml` in the current directory.
+
 ### Example 2: Export an object to an XML file
 
-This example shows how to export an object to an XML file and then create an object by importing
-the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing the
+XML from the file.
 
 ```powershell
-Get-Acl C:\test.txt | Export-Clixml -Path .\fileacl.xml
-$fileacl = Import-Clixml -Path .\fileacl.xml
+Get-Acl C:\test.txt | Export-Clixml -Path .\FileACL.xml
+$fileacl = Import-Clixml -Path .\FileACL.xml
 ```
 
-The `Get-Acl` cmdlet gets the security descriptor of the Test.txt file. It sends the object down
-the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of
-the object is stored in a file named FileACL.xml.
+The `Get-Acl` cmdlet gets the security descriptor of the `Test.txt` file. It sends the object down
+the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of the
+object is stored in a file named `FileACL.xml`.
 
-The `Import-Clixml` cmdlet creates an object from the XML in the FileACL.xml file. Then, it saves
+The `Import-Clixml` cmdlet creates an object from the XML in the `FileACL.xml` file. Then, it saves
 the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
-This example shows how to use a credential stored in a variable and save it to disk. The credential
-can then be imported into scripts.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential | Export-Clixml $credxmlpath
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential = Import-Clixml $credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential | Export-Clixml $Credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The `Export-Clixml` cmdlet encrypts credential objects by using the
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account can decrypt the contents of the credential object.
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
+The encryption ensures that only your user account on only that computer can decrypt the contents of
+the credential object. The exported `CLIXML` file can't be used on a different computer or by a
+different user.
 
-In this example, given a credential that you've stored in the `$credential` variable by running the
-`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
-the example, the file in which the credential is stored is represented by
-TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+In the example, the file in which the credential is stored is represented by
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
-`$credxmlpath`, that you specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
@@ -119,9 +127,9 @@ Accept wildcard characters: False
 ### -Depth
 
 Specifies how many levels of contained objects are included in the XML representation. The default
-value is 2.
+value is `2`.
 
-The default value can be overridden for the object type in the Types.ps1xml files. For more
+The default value can be overridden for the object type in the `Types.ps1xml` files. For more
 information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
@@ -178,7 +186,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -203,10 +211,9 @@ Accept wildcard characters: False
 ### -LiteralPath
 
 Specifies the path to the file where the XML representation of the object will be stored. Unlike
-**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
-are interpreted as wildcards. If the path includes escape characters, enclose it in single
-quotation marks. Single quotation marks tell PowerShell not to interpret any characters as escape
-sequences.
+**Path**, the value of the **LiteralPath** parameter is used exactly as it's typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single quotation
+marks. Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -222,8 +229,8 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Indicates that the cmdlet does not overwrite the contents of an existing file. By default, if a
-file exists in the specified path, `Export-Clixml` overwrites the file without warning.
+Indicates that the cmdlet doesn't overwrite the contents of an existing file. By default, if a file
+exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -232,7 +239,7 @@ Aliases: NoOverwrite
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -255,7 +262,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -273,14 +280,13 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
 
-You can pipe any object to `Export-Clixml`.
+You can pipeline any object to `Export-Clixml`.
 
 ## OUTPUTS
 
@@ -292,10 +298,6 @@ You can pipe any object to `Export-Clixml`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [ConvertTo-Html](ConvertTo-Html.md)
 
 [ConvertTo-Xml](ConvertTo-Xml.md)
@@ -303,3 +305,11 @@ You can pipe any object to `Export-Clixml`.
 [Export-Csv](Export-Csv.md)
 
 [Import-Clixml](Import-Clixml.md)
+
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
+
+[Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/5.0/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821813
 schema: 2.0.0
 title: Import-Clixml
 ---
+
 # Import-Clixml
 
 ## SYNOPSIS
@@ -18,7 +19,8 @@ Imports a CLIXML file and creates corresponding objects in PowerShell.
 ### ByPath (Default)
 
 ```
-Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [<CommonParameters>]
+Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [<CommonParameters>]
 ```
 
 ### ByLiteralPath
@@ -30,10 +32,12 @@ Import-Clixml -LiteralPath <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-Fi
 
 ## DESCRIPTION
 
-The `Import-Clixml` cmdlet imports a CLIXML file with data that represents Microsoft .NET Framework
-objects and creates the objects in PowerShell. A valuable use of `Import-Clixml` is to import
-credentials and secure strings that have been exported as secure XML by running the `Export-Clixml`
-cmdlet.
+The `Import-Clixml` cmdlet imports a Common Language Infrastructure (CLI) XML file with data that
+represents Microsoft .NET Framework objects and creates the PowerShell objects. For more information
+about CLI, see [Language independence](/dotnet/standard/language-independence).
+
+A valuable use of `Import-Clixml` on Windows computers is to import credentials and secure strings
+that were exported as secure XML using `Export-Clixml`. For an example, see Example 2.
 
 `Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
 file has no BOM, it assumes the encoding is UTF8.
@@ -42,19 +46,23 @@ file has no BOM, it assumes the encoding is UTF8.
 
 ### Example 1: Import a serialized file and recreate an object
 
-This command uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
-returned by `Get-Process`. It then uses `Import-Clixml` to retrieve the contents of the serialized
-file and re-create an object that is stored in the `$Processes` variable.
+This example uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
+returned by `Get-Process`. `Import-Clixml` retrieves the serialized file's contents and recreates an
+object that is stored in the `$Processes` variable.
 
 ```powershell
-Get-Process | Export-Clixml pi.xml
-$Processes = Import-Clixml pi.xml
+Get-Process | Export-Clixml -Path .\pi.xml
+$Processes = Import-Clixml -Path .\pi.xml
 ```
 
 ### Example 2: Import a secure credential object
 
 In this example, given a credential that you've stored in the `$Credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
@@ -64,18 +72,19 @@ $Credential = Import-Clixml $Credxmlpath
 ```
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
-This ensures that only your user account can decrypt the contents of the credential object.
+The encryption ensures that only your user account can decrypt the contents of the credential
+object. The exported `CLIXML` file can't be used on a different computer or by a different user.
 
 In the example, the file in which the credential is stored is represented by
-`TestScript.ps1.credential`. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-You pipe the credential object to `Export-Clixml`, and save it to the path, `$Credxmlpath`, that you
-specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
@@ -98,10 +107,11 @@ Accept wildcard characters: False
 ### -IncludeTotalCount
 
 Reports the total number of objects in the data set followed by the selected objects. If the cmdlet
-cannot determine the total count, it displays "Unknown total count." The integer has an Accuracy
-property that indicates the reliability of the total count value. The value of Accuracy ranges from
-0.0 to 1.0 where 0.0 means that the cmdlet could not count the objects, 1.0 means that the count is
-exact, and a value between 0.0 and 1.0 indicates an increasingly reliable estimate.
+can't determine the total count, it displays **Unknown total count**. The integer has an
+**Accuracy** property that indicates the reliability of the total count value. The value of
+**Accuracy** ranges from `0.0` to `1.0` where `0.0` means that the cmdlet couldn't count the
+objects, `1.0` means that the count is exact, and a value between `0.0` and `1.0` indicates an
+increasingly reliable estimate.
 
 ```yaml
 Type: SwitchParameter
@@ -117,10 +127,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is used exactly
-as it is typed. No characters are interpreted as wildcards. If the path includes escape characters,
-enclose it in single quotation marks. Single quotation marks tell PowerShell not to interpret any
-characters as escape sequences.
+Specifies the path to the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is
+used exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -136,7 +146,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the XML files.
+Specifies the path to the XML files.
 
 ```yaml
 Type: String[]
@@ -152,8 +162,8 @@ Accept wildcard characters: False
 
 ### -Skip
 
-Ignores the specified number of objects and then gets the remaining objects.
-Enter the number of objects to skip.
+Ignores the specified number of objects and then gets the remaining objects. Enter the number of
+objects to skip.
 
 ```yaml
 Type: UInt64
@@ -171,31 +181,33 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to `Import-Clixml`.
+You can pipeline a string that contains a path to `Import-Clixml`.
 
 ## OUTPUTS
 
 ### PSObject
 
-`Import-Clixml` returns objects that have been deserialized from the stored XML files.
+`Import-Clixml` returns objects that were deserialized from the stored XML files.
 
 ## NOTES
 
-* When specifying multiple values for a parameter, use commas to separate the values. For example,
-  `<parameter-name> <value1>, <value2>`.
+When specifying multiple values for a parameter, use commas to separate the values. For example,
+`<parameter-name> <value1>, <value2>`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](http://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
-
-[Securely Store Credentials on Disk](http://www.powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [Export-Clixml](Export-Clixml.md)
 
+[Introducing XML Serialization](/dotnet/standard/serialization/introducing-xml-serialization)
+
 [Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)

--- a/reference/5.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date: 08/19/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -11,54 +11,59 @@ title:  Stop-DscConfiguration
 # Stop-DscConfiguration
 
 ## SYNOPSIS
-Stops a running configuration.
+Stops a configuration job that is running.
 
 ## SYNTAX
 
+### All
+
 ```
-Stop-DscConfiguration [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Stop-DscConfiguration [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The `Stop-DscConfiguration` cmdlet stops a configuration job that is currently running.
-Specify which computers this cmdlet applies to by using Common Information Model (CIM) sessions.
-If there is no configuration job running, this cmdlet returns a warning message.
 
-This cmdlet is available only as part of the [November 2014 update rollup for Windows RT 8.1, Windows 8.1, and Windows Server 2012 R2](https://support.microsoft.com/kb/3000850) from the Microsoft Support library.
-Before you use this cmdlet, review the information in What's New in Windows PowerShellhttp://technet.microsoft.com/library/hh857339.aspx (http://technet.microsoft.com/library/hh857339.aspx) in the TechNet library.
+The `Stop-DscConfiguration` cmdlet stops a configuration job that is running. Specify which
+computers this cmdlet applies to by using Common Information Model (CIM) sessions. If there's no
+configuration job running, this cmdlet returns a warning message.
 
-This cmdlet does not support the *Confirm* parameter.
+`Stop-DscConfiguration` is only available as part of the
+[November 2014 update rollup for Windows RT 8.1, Windows 8.1, and Windows Server 2012 R2](https://support.microsoft.com/kb/3000850)
+from the Microsoft Support library. Before you use this cmdlet, review the information in
+[What's New in Windows PowerShell 5.0](../../docs-conceptual/whats-new/What-s-New-in-Windows-PowerShell-50.md)
 
 ## EXAMPLES
 
 ### Example 1: Stop a configuration job
-```
-PS C:\> $Session = New-CimSession -ComputerName "Server01" -Credential ACCOUNTS\PattiFuller
-PS C:\> Stop-DscConfiguration -CimSession $Session
+
+In this example, a CIM session is created using the `New-CimSession` cmdlet. The **CimSession**
+object is used to stop a running configuration job.
+
+```powershell
+$Session = New-CimSession -ComputerName Server01 -Credential ACCOUNTS\User01
+Stop-DscConfiguration -CimSession $Session
 ```
 
-The first command creates a CIM session by using the **New-CimSession** cmdlet, and then stores the **CimSession** object in the $Session variable.
-The command prompts you for a password.
-For more information, type `Get-Help New-CimSession`.
+`New-CimSession` uses the **ComputerName** parameter to specify the Server01 computer. The
+**Credential** parameter specifies the user account. The **CimSession** object is stored in the
+`$Session` variable. When the command is run, you're prompted for the user account's password.
 
-The second command stops a currently running configuration job on the computer identified by the **CimSession** object stored in $Session.
+`Stop-DscConfiguration` uses the **CimSession** parameter and the object stored in `$Session` to
+stop the configuration job.
 
 ## PARAMETERS
 
 ### -AsJob
-Indicates that this cmdlet runs the command as a background job.
 
-If you specify the *AsJob* parameter, the command returns an object that represents the job, and then displays the command prompt.
-You can continue to work in the session until the job finishes.
-The job is created on the local computer and the results from remote computers are automatically returned to the local computer.
-To manage the job, use the Job cmdlets.
-To get the job results, use the Receive-Job cmdlet.
+Indicates that this cmdlet runs the command as a background job. For more information about
+PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and
+[about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
 
-To use this parameter, the local and remote computers must be configured for remoting, and on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell with the Run as administrator option.
-For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
-
-For more information about Windows PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and [about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
+To use the **AsJob** parameter, the local and remote computers must be configured for remoting. On
+Windows Vista and later versions of the Windows operating system, you must open PowerShell with the
+**Run as administrator** option. For more information, see
+[about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 ```yaml
 Type: SwitchParameter
@@ -67,15 +72,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
-The default is the current session on the local computer.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output from `New-CimSession` or `Get-CimSession`.
 
 ```yaml
 Type: CimSession[]
@@ -90,7 +95,12 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.
+
+`Stop-DscConfiguration` doesn't support the **Confirm** parameter. If the **Confirm** parameter is
+used, an error is displayed.
+
+For PowerShell cmdlets that support **Confirm**, using the parameter prompts you for verification
+before a command is run.
 
 ```yaml
 Type: SwitchParameter
@@ -105,8 +115,8 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Specifies that this cmdlet cancels the current configuration immediately.
-If this parameter is not specified, the cmdlet cancels the configuration run after the current resource finishes running.
+
+Forces the command to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
@@ -115,15 +125,18 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
+
 Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
-If this parameter is omitted or a value of `0` is entered, then Windows PowerShell calculates an optimum throttle limit for the cmdlet based on the number of CIM cmdlets that are running on the computer.
-The throttle limit applies only to the current cmdlet, not to the session or to the computer.
+
+If this parameter is omitted or a value of `0` is entered, PowerShell calculates an optimum throttle
+limit based on the number of CIM cmdlets that are running on the computer. The throttle limit
+applies only to the current cmdlet, not to the session or to the computer.
 
 ```yaml
 Type: Int32
@@ -138,8 +151,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -154,7 +167,10 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -168,11 +184,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Windows PowerShell Desired State Configuration Overview](http://go.microsoft.com/fwlink/?LinkID=311940)
+[Get-CimSession](../CimCmdlets/Get-CimSession.md)
 
 [Get-DscConfiguration](Get-DscConfiguration.md)
 
 [Get-DscConfigurationStatus](Get-DscConfigurationStatus.md)
+
+[New-CimSession](../CimCmdlets/New-CimSession.md)
 
 [Restore-DscConfiguration](Restore-DscConfiguration.md)
 
@@ -181,3 +199,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Test-DscConfiguration](Test-DscConfiguration.md)
 
 [Update-DscConfiguration](Update-DscConfiguration.md)
+
+[Windows PowerShell Desired State Configuration Overview](/powershell/dsc/overview/overview)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/About_Using.md
@@ -1,15 +1,13 @@
 ---
-ms.date:  12/01/2017
+ms.date:  08/15/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Using
 ---
-
 # About Using
 
 ## SHORT DESCRIPTION
-
 Allows to indicate which namespaces are used in the session.
 
 ## LONG DESCRIPTION
@@ -32,16 +30,20 @@ Syntax #2, to reference PowerShell modules:
 using module <module-name>
 ```
 
-**Note**: The `using` statement, for modules, is intended to surface the
-classes in the module. If the module isn't loaded, the `using` fails.
+> [!NOTE]
+> `Import-Module` and the `#requires` statement only import the module
+> functions, aliases, and variables, as defined by the module. Classes are not
+> imported. The `using module` statement imports the classes defined in the
+> module. If the module isn't loaded in the current session, the `using`
+> statement fails.
 
 ## Examples
 
 The following script gets the cryptographic hash for the "Hello World" string.
 
 Note how the `using namespace System.Text` and `using namespace System.IO`
-simplify the references to `[UnicodeEncoding]` in *System.Text*; and, to
-`[Stream]` and to `[MemoryStream]` in *System.IO*.
+simplify the references to `[UnicodeEncoding]` in *System.Text* and `[Stream]`
+and to `[MemoryStream]` in *System.IO*.
 
 ```powershell
 using namespace System.Text
@@ -64,8 +66,8 @@ automatically.
 
 The following classes are defined in the module:
 
-- *Deck*
-- *Card*
+- **Deck**
+- **Card**
 
 ```powershell
 using module CardGames

--- a/reference/5.1/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/About_Using.md
@@ -12,19 +12,21 @@ Allows to indicate which namespaces are used in the session.
 
 ## LONG DESCRIPTION
 
-The `using` statement allows to indicate which namespaces are used in the
-session. Making easier to mention classes and members, as it requires less
-typing to mention them; also, classes from modules can be referenced too.
+The `using` statement allows you to specify which namespaces are used in the
+session. Adding namespaces simplifies usage of .NET classes and member and
+allows you to import classes from modules.
 
 The `using` statement needs to be the first statement in the script.
 
-Syntax #1, to reference .Net Framework namespaces:
+### Syntax
+
+To reference .NET Framework namespaces:
 
 ```
-using namespace <.Net-framework-namespace>
+using namespace <.NET-framework-namespace>
 ```
 
-Syntax #2, to reference PowerShell modules:
+To reference PowerShell modules:
 
 ```
 using module <module-name>
@@ -37,7 +39,7 @@ using module <module-name>
 > module. If the module isn't loaded in the current session, the `using`
 > statement fails.
 
-## Examples
+### Examples
 
 The following script gets the cryptographic hash for the "Hello World" string.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/About_Using.md
@@ -42,8 +42,8 @@ using module <module-name>
 The following script gets the cryptographic hash for the "Hello World" string.
 
 Note how the `using namespace System.Text` and `using namespace System.IO`
-simplify the references to `[UnicodeEncoding]` in *System.Text* and `[Stream]`
-and to `[MemoryStream]` in *System.IO*.
+simplify the references to `[UnicodeEncoding]` in `System.Text` and `[Stream]`
+and to `[MemoryStream]` in `System.IO`.
 
 ```powershell
 using namespace System.Text

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -229,7 +229,7 @@ Devices   : {$null, $null, Microsoft|Surface Pro 4|5072641000, $null...}
 
 ## Output in class methods
 
-Methods should have a return type defined. If a method does not return output,
+Methods should have a return type defined. If a method doesn't return output,
 then the output type should be `[void]`.
 
 In class methods, no objects get sent to the pipeline except those mentioned in
@@ -340,7 +340,7 @@ Microsoft Surface Pro 4 5072641000
 In this example, the **Device** class is defined with properties, a default
 constructor, and a constructor to initialize the instance.
 
-The default constructor sets the **brand** to *Undefined*, and leaves **model**
+The default constructor sets the **brand** to **Undefined**, and leaves **model**
 and **vendor-sku** with null values.
 
 ```powershell
@@ -389,7 +389,7 @@ class definition.
 ### Example using hidden attributes
 
 When a **Rack** object is created, the number of slots for devices is a fixed
-value that should not be changed at any time. This value is known at creation
+value that shouldn't be changed at any time. This value is known at creation
 time.
 
 Using the hidden attribute allows the developer to keep the number of slots
@@ -711,7 +711,7 @@ Model               : Fbk5040
 
 ## Calling base class constructors
 
-To invoke a base class constructor from a subclass, add the "base" keyword.
+To invoke a base class constructor from a subclass, add the `base` keyword.
 
 ```powershell
 class Person {
@@ -792,7 +792,7 @@ class ChildClass1 : BaseClass
 ## Interfaces
 
 The syntax for declaring interfaces is similar to C#. You can declare
-interfaces after base types or immediately after a colon (:) when there is no
+interfaces after base types or immediately after a colon (`:`) when there is no
 base type specified. Separate all type names with commas.
 
 ```powershell

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -1,43 +1,40 @@
 ---
-ms.date:  08/31/2018
+ms.date:  08/15/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Classes
 description:  Describes how you can use classes to create your own custom types.
 ---
-
 # About Classes
 
-## SHORT DESCRIPTION
-
+## Short description
 Describes how you can use classes to create your own custom types.
 
-## LONG DESCRIPTION
+## Long description
 
 PowerShell 5.0 adds a formal syntax to define classes and other user-defined
 types. The addition of classes enables developers and IT professionals to
-embrace PowerShell for a wider range of use cases. It simplifies development
-of PowerShell artifacts and accelerates coverage of management surfaces.
+embrace PowerShell for a wider range of use cases. It simplifies development of
+PowerShell artifacts and accelerates coverage of management surfaces.
 
-A class declaration is like a blueprint used to create instances of objects at
-run time. When you define a class, the class name is the name of the type. For
+A class declaration is a blueprint used to create instances of objects at run
+time. When you define a class, the class name is the name of the type. For
 example, if you declare a class named **Device** and initialize a variable
 `$dev` to a new instance of **Device**, `$dev` is an object or instance of type
 **Device**. Each instance of **Device** can have different values in its
 properties.
 
-## SUPPORTED SCENARIOS
+## Supported scenarios
 
-- Define custom types in PowerShell using familiar object-oriented
-  programming semantics like classes, properties, methods, inheritance,
-  etc.
+- Define custom types in PowerShell using familiar object-oriented programming
+  semantics like classes, properties, methods, inheritance, etc.
 - Debug types using the PowerShell language.
 - Generate and handle exceptions using formal mechanisms.
 - Define DSC resources and their associated types by using the PowerShell
   language.
 
-## SYNTAX
+## Syntax
 
 Classes are declared using the following syntax:
 
@@ -62,9 +59,8 @@ Classes are instantiated using either of the following syntaxes:
 ```
 
 > [!NOTE]
-> When using the `[<class-name>]::new(` syntax,
-> brackets around the class name are mandatory!
-> The brackets signal a type definition for PowerShell.
+> When using the `[<class-name>]::new(` syntax, brackets around the class name
+> are mandatory. The brackets signal a type definition for PowerShell.
 
 ### Example syntax and usage
 
@@ -80,17 +76,17 @@ $dev.Brand = "Microsoft"
 $dev
 ```
 
-```output
+```Output
 Brand
 -----
 Microsoft
 ```
 
-## CLASS PROPERTIES
+## Class properties
 
-Properties are variables declared at class scope.
-A property may be of any built-in type or an instance of another class.
-Classes have no restriction in the number of properties they have.
+Properties are variables declared at class scope. A property may be of any
+built-in type or an instance of another class. Classes have no restriction in
+the number of properties they have.
 
 ### Example class with simple properties
 
@@ -109,20 +105,17 @@ $device.VendorSku = "5072641000"
 $device
 ```
 
-```output
-
-
+```Output
 Brand     Model         VendorSku
 -----     -----         ---------
 Microsoft Surface Pro 4 5072641000
-
 ```
 
 ### Example complex types in class properties
 
-This example defines an empty **Rack** class using the **Device** class.
-The examples, following this one, show how to add devices to the rack
-and how to start with a pre-loaded rack.
+This example defines an empty **Rack** class using the **Device** class. The
+examples, following this one, show how to add devices to the rack and how to
+start with a pre-loaded rack.
 
 ```powershell
 class Device {
@@ -145,7 +138,7 @@ $rack = [Rack]::new()
 $rack
 ```
 
-```output
+```Output
 
 Brand     :
 Model     :
@@ -156,12 +149,11 @@ Devices   : {$null, $null, $null, $null...}
 
 ```
 
-## CLASS METHODS
+## Class methods
 
-Methods define the actions that a class can perform.
-Methods may take parameters that provide input data.
-Methods can return output.
-Data returned by a method can be any defined data type.
+Methods define the actions that a class can perform. Methods may take
+parameters that provide input data. Methods can return output. Data returned by
+a method can be any defined data type.
 
 ### Example simple class with properties and methods
 
@@ -216,7 +208,7 @@ $rack
 $rack.GetAvailableSlots()
 ```
 
-```output
+```Output
 
 Slots     : 8
 Brand     :
@@ -235,23 +227,23 @@ Devices   : {$null, $null, Microsoft|Surface Pro 4|5072641000, $null...}
 
 ```
 
-## OUTPUT IN CLASS METHODS
+## Output in class methods
 
-Methods should have a return type defined. If a method does not
-return output, then the output type should be `[void]`.
+Methods should have a return type defined. If a method does not return output,
+then the output type should be `[void]`.
 
-In class methods, no objects get sent to the pipeline except those mentioned
-in the `return` statement. There's no accidental output to the pipeline
-from the code.
+In class methods, no objects get sent to the pipeline except those mentioned in
+the `return` statement. There's no accidental output to the pipeline from the
+code.
 
 > [!NOTE]
-> This is fundamentally different from how PowerShell functions
-> handle output, where everything goes to the pipeline.
+> This is fundamentally different from how PowerShell functions handle output,
+> where everything goes to the pipeline.
 
 ### Method output
 
-This example demonstrates no accidental output to the pipeline from
-class methods, except on the `return` statement.
+This example demonstrates no accidental output to the pipeline from class
+methods, except on the `return` statement.
 
 ```powershell
 class FunWithIntegers
@@ -285,7 +277,7 @@ $ints.GetEvenIntegers()
 $ints.SayHello()
 ```
 
-```output
+```Output
 1
 3
 5
@@ -295,25 +287,25 @@ Hello World
 
 ```
 
-## CONSTRUCTOR
+## Constructor
 
 Constructors enable you to set default values and validate object logic at the
 moment of creating the instance of the class. Constructors have the same name
-as the class. Constructors might have arguments, to initialize the data
-members of the new object.
+as the class. Constructors might have arguments, to initialize the data members
+of the new object.
 
 The class can have zero or more constructors defined. If no constructor is
 defined, the class is given a default parameterless constructor. This
 constructor initializes all members to their default values. Object types and
 strings are given null values. When you define constructor, no default
-parameterless constructor is created. Create a parameterless constructor if
-one is needed.
+parameterless constructor is created. Create a parameterless constructor if one
+is needed.
 
 ### Constructor basic syntax
 
-In this example, the Device class is defined with properties and a
-constructor. To use this class, the user is required to provide values for the
-parameters listed in the constructor.
+In this example, the Device class is defined with properties and a constructor.
+To use this class, the user is required to provide values for the parameters
+listed in the constructor.
 
 ```powershell
 class Device {
@@ -337,11 +329,10 @@ class Device {
 $surface
 ```
 
-```output
+```Output
 Brand     Model         VendorSku
 -----     -----         ---------
 Microsoft Surface Pro 4 5072641000
-
 ```
 
 ### Example with multiple constructors
@@ -349,8 +340,8 @@ Microsoft Surface Pro 4 5072641000
 In this example, the **Device** class is defined with properties, a default
 constructor, and a constructor to initialize the instance.
 
-The default constructor sets the **brand** to *Undefined*,
-and leaves **model** and **vendor-sku** with null values.
+The default constructor sets the **brand** to *Undefined*, and leaves **model**
+and **vendor-sku** with null values.
 
 ```powershell
 class Device {
@@ -380,26 +371,26 @@ $somedevice
 $surface
 ```
 
-```output
+```Output
 Brand       Model           VendorSku
 -----       -----           ---------
 Undefined
 Microsoft   Surface Pro 4   5072641000
 ```
 
-## HIDDEN ATTRIBUTE
+## Hidden attribute
 
-The `hidden` attribute makes a property or method less visible. The property
-or method is still accessible to the user and is available in all scopes in
-which the object is available. Hidden members are hidden from the `Get-Member`
-cmdlet and can't be displayed using tab completion or IntelliSense outside of
-the class definition.
+The `hidden` attribute makes a property or method less visible. The property or
+method is still accessible to the user and is available in all scopes in which
+the object is available. Hidden members are hidden from the `Get-Member` cmdlet
+and can't be displayed using tab completion or IntelliSense outside of the
+class definition.
 
 ### Example using hidden attributes
 
-When a **Rack** object is created, the number of slots for devices is a
-fixed value that should not be changed at any time. This value is known at
-creation time.
+When a **Rack** object is created, the number of slots for devices is a fixed
+value that should not be changed at any time. This value is known at creation
+time.
 
 Using the hidden attribute allows the developer to keep the number of slots
 hidden and prevents unintentional changes the size of the rack.
@@ -435,33 +426,30 @@ $r1.Devices.Length
 $r1.Slots
 ```
 
-```output
-
+```Output
 Brand     Model         Devices
 -----     -----         -------
 Microsoft Surface Pro 4 {$null, $null, $null, $null...}
 16
 16
-
 ```
 
-Notice **Slots** property isn't shown in `$r1` output. However, the size
-was changed by the constructor.
+Notice **Slots** property isn't shown in `$r1` output. However, the size was
+changed by the constructor.
 
-## STATIC ATTRIBUTE
+## Static attribute
 
 The `static` attribute defines a property or a method that exists in the class
 and needs no instance.
 
-A static property is always available, independent of class instantiation.
-A static property is shared across all instances of the class.
-A static method is available always.
-All static properties live for the entire session span.
+A static property is always available, independent of class instantiation. A
+static property is shared across all instances of the class. A static method is
+available always. All static properties live for the entire session span.
 
 ### Example using static attributes and methods
 
-Assume the racks instantiated here exist in your data center.
-So, you would like to keep track of the racks in your code.
+Assume the racks instantiated here exist in your data center. So, you would
+like to keep track of the racks in your code.
 
 ```powershell
 class Device {
@@ -500,7 +488,7 @@ class Rack {
 }
 ```
 
-#### Testing static property and method exist
+### Testing static property and method exist
 
 ```
 PS> [Rack]::InstalledRacks.Length
@@ -536,7 +524,7 @@ WARNING: Turning off rack: Std0010
 
 Notice that the number of racks increases each time you run this example.
 
-## PROPERTY VALIDATION ATTRIBUTES
+## Property validation attributes
 
 Validation attributes allow you to test that values given to properties meet
 defined requirements. Validation is triggered the moment that the value is
@@ -556,10 +544,9 @@ Write-Output "Testing dev"
 $dev
 
 $dev.Brand = ""
-
 ```
 
-```output
+```Output
 Testing dev
 
 Brand Model
@@ -570,24 +557,22 @@ argument that is not null or empty, and then try the command again."
 At C:\tmp\Untitled-5.ps1:11 char:1
 + $dev.Brand = ""
 + ~~~~~~~~~~~~~~~
-    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationExcep
-tion
+    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationException
     + FullyQualifiedErrorId : ExceptionWhenSetting
 ```
 
-## INHERITANCE IN POWERSHELL CLASSES
+## Inheritance in PowerShell classes
 
 You can extend a class by creating a new class that derives from an existing
-class. The derived class inherits the properties of the base class. You can
-add or override methods and properties as required.
+class. The derived class inherits the properties of the base class. You can add
+or override methods and properties as required.
 
-PowerShell does not support multiple inheritance.
-Classes cannot inherit from more than one class.
-However, you can use interfaces for that purpose.
+PowerShell does not support multiple inheritance. Classes cannot inherit from
+more than one class. However, you can use interfaces for that purpose.
 
-Inheritance implementation is defined by the `:` operator;
-which means to extend this class or implements these interfaces.
-The derived class should always be leftmost in the class declaration.
+Inheritance implementation is defined by the `:` operator; which means to
+extend this class or implements these interfaces. The derived class should
+always be leftmost in the class declaration.
 
 ### Example using simple inheritance syntax
 
@@ -606,18 +591,16 @@ Class Derived : Base.Interface {...}
 
 ### Example of simple inheritance in PowerShell classes
 
-In this example the _Rack_ and _Device_ classes used in the previous examples
-are better defined to: avoid property repetitions, better align common
+In this example the **Rack** and **Device** classes used in the previous
+examples are better defined to: avoid property repetitions, better align common
 properties, and reuse common business logic.
 
-Most objects in the data center are company assets, which makes sense to
-start tracking them as assets.
-Device types are defined by the `DeviceType` enumeration, see
-[about_Enum](about_Enum.md) for details on enumerations.
+Most objects in the data center are company assets, which makes sense to start
+tracking them as assets. Device types are defined by the `DeviceType`
+enumeration, see [about_Enum](about_Enum.md) for details on enumerations.
 
-In our example, we're only defining `Rack` and `ComputeServer`; both
-extensions to the `Device` class.
-
+In our example, we're only defining `Rack` and `ComputeServer`; both extensions
+to the `Device` class.
 
 ```powershell
 enum DeviceType {
@@ -694,12 +677,10 @@ $FirstRack.Location = "F03R02.J10"
   })
 
 $FirstRack
-
 $FirstRack.Devices
 ```
 
-```output
-
+```Output
 Datacenter : PNW
 Location   : F03R02.J10
 Devices    : {r1s000, r1s001, r1s002, r1s003...}
@@ -726,14 +707,11 @@ Hostname            : r1s015
 Status              : Installed
 Brand               : Fabrikam, Inc.
 Model               : Fbk5040
-
 ```
 
-## CALLING BASE CLASS CONSTRUCTORS
+## Calling base class constructors
 
 To invoke a base class constructor from a subclass, add the "base" keyword.
-
-### Example using the base class constructor
 
 ```powershell
 class Person {
@@ -759,12 +737,12 @@ class Child : Person
 $littleone.Age
 ```
 
-```output
+```Output
 
 10
 ```
 
-## INVOKE BASE CLASS METHODS
+## Invoke base class methods
 
 To override existing methods in subclasses, declare methods by using the same
 name and signature.
@@ -782,7 +760,7 @@ class ChildClass1 : BaseClass
 [ChildClass1]::new().days()
 ```
 
-```output
+```Output
 
 2
 ```
@@ -805,17 +783,17 @@ class ChildClass1 : BaseClass
 [ChildClass1]::new().basedays()
 ```
 
-```output
+```Output
 
 2
 1
 ```
 
-## INTERFACES
+## Interfaces
 
-The syntax for declaring interfaces is similar to C#.
-You can declare interfaces after base types or immediately after a colon (:)
-when there is no base type specified. Separate all type names with commas.
+The syntax for declaring interfaces is similar to C#. You can declare
+interfaces after base types or immediately after a colon (:) when there is no
+base type specified. Separate all type names with commas.
 
 ```powershell
 class MyComparable : system.IComparable
@@ -835,8 +813,16 @@ class MyComparableBar : bar, system.IComparable
 }
 ```
 
-## SEE ALSO
+## Importing classes from a PowerShell module
+
+`Import-Module` and the `#requires` statement only import the module functions,
+aliases, and variables, as defined by the module. Classes are not imported. The
+`using module` statement imports the classes defined in the module. If the
+module isn't loaded in the current session, the `using` statement fails.
+
+## See also
 
 - [about_Enum](about_Enum.md)
 - [about_Language_Keywords](about_language_keywords.md)
 - [about_Methods](about_methods.md)
+- [about_Using](about_using.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
@@ -82,9 +82,9 @@ Import-Module [-Global] [-Prefix <String>] [-Function <String[]>] [-Cmdlet <Stri
 The `Import-Module` cmdlet adds one or more modules to the current session. The modules that you
 import must be installed on the local computer or a remote computer.
 
-Starting in Windows PowerShell 3.0, installed modules are automatically imported to the session when
-you use any commands or providers in the module. However, you can still use the `Import-Module`
-command to import a module and you can enable and disable automatic module importing by using the
+Starting in PowerShell 3.0, installed modules are automatically imported to the session when you use
+any commands or providers in the module. However, you can still use the `Import-Module` command to
+import a module and you can enable and disable automatic module importing by using the
 `$PSModuleAutoloadingPreference` preference variable. For more information about modules, see
 [about_Modules](About/about_Modules.md). For more information about the
 `$PSModuleAutoloadingPreference` variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
@@ -119,9 +119,9 @@ parameter of `Get-Module` to get the PowerShell modules in the **PSSession**. Wh
 modules, and then use the imported commands in the current session, the commands run implicitly in
 the **PSSession** on the remote computer. You can use this strategy to manage the remote computer.
 
-You can use a similar strategy to manage computers that do not have PowerShell remoting enabled,
+You can use a similar strategy to manage computers that don't have PowerShell remoting enabled,
 including computers that are not running the Windows operating system, and Windows computers that
-have PowerShell, but do not have PowerShell remoting enabled.
+have PowerShell, but don't have PowerShell remoting enabled.
 
 Start by creating a CIM session on the remote computer, which is a connection to Windows Management
 Instrumentation (WMI) on the remote computer. Then use the **CIMSession** parameter of
@@ -154,7 +154,7 @@ Get-Module -ListAvailable | Import-Module
 
 ### Example 3: Import the members of several modules into the current session
 
-This example imports the members of the **BitsTransfer** and **Dism** modules into the
+This example imports the members of the **PSDiagnostics** and **Dism** modules into the
 current session.
 
 ```powershell
@@ -169,8 +169,8 @@ modules that are not yet imported into the session.
 The **ModuleInfo** parameter of `Import-Module` is used to import the modules into the current
 session.
 
-These commands are equivalent to using a pipeline operator (|) to send the output of a `Get-Module`
-command to `Import-Module`.
+These commands are equivalent to using a pipeline operator (`|`) to send the output of a
+`Get-Module` command to `Import-Module`.
 
 ### Example 4: Import all modules specified by a path
 
@@ -276,7 +276,7 @@ Function        Start-xTrace                           6.1.0.0    PSDiagnostics
 Function        Stop-xTrace                            6.1.0.0    PSDiagnostics
 ```
 
-It uses the **Prefix** parameter of `Import-Module` adds the "x" prefix to all members that are
+It uses the **Prefix** parameter of `Import-Module` adds the **x** prefix to all members that are
 imported from the module and the **PassThru** parameter to return a module object that represents
 the imported module.
 
@@ -332,16 +332,16 @@ $a."Show-Calendar"()
 ```
 
 The first command uses the `Get-Module` cmdlet to get the available modules. The command uses a
-pipeline operator to pass the module objects to the Format-Table cmdlet, which lists the **Name**
+pipeline operator to pass the module objects to the `Format-Table` cmdlet, which lists the **Name**
 and **ModuleType** of each module in a table.
 
 The second command uses the `Import-Module` cmdlet to import the **Show-Calendar** script module.
 The command uses the **AsCustomObject** parameter to request a custom object and the **PassThru**
 parameter to return the object. The command saves the resulting custom object in the `$a` variable.
 
-The third command uses a pipeline operator to send the $a variable to the `Get-Member` cmdlet, which
-gets the properties and methods of the **PSCustomObject** in `$a`. The output shows a
-**Show-Calendar** script method.
+The third command uses a pipeline operator to send the `$a` variable to the `Get-Member` cmdlet,
+which gets the properties and methods of the **PSCustomObject** in `$a`. The output shows a
+**Show-Calendar()** script method.
 
 The last command uses the **Show-Calendar** script method. The method name must be enclosed in
 quotation marks, because it includes a hyphen.
@@ -495,9 +495,9 @@ variable.
 The third command uses the **PSSession** parameter of the `Import-Module` cmdlet to import the
 **NetSecurity** module from the session in the `$s` variable into the current session.
 
-The fourth command uses the `Get-Command` cmdlet to get commands that begin with "Get" and include
-"Firewall" from the NetSecurity module.The output gets the commands and confirms that the module and
-its cmdlets were imported into the current session.
+The fourth command uses the `Get-Command` cmdlet to get commands that begin with **Get** and include
+**Firewall** from the **NetSecurity** module.The output gets the commands and confirms that the
+module and its cmdlets were imported into the current session.
 
 The fifth command uses the `Get-NetFirewallRule` cmdlet to get Windows Remote Management firewall
 rules on the Server01 computer. This command is equivalent to using the `Invoke-Command` cmdlet to
@@ -609,7 +609,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -692,7 +692,7 @@ current session. When you use the commands from the imported module in the curre
 commands actually run on the remote computer.
 
 You can use this parameter to import modules from computers and devices that are not running the
-Windows operating system, and Windows computers that have PowerShell, but do not have PowerShell
+Windows operating system, and Windows computers that have PowerShell, but don't have PowerShell
 remoting enabled.
 
 This parameter was introduced in Windows PowerShell 3.0.
@@ -752,7 +752,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -768,7 +768,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -832,7 +832,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -943,7 +943,7 @@ Aliases: NoOverwrite
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -960,7 +960,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -1037,7 +1037,7 @@ a script.
 This parameter was introduced in Windows PowerShell 3.0.
 
 Scripts that use **RequiredVersion** to import modules that are included with existing releases of
-the Windows operating system do not automatically run in future releases of the Windows operating
+the Windows operating system don't automatically run in future releases of the Windows operating
 system. This is because PowerShell module version numbers in future releases of the Windows
 operating system are higher than module version numbers in existing releases of the Windows
 operating system.
@@ -1068,8 +1068,8 @@ scriptblock, all the commands are imported into the global session state. You ca
 parameter with the value of **Local** to import module content into the script or scriptblock scope.
 
 When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
-commands from nested modules, into the caller's session state. Specifying **-Scope Global** or
-**-Global** indicates that this cmdlet imports modules into the global session state so they are
+commands from nested modules, into the caller's session state. Specifying `-Scope Global` or
+`-Global` indicates that this cmdlet imports modules into the global session state so they are
 available to all commands in the session.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of Global.
@@ -1112,7 +1112,7 @@ Accept wildcard characters: False
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -1147,7 +1147,7 @@ generate any output. If you specify the **PassThru** parameter, the cmdlet gener
 * To update the formatting data for commands that have been imported from a module, use the
   `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in
   the session that were imported from modules. If the formatting file for a module changes, you can
-  run an `Update-FormatData` command to update the formatting data for imported commands. You do not
+  run an `Update-FormatData` command to update the formatting data for imported commands. You don't
   need to import the module again.
 
 * Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are
@@ -1189,7 +1189,7 @@ generate any output. If you specify the **PassThru** parameter, the cmdlet gener
   alternate CIM provider that has the same basic features.
 
   You can use the CIM session feature on computers that are not running a Windows operating system
-  and on Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
+  and on Windows computers that have PowerShell, but don't have PowerShell remoting enabled.
 
   You can also use the CIM parameters to get CIM modules from computers that have PowerShell
   remoting enabled, including the local computer. When you create a CIM session on the local

--- a/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821492
 schema: 2.0.0
 title: Import-Module
@@ -17,6 +17,7 @@ Adds modules to the current session.
 ## SYNTAX
 
 ### Name (Default)
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
  [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>]
@@ -25,6 +26,7 @@ Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String
 ```
 
 ### PSSession
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
  [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>]
@@ -33,6 +35,7 @@ Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String
 ```
 
 ### CimSession
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
  [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>]
@@ -42,6 +45,7 @@ Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String
 ```
 
 ### FullyQualifiedName
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]> [-Function <String[]>]
  [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject]
@@ -49,6 +53,7 @@ Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecific
 ```
 
 ### FullyQualifiedNameAndPSSession
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]> [-Function <String[]>]
  [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject]
@@ -57,6 +62,7 @@ Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecific
 ```
 
 ### Assembly
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-Assembly] <Assembly[]> [-Function <String[]>] [-Cmdlet <String[]>]
  [-Variable <String[]>] [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-ArgumentList <Object[]>]
@@ -64,6 +70,7 @@ Import-Module [-Global] [-Prefix <String>] [-Assembly] <Assembly[]> [-Function <
 ```
 
 ### ModuleInfo
+
 ```
 Import-Module [-Global] [-Prefix <String>] [-Function <String[]>] [-Cmdlet <String[]>] [-Variable <String[]>]
  [-Alias <String[]>] [-Force] [-PassThru] [-AsCustomObject] [-ModuleInfo] <PSModuleInfo[]>
@@ -71,88 +78,109 @@ Import-Module [-Global] [-Prefix <String>] [-Function <String[]>] [-Cmdlet <Stri
 ```
 
 ## DESCRIPTION
-The **Import-Module** cmdlet adds one or more modules to the current session.
-The modules that you import must be installed on the local computer or a remote computer.
 
-Starting in Windows PowerShell 3.0, installed modules are automatically imported to the session when you use any commands or providers in the module.
-However, you can still use the `Import-Module` command to import a module and you can enable and disable automatic module importing by using the `$PSModuleAutoloadingPreference` preference variable.
-For more information about modules, see [about_Modules](About/about_Modules.md).
-For more information about the `$PSModuleAutoloadingPreference` variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
+The `Import-Module` cmdlet adds one or more modules to the current session. The modules that you
+import must be installed on the local computer or a remote computer.
 
-A module is a package that contains members that can be used in Windows PowerShell.
-Members include cmdlets, providers, scripts, functions, variables, and other tools and files.
-After a module is imported, you can use the module members in your session.
+Starting in Windows PowerShell 3.0, installed modules are automatically imported to the session when
+you use any commands or providers in the module. However, you can still use the `Import-Module`
+command to import a module and you can enable and disable automatic module importing by using the
+`$PSModuleAutoloadingPreference` preference variable. For more information about modules, see
+[about_Modules](About/about_Modules.md). For more information about the
+`$PSModuleAutoloadingPreference` variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
 
-To import a module, use the `Name`, `Assembly`,  `ModuleInfo`, `MinimumVersion` and `RequiredVersion` parameters to identify the module to import.
-By default, `Import-Module` imports all members that the module exports, but you can use the `Alias`, `Function`, `Cmdlet`, and `Variable` parameters to restrict the members that are imported.
-You can also use the `NoClobber` parameter to prevent `Import-Module` from importing members that have the same names as members in the current session.
+A module is a package that contains members that can be used in PowerShell. Members include cmdlets,
+providers, scripts, functions, variables, and other tools and files. After a module is imported, you
+can use the module members in your session.
 
-`Import-Module` imports a module only into the current session.
-To import the module into all sessions, add an `Import-Module` command to your Windows PowerShell profile.
-For more information about profiles, see [about_Profiles](/powershell/module/microsoft.powershell.core/about/about_profiles).
+To import a module, use the **Name**, **Assembly**, **ModuleInfo**, **MinimumVersion** and
+**RequiredVersion** parameters to identify the module to import. By default, `Import-Module` imports
+all members that the module exports, but you can use the **Alias**, **Function**, **Cmdlet**, and
+**Variable** parameters to restrict the members that are imported. You can also use the
+**NoClobber** parameter to prevent `Import-Module` from importing members that have the same names
+as members in the current session.
 
-Starting in Windows PowerShell 3.0, you can use `Import-Module` to import Common Information Model (CIM) modules, in which the cmdlets are defined in Cmdlet Definition XML (CDXML) files.
-This feature allows you to use cmdlets that are implemented in non-managed code assemblies, such as those written in C++.
+`Import-Module` imports a module only into the current session. To import the module into all
+sessions, add an `Import-Module` command to your PowerShell profile. For more information about
+profiles, see [about_Profiles](About/about_Profiles.md).
 
-With these new features, `Import-Module` cmdlet becomes a primary tool for managing heterogeneous enterprises that include computers that run the Windows operating system and computers that are running other operating systems.
+Starting in Windows PowerShell 3.0, you can use `Import-Module` to import Common Information Model
+(CIM) modules, in which the cmdlets are defined in Cmdlet Definition XML (CDXML) files. This feature
+allows you to use cmdlets that are implemented in non-managed code assemblies, such as those written
+in C++.
 
-To manage remote computers that run the Windows operating system that have Windows PowerShell and Windows PowerShell remoting enabled, create a **PSSession** on the remote computer and then use the *PSSession* parameter of **Get-Module** to get the Windows PowerShell modules in the **PSSession**.
-When you import the modules, and then use the imported commands in the current session, the commands run implicitly in the **PSSession** on the remote computer.
-You can use this strategy to manage the remote computer.
+With these new features, `Import-Module` cmdlet becomes a primary tool for managing heterogeneous
+enterprises that include computers that run the Windows operating system and computers that are
+running other operating systems.
 
-You can use a similar strategy to manage computers that do not have Windows PowerShell remoting enabled, including computers that are not running the Windows operating system, and Windows computers that have Windows PowerShell, but do not have Windows PowerShell remoting enabled.
+To manage remote computers that run the Windows operating system that have PowerShell and PowerShell
+remoting enabled, create a **PSSession** on the remote computer and then use the **PSSession**
+parameter of `Get-Module` to get the PowerShell modules in the **PSSession**. When you import the
+modules, and then use the imported commands in the current session, the commands run implicitly in
+the **PSSession** on the remote computer. You can use this strategy to manage the remote computer.
 
-Start by creating a CIM session on the remote computer, which is a connection to Windows Management Instrumentation (WMI) on the remote computer.
-Then use the *CIMSession* parameter of `Import-Module` to import CIM modules from the remote computer.
-When you import a CIM module and then run the imported commands, the commands run implicitly on the remote computer.
-You can use this WMI and CIM strategy to manage the remote computer.
+You can use a similar strategy to manage computers that do not have PowerShell remoting enabled,
+including computers that are not running the Windows operating system, and Windows computers that
+have PowerShell, but do not have PowerShell remoting enabled.
+
+Start by creating a CIM session on the remote computer, which is a connection to Windows Management
+Instrumentation (WMI) on the remote computer. Then use the **CIMSession** parameter of
+`Import-Module` to import CIM modules from the remote computer. When you import a CIM module and
+then run the imported commands, the commands run implicitly on the remote computer. You can use this
+WMI and CIM strategy to manage the remote computer.
 
 ## EXAMPLES
 
 ### Example 1: Import the members of a module into the current session
+
+This example imports the members of the **PSDiagnostics** module into the current session. The
+**Name** parameter name is optional and can be omitted.
+
 ```powershell
-Import-Module -Name BitsTransfer
+Import-Module -Name PSDiagnostics
 ```
 
-This command imports the members of the `BitsTransfer` module into the current session.
-
-The `Name` parameter name is optional and can be omitted.
-
-By default, `Import-Module` does not generate any output when it imports a module.
-To request output, use the `PassThru` or `AsCustomObject` parameter, or the `Verbose` common parameter.
+By default, `Import-Module` does not generate any output when it imports a module. To request
+output, use the **PassThru** or **AsCustomObject** parameter, or the **Verbose** common parameter.
 
 ### Example 2: Import all modules specified by the module path
+
+This example imports all available modules in the path specified by the `$env:PSModulePath`
+environment variable into the current session.
 
 ```powershell
 Get-Module -ListAvailable | Import-Module
 ```
 
-This command imports all available modules in the path specified by the PSModulePath environment variable (`$env:PSModulePath`) into the current session.
-
 ### Example 3: Import the members of several modules into the current session
 
+This example imports the members of the **BitsTransfer** and **Dism** modules into the
+current session.
+
 ```powershell
-$m = Get-Module -ListAvailable BitsTransfer, ServerManager
+$m = Get-Module -ListAvailable PSDiagnostics, Dism
 Import-Module -ModuleInfo $m
 ```
 
-These commands import the members of the **BitsTransfer** and **ServerManager** modules into the current session.
+The `Get-Module` cmdlet gets the **PSDiagnostics** and **Dism** modules and saves the
+objects in the `$m` variable. The **ListAvailable** parameter is required when you are getting
+modules that are not yet imported into the session.
 
-The first command uses the `Get-Module` cmdlet to get the `BitsTransfer` and `ServerManager` modules.
-It saves the objects in the `$m` variable.
-The `ListAvailable` parameter is required when you are getting modules that are not yet imported into the session.
+The **ModuleInfo** parameter of `Import-Module` is used to import the modules into the current
+session.
 
-The second command uses the `ModuleInfo` parameter of `Import-Module` to import the modules into the current session.
-
-These commands are equivalent to using a pipeline operator `|` to send the output of a `Get-Module` command to `Import-Module`.
+These commands are equivalent to using a pipeline operator (|) to send the output of a `Get-Module`
+command to `Import-Module`.
 
 ### Example 4: Import all modules specified by a path
+
+This example uses an explicit path to identify the module to import.
 
 ```powershell
 Import-Module -Name c:\ps-test\modules\test -Verbose
 ```
 
-```output
+```Output
 VERBOSE: Loading module from path 'C:\ps-test\modules\Test\Test.psm1'.
 VERBOSE: Exporting function 'my-parm'.
 VERBOSE: Exporting function 'Get-Parameter'.
@@ -160,110 +188,121 @@ VERBOSE: Exporting function 'Get-Specification'.
 VERBOSE: Exporting function 'Get-SpecDetails'.
 ```
 
-This command uses an explicit path to identify the module to import.
-
-It also uses the `Verbose` common parameter to get a list of the items imported from the module.
-Without the `Verbose`, `PassThru`, or `AsCustomObject` parameter, `Import-Module` does not generate any output when it imports a module.
+Using the **Verbose** parameter causes `Import-Module` to report progress as it loads the module.
+Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, `Import-Module` does not
+generate any output when it imports a module.
 
 ### Example 5: Restrict module members imported into a session
 
-```powershell
-Import-Module BitsTransfer -Cmdlet Add-BitsFile, Get-BitsTransfer
-(Get-Module BitsTransfer).ExportedCmdlets
-```
-
-```output
-Key                   Value
----                   -----
-Add-BitsFile          Add-BitsFile
-Complete-BitsTransfer Complete-BitsTransfer
-Get-BitsTransfer      Get-BitsTransfer
-Remove-BitsTransfer   Remove-BitsTransfer
-Resume-BitsTransfer   Resume-BitsTransfer
-Set-BitsTransfer      Set-BitsTransfer
-Start-BitsTransfer    Start-BitsTransfer
-Suspend-BitsTransfer  Suspend-BitsTransfer
-```
+This example shows how to restrict which module members are imported into the session and the effect
+of this command on the session.
 
 ```powershell
-Get-Command -Module BitsTransfer
+Import-Module PSDiagnostics -Function Disable-PSTrace, Enable-PSTrace
+(Get-Module PSDiagnostics).ExportedCommands
 ```
 
-```output
-CommandType Name             Version Source
------------ ----             ------- ------
-Cmdlet      Add-BitsFile     2.0.0.0 BitsTransfer
-Cmdlet      Get-BitsTransfer 2.0.0.0 BitsTransfer
+```Output
+Key                          Value
+---                          -----
+Disable-PSTrace              Disable-PSTrace
+Disable-PSWSManCombinedTrace Disable-PSWSManCombinedTrace
+Disable-WSManTrace           Disable-WSManTrace
+Enable-PSTrace               Enable-PSTrace
+Enable-PSWSManCombinedTrace  Enable-PSWSManCombinedTrace
+Enable-WSManTrace            Enable-WSManTrace
+Get-LogProperties            Get-LogProperties
+Set-LogProperties            Set-LogProperties
+Start-Trace                  Start-Trace
+Stop-Trace                   Stop-Trace
 ```
 
-This example shows how to restrict the module members that are imported into the session and the effect of this command on the session.
+```powershell
+Get-Command -Module PSDiagnostics
+```
 
-The first command imports only the `Add-BitsFile` and `Get-BitsTransfer` cmdlets from the `BitsTransfer` module.
-The command uses the `Cmdlet` parameter to restrict the cmdlets that the module imports.
-You can also use the `Alias`, `Variable`, and `Function` parameters to restrict other members that a module imports.
+```Output
+CommandType     Name                 Version    Source
+-----------     ----                 -------    ------
+Function        Disable-PSTrace      6.1.0.0    PSDiagnostics
+Function        Enable-PSTrace       6.1.0.0    PSDiagnostics
+```
 
-The second command uses the `Get-Module` cmdlet to get the object that represents the `BitsTransfer` module.
-The `ExportedCmdlets` property lists all of the cmdlets that the module exports, even when they were not all imported.
+The first command imports only the `Disable-PSTrace` and `Enable-PSTrace` cmdlets from the
+**PSDiagnostics** module. The **Function** parameter limits the members that are imported from the
+module. You can also use the **Alias**, **Variable**, and **Cmdlet** parameters to restrict other
+members that a module imports.
 
-The third command uses the `Module` parameter of the `Get-Command` cmdlet to get the commands that were imported from the `BitsTransfer` module.
-The results confirm that only the `Add-BitsFile` and `Get-BitsTransfer` cmdlets were imported.
+The `Get-Module` cmdlet gets the object that represents the **PSDiagnostics** module. The
+**ExportedCmdlets** property lists all the cmdlets that the module exports, even though they were
+not all imported.
+
+In the third command, the **Module** parameter of the `Get-Command` cmdlet gets the commands that
+were imported from the **PSDiagnostics** module. The results confirm that only the `Disable-PSTrace`
+and `Enable-PSTrace` cmdlets were imported.
 
 ### Example 6: Import the members of a module and add a prefix
 
-```powershell
-Import-Module BitsTransfer -Prefix PS -PassThru
-```
-
-```output
-ModuleType Name                                ExportedCommands
----------- ----                                ----------------
-Manifest   bitstransfer                        {Add-BitsFile, Complete-...
-```
+This example imports the **PSDiagnostics** module into the current session, adds a prefix to the
+member names, and then displays the prefixed member names. The prefix applies only to the members in
+the current session. It does not change the module.
 
 ```powershell
-Get-Command -Module BitsTransfer
+Import-Module PSDiagnostics -Prefix x -PassThru
 ```
 
-```output
-CommandType     Name                                               ModuleName
------------     ----                                               ----------
-Cmdlet          Add-BitsFile                                       bitstransfer
-Cmdlet          Add-PSBitsFile                                     bitstransfer
-Cmdlet          Complete-BitsTransfer                              bitstransfer
-Cmdlet          Complete-PSBitsTransfer                            bitstransfer
-Cmdlet          Get-BitsTransfer                                   bitstransfer
-Cmdlet          Get-PSBitsTransfer                                 bitstransfer
-Cmdlet          Remove-BitsTransfer                                bitstransfer
-Cmdlet          Remove-PSBitsTransfer                              bitstransfer
-Cmdlet          Resume-BitsTransfer                                bitstransfer
-Cmdlet          Resume-PSBitsTransfer                              bitstransfer
-Cmdlet          Set-BitsTransfer                                   bitstransfer
-Cmdlet          Set-PSBitsTransfer                                 bitstransfer
-Cmdlet          Start-BitsTransfer                                 bitstransfer
-Cmdlet          Start-PSBitsTransfer                               bitstransfer
-Cmdlet          Suspend-BitsTransfer                               bitstransfer
-Cmdlet          Suspend-PSBitsTransfer                             bitstransfer
+```Output
+ModuleType Version    Name               ExportedCommands
+---------- -------    ----               ----------------
+Script     6.1.0.0    PSDiagnostics      {Disable-xPSTrace, Disable-xPSWSManCombinedTrace, Disable-xW...
 ```
-
-These commands import the `BitsTransfer` module into the current session, add a prefix to the member names, and then display the prefixed member names.
-
-The first command uses the `Import-Module` cmdlet to import the `BitsTransfer` module.
-It uses the `Prefix` parameter to add the PS prefix to all members that are imported from the module and the `PassThru` parameter to return a module object that represents the imported module.
-
-The second command uses the `Get-Command` cmdlet to get the members that have been imported from the module.
-It uses the `Module` parameter to specify the module.
-The output shows that the module members were correctly prefixed.
-
-The prefix that you use applies only to the members in the current session.
-It does not change the module.
-
-### Example 7: Use the AsCustomObject parameter
 
 ```powershell
-Get-Module -ListAvailable | Format-Table -Property Name, ModuleType -AutoSize
+Get-Command -Module PSDiagnostics
 ```
 
-```output
+```Output
+CommandType     Name                                   Version    Source
+-----------     ----                                   -------    ------
+Function        Disable-xPSTrace                       6.1.0.0    PSDiagnostics
+Function        Disable-xPSWSManCombinedTrace          6.1.0.0    PSDiagnostics
+Function        Disable-xWSManTrace                    6.1.0.0    PSDiagnostics
+Function        Enable-xPSTrace                        6.1.0.0    PSDiagnostics
+Function        Enable-xPSWSManCombinedTrace           6.1.0.0    PSDiagnostics
+Function        Enable-xWSManTrace                     6.1.0.0    PSDiagnostics
+Function        Get-xLogProperties                     6.1.0.0    PSDiagnostics
+Function        Set-xLogProperties                     6.1.0.0    PSDiagnostics
+Function        Start-xTrace                           6.1.0.0    PSDiagnostics
+Function        Stop-xTrace                            6.1.0.0    PSDiagnostics
+```
+
+It uses the **Prefix** parameter of `Import-Module` adds the "x" prefix to all members that are
+imported from the module and the **PassThru** parameter to return a module object that represents
+the imported module.
+
+The `Get-Command` cmdlet to get the members that have been imported from the module. The output
+shows that the module members were correctly prefixed.
+
+### Example 7: Get and use a custom object
+
+These commands demonstrate how to get and use the custom object that **Import-Module** returns.
+
+Custom objects include synthetic members that represent each of the imported module members. For
+example, the cmdlets and functions in a module are converted to script methods of the custom object.
+
+Custom objects are very useful in scripting. They are also useful when several imported objects have
+the same names. Using the script method of an object is equivalent to specifying the fully qualified
+name of an imported member, including its module name.
+
+The **AsCustomObject** parameter can be used only when importing a script module, so the first task
+is to determine which of the available modules is a script module.
+
+
+```powershell
+Get-Module -List | Format-Table -Property Name, ModuleType -AutoSize
+```
+
+```Output
 Name          ModuleType
 ----          ----------
 Show-Calendar     Script
@@ -277,8 +316,8 @@ $a = Import-Module -Name Show-Calendar -AsCustomObject -Passthru
 $a | Get-Member
 ```
 
-```output
-TypeName: System.Management.Automation.PSCustomObject
+```Output
+    TypeName: System.Management.Automation.PSCustomObject
 Name          MemberType   Definition
 ----          ----------   ----------
 Equals        Method       bool Equals(System.Object obj)
@@ -292,65 +331,66 @@ Show-Calendar ScriptMethod System.Object Show-Calendar();
 $a."Show-Calendar"()
 ```
 
-These commands demonstrate how to get and use the custom object that `Import-Module` returns.
+The first command uses the `Get-Module` cmdlet to get the available modules. The command uses a
+pipeline operator to pass the module objects to the Format-Table cmdlet, which lists the **Name**
+and **ModuleType** of each module in a table.
 
-Custom objects include synthetic members that represent each of the imported module members.
-For example, the cmdlets and functions in a module are converted to script methods of the custom object.
+The second command uses the `Import-Module` cmdlet to import the **Show-Calendar** script module.
+The command uses the **AsCustomObject** parameter to request a custom object and the **PassThru**
+parameter to return the object. The command saves the resulting custom object in the `$a` variable.
 
-Custom objects are very useful in scripting.
-They are also useful when several imported objects have the same names.
-Using the script method of an object is equivalent to specifying the fully qualified name of an imported member, including its module name.
+The third command uses a pipeline operator to send the $a variable to the `Get-Member` cmdlet, which
+gets the properties and methods of the **PSCustomObject** in `$a`. The output shows a
+**Show-Calendar** script method.
 
-The `AsCustomObject` parameter can be used only when importing a script module, so the first task is to determine which of the available modules is a script module.
+The last command uses the **Show-Calendar** script method. The method name must be enclosed in
+quotation marks, because it includes a hyphen.
 
-After viewing available modules with `-ListAvailable`, the second command uses the `Import-Module` cmdlet to import the `PSDiagnostics` script module.
-The `AsCustomObject` parameter is used to request a custom object and the `PassThru` parameter to return the object and save it in the `$a` variable.
+### Example 8: Re-import a module into the same session
 
-The `$a` variable is then piped to the `Get-Member` cmdlet, which gets the properties and methods of the PSCustomObject in `$a`.
-The output shows a `Show-Calendar` script method.
-
-The last command uses the `Show-Calendar` script method.
-The method name must be enclosed in quotation marks, because it includes a hyphen.
-
-### Example 8: Use the Force parameter to re-import a module
+This example shows how to use the **Force** parameter of `Import-Module` when you are re-importing a
+module into the same session.
 
 ```powershell
-Import-Module BitsTransfer
-Import-Module BitsTransfer -Force -Prefix PS
+Import-Module PSDiagnostics
+Import-Module PSDiagnostics -Force -Prefix PS
 ```
 
-This example shows how to use the `Force` parameter of `Import-Module` when you are re-importing a module into the same session.
+The first command imports the **PSDiagnostics** module. The second command imports the module again,
+this time using the **Prefix** parameter.
 
-The first command imports the `BitsTransfer` module.
-The second command imports the module again, this time using the `Prefix` parameter.
-
-The second command also includes the `Force` parameter, which removes the module and then imports it again.
-Without this parameter, the session would include two copies of each `BitsTransfer` cmdlet, one with the standard name and one with the prefixed name.
+Using the **Force** parameter, `Import-Module` removes the module and then imports it again. Without
+this parameter, the session would include two copies of each **PSDiagnostics** cmdlet, one with the
+standard name and one with the prefixed name.
 
 ### Example 9: Run commands that have been hidden by imported commands
 
+This example shows how to run commands that have been hidden by imported commands. The
+**TestModule** module. includes a function named `Get-Date` that returns the year and day of the
+year.
+
 ```powershell
 Get-Date
 ```
 
-```output
-Thursday, March 15, 2012 6:47:04 PM
+```Output
+Thursday, August 15, 2019 2:26:12 PM
 ```
 
 ```powershell
-Import-Module TestModule -Function Get-Date
+Import-Module TestModule
 Get-Date
 ```
 
-```output
-12075
+```Output
+19227
 ```
 
 ```powershell
 Get-Command Get-Date -All | Format-Table -Property CommandType, Name, ModuleName -AutoSize
 ```
 
-```output
+```Output
 CommandType     Name         ModuleName
 -----------     ----         ----------
 Function        Get-Date     TestModule
@@ -361,43 +401,50 @@ Cmdlet          Get-Date     Microsoft.PowerShell.Utility
 Microsoft.PowerShell.Utility\Get-Date
 ```
 
-```output
-Saturday, September 12, 2009 6:33:23 PM
+```Output
+Thursday, August 15, 2019 2:28:31 PM
 ```
 
-This example shows how to run commands that have been hidden by imported commands.
+The first Get-Date` cmdlet returns a **DateTime** object with the current date. After importing the
+**TestModule** module, `Get-Date` returns the year and day of the year.
 
-The First two commands show the typical execution of the `Get-date` cmdlet.
+Using the **All** parameter of the `Get-Command` we get all of the `Get-Date` commands in the
+session. The results show that there are two `Get-Date` commands in the session, a function from the
+**TestModule** module and a cmdlet from the **Microsoft.PowerShell.Utility** module.
 
-Afterwards, a new `Get-Date` function is imported from the `TestModule` module.
-Because functions take precedence over cmdlets, when `Get-Date` is called again, the `TestModule` module version runs, instead of the `Get-Date` cmdlet.
+Because functions take precedence over cmdlets, the `Get-Date` function from the **TestModule**
+module runs, instead of the `Get-Date` cmdlet. To run the original version of `Get-Date` you must
+qualify the command name with the module name.
 
-Using the `All` parameter of `Get-Command`, it is shown that there are now two `Get-Date` commands in the session.
-A function from the `TestModule` module and a cmdlet from the `Microsoft.PowerShell.Utility` module.
+For more information about command precedence in PowerShell, see [about_Command_Precedence](about/about_Command_Precedence.md).
 
-The last command runs the hidden cmdlet by qualifying the command name with the module name.
-
-For more information about command precedence in Windows PowerShell, see [about_Command_Precedence](/powershell/module/microsoft.powershell.core/about/about_command_precedence).
-
-### Example 10: Specify a MinimumVersion for import
+### Example 10: Import a minimum version of a module
 
 ```powershell
 Import-Module -Name PSWorkflow -MinimumVersion 3.0.0.0
 ```
 
-This command imports the PSWorkflow module.
-It uses the `MinimumVersion` (alias=Version) parameter of `Import-Module` to import only version 3.0.0.0 or greater of the module.
+This command imports the **PSWorkflow** module. It uses the **MinimumVersion** parameter of
+`Import-Module` to import only version 3.0.0.0 or greater of the module.
 
-You can also use the `RequiredVersion` parameter to import a particular version of a module, or use the `Module` and `Version` parameters of the `#Requires` keyword to require a particular version of a module in a script.
+You can also use the **RequiredVersion** parameter to import a particular version of a module, or
+use the **Module** and **Version** parameters of the `#Requires` keyword to require a particular
+version of a module in a script.
 
-### Example 11: Import a Module from a remote computer
+### Example 11: Import a module from a remote computer
+
+This example shows how to use the `Import-Module` cmdlet to import a module from a remote computer.
+This command uses the Implicit Remoting feature of PowerShell.
+
+When you import modules from another session, you can use the cmdlets in the current session.
+However, commands that use the cmdlets actually run in the remote session.
 
 ```powershell
 $s = New-PSSession -ComputerName Server01
 Get-Module -PSSession $s -ListAvailable -Name NetSecurity
 ```
 
-```output
+```Output
 ModuleType Name                                ExportedCommands
 ---------- ----                                ----------------
 Manifest   NetSecurity                         {New-NetIPsecAuthProposal, New-NetIPsecMainModeCryptoProposal, New-Ne...
@@ -405,24 +452,29 @@ Manifest   NetSecurity                         {New-NetIPsecAuthProposal, New-Ne
 
 ```powershell
 Import-Module -PSSession $s -Name NetSecurity
-# Use `Get-NetFirewallRule` to get Windows Remote Management firewall rules on the Server01 computer.
-Get-NetFirewallRule -DisplayName "Windows Remote Management*" | Format-Table -Property DisplayName, Name -AutoSize
+Get-Command -Module NetSecurity -Name Get-*Firewall*
 ```
 
-```output
-DisplayName                                              Name
------------                                              ----
-Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP
-Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP-PUBLIC
-Windows Remote Management - Compatibility Mode (HTTP-In) WINRM-HTTP-Compat-In-TCP
+```Output
+CommandType     Name                                               ModuleName
+-----------     ----                                               ----------
+Function        Get-NetFirewallAddressFilter                       NetSecurity
+Function        Get-NetFirewallApplicationFilter                   NetSecurity
+Function        Get-NetFirewallInterfaceFilter                     NetSecurity
+Function        Get-NetFirewallInterfaceTypeFilter                 NetSecurity
+Function        Get-NetFirewallPortFilter                          NetSecurity
+Function        Get-NetFirewallProfile                             NetSecurity
+Function        Get-NetFirewallRule                                NetSecurity
+Function        Get-NetFirewallSecurityFilter                      NetSecurity
+Function        Get-NetFirewallServiceFilter                       NetSecurity
+Function        Get-NetFirewallSetting                             NetSecurity
 ```
 
 ```powershell
-# Perform the same operation as above using Invoke-Command.
-Invoke-Command -Session $s {Get-NetFirewallRule -DisplayName "Windows Remote Management*"} | Format-Table -Property DisplayName, Name -AutoSize
+Get-NetFirewallRule -DisplayName "Windows Remote Management*" | Format-Table -Property DisplayName, Name -AutoSize
 ```
 
-```output
+```Output
 DisplayName                                              Name
 -----------                                              ----
 Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP
@@ -430,18 +482,49 @@ Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP-PUBLI
 Windows Remote Management - Compatibility Mode (HTTP-In) WINRM-HTTP-Compat-In-TCP
 ```
 
-This example shows how to use the `Import-Module` cmdlet to import a module from a remote computer.
-This command uses the Implicit Remoting feature of Windows PowerShell.
+The first command uses the `New-PSSession` cmdlet to create a remote session (**PSSession**) to the
+Server01 computer. The command saves the **PSSession** in the `$s` variable.
 
-When you import modules from another session, you can use the cmdlets in the current session.
-However, commands that use the cmdlets actually run in the remote session.
+The second command uses the **PSSession** parameter of the `Get-Module` cmdlet to get the
+**NetSecurity** module in the session in the `$s` variable. This command is equivalent to using the
+`Invoke-Command` cmdlet to run a `Get-Module` command in the session in `$s`
+(`Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity`).The output shows that the
+**NetSecurity** module is installed on the computer and is available to the session in the `$s`
+variable.
+
+The third command uses the **PSSession** parameter of the `Import-Module` cmdlet to import the
+**NetSecurity** module from the session in the `$s` variable into the current session.
+
+The fourth command uses the `Get-Command` cmdlet to get commands that begin with "Get" and include
+"Firewall" from the NetSecurity module.The output gets the commands and confirms that the module and
+its cmdlets were imported into the current session.
+
+The fifth command uses the `Get-NetFirewallRule` cmdlet to get Windows Remote Management firewall
+rules on the Server01 computer. This command is equivalent to using the `Invoke-Command` cmdlet to
+run a `Get-NetFirewallRule` command on the session in the `$s` variable.
 
 ### Example 12: Manage storage on a remote computer without the Windows operating system
-The commands in this example enable you to manage the storage systems of a remote computer that is not running a Windows operating system.
 
-In this example, because the administrator of the computer has installed the Module Discovery WMI provider, the CIM commands can use the default values, which are designed for the provider.
+In this example, because the administrator of the computer has installed the Module Discovery WMI
+provider, the CIM commands can use the default values, which are designed for the provider.
 
-The session connects to WMI on the remote computer and saves the CIM session in the $cs variable.
+The commands in this example enable you to manage the storage systems of a remote computer that is
+not running the Windows operating system.
+
+The first command uses the `New-CimSession` cmdlet to create a session on the RSDGF03 remote
+computer. The session connects to WMI on the remote computer. The command saves the CIM session in
+the `$cs` variable.
+
+The second command uses the CIM session in the `$cs` variable to run an `Import-Module` command on
+the RSDGF03 computer. The command uses the **Name** parameter to specify the **Storage** CIM module.
+
+The third command runs the `Get-Command` command on the `Get-Disk` command in the **Storage**
+module. When you import a CIM module into the local session, PowerShell converts the CDXML files for
+each command into PowerShell scripts, which appear as functions in the local session.
+
+The fourth command runs the `Get-Disk` command. Although the command is typed in the local session,
+it runs implicitly on the remote computer from which it was imported.The command gets objects from
+the remote computer and returns them to the local session.
 
 ```powershell
 $cs = New-CimSession -ComputerName RSDGF03
@@ -451,7 +534,7 @@ Import-Module -CimSession $cs -Name Storage
 Get-Command Get-Disk
 ```
 
-```output
+```Output
 CommandType     Name                  ModuleName
 -----------     ----                  ----------
 Function        Get-Disk              Storage
@@ -462,7 +545,7 @@ Function        Get-Disk              Storage
 Get-Disk
 ```
 
-```output
+```Output
 Number Friendly Name              OperationalStatus          Total Size Partition Style
 ------ -------------              -----------------          ---------- ---------------
 0      Virtual HD ATA Device      Online                          40 GB MBR
@@ -471,9 +554,9 @@ Number Friendly Name              OperationalStatus          Total Size Partitio
 ## PARAMETERS
 
 ### -Alias
-Specifies the aliases that this cmdlet imports from the module into the current session.
-Enter a comma-separated list of aliases.
-Wildcard characters are permitted.
+
+Specifies the aliases that this cmdlet imports from the module into the current session. Enter a
+comma-separated list of aliases. Wildcard characters are permitted.
 
 Some modules automatically export selected aliases into your session when you import the module.
 This parameter lets you select from among the exported aliases.
@@ -487,15 +570,16 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -ArgumentList
-Specifies an array of arguments, or parameter values, that are passed to a script module during the **Import-Module** command.
-This parameter is valid only when you are importing a script module.
 
-You can also refer to the *ArgumentList* parameter by its alias, *args*.
-For more information, see [about_Aliases](About/about_Aliases.md).
+Specifies an array of arguments, or parameter values, that are passed to a script module during the
+`Import-Module` command. This parameter is valid only when you are importing a script module.
+
+You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information,
+see [about_Aliases](About/about_Aliases.md).
 
 ```yaml
 Type: Object[]
@@ -510,11 +594,13 @@ Accept wildcard characters: False
 ```
 
 ### -AsCustomObject
-Indicates that this cmdlet returns a custom object with members that represent the imported module members.
-This parameter is valid only for script modules.
 
-When you use the *AsCustomObject* parameter, **Import-Module** imports the module members into the session and then returns a **PSCustomObject** object instead of a **PSModuleInfo** object.
-You can save the custom object in a variable and use dot notation to invoke the members.
+Indicates that this cmdlet returns a custom object with members that represent the imported module
+members. This parameter is valid only for script modules.
+
+When you use the **AsCustomObject** parameter, `Import-Module` imports the module members into the
+session and then returns a **PSCustomObject** object instead of a **PSModuleInfo** object. You can
+save the custom object in a variable and use dot notation to invoke the members.
 
 ```yaml
 Type: SwitchParameter
@@ -529,14 +615,15 @@ Accept wildcard characters: False
 ```
 
 ### -Assembly
-Specifies an array of assembly objects.
-This cmdlet imports the cmdlets and providers implemented in the specified assembly objects.
-Enter a variable that contains assembly objects or a command that creates assembly objects.
-You can also pipe an assembly object to **Import-Module**.
 
-When you use this parameter, only the cmdlets and providers implemented by the specified assemblies are imported.
-If the module contains other files, they are not imported, and you might be missing important members of the module.
-Use this parameter for debugging and testing the module, or when you are instructed to use it by the module author.
+Specifies an array of assembly objects. This cmdlet imports the cmdlets and providers implemented in
+the specified assembly objects. Enter a variable that contains assembly objects or a command that
+creates assembly objects. You can also pipe an assembly object to `Import-Module`.
+
+When you use this parameter, only the cmdlets and providers implemented by the specified assemblies
+are imported. If the module contains other files, they are not imported, and you might be missing
+important members of the module. Use this parameter for debugging and testing the module, or when
+you are instructed to use it by the module author.
 
 ```yaml
 Type: Assembly[]
@@ -551,10 +638,12 @@ Accept wildcard characters: False
 ```
 
 ### -CimNamespace
-Specifies the namespace of an alternate CIM provider that exposes CIM modules.
-The default value is the namespace of the Module Discovery WMI provider.
 
-Use this parameter to import CIM modules from computers and devices that are not running a Windows operating system.
+Specifies the namespace of an alternate CIM provider that exposes CIM modules. The default value is
+the namespace of the Module Discovery WMI provider.
+
+Use this parameter to import CIM modules from computers and devices that are not running a Windows
+operating system.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -571,10 +660,12 @@ Accept wildcard characters: False
 ```
 
 ### -CimResourceUri
-Specifies an alternate location for CIM modules.
-The default value is the resource URI of the Module Discovery WMI provider on the remote computer.
 
-Use this parameter to import CIM modules from computers and devices that are not running a Windows operating system.
+Specifies an alternate location for CIM modules. The default value is the resource URI of the Module
+Discovery WMI provider on the remote computer.
+
+Use this parameter to import CIM modules from computers and devices that are not running a Windows
+operating system.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -591,13 +682,18 @@ Accept wildcard characters: False
 ```
 
 ### -CimSession
-Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) command.
 
-**Import-Module** uses the CIM session connection to import modules from the remote computer into the current session.
-When you use the commands from the imported module in the current session, the commands actually run on the remote computer.
+Specifies a CIM session on the remote computer. Enter a variable that contains the CIM session or a
+command that gets the CIM session, such as a [Get-CimSession](../CimCmdlets/Get-CimSession.md)
+command.
 
-You can use this parameter to import modules from computers and devices that are not running the Windows operating system, and Windows computers that have Windows PowerShell, but do not have Windows PowerShell remoting enabled.
+`Import-Module` uses the CIM session connection to import modules from the remote computer into the
+current session. When you use the commands from the imported module in the current session, the
+commands actually run on the remote computer.
+
+You can use this parameter to import modules from computers and devices that are not running the
+Windows operating system, and Windows computers that have PowerShell, but do not have PowerShell
+remoting enabled.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -614,6 +710,7 @@ Accept wildcard characters: False
 ```
 
 ### -Cmdlet
+
 Specifies an array of cmdlets that this cmdlet imports from the module into the current session.
 Wildcard characters are permitted.
 
@@ -633,16 +730,20 @@ Accept wildcard characters: False
 ```
 
 ### -DisableNameChecking
-Indicates that this cmdlet suppresses the message that warns you when you import a cmdlet or function whose name includes an unapproved verb or a prohibited character.
 
-By default, when a module that you import exports cmdlets or functions that have unapproved verbs in their names, Windows PowerShell displays the following warning message:
+Indicates that this cmdlet suppresses the message that warns you when you import a cmdlet or
+function whose name includes an unapproved verb or a prohibited character.
 
-"WARNING: Some imported command names include unapproved verbs which might make them less discoverable.
-Use the Verbose parameter for more detail or type Get-Verb to see the list of approved verbs."
+By default, when a module that you import exports cmdlets or functions that have unapproved verbs in
+their names, PowerShell displays the following warning message:
 
-This message is only a warning.
-The complete module is still imported, including the non-conforming commands.
-Although the message is displayed to module users, the naming problem should be fixed by the module author.
+> WARNING: Some imported command names include unapproved verbs which might make them less
+> discoverable. Use the Verbose parameter for more detail or type Get-Verb to see the list of
+> approved verbs.
+
+This message is only a warning. The complete module is still imported, including the non-conforming
+commands. Although the message is displayed to module users, the naming problem should be fixed by
+the module author.
 
 ```yaml
 Type: SwitchParameter
@@ -657,6 +758,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 This parameter causes a module to be loaded, or reloaded, over top of the current one
 
 ```yaml
@@ -672,6 +774,7 @@ Accept wildcard characters: False
 ```
 
 ### -FullyQualifiedName
+
 Specifies the fully qualified name of the module specification.
 
 ```yaml
@@ -687,6 +790,7 @@ Accept wildcard characters: False
 ```
 
 ### -Function
+
 Specifies an array of functions that this cmdlet imports from the module into the current session.
 Wildcard characters are permitted.
 
@@ -706,15 +810,20 @@ Accept wildcard characters: False
 ```
 
 ### -Global
-Indicates that this cmdlet imports modules into the global session state so they are available to all commands in the session.
 
-By default, when Import-Module cmdlet is called from the command prompt, script file, or scriptblock, all the commands are imported into the global session state.
+Indicates that this cmdlet imports modules into the global session state so they are available to
+all commands in the session.
 
-When invoked from another module, Import-Module cmdlet imports the commands in a module, including commands from nested modules, into the caller's session state.
+By default, when `Import-Module` cmdlet is called from the command prompt, script file, or
+scriptblock, all the commands are imported into the global session state.
+
+When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
+commands from nested modules, into the caller's session state.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of Global.
 
-To restrict the commands that a module exports, use an `Export-ModuleMember` command in the script module.
+To restrict the commands that a module exports, use an `Export-ModuleMember` command in the script
+module.
 
 ```yaml
 Type: SwitchParameter
@@ -729,9 +838,9 @@ Accept wildcard characters: False
 ```
 
 ### -MaximumVersion
-Specifies a maximum version.
-This cmdlet imports only a version of the module that is less than or equal to the specified value.
-If no version qualifies, **Import-Module** generates an error.
+
+Specifies a maximum version. This cmdlet imports only a version of the module that is less than or
+equal to the specified value. If no version qualifies, `Import-Module` generates an error.
 
 ```yaml
 Type: String
@@ -746,16 +855,17 @@ Accept wildcard characters: False
 ```
 
 ### -MinimumVersion
-Specifies a minimum version.
-This cmdlet imports only a version of the module that is greater than or equal to the specified value.
-If no version qualifies, **Import-Module** generates an error.
 
-By default, **Import-Module** imports the module without checking the version number.
+Specifies a minimum version. This cmdlet imports only a version of the module that is greater than
+or equal to the specified value. If no version qualifies, `Import-Module` generates an error.
 
-Use the *MinimumVersion* parameter name or its alias, Version.
+By default, `Import-Module` imports the module without checking the version number.
 
-To specify an exact version, use the *RequiredVersion* parameter.
-You can also use the *Module* and *Version* parameters of the **#Requires** keyword to require a specific version of a module in a script.
+Use the **MinimumVersion** parameter name or its alias, Version.
+
+To specify an exact version, use the **RequiredVersion** parameter. You can also use the **Module**
+and **Version** parameters of the **#Requires** keyword to require a specific version of a module in
+a script.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -772,9 +882,10 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleInfo
-Specifies an array of module objects to import.
-Enter a variable that contains the module objects, or a command that gets the module objects, such as the following command: `Get-Module -ListAvailable`.
-You can also pipe module objects to **Import-Module**.
+
+Specifies an array of module objects to import. Enter a variable that contains the module objects,
+or a command that gets the module objects, such as the following command:
+`Get-Module -ListAvailable`. You can also pipe module objects to `Import-Module`.
 
 ```yaml
 Type: PSModuleInfo[]
@@ -789,17 +900,17 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies the names of the modules to import.
-Enter the name of the module or the name of a file in the module, such as a .psd1, .psm1, .dll, or ps1 file.
-File paths are optional.
-Wildcard characters are not permitted.
-You can also pipe module names and file names to **Import-Module**.
 
-If you omit a path, **Import-Module** looks for the module in the paths saved in the PSModulePath environment variable ($env:PSModulePath).
+Specifies the names of the modules to import. Enter the name of the module or the name of a file in
+the module, such as a .psd1, .psm1, .dll, or ps1 file. File paths are optional. Wildcard characters
+are not permitted. You can also pipe module names and file names to `Import-Module`.
 
-Specify only the module name whenever possible.
-When you specify a file name, only the members that are implemented in that file are imported.
-If the module contains other files, they are not imported, and you might be missing important members of the module.
+If you omit a path, `Import-Module` looks for the module in the paths saved in the
+`$env:PSModulePath` environment variable.
+
+Specify only the module name whenever possible. When you specify a file name, only the members that
+are implemented in that file are imported. If the module contains other files, they are not
+imported, and you might be missing important members of the module.
 
 ```yaml
 Type: String[]
@@ -814,12 +925,14 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Indicates that this cmdlet does not import commands that have the same names as existing commands in the current session.
-By default, **Import-Module** imports all exported module commands.
 
-Commands that have the same names can hide or replace commands in the session.
-To avoid command name conflicts in a session, use the *Prefix* or *NoClobber* parameters.
-For more information about name conflicts and command precedence, see "Modules and Name Conflicts" in about_Modules and about_Command_Precedence.
+Indicates that this cmdlet does not import commands that have the same names as existing commands in
+the current session. By default, `Import-Module` imports all exported module commands.
+
+Commands that have the same names can hide or replace commands in the session. To avoid command name
+conflicts in a session, use the **Prefix** or **NoClobber** parameters. For more information about
+name conflicts and command precedence, see "Modules and Name Conflicts" in [about_Modules](about/about_Modules.md)
+and [about_Command_Precedence](about/about_Command_Precedence.md).
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -836,8 +949,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+
+Returns an object representing the item with which you are working. By default, this cmdlet does not
+generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -852,16 +966,19 @@ Accept wildcard characters: False
 ```
 
 ### -Prefix
+
 Specifies a prefix that this cmdlet adds to the nouns in the names of imported module members.
 
-Use this parameter to avoid name conflicts that might occur when different members in the session have the same name.
-This parameter does not change the module, and it does not affect files that the module imports for its own use.
-These are known as nested modules.
-This cmdlet affects only the names of members in the current session.
+Use this parameter to avoid name conflicts that might occur when different members in the session
+have the same name. This parameter does not change the module, and it does not affect files that the
+module imports for its own use. These are known as nested modules. This cmdlet affects only the
+names of members in the current session.
 
-For example, if you specify the prefix UTC and then import a Get-Date cmdlet, the cmdlet is known in the session as **Get-UTCDate**, and it is not confused with the original **Get-Date** cmdlet.
+For example, if you specify the prefix UTC and then import a `Get-Date` cmdlet, the cmdlet is known
+in the session as `Get-UTCDate`, and it is not confused with the original `Get-Date` cmdlet.
 
-The value of this parameter takes precedence over the **DefaultCommandPrefix** property of the module, which specifies the default prefix.
+The value of this parameter takes precedence over the **DefaultCommandPrefix** property of the
+module, which specifies the default prefix.
 
 ```yaml
 Type: String
@@ -876,17 +993,21 @@ Accept wildcard characters: False
 ```
 
 ### -PSSession
-Specifies a Windows PowerShell user-managed session (**PSSession**) from which this cmdlet import modules into the current session.
-Enter a variable that contains a **PSSession** or a command that gets a **PSSession**, such as a Get-PSSession command.
 
-When you import a module from a different session into the current session, you can use the cmdlets from the module in the current session, just as you would use cmdlets from a local module.
-Commands that use the remote cmdlets actually run in the remote session, but the remoting details are managed in the background by Windows PowerShell.
+Specifies a PowerShell user-managed session (**PSSession**) from which this cmdlet import modules
+into the current session. Enter a variable that contains a **PSSession** or a command that gets a
+**PSSession**, such as a `Get-PSSession` command.
 
-This parameter uses the Implicit Remoting feature of Windows PowerShell.
-It is equivalent to using the Import-PSSession cmdlet to import particular modules from a session.
+When you import a module from a different session into the current session, you can use the cmdlets
+from the module in the current session, just as you would use cmdlets from a local module. Commands
+that use the remote cmdlets actually run in the remote session, but the remoting details are managed
+in the background by PowerShell.
 
-**Import-Module** cannot import Windows PowerShell Core modules from another session.
-The Windows PowerShell Core modules have names that begin with Microsoft.PowerShell.
+This parameter uses the Implicit Remoting feature of PowerShell. It is equivalent to using the
+`Import-PSSession` cmdlet to import particular modules from a session.
+
+`Import-Module` cannot import PowerShell Core modules from another session. The PowerShell Core
+modules have names that begin with Microsoft.PowerShell.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -903,18 +1024,23 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredVersion
-Specifies a version of the module that this cmdlet imports.
-If the version is not installed, **Import-Module** generates an error.
 
-By default, **Import-Module** imports the module without checking the version number.
+Specifies a version of the module that this cmdlet imports. If the version is not installed,
+`Import-Module` generates an error.
 
-To specify a minimum version, use the *MinimumVersion* parameter.
-You can also use the *Module* and *Version* parameters of the **#Requires** keyword to require a specific version of a module in a script.
+By default, `Import-Module` imports the module without checking the version number.
+
+To specify a minimum version, use the **MinimumVersion** parameter. You can also use the **Module**
+and **Version** parameters of the **#Requires** keyword to require a specific version of a module in
+a script.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
-Scripts that use *RequiredVersion* to import modules that are included with existing releases of the Windows operating system do not automatically run in future releases of the Windows operating system.
-This is because Windows PowerShell module version numbers in future releases of the Windows operating system are higher than module version numbers in existing releases of the Windows operating system.
+Scripts that use **RequiredVersion** to import modules that are included with existing releases of
+the Windows operating system do not automatically run in future releases of the Windows operating
+system. This is because PowerShell module version numbers in future releases of the Windows
+operating system are higher than module version numbers in existing releases of the Windows
+operating system.
 
 ```yaml
 Type: Version
@@ -929,18 +1055,22 @@ Accept wildcard characters: False
 ```
 
 ### -Scope
+
 Specifies a scope into which this cmdlet imports the module.
 
 The acceptable values for this parameter are:
 
-- **Global**. Available to all commands in the session. Equivalent to the *Global* parameter.
+- **Global**. Available to all commands in the session. Equivalent to the **Global** parameter.
 - **Local**. Available only in the current scope.
 
-By default, when Import-Module cmdlet is called from the command prompt, script file, or scriptblock, all the commands are imported into the global session state.
-You can use the **-Scope** parameter with the value of **Local** to import module content into the script or scriptblock scope.
+By default, when `Import-Module` cmdlet is called from the command prompt, script file, or
+scriptblock, all the commands are imported into the global session state. You can use the **-Scope**
+parameter with the value of **Local** to import module content into the script or scriptblock scope.
 
-When invoked from another module, Import-Module cmdlet imports the commands in a module, including commands from nested modules, into the caller's session state.
-Specifying **-Scope Global** or **-Global** indicates that this cmdlet imports modules into the global session state so they are available to all commands in the session.
+When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
+commands from nested modules, into the caller's session state. Specifying **-Scope Global** or
+**-Global** indicates that this cmdlet imports modules into the global session state so they are
+available to all commands in the session.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of Global.
 
@@ -960,9 +1090,9 @@ Accept wildcard characters: False
 ```
 
 ### -Variable
+
 Specifies an array of variables that this cmdlet imports from the module into the current session.
-Enter a list of variables.
-Wildcard characters are permitted.
+Enter a list of variables. Wildcard characters are permitted.
 
 Some modules automatically export selected variables into your session when you import the module.
 This parameter lets you select from among the exported variables.
@@ -980,53 +1110,90 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String, System.Management.Automation.PSModuleInfo, System.Reflection.Assembly
 
-You can pipe a module name, module object, or assembly object to `Import-Module`.
+You can pipe a module name, module object, or assembly object to this cmdlet.
 
 ## OUTPUTS
 
 ### None, System.Management.Automation.PSModuleInfo, or System.Management.Automation.PSCustomObject
 
-By default, **Import-Module** does not generate any output.
-If you specify the *PassThru* parameter, the cmdlet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
-If you specify the *AsCustomObject* parameter, it generates a **PSCustomObject** object.
+This cmdlet returns a **PSModuleInfo** or **PSCustomObject**. By default, `Import-Module` does not
+generate any output. If you specify the **PassThru** parameter, the cmdlet generates a
+**System.Management.Automation.PSModuleInfo** object that represents the module. If you specify the
+**AsCustomObject** parameter, it generates a **PSCustomObject** object.
 
 ## NOTES
 
-- Before you can import a module, the module must be installed on the local computer, that is, the module directory must be copied to a directory that is accessible to your local computer. For more information, see [about_Modules](About/about_Modules.md).
+* Before you can import a module, the module must be installed on the local computer. That is, the
+  module directory must be copied to a directory that is accessible to your local computer. For more
+  information, see [about_Modules](About/about_Modules.md).
 
-  You can also use the `PSSession` and `CIMSession` parameters to import modules that are installed on remote computers.
-However, commands that use the cmdlets in these modules actually run in the remote session on the remote computer.
+  You can also use the **PSSession** and **CIMSession** parameters to import modules that are
+  installed on remote computers. However, commands that use the cmdlets in these modules actually
+  run in the remote session on the remote computer.
 
-- If you import members with the same name and the same type into your session, Windows PowerShell uses the member imported last by default. Variables and aliases are replaced, and the originals are not accessible. Functions, cmdlets and providers are merely "shadowed" by the new members, and they can be accessed by qualifying the command name with the name of its snap-in, module, or function path.
-- To update the formatting data for commands that have been imported from a module, use the `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in the session that were imported from modules. If the formatting file for a module changes, you can run an `Update-FormatData` command to update the formatting data for imported commands. You do not need to import the module again.
-- Beginning in Windows PowerShell 3.0, the core commands that are installed with Windows PowerShell are packaged in modules. In Windows PowerShell 2.0, and in host programs that create older-style sessions in later versions of Windows PowerShell, the core commands are packaged in snap-ins ("PSSnapins"). The exception is `Microsoft.PowerShell.Core`, which is always a snap-in. Also, remote sessions, such as those started by the `New-PSSession` cmdlet, are older-style sessions that include core snap-ins.
+* If you import members with the same name and the same type into your session, PowerShell uses the
+  member imported last by default. Variables and aliases are replaced, and the originals are not
+  accessible. Functions, cmdlets and providers are merely shadowed by the new members. They can be
+  accessed by qualifying the command name with the name of its snap-in, module, or function path.
 
-  For information about the `CreateDefault2` method that creates newer-style sessions with core modules, see [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2) in the MSDN library.
+* To update the formatting data for commands that have been imported from a module, use the
+  `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in
+  the session that were imported from modules. If the formatting file for a module changes, you can
+  run an `Update-FormatData` command to update the formatting data for imported commands. You do not
+  need to import the module again.
 
-- `Import-Module` cannot import Windows PowerShell Core modules from another session. The Windows PowerShell Core modules have names that begin with Microsoft.PowerShell.
-- In Windows PowerShell 2.0, some of the property values of the module object, such as the `ExportedCmdlets` and `NestedModules` property values, were not populated until the module was imported and were not available on the module object that the `PassThru` parameter returns. In Windows PowerShell 3.0, all module property values are populated.
-- If you attempt to import a module that contains mixed-mode assemblies that are not compatible with Windows PowerShell 3.0, `Import-Module` returns an error message like the following one.
+* Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are
+  packaged in modules. In Windows PowerShell 2.0, and in host programs that create older-style
+  sessions in later versions of PowerShell, the core commands are packaged in snap-ins
+  (**PSSnapins**). The exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also,
+  remote sessions, such as those started by the `New-PSSession` cmdlet, are older-style sessions
+  that include core snap-ins.
 
-  `Import-Module : Mixed mode assembly is built against version 'v2.0.50727' of the runtime and cannot be loaded in the 4.0 runtime without additional configuration information.`
+  For information about the **CreateDefault2** method that creates newer-style sessions with core
+  modules, see the [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2).
 
-  This error occurs when a module that is designed for Windows PowerShell 2.0 contains at least one mixed-module assembly, that is, an assembly that includes both managed and non-managed code, such as C++ and C#.
+* `Import-Module` cannot import PowerShell Core modules from another session. The PowerShell Core
+  modules have names that begin with Microsoft.PowerShell.
 
-  To import a module that contains mixed-mode assemblies, start Windows PowerShell 2.0 by using the following command, and then try the `Import-Module` command again.
+* In Windows PowerShell 2.0, some of the property values of the module object, such as the
+  **ExportedCmdlets** and **NestedModules** property values, were not populated until the module was
+  imported and were not available on the module object that the **PassThru** parameter returns. In
+  Windows PowerShell 3.0, all module property values are populated.
+
+* If you attempt to import a module that contains mixed-mode assemblies that are not compatible with
+  Windows PowerShell 3.0, `Import-Module` returns an error message like the following one.
+
+  > Import-Module : Mixed mode assembly is built against version 'v2.0.50727' of the runtime and
+  > cannot be loaded in the 4.0 runtime without additional configuration information.
+
+  This error occurs when a module that is designed for Windows PowerShell 2.0 contains at least one
+  mixed-module assembly, that is, an assembly that includes both managed and non-managed code, such
+  as C++ and C#.
+
+  To import a module that contains mixed-mode assemblies, start Windows PowerShell 2.0 by using the
+  following command, and then try the `Import-Module` command again.
 
   `PowerShell.exe -Version 2.0`
 
-- To use the CIM session feature, the remote computer must have WS-Management remoting and Windows Management Instrumentation (WMI), which is the Microsoft implementation of the Common Information Model (CIM) standard. The computer must also have the Module Discovery WMI provider or an alternate CIM provider that has the same basic features.
+* To use the CIM session feature, the remote computer must have WS-Management remoting and Windows
+  Management Instrumentation (WMI), which is the Microsoft implementation of the Common Information
+  Model (CIM) standard. The computer must also have the Module Discovery WMI provider or an
+  alternate CIM provider that has the same basic features.
 
-  You can use the CIM session feature on computers that are not running a Windows operating system and on Windows computers that have Windows PowerShell, but do not have Windows PowerShell remoting enabled.
+  You can use the CIM session feature on computers that are not running a Windows operating system
+  and on Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
 
-  You can also use the CIM parameters to get CIM modules from computers that have Windows PowerShell remoting enabled, including the local computer.
-When you create a CIM session on the local computer, Windows PowerShell uses DCOM, instead of WMI, to create the session.
+  You can also use the CIM parameters to get CIM modules from computers that have PowerShell
+  remoting enabled, including the local computer. When you create a CIM session on the local
+  computer, PowerShell uses DCOM, instead of WMI, to create the session.
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/14/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821767
 schema: 2.0.0
 title: Export-Clixml
 ---
+
 # Export-Clixml
 
 ## SYNOPSIS
@@ -18,94 +19,117 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ### ByPath (Default)
 
 ```
-Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml [-Path] <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
-it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
-contents of that file.
+The `Export-Clixml` cmdlet creates a Common Language Infrastructure (CLI) XML-based representation
+of an object or objects and stores it in a file. You can then use the `Import-Clixml` cmdlet to
+recreate the saved object based on the contents of that file.
+For more information about CLI, see [Language independence](/dotnet/standard/language-independence).
 
-This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
-a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
+file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
 
-A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
-an example of how to do this, see Example 3.
+A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
+securely as XML. For an example, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
 
-This command creates an XML file that stores a representation of the string, "This is a test" in
-the current directory.
+This example creates an XML file that stores in the current directory, a representation of the
+string **This is a test**.
 
 ```powershell
 "This is a test" | Export-Clixml -Path .\sample.xml
 ```
 
+The string **This is a test** is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
+to create an XML file named `sample.xml` in the current directory.
+
 ### Example 2: Export an object to an XML file
 
-This example shows how to export an object to an XML file and then create an object by importing
-the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing the
+XML from the file.
 
 ```powershell
-Get-Acl C:\test.txt | Export-Clixml -Path .\fileacl.xml
-$fileacl = Import-Clixml -Path .\fileacl.xml
+Get-Acl C:\test.txt | Export-Clixml -Path .\FileACL.xml
+$fileacl = Import-Clixml -Path .\FileACL.xml
 ```
 
-The `Get-Acl` cmdlet gets the security descriptor of the Test.txt file. It sends the object down
-the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of
-the object is stored in a file named FileACL.xml.
+The `Get-Acl` cmdlet gets the security descriptor of the `Test.txt` file. It sends the object down
+the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of the
+object is stored in a file named `FileACL.xml`.
 
-The `Import-Clixml` cmdlet creates an object from the XML in the FileACL.xml file. Then, it saves
+The `Import-Clixml` cmdlet creates an object from the XML in the `FileACL.xml` file. Then, it saves
 the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
-This example shows how to use a credential stored in a variable and save it to disk. The credential
-can then be imported into scripts.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential | Export-Clixml $credxmlpath
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential = Import-Clixml $credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential | Export-Clixml $Credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The `Export-Clixml` cmdlet encrypts credential objects by using the
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account can decrypt the contents of the credential object.
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
+The encryption ensures that only your user account on only that computer can decrypt the contents of
+the credential object. The exported `CLIXML` file can't be used on a different computer or by a
+different user.
 
-In this example, given a credential that you've stored in the `$credential` variable by running the
-`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
-the example, the file in which the credential is stored is represented by
-TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+In the example, the file in which the credential is stored is represented by
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
-`$credxmlpath`, that you specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Depth
 
 Specifies how many levels of contained objects are included in the XML representation. The default
-value is 2.
+value is `2`.
 
-The default value can be overridden for the object type in the Types.ps1xml files. For more
+The default value can be overridden for the object type in the `Types.ps1xml` files. For more
 information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
@@ -162,7 +186,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -187,10 +211,9 @@ Accept wildcard characters: False
 ### -LiteralPath
 
 Specifies the path to the file where the XML representation of the object will be stored. Unlike
-**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
-are interpreted as wildcards. If the path includes escape characters, enclose it in single
-quotation marks. Single quotation marks tell PowerShell not to interpret any characters as escape
-sequences.
+**Path**, the value of the **LiteralPath** parameter is used exactly as it's typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single quotation
+marks. Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -206,8 +229,8 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Indicates that the cmdlet does not overwrite the contents of an existing file. By default, if a
-file exists in the specified path, `Export-Clixml` overwrites the file without warning.
+Indicates that the cmdlet doesn't overwrite the contents of an existing file. By default, if a file
+exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -216,7 +239,7 @@ Aliases: NoOverwrite
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -237,25 +260,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -273,14 +280,13 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
 
-You can pipe any object to `Export-Clixml`.
+You can pipeline any object to `Export-Clixml`.
 
 ## OUTPUTS
 
@@ -292,10 +298,6 @@ You can pipe any object to `Export-Clixml`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [ConvertTo-Html](ConvertTo-Html.md)
 
 [ConvertTo-Xml](ConvertTo-Xml.md)
@@ -303,3 +305,11 @@ You can pipe any object to `Export-Clixml`.
 [Export-Csv](Export-Csv.md)
 
 [Import-Clixml](Import-Clixml.md)
+
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
+
+[Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821813
 schema: 2.0.0
 title: Import-Clixml
 ---
+
 # Import-Clixml
 
 ## SYNOPSIS
@@ -18,7 +19,8 @@ Imports a CLIXML file and creates corresponding objects in PowerShell.
 ### ByPath (Default)
 
 ```
-Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [<CommonParameters>]
+Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [<CommonParameters>]
 ```
 
 ### ByLiteralPath
@@ -30,10 +32,12 @@ Import-Clixml -LiteralPath <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-Fi
 
 ## DESCRIPTION
 
-The `Import-Clixml` cmdlet imports a CLIXML file with data that represents Microsoft .NET Framework
-objects and creates the objects in PowerShell. A valuable use of `Import-Clixml` is to import
-credentials and secure strings that have been exported as secure XML by running the `Export-Clixml`
-cmdlet.
+The `Import-Clixml` cmdlet imports a Common Language Infrastructure (CLI) XML file with data that
+represents Microsoft .NET Framework objects and creates the PowerShell objects. For more information
+about CLI, see [Language independence](/dotnet/standard/language-independence).
+
+A valuable use of `Import-Clixml` on Windows computers is to import credentials and secure strings
+that were exported as secure XML using `Export-Clixml`. For an example, see Example 2.
 
 `Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
 file has no BOM, it assumes the encoding is UTF8.
@@ -42,19 +46,23 @@ file has no BOM, it assumes the encoding is UTF8.
 
 ### Example 1: Import a serialized file and recreate an object
 
-This command uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
-returned by `Get-Process`. It then uses `Import-Clixml` to retrieve the contents of the serialized
-file and re-create an object that is stored in the `$Processes` variable.
+This example uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
+returned by `Get-Process`. `Import-Clixml` retrieves the serialized file's contents and recreates an
+object that is stored in the `$Processes` variable.
 
 ```powershell
-Get-Process | Export-Clixml pi.xml
-$Processes = Import-Clixml pi.xml
+Get-Process | Export-Clixml -Path .\pi.xml
+$Processes = Import-Clixml -Path .\pi.xml
 ```
 
 ### Example 2: Import a secure credential object
 
 In this example, given a credential that you've stored in the `$Credential` variable by running the
 `Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
@@ -64,18 +72,19 @@ $Credential = Import-Clixml $Credxmlpath
 ```
 
 The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
-This ensures that only your user account can decrypt the contents of the credential object.
+The encryption ensures that only your user account can decrypt the contents of the credential
+object. The exported `CLIXML` file can't be used on a different computer or by a different user.
 
 In the example, the file in which the credential is stored is represented by
-`TestScript.ps1.credential`. Replace TestScript with the name of the script with which you are
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-You pipe the credential object to `Export-Clixml`, and save it to the path, `$Credxmlpath`, that you
-specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
@@ -98,10 +107,11 @@ Accept wildcard characters: False
 ### -IncludeTotalCount
 
 Reports the total number of objects in the data set followed by the selected objects. If the cmdlet
-cannot determine the total count, it displays "Unknown total count." The integer has an Accuracy
-property that indicates the reliability of the total count value. The value of Accuracy ranges from
-0.0 to 1.0 where 0.0 means that the cmdlet could not count the objects, 1.0 means that the count is
-exact, and a value between 0.0 and 1.0 indicates an increasingly reliable estimate.
+can't determine the total count, it displays **Unknown total count**. The integer has an
+**Accuracy** property that indicates the reliability of the total count value. The value of
+**Accuracy** ranges from `0.0` to `1.0` where `0.0` means that the cmdlet couldn't count the
+objects, `1.0` means that the count is exact, and a value between `0.0` and `1.0` indicates an
+increasingly reliable estimate.
 
 ```yaml
 Type: SwitchParameter
@@ -117,10 +127,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is used exactly
-as it is typed. No characters are interpreted as wildcards. If the path includes escape characters,
-enclose it in single quotation marks. Single quotation marks tell PowerShell not to interpret any
-characters as escape sequences.
+Specifies the path to the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is
+used exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -136,7 +146,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the XML files.
+Specifies the path to the XML files.
 
 ```yaml
 Type: String[]
@@ -152,8 +162,8 @@ Accept wildcard characters: False
 
 ### -Skip
 
-Ignores the specified number of objects and then gets the remaining objects.
-Enter the number of objects to skip.
+Ignores the specified number of objects and then gets the remaining objects. Enter the number of
+objects to skip.
 
 ```yaml
 Type: UInt64
@@ -171,31 +181,33 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to `Import-Clixml`.
+You can pipeline a string that contains a path to `Import-Clixml`.
 
 ## OUTPUTS
 
 ### PSObject
 
-`Import-Clixml` returns objects that have been deserialized from the stored XML files.
+`Import-Clixml` returns objects that were deserialized from the stored XML files.
 
 ## NOTES
 
-* When specifying multiple values for a parameter, use commas to separate the values. For example,
-  `<parameter-name> <value1>, <value2>`.
+When specifying multiple values for a parameter, use commas to separate the values. For example,
+`<parameter-name> <value1>, <value2>`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](http://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
-
-[Securely Store Credentials on Disk](http://www.powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [Export-Clixml](Export-Clixml.md)
 
+[Introducing XML Serialization](/dotnet/standard/serialization/introducing-xml-serialization)
+
 [Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)

--- a/reference/5.1/PSDesiredStateConfiguration/Stop-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Stop-DscConfiguration.md
@@ -3,7 +3,7 @@ external help file: Stop-DscConfiguration.cdxml-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PSDesiredStateConfiguration
-ms.date: 06/09/2017
+ms.date: 08/19/2019
 online version: https://go.microsoft.com/fwlink/?linkid=821463
 schema: 2.0.0
 title: Stop-DscConfiguration
@@ -12,43 +12,59 @@ title: Stop-DscConfiguration
 # Stop-DscConfiguration
 
 ## SYNOPSIS
-Stops a running configuration.
+Stops a configuration job that is running.
 
 ## SYNTAX
 
+### All
+
 ```
-Stop-DscConfiguration [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Stop-DscConfiguration [-Force] [-CimSession <CimSession[]>] [-ThrottleLimit <Int32>] [-AsJob]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The `Stop-DscConfiguration` cmdlet stops a configuration job that is currently running.
-Specify which computers this cmdlet applies to by using Common Information Model (CIM) sessions.
-If there is no configuration job running, this cmdlet returns a warning message.
 
-This cmdlet is available only as part of the [November 2014 update rollup for Windows RT 8.1, Windows 8.1, and Windows Server 2012 R2](https://support.microsoft.com/kb/3000850) from the Microsoft Support library.
-Before you use this cmdlet, review the information in What's New in Windows PowerShellhttp://technet.microsoft.com/library/hh857339.aspx (http://technet.microsoft.com/library/hh857339.aspx) in the TechNet library.
+The `Stop-DscConfiguration` cmdlet stops a configuration job that is running. Specify which
+computers this cmdlet applies to by using Common Information Model (CIM) sessions. If there's no
+configuration job running, this cmdlet returns a warning message.
 
-This cmdlet does not support the *Confirm* parameter.
+`Stop-DscConfiguration` is only available as part of the
+[November 2014 update rollup for Windows RT 8.1, Windows 8.1, and Windows Server 2012 R2](https://support.microsoft.com/kb/3000850)
+from the Microsoft Support library. Before you use this cmdlet, review the information in
+[What's New in Windows PowerShell 5.0](../../docs-conceptual/whats-new/What-s-New-in-Windows-PowerShell-50.md)
 
 ## EXAMPLES
 
 ### Example 1: Stop a configuration job
-```
-PS C:\> $Session = New-CimSession -ComputerName "Server01" -Credential ACCOUNTS\PattiFuller
-PS C:\> Stop-DscConfiguration -CimSession $Session
+
+In this example, a CIM session is created using the `New-CimSession` cmdlet. The **CimSession**
+object is used to stop a running configuration job.
+
+```powershell
+$Session = New-CimSession -ComputerName Server01 -Credential ACCOUNTS\User01
+Stop-DscConfiguration -CimSession $Session
 ```
 
-The first command creates a CIM session by using the **New-CimSession** cmdlet, and then stores the **CimSession** object in the $Session variable.
-The command prompts you for a password.
-For more information, type `Get-Help New-CimSession`.
+`New-CimSession` uses the **ComputerName** parameter to specify the Server01 computer. The
+**Credential** parameter specifies the user account. The **CimSession** object is stored in the
+`$Session` variable. When the command is run, you're prompted for the user account's password.
 
-The second command stops a currently running configuration job on the computer identified by the **CimSession** object stored in $Session.
+`Stop-DscConfiguration` uses the **CimSession** parameter and the object stored in `$Session` to
+stop the configuration job.
 
 ## PARAMETERS
 
 ### -AsJob
-Indicates that this cmdlet runs the command as a background job.
+
+Indicates that this cmdlet runs the command as a background job. For more information about
+PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and
+[about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
+
+To use the **AsJob** parameter, the local and remote computers must be configured for remoting. On
+Windows Vista and later versions of the Windows operating system, you must open PowerShell with the
+**Run as administrator** option. For more information, see
+[about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 ```yaml
 Type: SwitchParameter
@@ -57,14 +73,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -CimSession
-Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a **New-CimSession** or **Get-CimSession** cmdlet.
+
+Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session
+object, such as the output from `New-CimSession` or `Get-CimSession`.
 
 ```yaml
 Type: CimSession[]
@@ -78,38 +95,13 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Force
-Forces the command to run without asking for user confirmation.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ThrottleLimit
-Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.
+
+`Stop-DscConfiguration` doesn't support the **Confirm** parameter. If the **Confirm** parameter is
+used, an error is displayed.
+
+For PowerShell cmdlets that support **Confirm**, using the parameter prompts you for verification
+before a command is run.
 
 ```yaml
 Type: SwitchParameter
@@ -123,9 +115,45 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Force
+
+Forces the command to run without asking for user confirmation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ThrottleLimit
+
+Specifies the maximum number of concurrent operations that can be established to run the cmdlet.
+
+If this parameter is omitted or a value of `0` is entered, PowerShell calculates an optimum throttle
+limit based on the number of CIM cmdlets that are running on the computer. The throttle limit
+applies only to the current cmdlet, not to the session or to the computer.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -140,7 +168,10 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -154,11 +185,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Windows PowerShell Desired State Configuration Overview](http://go.microsoft.com/fwlink/?LinkID=311940)
+[Get-CimSession](../CimCmdlets/Get-CimSession.md)
 
 [Get-DscConfiguration](Get-DscConfiguration.md)
 
 [Get-DscConfigurationStatus](Get-DscConfigurationStatus.md)
+
+[New-CimSession](../CimCmdlets/New-CimSession.md)
 
 [Restore-DscConfiguration](Restore-DscConfiguration.md)
 
@@ -167,3 +200,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Test-DscConfiguration](Test-DscConfiguration.md)
 
 [Update-DscConfiguration](Update-DscConfiguration.md)
+
+[Windows PowerShell Desired State Configuration Overview](/powershell/dsc/overview/overview)

--- a/reference/6/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/About_Using.md
@@ -12,19 +12,21 @@ Allows to indicate which namespaces are used in the session.
 
 ## LONG DESCRIPTION
 
-The `using` statement allows to indicate which namespaces are used in the
-session. Making easier to mention classes and members, as it requires less
-typing to mention them; also, classes from modules can be referenced too.
+The `using` statement allows you to specify which namespaces are used in the
+session. Adding namespaces simplifies usage of .NET classes and member and
+allows you to import classes from modules.
 
 The `using` statement needs to be the first statement in the script.
 
-Syntax #1, to reference .Net Framework namespaces:
+### Syntax
+
+To reference .NET Framework namespaces:
 
 ```
-using namespace <.Net-framework-namespace>
+using namespace <.NET-framework-namespace>
 ```
 
-Syntax #2, to reference PowerShell modules:
+To reference PowerShell modules:
 
 ```
 using module <module-name>
@@ -37,7 +39,7 @@ using module <module-name>
 > module. If the module isn't loaded in the current session, the `using`
 > statement fails.
 
-## Examples
+### Examples
 
 The following script gets the cryptographic hash for the "Hello World" string.
 

--- a/reference/6/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/About_Using.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  12/01/2017
+ms.date:  08/15/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -30,16 +30,20 @@ Syntax #2, to reference PowerShell modules:
 using module <module-name>
 ```
 
-**Note**: The `using` statement, for modules, is intended to surface the
-classes in the module. If the module isn't loaded, the `using` fails.
+> [!NOTE]
+> `Import-Module` and the `#requires` statement only import the module
+> functions, aliases, and variables, as defined by the module. Classes are not
+> imported. The `using module` statement imports the classes defined in the
+> module. If the module isn't loaded in the current session, the `using`
+> statement fails.
 
 ## Examples
 
 The following script gets the cryptographic hash for the "Hello World" string.
 
 Note how the `using namespace System.Text` and `using namespace System.IO`
-simplify the references to `[UnicodeEncoding]` in *System.Text*; and, to
-`[Stream]` and to `[MemoryStream]` in *System.IO*.
+simplify the references to `[UnicodeEncoding]` in *System.Text* and `[Stream]`
+and to `[MemoryStream]` in *System.IO*.
 
 ```powershell
 using namespace System.Text
@@ -62,8 +66,8 @@ automatically.
 
 The following classes are defined in the module:
 
-- *Deck*
-- *Card*
+- **Deck**
+- **Card**
 
 ```powershell
 using module CardGames

--- a/reference/6/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/About_Using.md
@@ -42,8 +42,8 @@ using module <module-name>
 The following script gets the cryptographic hash for the "Hello World" string.
 
 Note how the `using namespace System.Text` and `using namespace System.IO`
-simplify the references to `[UnicodeEncoding]` in *System.Text* and `[Stream]`
-and to `[MemoryStream]` in *System.IO*.
+simplify the references to `[UnicodeEncoding]` in `System.Text` and `[Stream]`
+and to `[MemoryStream]` in `System.IO`.
 
 ```powershell
 using namespace System.Text

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -229,7 +229,7 @@ Devices   : {$null, $null, Microsoft|Surface Pro 4|5072641000, $null...}
 
 ## Output in class methods
 
-Methods should have a return type defined. If a method does not return output,
+Methods should have a return type defined. If a method doesn't return output,
 then the output type should be `[void]`.
 
 In class methods, no objects get sent to the pipeline except those mentioned in
@@ -340,7 +340,7 @@ Microsoft Surface Pro 4 5072641000
 In this example, the **Device** class is defined with properties, a default
 constructor, and a constructor to initialize the instance.
 
-The default constructor sets the **brand** to *Undefined*, and leaves **model**
+The default constructor sets the **brand** to **Undefined**, and leaves **model**
 and **vendor-sku** with null values.
 
 ```powershell
@@ -389,7 +389,7 @@ class definition.
 ### Example using hidden attributes
 
 When a **Rack** object is created, the number of slots for devices is a fixed
-value that should not be changed at any time. This value is known at creation
+value that shouldn't be changed at any time. This value is known at creation
 time.
 
 Using the hidden attribute allows the developer to keep the number of slots
@@ -711,7 +711,7 @@ Model               : Fbk5040
 
 ## Calling base class constructors
 
-To invoke a base class constructor from a subclass, add the "base" keyword.
+To invoke a base class constructor from a subclass, add the `base` keyword.
 
 ```powershell
 class Person {
@@ -792,7 +792,7 @@ class ChildClass1 : BaseClass
 ## Interfaces
 
 The syntax for declaring interfaces is similar to C#. You can declare
-interfaces after base types or immediately after a colon (:) when there is no
+interfaces after base types or immediately after a colon (`:`) when there is no
 base type specified. Separate all type names with commas.
 
 ```powershell

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  08/31/2018
+ms.date:  08/15/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -8,34 +8,33 @@ description:  Describes how you can use classes to create your own custom types.
 ---
 # About Classes
 
-## SHORT DESCRIPTION
+## Short description
 Describes how you can use classes to create your own custom types.
 
-## LONG DESCRIPTION
+## Long description
 
 PowerShell 5.0 adds a formal syntax to define classes and other user-defined
 types. The addition of classes enables developers and IT professionals to
-embrace PowerShell for a wider range of use cases. It simplifies development
-of PowerShell artifacts and accelerates coverage of management surfaces.
+embrace PowerShell for a wider range of use cases. It simplifies development of
+PowerShell artifacts and accelerates coverage of management surfaces.
 
-A class declaration is like a blueprint used to create instances of objects at
-run time. When you define a class, the class name is the name of the type. For
+A class declaration is a blueprint used to create instances of objects at run
+time. When you define a class, the class name is the name of the type. For
 example, if you declare a class named **Device** and initialize a variable
 `$dev` to a new instance of **Device**, `$dev` is an object or instance of type
 **Device**. Each instance of **Device** can have different values in its
 properties.
 
-## SUPPORTED SCENARIOS
+## Supported scenarios
 
-- Define custom types in PowerShell using familiar object-oriented
-  programming semantics like classes, properties, methods, inheritance,
-  etc.
+- Define custom types in PowerShell using familiar object-oriented programming
+  semantics like classes, properties, methods, inheritance, etc.
 - Debug types using the PowerShell language.
 - Generate and handle exceptions using formal mechanisms.
 - Define DSC resources and their associated types by using the PowerShell
   language.
 
-## SYNTAX
+## Syntax
 
 Classes are declared using the following syntax:
 
@@ -60,9 +59,8 @@ Classes are instantiated using either of the following syntaxes:
 ```
 
 > [!NOTE]
-> When using the `[<class-name>]::new(` syntax,
-> brackets around the class name are mandatory!
-> The brackets signal a type definition for PowerShell.
+> When using the `[<class-name>]::new(` syntax, brackets around the class name
+> are mandatory. The brackets signal a type definition for PowerShell.
 
 ### Example syntax and usage
 
@@ -78,17 +76,17 @@ $dev.Brand = "Microsoft"
 $dev
 ```
 
-```output
+```Output
 Brand
 -----
 Microsoft
 ```
 
-## CLASS PROPERTIES
+## Class properties
 
-Properties are variables declared at class scope.
-A property may be of any built-in type or an instance of another class.
-Classes have no restriction in the number of properties they have.
+Properties are variables declared at class scope. A property may be of any
+built-in type or an instance of another class. Classes have no restriction in
+the number of properties they have.
 
 ### Example class with simple properties
 
@@ -107,20 +105,17 @@ $device.VendorSku = "5072641000"
 $device
 ```
 
-```output
-
-
+```Output
 Brand     Model         VendorSku
 -----     -----         ---------
 Microsoft Surface Pro 4 5072641000
-
 ```
 
 ### Example complex types in class properties
 
-This example defines an empty **Rack** class using the **Device** class.
-The examples, following this one, show how to add devices to the rack
-and how to start with a pre-loaded rack.
+This example defines an empty **Rack** class using the **Device** class. The
+examples, following this one, show how to add devices to the rack and how to
+start with a pre-loaded rack.
 
 ```powershell
 class Device {
@@ -143,7 +138,7 @@ $rack = [Rack]::new()
 $rack
 ```
 
-```output
+```Output
 
 Brand     :
 Model     :
@@ -154,12 +149,11 @@ Devices   : {$null, $null, $null, $null...}
 
 ```
 
-## CLASS METHODS
+## Class methods
 
-Methods define the actions that a class can perform.
-Methods may take parameters that provide input data.
-Methods can return output.
-Data returned by a method can be any defined data type.
+Methods define the actions that a class can perform. Methods may take
+parameters that provide input data. Methods can return output. Data returned by
+a method can be any defined data type.
 
 ### Example simple class with properties and methods
 
@@ -214,7 +208,7 @@ $rack
 $rack.GetAvailableSlots()
 ```
 
-```output
+```Output
 
 Slots     : 8
 Brand     :
@@ -233,23 +227,23 @@ Devices   : {$null, $null, Microsoft|Surface Pro 4|5072641000, $null...}
 
 ```
 
-## OUTPUT IN CLASS METHODS
+## Output in class methods
 
-Methods should have a return type defined. If a method does not
-return output, then the output type should be `[void]`.
+Methods should have a return type defined. If a method does not return output,
+then the output type should be `[void]`.
 
-In class methods, no objects get sent to the pipeline except those mentioned
-in the `return` statement. There's no accidental output to the pipeline
-from the code.
+In class methods, no objects get sent to the pipeline except those mentioned in
+the `return` statement. There's no accidental output to the pipeline from the
+code.
 
 > [!NOTE]
-> This is fundamentally different from how PowerShell functions
-> handle output, where everything goes to the pipeline.
+> This is fundamentally different from how PowerShell functions handle output,
+> where everything goes to the pipeline.
 
 ### Method output
 
-This example demonstrates no accidental output to the pipeline from
-class methods, except on the `return` statement.
+This example demonstrates no accidental output to the pipeline from class
+methods, except on the `return` statement.
 
 ```powershell
 class FunWithIntegers
@@ -283,7 +277,7 @@ $ints.GetEvenIntegers()
 $ints.SayHello()
 ```
 
-```output
+```Output
 1
 3
 5
@@ -293,25 +287,25 @@ Hello World
 
 ```
 
-## CONSTRUCTOR
+## Constructor
 
 Constructors enable you to set default values and validate object logic at the
 moment of creating the instance of the class. Constructors have the same name
-as the class. Constructors might have arguments, to initialize the data
-members of the new object.
+as the class. Constructors might have arguments, to initialize the data members
+of the new object.
 
 The class can have zero or more constructors defined. If no constructor is
 defined, the class is given a default parameterless constructor. This
 constructor initializes all members to their default values. Object types and
 strings are given null values. When you define constructor, no default
-parameterless constructor is created. Create a parameterless constructor if
-one is needed.
+parameterless constructor is created. Create a parameterless constructor if one
+is needed.
 
 ### Constructor basic syntax
 
-In this example, the Device class is defined with properties and a
-constructor. To use this class, the user is required to provide values for the
-parameters listed in the constructor.
+In this example, the Device class is defined with properties and a constructor.
+To use this class, the user is required to provide values for the parameters
+listed in the constructor.
 
 ```powershell
 class Device {
@@ -335,11 +329,10 @@ class Device {
 $surface
 ```
 
-```output
+```Output
 Brand     Model         VendorSku
 -----     -----         ---------
 Microsoft Surface Pro 4 5072641000
-
 ```
 
 ### Example with multiple constructors
@@ -347,8 +340,8 @@ Microsoft Surface Pro 4 5072641000
 In this example, the **Device** class is defined with properties, a default
 constructor, and a constructor to initialize the instance.
 
-The default constructor sets the **brand** to *Undefined*,
-and leaves **model** and **vendor-sku** with null values.
+The default constructor sets the **brand** to *Undefined*, and leaves **model**
+and **vendor-sku** with null values.
 
 ```powershell
 class Device {
@@ -378,26 +371,26 @@ $somedevice
 $surface
 ```
 
-```output
+```Output
 Brand       Model           VendorSku
 -----       -----           ---------
 Undefined
 Microsoft   Surface Pro 4   5072641000
 ```
 
-## HIDDEN ATTRIBUTE
+## Hidden attribute
 
-The `hidden` attribute makes a property or method less visible. The property
-or method is still accessible to the user and is available in all scopes in
-which the object is available. Hidden members are hidden from the `Get-Member`
-cmdlet and can't be displayed using tab completion or IntelliSense outside of
-the class definition.
+The `hidden` attribute makes a property or method less visible. The property or
+method is still accessible to the user and is available in all scopes in which
+the object is available. Hidden members are hidden from the `Get-Member` cmdlet
+and can't be displayed using tab completion or IntelliSense outside of the
+class definition.
 
 ### Example using hidden attributes
 
-When a **Rack** object is created, the number of slots for devices is a
-fixed value that should not be changed at any time. This value is known at
-creation time.
+When a **Rack** object is created, the number of slots for devices is a fixed
+value that should not be changed at any time. This value is known at creation
+time.
 
 Using the hidden attribute allows the developer to keep the number of slots
 hidden and prevents unintentional changes the size of the rack.
@@ -433,33 +426,30 @@ $r1.Devices.Length
 $r1.Slots
 ```
 
-```output
-
+```Output
 Brand     Model         Devices
 -----     -----         -------
 Microsoft Surface Pro 4 {$null, $null, $null, $null...}
 16
 16
-
 ```
 
-Notice **Slots** property isn't shown in `$r1` output. However, the size
-was changed by the constructor.
+Notice **Slots** property isn't shown in `$r1` output. However, the size was
+changed by the constructor.
 
-## STATIC ATTRIBUTE
+## Static attribute
 
 The `static` attribute defines a property or a method that exists in the class
 and needs no instance.
 
-A static property is always available, independent of class instantiation.
-A static property is shared across all instances of the class.
-A static method is available always.
-All static properties live for the entire session span.
+A static property is always available, independent of class instantiation. A
+static property is shared across all instances of the class. A static method is
+available always. All static properties live for the entire session span.
 
 ### Example using static attributes and methods
 
-Assume the racks instantiated here exist in your data center.
-So, you would like to keep track of the racks in your code.
+Assume the racks instantiated here exist in your data center. So, you would
+like to keep track of the racks in your code.
 
 ```powershell
 class Device {
@@ -498,7 +488,7 @@ class Rack {
 }
 ```
 
-#### Testing static property and method exist
+### Testing static property and method exist
 
 ```
 PS> [Rack]::InstalledRacks.Length
@@ -534,7 +524,7 @@ WARNING: Turning off rack: Std0010
 
 Notice that the number of racks increases each time you run this example.
 
-## PROPERTY VALIDATION ATTRIBUTES
+## Property validation attributes
 
 Validation attributes allow you to test that values given to properties meet
 defined requirements. Validation is triggered the moment that the value is
@@ -554,10 +544,9 @@ Write-Output "Testing dev"
 $dev
 
 $dev.Brand = ""
-
 ```
 
-```output
+```Output
 Testing dev
 
 Brand Model
@@ -568,24 +557,22 @@ argument that is not null or empty, and then try the command again."
 At C:\tmp\Untitled-5.ps1:11 char:1
 + $dev.Brand = ""
 + ~~~~~~~~~~~~~~~
-    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationExcep
-tion
+    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationException
     + FullyQualifiedErrorId : ExceptionWhenSetting
 ```
 
-## INHERITANCE IN POWERSHELL CLASSES
+## Inheritance in PowerShell classes
 
 You can extend a class by creating a new class that derives from an existing
-class. The derived class inherits the properties of the base class. You can
-add or override methods and properties as required.
+class. The derived class inherits the properties of the base class. You can add
+or override methods and properties as required.
 
-PowerShell does not support multiple inheritance.
-Classes cannot inherit from more than one class.
-However, you can use interfaces for that purpose.
+PowerShell does not support multiple inheritance. Classes cannot inherit from
+more than one class. However, you can use interfaces for that purpose.
 
-Inheritance implementation is defined by the `:` operator;
-which means to extend this class or implements these interfaces.
-The derived class should always be leftmost in the class declaration.
+Inheritance implementation is defined by the `:` operator; which means to
+extend this class or implements these interfaces. The derived class should
+always be leftmost in the class declaration.
 
 ### Example using simple inheritance syntax
 
@@ -604,18 +591,16 @@ Class Derived : Base.Interface {...}
 
 ### Example of simple inheritance in PowerShell classes
 
-In this example the _Rack_ and _Device_ classes used in the previous examples
-are better defined to: avoid property repetitions, better align common
+In this example the **Rack** and **Device** classes used in the previous
+examples are better defined to: avoid property repetitions, better align common
 properties, and reuse common business logic.
 
-Most objects in the data center are company assets, which makes sense to
-start tracking them as assets.
-Device types are defined by the `DeviceType` enumeration, see
-[about_Enum](about_Enum.md) for details on enumerations.
+Most objects in the data center are company assets, which makes sense to start
+tracking them as assets. Device types are defined by the `DeviceType`
+enumeration, see [about_Enum](about_Enum.md) for details on enumerations.
 
-In our example, we're only defining `Rack` and `ComputeServer`; both
-extensions to the `Device` class.
-
+In our example, we're only defining `Rack` and `ComputeServer`; both extensions
+to the `Device` class.
 
 ```powershell
 enum DeviceType {
@@ -692,12 +677,10 @@ $FirstRack.Location = "F03R02.J10"
   })
 
 $FirstRack
-
 $FirstRack.Devices
 ```
 
-```output
-
+```Output
 Datacenter : PNW
 Location   : F03R02.J10
 Devices    : {r1s000, r1s001, r1s002, r1s003...}
@@ -724,14 +707,11 @@ Hostname            : r1s015
 Status              : Installed
 Brand               : Fabrikam, Inc.
 Model               : Fbk5040
-
 ```
 
-## CALLING BASE CLASS CONSTRUCTORS
+## Calling base class constructors
 
 To invoke a base class constructor from a subclass, add the "base" keyword.
-
-### Example using the base class constructor
 
 ```powershell
 class Person {
@@ -757,12 +737,12 @@ class Child : Person
 $littleone.Age
 ```
 
-```output
+```Output
 
 10
 ```
 
-## INVOKE BASE CLASS METHODS
+## Invoke base class methods
 
 To override existing methods in subclasses, declare methods by using the same
 name and signature.
@@ -780,7 +760,7 @@ class ChildClass1 : BaseClass
 [ChildClass1]::new().days()
 ```
 
-```output
+```Output
 
 2
 ```
@@ -803,17 +783,17 @@ class ChildClass1 : BaseClass
 [ChildClass1]::new().basedays()
 ```
 
-```output
+```Output
 
 2
 1
 ```
 
-## INTERFACES
+## Interfaces
 
-The syntax for declaring interfaces is similar to C#.
-You can declare interfaces after base types or immediately after a colon (:)
-when there is no base type specified. Separate all type names with commas.
+The syntax for declaring interfaces is similar to C#. You can declare
+interfaces after base types or immediately after a colon (:) when there is no
+base type specified. Separate all type names with commas.
 
 ```powershell
 class MyComparable : system.IComparable
@@ -833,8 +813,16 @@ class MyComparableBar : bar, system.IComparable
 }
 ```
 
-## SEE ALSO
+## Importing classes from a PowerShell module
+
+`Import-Module` and the `#requires` statement only import the module functions,
+aliases, and variables, as defined by the module. Classes are not imported. The
+`using module` statement imports the classes defined in the module. If the
+module isn't loaded in the current session, the `using` statement fails.
+
+## See also
 
 - [about_Enum](about_Enum.md)
 - [about_Language_Keywords](about_language_keywords.md)
 - [about_Methods](about_methods.md)
+- [about_Using](about_using.md)

--- a/reference/6/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Import-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 03/28/2019
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096177
 schema: 2.0.0
 title: Import-Module
@@ -17,139 +17,170 @@ Adds modules to the current session.
 ## SYNTAX
 
 ### Name (Default)
+
 ```
-Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
- [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject]
- [-MinimumVersion <Version>] [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>]
- [-DisableNameChecking] [-NoClobber] [-Scope <String>] [<CommonParameters>]
+Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>]
+ [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck]
+ [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>] [-MaximumVersion <String>]
+ [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber]
+ [-Scope <String>]  [<CommonParameters>]
 ```
 
 ### PSSession
+
 ```
-Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
- [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject]
- [-MinimumVersion <Version>] [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>]
- [-DisableNameChecking] [-NoClobber] [-Scope <String>] -PSSession <PSSession> [<CommonParameters>]
+Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>]
+ [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck]
+ [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>] [-MaximumVersion <String>]
+ [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber]
+ [-Scope <String>] -PSSession <PSSession>  [<CommonParameters>]
 ```
 
 ### CimSession
-```
-Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
- [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject]
- [-MinimumVersion <Version>] [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>]
- [-DisableNameChecking] [-NoClobber] [-Scope <String>] -CimSession <CimSession> [-CimResourceUri <Uri>]
- [-CimNamespace <String>] [<CommonParameters>]
-```
 
-### FullyQualifiedName
 ```
-Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]> [-Function <String[]>]
- [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru]
- [-AsCustomObject] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>]
+Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>]
+ [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck]
+ [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>] [-MaximumVersion <String>]
+ [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber]
+ [-Scope <String>] -CimSession <CimSession> [-CimResourceUri <Uri>] [-CimNamespace <String>]
  [<CommonParameters>]
 ```
 
-### FullyQualifiedNameAndPSSession
+### FullyQualifiedName
+
 ```
-Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]> [-Function <String[]>]
- [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru]
- [-AsCustomObject] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>]
- -PSSession <PSSession> [<CommonParameters>]
+Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]>
+ [-Function <String[]>] [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force]
+ [-SkipEditionCheck] [-PassThru] [-AsCustomObject] [-ArgumentList <Object[]>] [-DisableNameChecking]
+ [-NoClobber] [-Scope <String>]  [<CommonParameters>]
+```
+
+### FullyQualifiedNameAndPSSession
+
+```
+Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]>
+ [-Function <String[]>] [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force]
+ [-SkipEditionCheck] [-PassThru] [-AsCustomObject] [-ArgumentList <Object[]>] [-DisableNameChecking]
+ [-NoClobber] [-Scope <String>] -PSSession <PSSession>  [<CommonParameters>]
 ```
 
 ### Assembly
+
 ```
-Import-Module [-Global] [-Prefix <String>] [-Assembly] <Assembly[]> [-Function <String[]>] [-Cmdlet <String[]>]
- [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject]
- [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>] [<CommonParameters>]
+Import-Module [-Global] [-Prefix <String>] [-Assembly] <Assembly[]> [-Function <String[]>]
+ [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck]
+ [-PassThru] [-AsCustomObject] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber]
+ [-Scope <String>]  [<CommonParameters>]
 ```
 
 ### ModuleInfo
+
 ```
-Import-Module [-Global] [-Prefix <String>] [-Function <String[]>] [-Cmdlet <String[]>] [-Variable <String[]>]
- [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject] [-ModuleInfo] <PSModuleInfo[]>
- [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>] [<CommonParameters>]
+Import-Module [-Global] [-Prefix <String>] [-Function <String[]>] [-Cmdlet <String[]>]
+ [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru]
+ [-AsCustomObject] [-ModuleInfo] <PSModuleInfo[]> [-ArgumentList <Object[]>] [-DisableNameChecking]
+ [-NoClobber] [-Scope <String>]  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The **Import-Module** cmdlet adds one or more modules to the current session.
-The modules that you import must be installed on the local computer or a remote computer.
+The `Import-Module` cmdlet adds one or more modules to the current session. The modules that you
+import must be installed on the local computer or a remote computer.
 
-Starting in Windows PowerShell 3.0, installed modules are automatically imported to the session when you use any commands or providers in the module.
-However, you can still use the **Import-Module** command to import a module and you can enable and disable automatic module importing by using the $PSModuleAutoloadingPreference preference variable.
-For more information about modules, see [about_Modules](About/about_Modules.md).
-For more information about the $PSModuleAutoloadingPreference variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
+Starting in Windows PowerShell 3.0, installed modules are automatically imported to the session when
+you use any commands or providers in the module. However, you can still use the `Import-Module`
+command to import a module and you can enable and disable automatic module importing by using the
+`$PSModuleAutoloadingPreference` preference variable. For more information about modules, see
+[about_Modules](About/about_Modules.md). For more information about the
+`$PSModuleAutoloadingPreference` variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
 
-A module is a package that contains members that can be used in PowerShell.
-Members include cmdlets, providers, scripts, functions, variables, and other tools and files.
-After a module is imported, you can use the module members in your session.
+A module is a package that contains members that can be used in PowerShell. Members include cmdlets,
+providers, scripts, functions, variables, and other tools and files. After a module is imported, you
+can use the module members in your session.
 
-To import a module, use the *Name*, *Assembly*, *ModuleInfo*, *MinimumVersion* and *RequiredVersion* parameters to identify the module to import.
-By default, **Import-Module** imports all members that the module exports, but you can use the *Alias*, *Function*, *Cmdlet*, and *Variable* parameters to restrict the members that are imported.
-You can also use the *NoClobber* parameter to prevent **Import-Module** from importing members that have the same names as members in the current session.
+To import a module, use the **Name**, **Assembly**, **ModuleInfo**, **MinimumVersion** and
+**RequiredVersion** parameters to identify the module to import. By default, `Import-Module` imports
+all members that the module exports, but you can use the **Alias**, **Function**, **Cmdlet**, and
+**Variable** parameters to restrict the members that are imported. You can also use the
+**NoClobber** parameter to prevent `Import-Module` from importing members that have the same names
+as members in the current session.
 
-**Import-Module** imports a module only into the current session.
-To import the module into all sessions, add an **Import-Module** command to your PowerShell profile.
-For more information about profiles, see [about_Profiles](About/about_Profiles.md).
+`Import-Module` imports a module only into the current session. To import the module into all
+sessions, add an `Import-Module` command to your PowerShell profile. For more information about
+profiles, see [about_Profiles](About/about_Profiles.md).
 
-Starting in Windows PowerShell 3.0, you can use **Import-Module** to import Common Information Model (CIM) modules, in which the cmdlets are defined in Cmdlet Definition XML (CDXML) files.
-This feature allows you to use cmdlets that are implemented in non-managed code assemblies, such as those written in C++.
+Starting in Windows PowerShell 3.0, you can use `Import-Module` to import Common Information Model
+(CIM) modules, in which the cmdlets are defined in Cmdlet Definition XML (CDXML) files. This feature
+allows you to use cmdlets that are implemented in non-managed code assemblies, such as those written
+in C++.
 
-With these new features, **Import-Module** cmdlet becomes a primary tool for managing heterogeneous enterprises that include computers that run the Windows operating system and computers that are running other operating systems.
+With these new features, `Import-Module` cmdlet becomes a primary tool for managing heterogeneous
+enterprises that include computers that run the Windows operating system and computers that are
+running other operating systems.
 
-To manage remote computers that run the Windows operating system that have PowerShell and PowerShell remoting enabled, create a **PSSession** on the remote computer and then use the *PSSession* parameter of **Get-Module** to get the PowerShell modules in the **PSSession**.
-When you import the modules, and then use the imported commands in the current session, the commands run implicitly in the **PSSession** on the remote computer.
-You can use this strategy to manage the remote computer.
+To manage remote computers that run the Windows operating system that have PowerShell and PowerShell
+remoting enabled, create a **PSSession** on the remote computer and then use the **PSSession**
+parameter of `Get-Module` to get the PowerShell modules in the **PSSession**. When you import the
+modules, and then use the imported commands in the current session, the commands run implicitly in
+the **PSSession** on the remote computer. You can use this strategy to manage the remote computer.
 
-You can use a similar strategy to manage computers that do not have PowerShell remoting enabled, including computers that are not running the Windows operating system, and Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
+You can use a similar strategy to manage computers that do not have PowerShell remoting enabled,
+including computers that are not running the Windows operating system, and Windows computers that
+have PowerShell, but do not have PowerShell remoting enabled.
 
-Start by creating a CIM session on the remote computer, which is a connection to Windows Management Instrumentation (WMI) on the remote computer.
-Then use the *CIMSession* parameter of **Import-Module** to import CIM modules from the remote computer.
-When you import a CIM module and then run the imported commands, the commands run implicitly on the remote computer.
-You can use this WMI and CIM strategy to manage the remote computer.
+Start by creating a CIM session on the remote computer, which is a connection to Windows Management
+Instrumentation (WMI) on the remote computer. Then use the **CIMSession** parameter of
+`Import-Module` to import CIM modules from the remote computer. When you import a CIM module and
+then run the imported commands, the commands run implicitly on the remote computer. You can use this
+WMI and CIM strategy to manage the remote computer.
 
 ## EXAMPLES
 
 ### Example 1: Import the members of a module into the current session
 
+This example imports the members of the **PSDiagnostics** module into the current session. The
+**Name** parameter name is optional and can be omitted.
+
 ```powershell
-Import-Module -Name BitsTransfer
+Import-Module -Name PSDiagnostics
 ```
 
-This command imports the members of the **BitsTransfer** module into the current session.
-
-The *Name* parameter name is optional and can be omitted.
-
-By default, **Import-Module** does not generate any output when it imports a module.
-To request output, use the *PassThru* or *AsCustomObject* parameter, or the *Verbose* common parameter.
+By default, `Import-Module` does not generate any output when it imports a module. To request
+output, use the **PassThru** or **AsCustomObject** parameter, or the **Verbose** common parameter.
 
 ### Example 2: Import all modules specified by the module path
+
+This example imports all available modules in the path specified by the `$env:PSModulePath`
+environment variable into the current session.
 
 ```powershell
 Get-Module -ListAvailable | Import-Module
 ```
 
-This command imports all available modules in the path specified by the PSModulePath environment variable ($env:PSModulePath) into the current session.
-
 ### Example 3: Import the members of several modules into the current session
 
+This example imports the members of the **BitsTransfer** and **Dism** modules into the
+current session.
+
 ```powershell
-$m = Get-Module -ListAvailable BitsTransfer, ServerManager
+$m = Get-Module -ListAvailable PSDiagnostics, Dism
 Import-Module -ModuleInfo $m
 ```
 
-These commands import the members of the **BitsTransfer** and **ServerManager** modules into the current session.
+The `Get-Module` cmdlet gets the **PSDiagnostics** and **Dism** modules and saves the
+objects in the `$m` variable. The **ListAvailable** parameter is required when you are getting
+modules that are not yet imported into the session.
 
-The first command uses the Get-Module cmdlet to get the **BitsTransfer** and **ServerManager** modules.
-It saves the objects in the $m variable.
-The *ListAvailable* parameter is required when you are getting modules that are not yet imported into the session.
+The **ModuleInfo** parameter of `Import-Module` is used to import the modules into the current
+session.
 
-The second command uses the *ModuleInfo* parameter of **Import-Module** to import the modules into the current session.
-
-These commands are equivalent to using a pipeline operator (|) to send the output of a **Get-Module** command to **Import-Module**.
+These commands are equivalent to using a pipeline operator (|) to send the output of a `Get-Module`
+command to `Import-Module`.
 
 ### Example 4: Import all modules specified by a path
+
+This example uses an explicit path to identify the module to import.
 
 ```powershell
 Import-Module -Name c:\ps-test\modules\test -Verbose
@@ -163,104 +194,115 @@ VERBOSE: Exporting function 'Get-Specification'.
 VERBOSE: Exporting function 'Get-SpecDetails'.
 ```
 
-This command uses an explicit path to identify the module to import.
-
-It also uses the *Verbose* common parameter to get a list of the items imported from the module.
-Without the *Verbose*, *PassThru*, or *AsCustomObject* parameter, **Import-Module** does not generate any output when it imports a module.
+Using the **Verbose** parameter causes `Import-Module` to report progress as it loads the module.
+Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, `Import-Module` does not
+generate any output when it imports a module.
 
 ### Example 5: Restrict module members imported into a session
 
+This example shows how to restrict which module members are imported into the session and the effect
+of this command on the session.
+
 ```powershell
-Import-Module BitsTransfer -Cmdlet Add-BitsFile, Get-BitsTransfer
-(Get-Module BitsTransfer).ExportedCmdlets
+Import-Module PSDiagnostics -Function Disable-PSTrace, Enable-PSTrace
+(Get-Module PSDiagnostics).ExportedCommands
 ```
 
 ```Output
-Key                   Value
----                   -----
-Add-BitsFile          Add-BitsFile
-Complete-BitsTransfer Complete-BitsTransfer
-Get-BitsTransfer      Get-BitsTransfer
-Remove-BitsTransfer   Remove-BitsTransfer
-Resume-BitsTransfer   Resume-BitsTransfer
-Set-BitsTransfer      Set-BitsTransfer
-Start-BitsTransfer    Start-BitsTransfer
-Suspend-BitsTransfer  Suspend-BitsTransfer
+Key                          Value
+---                          -----
+Disable-PSTrace              Disable-PSTrace
+Disable-PSWSManCombinedTrace Disable-PSWSManCombinedTrace
+Disable-WSManTrace           Disable-WSManTrace
+Enable-PSTrace               Enable-PSTrace
+Enable-PSWSManCombinedTrace  Enable-PSWSManCombinedTrace
+Enable-WSManTrace            Enable-WSManTrace
+Get-LogProperties            Get-LogProperties
+Set-LogProperties            Set-LogProperties
+Start-Trace                  Start-Trace
+Stop-Trace                   Stop-Trace
 ```
 
 ```powershell
-Get-Command -Module BitsTransfer
+Get-Command -Module PSDiagnostics
 ```
 
 ```Output
-CommandType Name             Version Source
------------ ----             ------- ------
-Cmdlet      Add-BitsFile     2.0.0.0 BitsTransfer
-Cmdlet      Get-BitsTransfer 2.0.0.0 BitsTransfer
+CommandType     Name                 Version    Source
+-----------     ----                 -------    ------
+Function        Disable-PSTrace      6.1.0.0    PSDiagnostics
+Function        Enable-PSTrace       6.1.0.0    PSDiagnostics
 ```
 
-This example shows how to restrict the module members that are imported into the session and the effect of this command on the session.
+The first command imports only the `Disable-PSTrace` and `Enable-PSTrace` cmdlets from the
+**PSDiagnostics** module. The **Function** parameter limits the members that are imported from the
+module. You can also use the **Alias**, **Variable**, and **Cmdlet** parameters to restrict other
+members that a module imports.
 
-The first command imports only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets from the **BitsTransfer** module.
-The command uses the *Cmdlet* parameter to restrict the cmdlets that the module imports.
-You can also use the *Alias*, *Variable*, and *Function* parameters to restrict other members that a module imports.
+The `Get-Module` cmdlet gets the object that represents the **PSDiagnostics** module. The
+**ExportedCmdlets** property lists all the cmdlets that the module exports, even though they were
+not all imported.
 
-The second command uses the Get-Module cmdlet to get the object that represents the **BitsTransfer** module.
-The **ExportedCmdlets** property lists all of the cmdlets that the module exports, even when they were not all imported.
-
-The third command uses the *Module* parameter of the Get-Command cmdlet to get the commands that were imported from the **BitsTransfer** module.
-The results confirm that only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets were imported.
+In the third command, the **Module** parameter of the `Get-Command` cmdlet gets the commands that
+were imported from the **PSDiagnostics** module. The results confirm that only the `Disable-PSTrace`
+and `Enable-PSTrace` cmdlets were imported.
 
 ### Example 6: Import the members of a module and add a prefix
 
+This example imports the **PSDiagnostics** module into the current session, adds a prefix to the
+member names, and then displays the prefixed member names. The prefix applies only to the members in
+the current session. It does not change the module.
+
 ```powershell
-Import-Module BitsTransfer -Prefix PS -PassThru
+Import-Module PSDiagnostics -Prefix x -PassThru
 ```
 
 ```Output
-ModuleType Name                                ExportedCommands
----------- ----                                ----------------
-Manifest   bitstransfer                        {Add-BitsFile, Complete-...
+ModuleType Version    Name               ExportedCommands
+---------- -------    ----               ----------------
+Script     6.1.0.0    PSDiagnostics      {Disable-xPSTrace, Disable-xPSWSManCombinedTrace, Disable-xW...
 ```
 
 ```powershell
-Get-Command -Module BitsTransfer
+Get-Command -Module PSDiagnostics
 ```
 
 ```Output
-CommandType     Name                                               ModuleName
------------     ----                                               ----------
-Cmdlet          Add-BitsFile                                       bitstransfer
-Cmdlet          Add-PSBitsFile                                     bitstransfer
-Cmdlet          Complete-BitsTransfer                              bitstransfer
-Cmdlet          Complete-PSBitsTransfer                            bitstransfer
-Cmdlet          Get-BitsTransfer                                   bitstransfer
-Cmdlet          Get-PSBitsTransfer                                 bitstransfer
-Cmdlet          Remove-BitsTransfer                                bitstransfer
-Cmdlet          Remove-PSBitsTransfer                              bitstransfer
-Cmdlet          Resume-BitsTransfer                                bitstransfer
-Cmdlet          Resume-PSBitsTransfer                              bitstransfer
-Cmdlet          Set-BitsTransfer                                   bitstransfer
-Cmdlet          Set-PSBitsTransfer                                 bitstransfer
-Cmdlet          Start-BitsTransfer                                 bitstransfer
-Cmdlet          Start-PSBitsTransfer                               bitstransfer
-Cmdlet          Suspend-BitsTransfer                               bitstransfer
-Cmdlet          Suspend-PSBitsTransfer                             bitstransfer
+CommandType     Name                                   Version    Source
+-----------     ----                                   -------    ------
+Function        Disable-xPSTrace                       6.1.0.0    PSDiagnostics
+Function        Disable-xPSWSManCombinedTrace          6.1.0.0    PSDiagnostics
+Function        Disable-xWSManTrace                    6.1.0.0    PSDiagnostics
+Function        Enable-xPSTrace                        6.1.0.0    PSDiagnostics
+Function        Enable-xPSWSManCombinedTrace           6.1.0.0    PSDiagnostics
+Function        Enable-xWSManTrace                     6.1.0.0    PSDiagnostics
+Function        Get-xLogProperties                     6.1.0.0    PSDiagnostics
+Function        Set-xLogProperties                     6.1.0.0    PSDiagnostics
+Function        Start-xTrace                           6.1.0.0    PSDiagnostics
+Function        Stop-xTrace                            6.1.0.0    PSDiagnostics
 ```
 
-These commands import the **BitsTransfer** module into the current session, add a prefix to the member names, and then display the prefixed member names.
+It uses the **Prefix** parameter of `Import-Module` adds the "x" prefix to all members that are
+imported from the module and the **PassThru** parameter to return a module object that represents
+the imported module.
 
-The first command uses the **Import-Module** cmdlet to import the **BitsTransfer** module.
-It uses the *Prefix* parameter to add the PS prefix to all members that are imported from the module and the *PassThru* parameter to return a module object that represents the imported module.
-
-The second command uses the **Get-Command** cmdlet to get the members that have been imported from the module.
-It uses the *Module* parameter to specify the module.
-The output shows that the module members were correctly prefixed.
-
-The prefix that you use applies only to the members in the current session.
-It does not change the module.
+The `Get-Command` cmdlet to get the members that have been imported from the module. The output
+shows that the module members were correctly prefixed.
 
 ### Example 7: Get and use a custom object
+
+These commands demonstrate how to get and use the custom object that **Import-Module** returns.
+
+Custom objects include synthetic members that represent each of the imported module members. For
+example, the cmdlets and functions in a module are converted to script methods of the custom object.
+
+Custom objects are very useful in scripting. They are also useful when several imported objects have
+the same names. Using the script method of an object is equivalent to specifying the fully qualified
+name of an imported member, including its module name.
+
+The **AsCustomObject** parameter can be used only when importing a script module, so the first task
+is to determine which of the available modules is a script module.
+
 
 ```powershell
 Get-Module -List | Format-Table -Property Name, ModuleType -AutoSize
@@ -295,53 +337,50 @@ Show-Calendar ScriptMethod System.Object Show-Calendar();
 $a."Show-Calendar"()
 ```
 
-These commands demonstrate how to get and use the custom object that **Import-Module** returns.
+The first command uses the `Get-Module` cmdlet to get the available modules. The command uses a
+pipeline operator to pass the module objects to the Format-Table cmdlet, which lists the **Name**
+and **ModuleType** of each module in a table.
 
-Custom objects include synthetic members that represent each of the imported module members.
-For example, the cmdlets and functions in a module are converted to script methods of the custom object.
+The second command uses the `Import-Module` cmdlet to import the **Show-Calendar** script module.
+The command uses the **AsCustomObject** parameter to request a custom object and the **PassThru**
+parameter to return the object. The command saves the resulting custom object in the `$a` variable.
 
-Custom objects are very useful in scripting.
-They are also useful when several imported objects have the same names.
-Using the script method of an object is equivalent to specifying the fully qualified name of an imported member, including its module name.
+The third command uses a pipeline operator to send the $a variable to the `Get-Member` cmdlet, which
+gets the properties and methods of the **PSCustomObject** in `$a`. The output shows a
+**Show-Calendar** script method.
 
-The *AsCustomObject* parameter can be used only when importing a script module, so the first task is to determine which of the available modules is a script module.
-
-The first command uses the Get-Module cmdlet to get the available modules.
-The command uses a pipeline operator to pass the module objects to the Format-Table cmdlet, which lists the **Name** and **ModuleType** of each module in a table.
-
-The second command uses the **Import-Module** cmdlet to import the **PSDiagnostics** script module.
-The command uses the *AsCustomObject* parameter to request a custom object and the *PassThru* parameter to return the object.
-The command saves the resulting custom object in the $a variable.
-
-The third command uses a pipeline operator to send the $a variable to the Get-Member cmdlet, which gets the properties and methods of the **PSCustomObject** in $a.
-The output shows a **Show-Calendar** script method.
-
-The last command uses the **Show-Calendar** script method.
-The method name must be enclosed in quotation marks, because it includes a hyphen.
+The last command uses the **Show-Calendar** script method. The method name must be enclosed in
+quotation marks, because it includes a hyphen.
 
 ### Example 8: Re-import a module into the same session
 
+This example shows how to use the **Force** parameter of `Import-Module` when you are re-importing a
+module into the same session.
+
 ```powershell
-Import-Module BitsTransfer
-Import-Module BitsTransfer -Force -Prefix PS
+Import-Module PSDiagnostics
+Import-Module PSDiagnostics -Force -Prefix PS
 ```
 
-This example shows how to use the *Force* parameter of **Import-Module** when you are re-importing a module into the same session.
+The first command imports the **PSDiagnostics** module. The second command imports the module again,
+this time using the **Prefix** parameter.
 
-The first command imports the **BitsTransfer** module.
-The second command imports the module again, this time using the *Prefix* parameter.
-
-The second command also includes the *Force* parameter, which removes the module and then imports it again.
-Without this parameter, the session would include two copies of each **BitsTransfer** cmdlet, one with the standard name and one with the prefixed name.
+Using the **Force** parameter, `Import-Module` removes the module and then imports it again. Without
+this parameter, the session would include two copies of each **PSDiagnostics** cmdlet, one with the
+standard name and one with the prefixed name.
 
 ### Example 9: Run commands that have been hidden by imported commands
+
+This example shows how to run commands that have been hidden by imported commands. The
+**TestModule** module. includes a function named `Get-Date` that returns the year and day of the
+year.
 
 ```powershell
 Get-Date
 ```
 
 ```Output
-Thursday, March 15, 2012 6:47:04 PM
+Thursday, August 15, 2019 2:26:12 PM
 ```
 
 ```powershell
@@ -350,7 +389,7 @@ Get-Date
 ```
 
 ```Output
-12075
+19227
 ```
 
 ```powershell
@@ -369,24 +408,19 @@ Microsoft.PowerShell.Utility\Get-Date
 ```
 
 ```Output
-Saturday, September 12, 2009 6:33:23 PM
+Thursday, August 15, 2019 2:28:31 PM
 ```
 
-This example shows how to run commands that have been hidden by imported commands.
+The first Get-Date` cmdlet returns a **DateTime** object with the current date. After importing the
+**TestModule** module, `Get-Date` returns the year and day of the year.
 
-The first command run the Get-Date cmdlet.
-It returns a **DateTime** object with the current date.
+Using the **All** parameter of the `Get-Command` we get all of the `Get-Date` commands in the
+session. The results show that there are two `Get-Date` commands in the session, a function from the
+**TestModule** module and a cmdlet from the **Microsoft.PowerShell.Utility** module.
 
-The second command imports the **TestModule** module.
-This module includes a function named **Get-Date** that returns the year and day of the year.
-
-The third command runs the **Get-Date** command again.
-Because functions take precedence over cmdlets, the **Get-Date** function from the **TestModule** module runs, instead of the **Get-Date** cmdlet.
-
-The fourth command uses the *All* parameter of the **Get-Command** to get all of the Get-Date commands in the session.
-The results show that there are two **Get-Date** commands in the session, a function from the **TestModule** module and a cmdlet from the **Microsoft.PowerShell.Utility** module.
-
-The fifth command runs the hidden cmdlet by qualifying the command name with the module name.
+Because functions take precedence over cmdlets, the `Get-Date` function from the **TestModule**
+module runs, instead of the `Get-Date` cmdlet. To run the original version of `Get-Date` you must
+qualify the command name with the module name.
 
 For more information about command precedence in PowerShell, see [about_Command_Precedence](about/about_Command_Precedence.md).
 
@@ -396,14 +430,16 @@ For more information about command precedence in PowerShell, see [about_Command_
 Import-Module -Name PSWorkflow -MinimumVersion 3.0.0.0
 ```
 
-This command imports the **PSWorkflow** module.
-It uses the *MinimumVersion* parameter of **Import-Module** to import only version 3.0.0.0 or greater of the module.
+This command imports the **PSWorkflow** module. It uses the **MinimumVersion** parameter of
+`Import-Module` to import only version 3.0.0.0 or greater of the module.
 
-You can also use the *RequiredVersion* parameter to import a particular version of a module, or use the *Module* and *Version* parameters of the **#Requires** keyword to require a particular version of a module in a script.
+You can also use the **RequiredVersion** parameter to import a particular version of a module, or
+use the **Module** and **Version** parameters of the `#Requires` keyword to require a particular
+version of a module in a script.
 
 ### Example 11: Import a module from a remote computer
 
-This example shows how to use the **Import-Module** cmdlet to import a module from a remote computer.
+This example shows how to use the `Import-Module` cmdlet to import a module from a remote computer.
 This command uses the Implicit Remoting feature of PowerShell.
 
 When you import modules from another session, you can use the cmdlets in the current session.
@@ -412,14 +448,20 @@ However, commands that use the cmdlets actually run in the remote session.
 ```powershell
 $s = New-PSSession -ComputerName Server01
 Get-Module -PSSession $s -ListAvailable -Name NetSecurity
+```
 
+```Output
 ModuleType Name                                ExportedCommands
 ---------- ----                                ----------------
 Manifest   NetSecurity                         {New-NetIPsecAuthProposal, New-NetIPsecMainModeCryptoProposal, New-Ne...
+```
 
+```powershell
 Import-Module -PSSession $s -Name NetSecurity
 Get-Command -Module NetSecurity -Name Get-*Firewall*
+```
 
+```Output
 CommandType     Name                                               ModuleName
 -----------     ----                                               ----------
 Function        Get-NetFirewallAddressFilter                       NetSecurity
@@ -432,9 +474,13 @@ Function        Get-NetFirewallRule                                NetSecurity
 Function        Get-NetFirewallSecurityFilter                      NetSecurity
 Function        Get-NetFirewallServiceFilter                       NetSecurity
 Function        Get-NetFirewallSetting                             NetSecurity
+```
 
+```powershell
 Get-NetFirewallRule -DisplayName "Windows Remote Management*" | Format-Table -Property DisplayName, Name -AutoSize
+```
 
+```Output
 DisplayName                                              Name
 -----------                                              ----
 Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP
@@ -442,41 +488,70 @@ Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP-PUBLI
 Windows Remote Management - Compatibility Mode (HTTP-In) WINRM-HTTP-Compat-In-TCP
 ```
 
-The first command uses the New-PSSession cmdlet to create a remote session (**PSSession**) to the Server01 computer. The command saves the **PSSession** in the $s variable.
+The first command uses the `New-PSSession` cmdlet to create a remote session (**PSSession**) to the
+Server01 computer. The command saves the **PSSession** in the `$s` variable.
 
-The second command uses the *PSSession* parameter of the Get-Module cmdlet to get the **NetSecurity** module in the session in the $s variable.This command is equivalent to using the Invoke-Command cmdlet to run a **Get-Module** command in the session in $s ([CODE_Snippit]Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity[CODE_Snippit]).The output shows that the **NetSecurity** module is installed on the computer and is available to the session in the $s variable.
+The second command uses the **PSSession** parameter of the `Get-Module` cmdlet to get the
+**NetSecurity** module in the session in the `$s` variable. This command is equivalent to using the
+`Invoke-Command` cmdlet to run a `Get-Module` command in the session in `$s`
+(`Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity`).The output shows that the
+**NetSecurity** module is installed on the computer and is available to the session in the `$s`
+variable.
 
-The third command uses the *PSSession* parameter of the **Import-Module** cmdlet to import the **NetSecurity** module from the session in the $s variable into the current session.
+The third command uses the **PSSession** parameter of the `Import-Module` cmdlet to import the
+**NetSecurity** module from the session in the `$s` variable into the current session.
 
-The fourth command uses the **Get-Command** cmdlet to get commands that begin with "Get" and include "Firewall" from the Net-Security module.The output gets the commands and confirms that the module and its cmdlets were imported into the current session.
+The fourth command uses the `Get-Command` cmdlet to get commands that begin with "Get" and include
+"Firewall" from the NetSecurity module.The output gets the commands and confirms that the module and
+its cmdlets were imported into the current session.
 
-The fifth command uses the **Get-NetFirewallRule** cmdlet to get Windows Remote Management firewall rules on the Server01 computer. This command is equivalent to using the Invoke-Command cmdlet to run a **Get-NetFirewallRule** command on the session in the `$s` variable.
+The fifth command uses the `Get-NetFirewallRule` cmdlet to get Windows Remote Management firewall
+rules on the Server01 computer. This command is equivalent to using the `Invoke-Command` cmdlet to
+run a `Get-NetFirewallRule` command on the session in the `$s` variable.
 
 ### Example 12: Manage storage on a remote computer without the Windows operating system
 
-In this example, because the administrator of the computer has installed the Module Discovery WMI provider, the CIM commands can use the default values, which are designed for the provider.
+In this example, because the administrator of the computer has installed the Module Discovery WMI
+provider, the CIM commands can use the default values, which are designed for the provider.
 
-The commands in this example enable you to manage the storage systems of a remote computer that is not running the Windows operating system.
+The commands in this example enable you to manage the storage systems of a remote computer that is
+not running the Windows operating system.
 
-The first command uses the **New-CimSession** cmdlet to create a session on the RSDGF03 remote computer. The session connects to WMI on the remote computer. The command saves the CIM session in the $cs variable.
+The first command uses the `New-CimSession` cmdlet to create a session on the RSDGF03 remote
+computer. The session connects to WMI on the remote computer. The command saves the CIM session in
+the `$cs` variable.
 
-The second command uses the CIM session in the $cs variable to run an **Import-Module** command on the RSDGF03 computer. The command uses the *Name* parameter to specify the **Storage** CIM module.
+The second command uses the CIM session in the `$cs` variable to run an `Import-Module` command on
+the RSDGF03 computer. The command uses the **Name** parameter to specify the **Storage** CIM module.
 
-The third command runs the **Get-Command** command on the **Get-Disk** command in the **Storage** module.When you import a CIM module into the local session, PowerShell converts the CDXML files for each command into PowerShell scripts, which appear as functions in the local session.
+The third command runs the `Get-Command` command on the `Get-Disk` command in the **Storage**
+module. When you import a CIM module into the local session, PowerShell converts the CDXML files for
+each command into PowerShell scripts, which appear as functions in the local session.
 
-The fourth command runs the **Get-Disk** command. Although the command is typed in the local session, it runs implicitly on the remote computer from which it was imported.The command gets objects from the remote computer and returns them to the local session.
+The fourth command runs the `Get-Disk` command. Although the command is typed in the local session,
+it runs implicitly on the remote computer from which it was imported.The command gets objects from
+the remote computer and returns them to the local session.
 
 ```powershell
 $cs = New-CimSession -ComputerName RSDGF03
 Import-Module -CimSession $cs -Name Storage
+# Importing a CIM module, converts the CDXML files for each command into PowerShell scripts.
+# These appear as functions in the local session.
 Get-Command Get-Disk
+```
 
+```Output
 CommandType     Name                  ModuleName
 -----------     ----                  ----------
 Function        Get-Disk              Storage
+```
 
+```powershell
+# Use implicit remoting to query disks on the remote computer from which the module was imported.
 Get-Disk
+```
 
+```Output
 Number Friendly Name              OperationalStatus          Total Size Partition Style
 ------ -------------              -----------------          ---------- ---------------
 0      Virtual HD ATA Device      Online                          40 GB MBR
@@ -486,9 +561,8 @@ Number Friendly Name              OperationalStatus          Total Size Partitio
 
 ### -Alias
 
-Specifies the aliases that this cmdlet imports from the module into the current session.
-Enter a comma-separated list of aliases.
-Wildcard characters are permitted.
+Specifies the aliases that this cmdlet imports from the module into the current session. Enter a
+comma-separated list of aliases. Wildcard characters are permitted.
 
 Some modules automatically export selected aliases into your session when you import the module.
 This parameter lets you select from among the exported aliases.
@@ -502,16 +576,16 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -ArgumentList
 
-Specifies an array of arguments, or parameter values, that are passed to a script module during the **Import-Module** command.
-This parameter is valid only when you are importing a script module.
+Specifies an array of arguments, or parameter values, that are passed to a script module during the
+`Import-Module` command. This parameter is valid only when you are importing a script module.
 
-You can also refer to the *ArgumentList* parameter by its alias, *args*.
-For more information, see [about_Aliases](About/about_Aliases.md).
+You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information,
+see [about_Aliases](About/about_Aliases.md).
 
 ```yaml
 Type: Object[]
@@ -527,11 +601,12 @@ Accept wildcard characters: False
 
 ### -AsCustomObject
 
-Indicates that this cmdlet returns a custom object with members that represent the imported module members.
-This parameter is valid only for script modules.
+Indicates that this cmdlet returns a custom object with members that represent the imported module
+members. This parameter is valid only for script modules.
 
-When you use the *AsCustomObject* parameter, **Import-Module** imports the module members into the session and then returns a **PSCustomObject** object instead of a **PSModuleInfo** object.
-You can save the custom object in a variable and use dot notation to invoke the members.
+When you use the **AsCustomObject** parameter, `Import-Module` imports the module members into the
+session and then returns a **PSCustomObject** object instead of a **PSModuleInfo** object. You can
+save the custom object in a variable and use dot notation to invoke the members.
 
 ```yaml
 Type: SwitchParameter
@@ -547,14 +622,14 @@ Accept wildcard characters: False
 
 ### -Assembly
 
-Specifies an array of assembly objects.
-This cmdlet imports the cmdlets and providers implemented in the specified assembly objects.
-Enter a variable that contains assembly objects or a command that creates assembly objects.
-You can also pipe an assembly object to **Import-Module**.
+Specifies an array of assembly objects. This cmdlet imports the cmdlets and providers implemented in
+the specified assembly objects. Enter a variable that contains assembly objects or a command that
+creates assembly objects. You can also pipe an assembly object to `Import-Module`.
 
-When you use this parameter, only the cmdlets and providers implemented by the specified assemblies are imported.
-If the module contains other files, they are not imported, and you might be missing important members of the module.
-Use this parameter for debugging and testing the module, or when you are instructed to use it by the module author.
+When you use this parameter, only the cmdlets and providers implemented by the specified assemblies
+are imported. If the module contains other files, they are not imported, and you might be missing
+important members of the module. Use this parameter for debugging and testing the module, or when
+you are instructed to use it by the module author.
 
 ```yaml
 Type: Assembly[]
@@ -570,10 +645,11 @@ Accept wildcard characters: False
 
 ### -CimNamespace
 
-Specifies the namespace of an alternate CIM provider that exposes CIM modules.
-The default value is the namespace of the Module Discovery WMI provider.
+Specifies the namespace of an alternate CIM provider that exposes CIM modules. The default value is
+the namespace of the Module Discovery WMI provider.
 
-Use this parameter to import CIM modules from computers and devices that are not running a Windows operating system.
+Use this parameter to import CIM modules from computers and devices that are not running a Windows
+operating system.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -591,10 +667,11 @@ Accept wildcard characters: False
 
 ### -CimResourceUri
 
-Specifies an alternate location for CIM modules.
-The default value is the resource URI of the Module Discovery WMI provider on the remote computer.
+Specifies an alternate location for CIM modules. The default value is the resource URI of the Module
+Discovery WMI provider on the remote computer.
 
-Use this parameter to import CIM modules from computers and devices that are not running a Windows operating system.
+Use this parameter to import CIM modules from computers and devices that are not running a Windows
+operating system.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -612,13 +689,17 @@ Accept wildcard characters: False
 
 ### -CimSession
 
-Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](../CimCmdlets/Get-CimSession.md) command.
+Specifies a CIM session on the remote computer. Enter a variable that contains the CIM session or a
+command that gets the CIM session, such as a [Get-CimSession](../CimCmdlets/Get-CimSession.md)
+command.
 
-**Import-Module** uses the CIM session connection to import modules from the remote computer into the current session.
-When you use the commands from the imported module in the current session, the commands actually run on the remote computer.
+`Import-Module` uses the CIM session connection to import modules from the remote computer into the
+current session. When you use the commands from the imported module in the current session, the
+commands actually run on the remote computer.
 
-You can use this parameter to import modules from computers and devices that are not running the Windows operating system, and Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
+You can use this parameter to import modules from computers and devices that are not running the
+Windows operating system, and Windows computers that have PowerShell, but do not have PowerShell
+remoting enabled.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -656,16 +737,19 @@ Accept wildcard characters: False
 
 ### -DisableNameChecking
 
-Indicates that this cmdlet suppresses the message that warns you when you import a cmdlet or function whose name includes an unapproved verb or a prohibited character.
+Indicates that this cmdlet suppresses the message that warns you when you import a cmdlet or
+function whose name includes an unapproved verb or a prohibited character.
 
-By default, when a module that you import exports cmdlets or functions that have unapproved verbs in their names, PowerShell displays the following warning message:
+By default, when a module that you import exports cmdlets or functions that have unapproved verbs in
+their names, PowerShell displays the following warning message:
 
-"WARNING: Some imported command names include unapproved verbs which might make them less discoverable.
-Use the Verbose parameter for more detail or type Get-Verb to see the list of approved verbs."
+> WARNING: Some imported command names include unapproved verbs which might make them less
+> discoverable. Use the Verbose parameter for more detail or type Get-Verb to see the list of
+> approved verbs.
 
-This message is only a warning.
-The complete module is still imported, including the non-conforming commands.
-Although the message is displayed to module users, the naming problem should be fixed by the module author.
+This message is only a warning. The complete module is still imported, including the non-conforming
+commands. Although the message is displayed to module users, the naming problem should be fixed by
+the module author.
 
 ```yaml
 Type: SwitchParameter
@@ -733,15 +817,19 @@ Accept wildcard characters: False
 
 ### -Global
 
-Indicates that this cmdlet imports modules into the global session state so they are available to all commands in the session.
+Indicates that this cmdlet imports modules into the global session state so they are available to
+all commands in the session.
 
-By default, when Import-Module cmdlet is called from the command prompt, script file, or scriptblock, all the commands are imported into the global session state.
+By default, when `Import-Module` cmdlet is called from the command prompt, script file, or
+scriptblock, all the commands are imported into the global session state.
 
-When invoked from another module, Import-Module cmdlet imports the commands in a module, including commands from nested modules, into the caller's session state.
+When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
+commands from nested modules, into the caller's session state.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of Global.
 
-To restrict the commands that a module exports, use an `Export-ModuleMember` command in the script module.
+To restrict the commands that a module exports, use an `Export-ModuleMember` command in the script
+module.
 
 ```yaml
 Type: SwitchParameter
@@ -755,18 +843,35 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -MaximumVersion
+
+Specifies a maximum version. This cmdlet imports only a version of the module that is less than or
+equal to the specified value. If no version qualifies, `Import-Module` generates an error.
+
+```yaml
+Type: String
+Parameter Sets: Name, PSSession, CimSession
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -MinimumVersion
 
-Specifies a minimum version.
-This cmdlet imports only a version of the module that is greater than or equal to the specified value.
-If no version qualifies, **Import-Module** generates an error.
+Specifies a minimum version. This cmdlet imports only a version of the module that is greater than
+or equal to the specified value. If no version qualifies, `Import-Module` generates an error.
 
-By default, **Import-Module** imports the module without checking the version number.
+By default, `Import-Module` imports the module without checking the version number.
 
-Use the *MinimumVersion* parameter name or its alias, Version.
+Use the **MinimumVersion** parameter name or its alias, Version.
 
-To specify an exact version, use the *RequiredVersion* parameter.
-You can also use the *Module* and *Version* parameters of the **#Requires** keyword to require a specific version of a module in a script.
+To specify an exact version, use the **RequiredVersion** parameter. You can also use the **Module**
+and **Version** parameters of the **#Requires** keyword to require a specific version of a module in
+a script.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -784,9 +889,9 @@ Accept wildcard characters: False
 
 ### -ModuleInfo
 
-Specifies an array of module objects to import.
-Enter a variable that contains the module objects, or a command that gets the module objects, such as the following command: `Get-Module -ListAvailable`.
-You can also pipe module objects to **Import-Module**.
+Specifies an array of module objects to import. Enter a variable that contains the module objects,
+or a command that gets the module objects, such as the following command:
+`Get-Module -ListAvailable`. You can also pipe module objects to `Import-Module`.
 
 ```yaml
 Type: PSModuleInfo[]
@@ -802,17 +907,16 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies the names of the modules to import.
-Enter the name of the module or the name of a file in the module, such as a .psd1, .psm1, .dll, or ps1 file.
-File paths are optional.
-Wildcard characters are not permitted.
-You can also pipe module names and file names to **Import-Module**.
+Specifies the names of the modules to import. Enter the name of the module or the name of a file in
+the module, such as a .psd1, .psm1, .dll, or ps1 file. File paths are optional. Wildcard characters
+are not permitted. You can also pipe module names and file names to `Import-Module`.
 
-If you omit a path, **Import-Module** looks for the module in the paths saved in the PSModulePath environment variable ($env:PSModulePath).
+If you omit a path, `Import-Module` looks for the module in the paths saved in the
+`$env:PSModulePath` environment variable.
 
-Specify only the module name whenever possible.
-When you specify a file name, only the members that are implemented in that file are imported.
-If the module contains other files, they are not imported, and you might be missing important members of the module.
+Specify only the module name whenever possible. When you specify a file name, only the members that
+are implemented in that file are imported. If the module contains other files, they are not
+imported, and you might be missing important members of the module.
 
 ```yaml
 Type: String[]
@@ -828,12 +932,13 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Indicates that this cmdlet does not import commands that have the same names as existing commands in the current session.
-By default, **Import-Module** imports all exported module commands.
+Indicates that this cmdlet does not import commands that have the same names as existing commands in
+the current session. By default, `Import-Module` imports all exported module commands.
 
-Commands that have the same names can hide or replace commands in the session.
-To avoid command name conflicts in a session, use the *Prefix* or *NoClobber* parameters.
-For more information about name conflicts and command precedence, see "Modules and Name Conflicts" in about_Modules and about_Command_Precedence.
+Commands that have the same names can hide or replace commands in the session. To avoid command name
+conflicts in a session, use the **Prefix** or **NoClobber** parameters. For more information about
+name conflicts and command precedence, see "Modules and Name Conflicts" in [about_Modules](about/about_Modules.md)
+and [about_Command_Precedence](about/about_Command_Precedence.md).
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -849,38 +954,10 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -PSSession
-
-Specifies a PowerShell user-managed session (**PSSession**) from which this cmdlet import modules into the current session.
-Enter a variable that contains a **PSSession** or a command that gets a **PSSession**, such as a Get-PSSession command.
-
-When you import a module from a different session into the current session, you can use the cmdlets from the module in the current session, just as you would use cmdlets from a local module.
-Commands that use the remote cmdlets actually run in the remote session, but the remoting details are managed in the background by PowerShell.
-
-This parameter uses the Implicit Remoting feature of PowerShell.
-It is equivalent to using the Import-PSSession cmdlet to import particular modules from a session.
-
-**Import-Module** cannot import PowerShell Core modules from another session.
-The PowerShell Core modules have names that begin with Microsoft.PowerShell.
-
-This parameter was introduced in Windows PowerShell 3.0.
-
-```yaml
-Type: PSSession
-Parameter Sets: PSSession, FullyQualifiedNameAndPSSession
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -PassThru
 
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+Returns an object representing the item with which you are working. By default, this cmdlet does not
+generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -898,14 +975,16 @@ Accept wildcard characters: False
 
 Specifies a prefix that this cmdlet adds to the nouns in the names of imported module members.
 
-Use this parameter to avoid name conflicts that might occur when different members in the session have the same name.
-This parameter does not change the module, and it does not affect files that the module imports for its own use.
-These are known as nested modules.
-This cmdlet affects only the names of members in the current session.
+Use this parameter to avoid name conflicts that might occur when different members in the session
+have the same name. This parameter does not change the module, and it does not affect files that the
+module imports for its own use. These are known as nested modules. This cmdlet affects only the
+names of members in the current session.
 
-For example, if you specify the prefix UTC and then import a Get-Date cmdlet, the cmdlet is known in the session as **Get-UTCDate**, and it is not confused with the original **Get-Date** cmdlet.
+For example, if you specify the prefix UTC and then import a `Get-Date` cmdlet, the cmdlet is known
+in the session as `Get-UTCDate`, and it is not confused with the original `Get-Date` cmdlet.
 
-The value of this parameter takes precedence over the **DefaultCommandPrefix** property of the module, which specifies the default prefix.
+The value of this parameter takes precedence over the **DefaultCommandPrefix** property of the
+module, which specifies the default prefix.
 
 ```yaml
 Type: String
@@ -919,20 +998,55 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RequiredVersion
+### -PSSession
 
-Specifies a version of the module that this cmdlet imports.
-If the version is not installed, **Import-Module** generates an error.
+Specifies a PowerShell user-managed session (**PSSession**) from which this cmdlet import modules
+into the current session. Enter a variable that contains a **PSSession** or a command that gets a
+**PSSession**, such as a `Get-PSSession` command.
 
-By default, **Import-Module** imports the module without checking the version number.
+When you import a module from a different session into the current session, you can use the cmdlets
+from the module in the current session, just as you would use cmdlets from a local module. Commands
+that use the remote cmdlets actually run in the remote session, but the remoting details are managed
+in the background by PowerShell.
 
-To specify a minimum version, use the *MinimumVersion* parameter.
-You can also use the *Module* and *Version* parameters of the **#Requires** keyword to require a specific version of a module in a script.
+This parameter uses the Implicit Remoting feature of PowerShell. It is equivalent to using the
+`Import-PSSession` cmdlet to import particular modules from a session.
+
+`Import-Module` cannot import PowerShell Core modules from another session. The PowerShell Core
+modules have names that begin with Microsoft.PowerShell.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
-Scripts that use *RequiredVersion* to import modules that are included with existing releases of the Windows operating system do not automatically run in future releases of the Windows operating system.
-This is because PowerShell module version numbers in future releases of the Windows operating system are higher than module version numbers in existing releases of the Windows operating system.
+```yaml
+Type: PSSession
+Parameter Sets: PSSession, FullyQualifiedNameAndPSSession
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequiredVersion
+
+Specifies a version of the module that this cmdlet imports. If the version is not installed,
+`Import-Module` generates an error.
+
+By default, `Import-Module` imports the module without checking the version number.
+
+To specify a minimum version, use the **MinimumVersion** parameter. You can also use the **Module**
+and **Version** parameters of the **#Requires** keyword to require a specific version of a module in
+a script.
+
+This parameter was introduced in Windows PowerShell 3.0.
+
+Scripts that use **RequiredVersion** to import modules that are included with existing releases of
+the Windows operating system do not automatically run in future releases of the Windows operating
+system. This is because PowerShell module version numbers in future releases of the Windows
+operating system are higher than module version numbers in existing releases of the Windows
+operating system.
 
 ```yaml
 Type: Version
@@ -952,14 +1066,17 @@ Specifies a scope into which this cmdlet imports the module.
 
 The acceptable values for this parameter are:
 
-- **Global**. Available to all commands in the session. Equivalent to the *Global* parameter.
+- **Global**. Available to all commands in the session. Equivalent to the **Global** parameter.
 - **Local**. Available only in the current scope.
 
-By default, when Import-Module cmdlet is called from the command prompt, script file, or scriptblock, all the commands are imported into the global session state.
-You can use the **-Scope** parameter with the value of **Local** to import module content into the script or scriptblock scope.
+By default, when `Import-Module` cmdlet is called from the command prompt, script file, or
+scriptblock, all the commands are imported into the global session state. You can use the **-Scope**
+parameter with the value of **Local** to import module content into the script or scriptblock scope.
 
-When invoked from another module, Import-Module cmdlet imports the commands in a module, including commands from nested modules, into the caller's session state.
-Specifying **-Scope Global** or **-Global** indicates that this cmdlet imports modules into the global session state so they are available to all commands in the session.
+When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
+commands from nested modules, into the caller's session state. Specifying **-Scope Global** or
+**-Global** indicates that this cmdlet imports modules into the global session state so they are
+available to all commands in the session.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of Global.
 
@@ -981,8 +1098,7 @@ Accept wildcard characters: False
 ### -Variable
 
 Specifies an array of variables that this cmdlet imports from the module into the current session.
-Enter a list of variables.
-Wildcard characters are permitted.
+Enter a list of variables. Wildcard characters are permitted.
 
 Some modules automatically export selected variables into your session when you import the module.
 This parameter lets you select from among the exported variables.
@@ -999,35 +1115,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -MaximumVersion
-
-Specifies a maximum version.
-This cmdlet imports only a version of the module that is less than or equal to the specified value.
-If no version qualifies, **Import-Module** generates an error.
-
-```yaml
-Type: String
-Parameter Sets: Name, PSSession, CimSession
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -SkipEditionCheck
 
 Skips the check on the `CompatiblePSEditions` field.
 
-Allows loading a module from the `%windir%\System32\WindowsPowerShell\v1.0\Modules`
-module directory into PowerShell Core when that module does not specify `Core` in the
+Allows loading a module from the `"$($env:windir)\System32\WindowsPowerShell\v1.0\Modules"` module
+directory into PowerShell Core when that module does not specify `Core` in the
 `CompatiblePSEditions` manifest field.
 
-When importing a module from another path, this switch does nothing,
-since the check is not performed.
-On Linux and macOS, this switch does nothing.
+When importing a module from another path, this switch does nothing, since the check is not
+performed. On Linux and macOS, this switch does nothing.
 
 See [about_PowerShell_Editions](About/about_PowerShell_Editions.md) for more information.
 
@@ -1049,7 +1146,9 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -1061,42 +1160,76 @@ You can pipe a module name, module object, or assembly object to this cmdlet.
 
 ### None, System.Management.Automation.PSModuleInfo, or System.Management.Automation.PSCustomObject
 
-This cmdlet returns a **PSModuleInfo** or **PSCustomObject**.
-By default, **Import-Module** does not generate any output.
-If you specify the *PassThru* parameter, the cmdlet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
-If you specify the *AsCustomObject* parameter, it generates a **PSCustomObject** object.
+This cmdlet returns a **PSModuleInfo** or **PSCustomObject**. By default, `Import-Module` does not
+generate any output. If you specify the **PassThru** parameter, the cmdlet generates a
+**System.Management.Automation.PSModuleInfo** object that represents the module. If you specify the
+**AsCustomObject** parameter, it generates a **PSCustomObject** object.
 
 ## NOTES
 
-* Before you can import a module, the module must be installed on the local computer. That is, the module directory must be copied to a directory that is accessible to your local computer. For more information, see [about_Modules](About/about_Modules.md).
+* Before you can import a module, the module must be installed on the local computer. That is, the
+  module directory must be copied to a directory that is accessible to your local computer. For more
+  information, see [about_Modules](About/about_Modules.md).
 
-  You can also use the *PSSession* and *CIMSession* parameters to import modules that are installed on remote computers.
-However, commands that use the cmdlets in these modules actually run in the remote session on the remote computer.
+  You can also use the **PSSession** and **CIMSession** parameters to import modules that are
+  installed on remote computers. However, commands that use the cmdlets in these modules actually
+  run in the remote session on the remote computer.
 
-* If you import members with the same name and the same type into your session, PowerShell uses the member imported last by default. Variables and aliases are replaced, and the originals are not accessible. Functions, cmdlets and providers are merely shadowed by the new members. They can be accessed by qualifying the command name with the name of its snap-in, module, or function path.
-* To update the formatting data for commands that have been imported from a module, use the Update-FormatData cmdlet. **Update-FormatData** also updates the formatting data for commands in the session that were imported from modules. If the formatting file for a module changes, you can run an **Update-FormatData** command to update the formatting data for imported commands. You do not need to import the module again.
-* Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are packaged in modules. In Windows PowerShell 2.0, and in host programs that create older-style sessions in later versions of PowerShell, the core commands are packaged in snap-ins (**PSSnapins**). The exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also, remote sessions, such as those started by the New-PSSession cmdlet, are older-style sessions that include core snap-ins.
+* If you import members with the same name and the same type into your session, PowerShell uses the
+  member imported last by default. Variables and aliases are replaced, and the originals are not
+  accessible. Functions, cmdlets and providers are merely shadowed by the new members. They can be
+  accessed by qualifying the command name with the name of its snap-in, module, or function path.
 
-  For information about the **CreateDefault2** method that creates newer-style sessions with core modules, see [CreateDefault2 Method](https://msdn.microsoft.com/library/system.management.automation.runspaces.initialsessionstate.createdefault2) in the MSDN library.
+* To update the formatting data for commands that have been imported from a module, use the
+  `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in
+  the session that were imported from modules. If the formatting file for a module changes, you can
+  run an `Update-FormatData` command to update the formatting data for imported commands. You do not
+  need to import the module again.
 
-* **Import-Module** cannot import PowerShell Core modules from another session. The PowerShell Core modules have names that begin with Microsoft.PowerShell.
-* In Windows PowerShell 2.0, some of the property values of the module object, such as the **ExportedCmdlets** and **NestedModules** property values, were not populated until the module was imported and were not available on the module object that the *PassThru* parameter returns. In Windows PowerShell 3.0, all module property values are populated.
-* If you attempt to import a module that contains mixed-mode assemblies that are not compatible with Windows PowerShell 3.0, **Import-Module** returns an error message like the following one.
+* Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are
+  packaged in modules. In Windows PowerShell 2.0, and in host programs that create older-style
+  sessions in later versions of PowerShell, the core commands are packaged in snap-ins
+  (**PSSnapins**). The exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also,
+  remote sessions, such as those started by the `New-PSSession` cmdlet, are older-style sessions
+  that include core snap-ins.
 
-  `Import-Module : Mixed mode assembly is built against version 'v2.0.50727' of the runtime and cannot be loaded in the 4.0 runtime without additional configuration information.`
+  For information about the **CreateDefault2** method that creates newer-style sessions with core
+  modules, see the [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2).
 
-  This error occurs when a module that is designed for Windows PowerShell 2.0 contains at least one mixed-module assembly, that is, an assembly that includes both managed and non-managed code, such as C++ and C#.
+* `Import-Module` cannot import PowerShell Core modules from another session. The PowerShell Core
+  modules have names that begin with Microsoft.PowerShell.
 
-  To import a module that contains mixed-mode assemblies, start Windows PowerShell 2.0 by using the following command, and then try the **Import-Module** command again.
+* In Windows PowerShell 2.0, some of the property values of the module object, such as the
+  **ExportedCmdlets** and **NestedModules** property values, were not populated until the module was
+  imported and were not available on the module object that the **PassThru** parameter returns. In
+  Windows PowerShell 3.0, all module property values are populated.
+
+* If you attempt to import a module that contains mixed-mode assemblies that are not compatible with
+  Windows PowerShell 3.0, `Import-Module` returns an error message like the following one.
+
+  > Import-Module : Mixed mode assembly is built against version 'v2.0.50727' of the runtime and
+  > cannot be loaded in the 4.0 runtime without additional configuration information.
+
+  This error occurs when a module that is designed for Windows PowerShell 2.0 contains at least one
+  mixed-module assembly, that is, an assembly that includes both managed and non-managed code, such
+  as C++ and C#.
+
+  To import a module that contains mixed-mode assemblies, start Windows PowerShell 2.0 by using the
+  following command, and then try the `Import-Module` command again.
 
   `PowerShell.exe -Version 2.0`
 
-* To use the CIM session feature, the remote computer must have WS-Management remoting and Windows Management Instrumentation (WMI), which is the Microsoft implementation of the Common Information Model (CIM) standard. The computer must also have the Module Discovery WMI provider or an alternate CIM provider that has the same basic features.
+* To use the CIM session feature, the remote computer must have WS-Management remoting and Windows
+  Management Instrumentation (WMI), which is the Microsoft implementation of the Common Information
+  Model (CIM) standard. The computer must also have the Module Discovery WMI provider or an
+  alternate CIM provider that has the same basic features.
 
-  You can use the CIM session feature on computers that are not running a Windows operating system and on Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
+  You can use the CIM session feature on computers that are not running a Windows operating system
+  and on Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
 
-  You can also use the CIM parameters to get CIM modules from computers that have PowerShell remoting enabled, including the local computer.
-When you create a CIM session on the local computer, PowerShell uses DCOM, instead of WMI, to create the session.
+  You can also use the CIM parameters to get CIM modules from computers that have PowerShell
+  remoting enabled, including the local computer. When you create a CIM session on the local
+  computer, PowerShell uses DCOM, instead of WMI, to create the session.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Import-Module.md
@@ -88,9 +88,9 @@ Import-Module [-Global] [-Prefix <String>] [-Function <String[]>] [-Cmdlet <Stri
 The `Import-Module` cmdlet adds one or more modules to the current session. The modules that you
 import must be installed on the local computer or a remote computer.
 
-Starting in Windows PowerShell 3.0, installed modules are automatically imported to the session when
-you use any commands or providers in the module. However, you can still use the `Import-Module`
-command to import a module and you can enable and disable automatic module importing by using the
+Starting in PowerShell 3.0, installed modules are automatically imported to the session when you use
+any commands or providers in the module. However, you can still use the `Import-Module` command to
+import a module and you can enable and disable automatic module importing by using the
 `$PSModuleAutoloadingPreference` preference variable. For more information about modules, see
 [about_Modules](About/about_Modules.md). For more information about the
 `$PSModuleAutoloadingPreference` variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
@@ -125,9 +125,9 @@ parameter of `Get-Module` to get the PowerShell modules in the **PSSession**. Wh
 modules, and then use the imported commands in the current session, the commands run implicitly in
 the **PSSession** on the remote computer. You can use this strategy to manage the remote computer.
 
-You can use a similar strategy to manage computers that do not have PowerShell remoting enabled,
+You can use a similar strategy to manage computers that don't have PowerShell remoting enabled,
 including computers that are not running the Windows operating system, and Windows computers that
-have PowerShell, but do not have PowerShell remoting enabled.
+have PowerShell, but don't have PowerShell remoting enabled.
 
 Start by creating a CIM session on the remote computer, which is a connection to Windows Management
 Instrumentation (WMI) on the remote computer. Then use the **CIMSession** parameter of
@@ -160,7 +160,7 @@ Get-Module -ListAvailable | Import-Module
 
 ### Example 3: Import the members of several modules into the current session
 
-This example imports the members of the **BitsTransfer** and **Dism** modules into the
+This example imports the members of the **PSDiagnostics** and **Dism** modules into the
 current session.
 
 ```powershell
@@ -175,8 +175,8 @@ modules that are not yet imported into the session.
 The **ModuleInfo** parameter of `Import-Module` is used to import the modules into the current
 session.
 
-These commands are equivalent to using a pipeline operator (|) to send the output of a `Get-Module`
-command to `Import-Module`.
+These commands are equivalent to using a pipeline operator (`|`) to send the output of a
+`Get-Module` command to `Import-Module`.
 
 ### Example 4: Import all modules specified by a path
 
@@ -282,7 +282,7 @@ Function        Start-xTrace                           6.1.0.0    PSDiagnostics
 Function        Stop-xTrace                            6.1.0.0    PSDiagnostics
 ```
 
-It uses the **Prefix** parameter of `Import-Module` adds the "x" prefix to all members that are
+It uses the **Prefix** parameter of `Import-Module` adds the **x** prefix to all members that are
 imported from the module and the **PassThru** parameter to return a module object that represents
 the imported module.
 
@@ -338,16 +338,16 @@ $a."Show-Calendar"()
 ```
 
 The first command uses the `Get-Module` cmdlet to get the available modules. The command uses a
-pipeline operator to pass the module objects to the Format-Table cmdlet, which lists the **Name**
+pipeline operator to pass the module objects to the `Format-Table` cmdlet, which lists the **Name**
 and **ModuleType** of each module in a table.
 
 The second command uses the `Import-Module` cmdlet to import the **Show-Calendar** script module.
 The command uses the **AsCustomObject** parameter to request a custom object and the **PassThru**
 parameter to return the object. The command saves the resulting custom object in the `$a` variable.
 
-The third command uses a pipeline operator to send the $a variable to the `Get-Member` cmdlet, which
-gets the properties and methods of the **PSCustomObject** in `$a`. The output shows a
-**Show-Calendar** script method.
+The third command uses a pipeline operator to send the `$a` variable to the `Get-Member` cmdlet,
+which gets the properties and methods of the **PSCustomObject** in `$a`. The output shows a
+**Show-Calendar()** script method.
 
 The last command uses the **Show-Calendar** script method. The method name must be enclosed in
 quotation marks, because it includes a hyphen.
@@ -501,9 +501,9 @@ variable.
 The third command uses the **PSSession** parameter of the `Import-Module` cmdlet to import the
 **NetSecurity** module from the session in the `$s` variable into the current session.
 
-The fourth command uses the `Get-Command` cmdlet to get commands that begin with "Get" and include
-"Firewall" from the NetSecurity module.The output gets the commands and confirms that the module and
-its cmdlets were imported into the current session.
+The fourth command uses the `Get-Command` cmdlet to get commands that begin with **Get** and include
+**Firewall** from the **NetSecurity** module.The output gets the commands and confirms that the
+module and its cmdlets were imported into the current session.
 
 The fifth command uses the `Get-NetFirewallRule` cmdlet to get Windows Remote Management firewall
 rules on the Server01 computer. This command is equivalent to using the `Invoke-Command` cmdlet to
@@ -615,7 +615,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -698,7 +698,7 @@ current session. When you use the commands from the imported module in the curre
 commands actually run on the remote computer.
 
 You can use this parameter to import modules from computers and devices that are not running the
-Windows operating system, and Windows computers that have PowerShell, but do not have PowerShell
+Windows operating system, and Windows computers that have PowerShell, but don't have PowerShell
 remoting enabled.
 
 This parameter was introduced in Windows PowerShell 3.0.
@@ -758,7 +758,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -774,7 +774,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -838,7 +838,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -949,7 +949,7 @@ Aliases: NoOverwrite
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -966,7 +966,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -1043,7 +1043,7 @@ a script.
 This parameter was introduced in Windows PowerShell 3.0.
 
 Scripts that use **RequiredVersion** to import modules that are included with existing releases of
-the Windows operating system do not automatically run in future releases of the Windows operating
+the Windows operating system don't automatically run in future releases of the Windows operating
 system. This is because PowerShell module version numbers in future releases of the Windows
 operating system are higher than module version numbers in existing releases of the Windows
 operating system.
@@ -1074,8 +1074,8 @@ scriptblock, all the commands are imported into the global session state. You ca
 parameter with the value of **Local** to import module content into the script or scriptblock scope.
 
 When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
-commands from nested modules, into the caller's session state. Specifying **-Scope Global** or
-**-Global** indicates that this cmdlet imports modules into the global session state so they are
+commands from nested modules, into the caller's session state. Specifying `-Scope Global` or
+`-Global` indicates that this cmdlet imports modules into the global session state so they are
 available to all commands in the session.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of Global.
@@ -1140,7 +1140,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -1148,7 +1148,7 @@ Accept wildcard characters: False
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -1183,7 +1183,7 @@ generate any output. If you specify the **PassThru** parameter, the cmdlet gener
 * To update the formatting data for commands that have been imported from a module, use the
   `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in
   the session that were imported from modules. If the formatting file for a module changes, you can
-  run an `Update-FormatData` command to update the formatting data for imported commands. You do not
+  run an `Update-FormatData` command to update the formatting data for imported commands. You don't
   need to import the module again.
 
 * Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are
@@ -1225,7 +1225,7 @@ generate any output. If you specify the **PassThru** parameter, the cmdlet gener
   alternate CIM provider that has the same basic features.
 
   You can use the CIM session feature on computers that are not running a Windows operating system
-  and on Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
+  and on Windows computers that have PowerShell, but don't have PowerShell remoting enabled.
 
   You can also use the CIM parameters to get CIM modules from computers that have PowerShell
   remoting enabled, including the local computer. When you create a CIM session on the local

--- a/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 1/22/2019
+ms.date: 08/14/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096977
 schema: 2.0.0
 title: Export-Clixml
 ---
+
 # Export-Clixml
 
 ## SYNOPSIS
@@ -18,96 +19,117 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ### ByPath (Default)
 
 ```
-Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml [-Path] <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
-it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
-contents of that file.
+The `Export-Clixml` cmdlet creates a Common Language Infrastructure (CLI) XML-based representation
+of an object or objects and stores it in a file. You can then use the `Import-Clixml` cmdlet to
+recreate the saved object based on the contents of that file.
+For more information about CLI, see [Language independence](/dotnet/standard/language-independence).
 
-This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
-a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
+file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
 
-A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
-an example of how to do this, see Example 3.
+A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
+securely as XML. For an example, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
 
-This command creates an XML file that stores a representation of the string, "This is a test" in
-the current directory.
+This example creates an XML file that stores in the current directory, a representation of the
+string **This is a test**.
 
 ```powershell
 "This is a test" | Export-Clixml -Path .\sample.xml
 ```
 
+The string **This is a test** is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
+to create an XML file named `sample.xml` in the current directory.
+
 ### Example 2: Export an object to an XML file
 
-This example shows how to export an object to an XML file and then create an object by importing
-the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing the
+XML from the file.
 
 ```powershell
-Get-Acl C:\test.txt | Export-Clixml -Path .\fileacl.xml
-$fileacl = Import-Clixml -Path .\fileacl.xml
+Get-Acl C:\test.txt | Export-Clixml -Path .\FileACL.xml
+$fileacl = Import-Clixml -Path .\FileACL.xml
 ```
 
-The `Get-Acl` cmdlet gets the security descriptor of the Test.txt file. It sends the object down
-the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of
-the object is stored in a file named FileACL.xml.
+The `Get-Acl` cmdlet gets the security descriptor of the `Test.txt` file. It sends the object down
+the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of the
+object is stored in a file named `FileACL.xml`.
 
-The `Import-Clixml` cmdlet creates an object from the XML in the FileACL.xml file. Then, it saves
+The `Import-Clixml` cmdlet creates an object from the XML in the `FileACL.xml` file. Then, it saves
 the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
-This example shows how to use a credential stored in a variable and save it to disk. The credential
-can then be imported into scripts.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential | Export-Clixml $credxmlpath
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential = Import-Clixml $credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential | Export-Clixml $Credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The `Export-Clixml` cmdlet encrypts credential objects by using the
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account on only that computer can decrypt the contents of the
-credential object. The exported CliXml file can neither be used on a different computer nor by a
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
+The encryption ensures that only your user account on only that computer can decrypt the contents of
+the credential object. The exported `CLIXML` file can't be used on a different computer or by a
 different user.
 
-In this example, given a credential that you've stored in the `$credential` variable by running the
-`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
-the example, the file in which the credential is stored is represented by
-TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+In the example, the file in which the credential is stored is represented by
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
-`$credxmlpath`, that you specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Depth
 
 Specifies how many levels of contained objects are included in the XML representation. The default
-value is 2.
+value is `2`.
 
-The default value can be overridden for the object type in the Types.ps1xml files. For more
+The default value can be overridden for the object type in the `Types.ps1xml` files. For more
 information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
@@ -170,7 +192,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -195,10 +217,9 @@ Accept wildcard characters: False
 ### -LiteralPath
 
 Specifies the path to the file where the XML representation of the object will be stored. Unlike
-**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
-are interpreted as wildcards. If the path includes escape characters, enclose it in single
-quotation marks. Single quotation marks tell PowerShell not to interpret any characters as
-escape sequences.
+**Path**, the value of the **LiteralPath** parameter is used exactly as it's typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single quotation
+marks. Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -214,8 +235,8 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Indicates that the cmdlet does not overwrite the contents of an existing file. By default, if a
-file exists in the specified path, `Export-Clixml` overwrites the file without warning.
+Indicates that the cmdlet doesn't overwrite the contents of an existing file. By default, if a file
+exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -224,7 +245,7 @@ Aliases: NoOverwrite
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -245,25 +266,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -281,14 +286,13 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
 
-You can pipe any object to `Export-Clixml`.
+You can pipeline any object to `Export-Clixml`.
 
 ## OUTPUTS
 
@@ -300,10 +304,6 @@ You can pipe any object to `Export-Clixml`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [ConvertTo-Html](ConvertTo-Html.md)
 
 [ConvertTo-Xml](ConvertTo-Xml.md)
@@ -311,3 +311,11 @@ You can pipe any object to `Export-Clixml`.
 [Export-Csv](Export-Csv.md)
 
 [Import-Clixml](Import-Clixml.md)
+
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
+
+[Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/6/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096532
 schema: 2.0.0
 title: Import-Clixml
 ---
+
 # Import-Clixml
 
 ## SYNOPSIS
@@ -18,7 +19,8 @@ Imports a CLIXML file and creates corresponding objects in PowerShell.
 ### ByPath (Default)
 
 ```
-Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [<CommonParameters>]
+Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [<CommonParameters>]
 ```
 
 ### ByLiteralPath
@@ -30,52 +32,65 @@ Import-Clixml -LiteralPath <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-Fi
 
 ## DESCRIPTION
 
-The **Import-CliXml** cmdlet imports a CLIXML file with data that represents Microsoft .NET Framework objects and creates the objects in PowerShell.
+The `Import-Clixml` cmdlet imports a Common Language Infrastructure (CLI) XML file with data that
+represents Microsoft .NET Framework objects and creates the PowerShell objects. For more information
+about CLI, see [Language independence](/dotnet/standard/language-independence).
 
-A valuable use of **Import-CliXml** is to import credentials and secure strings that have been exported as secure XML by running the Export-Clixml cmdlet.
-For an example of how to do this, see Example 2.
+A valuable use of `Import-Clixml` on Windows computers is to import credentials and secure strings
+that were exported as secure XML using `Export-Clixml`. For an example, see Example 2.
+
+`Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
+file has no BOM, it assumes the encoding is UTF8.
 
 ## EXAMPLES
 
 ### Example 1: Import a serialized file and recreate an object
 
-```powershell
-Get-Process | Export-Clixml pi.xml
-$Processes = Import-Clixml pi.xml
-```
+This example uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
+returned by `Get-Process`. `Import-Clixml` retrieves the serialized file's contents and recreates an
+object that is stored in the `$Processes` variable.
 
-This command uses the Export-Clixml cmdlet to save a serialized copy of the process information returned by Get-Process.
-It then uses **Import-Clixml** to retrieve the contents of the serialized file and re-create an object that is stored in the $Processes variable.
+```powershell
+Get-Process | Export-Clixml -Path .\pi.xml
+$Processes = Import-Clixml -Path .\pi.xml
+```
 
 ### Example 2: Import a secure credential object
 
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
+
 ```powershell
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-$Credential | Export-CliXml $Credxmlpath
+$Credential | Export-Clixml $Credxmlpath
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-$Credential = Import-CliXml $Credxmlpath
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The **Export-CliXml** cmdlet encrypts credential objects by using the [Windows Data Protection API](http://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account can decrypt the contents of the credential object.
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
+The encryption ensures that only your user account can decrypt the contents of the credential
+object. The exported `CLIXML` file can't be used on a different computer or by a different user.
 
-In this example, given a credential that you've stored in the $Credential variable by running the Get-Credential cmdlet, you can run the **Export-CliXml** cmdlet to save the credential to disk.
+In the example, the file in which the credential is stored is represented by
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
+loading the credential.
 
-In the example, the file in which the credential is stored is represented by TestScript.ps1.credential.
-Replace TestScript with the name of the script with which you are loading the credential.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-In the second command, you pipe the credential object to **Export-CliXml**, and save it to the path, $Credxmlpath, that you specified in the first command.
-
-To import the credential automatically into your script, run the final two commands.
-This time, you are running Import-Clixml to import the secured credential object into your script.
-This eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
 ### -First
 
-Gets only the specified number of objects.
-Enter the number of objects to get.
+Gets only the specified number of objects. Enter the number of objects to get.
 
 ```yaml
 Type: UInt64
@@ -91,9 +106,12 @@ Accept wildcard characters: False
 
 ### -IncludeTotalCount
 
-Reports the total number of objects in the data set (an integer) followed by the selected objects.
-If the cmdlet cannot determine the total count, it displays "Unknown total count." The integer has an Accuracy property that indicates the reliability of the total count value.
-The value of Accuracy ranges from 0.0 to 1.0 where 0.0 means that the cmdlet could not count the objects, 1.0 means that the count is exact, and a value between 0.0 and 1.0 indicates an increasingly reliable estimate.
+Reports the total number of objects in the data set followed by the selected objects. If the cmdlet
+can't determine the total count, it displays **Unknown total count**. The integer has an
+**Accuracy** property that indicates the reliability of the total count value. The value of
+**Accuracy** ranges from `0.0` to `1.0` where `0.0` means that the cmdlet couldn't count the
+objects, `1.0` means that the count is exact, and a value between `0.0` and `1.0` indicates an
+increasingly reliable estimate.
 
 ```yaml
 Type: SwitchParameter
@@ -109,11 +127,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the XML files.
-Unlike *Path*, the value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies the path to the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is
+used exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -129,7 +146,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the XML files.
+Specifies the path to the XML files.
 
 ```yaml
 Type: String[]
@@ -145,8 +162,8 @@ Accept wildcard characters: False
 
 ### -Skip
 
-Ignores the specified number of objects and then gets the remaining objects.
-Enter the number of objects to skip.
+Ignores the specified number of objects and then gets the remaining objects. Enter the number of
+objects to skip.
 
 ```yaml
 Type: UInt64
@@ -162,29 +179,35 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to **Import-Clixml**.
+You can pipeline a string that contains a path to `Import-Clixml`.
 
 ## OUTPUTS
 
 ### PSObject
 
-**Import-Clixml** returns objects that have been deserialized from the stored XML files.
+`Import-Clixml` returns objects that were deserialized from the stored XML files.
 
 ## NOTES
 
 When specifying multiple values for a parameter, use commas to separate the values. For example,
-"\<parameter-name\> \<value1\>, \<value2\>".
+`<parameter-name> <value1>, <value2>`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
+[Export-Clixml](Export-Clixml.md)
+
+[Introducing XML Serialization](/dotnet/standard/serialization/introducing-xml-serialization)
+
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
 
 [Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
-[Export-Clixml](Export-Clixml.md)
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)

--- a/reference/7/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/About_Using.md
@@ -12,19 +12,21 @@ Allows to indicate which namespaces are used in the session.
 
 ## LONG DESCRIPTION
 
-The `using` statement allows to indicate which namespaces are used in the
-session. Making easier to mention classes and members, as it requires less
-typing to mention them; also, classes from modules can be referenced too.
+The `using` statement allows you to specify which namespaces are used in the
+session. Adding namespaces simplifies usage of .NET classes and member and
+allows you to import classes from modules.
 
 The `using` statement needs to be the first statement in the script.
 
-Syntax #1, to reference .Net Framework namespaces:
+### Syntax
+
+To reference .NET Framework namespaces:
 
 ```
-using namespace <.Net-framework-namespace>
+using namespace <.NET-framework-namespace>
 ```
 
-Syntax #2, to reference PowerShell modules:
+To reference PowerShell modules:
 
 ```
 using module <module-name>
@@ -37,7 +39,7 @@ using module <module-name>
 > module. If the module isn't loaded in the current session, the `using`
 > statement fails.
 
-## Examples
+### Examples
 
 The following script gets the cryptographic hash for the "Hello World" string.
 

--- a/reference/7/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/About_Using.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  12/01/2017
+ms.date:  08/15/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -30,16 +30,20 @@ Syntax #2, to reference PowerShell modules:
 using module <module-name>
 ```
 
-**Note**: The `using` statement, for modules, is intended to surface the
-classes in the module. If the module isn't loaded, the `using` fails.
+> [!NOTE]
+> `Import-Module` and the `#requires` statement only import the module
+> functions, aliases, and variables, as defined by the module. Classes are not
+> imported. The `using module` statement imports the classes defined in the
+> module. If the module isn't loaded in the current session, the `using`
+> statement fails.
 
 ## Examples
 
 The following script gets the cryptographic hash for the "Hello World" string.
 
 Note how the `using namespace System.Text` and `using namespace System.IO`
-simplify the references to `[UnicodeEncoding]` in *System.Text*; and, to
-`[Stream]` and to `[MemoryStream]` in *System.IO*.
+simplify the references to `[UnicodeEncoding]` in *System.Text* and `[Stream]`
+and to `[MemoryStream]` in *System.IO*.
 
 ```powershell
 using namespace System.Text
@@ -62,8 +66,8 @@ automatically.
 
 The following classes are defined in the module:
 
-- *Deck*
-- *Card*
+- **Deck**
+- **Card**
 
 ```powershell
 using module CardGames

--- a/reference/7/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/About_Using.md
@@ -42,8 +42,8 @@ using module <module-name>
 The following script gets the cryptographic hash for the "Hello World" string.
 
 Note how the `using namespace System.Text` and `using namespace System.IO`
-simplify the references to `[UnicodeEncoding]` in *System.Text* and `[Stream]`
-and to `[MemoryStream]` in *System.IO*.
+simplify the references to `[UnicodeEncoding]` in `System.Text` and `[Stream]`
+and to `[MemoryStream]` in `System.IO`.
 
 ```powershell
 using namespace System.Text

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -229,7 +229,7 @@ Devices   : {$null, $null, Microsoft|Surface Pro 4|5072641000, $null...}
 
 ## Output in class methods
 
-Methods should have a return type defined. If a method does not return output,
+Methods should have a return type defined. If a method doesn't return output,
 then the output type should be `[void]`.
 
 In class methods, no objects get sent to the pipeline except those mentioned in
@@ -340,7 +340,7 @@ Microsoft Surface Pro 4 5072641000
 In this example, the **Device** class is defined with properties, a default
 constructor, and a constructor to initialize the instance.
 
-The default constructor sets the **brand** to *Undefined*, and leaves **model**
+The default constructor sets the **brand** to **Undefined**, and leaves **model**
 and **vendor-sku** with null values.
 
 ```powershell
@@ -389,7 +389,7 @@ class definition.
 ### Example using hidden attributes
 
 When a **Rack** object is created, the number of slots for devices is a fixed
-value that should not be changed at any time. This value is known at creation
+value that shouldn't be changed at any time. This value is known at creation
 time.
 
 Using the hidden attribute allows the developer to keep the number of slots
@@ -711,7 +711,7 @@ Model               : Fbk5040
 
 ## Calling base class constructors
 
-To invoke a base class constructor from a subclass, add the "base" keyword.
+To invoke a base class constructor from a subclass, add the `base` keyword.
 
 ```powershell
 class Person {
@@ -792,7 +792,7 @@ class ChildClass1 : BaseClass
 ## Interfaces
 
 The syntax for declaring interfaces is similar to C#. You can declare
-interfaces after base types or immediately after a colon (:) when there is no
+interfaces after base types or immediately after a colon (`:`) when there is no
 base type specified. Separate all type names with commas.
 
 ```powershell

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  08/31/2018
+ms.date:  08/15/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -8,34 +8,33 @@ description:  Describes how you can use classes to create your own custom types.
 ---
 # About Classes
 
-## SHORT DESCRIPTION
+## Short description
 Describes how you can use classes to create your own custom types.
 
-## LONG DESCRIPTION
+## Long description
 
 PowerShell 5.0 adds a formal syntax to define classes and other user-defined
 types. The addition of classes enables developers and IT professionals to
-embrace PowerShell for a wider range of use cases. It simplifies development
-of PowerShell artifacts and accelerates coverage of management surfaces.
+embrace PowerShell for a wider range of use cases. It simplifies development of
+PowerShell artifacts and accelerates coverage of management surfaces.
 
-A class declaration is like a blueprint used to create instances of objects at
-run time. When you define a class, the class name is the name of the type. For
+A class declaration is a blueprint used to create instances of objects at run
+time. When you define a class, the class name is the name of the type. For
 example, if you declare a class named **Device** and initialize a variable
 `$dev` to a new instance of **Device**, `$dev` is an object or instance of type
 **Device**. Each instance of **Device** can have different values in its
 properties.
 
-## SUPPORTED SCENARIOS
+## Supported scenarios
 
-- Define custom types in PowerShell using familiar object-oriented
-  programming semantics like classes, properties, methods, inheritance,
-  etc.
+- Define custom types in PowerShell using familiar object-oriented programming
+  semantics like classes, properties, methods, inheritance, etc.
 - Debug types using the PowerShell language.
 - Generate and handle exceptions using formal mechanisms.
 - Define DSC resources and their associated types by using the PowerShell
   language.
 
-## SYNTAX
+## Syntax
 
 Classes are declared using the following syntax:
 
@@ -60,9 +59,8 @@ Classes are instantiated using either of the following syntaxes:
 ```
 
 > [!NOTE]
-> When using the `[<class-name>]::new(` syntax,
-> brackets around the class name are mandatory!
-> The brackets signal a type definition for PowerShell.
+> When using the `[<class-name>]::new(` syntax, brackets around the class name
+> are mandatory. The brackets signal a type definition for PowerShell.
 
 ### Example syntax and usage
 
@@ -78,17 +76,17 @@ $dev.Brand = "Microsoft"
 $dev
 ```
 
-```output
+```Output
 Brand
 -----
 Microsoft
 ```
 
-## CLASS PROPERTIES
+## Class properties
 
-Properties are variables declared at class scope.
-A property may be of any built-in type or an instance of another class.
-Classes have no restriction in the number of properties they have.
+Properties are variables declared at class scope. A property may be of any
+built-in type or an instance of another class. Classes have no restriction in
+the number of properties they have.
 
 ### Example class with simple properties
 
@@ -107,20 +105,17 @@ $device.VendorSku = "5072641000"
 $device
 ```
 
-```output
-
-
+```Output
 Brand     Model         VendorSku
 -----     -----         ---------
 Microsoft Surface Pro 4 5072641000
-
 ```
 
 ### Example complex types in class properties
 
-This example defines an empty **Rack** class using the **Device** class.
-The examples, following this one, show how to add devices to the rack
-and how to start with a pre-loaded rack.
+This example defines an empty **Rack** class using the **Device** class. The
+examples, following this one, show how to add devices to the rack and how to
+start with a pre-loaded rack.
 
 ```powershell
 class Device {
@@ -143,7 +138,7 @@ $rack = [Rack]::new()
 $rack
 ```
 
-```output
+```Output
 
 Brand     :
 Model     :
@@ -154,12 +149,11 @@ Devices   : {$null, $null, $null, $null...}
 
 ```
 
-## CLASS METHODS
+## Class methods
 
-Methods define the actions that a class can perform.
-Methods may take parameters that provide input data.
-Methods can return output.
-Data returned by a method can be any defined data type.
+Methods define the actions that a class can perform. Methods may take
+parameters that provide input data. Methods can return output. Data returned by
+a method can be any defined data type.
 
 ### Example simple class with properties and methods
 
@@ -214,7 +208,7 @@ $rack
 $rack.GetAvailableSlots()
 ```
 
-```output
+```Output
 
 Slots     : 8
 Brand     :
@@ -233,23 +227,23 @@ Devices   : {$null, $null, Microsoft|Surface Pro 4|5072641000, $null...}
 
 ```
 
-## OUTPUT IN CLASS METHODS
+## Output in class methods
 
-Methods should have a return type defined. If a method does not
-return output, then the output type should be `[void]`.
+Methods should have a return type defined. If a method does not return output,
+then the output type should be `[void]`.
 
-In class methods, no objects get sent to the pipeline except those mentioned
-in the `return` statement. There's no accidental output to the pipeline
-from the code.
+In class methods, no objects get sent to the pipeline except those mentioned in
+the `return` statement. There's no accidental output to the pipeline from the
+code.
 
 > [!NOTE]
-> This is fundamentally different from how PowerShell functions
-> handle output, where everything goes to the pipeline.
+> This is fundamentally different from how PowerShell functions handle output,
+> where everything goes to the pipeline.
 
 ### Method output
 
-This example demonstrates no accidental output to the pipeline from
-class methods, except on the `return` statement.
+This example demonstrates no accidental output to the pipeline from class
+methods, except on the `return` statement.
 
 ```powershell
 class FunWithIntegers
@@ -283,7 +277,7 @@ $ints.GetEvenIntegers()
 $ints.SayHello()
 ```
 
-```output
+```Output
 1
 3
 5
@@ -293,25 +287,25 @@ Hello World
 
 ```
 
-## CONSTRUCTOR
+## Constructor
 
 Constructors enable you to set default values and validate object logic at the
 moment of creating the instance of the class. Constructors have the same name
-as the class. Constructors might have arguments, to initialize the data
-members of the new object.
+as the class. Constructors might have arguments, to initialize the data members
+of the new object.
 
 The class can have zero or more constructors defined. If no constructor is
 defined, the class is given a default parameterless constructor. This
 constructor initializes all members to their default values. Object types and
 strings are given null values. When you define constructor, no default
-parameterless constructor is created. Create a parameterless constructor if
-one is needed.
+parameterless constructor is created. Create a parameterless constructor if one
+is needed.
 
 ### Constructor basic syntax
 
-In this example, the Device class is defined with properties and a
-constructor. To use this class, the user is required to provide values for the
-parameters listed in the constructor.
+In this example, the Device class is defined with properties and a constructor.
+To use this class, the user is required to provide values for the parameters
+listed in the constructor.
 
 ```powershell
 class Device {
@@ -335,11 +329,10 @@ class Device {
 $surface
 ```
 
-```output
+```Output
 Brand     Model         VendorSku
 -----     -----         ---------
 Microsoft Surface Pro 4 5072641000
-
 ```
 
 ### Example with multiple constructors
@@ -347,8 +340,8 @@ Microsoft Surface Pro 4 5072641000
 In this example, the **Device** class is defined with properties, a default
 constructor, and a constructor to initialize the instance.
 
-The default constructor sets the **brand** to *Undefined*,
-and leaves **model** and **vendor-sku** with null values.
+The default constructor sets the **brand** to *Undefined*, and leaves **model**
+and **vendor-sku** with null values.
 
 ```powershell
 class Device {
@@ -378,26 +371,26 @@ $somedevice
 $surface
 ```
 
-```output
+```Output
 Brand       Model           VendorSku
 -----       -----           ---------
 Undefined
 Microsoft   Surface Pro 4   5072641000
 ```
 
-## HIDDEN ATTRIBUTE
+## Hidden attribute
 
-The `hidden` attribute makes a property or method less visible. The property
-or method is still accessible to the user and is available in all scopes in
-which the object is available. Hidden members are hidden from the `Get-Member`
-cmdlet and can't be displayed using tab completion or IntelliSense outside of
-the class definition.
+The `hidden` attribute makes a property or method less visible. The property or
+method is still accessible to the user and is available in all scopes in which
+the object is available. Hidden members are hidden from the `Get-Member` cmdlet
+and can't be displayed using tab completion or IntelliSense outside of the
+class definition.
 
 ### Example using hidden attributes
 
-When a **Rack** object is created, the number of slots for devices is a
-fixed value that should not be changed at any time. This value is known at
-creation time.
+When a **Rack** object is created, the number of slots for devices is a fixed
+value that should not be changed at any time. This value is known at creation
+time.
 
 Using the hidden attribute allows the developer to keep the number of slots
 hidden and prevents unintentional changes the size of the rack.
@@ -433,33 +426,30 @@ $r1.Devices.Length
 $r1.Slots
 ```
 
-```output
-
+```Output
 Brand     Model         Devices
 -----     -----         -------
 Microsoft Surface Pro 4 {$null, $null, $null, $null...}
 16
 16
-
 ```
 
-Notice **Slots** property isn't shown in `$r1` output. However, the size
-was changed by the constructor.
+Notice **Slots** property isn't shown in `$r1` output. However, the size was
+changed by the constructor.
 
-## STATIC ATTRIBUTE
+## Static attribute
 
 The `static` attribute defines a property or a method that exists in the class
 and needs no instance.
 
-A static property is always available, independent of class instantiation.
-A static property is shared across all instances of the class.
-A static method is available always.
-All static properties live for the entire session span.
+A static property is always available, independent of class instantiation. A
+static property is shared across all instances of the class. A static method is
+available always. All static properties live for the entire session span.
 
 ### Example using static attributes and methods
 
-Assume the racks instantiated here exist in your data center.
-So, you would like to keep track of the racks in your code.
+Assume the racks instantiated here exist in your data center. So, you would
+like to keep track of the racks in your code.
 
 ```powershell
 class Device {
@@ -498,7 +488,7 @@ class Rack {
 }
 ```
 
-#### Testing static property and method exist
+### Testing static property and method exist
 
 ```
 PS> [Rack]::InstalledRacks.Length
@@ -534,7 +524,7 @@ WARNING: Turning off rack: Std0010
 
 Notice that the number of racks increases each time you run this example.
 
-## PROPERTY VALIDATION ATTRIBUTES
+## Property validation attributes
 
 Validation attributes allow you to test that values given to properties meet
 defined requirements. Validation is triggered the moment that the value is
@@ -554,10 +544,9 @@ Write-Output "Testing dev"
 $dev
 
 $dev.Brand = ""
-
 ```
 
-```output
+```Output
 Testing dev
 
 Brand Model
@@ -568,24 +557,22 @@ argument that is not null or empty, and then try the command again."
 At C:\tmp\Untitled-5.ps1:11 char:1
 + $dev.Brand = ""
 + ~~~~~~~~~~~~~~~
-    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationExcep
-tion
+    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationException
     + FullyQualifiedErrorId : ExceptionWhenSetting
 ```
 
-## INHERITANCE IN POWERSHELL CLASSES
+## Inheritance in PowerShell classes
 
 You can extend a class by creating a new class that derives from an existing
-class. The derived class inherits the properties of the base class. You can
-add or override methods and properties as required.
+class. The derived class inherits the properties of the base class. You can add
+or override methods and properties as required.
 
-PowerShell does not support multiple inheritance.
-Classes cannot inherit from more than one class.
-However, you can use interfaces for that purpose.
+PowerShell does not support multiple inheritance. Classes cannot inherit from
+more than one class. However, you can use interfaces for that purpose.
 
-Inheritance implementation is defined by the `:` operator;
-which means to extend this class or implements these interfaces.
-The derived class should always be leftmost in the class declaration.
+Inheritance implementation is defined by the `:` operator; which means to
+extend this class or implements these interfaces. The derived class should
+always be leftmost in the class declaration.
 
 ### Example using simple inheritance syntax
 
@@ -604,18 +591,16 @@ Class Derived : Base.Interface {...}
 
 ### Example of simple inheritance in PowerShell classes
 
-In this example the _Rack_ and _Device_ classes used in the previous examples
-are better defined to: avoid property repetitions, better align common
+In this example the **Rack** and **Device** classes used in the previous
+examples are better defined to: avoid property repetitions, better align common
 properties, and reuse common business logic.
 
-Most objects in the data center are company assets, which makes sense to
-start tracking them as assets.
-Device types are defined by the `DeviceType` enumeration, see
-[about_Enum](about_Enum.md) for details on enumerations.
+Most objects in the data center are company assets, which makes sense to start
+tracking them as assets. Device types are defined by the `DeviceType`
+enumeration, see [about_Enum](about_Enum.md) for details on enumerations.
 
-In our example, we're only defining `Rack` and `ComputeServer`; both
-extensions to the `Device` class.
-
+In our example, we're only defining `Rack` and `ComputeServer`; both extensions
+to the `Device` class.
 
 ```powershell
 enum DeviceType {
@@ -692,12 +677,10 @@ $FirstRack.Location = "F03R02.J10"
   })
 
 $FirstRack
-
 $FirstRack.Devices
 ```
 
-```output
-
+```Output
 Datacenter : PNW
 Location   : F03R02.J10
 Devices    : {r1s000, r1s001, r1s002, r1s003...}
@@ -724,14 +707,11 @@ Hostname            : r1s015
 Status              : Installed
 Brand               : Fabrikam, Inc.
 Model               : Fbk5040
-
 ```
 
-## CALLING BASE CLASS CONSTRUCTORS
+## Calling base class constructors
 
 To invoke a base class constructor from a subclass, add the "base" keyword.
-
-### Example using the base class constructor
 
 ```powershell
 class Person {
@@ -757,12 +737,12 @@ class Child : Person
 $littleone.Age
 ```
 
-```output
+```Output
 
 10
 ```
 
-## INVOKE BASE CLASS METHODS
+## Invoke base class methods
 
 To override existing methods in subclasses, declare methods by using the same
 name and signature.
@@ -780,7 +760,7 @@ class ChildClass1 : BaseClass
 [ChildClass1]::new().days()
 ```
 
-```output
+```Output
 
 2
 ```
@@ -803,17 +783,17 @@ class ChildClass1 : BaseClass
 [ChildClass1]::new().basedays()
 ```
 
-```output
+```Output
 
 2
 1
 ```
 
-## INTERFACES
+## Interfaces
 
-The syntax for declaring interfaces is similar to C#.
-You can declare interfaces after base types or immediately after a colon (:)
-when there is no base type specified. Separate all type names with commas.
+The syntax for declaring interfaces is similar to C#. You can declare
+interfaces after base types or immediately after a colon (:) when there is no
+base type specified. Separate all type names with commas.
 
 ```powershell
 class MyComparable : system.IComparable
@@ -833,8 +813,16 @@ class MyComparableBar : bar, system.IComparable
 }
 ```
 
-## SEE ALSO
+## Importing classes from a PowerShell module
+
+`Import-Module` and the `#requires` statement only import the module functions,
+aliases, and variables, as defined by the module. Classes are not imported. The
+`using module` statement imports the classes defined in the module. If the
+module isn't loaded in the current session, the `using` statement fails.
+
+## See also
 
 - [about_Enum](about_Enum.md)
 - [about_Language_Keywords](about_language_keywords.md)
 - [about_Methods](about_methods.md)
+- [about_Using](about_using.md)

--- a/reference/7/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/7/Microsoft.PowerShell.Core/Import-Module.md
@@ -88,9 +88,9 @@ Import-Module [-Global] [-Prefix <String>] [-Function <String[]>] [-Cmdlet <Stri
 The `Import-Module` cmdlet adds one or more modules to the current session. The modules that you
 import must be installed on the local computer or a remote computer.
 
-Starting in Windows PowerShell 3.0, installed modules are automatically imported to the session when
-you use any commands or providers in the module. However, you can still use the `Import-Module`
-command to import a module and you can enable and disable automatic module importing by using the
+Starting in PowerShell 3.0, installed modules are automatically imported to the session when you use
+any commands or providers in the module. However, you can still use the `Import-Module` command to
+import a module and you can enable and disable automatic module importing by using the
 `$PSModuleAutoloadingPreference` preference variable. For more information about modules, see
 [about_Modules](About/about_Modules.md). For more information about the
 `$PSModuleAutoloadingPreference` variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
@@ -125,9 +125,9 @@ parameter of `Get-Module` to get the PowerShell modules in the **PSSession**. Wh
 modules, and then use the imported commands in the current session, the commands run implicitly in
 the **PSSession** on the remote computer. You can use this strategy to manage the remote computer.
 
-You can use a similar strategy to manage computers that do not have PowerShell remoting enabled,
+You can use a similar strategy to manage computers that don't have PowerShell remoting enabled,
 including computers that are not running the Windows operating system, and Windows computers that
-have PowerShell, but do not have PowerShell remoting enabled.
+have PowerShell, but don't have PowerShell remoting enabled.
 
 Start by creating a CIM session on the remote computer, which is a connection to Windows Management
 Instrumentation (WMI) on the remote computer. Then use the **CIMSession** parameter of
@@ -160,7 +160,7 @@ Get-Module -ListAvailable | Import-Module
 
 ### Example 3: Import the members of several modules into the current session
 
-This example imports the members of the **BitsTransfer** and **Dism** modules into the
+This example imports the members of the **PSDiagnostics** and **Dism** modules into the
 current session.
 
 ```powershell
@@ -175,8 +175,8 @@ modules that are not yet imported into the session.
 The **ModuleInfo** parameter of `Import-Module` is used to import the modules into the current
 session.
 
-These commands are equivalent to using a pipeline operator (|) to send the output of a `Get-Module`
-command to `Import-Module`.
+These commands are equivalent to using a pipeline operator (`|`) to send the output of a
+`Get-Module` command to `Import-Module`.
 
 ### Example 4: Import all modules specified by a path
 
@@ -282,7 +282,7 @@ Function        Start-xTrace                           6.1.0.0    PSDiagnostics
 Function        Stop-xTrace                            6.1.0.0    PSDiagnostics
 ```
 
-It uses the **Prefix** parameter of `Import-Module` adds the "x" prefix to all members that are
+It uses the **Prefix** parameter of `Import-Module` adds the **x** prefix to all members that are
 imported from the module and the **PassThru** parameter to return a module object that represents
 the imported module.
 
@@ -338,16 +338,16 @@ $a."Show-Calendar"()
 ```
 
 The first command uses the `Get-Module` cmdlet to get the available modules. The command uses a
-pipeline operator to pass the module objects to the Format-Table cmdlet, which lists the **Name**
+pipeline operator to pass the module objects to the `Format-Table` cmdlet, which lists the **Name**
 and **ModuleType** of each module in a table.
 
 The second command uses the `Import-Module` cmdlet to import the **Show-Calendar** script module.
 The command uses the **AsCustomObject** parameter to request a custom object and the **PassThru**
 parameter to return the object. The command saves the resulting custom object in the `$a` variable.
 
-The third command uses a pipeline operator to send the $a variable to the `Get-Member` cmdlet, which
-gets the properties and methods of the **PSCustomObject** in `$a`. The output shows a
-**Show-Calendar** script method.
+The third command uses a pipeline operator to send the `$a` variable to the `Get-Member` cmdlet,
+which gets the properties and methods of the **PSCustomObject** in `$a`. The output shows a
+**Show-Calendar()** script method.
 
 The last command uses the **Show-Calendar** script method. The method name must be enclosed in
 quotation marks, because it includes a hyphen.
@@ -501,9 +501,9 @@ variable.
 The third command uses the **PSSession** parameter of the `Import-Module` cmdlet to import the
 **NetSecurity** module from the session in the `$s` variable into the current session.
 
-The fourth command uses the `Get-Command` cmdlet to get commands that begin with "Get" and include
-"Firewall" from the NetSecurity module.The output gets the commands and confirms that the module and
-its cmdlets were imported into the current session.
+The fourth command uses the `Get-Command` cmdlet to get commands that begin with **Get** and include
+**Firewall** from the **NetSecurity** module.The output gets the commands and confirms that the
+module and its cmdlets were imported into the current session.
 
 The fifth command uses the `Get-NetFirewallRule` cmdlet to get Windows Remote Management firewall
 rules on the Server01 computer. This command is equivalent to using the `Invoke-Command` cmdlet to
@@ -615,7 +615,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -698,7 +698,7 @@ current session. When you use the commands from the imported module in the curre
 commands actually run on the remote computer.
 
 You can use this parameter to import modules from computers and devices that are not running the
-Windows operating system, and Windows computers that have PowerShell, but do not have PowerShell
+Windows operating system, and Windows computers that have PowerShell, but don't have PowerShell
 remoting enabled.
 
 This parameter was introduced in Windows PowerShell 3.0.
@@ -758,7 +758,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -774,7 +774,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -838,7 +838,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -949,7 +949,7 @@ Aliases: NoOverwrite
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -966,7 +966,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -1043,7 +1043,7 @@ a script.
 This parameter was introduced in Windows PowerShell 3.0.
 
 Scripts that use **RequiredVersion** to import modules that are included with existing releases of
-the Windows operating system do not automatically run in future releases of the Windows operating
+the Windows operating system don't automatically run in future releases of the Windows operating
 system. This is because PowerShell module version numbers in future releases of the Windows
 operating system are higher than module version numbers in existing releases of the Windows
 operating system.
@@ -1074,8 +1074,8 @@ scriptblock, all the commands are imported into the global session state. You ca
 parameter with the value of **Local** to import module content into the script or scriptblock scope.
 
 When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
-commands from nested modules, into the caller's session state. Specifying **-Scope Global** or
-**-Global** indicates that this cmdlet imports modules into the global session state so they are
+commands from nested modules, into the caller's session state. Specifying `-Scope Global` or
+`-Global` indicates that this cmdlet imports modules into the global session state so they are
 available to all commands in the session.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of Global.
@@ -1140,7 +1140,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -1148,7 +1148,7 @@ Accept wildcard characters: False
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -1183,7 +1183,7 @@ generate any output. If you specify the **PassThru** parameter, the cmdlet gener
 * To update the formatting data for commands that have been imported from a module, use the
   `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in
   the session that were imported from modules. If the formatting file for a module changes, you can
-  run an `Update-FormatData` command to update the formatting data for imported commands. You do not
+  run an `Update-FormatData` command to update the formatting data for imported commands. You don't
   need to import the module again.
 
 * Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are
@@ -1225,7 +1225,7 @@ generate any output. If you specify the **PassThru** parameter, the cmdlet gener
   alternate CIM provider that has the same basic features.
 
   You can use the CIM session feature on computers that are not running a Windows operating system
-  and on Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
+  and on Windows computers that have PowerShell, but don't have PowerShell remoting enabled.
 
   You can also use the CIM parameters to get CIM modules from computers that have PowerShell
   remoting enabled, including the local computer. When you create a CIM session on the local

--- a/reference/7/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/7/Microsoft.PowerShell.Core/Import-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 03/28/2019
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096585
 schema: 2.0.0
 title: Import-Module
@@ -17,139 +17,170 @@ Adds modules to the current session.
 ## SYNTAX
 
 ### Name (Default)
+
 ```
-Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
- [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject]
- [-MinimumVersion <Version>] [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>]
- [-DisableNameChecking] [-NoClobber] [-Scope <String>] [<CommonParameters>]
+Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>]
+ [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck]
+ [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>] [-MaximumVersion <String>]
+ [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber]
+ [-Scope <String>]  [<CommonParameters>]
 ```
 
 ### PSSession
+
 ```
-Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
- [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject]
- [-MinimumVersion <Version>] [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>]
- [-DisableNameChecking] [-NoClobber] [-Scope <String>] -PSSession <PSSession> [<CommonParameters>]
+Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>]
+ [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck]
+ [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>] [-MaximumVersion <String>]
+ [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber]
+ [-Scope <String>] -PSSession <PSSession>  [<CommonParameters>]
 ```
 
 ### CimSession
-```
-Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>] [-Cmdlet <String[]>]
- [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject]
- [-MinimumVersion <Version>] [-MaximumVersion <String>] [-RequiredVersion <Version>] [-ArgumentList <Object[]>]
- [-DisableNameChecking] [-NoClobber] [-Scope <String>] -CimSession <CimSession> [-CimResourceUri <Uri>]
- [-CimNamespace <String>] [<CommonParameters>]
-```
 
-### FullyQualifiedName
 ```
-Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]> [-Function <String[]>]
- [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru]
- [-AsCustomObject] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>]
+Import-Module [-Global] [-Prefix <String>] [-Name] <String[]> [-Function <String[]>]
+ [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck]
+ [-PassThru] [-AsCustomObject] [-MinimumVersion <Version>] [-MaximumVersion <String>]
+ [-RequiredVersion <Version>] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber]
+ [-Scope <String>] -CimSession <CimSession> [-CimResourceUri <Uri>] [-CimNamespace <String>]
  [<CommonParameters>]
 ```
 
-### FullyQualifiedNameAndPSSession
+### FullyQualifiedName
+
 ```
-Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]> [-Function <String[]>]
- [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru]
- [-AsCustomObject] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>]
- -PSSession <PSSession> [<CommonParameters>]
+Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]>
+ [-Function <String[]>] [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force]
+ [-SkipEditionCheck] [-PassThru] [-AsCustomObject] [-ArgumentList <Object[]>] [-DisableNameChecking]
+ [-NoClobber] [-Scope <String>]  [<CommonParameters>]
+```
+
+### FullyQualifiedNameAndPSSession
+
+```
+Import-Module [-Global] [-Prefix <String>] [-FullyQualifiedName] <ModuleSpecification[]>
+ [-Function <String[]>] [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force]
+ [-SkipEditionCheck] [-PassThru] [-AsCustomObject] [-ArgumentList <Object[]>] [-DisableNameChecking]
+ [-NoClobber] [-Scope <String>] -PSSession <PSSession>  [<CommonParameters>]
 ```
 
 ### Assembly
+
 ```
-Import-Module [-Global] [-Prefix <String>] [-Assembly] <Assembly[]> [-Function <String[]>] [-Cmdlet <String[]>]
- [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject]
- [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>] [<CommonParameters>]
+Import-Module [-Global] [-Prefix <String>] [-Assembly] <Assembly[]> [-Function <String[]>]
+ [-Cmdlet <String[]>] [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck]
+ [-PassThru] [-AsCustomObject] [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber]
+ [-Scope <String>]  [<CommonParameters>]
 ```
 
 ### ModuleInfo
+
 ```
-Import-Module [-Global] [-Prefix <String>] [-Function <String[]>] [-Cmdlet <String[]>] [-Variable <String[]>]
- [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru] [-AsCustomObject] [-ModuleInfo] <PSModuleInfo[]>
- [-ArgumentList <Object[]>] [-DisableNameChecking] [-NoClobber] [-Scope <String>] [<CommonParameters>]
+Import-Module [-Global] [-Prefix <String>] [-Function <String[]>] [-Cmdlet <String[]>]
+ [-Variable <String[]>] [-Alias <String[]>] [-Force] [-SkipEditionCheck] [-PassThru]
+ [-AsCustomObject] [-ModuleInfo] <PSModuleInfo[]> [-ArgumentList <Object[]>] [-DisableNameChecking]
+ [-NoClobber] [-Scope <String>]  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The **Import-Module** cmdlet adds one or more modules to the current session.
-The modules that you import must be installed on the local computer or a remote computer.
+The `Import-Module` cmdlet adds one or more modules to the current session. The modules that you
+import must be installed on the local computer or a remote computer.
 
-Starting in Windows PowerShell 3.0, installed modules are automatically imported to the session when you use any commands or providers in the module.
-However, you can still use the **Import-Module** command to import a module and you can enable and disable automatic module importing by using the $PSModuleAutoloadingPreference preference variable.
-For more information about modules, see [about_Modules](About/about_Modules.md).
-For more information about the $PSModuleAutoloadingPreference variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
+Starting in Windows PowerShell 3.0, installed modules are automatically imported to the session when
+you use any commands or providers in the module. However, you can still use the `Import-Module`
+command to import a module and you can enable and disable automatic module importing by using the
+`$PSModuleAutoloadingPreference` preference variable. For more information about modules, see
+[about_Modules](About/about_Modules.md). For more information about the
+`$PSModuleAutoloadingPreference` variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
 
-A module is a package that contains members that can be used in PowerShell.
-Members include cmdlets, providers, scripts, functions, variables, and other tools and files.
-After a module is imported, you can use the module members in your session.
+A module is a package that contains members that can be used in PowerShell. Members include cmdlets,
+providers, scripts, functions, variables, and other tools and files. After a module is imported, you
+can use the module members in your session.
 
-To import a module, use the *Name*, *Assembly*, *ModuleInfo*, *MinimumVersion* and *RequiredVersion* parameters to identify the module to import.
-By default, **Import-Module** imports all members that the module exports, but you can use the *Alias*, *Function*, *Cmdlet*, and *Variable* parameters to restrict the members that are imported.
-You can also use the *NoClobber* parameter to prevent **Import-Module** from importing members that have the same names as members in the current session.
+To import a module, use the **Name**, **Assembly**, **ModuleInfo**, **MinimumVersion** and
+**RequiredVersion** parameters to identify the module to import. By default, `Import-Module` imports
+all members that the module exports, but you can use the **Alias**, **Function**, **Cmdlet**, and
+**Variable** parameters to restrict the members that are imported. You can also use the
+**NoClobber** parameter to prevent `Import-Module` from importing members that have the same names
+as members in the current session.
 
-**Import-Module** imports a module only into the current session.
-To import the module into all sessions, add an **Import-Module** command to your PowerShell profile.
-For more information about profiles, see [about_Profiles](About/about_Profiles.md).
+`Import-Module` imports a module only into the current session. To import the module into all
+sessions, add an `Import-Module` command to your PowerShell profile. For more information about
+profiles, see [about_Profiles](About/about_Profiles.md).
 
-Starting in Windows PowerShell 3.0, you can use **Import-Module** to import Common Information Model (CIM) modules, in which the cmdlets are defined in Cmdlet Definition XML (CDXML) files.
-This feature allows you to use cmdlets that are implemented in non-managed code assemblies, such as those written in C++.
+Starting in Windows PowerShell 3.0, you can use `Import-Module` to import Common Information Model
+(CIM) modules, in which the cmdlets are defined in Cmdlet Definition XML (CDXML) files. This feature
+allows you to use cmdlets that are implemented in non-managed code assemblies, such as those written
+in C++.
 
-With these new features, **Import-Module** cmdlet becomes a primary tool for managing heterogeneous enterprises that include computers that run the Windows operating system and computers that are running other operating systems.
+With these new features, `Import-Module` cmdlet becomes a primary tool for managing heterogeneous
+enterprises that include computers that run the Windows operating system and computers that are
+running other operating systems.
 
-To manage remote computers that run the Windows operating system that have PowerShell and PowerShell remoting enabled, create a **PSSession** on the remote computer and then use the *PSSession* parameter of **Get-Module** to get the PowerShell modules in the **PSSession**.
-When you import the modules, and then use the imported commands in the current session, the commands run implicitly in the **PSSession** on the remote computer.
-You can use this strategy to manage the remote computer.
+To manage remote computers that run the Windows operating system that have PowerShell and PowerShell
+remoting enabled, create a **PSSession** on the remote computer and then use the **PSSession**
+parameter of `Get-Module` to get the PowerShell modules in the **PSSession**. When you import the
+modules, and then use the imported commands in the current session, the commands run implicitly in
+the **PSSession** on the remote computer. You can use this strategy to manage the remote computer.
 
-You can use a similar strategy to manage computers that do not have PowerShell remoting enabled, including computers that are not running the Windows operating system, and Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
+You can use a similar strategy to manage computers that do not have PowerShell remoting enabled,
+including computers that are not running the Windows operating system, and Windows computers that
+have PowerShell, but do not have PowerShell remoting enabled.
 
-Start by creating a CIM session on the remote computer, which is a connection to Windows Management Instrumentation (WMI) on the remote computer.
-Then use the *CIMSession* parameter of **Import-Module** to import CIM modules from the remote computer.
-When you import a CIM module and then run the imported commands, the commands run implicitly on the remote computer.
-You can use this WMI and CIM strategy to manage the remote computer.
+Start by creating a CIM session on the remote computer, which is a connection to Windows Management
+Instrumentation (WMI) on the remote computer. Then use the **CIMSession** parameter of
+`Import-Module` to import CIM modules from the remote computer. When you import a CIM module and
+then run the imported commands, the commands run implicitly on the remote computer. You can use this
+WMI and CIM strategy to manage the remote computer.
 
 ## EXAMPLES
 
 ### Example 1: Import the members of a module into the current session
 
+This example imports the members of the **PSDiagnostics** module into the current session. The
+**Name** parameter name is optional and can be omitted.
+
 ```powershell
-Import-Module -Name BitsTransfer
+Import-Module -Name PSDiagnostics
 ```
 
-This command imports the members of the **BitsTransfer** module into the current session.
-
-The *Name* parameter name is optional and can be omitted.
-
-By default, **Import-Module** does not generate any output when it imports a module.
-To request output, use the *PassThru* or *AsCustomObject* parameter, or the *Verbose* common parameter.
+By default, `Import-Module` does not generate any output when it imports a module. To request
+output, use the **PassThru** or **AsCustomObject** parameter, or the **Verbose** common parameter.
 
 ### Example 2: Import all modules specified by the module path
+
+This example imports all available modules in the path specified by the `$env:PSModulePath`
+environment variable into the current session.
 
 ```powershell
 Get-Module -ListAvailable | Import-Module
 ```
 
-This command imports all available modules in the path specified by the PSModulePath environment variable ($env:PSModulePath) into the current session.
-
 ### Example 3: Import the members of several modules into the current session
 
+This example imports the members of the **BitsTransfer** and **Dism** modules into the
+current session.
+
 ```powershell
-$m = Get-Module -ListAvailable BitsTransfer, ServerManager
+$m = Get-Module -ListAvailable PSDiagnostics, Dism
 Import-Module -ModuleInfo $m
 ```
 
-These commands import the members of the **BitsTransfer** and **ServerManager** modules into the current session.
+The `Get-Module` cmdlet gets the **PSDiagnostics** and **Dism** modules and saves the
+objects in the `$m` variable. The **ListAvailable** parameter is required when you are getting
+modules that are not yet imported into the session.
 
-The first command uses the Get-Module cmdlet to get the **BitsTransfer** and **ServerManager** modules.
-It saves the objects in the $m variable.
-The *ListAvailable* parameter is required when you are getting modules that are not yet imported into the session.
+The **ModuleInfo** parameter of `Import-Module` is used to import the modules into the current
+session.
 
-The second command uses the *ModuleInfo* parameter of **Import-Module** to import the modules into the current session.
-
-These commands are equivalent to using a pipeline operator (|) to send the output of a **Get-Module** command to **Import-Module**.
+These commands are equivalent to using a pipeline operator (|) to send the output of a `Get-Module`
+command to `Import-Module`.
 
 ### Example 4: Import all modules specified by a path
+
+This example uses an explicit path to identify the module to import.
 
 ```powershell
 Import-Module -Name c:\ps-test\modules\test -Verbose
@@ -163,104 +194,115 @@ VERBOSE: Exporting function 'Get-Specification'.
 VERBOSE: Exporting function 'Get-SpecDetails'.
 ```
 
-This command uses an explicit path to identify the module to import.
-
-It also uses the *Verbose* common parameter to get a list of the items imported from the module.
-Without the *Verbose*, *PassThru*, or *AsCustomObject* parameter, **Import-Module** does not generate any output when it imports a module.
+Using the **Verbose** parameter causes `Import-Module` to report progress as it loads the module.
+Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, `Import-Module` does not
+generate any output when it imports a module.
 
 ### Example 5: Restrict module members imported into a session
 
+This example shows how to restrict which module members are imported into the session and the effect
+of this command on the session.
+
 ```powershell
-Import-Module BitsTransfer -Cmdlet Add-BitsFile, Get-BitsTransfer
-(Get-Module BitsTransfer).ExportedCmdlets
+Import-Module PSDiagnostics -Function Disable-PSTrace, Enable-PSTrace
+(Get-Module PSDiagnostics).ExportedCommands
 ```
 
 ```Output
-Key                   Value
----                   -----
-Add-BitsFile          Add-BitsFile
-Complete-BitsTransfer Complete-BitsTransfer
-Get-BitsTransfer      Get-BitsTransfer
-Remove-BitsTransfer   Remove-BitsTransfer
-Resume-BitsTransfer   Resume-BitsTransfer
-Set-BitsTransfer      Set-BitsTransfer
-Start-BitsTransfer    Start-BitsTransfer
-Suspend-BitsTransfer  Suspend-BitsTransfer
+Key                          Value
+---                          -----
+Disable-PSTrace              Disable-PSTrace
+Disable-PSWSManCombinedTrace Disable-PSWSManCombinedTrace
+Disable-WSManTrace           Disable-WSManTrace
+Enable-PSTrace               Enable-PSTrace
+Enable-PSWSManCombinedTrace  Enable-PSWSManCombinedTrace
+Enable-WSManTrace            Enable-WSManTrace
+Get-LogProperties            Get-LogProperties
+Set-LogProperties            Set-LogProperties
+Start-Trace                  Start-Trace
+Stop-Trace                   Stop-Trace
 ```
 
 ```powershell
-Get-Command -Module BitsTransfer
+Get-Command -Module PSDiagnostics
 ```
 
 ```Output
-CommandType Name             Version Source
------------ ----             ------- ------
-Cmdlet      Add-BitsFile     2.0.0.0 BitsTransfer
-Cmdlet      Get-BitsTransfer 2.0.0.0 BitsTransfer
+CommandType     Name                 Version    Source
+-----------     ----                 -------    ------
+Function        Disable-PSTrace      6.1.0.0    PSDiagnostics
+Function        Enable-PSTrace       6.1.0.0    PSDiagnostics
 ```
 
-This example shows how to restrict the module members that are imported into the session and the effect of this command on the session.
+The first command imports only the `Disable-PSTrace` and `Enable-PSTrace` cmdlets from the
+**PSDiagnostics** module. The **Function** parameter limits the members that are imported from the
+module. You can also use the **Alias**, **Variable**, and **Cmdlet** parameters to restrict other
+members that a module imports.
 
-The first command imports only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets from the **BitsTransfer** module.
-The command uses the *Cmdlet* parameter to restrict the cmdlets that the module imports.
-You can also use the *Alias*, *Variable*, and *Function* parameters to restrict other members that a module imports.
+The `Get-Module` cmdlet gets the object that represents the **PSDiagnostics** module. The
+**ExportedCmdlets** property lists all the cmdlets that the module exports, even though they were
+not all imported.
 
-The second command uses the Get-Module cmdlet to get the object that represents the **BitsTransfer** module.
-The **ExportedCmdlets** property lists all of the cmdlets that the module exports, even when they were not all imported.
-
-The third command uses the *Module* parameter of the Get-Command cmdlet to get the commands that were imported from the **BitsTransfer** module.
-The results confirm that only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets were imported.
+In the third command, the **Module** parameter of the `Get-Command` cmdlet gets the commands that
+were imported from the **PSDiagnostics** module. The results confirm that only the `Disable-PSTrace`
+and `Enable-PSTrace` cmdlets were imported.
 
 ### Example 6: Import the members of a module and add a prefix
 
+This example imports the **PSDiagnostics** module into the current session, adds a prefix to the
+member names, and then displays the prefixed member names. The prefix applies only to the members in
+the current session. It does not change the module.
+
 ```powershell
-Import-Module BitsTransfer -Prefix PS -PassThru
+Import-Module PSDiagnostics -Prefix x -PassThru
 ```
 
 ```Output
-ModuleType Name                                ExportedCommands
----------- ----                                ----------------
-Manifest   bitstransfer                        {Add-BitsFile, Complete-...
+ModuleType Version    Name               ExportedCommands
+---------- -------    ----               ----------------
+Script     6.1.0.0    PSDiagnostics      {Disable-xPSTrace, Disable-xPSWSManCombinedTrace, Disable-xW...
 ```
 
 ```powershell
-Get-Command -Module BitsTransfer
+Get-Command -Module PSDiagnostics
 ```
 
 ```Output
-CommandType     Name                                               ModuleName
------------     ----                                               ----------
-Cmdlet          Add-BitsFile                                       bitstransfer
-Cmdlet          Add-PSBitsFile                                     bitstransfer
-Cmdlet          Complete-BitsTransfer                              bitstransfer
-Cmdlet          Complete-PSBitsTransfer                            bitstransfer
-Cmdlet          Get-BitsTransfer                                   bitstransfer
-Cmdlet          Get-PSBitsTransfer                                 bitstransfer
-Cmdlet          Remove-BitsTransfer                                bitstransfer
-Cmdlet          Remove-PSBitsTransfer                              bitstransfer
-Cmdlet          Resume-BitsTransfer                                bitstransfer
-Cmdlet          Resume-PSBitsTransfer                              bitstransfer
-Cmdlet          Set-BitsTransfer                                   bitstransfer
-Cmdlet          Set-PSBitsTransfer                                 bitstransfer
-Cmdlet          Start-BitsTransfer                                 bitstransfer
-Cmdlet          Start-PSBitsTransfer                               bitstransfer
-Cmdlet          Suspend-BitsTransfer                               bitstransfer
-Cmdlet          Suspend-PSBitsTransfer                             bitstransfer
+CommandType     Name                                   Version    Source
+-----------     ----                                   -------    ------
+Function        Disable-xPSTrace                       6.1.0.0    PSDiagnostics
+Function        Disable-xPSWSManCombinedTrace          6.1.0.0    PSDiagnostics
+Function        Disable-xWSManTrace                    6.1.0.0    PSDiagnostics
+Function        Enable-xPSTrace                        6.1.0.0    PSDiagnostics
+Function        Enable-xPSWSManCombinedTrace           6.1.0.0    PSDiagnostics
+Function        Enable-xWSManTrace                     6.1.0.0    PSDiagnostics
+Function        Get-xLogProperties                     6.1.0.0    PSDiagnostics
+Function        Set-xLogProperties                     6.1.0.0    PSDiagnostics
+Function        Start-xTrace                           6.1.0.0    PSDiagnostics
+Function        Stop-xTrace                            6.1.0.0    PSDiagnostics
 ```
 
-These commands import the **BitsTransfer** module into the current session, add a prefix to the member names, and then display the prefixed member names.
+It uses the **Prefix** parameter of `Import-Module` adds the "x" prefix to all members that are
+imported from the module and the **PassThru** parameter to return a module object that represents
+the imported module.
 
-The first command uses the **Import-Module** cmdlet to import the **BitsTransfer** module.
-It uses the *Prefix* parameter to add the PS prefix to all members that are imported from the module and the *PassThru* parameter to return a module object that represents the imported module.
-
-The second command uses the **Get-Command** cmdlet to get the members that have been imported from the module.
-It uses the *Module* parameter to specify the module.
-The output shows that the module members were correctly prefixed.
-
-The prefix that you use applies only to the members in the current session.
-It does not change the module.
+The `Get-Command` cmdlet to get the members that have been imported from the module. The output
+shows that the module members were correctly prefixed.
 
 ### Example 7: Get and use a custom object
+
+These commands demonstrate how to get and use the custom object that **Import-Module** returns.
+
+Custom objects include synthetic members that represent each of the imported module members. For
+example, the cmdlets and functions in a module are converted to script methods of the custom object.
+
+Custom objects are very useful in scripting. They are also useful when several imported objects have
+the same names. Using the script method of an object is equivalent to specifying the fully qualified
+name of an imported member, including its module name.
+
+The **AsCustomObject** parameter can be used only when importing a script module, so the first task
+is to determine which of the available modules is a script module.
+
 
 ```powershell
 Get-Module -List | Format-Table -Property Name, ModuleType -AutoSize
@@ -295,53 +337,50 @@ Show-Calendar ScriptMethod System.Object Show-Calendar();
 $a."Show-Calendar"()
 ```
 
-These commands demonstrate how to get and use the custom object that **Import-Module** returns.
+The first command uses the `Get-Module` cmdlet to get the available modules. The command uses a
+pipeline operator to pass the module objects to the Format-Table cmdlet, which lists the **Name**
+and **ModuleType** of each module in a table.
 
-Custom objects include synthetic members that represent each of the imported module members.
-For example, the cmdlets and functions in a module are converted to script methods of the custom object.
+The second command uses the `Import-Module` cmdlet to import the **Show-Calendar** script module.
+The command uses the **AsCustomObject** parameter to request a custom object and the **PassThru**
+parameter to return the object. The command saves the resulting custom object in the `$a` variable.
 
-Custom objects are very useful in scripting.
-They are also useful when several imported objects have the same names.
-Using the script method of an object is equivalent to specifying the fully qualified name of an imported member, including its module name.
+The third command uses a pipeline operator to send the $a variable to the `Get-Member` cmdlet, which
+gets the properties and methods of the **PSCustomObject** in `$a`. The output shows a
+**Show-Calendar** script method.
 
-The *AsCustomObject* parameter can be used only when importing a script module, so the first task is to determine which of the available modules is a script module.
-
-The first command uses the Get-Module cmdlet to get the available modules.
-The command uses a pipeline operator to pass the module objects to the Format-Table cmdlet, which lists the **Name** and **ModuleType** of each module in a table.
-
-The second command uses the **Import-Module** cmdlet to import the **PSDiagnostics** script module.
-The command uses the *AsCustomObject* parameter to request a custom object and the *PassThru* parameter to return the object.
-The command saves the resulting custom object in the $a variable.
-
-The third command uses a pipeline operator to send the $a variable to the Get-Member cmdlet, which gets the properties and methods of the **PSCustomObject** in $a.
-The output shows a **Show-Calendar** script method.
-
-The last command uses the **Show-Calendar** script method.
-The method name must be enclosed in quotation marks, because it includes a hyphen.
+The last command uses the **Show-Calendar** script method. The method name must be enclosed in
+quotation marks, because it includes a hyphen.
 
 ### Example 8: Re-import a module into the same session
 
+This example shows how to use the **Force** parameter of `Import-Module` when you are re-importing a
+module into the same session.
+
 ```powershell
-Import-Module BitsTransfer
-Import-Module BitsTransfer -Force -Prefix PS
+Import-Module PSDiagnostics
+Import-Module PSDiagnostics -Force -Prefix PS
 ```
 
-This example shows how to use the *Force* parameter of **Import-Module** when you are re-importing a module into the same session.
+The first command imports the **PSDiagnostics** module. The second command imports the module again,
+this time using the **Prefix** parameter.
 
-The first command imports the **BitsTransfer** module.
-The second command imports the module again, this time using the *Prefix* parameter.
-
-The second command also includes the *Force* parameter, which removes the module and then imports it again.
-Without this parameter, the session would include two copies of each **BitsTransfer** cmdlet, one with the standard name and one with the prefixed name.
+Using the **Force** parameter, `Import-Module` removes the module and then imports it again. Without
+this parameter, the session would include two copies of each **PSDiagnostics** cmdlet, one with the
+standard name and one with the prefixed name.
 
 ### Example 9: Run commands that have been hidden by imported commands
+
+This example shows how to run commands that have been hidden by imported commands. The
+**TestModule** module. includes a function named `Get-Date` that returns the year and day of the
+year.
 
 ```powershell
 Get-Date
 ```
 
 ```Output
-Thursday, March 15, 2012 6:47:04 PM
+Thursday, August 15, 2019 2:26:12 PM
 ```
 
 ```powershell
@@ -350,7 +389,7 @@ Get-Date
 ```
 
 ```Output
-12075
+19227
 ```
 
 ```powershell
@@ -369,24 +408,19 @@ Microsoft.PowerShell.Utility\Get-Date
 ```
 
 ```Output
-Saturday, September 12, 2009 6:33:23 PM
+Thursday, August 15, 2019 2:28:31 PM
 ```
 
-This example shows how to run commands that have been hidden by imported commands.
+The first Get-Date` cmdlet returns a **DateTime** object with the current date. After importing the
+**TestModule** module, `Get-Date` returns the year and day of the year.
 
-The first command run the Get-Date cmdlet.
-It returns a **DateTime** object with the current date.
+Using the **All** parameter of the `Get-Command` we get all of the `Get-Date` commands in the
+session. The results show that there are two `Get-Date` commands in the session, a function from the
+**TestModule** module and a cmdlet from the **Microsoft.PowerShell.Utility** module.
 
-The second command imports the **TestModule** module.
-This module includes a function named **Get-Date** that returns the year and day of the year.
-
-The third command runs the **Get-Date** command again.
-Because functions take precedence over cmdlets, the **Get-Date** function from the **TestModule** module runs, instead of the **Get-Date** cmdlet.
-
-The fourth command uses the *All* parameter of the **Get-Command** to get all of the Get-Date commands in the session.
-The results show that there are two **Get-Date** commands in the session, a function from the **TestModule** module and a cmdlet from the **Microsoft.PowerShell.Utility** module.
-
-The fifth command runs the hidden cmdlet by qualifying the command name with the module name.
+Because functions take precedence over cmdlets, the `Get-Date` function from the **TestModule**
+module runs, instead of the `Get-Date` cmdlet. To run the original version of `Get-Date` you must
+qualify the command name with the module name.
 
 For more information about command precedence in PowerShell, see [about_Command_Precedence](about/about_Command_Precedence.md).
 
@@ -396,14 +430,16 @@ For more information about command precedence in PowerShell, see [about_Command_
 Import-Module -Name PSWorkflow -MinimumVersion 3.0.0.0
 ```
 
-This command imports the **PSWorkflow** module.
-It uses the *MinimumVersion* parameter of **Import-Module** to import only version 3.0.0.0 or greater of the module.
+This command imports the **PSWorkflow** module. It uses the **MinimumVersion** parameter of
+`Import-Module` to import only version 3.0.0.0 or greater of the module.
 
-You can also use the *RequiredVersion* parameter to import a particular version of a module, or use the *Module* and *Version* parameters of the **#Requires** keyword to require a particular version of a module in a script.
+You can also use the **RequiredVersion** parameter to import a particular version of a module, or
+use the **Module** and **Version** parameters of the `#Requires` keyword to require a particular
+version of a module in a script.
 
 ### Example 11: Import a module from a remote computer
 
-This example shows how to use the **Import-Module** cmdlet to import a module from a remote computer.
+This example shows how to use the `Import-Module` cmdlet to import a module from a remote computer.
 This command uses the Implicit Remoting feature of PowerShell.
 
 When you import modules from another session, you can use the cmdlets in the current session.
@@ -412,14 +448,20 @@ However, commands that use the cmdlets actually run in the remote session.
 ```powershell
 $s = New-PSSession -ComputerName Server01
 Get-Module -PSSession $s -ListAvailable -Name NetSecurity
+```
 
+```Output
 ModuleType Name                                ExportedCommands
 ---------- ----                                ----------------
 Manifest   NetSecurity                         {New-NetIPsecAuthProposal, New-NetIPsecMainModeCryptoProposal, New-Ne...
+```
 
+```powershell
 Import-Module -PSSession $s -Name NetSecurity
 Get-Command -Module NetSecurity -Name Get-*Firewall*
+```
 
+```Output
 CommandType     Name                                               ModuleName
 -----------     ----                                               ----------
 Function        Get-NetFirewallAddressFilter                       NetSecurity
@@ -432,9 +474,13 @@ Function        Get-NetFirewallRule                                NetSecurity
 Function        Get-NetFirewallSecurityFilter                      NetSecurity
 Function        Get-NetFirewallServiceFilter                       NetSecurity
 Function        Get-NetFirewallSetting                             NetSecurity
+```
 
+```powershell
 Get-NetFirewallRule -DisplayName "Windows Remote Management*" | Format-Table -Property DisplayName, Name -AutoSize
+```
 
+```Output
 DisplayName                                              Name
 -----------                                              ----
 Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP
@@ -442,41 +488,67 @@ Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP-PUBLI
 Windows Remote Management - Compatibility Mode (HTTP-In) WINRM-HTTP-Compat-In-TCP
 ```
 
-The first command uses the New-PSSession cmdlet to create a remote session (**PSSession**) to the Server01 computer. The command saves the **PSSession** in the $s variable.
+The first command uses the `New-PSSession` cmdlet to create a remote session (**PSSession**) to the
+Server01 computer. The command saves the **PSSession** in the `$s` variable.
 
-The second command uses the *PSSession* parameter of the Get-Module cmdlet to get the **NetSecurity** module in the session in the $s variable.This command is equivalent to using the Invoke-Command cmdlet to run a **Get-Module** command in the session in $s ([CODE_Snippit]Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity[CODE_Snippit]).The output shows that the **NetSecurity** module is installed on the computer and is available to the session in the $s variable.
+The second command uses the **PSSession** parameter of the `Get-Module` cmdlet to get the
+**NetSecurity** module in the session in the `$s` variable. This command is equivalent to using the
+`Invoke-Command` cmdlet to run a `Get-Module` command in the session in `$s`
+(`Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity`).The output shows that the
+**NetSecurity** module is installed on the computer and is available to the session in the `$s`
+variable.
 
-The third command uses the *PSSession* parameter of the **Import-Module** cmdlet to import the **NetSecurity** module from the session in the $s variable into the current session.
+The third command uses the **PSSession** parameter of the `Import-Module` cmdlet to import the
+**NetSecurity** module from the session in the `$s` variable into the current session.
 
-The fourth command uses the **Get-Command** cmdlet to get commands that begin with "Get" and include "Firewall" from the Net-Security module.The output gets the commands and confirms that the module and its cmdlets were imported into the current session.
+The fourth command uses the `Get-Command` cmdlet to get commands that begin with "Get" and include
+"Firewall" from the NetSecurity module.The output gets the commands and confirms that the module and
+its cmdlets were imported into the current session.
 
-The fifth command uses the **Get-NetFirewallRule** cmdlet to get Windows Remote Management firewall rules on the Server01 computer. This command is equivalent to using the Invoke-Command cmdlet to run a **Get-NetFirewallRule** command on the session in the `$s` variable.
+The fifth command uses the `Get-NetFirewallRule` cmdlet to get Windows Remote Management firewall
+rules on the Server01 computer. This command is equivalent to using the `Invoke-Command` cmdlet to
+run a `Get-NetFirewallRule` command on the session in the `$s` variable.
 
 ### Example 12: Manage storage on a remote computer without the Windows operating system
 
-In this example, because the administrator of the computer has installed the Module Discovery WMI provider, the CIM commands can use the default values, which are designed for the provider.
+In this example, because the administrator of the computer has installed the Module Discovery WMI
+provider, the CIM commands can use the default values, which are designed for the provider.
 
-The commands in this example enable you to manage the storage systems of a remote computer that is not running the Windows operating system.
+The commands in this example enable you to manage the storage systems of a remote computer that is
+not running the Windows operating system.
 
-The first command uses the **New-CimSession** cmdlet to create a session on the RSDGF03 remote computer. The session connects to WMI on the remote computer. The command saves the CIM session in the $cs variable.
+The first command uses the `New-CimSession` cmdlet to create a session on the RSDGF03 remote
+computer. The session connects to WMI on the remote computer. The command saves the CIM session in
+the `$cs` variable.
 
-The second command uses the CIM session in the $cs variable to run an **Import-Module** command on the RSDGF03 computer. The command uses the *Name* parameter to specify the **Storage** CIM module.
+The second command uses the CIM session in the `$cs` variable to run an `Import-Module` command on
+the RSDGF03 computer. The command uses the **Name** parameter to specify the **Storage** CIM module.
 
-The third command runs the **Get-Command** command on the **Get-Disk** command in the **Storage** module.When you import a CIM module into the local session, PowerShell converts the CDXML files for each command into PowerShell scripts, which appear as functions in the local session.
+The third command runs the `Get-Command` command on the `Get-Disk` command in the **Storage**
+module. When you import a CIM module into the local session, PowerShell converts the CDXML files for
+each command into PowerShell scripts, which appear as functions in the local session.
 
-The fourth command runs the **Get-Disk** command. Although the command is typed in the local session, it runs implicitly on the remote computer from which it was imported.The command gets objects from the remote computer and returns them to the local session.
+The fourth command runs the `Get-Disk` command. Although the command is typed in the local session,
+it runs implicitly on the remote computer from which it was imported.The command gets objects from
+the remote computer and returns them to the local session.
 
 ```powershell
 $cs = New-CimSession -ComputerName RSDGF03
 Import-Module -CimSession $cs -Name Storage
 Get-Command Get-Disk
+```
 
+```Output
 CommandType     Name                  ModuleName
 -----------     ----                  ----------
 Function        Get-Disk              Storage
+```
 
+```powershell
 Get-Disk
+```
 
+```Output
 Number Friendly Name              OperationalStatus          Total Size Partition Style
 ------ -------------              -----------------          ---------- ---------------
 0      Virtual HD ATA Device      Online                          40 GB MBR
@@ -486,9 +558,8 @@ Number Friendly Name              OperationalStatus          Total Size Partitio
 
 ### -Alias
 
-Specifies the aliases that this cmdlet imports from the module into the current session.
-Enter a comma-separated list of aliases.
-Wildcard characters are permitted.
+Specifies the aliases that this cmdlet imports from the module into the current session. Enter a
+comma-separated list of aliases. Wildcard characters are permitted.
 
 Some modules automatically export selected aliases into your session when you import the module.
 This parameter lets you select from among the exported aliases.
@@ -502,16 +573,16 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -ArgumentList
 
-Specifies an array of arguments, or parameter values, that are passed to a script module during the **Import-Module** command.
-This parameter is valid only when you are importing a script module.
+Specifies an array of arguments, or parameter values, that are passed to a script module during the
+`Import-Module` command. This parameter is valid only when you are importing a script module.
 
-You can also refer to the *ArgumentList* parameter by its alias, *args*.
-For more information, see [about_Aliases](About/about_Aliases.md).
+You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information,
+see [about_Aliases](About/about_Aliases.md).
 
 ```yaml
 Type: Object[]
@@ -527,11 +598,12 @@ Accept wildcard characters: False
 
 ### -AsCustomObject
 
-Indicates that this cmdlet returns a custom object with members that represent the imported module members.
-This parameter is valid only for script modules.
+Indicates that this cmdlet returns a custom object with members that represent the imported module
+members. This parameter is valid only for script modules.
 
-When you use the *AsCustomObject* parameter, **Import-Module** imports the module members into the session and then returns a **PSCustomObject** object instead of a **PSModuleInfo** object.
-You can save the custom object in a variable and use dot notation to invoke the members.
+When you use the **AsCustomObject** parameter, `Import-Module` imports the module members into the
+session and then returns a **PSCustomObject** object instead of a **PSModuleInfo** object. You can
+save the custom object in a variable and use dot notation to invoke the members.
 
 ```yaml
 Type: SwitchParameter
@@ -547,14 +619,14 @@ Accept wildcard characters: False
 
 ### -Assembly
 
-Specifies an array of assembly objects.
-This cmdlet imports the cmdlets and providers implemented in the specified assembly objects.
-Enter a variable that contains assembly objects or a command that creates assembly objects.
-You can also pipe an assembly object to **Import-Module**.
+Specifies an array of assembly objects. This cmdlet imports the cmdlets and providers implemented in
+the specified assembly objects. Enter a variable that contains assembly objects or a command that
+creates assembly objects. You can also pipe an assembly object to `Import-Module`.
 
-When you use this parameter, only the cmdlets and providers implemented by the specified assemblies are imported.
-If the module contains other files, they are not imported, and you might be missing important members of the module.
-Use this parameter for debugging and testing the module, or when you are instructed to use it by the module author.
+When you use this parameter, only the cmdlets and providers implemented by the specified assemblies
+are imported. If the module contains other files, they are not imported, and you might be missing
+important members of the module. Use this parameter for debugging and testing the module, or when
+you are instructed to use it by the module author.
 
 ```yaml
 Type: Assembly[]
@@ -570,10 +642,11 @@ Accept wildcard characters: False
 
 ### -CimNamespace
 
-Specifies the namespace of an alternate CIM provider that exposes CIM modules.
-The default value is the namespace of the Module Discovery WMI provider.
+Specifies the namespace of an alternate CIM provider that exposes CIM modules. The default value is
+the namespace of the Module Discovery WMI provider.
 
-Use this parameter to import CIM modules from computers and devices that are not running a Windows operating system.
+Use this parameter to import CIM modules from computers and devices that are not running a Windows
+operating system.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -591,10 +664,11 @@ Accept wildcard characters: False
 
 ### -CimResourceUri
 
-Specifies an alternate location for CIM modules.
-The default value is the resource URI of the Module Discovery WMI provider on the remote computer.
+Specifies an alternate location for CIM modules. The default value is the resource URI of the Module
+Discovery WMI provider on the remote computer.
 
-Use this parameter to import CIM modules from computers and devices that are not running a Windows operating system.
+Use this parameter to import CIM modules from computers and devices that are not running a Windows
+operating system.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -612,13 +686,17 @@ Accept wildcard characters: False
 
 ### -CimSession
 
-Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](../CimCmdlets/Get-CimSession.md) command.
+Specifies a CIM session on the remote computer. Enter a variable that contains the CIM session or a
+command that gets the CIM session, such as a [Get-CimSession](../CimCmdlets/Get-CimSession.md)
+command.
 
-**Import-Module** uses the CIM session connection to import modules from the remote computer into the current session.
-When you use the commands from the imported module in the current session, the commands actually run on the remote computer.
+`Import-Module` uses the CIM session connection to import modules from the remote computer into the
+current session. When you use the commands from the imported module in the current session, the
+commands actually run on the remote computer.
 
-You can use this parameter to import modules from computers and devices that are not running the Windows operating system, and Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
+You can use this parameter to import modules from computers and devices that are not running the
+Windows operating system, and Windows computers that have PowerShell, but do not have PowerShell
+remoting enabled.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -656,16 +734,19 @@ Accept wildcard characters: False
 
 ### -DisableNameChecking
 
-Indicates that this cmdlet suppresses the message that warns you when you import a cmdlet or function whose name includes an unapproved verb or a prohibited character.
+Indicates that this cmdlet suppresses the message that warns you when you import a cmdlet or
+function whose name includes an unapproved verb or a prohibited character.
 
-By default, when a module that you import exports cmdlets or functions that have unapproved verbs in their names, PowerShell displays the following warning message:
+By default, when a module that you import exports cmdlets or functions that have unapproved verbs in
+their names, PowerShell displays the following warning message:
 
-"WARNING: Some imported command names include unapproved verbs which might make them less discoverable.
-Use the Verbose parameter for more detail or type Get-Verb to see the list of approved verbs."
+> WARNING: Some imported command names include unapproved verbs which might make them less
+> discoverable. Use the Verbose parameter for more detail or type Get-Verb to see the list of
+> approved verbs.
 
-This message is only a warning.
-The complete module is still imported, including the non-conforming commands.
-Although the message is displayed to module users, the naming problem should be fixed by the module author.
+This message is only a warning. The complete module is still imported, including the non-conforming
+commands. Although the message is displayed to module users, the naming problem should be fixed by
+the module author.
 
 ```yaml
 Type: SwitchParameter
@@ -733,15 +814,19 @@ Accept wildcard characters: False
 
 ### -Global
 
-Indicates that this cmdlet imports modules into the global session state so they are available to all commands in the session.
+Indicates that this cmdlet imports modules into the global session state so they are available to
+all commands in the session.
 
-By default, when Import-Module cmdlet is called from the command prompt, script file, or scriptblock, all the commands are imported into the global session state.
+By default, when `Import-Module` cmdlet is called from the command prompt, script file, or
+scriptblock, all the commands are imported into the global session state.
 
-When invoked from another module, Import-Module cmdlet imports the commands in a module, including commands from nested modules, into the caller's session state.
+When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
+commands from nested modules, into the caller's session state.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of Global.
 
-To restrict the commands that a module exports, use an `Export-ModuleMember` command in the script module.
+To restrict the commands that a module exports, use an `Export-ModuleMember` command in the script
+module.
 
 ```yaml
 Type: SwitchParameter
@@ -757,16 +842,16 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies a minimum version.
-This cmdlet imports only a version of the module that is greater than or equal to the specified value.
-If no version qualifies, **Import-Module** generates an error.
+Specifies a minimum version. This cmdlet imports only a version of the module that is greater than
+or equal to the specified value. If no version qualifies, `Import-Module` generates an error.
 
-By default, **Import-Module** imports the module without checking the version number.
+By default, `Import-Module` imports the module without checking the version number.
 
-Use the *MinimumVersion* parameter name or its alias, Version.
+Use the **MinimumVersion** parameter name or its alias, Version.
 
-To specify an exact version, use the *RequiredVersion* parameter.
-You can also use the *Module* and *Version* parameters of the **#Requires** keyword to require a specific version of a module in a script.
+To specify an exact version, use the **RequiredVersion** parameter. You can also use the **Module**
+and **Version** parameters of the **#Requires** keyword to require a specific version of a module in
+a script.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -784,9 +869,9 @@ Accept wildcard characters: False
 
 ### -ModuleInfo
 
-Specifies an array of module objects to import.
-Enter a variable that contains the module objects, or a command that gets the module objects, such as the following command: `Get-Module -ListAvailable`.
-You can also pipe module objects to **Import-Module**.
+Specifies an array of module objects to import. Enter a variable that contains the module objects,
+or a command that gets the module objects, such as the following command:
+`Get-Module -ListAvailable`. You can also pipe module objects to `Import-Module`.
 
 ```yaml
 Type: PSModuleInfo[]
@@ -802,17 +887,16 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies the names of the modules to import.
-Enter the name of the module or the name of a file in the module, such as a .psd1, .psm1, .dll, or ps1 file.
-File paths are optional.
-Wildcard characters are not permitted.
-You can also pipe module names and file names to **Import-Module**.
+Specifies the names of the modules to import. Enter the name of the module or the name of a file in
+the module, such as a .psd1, .psm1, .dll, or ps1 file. File paths are optional. Wildcard characters
+are not permitted. You can also pipe module names and file names to `Import-Module`.
 
-If you omit a path, **Import-Module** looks for the module in the paths saved in the PSModulePath environment variable ($env:PSModulePath).
+If you omit a path, `Import-Module` looks for the module in the paths saved in the
+`$env:PSModulePath` environment variable.
 
-Specify only the module name whenever possible.
-When you specify a file name, only the members that are implemented in that file are imported.
-If the module contains other files, they are not imported, and you might be missing important members of the module.
+Specify only the module name whenever possible. When you specify a file name, only the members that
+are implemented in that file are imported. If the module contains other files, they are not
+imported, and you might be missing important members of the module.
 
 ```yaml
 Type: String[]
@@ -828,12 +912,13 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Indicates that this cmdlet does not import commands that have the same names as existing commands in the current session.
-By default, **Import-Module** imports all exported module commands.
+Indicates that this cmdlet does not import commands that have the same names as existing commands in
+the current session. By default, `Import-Module` imports all exported module commands.
 
-Commands that have the same names can hide or replace commands in the session.
-To avoid command name conflicts in a session, use the *Prefix* or *NoClobber* parameters.
-For more information about name conflicts and command precedence, see "Modules and Name Conflicts" in about_Modules and about_Command_Precedence.
+Commands that have the same names can hide or replace commands in the session. To avoid command name
+conflicts in a session, use the **Prefix** or **NoClobber** parameters. For more information about
+name conflicts and command precedence, see "Modules and Name Conflicts" in [about_Modules](about/about_Modules.md)
+and [about_Command_Precedence](about/about_Command_Precedence.md).
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -851,17 +936,20 @@ Accept wildcard characters: False
 
 ### -PSSession
 
-Specifies a PowerShell user-managed session (**PSSession**) from which this cmdlet import modules into the current session.
-Enter a variable that contains a **PSSession** or a command that gets a **PSSession**, such as a Get-PSSession command.
+Specifies a PowerShell user-managed session (**PSSession**) from which this cmdlet import modules
+into the current session. Enter a variable that contains a **PSSession** or a command that gets a
+**PSSession**, such as a `Get-PSSession` command.
 
-When you import a module from a different session into the current session, you can use the cmdlets from the module in the current session, just as you would use cmdlets from a local module.
-Commands that use the remote cmdlets actually run in the remote session, but the remoting details are managed in the background by PowerShell.
+When you import a module from a different session into the current session, you can use the cmdlets
+from the module in the current session, just as you would use cmdlets from a local module. Commands
+that use the remote cmdlets actually run in the remote session, but the remoting details are managed
+in the background by PowerShell.
 
-This parameter uses the Implicit Remoting feature of PowerShell.
-It is equivalent to using the Import-PSSession cmdlet to import particular modules from a session.
+This parameter uses the Implicit Remoting feature of PowerShell. It is equivalent to using the
+`Import-PSSession` cmdlet to import particular modules from a session.
 
-**Import-Module** cannot import PowerShell Core modules from another session.
-The PowerShell Core modules have names that begin with Microsoft.PowerShell.
+`Import-Module` cannot import PowerShell Core modules from another session. The PowerShell Core
+modules have names that begin with Microsoft.PowerShell.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -879,8 +967,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
+Returns an object representing the item with which you are working. By default, this cmdlet does not
+generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -898,14 +986,16 @@ Accept wildcard characters: False
 
 Specifies a prefix that this cmdlet adds to the nouns in the names of imported module members.
 
-Use this parameter to avoid name conflicts that might occur when different members in the session have the same name.
-This parameter does not change the module, and it does not affect files that the module imports for its own use.
-These are known as nested modules.
-This cmdlet affects only the names of members in the current session.
+Use this parameter to avoid name conflicts that might occur when different members in the session
+have the same name. This parameter does not change the module, and it does not affect files that the
+module imports for its own use. These are known as nested modules. This cmdlet affects only the
+names of members in the current session.
 
-For example, if you specify the prefix UTC and then import a Get-Date cmdlet, the cmdlet is known in the session as **Get-UTCDate**, and it is not confused with the original **Get-Date** cmdlet.
+For example, if you specify the prefix UTC and then import a `Get-Date` cmdlet, the cmdlet is known
+in the session as `Get-UTCDate`, and it is not confused with the original `Get-Date` cmdlet.
 
-The value of this parameter takes precedence over the **DefaultCommandPrefix** property of the module, which specifies the default prefix.
+The value of this parameter takes precedence over the **DefaultCommandPrefix** property of the
+module, which specifies the default prefix.
 
 ```yaml
 Type: String
@@ -921,18 +1011,22 @@ Accept wildcard characters: False
 
 ### -RequiredVersion
 
-Specifies a version of the module that this cmdlet imports.
-If the version is not installed, **Import-Module** generates an error.
+Specifies a version of the module that this cmdlet imports. If the version is not installed,
+`Import-Module` generates an error.
 
-By default, **Import-Module** imports the module without checking the version number.
+By default, `Import-Module` imports the module without checking the version number.
 
-To specify a minimum version, use the *MinimumVersion* parameter.
-You can also use the *Module* and *Version* parameters of the **#Requires** keyword to require a specific version of a module in a script.
+To specify a minimum version, use the **MinimumVersion** parameter. You can also use the **Module**
+and **Version** parameters of the **#Requires** keyword to require a specific version of a module in
+a script.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
-Scripts that use *RequiredVersion* to import modules that are included with existing releases of the Windows operating system do not automatically run in future releases of the Windows operating system.
-This is because PowerShell module version numbers in future releases of the Windows operating system are higher than module version numbers in existing releases of the Windows operating system.
+Scripts that use **RequiredVersion** to import modules that are included with existing releases of
+the Windows operating system do not automatically run in future releases of the Windows operating
+system. This is because PowerShell module version numbers in future releases of the Windows
+operating system are higher than module version numbers in existing releases of the Windows
+operating system.
 
 ```yaml
 Type: Version
@@ -952,14 +1046,17 @@ Specifies a scope into which this cmdlet imports the module.
 
 The acceptable values for this parameter are:
 
-- **Global**. Available to all commands in the session. Equivalent to the *Global* parameter.
+- **Global**. Available to all commands in the session. Equivalent to the **Global** parameter.
 - **Local**. Available only in the current scope.
 
-By default, when Import-Module cmdlet is called from the command prompt, script file, or scriptblock, all the commands are imported into the global session state.
-You can use the **-Scope** parameter with the value of **Local** to import module content into the script or scriptblock scope.
+By default, when `Import-Module` cmdlet is called from the command prompt, script file, or
+scriptblock, all the commands are imported into the global session state. You can use the **-Scope**
+parameter with the value of **Local** to import module content into the script or scriptblock scope.
 
-When invoked from another module, Import-Module cmdlet imports the commands in a module, including commands from nested modules, into the caller's session state.
-Specifying **-Scope Global** or **-Global** indicates that this cmdlet imports modules into the global session state so they are available to all commands in the session.
+When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
+commands from nested modules, into the caller's session state. Specifying **-Scope Global** or
+**-Global** indicates that this cmdlet imports modules into the global session state so they are
+available to all commands in the session.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of Global.
 
@@ -981,8 +1078,7 @@ Accept wildcard characters: False
 ### -Variable
 
 Specifies an array of variables that this cmdlet imports from the module into the current session.
-Enter a list of variables.
-Wildcard characters are permitted.
+Enter a list of variables. Wildcard characters are permitted.
 
 Some modules automatically export selected variables into your session when you import the module.
 This parameter lets you select from among the exported variables.
@@ -1001,9 +1097,8 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies a maximum version.
-This cmdlet imports only a version of the module that is less than or equal to the specified value.
-If no version qualifies, **Import-Module** generates an error.
+Specifies a maximum version. This cmdlet imports only a version of the module that is less than or
+equal to the specified value. If no version qualifies, `Import-Module` generates an error.
 
 ```yaml
 Type: String
@@ -1021,13 +1116,12 @@ Accept wildcard characters: False
 
 Skips the check on the `CompatiblePSEditions` field.
 
-Allows loading a module from the `%windir%\System32\WindowsPowerShell\v1.0\Modules`
-module directory into PowerShell Core when that module does not specify `Core` in the
+Allows loading a module from the `"$($env:windir)\System32\WindowsPowerShell\v1.0\Modules"` module
+directory into PowerShell Core when that module does not specify `Core` in the
 `CompatiblePSEditions` manifest field.
 
-When importing a module from another path, this switch does nothing,
-since the check is not performed.
-On Linux and macOS, this switch does nothing.
+When importing a module from another path, this switch does nothing, since the check is not
+performed. On Linux and macOS, this switch does nothing.
 
 See [about_PowerShell_Editions](About/about_PowerShell_Editions.md) for more information.
 
@@ -1049,7 +1143,9 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -1061,42 +1157,76 @@ You can pipe a module name, module object, or assembly object to this cmdlet.
 
 ### None, System.Management.Automation.PSModuleInfo, or System.Management.Automation.PSCustomObject
 
-This cmdlet returns a **PSModuleInfo** or **PSCustomObject**.
-By default, **Import-Module** does not generate any output.
-If you specify the *PassThru* parameter, the cmdlet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
-If you specify the *AsCustomObject* parameter, it generates a **PSCustomObject** object.
+This cmdlet returns a **PSModuleInfo** or **PSCustomObject**. By default, `Import-Module` does not
+generate any output. If you specify the **PassThru** parameter, the cmdlet generates a
+**System.Management.Automation.PSModuleInfo** object that represents the module. If you specify the
+**AsCustomObject** parameter, it generates a **PSCustomObject** object.
 
 ## NOTES
 
-* Before you can import a module, the module must be installed on the local computer. That is, the module directory must be copied to a directory that is accessible to your local computer. For more information, see [about_Modules](About/about_Modules.md).
+* Before you can import a module, the module must be installed on the local computer. That is, the
+  module directory must be copied to a directory that is accessible to your local computer. For more
+  information, see [about_Modules](About/about_Modules.md).
 
-  You can also use the *PSSession* and *CIMSession* parameters to import modules that are installed on remote computers.
-However, commands that use the cmdlets in these modules actually run in the remote session on the remote computer.
+  You can also use the **PSSession** and **CIMSession** parameters to import modules that are
+  installed on remote computers. However, commands that use the cmdlets in these modules actually
+  run in the remote session on the remote computer.
 
-* If you import members with the same name and the same type into your session, PowerShell uses the member imported last by default. Variables and aliases are replaced, and the originals are not accessible. Functions, cmdlets and providers are merely shadowed by the new members. They can be accessed by qualifying the command name with the name of its snap-in, module, or function path.
-* To update the formatting data for commands that have been imported from a module, use the Update-FormatData cmdlet. **Update-FormatData** also updates the formatting data for commands in the session that were imported from modules. If the formatting file for a module changes, you can run an **Update-FormatData** command to update the formatting data for imported commands. You do not need to import the module again.
-* Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are packaged in modules. In Windows PowerShell 2.0, and in host programs that create older-style sessions in later versions of PowerShell, the core commands are packaged in snap-ins (**PSSnapins**). The exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also, remote sessions, such as those started by the New-PSSession cmdlet, are older-style sessions that include core snap-ins.
+* If you import members with the same name and the same type into your session, PowerShell uses the
+  member imported last by default. Variables and aliases are replaced, and the originals are not
+  accessible. Functions, cmdlets and providers are merely shadowed by the new members. They can be
+  accessed by qualifying the command name with the name of its snap-in, module, or function path.
 
-  For information about the **CreateDefault2** method that creates newer-style sessions with core modules, see [CreateDefault2 Method](https://msdn.microsoft.com/library/system.management.automation.runspaces.initialsessionstate.createdefault2) in the MSDN library.
+* To update the formatting data for commands that have been imported from a module, use the
+  `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in
+  the session that were imported from modules. If the formatting file for a module changes, you can
+  run an `Update-FormatData` command to update the formatting data for imported commands. You do not
+  need to import the module again.
 
-* **Import-Module** cannot import PowerShell Core modules from another session. The PowerShell Core modules have names that begin with Microsoft.PowerShell.
-* In Windows PowerShell 2.0, some of the property values of the module object, such as the **ExportedCmdlets** and **NestedModules** property values, were not populated until the module was imported and were not available on the module object that the *PassThru* parameter returns. In Windows PowerShell 3.0, all module property values are populated.
-* If you attempt to import a module that contains mixed-mode assemblies that are not compatible with Windows PowerShell 3.0, **Import-Module** returns an error message like the following one.
+* Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are
+  packaged in modules. In Windows PowerShell 2.0, and in host programs that create older-style
+  sessions in later versions of PowerShell, the core commands are packaged in snap-ins
+  (**PSSnapins**). The exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also,
+  remote sessions, such as those started by the `New-PSSession` cmdlet, are older-style sessions
+  that include core snap-ins.
 
-  `Import-Module : Mixed mode assembly is built against version 'v2.0.50727' of the runtime and cannot be loaded in the 4.0 runtime without additional configuration information.`
+  For information about the **CreateDefault2** method that creates newer-style sessions with core
+  modules, see the [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2).
 
-  This error occurs when a module that is designed for Windows PowerShell 2.0 contains at least one mixed-module assembly, that is, an assembly that includes both managed and non-managed code, such as C++ and C#.
+* `Import-Module` cannot import PowerShell Core modules from another session. The PowerShell Core
+  modules have names that begin with Microsoft.PowerShell.
 
-  To import a module that contains mixed-mode assemblies, start Windows PowerShell 2.0 by using the following command, and then try the **Import-Module** command again.
+* In Windows PowerShell 2.0, some of the property values of the module object, such as the
+  **ExportedCmdlets** and **NestedModules** property values, were not populated until the module was
+  imported and were not available on the module object that the **PassThru** parameter returns. In
+  Windows PowerShell 3.0, all module property values are populated.
+
+* If you attempt to import a module that contains mixed-mode assemblies that are not compatible with
+  Windows PowerShell 3.0, `Import-Module` returns an error message like the following one.
+
+  > Import-Module : Mixed mode assembly is built against version 'v2.0.50727' of the runtime and
+  > cannot be loaded in the 4.0 runtime without additional configuration information.
+
+  This error occurs when a module that is designed for Windows PowerShell 2.0 contains at least one
+  mixed-module assembly, that is, an assembly that includes both managed and non-managed code, such
+  as C++ and C#.
+
+  To import a module that contains mixed-mode assemblies, start Windows PowerShell 2.0 by using the
+  following command, and then try the `Import-Module` command again.
 
   `PowerShell.exe -Version 2.0`
 
-* To use the CIM session feature, the remote computer must have WS-Management remoting and Windows Management Instrumentation (WMI), which is the Microsoft implementation of the Common Information Model (CIM) standard. The computer must also have the Module Discovery WMI provider or an alternate CIM provider that has the same basic features.
+* To use the CIM session feature, the remote computer must have WS-Management remoting and Windows
+  Management Instrumentation (WMI), which is the Microsoft implementation of the Common Information
+  Model (CIM) standard. The computer must also have the Module Discovery WMI provider or an
+  alternate CIM provider that has the same basic features.
 
-  You can use the CIM session feature on computers that are not running a Windows operating system and on Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
+  You can use the CIM session feature on computers that are not running a Windows operating system
+  and on Windows computers that have PowerShell, but do not have PowerShell remoting enabled.
 
-  You can also use the CIM parameters to get CIM modules from computers that have PowerShell remoting enabled, including the local computer.
-When you create a CIM session on the local computer, PowerShell uses DCOM, instead of WMI, to create the session.
+  You can also use the CIM parameters to get CIM modules from computers that have PowerShell
+  remoting enabled, including the local computer. When you create a CIM session on the local
+  computer, PowerShell uses DCOM, instead of WMI, to create the session.
 
 ## RELATED LINKS
 

--- a/reference/7/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/7/Microsoft.PowerShell.Core/Import-Module.md
@@ -535,6 +535,8 @@ the remote computer and returns them to the local session.
 ```powershell
 $cs = New-CimSession -ComputerName RSDGF03
 Import-Module -CimSession $cs -Name Storage
+# Importing a CIM module, converts the CDXML files for each command into PowerShell scripts.
+# These appear as functions in the local session.
 Get-Command Get-Disk
 ```
 
@@ -545,6 +547,7 @@ Function        Get-Disk              Storage
 ```
 
 ```powershell
+# Use implicit remoting to query disks on the remote computer from which the module was imported.
 Get-Disk
 ```
 
@@ -840,6 +843,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -MaximumVersion
+
+Specifies a maximum version. This cmdlet imports only a version of the module that is less than or
+equal to the specified value. If no version qualifies, `Import-Module` generates an error.
+
+```yaml
+Type: String
+Parameter Sets: Name, PSSession, CimSession
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -MinimumVersion
 
 Specifies a minimum version. This cmdlet imports only a version of the module that is greater than
@@ -934,37 +954,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -PSSession
-
-Specifies a PowerShell user-managed session (**PSSession**) from which this cmdlet import modules
-into the current session. Enter a variable that contains a **PSSession** or a command that gets a
-**PSSession**, such as a `Get-PSSession` command.
-
-When you import a module from a different session into the current session, you can use the cmdlets
-from the module in the current session, just as you would use cmdlets from a local module. Commands
-that use the remote cmdlets actually run in the remote session, but the remoting details are managed
-in the background by PowerShell.
-
-This parameter uses the Implicit Remoting feature of PowerShell. It is equivalent to using the
-`Import-PSSession` cmdlet to import particular modules from a session.
-
-`Import-Module` cannot import PowerShell Core modules from another session. The PowerShell Core
-modules have names that begin with Microsoft.PowerShell.
-
-This parameter was introduced in Windows PowerShell 3.0.
-
-```yaml
-Type: PSSession
-Parameter Sets: PSSession, FullyQualifiedNameAndPSSession
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -PassThru
 
 Returns an object representing the item with which you are working. By default, this cmdlet does not
@@ -1003,6 +992,37 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PSSession
+
+Specifies a PowerShell user-managed session (**PSSession**) from which this cmdlet import modules
+into the current session. Enter a variable that contains a **PSSession** or a command that gets a
+**PSSession**, such as a `Get-PSSession` command.
+
+When you import a module from a different session into the current session, you can use the cmdlets
+from the module in the current session, just as you would use cmdlets from a local module. Commands
+that use the remote cmdlets actually run in the remote session, but the remoting details are managed
+in the background by PowerShell.
+
+This parameter uses the Implicit Remoting feature of PowerShell. It is equivalent to using the
+`Import-PSSession` cmdlet to import particular modules from a session.
+
+`Import-Module` cannot import PowerShell Core modules from another session. The PowerShell Core
+modules have names that begin with Microsoft.PowerShell.
+
+This parameter was introduced in Windows PowerShell 3.0.
+
+```yaml
+Type: PSSession
+Parameter Sets: PSSession, FullyQualifiedNameAndPSSession
+Aliases:
+
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -1086,23 +1106,6 @@ This parameter lets you select from among the exported variables.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -MaximumVersion
-
-Specifies a maximum version. This cmdlet imports only a version of the module that is less than or
-equal to the specified value. If no version qualifies, `Import-Module` generates an error.
-
-```yaml
-Type: String
-Parameter Sets: Name, PSSession, CimSession
 Aliases:
 
 Required: False

--- a/reference/7/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 1/22/2019
+ms.date: 08/14/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096926
 schema: 2.0.0
 title: Export-Clixml
 ---
+
 # Export-Clixml
 
 ## SYNOPSIS
@@ -18,96 +19,117 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ### ByPath (Default)
 
 ```
-Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml [-Path] <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
-[-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-Clixml -LiteralPath <String> -InputObject <PSObject> [-Depth <Int32>] [-Force] [-NoClobber]
+ [-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
-it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
-contents of that file.
+The `Export-Clixml` cmdlet creates a Common Language Infrastructure (CLI) XML-based representation
+of an object or objects and stores it in a file. You can then use the `Import-Clixml` cmdlet to
+recreate the saved object based on the contents of that file.
+For more information about CLI, see [Language independence](/dotnet/standard/language-independence).
 
-This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
-a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
+file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
 
-A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
-an example of how to do this, see Example 3.
+A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
+securely as XML. For an example, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
 
-This command creates an XML file that stores a representation of the string, "This is a test" in
-the current directory.
+This example creates an XML file that stores in the current directory, a representation of the
+string **This is a test**.
 
 ```powershell
 "This is a test" | Export-Clixml -Path .\sample.xml
 ```
 
+The string **This is a test** is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
+to create an XML file named `sample.xml` in the current directory.
+
 ### Example 2: Export an object to an XML file
 
-This example shows how to export an object to an XML file and then create an object by importing
-the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing the
+XML from the file.
 
 ```powershell
-Get-Acl C:\test.txt | Export-Clixml -Path .\fileacl.xml
-$fileacl = Import-Clixml -Path .\fileacl.xml
+Get-Acl C:\test.txt | Export-Clixml -Path .\FileACL.xml
+$fileacl = Import-Clixml -Path .\FileACL.xml
 ```
 
-The `Get-Acl` cmdlet gets the security descriptor of the Test.txt file. It sends the object down
-the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of
-the object is stored in a file named FileACL.xml.
+The `Get-Acl` cmdlet gets the security descriptor of the `Test.txt` file. It sends the object down
+the pipeline to pass the security descriptor to `Export-Clixml`. The XML-based representation of the
+object is stored in a file named `FileACL.xml`.
 
-The `Import-Clixml` cmdlet creates an object from the XML in the FileACL.xml file. Then, it saves
+The `Import-Clixml` cmdlet creates an object from the XML in the `FileACL.xml` file. Then, it saves
 the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
-This example shows how to use a credential stored in a variable and save it to disk. The credential
-can then be imported into scripts.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential | Export-Clixml $credxmlpath
-$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-$credential = Import-Clixml $credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential | Export-Clixml $Credxmlpath
+$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The `Export-Clixml` cmdlet encrypts credential objects by using the
-[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account on only that computer can decrypt the contents of the
-credential object. The exported CliXml file can neither be used on a different computer nor by a
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
+The encryption ensures that only your user account on only that computer can decrypt the contents of
+the credential object. The exported `CLIXML` file can't be used on a different computer or by a
 different user.
 
-In this example, given a credential that you've stored in the `$credential` variable by running the
-`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
-the example, the file in which the credential is stored is represented by
-TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+In the example, the file in which the credential is stored is represented by
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
 loading the credential.
 
-In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
-`$credxmlpath`, that you specified in the first command.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands. This time, you
-are running `Import-Clixml` to import the secured credential object into your script. This
-eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Depth
 
 Specifies how many levels of contained objects are included in the XML representation. The default
-value is 2.
+value is `2`.
 
-The default value can be overridden for the object type in the Types.ps1xml files. For more
+The default value can be overridden for the object type in the `Types.ps1xml` files. For more
 information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
@@ -170,7 +192,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -195,10 +217,9 @@ Accept wildcard characters: False
 ### -LiteralPath
 
 Specifies the path to the file where the XML representation of the object will be stored. Unlike
-**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
-are interpreted as wildcards. If the path includes escape characters, enclose it in single
-quotation marks. Single quotation marks tell PowerShell not to interpret any characters as
-escape sequences.
+**Path**, the value of the **LiteralPath** parameter is used exactly as it's typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single quotation
+marks. Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -214,8 +235,8 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Indicates that the cmdlet does not overwrite the contents of an existing file. By default, if a
-file exists in the specified path, `Export-Clixml` overwrites the file without warning.
+Indicates that the cmdlet doesn't overwrite the contents of an existing file. By default, if a file
+exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -224,7 +245,7 @@ Aliases: NoOverwrite
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -245,25 +266,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: SwitchParameter
@@ -281,14 +286,13 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
 
-You can pipe any object to `Export-Clixml`.
+You can pipeline any object to `Export-Clixml`.
 
 ## OUTPUTS
 
@@ -300,10 +304,6 @@ You can pipe any object to `Export-Clixml`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
-
-[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
-
 [ConvertTo-Html](ConvertTo-Html.md)
 
 [ConvertTo-Xml](ConvertTo-Xml.md)
@@ -311,3 +311,11 @@ You can pipe any object to `Export-Clixml`.
 [Export-Csv](Export-Csv.md)
 
 [Import-Clixml](Import-Clixml.md)
+
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
+
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)
+
+[Windows.Security.Cryptography.DataProtection](/uwp/api/windows.security.cryptography.dataprotection)

--- a/reference/7/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/15/2019
 online version: https://go.microsoft.com/fwlink/?linkid=2096618
 schema: 2.0.0
 title: Import-Clixml
 ---
+
 # Import-Clixml
 
 ## SYNOPSIS
@@ -18,7 +19,8 @@ Imports a CLIXML file and creates corresponding objects in PowerShell.
 ### ByPath (Default)
 
 ```
-Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>] [<CommonParameters>]
+Import-Clixml [-Path] <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-First <UInt64>]
+ [<CommonParameters>]
 ```
 
 ### ByLiteralPath
@@ -30,52 +32,65 @@ Import-Clixml -LiteralPath <String[]> [-IncludeTotalCount] [-Skip <UInt64>] [-Fi
 
 ## DESCRIPTION
 
-The **Import-CliXml** cmdlet imports a CLIXML file with data that represents Microsoft .NET Framework objects and creates the objects in PowerShell.
+The `Import-Clixml` cmdlet imports a Common Language Infrastructure (CLI) XML file with data that
+represents Microsoft .NET Framework objects and creates the PowerShell objects. For more information
+about CLI, see [Language independence](/dotnet/standard/language-independence).
 
-A valuable use of **Import-CliXml** is to import credentials and secure strings that have been exported as secure XML by running the Export-Clixml cmdlet.
-For an example of how to do this, see Example 2.
+A valuable use of `Import-Clixml` on Windows computers is to import credentials and secure strings
+that were exported as secure XML using `Export-Clixml`. For an example, see Example 2.
+
+`Import-Clixml` uses the byte-order-mark (BOM) to detect the encoding format of the file. If the
+file has no BOM, it assumes the encoding is UTF8.
 
 ## EXAMPLES
 
 ### Example 1: Import a serialized file and recreate an object
 
-```powershell
-Get-Process | Export-Clixml pi.xml
-$Processes = Import-Clixml pi.xml
-```
+This example uses the `Export-Clixml` cmdlet to save a serialized copy of the process information
+returned by `Get-Process`. `Import-Clixml` retrieves the serialized file's contents and recreates an
+object that is stored in the `$Processes` variable.
 
-This command uses the Export-Clixml cmdlet to save a serialized copy of the process information returned by Get-Process.
-It then uses **Import-Clixml** to retrieve the contents of the serialized file and re-create an object that is stored in the $Processes variable.
+```powershell
+Get-Process | Export-Clixml -Path .\pi.xml
+$Processes = Import-Clixml -Path .\pi.xml
+```
 
 ### Example 2: Import a secure credential object
 
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk.
+
+> [!IMPORTANT]
+> `Export-Clixml` only exports encrypted credentials on Windows. On non-Windows operating systems
+> such as macOS and Linux, credentials are exported in plain text.
+
 ```powershell
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-$Credential | Export-CliXml $Credxmlpath
+$Credential | Export-Clixml $Credxmlpath
 $Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-$Credential = Import-CliXml $Credxmlpath
+$Credential = Import-Clixml $Credxmlpath
 ```
 
-The **Export-CliXml** cmdlet encrypts credential objects by using the [Windows Data Protection API](http://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account can decrypt the contents of the credential object.
+The `Export-Clixml` cmdlet encrypts credential objects by using the Windows [Data Protection API](/previous-versions/windows/apps/hh464970(v=win.10)).
+The encryption ensures that only your user account can decrypt the contents of the credential
+object. The exported `CLIXML` file can't be used on a different computer or by a different user.
 
-In this example, given a credential that you've stored in the $Credential variable by running the Get-Credential cmdlet, you can run the **Export-CliXml** cmdlet to save the credential to disk.
+In the example, the file in which the credential is stored is represented by
+`TestScript.ps1.credential`. Replace **TestScript** with the name of the script with which you're
+loading the credential.
 
-In the example, the file in which the credential is stored is represented by TestScript.ps1.credential.
-Replace TestScript with the name of the script with which you are loading the credential.
+You send the credential object down the pipeline to `Export-Clixml`, and save it to the path,
+`$Credxmlpath`, that you specified in the first command.
 
-In the second command, you pipe the credential object to **Export-CliXml**, and save it to the path, $Credxmlpath, that you specified in the first command.
-
-To import the credential automatically into your script, run the final two commands.
-This time, you are running Import-Clixml to import the secured credential object into your script.
-This eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. Run
+`Import-Clixml` to import the secured credential object into your script. This import eliminates the
+risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
 ### -First
 
-Gets only the specified number of objects.
-Enter the number of objects to get.
+Gets only the specified number of objects. Enter the number of objects to get.
 
 ```yaml
 Type: UInt64
@@ -91,9 +106,12 @@ Accept wildcard characters: False
 
 ### -IncludeTotalCount
 
-Reports the total number of objects in the data set (an integer) followed by the selected objects.
-If the cmdlet cannot determine the total count, it displays "Unknown total count." The integer has an Accuracy property that indicates the reliability of the total count value.
-The value of Accuracy ranges from 0.0 to 1.0 where 0.0 means that the cmdlet could not count the objects, 1.0 means that the count is exact, and a value between 0.0 and 1.0 indicates an increasingly reliable estimate.
+Reports the total number of objects in the data set followed by the selected objects. If the cmdlet
+can't determine the total count, it displays **Unknown total count**. The integer has an
+**Accuracy** property that indicates the reliability of the total count value. The value of
+**Accuracy** ranges from `0.0` to `1.0` where `0.0` means that the cmdlet couldn't count the
+objects, `1.0` means that the count is exact, and a value between `0.0` and `1.0` indicates an
+increasingly reliable estimate.
 
 ```yaml
 Type: SwitchParameter
@@ -109,11 +127,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the XML files.
-Unlike *Path*, the value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies the path to the XML files. Unlike **Path**, the value of the **LiteralPath** parameter is
+used exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -129,7 +146,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the XML files.
+Specifies the path to the XML files.
 
 ```yaml
 Type: String[]
@@ -145,8 +162,8 @@ Accept wildcard characters: False
 
 ### -Skip
 
-Ignores the specified number of objects and then gets the remaining objects.
-Enter the number of objects to skip.
+Ignores the specified number of objects and then gets the remaining objects. Enter the number of
+objects to skip.
 
 ```yaml
 Type: UInt64
@@ -162,29 +179,35 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to **Import-Clixml**.
+You can pipeline a string that contains a path to `Import-Clixml`.
 
 ## OUTPUTS
 
 ### PSObject
 
-**Import-Clixml** returns objects that have been deserialized from the stored XML files.
+`Import-Clixml` returns objects that were deserialized from the stored XML files.
 
 ## NOTES
 
 When specifying multiple values for a parameter, use commas to separate the values. For example,
-"\<parameter-name\> \<value1\>, \<value2\>".
+`<parameter-name> <value1>, <value2>`.
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
+[Export-Clixml](Export-Clixml.md)
+
+[Introducing XML Serialization](/dotnet/standard/serialization/introducing-xml-serialization)
+
+[Join-Path](../Microsoft.PowerShell.Management/Join-Path.md)
 
 [Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
-[Export-Clixml](Export-Clixml.md)
+[Use PowerShell to Pass Credentials to Legacy Systems](https://devblogs.microsoft.com/scripting/use-powershell-to-pass-credentials-to-legacy-systems/)


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->

Classes and `using` were introduced in v5.0. 
Fixes #4630 
Fixes [AB#1585254](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1585254)

Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
