### PR TITLE
Fixes #4709 - Updated the description for List parameter

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -8,6 +8,7 @@ online version: https://go.microsoft.com/fwlink/?linkid=113388
 schema: 2.0.0
 title: Select-String
 ---
+
 # Select-String
 
 ## SYNOPSIS
@@ -19,29 +20,27 @@ Finds text in strings and files.
 
 ```
 Select-String [-Pattern] <string[]> [-Path] <string[]> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
+ [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ### Object
 
 ```
 Select-String [-Pattern] <string[]> -InputObject <psobject> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
+ [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ### LiteralFile
 
 ```
 Select-String [-Pattern] <string[]> -LiteralPath <string[]> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
+ [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-
-The **sls** alias for the `Select-String`.
 
 The `Select-String` cmdlet searches for text and text patterns in input strings and files. You can
 use `Select-String` similar to **grep** in UNIX or **findstr.exe** in Windows.
@@ -55,18 +54,18 @@ match is found.
 `Select-String` uses regular expression matching, but it can also perform a match that searches the
 input for the text that you specify.
 
-`Select-String` can display all the text matches or stop after the first match in each input
-file. `Select-String` can be used to display all text that does not match the specified pattern.
+`Select-String` can display all the text matches or stop after the first match in each input file.
+`Select-String` can be used to display all text that doesn't match the specified pattern.
 
 You can also specify that `Select-String` should expect a particular character encoding, such as
-when you are searching files of Unicode text. `Select-String` uses the byte-order-mark (BOM) to
+when you're searching files of Unicode text. `Select-String` uses the byte-order-mark (BOM) to
 detect the encoding format of the file. If the file has no BOM, it assumes the encoding is UTF8.
 
 ## EXAMPLES
 
 ### Example 1: Find a case-sensitive match
 
-This command performs a case-sensitive match of the text that was sent down the pipeline to the
+This example does a case-sensitive match of the text that was sent down the pipeline to the
 `Select-String` cmdlet.
 
 ```powershell
@@ -76,7 +75,7 @@ This command performs a case-sensitive match of the text that was sent down the 
 The text strings **Hello** and **HELLO** are sent down the pipeline to the `Select-String` cmdlet.
 `Select-String` uses the **Pattern** parameter to specify **HELLO**. The **CaseSensitive** parameter
 specifies that the case must match only the upper-case pattern. **SimpleMatch** is an optional
-parameter and specifies that the string in the pattern is not interpreted as a regular expression.
+parameter and specifies that the string in the pattern isn't interpreted as a regular expression.
 `Select-String` displays **HELLO** in the PowerShell console.
 
 ### Example 2: Find matches in text files
@@ -131,7 +130,7 @@ number precede each line of content that contains a match for the **Pattern** pa
 ### Example 4: Use Select-String in a function
 
 This example creates a function to search for a pattern in the PowerShell help files. For this
-example, the function only exists in the PowerShell session. When the PowerShell session is closed
+example, the function only exists in the PowerShell session. When the PowerShell session is closed,
 the function is deleted. For more information, see [about_Functions](../Microsoft.PowerShell.Core/About/about_Functions.md).
 
 ```
@@ -152,7 +151,7 @@ C:\Windows\System32\WindowsPowerShell\v1.0\en-US\about_ActivityCommonParameters.
 The function is created on the PowerShell command line. The `Function` command uses the name
 **Search-Help**. Press **Enter** to begin adding statements to the function. From the `>>` prompt,
 add each statement and press **Enter** as shown in the example. After the closing bracket is added,
-you are returned to a PowerShell prompt.
+you're returned to a PowerShell prompt.
 
 The function contains two commands. The `$PSHelp` variable stores the path to the PowerShell help
 files. `$PSHOME` is the PowerShell installation directory with the subdirectory **en-US** that
@@ -205,7 +204,7 @@ the output in the PowerShell console.
 
 ### Example 7: Find strings that do not match a pattern
 
-This example shows how to exclude lines of data that do not match a pattern.
+This example shows how to exclude lines of data that don't match a pattern.
 
 ```powershell
 Get-Command | Out-File -FilePath .\Command.txt
@@ -216,7 +215,7 @@ The `Get-Command` cmdlet sends objects down the pipeline to the `Out-File` to cr
 **Command.txt** file in the current directory. `Select-String` uses the **Path** parameter to
 specify the **Command.txt** file. The **Pattern** parameter specifies **Get** and **Set** as the
 search pattern. The **NotMatch** parameter excludes **Get** and **Set** from the results.
-`Select-String` displays the output in the PowerShell console that does not include **Get** or
+`Select-String` displays the output in the PowerShell console that doesn't include **Get** or
 **Set**.
 
 ### Example 8: Find lines before and after a match
@@ -287,7 +286,7 @@ are stored in the `$A` variable. The `$A` variable is sent down the pipeline to 
 cmdlet. `Select-String` uses the **Pattern** parameter to search each file for the string
 **PowerShell**.
 
-From the PowerShell command line, the `$A` variable contents are displayed. There is a line that
+From the PowerShell command line, the `$A` variable contents are displayed. There's a line that
 contains two occurrences of the string **PowerShell**.
 
 The `$A.Matches` property lists the first occurrence of the pattern **PowerShell** on each line.
@@ -327,7 +326,7 @@ Accept wildcard characters: False
 
 ### -CaseSensitive
 
-Indicates that the cmdlet matches are case-sensitive. By default, matches are not case-sensitive.
+Indicates that the cmdlet matches are case-sensitive. By default, matches aren't case-sensitive.
 
 ```yaml
 Type: SwitchParameter
@@ -353,7 +352,7 @@ after the match. For example, `-Context 2,3`.
 In the default display, lines with a match are indicated by a right angle bracket (`>`) (ASCII 62)
 in the first column of the display. Unmarked lines are the context.
 
-The **Context** parameter does not change the number of objects generated by `Select-String`.
+The **Context** parameter doesn't change the number of objects generated by `Select-String`.
 `Select-String` generates one [MatchInfo](/dotnet/api/microsoft.powershell.commands.matchinfo)
 object for each match. The context is stored as an array of strings in the **Context** property of
 the object.
@@ -361,7 +360,7 @@ the object.
 When the output of a `Select-String` command is sent down the pipeline to another `Select-String`
 command, the receiving command searches only the text in the matched line. The matched line is the
 value of the **Line** property of the **MatchInfo** object, not the text in the context lines. As a
-result, the **Context** parameter is not valid on the receiving `Select-String` command.
+result, the **Context** parameter isn't valid on the receiving `Select-String` command.
 
 When the context includes a match, the **MatchInfo** object for each match includes all the context
 lines, but the overlapping lines appear only once in the display.
@@ -445,7 +444,7 @@ Accept wildcard characters: True
 Specifies the text to be searched. Enter a variable that contains the text, or type a command or
 expression that gets the text.
 
-Using the **InputObject** parameter is not the same as sending strings down the pipeline to
+Using the **InputObject** parameter isn't the same as sending strings down the pipeline to
 `Select-String`.
 
 When you pipe more than one string to the `Select-String` cmdlet, it searches for the specified text
@@ -469,8 +468,11 @@ Accept wildcard characters: False
 
 ### -List
 
-Indicates that the cmdlet returns only the first match in each input file. By default,
-`Select-String` returns a **MatchInfo** object for each match it finds.
+Use **List** to retrieve a list of input files whose contents match the regular expression. The
+first instance of text that matches the regular expression in each matching input file will be shown
+after the input file name.
+
+By default, `Select-String` returns a **MatchInfo** object for each match it finds.
 
 ```yaml
 Type: SwitchParameter
@@ -484,9 +486,28 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -LiteralPath
+
+Specifies the path to the files to be searched. The value of the **LiteralPath** parameter is used
+exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences. For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md).
+
+```yaml
+Type: String[]
+Parameter Sets: LiteralFile
+Aliases: PSPath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -NotMatch
 
-The **NotMatch** parameter finds text that does not match the specified pattern.
+The **NotMatch** parameter finds text that doesn't match the specified pattern.
 
 ```yaml
 Type: SwitchParameter
