### PR TITLE
Fixes typo in Get-ChildItem references

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -274,7 +274,7 @@ UEFI
 ```
 
 ```powershell
-Get-ChildItem -Path HLKM:\HARDWARE -Exclude D*
+Get-ChildItem -Path HKLM:\HARDWARE -Exclude D*
 ```
 
 ```Output

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -274,7 +274,7 @@ UEFI
 ```
 
 ```powershell
-Get-ChildItem -Path HLKM:\HARDWARE -Exclude D*
+Get-ChildItem -Path HKLM:\HARDWARE -Exclude D*
 ```
 
 ```Output

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -275,7 +275,7 @@ UEFI
 ```
 
 ```powershell
-Get-ChildItem -Path HLKM:\HARDWARE -Exclude D*
+Get-ChildItem -Path HKLM:\HARDWARE -Exclude D*
 ```
 
 ```Output

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -275,7 +275,7 @@ UEFI
 ```
 
 ```powershell
-Get-ChildItem -Path HLKM:\HARDWARE -Exclude D*
+Get-ChildItem -Path HKLM:\HARDWARE -Exclude D*
 ```
 
 ```Output

--- a/reference/6/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -274,7 +274,7 @@ UEFI
 ```
 
 ```powershell
-Get-ChildItem -Path HLKM:\HARDWARE -Exclude D*
+Get-ChildItem -Path HKLM:\HARDWARE -Exclude D*
 ```
 
 ```Output

--- a/reference/7/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/7/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -274,7 +274,7 @@ UEFI
 ```
 
 ```powershell
-Get-ChildItem -Path HLKM:\HARDWARE -Exclude D*
+Get-ChildItem -Path HKLM:\HARDWARE -Exclude D*
 ```
 
 ```Output


### PR DESCRIPTION
Fixes typo in Get-ChildItem references

Version(s) of document impacted
------------------------------
- [X] Impacts 7 document
- [X] Impacts 6 document
- [x] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document
