### PR TITLE
Update pullServer.md

### DIFF
--- a/dsc/pull-server/pullServer.md
+++ b/dsc/pull-server/pullServer.md
@@ -294,7 +294,7 @@ Each resource module needs to be zipped and named
 according to the following pattern `{Module Name}_{Module Version}.zip`.
 
 For example, a module named xWebAdminstration with a module version
-of 3.1.2.0 would be named `xWebAdministration_3.2.1.0.zip`.
+of 3.1.2.0 would be named `xWebAdministration_3.1.2.0.zip`.
 Each version of a module must be contained in a single zip file.
 Since there is only a single version of a resource in each zip file,
 the module format added in WMF 5.0 with support for multiple module versions


### PR DESCRIPTION
I guess in the example was just typo showing the correct version numbers. "For example, a module named xWebAdminstration with a module version of 3.1.2.0 would be named `xWebAdministration_3.2.1.0.zip`." If this is the case should be fixed otherwise will be confusing for people naming the modules. They will think that they need to swap the numbers.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 7 document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