@@ -514,7 +535,7 @@ Parameter Sets: File
 Aliases:
 
 Required: True
-Position: 2
+Position: 1
 Default value: Local directory
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: True
@@ -533,7 +554,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -559,7 +580,7 @@ Accept wildcard characters: False
 ### -SimpleMatch
 
 Indicates that the cmdlet uses a simple match rather than a regular expression match. In a simple
-match, `Select-String` searches the input for the text in the **Pattern** parameter. It does not
+match, `Select-String` searches the input for the text in the **Pattern** parameter. It doesn't
 interpret the value of the **Pattern** parameter as a regular expression statement.
 
 ```yaml
@@ -571,25 +592,6 @@ Required: False
 Position: Named
 Default value: False (Regular expression match)
 Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -LiteralPath
-
-Specifies the path to the files to be searched. The value of the **LiteralPath** parameter is used
-exactly as it is typed. No characters are interpreted as wildcards. If the path includes escape
-characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
-interpret any characters as escape sequences. For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md).
-
-```yaml
-Type: String[]
-Parameter Sets: LiteralFile
-Aliases: PSPath
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -637,11 +639,11 @@ You can use the **SimpleMatch** parameter to override the regular expression mat
 **SimpleMatch** parameter finds instances of the value of the **Pattern** parameter in the input.
 
 The default output of `Select-String` is a **MatchInfo** object, which includes detailed information
-about the matches. The information in the object is useful when you are searching for text in files,
-because **MatchInfo** objects have properties such as **Filename** and **Line**. When the input is
-not from the file, the value of these parameters is **InputStream**.
+about the matches. The information in the object is useful when you're searching for text in files,
+because **MatchInfo** objects have properties such as **Filename** and **Line**. When the input
+isn't from the file, the value of these parameters is **InputStream**.
 
-If you do not need the information in the **MatchInfo** object, use the **Quiet** parameter. The
+If you don't need the information in the **MatchInfo** object, use the **Quiet** parameter. The
 **Quiet** parameter returns a Boolean value (True or False) to indicate whether it found a match,
 instead of a **MatchInfo** object.
 
@@ -675,5 +677,3 @@ To find the properties of a **MatchInfo** object, type the following command:
 [Get-WinEvent](../Microsoft.PowerShell.Diagnostics/Get-WinEvent.md)
 
 [Out-File](Out-File.md)
-
-

--- a/reference/3.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -468,9 +468,8 @@ Accept wildcard characters: False
 
 ### -List
 
-Use **List** to retrieve a list of input files whose contents match the regular expression. The
-first instance of text that matches the regular expression in each matching input file will be shown
-after the input file name.
+Only the first instance of matching text is returned from each input file. This is the most
+efficient way to retrieve a list files that have contents matching the regular expression.
 
 By default, `Select-String` returns a **MatchInfo** object for each match it finds.
 

--- a/reference/4.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -468,9 +468,8 @@ Accept wildcard characters: False
 
 ### -List
 
-Use **List** to retrieve a list of input files whose contents match the regular expression. The
-first instance of text that matches the regular expression in each matching input file will be shown
-after the input file name.
+Only the first instance of matching text is returned from each input file. This is the most
+efficient way to retrieve a list files that have contents matching the regular expression.
 
 By default, `Select-String` returns a **MatchInfo** object for each match it finds.
 

--- a/reference/4.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -8,6 +8,7 @@ online version: https://go.microsoft.com/fwlink/?linkid=294008
 schema: 2.0.0
 title: Select-String
 ---
+
 # Select-String
 
 ## SYNOPSIS
@@ -19,29 +20,27 @@ Finds text in strings and files.
 
 ```
 Select-String [-Pattern] <string[]> [-Path] <string[]> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
+ [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ### Object
 
 ```
 Select-String [-Pattern] <string[]> -InputObject <psobject> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
+ [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ### LiteralFile
 
 ```
 Select-String [-Pattern] <string[]> -LiteralPath <string[]> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
+ [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-
-The **sls** alias for the `Select-String`.
 
 The `Select-String` cmdlet searches for text and text patterns in input strings and files. You can
 use `Select-String` similar to **grep** in UNIX or **findstr.exe** in Windows.
@@ -55,18 +54,18 @@ match is found.
 `Select-String` uses regular expression matching, but it can also perform a match that searches the
 input for the text that you specify.
 
-`Select-String` can display all the text matches or stop after the first match in each input
-file. `Select-String` can be used to display all text that does not match the specified pattern.
+`Select-String` can display all the text matches or stop after the first match in each input file.
+`Select-String` can be used to display all text that doesn't match the specified pattern.
 
 You can also specify that `Select-String` should expect a particular character encoding, such as
-when you are searching files of Unicode text. `Select-String` uses the byte-order-mark (BOM) to
+when you're searching files of Unicode text. `Select-String` uses the byte-order-mark (BOM) to
 detect the encoding format of the file. If the file has no BOM, it assumes the encoding is UTF8.
 
 ## EXAMPLES
 
 ### Example 1: Find a case-sensitive match
 
-This command performs a case-sensitive match of the text that was sent down the pipeline to the
+This example does a case-sensitive match of the text that was sent down the pipeline to the
 `Select-String` cmdlet.
 
 ```powershell
@@ -76,7 +75,7 @@ This command performs a case-sensitive match of the text that was sent down the 
 The text strings **Hello** and **HELLO** are sent down the pipeline to the `Select-String` cmdlet.
 `Select-String` uses the **Pattern** parameter to specify **HELLO**. The **CaseSensitive** parameter
 specifies that the case must match only the upper-case pattern. **SimpleMatch** is an optional
-parameter and specifies that the string in the pattern is not interpreted as a regular expression.
+parameter and specifies that the string in the pattern isn't interpreted as a regular expression.
 `Select-String` displays **HELLO** in the PowerShell console.
 
 ### Example 2: Find matches in text files
@@ -131,7 +130,7 @@ number precede each line of content that contains a match for the **Pattern** pa
 ### Example 4: Use Select-String in a function
 
 This example creates a function to search for a pattern in the PowerShell help files. For this
-example, the function only exists in the PowerShell session. When the PowerShell session is closed
+example, the function only exists in the PowerShell session. When the PowerShell session is closed,
 the function is deleted. For more information, see [about_Functions](../Microsoft.PowerShell.Core/About/about_Functions.md).
 
 ```
@@ -152,7 +151,7 @@ C:\Windows\System32\WindowsPowerShell\v1.0\en-US\about_ActivityCommonParameters.
 The function is created on the PowerShell command line. The `Function` command uses the name
 **Search-Help**. Press **Enter** to begin adding statements to the function. From the `>>` prompt,
 add each statement and press **Enter** as shown in the example. After the closing bracket is added,
-you are returned to a PowerShell prompt.
+you're returned to a PowerShell prompt.
 
 The function contains two commands. The `$PSHelp` variable stores the path to the PowerShell help
 files. `$PSHOME` is the PowerShell installation directory with the subdirectory **en-US** that
@@ -205,7 +204,7 @@ the output in the PowerShell console.
 
 ### Example 7: Find strings that do not match a pattern
 
-This example shows how to exclude lines of data that do not match a pattern.
+This example shows how to exclude lines of data that don't match a pattern.
 
 ```powershell
 Get-Command | Out-File -FilePath .\Command.txt
@@ -216,7 +215,7 @@ The `Get-Command` cmdlet sends objects down the pipeline to the `Out-File` to cr
 **Command.txt** file in the current directory. `Select-String` uses the **Path** parameter to
 specify the **Command.txt** file. The **Pattern** parameter specifies **Get** and **Set** as the
 search pattern. The **NotMatch** parameter excludes **Get** and **Set** from the results.
-`Select-String` displays the output in the PowerShell console that does not include **Get** or
+`Select-String` displays the output in the PowerShell console that doesn't include **Get** or
 **Set**.
 
 ### Example 8: Find lines before and after a match
@@ -287,7 +286,7 @@ are stored in the `$A` variable. The `$A` variable is sent down the pipeline to 
 cmdlet. `Select-String` uses the **Pattern** parameter to search each file for the string
 **PowerShell**.
 
-From the PowerShell command line, the `$A` variable contents are displayed. There is a line that
+From the PowerShell command line, the `$A` variable contents are displayed. There's a line that
 contains two occurrences of the string **PowerShell**.
 
 The `$A.Matches` property lists the first occurrence of the pattern **PowerShell** on each line.
@@ -327,7 +326,7 @@ Accept wildcard characters: False
 
 ### -CaseSensitive
 
-Indicates that the cmdlet matches are case-sensitive. By default, matches are not case-sensitive.
+Indicates that the cmdlet matches are case-sensitive. By default, matches aren't case-sensitive.
 
 ```yaml
 Type: SwitchParameter
@@ -353,7 +352,7 @@ after the match. For example, `-Context 2,3`.
 In the default display, lines with a match are indicated by a right angle bracket (`>`) (ASCII 62)
 in the first column of the display. Unmarked lines are the context.
 
-The **Context** parameter does not change the number of objects generated by `Select-String`.
+The **Context** parameter doesn't change the number of objects generated by `Select-String`.
 `Select-String` generates one [MatchInfo](/dotnet/api/microsoft.powershell.commands.matchinfo)
 object for each match. The context is stored as an array of strings in the **Context** property of
 the object.
@@ -361,7 +360,7 @@ the object.
 When the output of a `Select-String` command is sent down the pipeline to another `Select-String`
 command, the receiving command searches only the text in the matched line. The matched line is the
 value of the **Line** property of the **MatchInfo** object, not the text in the context lines. As a
-result, the **Context** parameter is not valid on the receiving `Select-String` command.
+result, the **Context** parameter isn't valid on the receiving `Select-String` command.
 
 When the context includes a match, the **MatchInfo** object for each match includes all the context
 lines, but the overlapping lines appear only once in the display.
@@ -445,7 +444,7 @@ Accept wildcard characters: True
 Specifies the text to be searched. Enter a variable that contains the text, or type a command or
 expression that gets the text.
 
-Using the **InputObject** parameter is not the same as sending strings down the pipeline to
+Using the **InputObject** parameter isn't the same as sending strings down the pipeline to
 `Select-String`.
 
 When you pipe more than one string to the `Select-String` cmdlet, it searches for the specified text
@@ -469,8 +468,11 @@ Accept wildcard characters: False
 
 ### -List
 
-Indicates that the cmdlet returns only the first match in each input file. By default,
-`Select-String` returns a **MatchInfo** object for each match it finds.
+Use **List** to retrieve a list of input files whose contents match the regular expression. The
+first instance of text that matches the regular expression in each matching input file will be shown
+after the input file name.
+
+By default, `Select-String` returns a **MatchInfo** object for each match it finds.
 
 ```yaml
 Type: SwitchParameter
@@ -484,9 +486,28 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -LiteralPath
+
+Specifies the path to the files to be searched. The value of the **LiteralPath** parameter is used
+exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
+characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
+interpret any characters as escape sequences. For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md).
+
+```yaml
+Type: String[]
+Parameter Sets: LiteralFile
+Aliases: PSPath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -NotMatch
 
-The **NotMatch** parameter finds text that does not match the specified pattern.
+The **NotMatch** parameter finds text that doesn't match the specified pattern.
 
 ```yaml
 Type: SwitchParameter
