### PR TITLE
Fixed broken links to media folder in DSC docs

### DIFF
--- a/dsc/configurations/import-dscresource.md
+++ b/dsc/configurations/import-dscresource.md
@@ -132,11 +132,11 @@ Installing and using multiple versions of resources side by side was not support
 
 In the image below, two versions of the **xPSDesiredStateConfiguration** module are installed.
 
-![Multiple Resource Versions Fixed](../media/multiple-resource-versions-broken.md)
+![Multiple Resource Versions Fixed](../media/multiple-resource-versions-broken.png)
 
 Copy the contents of your desired module version to the top level of the module directory.
 
-![Multiple Resource Versions Fixed](../media/multiple-resource-versions-fixed.md)
+![Multiple Resource Versions Fixed](../media/multiple-resource-versions-fixed.png)
 
 ### Resource location
 

--- a/dsc/configurations/import-dscresource.md
+++ b/dsc/configurations/import-dscresource.md
@@ -73,7 +73,7 @@ This usage has the following benefits:
 
 When authoring the DSC configuration in ISE, PowerShell provides IntelliSence for resources and resource properties. Resource definitions under the `$pshome` module path are loaded automatically. When you import resources using the `Import-DSCResource` keyword, the specified resource definitions are added and Intellisense is expanded to include the imported resource's schema.
 
-![Resource Intellisense](/media/resource-intellisense.png)
+![Resource Intellisense](../media/resource-intellisense.png)
 
 > [!NOTE]
 > Beginning in PowerShell 5.0, tab completion was added to the ISE for DSC resources and their properties. For more information, see [Resources](../resources/resources.md).
@@ -132,11 +132,11 @@ Installing and using multiple versions of resources side by side was not support
 
 In the image below, two versions of the **xPSDesiredStateConfiguration** module are installed.
 
-![Multiple Resource Versions Fixed](/media/multiple-resource-versions-broken.md)
+![Multiple Resource Versions Fixed](../media/multiple-resource-versions-broken.md)
 
 Copy the contents of your desired module version to the top level of the module directory.
 
-![Multiple Resource Versions Fixed](/media/multiple-resource-versions-fixed.md)
+![Multiple Resource Versions Fixed](../media/multiple-resource-versions-fixed.md)
 
 ### Resource location
 

--- a/dsc/resources/get-test-set.md
+++ b/dsc/resources/get-test-set.md
@@ -8,7 +8,7 @@ title:  Get-Test-Set
 
 >Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0
 
-![Get, Test, and Set](/media/get-test-set.png)
+![Get, Test, and Set](../media/get-test-set.png)
 
 PowerShell Desired State Configuration is constructed around a **Get**, **Test**, and **Set** process. DSC [resources](resources.md) each contains methods to complete each of these operations. In a [Configuration](../configurations/configurations.md), you define resource blocks to fill in keys that become parameters for a resource's **Get**, **Test**, and **Set** methods.
 


### PR DESCRIPTION
Media links were absolute for some reason, which doesn't work on docs.microsoft.com. Per Contributing, links should be relative.