### PR TITLE
Added documentation for MaximumVersion key used with #Requires

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -101,6 +101,7 @@ following keys.
 
 > [!NOTE]
 > `RequiredVersion` was added in Windows PowerShell 5.0.
+> `MaximumVersion` was added in Windows PowerShell 5.1.
 
 For example:
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -93,7 +93,7 @@ following keys.
 
 - `ModuleName` - **Required** Specifies the module name.
 - `GUID` - **Optional** Specifies the GUID of the module.
-- It is also **Required** to specify one of the two below keys. These keys
+- It is also **Required** to specify one of the three below keys. These keys
   cannot be used together.
   - `ModuleVersion` - Specifies a minimum acceptable version of the module.
   - `RequiredVersion` - Specifies an exact, required version of the module.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -97,6 +97,7 @@ following keys.
   cannot be used together.
   - `ModuleVersion` - Specifies a minimum acceptable version of the module.
   - `RequiredVersion` - Specifies an exact, required version of the module.
+  - `MaximumVersion` - Specifies the maximum acceptable version of the module.
 
 > [!NOTE]
 > `RequiredVersion` was added in Windows PowerShell 5.0.
@@ -113,6 +114,12 @@ Requires that `Hyper-V` (**only** version `1.1`) is installed.
 
 ```powershell
 #Requires -Modules @{ ModuleName="Hyper-V"; RequiredVersion="1.1" }
+```
+
+Requires that `Hyper-V` (version `1.1` or lesser) is installed.
+
+```powershell
+#Requires -Modules @{ ModuleName="Hyper-V"; MaximumVersion="1.1" }
 ```
 
 Requires that any version of `PSScheduledJob` and `PSWorkflow`, is installed.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -101,6 +101,7 @@ following keys.
 
 > [!NOTE]
 > `RequiredVersion` was added in Windows PowerShell 5.0.
+> `MaximumVersion` was added in Windows PowerShell 5.1.
 
 For example:
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -93,7 +93,7 @@ following keys.
 
 - `ModuleName` - **Required** Specifies the module name.
 - `GUID` - **Optional** Specifies the GUID of the module.
-- It is also **Required** to specify one of the two below keys. These keys
+- It is also **Required** to specify one of the three below keys. These keys
   cannot be used together.
   - `ModuleVersion` - Specifies a minimum acceptable version of the module.
   - `RequiredVersion` - Specifies an exact, required version of the module.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -97,6 +97,7 @@ following keys.
   cannot be used together.
   - `ModuleVersion` - Specifies a minimum acceptable version of the module.
   - `RequiredVersion` - Specifies an exact, required version of the module.
+  - `MaximumVersion` - Specifies the maximum acceptable version of the module.
 
 > [!NOTE]
 > `RequiredVersion` was added in Windows PowerShell 5.0.
@@ -113,6 +114,12 @@ Require that `AzureRM.Netcore` (**only** version `0.12.0`) is installed.
 
 ```powershell
 #Requires -Modules @{ ModuleName="AzureRM.Netcore"; RequiredVersion="0.12.0" }
+```
+
+Requires that `AzureRM.Netcore` (version `0.12.0` or lesser) is installed.
+
+```powershell
+#Requires -Modules @{ ModuleName="AzureRM.Netcore"; MaximumVersion="0.12.0" }
 ```
 
 Require that any version of `AzureRM.Netcore` and `PowerShellGet` is installed.

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -101,6 +101,7 @@ following keys.
 
 > [!NOTE]
 > `RequiredVersion` was added in Windows PowerShell 5.0.
+> `MaximumVersion` was added in Windows PowerShell 5.1.
 
 For example:
 

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -93,7 +93,7 @@ following keys.
 
 - `ModuleName` - **Required** Specifies the module name.
 - `GUID` - **Optional** Specifies the GUID of the module.
-- It is also **Required** to specify one of the two below keys. These keys
+- It is also **Required** to specify one of the three below keys. These keys
   cannot be used together.
   - `ModuleVersion` - Specifies a minimum acceptable version of the module.
   - `RequiredVersion` - Specifies an exact, required version of the module.

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -97,6 +97,7 @@ following keys.
   cannot be used together.
   - `ModuleVersion` - Specifies a minimum acceptable version of the module.
   - `RequiredVersion` - Specifies an exact, required version of the module.
+  - `MaximumVersion` - Specifies the maximum acceptable version of the module.
 
 > [!NOTE]
 > `RequiredVersion` was added in Windows PowerShell 5.0.
@@ -113,6 +114,12 @@ Require that `AzureRM.Netcore` (**only** version `0.12.0`) is installed.
 
 ```powershell
 #Requires -Modules @{ ModuleName="AzureRM.Netcore"; RequiredVersion="0.12.0" }
+```
+
+Requires that `AzureRM.Netcore` (version `0.12.0` or lesser) is installed.
+
+```powershell
+#Requires -Modules @{ ModuleName="AzureRM.Netcore"; MaximumVersion="0.12.0" }
 ```
 
 Require that any version of `AzureRM.Netcore` and `PowerShellGet` is installed.


### PR DESCRIPTION
Addresses #4541 

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 7 document
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
- [X] Prior versions unavailable for validating documented behavior