@@ -514,7 +535,7 @@ Parameter Sets: File
 Aliases:
 
 Required: True
-Position: 2
+Position: 1
 Default value: Local directory
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: True
@@ -533,7 +554,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -559,7 +580,7 @@ Accept wildcard characters: False
 ### -SimpleMatch
 
 Indicates that the cmdlet uses a simple match rather than a regular expression match. In a simple
-match, `Select-String` searches the input for the text in the **Pattern** parameter. It does not
+match, `Select-String` searches the input for the text in the **Pattern** parameter. It doesn't
 interpret the value of the **Pattern** parameter as a regular expression statement.
 
 ```yaml
@@ -571,25 +592,6 @@ Required: False
 Position: Named
 Default value: False (Regular expression match)
 Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -LiteralPath
-
-Specifies the path to the files to be searched. The value of the **LiteralPath** parameter is used
-exactly as it is typed. No characters are interpreted as wildcards. If the path includes escape
-characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
-interpret any characters as escape sequences. For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md).
-
-```yaml
-Type: String[]
-Parameter Sets: LiteralFile
-Aliases: PSPath
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -637,11 +639,11 @@ You can use the **SimpleMatch** parameter to override the regular expression mat
 **SimpleMatch** parameter finds instances of the value of the **Pattern** parameter in the input.
 
 The default output of `Select-String` is a **MatchInfo** object, which includes detailed information
-about the matches. The information in the object is useful when you are searching for text in files,
-because **MatchInfo** objects have properties such as **Filename** and **Line**. When the input is
-not from the file, the value of these parameters is **InputStream**.
+about the matches. The information in the object is useful when you're searching for text in files,
+because **MatchInfo** objects have properties such as **Filename** and **Line**. When the input
+isn't from the file, the value of these parameters is **InputStream**.
 
-If you do not need the information in the **MatchInfo** object, use the **Quiet** parameter. The
+If you don't need the information in the **MatchInfo** object, use the **Quiet** parameter. The
 **Quiet** parameter returns a Boolean value (True or False) to indicate whether it found a match,
 instead of a **MatchInfo** object.
 
@@ -675,5 +677,3 @@ To find the properties of a **MatchInfo** object, type the following command:
 [Get-WinEvent](../Microsoft.PowerShell.Diagnostics/Get-WinEvent.md)
 
 [Out-File](Out-File.md)
-
-

--- a/reference/5.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -468,9 +468,8 @@ Accept wildcard characters: False
 
 ### -List
 
-Use **List** to retrieve a list of input files whose contents match the regular expression. The
-first instance of text that matches the regular expression in each matching input file will be shown
-after the input file name.
+Only the first instance of matching text is returned from each input file. This is the most
+efficient way to retrieve a list files that have contents matching the regular expression.
 
 By default, `Select-String` returns a **MatchInfo** object for each match it finds.
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -8,6 +8,7 @@ online version: https://go.microsoft.com/fwlink/?linkid=821853
 schema: 2.0.0
 title: Select-String
 ---
+
 # Select-String
 
 ## SYNOPSIS
@@ -19,29 +20,27 @@ Finds text in strings and files.
 
 ```
 Select-String [-Pattern] <string[]> [-Path] <string[]> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
+ [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ### Object
 
 ```
 Select-String [-Pattern] <string[]> -InputObject <psobject> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
