### PR TITLE
Fixed -ToSession description

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/6/Microsoft.PowerShell.Management/Copy-Item.md
@@ -447,7 +447,7 @@ Accept wildcard characters: False
 ### -ToSession
 
 Specifies the **PSSession** object to which a remote file is being copied. When you use this
-parameter, the **Path** and **LiteralPath** parameters refer to the local path on the remote
+parameter, the **Destination** parameter refers to the local path on the remote
 machine.
 
 ```yaml


### PR DESCRIPTION
The -ToSession description seems to have been a copy/paste from the -FromSession description. When using the -ToSession parameter, the -Destination parameter becomes local to the remote computer. This updates fixes that copy/paste error & provides the correct information.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 7 document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
