### PR TITLE
Fixes #3752 - Alias names are available across PS versions

### DIFF
--- a/reference/docs-conceptual/samples/Appendix-1---Compatibility-Aliases.md
+++ b/reference/docs-conceptual/samples/Appendix-1---Compatibility-Aliases.md
@@ -1,30 +1,50 @@
 ---
-ms.date:  06/05/2017
+ms.date:  09/09/2019
 keywords:  powershell,cmdlet
 title:  Appendix 1 Compatibility Aliases
 ---
 # Appendix 1 - Compatibility Aliases
 
-Windows PowerShell has several transition aliases that allow UNIX and Cmd users to use familiar command names in Windows PowerShell. The most common aliases are shown in the table below, along with the Windows PowerShell command behind the alias and the standard Windows PowerShell alias if one exists.
+PowerShell has several aliases that allow **UNIX** and **cmd.exe** users to use familiar commands.
+The commands and their related PowerShell cmdlet and PowerShell alias are shown in the following
+table:
 
-You can find the Windows PowerShell command that any alias points to from within Windows PowerShell by using the Get-Alias cmdlet. For example, type **get-alias cls**.
-
-```
-CommandType     Name                            Definition
------------     ----                            ----------
-Alias           cls                             Clear-Host
-```
-
-|CMD Command|UNIX Command|PS Command|PS Alias|
+|cmd.exe command|UNIX command|PowerShell cmdlet|PowerShell alias|
 |---------------|----------------|--------------|------------|
-|**dir**|**ls**|**Get-ChildItem**|**gci**|
-|**cls**|**clear**|**Clear-Host** (function)|**cls**|
-|**del, erase, rmdir**|**rm**|**Remove-Item**|**ri**|
-|**copy**|**cp**|**Copy-Item**|**ci**|
-|**move**|**mv**|**Move-Item**|**mi**|
-|**rename**|**mv**|**Rename-Item**|**rni**|
-|**type**|**cat**|**Get-Content**|**gc**|
-|**cd**|**cd**|**Set-Location**|**sl**|
-|**md**|**mkdir**|**New-Item**|**ni**|
-|**pushd**|**pushd**|**Push-Location**|**pushd**|
-|**popd**|**popd**|**Pop-Location**|**popd**|
+|**cls**|**clear**|`Clear-Host` (function)|`cls`|
+|**copy**|**cp**|`Copy-Item`|`cpi`|
+|**dir**|**ls**|`Get-ChildItem`|`gci`|
+|**type**|**cat**|`Get-Content`|`gc`|
+|**move**|**mv**|`Move-Item`|`mi`|
+|**md**|**mkdir**|`New-Item`|`ni`|
+|**pushd**|**pushd**|`Push-Location`|`pushd`|
+|**popd**|**popd**|`Pop-Location`|`popd`|
+|**del**, **erase**, **rd**, **rmdir**|**rm**|`Remove-Item`|`ri`|
+|**ren**|**mv**|`Rename-Item`|`rni`|
+|**cd**, **chdir**|**cd**|`Set-Location`|`sl`|
+
+To find the PowerShell aliases, use the [Get-Alias](/powershell/module/Microsoft.PowerShell.Utility/Get-Alias)
+cmdlet. To display a cmdlet's aliases, use the **Definition** parameter and specify the cmdlet name.
+Or, to find an alias's cmdlet name, use the **Name** parameter and specify the alias.
+
+```powershell
+Get-Alias -Definition Get-ChildItem
+```
+
+```Output
+CommandType     Name
+-----------     ----
+Alias           dir -> Get-ChildItem
+Alias           gci -> Get-ChildItem
+Alias           ls -> Get-ChildItem
+```
+
+```powershell
+Get-Alias -Name gci
+```
+
+```Output
+CommandType     Name
+-----------     ----
+Alias           gci -> Get-ChildItem
+```


### PR DESCRIPTION
Acrolinx scores
Original version: 81 (85 without the table)
Updated version: 87 (100 without the table)

- Fixes [AB#1595450](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1595450)
- Fixes #3752
- Copyedits, style, paragraph reflows