+ [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ### LiteralFile
 
 ```
 Select-String [-Pattern] <string[]> -LiteralPath <string[]> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
+ [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-
-The **sls** alias for the `Select-String`.
 
 The `Select-String` cmdlet searches for text and text patterns in input strings and files. You can
 use `Select-String` similar to **grep** in UNIX or **findstr.exe** in Windows.
@@ -55,18 +54,18 @@ match is found.
 `Select-String` uses regular expression matching, but it can also perform a match that searches the
 input for the text that you specify.
 
-`Select-String` can display all the text matches or stop after the first match in each input
-file. `Select-String` can be used to display all text that does not match the specified pattern.
+`Select-String` can display all the text matches or stop after the first match in each input file.
+`Select-String` can be used to display all text that doesn't match the specified pattern.
 
 You can also specify that `Select-String` should expect a particular character encoding, such as
-when you are searching files of Unicode text. `Select-String` uses the byte-order-mark (BOM) to
+when you're searching files of Unicode text. `Select-String` uses the byte-order-mark (BOM) to
 detect the encoding format of the file. If the file has no BOM, it assumes the encoding is UTF8.
 
 ## EXAMPLES
 
 ### Example 1: Find a case-sensitive match
 
-This command performs a case-sensitive match of the text that was sent down the pipeline to the
+This example does a case-sensitive match of the text that was sent down the pipeline to the
 `Select-String` cmdlet.
 
 ```powershell
@@ -76,7 +75,7 @@ This command performs a case-sensitive match of the text that was sent down the 
 The text strings **Hello** and **HELLO** are sent down the pipeline to the `Select-String` cmdlet.
 `Select-String` uses the **Pattern** parameter to specify **HELLO**. The **CaseSensitive** parameter
 specifies that the case must match only the upper-case pattern. **SimpleMatch** is an optional
-parameter and specifies that the string in the pattern is not interpreted as a regular expression.
+parameter and specifies that the string in the pattern isn't interpreted as a regular expression.
 `Select-String` displays **HELLO** in the PowerShell console.
 
 ### Example 2: Find matches in text files
@@ -131,7 +130,7 @@ number precede each line of content that contains a match for the **Pattern** pa
 ### Example 4: Use Select-String in a function
 
 This example creates a function to search for a pattern in the PowerShell help files. For this
-example, the function only exists in the PowerShell session. When the PowerShell session is closed
+example, the function only exists in the PowerShell session. When the PowerShell session is closed,
 the function is deleted. For more information, see [about_Functions](../Microsoft.PowerShell.Core/About/about_Functions.md).
 
 ```
@@ -152,7 +151,7 @@ C:\Windows\System32\WindowsPowerShell\v1.0\en-US\about_ActivityCommonParameters.
 The function is created on the PowerShell command line. The `Function` command uses the name
 **Search-Help**. Press **Enter** to begin adding statements to the function. From the `>>` prompt,
 add each statement and press **Enter** as shown in the example. After the closing bracket is added,
-you are returned to a PowerShell prompt.
+you're returned to a PowerShell prompt.
 
 The function contains two commands. The `$PSHelp` variable stores the path to the PowerShell help
 files. `$PSHOME` is the PowerShell installation directory with the subdirectory **en-US** that
@@ -205,7 +204,7 @@ the output in the PowerShell console.
 
 ### Example 7: Find strings that do not match a pattern
 
-This example shows how to exclude lines of data that do not match a pattern.
+This example shows how to exclude lines of data that don't match a pattern.
 
 ```powershell
 Get-Command | Out-File -FilePath .\Command.txt
@@ -216,7 +215,7 @@ The `Get-Command` cmdlet sends objects down the pipeline to the `Out-File` to cr
 **Command.txt** file in the current directory. `Select-String` uses the **Path** parameter to
 specify the **Command.txt** file. The **Pattern** parameter specifies **Get** and **Set** as the
 search pattern. The **NotMatch** parameter excludes **Get** and **Set** from the results.
-`Select-String` displays the output in the PowerShell console that does not include **Get** or
+`Select-String` displays the output in the PowerShell console that doesn't include **Get** or
 **Set**.
 
 ### Example 8: Find lines before and after a match
@@ -287,7 +286,7 @@ are stored in the `$A` variable. The `$A` variable is sent down the pipeline to 
 cmdlet. `Select-String` uses the **Pattern** parameter to search each file for the string
 **PowerShell**.
 
-From the PowerShell command line, the `$A` variable contents are displayed. There is a line that
+From the PowerShell command line, the `$A` variable contents are displayed. There's a line that
 contains two occurrences of the string **PowerShell**.
 
 The `$A.Matches` property lists the first occurrence of the pattern **PowerShell** on each line.
@@ -327,7 +326,7 @@ Accept wildcard characters: False
 
 ### -CaseSensitive
 
-Indicates that the cmdlet matches are case-sensitive. By default, matches are not case-sensitive.
+Indicates that the cmdlet matches are case-sensitive. By default, matches aren't case-sensitive.
 
 ```yaml
 Type: SwitchParameter
@@ -353,7 +352,7 @@ after the match. For example, `-Context 2,3`.
 In the default display, lines with a match are indicated by a right angle bracket (`>`) (ASCII 62)
 in the first column of the display. Unmarked lines are the context.
 
-The **Context** parameter does not change the number of objects generated by `Select-String`.
+The **Context** parameter doesn't change the number of objects generated by `Select-String`.
 `Select-String` generates one [MatchInfo](/dotnet/api/microsoft.powershell.commands.matchinfo)
 object for each match. The context is stored as an array of strings in the **Context** property of
 the object.
@@ -361,7 +360,7 @@ the object.
 When the output of a `Select-String` command is sent down the pipeline to another `Select-String`
 command, the receiving command searches only the text in the matched line. The matched line is the
 value of the **Line** property of the **MatchInfo** object, not the text in the context lines. As a
-result, the **Context** parameter is not valid on the receiving `Select-String` command.
+result, the **Context** parameter isn't valid on the receiving `Select-String` command.
 
 When the context includes a match, the **MatchInfo** object for each match includes all the context
 lines, but the overlapping lines appear only once in the display.
@@ -445,7 +444,7 @@ Accept wildcard characters: True
 Specifies the text to be searched. Enter a variable that contains the text, or type a command or
 expression that gets the text.
 
-Using the **InputObject** parameter is not the same as sending strings down the pipeline to
+Using the **InputObject** parameter isn't the same as sending strings down the pipeline to
 `Select-String`.
 
 When you pipe more than one string to the `Select-String` cmdlet, it searches for the specified text
@@ -469,8 +468,11 @@ Accept wildcard characters: False
 
 ### -List
 
-Indicates that the cmdlet returns only the first match in each input file. By default,
-`Select-String` returns a **MatchInfo** object for each match it finds.
+Use **List** to retrieve a list of input files whose contents match the regular expression. The
+first instance of text that matches the regular expression in each matching input file will be shown
+after the input file name.
+
+By default, `Select-String` returns a **MatchInfo** object for each match it finds.
 
 ```yaml
 Type: SwitchParameter
@@ -487,7 +489,7 @@ Accept wildcard characters: False
 ### -LiteralPath
 
 Specifies the path to the files to be searched. The value of the **LiteralPath** parameter is used
-exactly as it is typed. No characters are interpreted as wildcards. If the path includes escape
+exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
 characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
 interpret any characters as escape sequences. For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md).
 
@@ -505,7 +507,7 @@ Accept wildcard characters: False
 
 ### -NotMatch
 
-The **NotMatch** parameter finds text that does not match the specified pattern.
+The **NotMatch** parameter finds text that doesn't match the specified pattern.
 
 ```yaml
 Type: SwitchParameter
@@ -534,7 +536,7 @@ Aliases:
 
 Required: True
 Position: 1
-Default value: None
+Default value: Local directory
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: True
 ```
@@ -578,7 +580,7 @@ Accept wildcard characters: False
 ### -SimpleMatch
 
 Indicates that the cmdlet uses a simple match rather than a regular expression match. In a simple
-match, `Select-String` searches the input for the text in the **Pattern** parameter. It does not
+match, `Select-String` searches the input for the text in the **Pattern** parameter. It doesn't
 interpret the value of the **Pattern** parameter as a regular expression statement.
 
 ```yaml
@@ -637,11 +639,11 @@ You can use the **SimpleMatch** parameter to override the regular expression mat
 **SimpleMatch** parameter finds instances of the value of the **Pattern** parameter in the input.
 
 The default output of `Select-String` is a **MatchInfo** object, which includes detailed information
-about the matches. The information in the object is useful when you are searching for text in files,
-because **MatchInfo** objects have properties such as **Filename** and **Line**. When the input is
-not from the file, the value of these parameters is **InputStream**.
+about the matches. The information in the object is useful when you're searching for text in files,
+because **MatchInfo** objects have properties such as **Filename** and **Line**. When the input
+isn't from the file, the value of these parameters is **InputStream**.
 
-If you do not need the information in the **MatchInfo** object, use the **Quiet** parameter. The
+If you don't need the information in the **MatchInfo** object, use the **Quiet** parameter. The
 **Quiet** parameter returns a Boolean value (True or False) to indicate whether it found a match,
 instead of a **MatchInfo** object.
 
@@ -675,5 +677,3 @@ To find the properties of a **MatchInfo** object, type the following command:
 [Get-WinEvent](../Microsoft.PowerShell.Diagnostics/Get-WinEvent.md)
 
 [Out-File](Out-File.md)
-
-

--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-String.md
@@ -468,9 +468,8 @@ Accept wildcard characters: False
 
 ### -List
 
-Use **List** to retrieve a list of input files whose contents match the regular expression. The
-first instance of text that matches the regular expression in each matching input file will be shown
-after the input file name.
+Only the first instance of matching text is returned from each input file. This is the most
+efficient way to retrieve a list files that have contents matching the regular expression.
 
 By default, `Select-String` returns a **MatchInfo** object for each match it finds.
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-String.md
@@ -8,6 +8,7 @@ online version: https://go.microsoft.com/fwlink/?linkid=821853
 schema: 2.0.0
 title: Select-String
 ---
+
 # Select-String
 
 ## SYNOPSIS
@@ -19,29 +20,27 @@ Finds text in strings and files.
 
 ```
 Select-String [-Pattern] <string[]> [-Path] <string[]> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
