### PR TITLE
Fixes #4585 - Added content about .NET assemblies to ReferencedAssemblies parameter

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Add-Type.md
@@ -499,6 +499,9 @@ Specifies the assemblies upon which the type depends. By default, `Add-Type` ref
 and `System.Management.Automation.dll`. The assemblies that you specify by using this parameter are
 referenced in addition to the default assemblies.
 
+Beginning in PowerShell 6, **ReferencedAssemblies** doesn't include the default .NET assemblies. You
+must include a specific reference to them in the value passed to this parameter.
+
 You can't use the **CompilerOptions** and **ReferencedAssemblies** parameters in the same command.
 
 ```yaml

--- a/reference/7/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Add-Type.md
@@ -499,6 +499,9 @@ Specifies the assemblies upon which the type depends. By default, `Add-Type` ref
 and `System.Management.Automation.dll`. The assemblies that you specify by using this parameter are
 referenced in addition to the default assemblies.
 
+Beginning in PowerShell 6, **ReferencedAssemblies** doesn't include the default .NET assemblies. You
+must include a specific reference to them in the value passed to this parameter.
+
 You can't use the **CompilerOptions** and **ReferencedAssemblies** parameters in the same command.
 
 ```yaml


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6 of PowerShell
- [x] This issue only shows up in version 6 and 7 of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work

- Fixes [AB#1593782](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1593782)
- Fixes #4585