+ [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ### Object
 
 ```
 Select-String [-Pattern] <string[]> -InputObject <psobject> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
+ [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ### LiteralFile
 
 ```
 Select-String [-Pattern] <string[]> -LiteralPath <string[]> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <string>]
+ [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-
-The **sls** alias for the `Select-String`.
 
 The `Select-String` cmdlet searches for text and text patterns in input strings and files. You can
 use `Select-String` similar to **grep** in UNIX or **findstr.exe** in Windows.
@@ -55,18 +54,18 @@ match is found.
 `Select-String` uses regular expression matching, but it can also perform a match that searches the
 input for the text that you specify.
 
-`Select-String` can display all the text matches or stop after the first match in each input
-file. `Select-String` can be used to display all text that does not match the specified pattern.
+`Select-String` can display all the text matches or stop after the first match in each input file.
+`Select-String` can be used to display all text that doesn't match the specified pattern.
 
 You can also specify that `Select-String` should expect a particular character encoding, such as
-when you are searching files of Unicode text. `Select-String` uses the byte-order-mark (BOM) to
+when you're searching files of Unicode text. `Select-String` uses the byte-order-mark (BOM) to
 detect the encoding format of the file. If the file has no BOM, it assumes the encoding is UTF8.
 
 ## EXAMPLES
 
 ### Example 1: Find a case-sensitive match
 
-This command performs a case-sensitive match of the text that was sent down the pipeline to the
+This example does a case-sensitive match of the text that was sent down the pipeline to the
 `Select-String` cmdlet.
 
 ```powershell
@@ -76,7 +75,7 @@ This command performs a case-sensitive match of the text that was sent down the 
 The text strings **Hello** and **HELLO** are sent down the pipeline to the `Select-String` cmdlet.
 `Select-String` uses the **Pattern** parameter to specify **HELLO**. The **CaseSensitive** parameter
 specifies that the case must match only the upper-case pattern. **SimpleMatch** is an optional
-parameter and specifies that the string in the pattern is not interpreted as a regular expression.
+parameter and specifies that the string in the pattern isn't interpreted as a regular expression.
 `Select-String` displays **HELLO** in the PowerShell console.
 
 ### Example 2: Find matches in text files
@@ -131,7 +130,7 @@ number precede each line of content that contains a match for the **Pattern** pa
 ### Example 4: Use Select-String in a function
 
 This example creates a function to search for a pattern in the PowerShell help files. For this
-example, the function only exists in the PowerShell session. When the PowerShell session is closed
+example, the function only exists in the PowerShell session. When the PowerShell session is closed,
 the function is deleted. For more information, see [about_Functions](../Microsoft.PowerShell.Core/About/about_Functions.md).
 
 ```
@@ -152,7 +151,7 @@ C:\Windows\System32\WindowsPowerShell\v1.0\en-US\about_ActivityCommonParameters.
 The function is created on the PowerShell command line. The `Function` command uses the name
 **Search-Help**. Press **Enter** to begin adding statements to the function. From the `>>` prompt,
 add each statement and press **Enter** as shown in the example. After the closing bracket is added,
-you are returned to a PowerShell prompt.
+you're returned to a PowerShell prompt.
 
 The function contains two commands. The `$PSHelp` variable stores the path to the PowerShell help
 files. `$PSHOME` is the PowerShell installation directory with the subdirectory **en-US** that
@@ -205,7 +204,7 @@ the output in the PowerShell console.
 
 ### Example 7: Find strings that do not match a pattern
 
-This example shows how to exclude lines of data that do not match a pattern.
+This example shows how to exclude lines of data that don't match a pattern.
 
 ```powershell
 Get-Command | Out-File -FilePath .\Command.txt
@@ -216,7 +215,7 @@ The `Get-Command` cmdlet sends objects down the pipeline to the `Out-File` to cr
 **Command.txt** file in the current directory. `Select-String` uses the **Path** parameter to
 specify the **Command.txt** file. The **Pattern** parameter specifies **Get** and **Set** as the
 search pattern. The **NotMatch** parameter excludes **Get** and **Set** from the results.
-`Select-String` displays the output in the PowerShell console that does not include **Get** or
+`Select-String` displays the output in the PowerShell console that doesn't include **Get** or
 **Set**.
 
 ### Example 8: Find lines before and after a match
@@ -287,7 +286,7 @@ are stored in the `$A` variable. The `$A` variable is sent down the pipeline to 
 cmdlet. `Select-String` uses the **Pattern** parameter to search each file for the string
 **PowerShell**.
 
-From the PowerShell command line, the `$A` variable contents are displayed. There is a line that
+From the PowerShell command line, the `$A` variable contents are displayed. There's a line that
 contains two occurrences of the string **PowerShell**.
 
 The `$A.Matches` property lists the first occurrence of the pattern **PowerShell** on each line.
@@ -327,7 +326,7 @@ Accept wildcard characters: False
 
 ### -CaseSensitive
 
-Indicates that the cmdlet matches are case-sensitive. By default, matches are not case-sensitive.
+Indicates that the cmdlet matches are case-sensitive. By default, matches aren't case-sensitive.
 
 ```yaml
 Type: SwitchParameter
@@ -353,7 +352,7 @@ after the match. For example, `-Context 2,3`.
 In the default display, lines with a match are indicated by a right angle bracket (`>`) (ASCII 62)
 in the first column of the display. Unmarked lines are the context.
 
-The **Context** parameter does not change the number of objects generated by `Select-String`.
+The **Context** parameter doesn't change the number of objects generated by `Select-String`.
 `Select-String` generates one [MatchInfo](/dotnet/api/microsoft.powershell.commands.matchinfo)
 object for each match. The context is stored as an array of strings in the **Context** property of
 the object.
@@ -361,7 +360,7 @@ the object.
 When the output of a `Select-String` command is sent down the pipeline to another `Select-String`
 command, the receiving command searches only the text in the matched line. The matched line is the
 value of the **Line** property of the **MatchInfo** object, not the text in the context lines. As a
-result, the **Context** parameter is not valid on the receiving `Select-String` command.
+result, the **Context** parameter isn't valid on the receiving `Select-String` command.
 
 When the context includes a match, the **MatchInfo** object for each match includes all the context
 lines, but the overlapping lines appear only once in the display.
@@ -445,7 +444,7 @@ Accept wildcard characters: True
 Specifies the text to be searched. Enter a variable that contains the text, or type a command or
 expression that gets the text.
 
-Using the **InputObject** parameter is not the same as sending strings down the pipeline to
+Using the **InputObject** parameter isn't the same as sending strings down the pipeline to
 `Select-String`.
 
 When you pipe more than one string to the `Select-String` cmdlet, it searches for the specified text
@@ -469,8 +468,11 @@ Accept wildcard characters: False
 
 ### -List
 
-Indicates that the cmdlet returns only the first match in each input file. By default,
-`Select-String` returns a **MatchInfo** object for each match it finds.
+Use **List** to retrieve a list of input files whose contents match the regular expression. The
+first instance of text that matches the regular expression in each matching input file will be shown
+after the input file name.
+
+By default, `Select-String` returns a **MatchInfo** object for each match it finds.
 
 ```yaml
 Type: SwitchParameter
@@ -487,7 +489,7 @@ Accept wildcard characters: False
 ### -LiteralPath
 
 Specifies the path to the files to be searched. The value of the **LiteralPath** parameter is used
-exactly as it is typed. No characters are interpreted as wildcards. If the path includes escape
+exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
 characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
 interpret any characters as escape sequences. For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md).
 
@@ -505,7 +507,7 @@ Accept wildcard characters: False
 
 ### -NotMatch
 
-The **NotMatch** parameter finds text that does not match the specified pattern.
+The **NotMatch** parameter finds text that doesn't match the specified pattern.
 
 ```yaml
 Type: SwitchParameter
@@ -534,7 +536,7 @@ Aliases:
 
 Required: True
 Position: 1
-Default value: None
+Default value: Local directory
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: True
 ```
@@ -578,7 +580,7 @@ Accept wildcard characters: False
 ### -SimpleMatch
 
 Indicates that the cmdlet uses a simple match rather than a regular expression match. In a simple
-match, `Select-String` searches the input for the text in the **Pattern** parameter. It does not
+match, `Select-String` searches the input for the text in the **Pattern** parameter. It doesn't
 interpret the value of the **Pattern** parameter as a regular expression statement.
 
 ```yaml
@@ -637,11 +639,11 @@ You can use the **SimpleMatch** parameter to override the regular expression mat
 **SimpleMatch** parameter finds instances of the value of the **Pattern** parameter in the input.
 
 The default output of `Select-String` is a **MatchInfo** object, which includes detailed information
-about the matches. The information in the object is useful when you are searching for text in files,
-because **MatchInfo** objects have properties such as **Filename** and **Line**. When the input is
-not from the file, the value of these parameters is **InputStream**.
+about the matches. The information in the object is useful when you're searching for text in files,
+because **MatchInfo** objects have properties such as **Filename** and **Line**. When the input
+isn't from the file, the value of these parameters is **InputStream**.
 
-If you do not need the information in the **MatchInfo** object, use the **Quiet** parameter. The
+If you don't need the information in the **MatchInfo** object, use the **Quiet** parameter. The
 **Quiet** parameter returns a Boolean value (True or False) to indicate whether it found a match,
 instead of a **MatchInfo** object.
 
@@ -675,5 +677,3 @@ To find the properties of a **MatchInfo** object, type the following command:
 [Get-WinEvent](../Microsoft.PowerShell.Diagnostics/Get-WinEvent.md)
 
 [Out-File](Out-File.md)
-
-

--- a/reference/6/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Select-String.md
@@ -8,6 +8,7 @@ online version: https://go.microsoft.com/fwlink/?linkid=2096894
 schema: 2.0.0
 title: Select-String
 ---
+
 # Select-String
 
 ## SYNOPSIS
@@ -19,29 +20,27 @@ Finds text in strings and files.
 
 ```
 Select-String [-Pattern] <string[]> [-Path] <string[]> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <Encoding>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches]
+ [-Encoding <Encoding>] [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ### Object
 
 ```
 Select-String [-Pattern] <string[]> -InputObject <psobject> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <Encoding>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches]
+ [-Encoding <Encoding>] [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ### LiteralFile
 
 ```
 Select-String [-Pattern] <string[]> -LiteralPath <string[]> [-SimpleMatch] [-CaseSensitive] [-Quiet]
-[-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches] [-Encoding <Encoding>]
-[-Context <int[]>] [<CommonParameters>]
+ [-List] [-Include <string[]>] [-Exclude <string[]>] [-NotMatch] [-AllMatches]
+ [-Encoding <Encoding>] [-Context <Int32[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-
-The **sls** alias for the `Select-String`.
 
 The `Select-String` cmdlet searches for text and text patterns in input strings and files. You can
 use `Select-String` similar to **grep** in UNIX or **findstr.exe** in Windows.
@@ -55,18 +54,18 @@ match is found.
 `Select-String` uses regular expression matching, but it can also perform a match that searches the
 input for the text that you specify.
 
-`Select-String` can display all the text matches or stop after the first match in each input
-file. `Select-String` can be used to display all text that does not match the specified pattern.
+`Select-String` can display all the text matches or stop after the first match in each input file.
+`Select-String` can be used to display all text that doesn't match the specified pattern.
 
 You can also specify that `Select-String` should expect a particular character encoding, such as
-when you are searching files of Unicode text. `Select-String` uses the byte-order-mark (BOM) to
+when you're searching files of Unicode text. `Select-String` uses the byte-order-mark (BOM) to
 detect the encoding format of the file. If the file has no BOM, it assumes the encoding is UTF8.
 
 ## EXAMPLES
 
 ### Example 1: Find a case-sensitive match
 
-This command performs a case-sensitive match of the text that was sent down the pipeline to the
+This example does a case-sensitive match of the text that was sent down the pipeline to the
 `Select-String` cmdlet.
 
 ```powershell
@@ -76,7 +75,7 @@ This command performs a case-sensitive match of the text that was sent down the 
 The text strings **Hello** and **HELLO** are sent down the pipeline to the `Select-String` cmdlet.
 `Select-String` uses the **Pattern** parameter to specify **HELLO**. The **CaseSensitive** parameter
 specifies that the case must match only the upper-case pattern. **SimpleMatch** is an optional
-parameter and specifies that the string in the pattern is not interpreted as a regular expression.
+parameter and specifies that the string in the pattern isn't interpreted as a regular expression.
 `Select-String` displays **HELLO** in the PowerShell console.
 
 ### Example 2: Find matches in text files
@@ -131,7 +130,7 @@ number precede each line of content that contains a match for the **Pattern** pa
 ### Example 4: Use Select-String in a function
 
 This example creates a function to search for a pattern in the PowerShell help files. For this
-example, the function only exists in the PowerShell session. When the PowerShell session is closed
+example, the function only exists in the PowerShell session. When the PowerShell session is closed,
 the function is deleted. For more information, see [about_Functions](../Microsoft.PowerShell.Core/About/about_Functions.md).
 
 ```
@@ -153,7 +152,7 @@ C:\Program Files\PowerShell\6\en-US\default.help.txt:97:    about_Updatable_Help
 The function is created on the PowerShell command line. The `Function` command uses the name
 **Search-Help**. Press **Enter** to begin adding statements to the function. From the `>>` prompt,
 add each statement and press **Enter** as shown in the example. After the closing bracket is added,
-you are returned to a PowerShell prompt.
+you're returned to a PowerShell prompt.
 
 The function contains two commands. The `$PSHelp` variable stores the path to the PowerShell help
 files. `$PSHOME` is the PowerShell installation directory with the subdirectory **en-US** that
@@ -206,7 +205,7 @@ the output in the PowerShell console.
 
 ### Example 7: Find strings that do not match a pattern
 
-This example shows how to exclude lines of data that do not match a pattern.
+This example shows how to exclude lines of data that don't match a pattern.
 
 ```powershell
 Get-Command | Out-File -FilePath .\Command.txt
@@ -217,7 +216,7 @@ The `Get-Command` cmdlet sends objects down the pipeline to the `Out-File` to cr
 **Command.txt** file in the current directory. `Select-String` uses the **Path** parameter to
 specify the **Command.txt** file. The **Pattern** parameter specifies **Get** and **Set** as the
 search pattern. The **NotMatch** parameter excludes **Get** and **Set** from the results.
-`Select-String` displays the output in the PowerShell console that does not include **Get** or
+`Select-String` displays the output in the PowerShell console that doesn't include **Get** or
 **Set**.
 
 ### Example 8: Find lines before and after a match
@@ -288,7 +287,7 @@ are stored in the `$A` variable. The `$A` variable is sent down the pipeline to 
 cmdlet. `Select-String` uses the **Pattern** parameter to search each file for the string
 **PowerShell**.
 
-From the PowerShell command line, the `$A` variable contents are displayed. There is a line that
+From the PowerShell command line, the `$A` variable contents are displayed. There's a line that
 contains two occurrences of the string **PowerShell**.
 
 The `$A.Matches` property lists the first occurrence of the pattern **PowerShell** on each line.
@@ -328,7 +327,7 @@ Accept wildcard characters: False
 
 ### -CaseSensitive
 
-Indicates that the cmdlet matches are case-sensitive. By default, matches are not case-sensitive.
+Indicates that the cmdlet matches are case-sensitive. By default, matches aren't case-sensitive.
 
 ```yaml
 Type: SwitchParameter
@@ -354,7 +353,7 @@ after the match. For example, `-Context 2,3`.
 In the default display, lines with a match are indicated by a right angle bracket (`>`) (ASCII 62)
 in the first column of the display. Unmarked lines are the context.
 
-The **Context** parameter does not change the number of objects generated by `Select-String`.
+The **Context** parameter doesn't change the number of objects generated by `Select-String`.
 `Select-String` generates one [MatchInfo](/dotnet/api/microsoft.powershell.commands.matchinfo)
 object for each match. The context is stored as an array of strings in the **Context** property of
 the object.
@@ -362,7 +361,7 @@ the object.
 When the output of a `Select-String` command is sent down the pipeline to another `Select-String`
 command, the receiving command searches only the text in the matched line. The matched line is the
 value of the **Line** property of the **MatchInfo** object, not the text in the context lines. As a
-result, the **Context** parameter is not valid on the receiving `Select-String` command.
+result, the **Context** parameter isn't valid on the receiving `Select-String` command.
 
 When the context includes a match, the **MatchInfo** object for each match includes all the context
 lines, but the overlapping lines appear only once in the display.
@@ -452,7 +451,7 @@ Accept wildcard characters: True
 Specifies the text to be searched. Enter a variable that contains the text, or type a command or
 expression that gets the text.
 
-Using the **InputObject** parameter is not the same as sending strings down the pipeline to
+Using the **InputObject** parameter isn't the same as sending strings down the pipeline to
 `Select-String`.
 
 When you pipe more than one string to the `Select-String` cmdlet, it searches for the specified text
@@ -476,8 +475,11 @@ Accept wildcard characters: False
 
 ### -List
 
-Indicates that the cmdlet returns only the first match in each input file. By default,
-`Select-String` returns a **MatchInfo** object for each match it finds.
+Use **List** to retrieve a list of input files whose contents match the regular expression. The
+first instance of text that matches the regular expression in each matching input file will be shown
+after the input file name.
+
+By default, `Select-String` returns a **MatchInfo** object for each match it finds.
 
 ```yaml
 Type: SwitchParameter
@@ -494,7 +496,7 @@ Accept wildcard characters: False
 ### -LiteralPath
 
 Specifies the path to the files to be searched. The value of the **LiteralPath** parameter is used
-exactly as it is typed. No characters are interpreted as wildcards. If the path includes escape
+exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
 characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
 interpret any characters as escape sequences. For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md).
 
@@ -512,7 +514,7 @@ Accept wildcard characters: False
 
 ### -NotMatch
 
-The **NotMatch** parameter finds text that does not match the specified pattern.
+The **NotMatch** parameter finds text that doesn't match the specified pattern.
 
 ```yaml
 Type: SwitchParameter
@@ -541,7 +543,7 @@ Aliases:
 
 Required: True
 Position: 1
-Default value: None
+Default value: Local directory
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: True
 ```
@@ -585,7 +587,7 @@ Accept wildcard characters: False
 ### -SimpleMatch
 
 Indicates that the cmdlet uses a simple match rather than a regular expression match. In a simple
-match, `Select-String` searches the input for the text in the **Pattern** parameter. It does not
+match, `Select-String` searches the input for the text in the **Pattern** parameter. It doesn't
 interpret the value of the **Pattern** parameter as a regular expression statement.
 
 ```yaml
@@ -644,11 +646,11 @@ You can use the **SimpleMatch** parameter to override the regular expression mat
 **SimpleMatch** parameter finds instances of the value of the **Pattern** parameter in the input.
 
 The default output of `Select-String` is a **MatchInfo** object, which includes detailed information
-about the matches. The information in the object is useful when you are searching for text in files,
-because **MatchInfo** objects have properties such as **Filename** and **Line**. When the input is
-not from the file, the value of these parameters is **InputStream**.
+about the matches. The information in the object is useful when you're searching for text in files,
+because **MatchInfo** objects have properties such as **Filename** and **Line**. When the input
+isn't from the file, the value of these parameters is **InputStream**.
 
-If you do not need the information in the **MatchInfo** object, use the **Quiet** parameter. The
+If you don't need the information in the **MatchInfo** object, use the **Quiet** parameter. The
 **Quiet** parameter returns a Boolean value (True or False) to indicate whether it found a match,
 instead of a **MatchInfo** object.
 
@@ -682,5 +684,3 @@ To find the properties of a **MatchInfo** object, type the following command:
 [Get-WinEvent](../Microsoft.PowerShell.Diagnostics/Get-WinEvent.md)
 
 [Out-File](Out-File.md)
-
-

--- a/reference/6/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Select-String.md
@@ -475,9 +475,8 @@ Accept wildcard characters: False
 
 ### -List
 
-Use **List** to retrieve a list of input files whose contents match the regular expression. The
-first instance of text that matches the regular expression in each matching input file will be shown
-after the input file name.
+Only the first instance of matching text is returned from each input file. This is the most
+efficient way to retrieve a list files that have contents matching the regular expression.
 
 By default, `Select-String` returns a **MatchInfo** object for each match it finds.
 

--- a/reference/7/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Select-String.md
@@ -499,9 +499,8 @@ Accept wildcard characters: False
 
 ### -List
 
-Use **List** to retrieve a list of input files whose contents match the regular expression. The
-first instance of text that matches the regular expression in each matching input file will be shown
-after the input file name.
+Only the first instance of matching text is returned from each input file. This is the most
+efficient way to retrieve a list files that have contents matching the regular expression.
 
 By default, `Select-String` returns a **MatchInfo** object for each match it finds.
 

--- a/reference/7/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Select-String.md
@@ -66,8 +66,6 @@ Select-String [-Pattern] <String[]> -LiteralPath <String[]> [-SimpleMatch] [-Cas
 
 ## DESCRIPTION
 
-The **sls** alias for the `Select-String`.
-
 The `Select-String` cmdlet searches for text and text patterns in input strings and files. You can
 use `Select-String` similar to **grep** in UNIX or **findstr.exe** in Windows.
 
@@ -80,18 +78,18 @@ match is found.
 `Select-String` uses regular expression matching, but it can also perform a match that searches the
 input for the text that you specify.
 
-`Select-String` can display all the text matches or stop after the first match in each input
-file. `Select-String` can be used to display all text that does not match the specified pattern.
+`Select-String` can display all the text matches or stop after the first match in each input file.
+`Select-String` can be used to display all text that doesn't match the specified pattern.
 
 You can also specify that `Select-String` should expect a particular character encoding, such as
-when you are searching files of Unicode text. `Select-String` uses the byte-order-mark (BOM) to
+when you're searching files of Unicode text. `Select-String` uses the byte-order-mark (BOM) to
 detect the encoding format of the file. If the file has no BOM, it assumes the encoding is UTF8.
 
 ## EXAMPLES
 
 ### Example 1: Find a case-sensitive match
 
-This command performs a case-sensitive match of the text that was sent down the pipeline to the
+This example does a case-sensitive match of the text that was sent down the pipeline to the
 `Select-String` cmdlet.
 
 ```powershell
@@ -101,7 +99,7 @@ This command performs a case-sensitive match of the text that was sent down the 
 The text strings **Hello** and **HELLO** are sent down the pipeline to the `Select-String` cmdlet.
 `Select-String` uses the **Pattern** parameter to specify **HELLO**. The **CaseSensitive** parameter
 specifies that the case must match only the upper-case pattern. **SimpleMatch** is an optional
-parameter and specifies that the string in the pattern is not interpreted as a regular expression.
+parameter and specifies that the string in the pattern isn't interpreted as a regular expression.
 `Select-String` displays **HELLO** in the PowerShell console.
 
 ### Example 2: Find matches in text files
@@ -156,7 +154,7 @@ number precede each line of content that contains a match for the **Pattern** pa
 ### Example 4: Use Select-String in a function
 
 This example creates a function to search for a pattern in the PowerShell help files. For this
-example, the function only exists in the PowerShell session. When the PowerShell session is closed
+example, the function only exists in the PowerShell session. When the PowerShell session is closed,
 the function is deleted. For more information, see [about_Functions](../Microsoft.PowerShell.Core/About/about_Functions.md).
 
 ```
@@ -178,7 +176,7 @@ C:\Program Files\PowerShell\6\en-US\default.help.txt:97:    about_Updatable_Help
 The function is created on the PowerShell command line. The `Function` command uses the name
 **Search-Help**. Press **Enter** to begin adding statements to the function. From the `>>` prompt,
 add each statement and press **Enter** as shown in the example. After the closing bracket is added,
-you are returned to a PowerShell prompt.
+you're returned to a PowerShell prompt.
 
 The function contains two commands. The `$PSHelp` variable stores the path to the PowerShell help
 files. `$PSHOME` is the PowerShell installation directory with the subdirectory **en-US** that
@@ -231,7 +229,7 @@ the output in the PowerShell console.
 
 ### Example 7: Find strings that do not match a pattern
 
-This example shows how to exclude lines of data that do not match a pattern.
+This example shows how to exclude lines of data that don't match a pattern.
 
 ```powershell
 Get-Command | Out-File -FilePath .\Command.txt
@@ -242,7 +240,7 @@ The `Get-Command` cmdlet sends objects down the pipeline to the `Out-File` to cr
 **Command.txt** file in the current directory. `Select-String` uses the **Path** parameter to
 specify the **Command.txt** file. The **Pattern** parameter specifies **Get** and **Set** as the
 search pattern. The **NotMatch** parameter excludes **Get** and **Set** from the results.
-`Select-String` displays the output in the PowerShell console that does not include **Get** or
+`Select-String` displays the output in the PowerShell console that doesn't include **Get** or
 **Set**.
 
 ### Example 8: Find lines before and after a match
@@ -313,7 +311,7 @@ are stored in the `$A` variable. The `$A` variable is sent down the pipeline to 
 cmdlet. `Select-String` uses the **Pattern** parameter to search each file for the string
 **PowerShell**.
 
-From the PowerShell command line, the `$A` variable contents are displayed. There is a line that
+From the PowerShell command line, the `$A` variable contents are displayed. There's a line that
 contains two occurrences of the string **PowerShell**.
 
 The `$A.Matches` property lists the first occurrence of the pattern **PowerShell** on each line.
@@ -353,7 +351,7 @@ Accept wildcard characters: False
 
 ### -CaseSensitive
 
-Indicates that the cmdlet matches are case-sensitive. By default, matches are not case-sensitive.
+Indicates that the cmdlet matches are case-sensitive. By default, matches aren't case-sensitive.
 
 ```yaml
 Type: SwitchParameter
@@ -379,7 +377,7 @@ after the match. For example, `-Context 2,3`.
 In the default display, lines with a match are indicated by a right angle bracket (`>`) (ASCII 62)
 in the first column of the display. Unmarked lines are the context.
 
-The **Context** parameter does not change the number of objects generated by `Select-String`.
+The **Context** parameter doesn't change the number of objects generated by `Select-String`.
 `Select-String` generates one [MatchInfo](/dotnet/api/microsoft.powershell.commands.matchinfo)
 object for each match. The context is stored as an array of strings in the **Context** property of
 the object.
@@ -387,7 +385,7 @@ the object.
 When the output of a `Select-String` command is sent down the pipeline to another `Select-String`
 command, the receiving command searches only the text in the matched line. The matched line is the
 value of the **Line** property of the **MatchInfo** object, not the text in the context lines. As a
-result, the **Context** parameter is not valid on the receiving `Select-String` command.
+result, the **Context** parameter isn't valid on the receiving `Select-String` command.
 
 When the context includes a match, the **MatchInfo** object for each match includes all the context
 lines, but the overlapping lines appear only once in the display.
@@ -477,7 +475,7 @@ Accept wildcard characters: True
 Specifies the text to be searched. Enter a variable that contains the text, or type a command or
 expression that gets the text.
 
-Using the **InputObject** parameter is not the same as sending strings down the pipeline to
+Using the **InputObject** parameter isn't the same as sending strings down the pipeline to
 `Select-String`.
 
 When you pipe more than one string to the `Select-String` cmdlet, it searches for the specified text
@@ -501,8 +499,11 @@ Accept wildcard characters: False
 
 ### -List
 
-Indicates that the cmdlet returns only the first match in each input file. By default,
-`Select-String` returns a **MatchInfo** object for each match it finds.
+Use **List** to retrieve a list of input files whose contents match the regular expression. The
+first instance of text that matches the regular expression in each matching input file will be shown
+after the input file name.
+
+By default, `Select-String` returns a **MatchInfo** object for each match it finds.
 
 ```yaml
 Type: SwitchParameter
@@ -519,7 +520,7 @@ Accept wildcard characters: False
 ### -LiteralPath
 
 Specifies the path to the files to be searched. The value of the **LiteralPath** parameter is used
-exactly as it is typed. No characters are interpreted as wildcards. If the path includes escape
+exactly as it's typed. No characters are interpreted as wildcards. If the path includes escape
 characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not to
 interpret any characters as escape sequences. For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md).
 
@@ -537,7 +538,7 @@ Accept wildcard characters: False
 
 ### -NotMatch
 
-The **NotMatch** parameter finds text that does not match the specified pattern.
+The **NotMatch** parameter finds text that doesn't match the specified pattern.
 
 ```yaml
 Type: SwitchParameter
@@ -566,7 +567,7 @@ Aliases:
 
 Required: True
 Position: 1
-Default value: None
+Default value: Local directory
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: True
 ```
@@ -607,24 +608,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -SimpleMatch
-
-Indicates that the cmdlet uses a simple match rather than a regular expression match. In a simple
-match, `Select-String` searches the input for the text in the **Pattern** parameter. It does not
-interpret the value of the **Pattern** parameter as a regular expression statement.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Raw
 
 Causes the cmdlet to output only the matching strings, rather than **MatchInfo** objects. This is
@@ -637,6 +620,24 @@ Parameter Sets: ObjectRaw, FileRaw, LiteralFileRaw
 Aliases:
 
 Required: True
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SimpleMatch
+
+Indicates that the cmdlet uses a simple match rather than a regular expression match. In a simple
+match, `Select-String` searches the input for the text in the **Pattern** parameter. It doesn't
+interpret the value of the **Pattern** parameter as a regular expression statement.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: False
 Accept pipeline input: False
@@ -688,11 +689,11 @@ You can use the **SimpleMatch** parameter to override the regular expression mat
 **SimpleMatch** parameter finds instances of the value of the **Pattern** parameter in the input.
 
 The default output of `Select-String` is a **MatchInfo** object, which includes detailed information
-about the matches. The information in the object is useful when you are searching for text in files,
-because **MatchInfo** objects have properties such as **Filename** and **Line**. When the input is
-not from the file, the value of these parameters is **InputStream**.
+about the matches. The information in the object is useful when you're searching for text in files,
+because **MatchInfo** objects have properties such as **Filename** and **Line**. When the input
+isn't from the file, the value of these parameters is **InputStream**.
 
-If you do not need the information in the **MatchInfo** object, use the **Quiet** parameter. The
+If you don't need the information in the **MatchInfo** object, use the **Quiet** parameter. The
 **Quiet** parameter returns a Boolean value (True or False) to indicate whether it found a match,
 instead of a **MatchInfo** object.
 
@@ -726,5 +727,3 @@ To find the properties of a **MatchInfo** object, type the following command:
 [Get-WinEvent](../Microsoft.PowerShell.Diagnostics/Get-WinEvent.md)
 
 [Out-File](Out-File.md)
-
-


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

Acrolinx scores
Original version: 95
Updated version: 97

- Fixes [AB#1593065](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1593065)
- Fixes #4709
- Updated `-List` parameter with content from [PowerShell/PowerShell #10442](https://github.com/PowerShell/PowerShell/issues/10442)
- Minor copyedits, fixed spacing in parameter sets