### PR TITLE
Fixes #4198, Fixes #4243 - Added note about limit of 32 parameter sets, removed duplicated code block

### DIFF
--- a/developer/cmdlet/cmdlet-parameter-sets.md
+++ b/developer/cmdlet/cmdlet-parameter-sets.md
@@ -9,45 +9,78 @@ ms.topic: "article"
 ms.assetid: f902fd4d-8f6e-4ef1-b07f-59983039a0d1
 caps.latest.revision: 10
 ---
-# Cmdlet Parameter Sets
 
-Windows PowerShell uses parameter sets to enable you to write a single cmdlet that can perform different actions for different scenarios. Parameter sets enable you to expose different parameters to the user and to return different information based on the parameters specified by the user.
+# Cmdlet parameter sets
 
-## Examples of Parameter Sets
+PowerShell uses parameter sets to enable you to write a single cmdlet that can do different actions
+for different scenarios. Parameter sets enable you to expose different parameters to the user. And,
+to return different information based on the parameters specified by the user.
 
-For example, the `Get-EventLog` cmdlet (provided by Windows PowerShell) returns different information depending on whether the user specifies the `List` or `LogName` parameter. If the `List` parameter is specified, the cmdlet returns information about the log files themselves but not the event information they contain. If the `LogName` parameter is specified, the cmdlet returns information about the events in a specific event log. The `List` and `LogName` parameters identify two separate parameter sets.
+## Examples of parameter sets
 
-## Unique Parameter
+For example, the PowerShell `Get-EventLog` cmdlet returns different information depending on whether
+the user specifies the **List** or **LogName** parameter. If the **List** parameter is specified,
+the cmdlet returns information about the log files themselves but not the event information they
+contain. If the **LogName** parameter is specified, the cmdlet returns information about the events
+in a specific event log. The **List** and **LogName** parameters identify two separate parameter
+sets.
 
-Each parameter set must have a unique parameter that the Windows PowerShell runtime can use to expose the appropriate parameter set. If possible, the unique parameter should be a mandatory parameter. When a parameter is mandatory, the user is forced to specify the parameter, and the Windows PowerShell runtime can use that parameter to identify the parameter set to use. The unique parameter cannot be mandatory if your cmdlet is designed to be run without specifying any parameters.
+## Unique parameter
 
-## Multiple Parameter Sets
+Each parameter set must have a unique parameter that the PowerShell runtime uses to expose the
+appropriate parameter set. If possible, the unique parameter should be a mandatory parameter. When a
+parameter is mandatory, the user must specify the parameter, and the PowerShell runtime uses that
+parameter to identify the parameter set. The unique parameter can't be mandatory if your cmdlet is
+designed to run without specifying any parameters.
 
-In the following illustration, the left column shows three valid parameter sets. Parameter A is unique to the first parameter set, parameter B is unique to the second parameter set, and parameter C is unique to the third parameter set. However, in the right column, the parameter sets do not have a unique parameter.
+## Multiple parameter sets
+
+In the following illustration, the left column shows three valid parameter sets. **Parameter A** is
+unique to the first parameter set, **parameter B** is unique to the second parameter set, and
+**parameter C** is unique to the third parameter set. In the right column, the parameter sets don't
+have a unique parameter.
 
 ![ps_parametersets](../media/ps-parametersets.gif)
 
-## Parameter Set Requirements
+## Parameter set requirements
 
 The following requirements apply to all parameter sets.
 
-- Each parameter set must have at least one unique parameter. If possible, make this parameter a mandatory parameter.
+- Each parameter set must have at least one unique parameter. If possible, make this parameter a
+  mandatory parameter.
 
-- A parameter set that contains multiple positional parameters must define unique positions for each parameter. No two positional parameters can specify the same position.
+- A parameter set that contains multiple positional parameters must define unique positions for each
+  parameter. No two positional parameters can specify the same position.
 
-- Only one parameter in a set can declare the `ValueFromPipeline` keyword with a value of `true`. Multiple parameters can define the `ValueFromPipelineByPropertyName` keyword with a value of `true`.
+- Only one parameter in a set can declare the `ValueFromPipeline` keyword with a value of `true`.
+  Multiple parameters can define the `ValueFromPipelineByPropertyName` keyword with a value of
+  `true`.
 
 - If no parameter set is specified for a parameter, the parameter belongs to all parameter sets.
 
-## Default Parameter Sets
+> [!NOTE]
+> The parameters for a cmdlet or function can be included in a maximum of 32 parameter sets.
 
-When multiple parameter sets are defined, you can use the `DefaultParameterSetName` keyword of the Cmdlet attribute to specify the default parameter set. Windows PowerShell uses the default parameter set if it cannot determine the parameter set to use based on the information provided by the command. For more information about the Cmdlet attribute, see [Cmdlet Attribute Declaration](./cmdlet-attribute-declaration.md).
+## Default parameter sets
 
-## Declaring Parameter Sets
+When multiple parameter sets are defined, you can use the `DefaultParameterSetName` keyword of the
+**Cmdlet** attribute to specify the default parameter set. PowerShell uses the default parameter set
+if it can't determine the parameter set to use based on the information provided by the command. For
+more information about the **Cmdlet** attribute, see [Cmdlet Attribute Declaration](./cmdlet-attribute-declaration.md).
 
-To create a parameter set, you must specify the `ParameterSetName` keyword when you declare the Parameter attribute for every parameter in the parameter set. For parameters that belong to multiple parameter sets, add a Parameter attribute for each parameter set. This enables you to define the parameter differently for each parameter set. For example, you can define a parameter as mandatory in one set and optional in another. However, each parameter set must contain one unique parameter.
+## Declaring parameter sets
 
-In the following example, the `UserName` parameter is the unique parameter of the Test01 parameter set, and the `ComputerName` parameter is the unique parameter of the Test02 parameter set. The `SharedParam` parameter belongs to both sets and is mandatory for the Test01 parameter set but optional for the Test02 parameter set.
+To create a parameter set, you must specify the `ParameterSetName` keyword when you declare the
+**Parameter** attribute for every parameter in the parameter set. For parameters that belong to
+multiple parameter sets, add a **Parameter** attribute for each parameter set. This attribute
+enables you to define the parameter differently for each parameter set. For example, you can define
+a parameter as mandatory in one set and optional in another. However, each parameter set must
+contain one unique parameter. For more information, see [Parameter Attribute Declaration](parameter-attribute-declaration.md).
+
+In the following example, the **UserName** parameter is the unique parameter of the `Test01`
+parameter set, and the **ComputerName** parameter is the unique parameter of the `Test02` parameter
+set. The **SharedParam** parameter belongs to both sets and is mandatory for the `Test01` parameter
+set but optional for the `Test02` parameter set.
 
 ```csharp
 [Parameter(Position = 0, Mandatory = true,
@@ -75,12 +108,5 @@ public string SharedParam
     get { return sharedParam; }
     set { sharedParam = value; }
 }
-private string sharedParam;    [Parameter(Position = 0, Mandatory = true,
-           ParameterSetName = "Test01")]
-public string UserName
-{
-  get { return userName; }
-  set { userName = value; }
-}
-private string userName;
+private string sharedParam;
 ```

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,10 +1,11 @@
 ---
-ms.date:  11/28/2017
+ms.date: 05/20/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Functions_Advanced_Parameters
 ---
+
 # About Functions Advanced Parameters
 
 ## Short description
@@ -17,256 +18,258 @@ You can add parameters to the advanced functions that you write, and use
 parameter attributes and arguments to limit the parameter values that function
 users submit with the parameter.
 
-The parameters that you add to your function are available to users in
-addition to the common parameters that PowerShell adds automatically to all
-cmdlets and advanced functions. For more information about the Windows
-PowerShell common parameters, see
-[about_CommonParameters](about_CommonParameters.md).
+The parameters that you add to your function are available to users in addition
+to the common parameters that PowerShell adds automatically to all cmdlets and
+advanced functions. For more information about the PowerShell common
+parameters, see [about_CommonParameters](about_CommonParameters.md).
 
-Beginning in PowerShell 3.0, you can use splatting with @Args to represent the
-parameters in a command. This technique is valid on simple and advanced
-functions. For more information, see [about_Functions](about_Functions.md) and
-[about_Splatting](about_Splatting.md).
+Beginning in PowerShell 3.0, you can use splatting with `@Args` to represent
+the parameters in a command. Splatting is valid on simple and advanced
+functions. For more information, see [about_Functions](about_Functions.md) and [about_Splatting](about_Splatting.md).
 
-## Static Parameters
+## Static parameters
 
 Static parameters are parameters that are always available in the function.
 Most parameters in PowerShell cmdlets and scripts are static parameters.
 
-The following example shows the declaration of a ComputerName parameter that
-has the following characteristics:
+The following example shows the declaration of a **ComputerName** parameter
+that has the following characteristics:
 
-- It is mandatory (required).
+- It's mandatory (required).
 - It takes input from the pipeline.
 - It takes an array of strings as input.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ValueFromPipeline=$true)]
     [String[]]
     $ComputerName
 )
 ```
 
-## Attributes of Parameters
+## Attributes of parameters
 
 This section describes the attributes that you can add to function parameters.
 
-All attributes are optional. However, if you omit the `CmdletBinding` attribute,
-then to be recognized as an advanced function, the function must include the
-Parameter attribute.
+All attributes are optional. However, if you omit the **CmdletBinding**
+attribute, then to be recognized as an advanced function, the function must
+include the **Parameter** attribute.
 
-You can add one or multiple attributes in each parameter declaration. There is
+You can add one or multiple attributes in each parameter declaration. There's
 no limit to the number of attributes that you can add to a parameter
 declaration.
 
-### The Parameter Attribute
+### Parameter attribute
 
-The `Parameter` attribute is used to declare the attributes of function
+The **Parameter** attribute is used to declare the attributes of function
 parameters.
 
-The `Parameter` attribute is optional, and you can omit it if none of the
-parameters of your functions need attributes, but to be recognized as an
-advanced function (rather than a simple function), a function must have either
-the `CmdletBinding` attribute or the `Parameter` attribute, or both.
+The **Parameter** attribute is optional, and you can omit it if none of the
+parameters of your functions need attributes. But, to be recognized as an
+advanced function, rather than a simple function, a function must have either
+the **CmdletBinding** attribute or the **Parameter** attribute, or both.
 
-The `Parameter` attribute has arguments that define the characteristics of the
-parameter, such as whether the parameter is mandatory or optional.
+The **Parameter** attribute has arguments that define the characteristics of
+the parameter, such as whether the parameter is mandatory or optional.
 
-Use the following syntax to declare the Parameter attribute, an argument, and
-an argument value. The parentheses that enclose the argument and its value
-must follow "`Parameter`" with no intervening space.
+Use the following syntax to declare the **Parameter** attribute, an argument,
+and an argument value. The parentheses that enclose the argument and its value
+must follow **Parameter** with no intervening space.
 
 ```powershell
 Param(
-    [parameter(Argument=value)]
+    [Parameter(Argument=value)]
     $ParameterName
 )
 ```
 
 Use commas to separate arguments within the parentheses. Use the following
-syntax to declare two arguments of the `Parameter` attribute.
+syntax to declare two arguments of the **Parameter** attribute.
 
 ```powershell
 Param(
-    [parameter(Argument1=value1,
+    [Parameter(Argument1=value1,
     Argument2=value2)]
 )
 ```
 
-If you use the `Parameter` attribute without arguments (as an alternative to
-using the `CmdletBinding` attribute), the parentheses that follow the attribute
-name are still required.
+If you use the **Parameter** attribute without arguments, as an alternative to
+using the **CmdletBinding** attribute, the parentheses that follow the
+attribute name are still required.
 
 ```powershell
 Param(
-    [parameter()]
+    [Parameter()]
     $ParameterName
 )
 ```
 
-### Mandatory Argument
+### Mandatory argument
 
 The `Mandatory` argument indicates that the parameter is required. If this
-argument is not specified, the parameter is an optional parameter.
+argument isn't specified, the parameter is optional.
 
-The following example declares the `ComputerName` parameter. It uses the
+The following example declares the **ComputerName** parameter. It uses the
 `Mandatory` argument to make the parameter mandatory.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [String[]]
     $ComputerName
 )
 ```
 
-### Position Argument
+### Position argument
 
 The `Position` argument determines whether the parameter name is required when
 the parameter is used in a command. When a parameter declaration includes the
-`Position` argument, the parameter name can be omitted and PowerShell identifies
-the unnamed parameter value by its position (or order) in the list of unnamed
-parameter values in the command.
+`Position` argument, the parameter name can be omitted and PowerShell
+identifies the unnamed parameter value by its position, or order, in the list
+of unnamed parameter values in the command.
 
-If the `Position` argument is not specified, the parameter name (or a parameter
-name alias or abbreviation) must precede the parameter value whenever the
+If the `Position` argument isn't specified, the parameter name, or a parameter
+name alias or abbreviation, must precede the parameter value whenever the
 parameter is used in a command.
 
 By default, all function parameters are positional. PowerShell assigns position
 numbers to parameters in the order in which the parameters are declared in the
 function. To disable this feature, set the value of the `PositionalBinding`
-argument of the `CmdletBinding` attribute to `$False`.The `Position` argument
-takes precedence over the value of the `PositionalBinding` argument for the
-parameters on which it is declared. For more information, see
-`PositionalBinding` in [about_Functions_CmdletBindingAttribute](about_Functions_CmdletBindingAttribute.md).
+argument of the **CmdletBinding** attribute to `$False`. The `Position`
+argument takes precedence over the value of the `PositionalBinding` argument
+for the parameters on which it's declared. For more information, see
+`PositionalBinding` in
+[about_Functions_CmdletBindingAttribute](about_Functions_CmdletBindingAttribute.md).
 
-The value of the Position argument is specified as an integer. A position
-value of **"0"** represents the first position in the command, a position value
-of **"1"** represents the second position in the command, and so on.
+The value of the `Position` argument is specified as an integer. A position
+value of **0** represents the first position in the command, a position value
+of **1** represents the second position in the command, and so on.
 
 If a function has no positional parameters, PowerShell assigns positions to
 each parameter based on the order in which the parameters are declared.
-However, as a best practice, do not rely on this assignment. When you want
-parameters to be positional, use the Position argument.
+However, as a best practice, don't rely on this assignment. When you want
+parameters to be positional, use the `Position` argument.
 
 The following example declares the **ComputerName** parameter. It uses the
-Position argument with a value of **"0"**. As a result, when `-ComputerName` is
+`Position` argument with a value of **0**. As a result, when `-ComputerName` is
 omitted from command, its value must be the first or only unnamed parameter
 value in the command.
 
 ```powershell
 Param(
-    [parameter(Position=0)]
+    [Parameter(Position=0)]
     [String[]]
     $ComputerName
 )
 ```
 
 > [!NOTE]
-> When the Get-Help cmdlet displays the corresponding `Position`
-> parameter attribute, the position value is incremented by one.
+> When the `Get-Help` cmdlet displays the corresponding **Position** parameter
+> attribute, the position value is incremented by one.
 >
-> For example, a parameter with a Position argument value of **"0"**
-> has a parameter attribute of "`Position=1`"
+> For example, a parameter with a `Position` argument value of **0** has a
+> parameter attribute of **Position=1**.
 
-### ParameterSetName Argument
+### ParameterSetName argument
 
-The ParameterSetName argument specifies the parameter set to which a parameter
-belongs. If no parameter set is specified, the parameter belongs to all the
-parameter sets defined by the function. Therefore, to be unique, each
-parameter set must have at least one parameter that is not a member of any
-other parameter set.
+The `ParameterSetName` argument specifies the parameter set to which a
+parameter belongs. If no parameter set is specified, the parameter belongs to
+all the parameter sets defined by the function. Therefore, to be unique, each
+parameter set must have at least one parameter that isn't a member of any other
+parameter set.
 
-The following example declares a `ComputerName` parameter in the "Computer"
-parameter set, a `UserName` parameter in the "User" parameter set, and a
-`Summary` parameter in both parameter sets.
+> [!NOTE]
+> The parameters for a cmdlet or function can be included in a maximum of 32
+> parameter sets.
+
+The following example declares a **ComputerName** parameter in the `Computer`
+parameter set, a **UserName** parameter in the `User` parameter set, and a
+**Summary** parameter in both parameter sets.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ParameterSetName="Computer")]
     [String[]]
     $ComputerName,
 
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ParameterSetName="User")]
     [String[]]
     $UserName,
 
-    [parameter(Mandatory=$false)]
+    [Parameter(Mandatory=$false)]
     [Switch]
     $Summary
 )
 ```
 
-You can specify only one `ParameterSetName` value in each argument and only
-one `ParameterSetName` argument in each `Parameter` attribute. To indicate
-that a parameter appears in more than one parameter set, add additional
-`Parameter` attributes.
+You can specify only one `ParameterSetName` value in each argument and only one
+`ParameterSetName` argument in each **Parameter** attribute. To indicate that a
+parameter appears in more than one parameter set, add additional **Parameter**
+attributes.
 
-The following example explicitly adds the `Summary` parameter to the Computer
-and User parameter sets. The `Summary` parameter is **Mandatory** in one
-parameter set and **Optional** in the other.
+The following example explicitly adds the **Summary** parameter to the
+`Computer` and `User` parameter sets. The **Summary** parameter is optional in
+the `Computer` parameter set and mandatory in the `User` parameter set.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ParameterSetName="Computer")]
     [String[]]
     $ComputerName,
 
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ParameterSetName="User")]
     [String[]]
     $UserName,
 
-    [parameter(Mandatory=$false, ParameterSetName="Computer")]
-    [parameter(Mandatory=$true, ParameterSetName="User")]
+    [Parameter(Mandatory=$false, ParameterSetName="Computer")]
+    [Parameter(Mandatory=$true, ParameterSetName="User")]
     [Switch]
     $Summary
 )
 ```
 
-For more information about parameter sets, see "Cmdlet Parameter Sets" in the
-MSDN library at [Cmdlet Parameter Sets](/powershell/developer/cmdlet/cmdlet-parameter-sets)
+For more information about parameter sets, see [Cmdlet Parameter Sets](/powershell/developer/cmdlet/cmdlet-parameter-sets).
 
-### ValueFromPipeline Argument
+### ValueFromPipeline argument
 
-The `ValueFromPipeline` argument indicates that the parameter accepts input from
-a pipeline object. Specify this argument if the function accepts the entire
-object, not just a property of the object.
+The `ValueFromPipeline` argument indicates that the parameter accepts input
+from a pipeline object. Specify this argument if the function accepts the
+entire object, not just a property of the object.
 
-The following example declares a `ComputerName` parameter that is mandatory
-and accepts an object that is passed to the function from the pipeline.
+The following example declares a **ComputerName** parameter that's mandatory
+and accepts an object that's passed to the function from the pipeline.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ValueFromPipeline=$true)]
     [String[]]
     $ComputerName
 )
 ```
 
-### ValueFromPipelineByPropertyName Argument
+### ValueFromPipelineByPropertyName argument
 
 The `ValueFromPipelineByPropertyName` argument indicates that the parameter
 accepts input from a property of a pipeline object. The object property must
 have the same name or alias as the parameter.
 
-For example, if the function has a `ComputerName` parameter, and the piped
-object has a `ComputerName` property, the value of the `ComputerName`
-property is assigned to the `ComputerName` parameter of the function.
+For example, if the function has a **ComputerName** parameter, and the piped
+object has a **ComputerName** property, the value of the **ComputerName**
+property is assigned to the function's **ComputerName** parameter.
 
-The following example declares a `ComputerName` parameter that is mandatory
-and accepts input from the `ComputerName` property of the object that is
-passed to the function through the pipeline.
+The following example declares a **ComputerName** parameter that's mandatory
+and accepts input from the object's **ComputerName** property that's passed to
+the function through the pipeline.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ValueFromPipelineByPropertyName=$true)]
     [String[]]
     $ComputerName
@@ -275,29 +278,30 @@ Param(
 
 > [!NOTE]
 > A typed parameter that accepts pipeline input (`by Value`) or
-> (`by PropertyName`) enables use of **delay-bind** script blocks on the parameter.
+> (`by PropertyName`) enables use of **delay-bind** script blocks on the
+> parameter.
 >
 > The **delay-bind** script block is run automatically during
 > **ParameterBinding**. The result is bound to the parameter. Delay binding
-> does **not** work for parameters defined as type `ScriptBlock` or
-> `System.Object`, the script block is passed through
-> **without** being invoked.
+> **does not** work for parameters defined as type `ScriptBlock` or
+> `System.Object`, the script block is passed through **without** being
+> invoked.
 >
-> You can read about **delay-bind** script blocks here [about_Script_Blocks.md](about_Script_Blocks.md)
+> You can read about **delay-bind** script blocks here [about_Script_Blocks.md](about_Script_Blocks.md).
 
-### ValueFromRemainingArguments Argument
+### ValueFromRemainingArguments argument
 
-The `ValueFromRemainingArguments` argument indicates that the parameter
-accepts all of the parameters values in the command that are not assigned to
-other parameters of the function.
+The `ValueFromRemainingArguments` argument indicates that the parameter accepts
+all the parameter's values in the command that aren't assigned to other
+parameters of the function.
 
-There is a known issue for using collections with
-**ValueFromRemainingArguments** where the passed in collection is treated
-as a single element.
+There's a known issue for using collections with
+**ValueFromRemainingArguments** where the passed-in collection is treated as a
+single element.
 
-The following example demonstrates this issue. The `$Remaining` parameter
-should contain "one" at index 0 and "two" at index 1. Instead, both elements
-are combined into a single entity.
+The following example demonstrates this known issue. The **Remaining**
+parameter should contain **one** at **index 0** and **two** at **index 1**.
+Instead, both elements are combined into a single entity.
 
 ```powershell
 function Test-Remainder
@@ -326,126 +330,126 @@ Found 1 elements
 > [!NOTE]
 > This issue is resolved in PowerShell 6.2.
 
-### HelpMessage Argument
+### HelpMessage argument
 
-The `HelpMessage` argument specifies a string that contains a brief
-description of the parameter or its value. PowerShell displays this message in
-the prompt that appears when a mandatory parameter value is missing from a
-command. This argument has no effect on optional parameters.
+The `HelpMessage` argument specifies a string that contains a brief description
+of the parameter or its value. PowerShell displays this message in the prompt
+that appears when a mandatory parameter value is missing from a command. This
+argument has no effect on optional parameters.
 
-The following example declares a mandatory `ComputerName` parameter and a
+The following example declares a mandatory **ComputerName** parameter and a
 help message that explains the expected parameter value.
 
 ```powershell
 Param(
-    [parameter(mandatory=$true,
+    [Parameter(Mandatory=$true,
     HelpMessage="Enter one or more computer names separated by commas.")]
     [String[]]
     $ComputerName
 )
 ```
 
-### Alias Attribute
+### Alias attribute
 
-The `Alias` attribute establishes an alternate name for the parameter. There is
-no limit to the number of aliases that you can assign to a parameter.
+The **Alias** attribute establishes an alternate name for the parameter.
+There's no limit to the number of aliases that you can assign to a parameter.
 
-The following example shows a parameter declaration that adds the "CN" and
-"MachineName" aliases to the mandatory `ComputerName` parameter.
+The following example shows a parameter declaration that adds the **CN** and
+**MachineName** aliases to the mandatory **ComputerName** parameter.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
-    [alias("CN","MachineName")]
+    [Parameter(Mandatory=$true)]
+    [Alias("CN","MachineName")]
     [String[]]
     $ComputerName
 )
 ```
 
-### Parameter and Variable Validation Attributes
+### Parameter and variable validation attributes
 
-Validation attributes direct PowerShell to test the parameter values that
-users submit when they call the advanced function. If the parameter values
-fail the test, an error is generated and the function is not called. You can
-also use some of the validation attributes to restrict the values that users
-can specify for variables.
+Validation attributes direct PowerShell to test the parameter values that users
+submit when they call the advanced function. If the parameter values fail the
+test, an error is generated and the function isn't called. You can also use
+some of the validation attributes to restrict the values that users can specify
+for variables.
 
-### AllowNull Validation Attribute
+### AllowNull validation attribute
 
-The `AllowNull` attribute allows the value of a **Mandatory** parameter to be
-`$null`. The following example declares a `ComputerName` parameter that can have
-a Null value.
+The **AllowNull** attribute allows the value of a mandatory parameter to be
+`$null`. The following example declares a **ComputerName** parameter that can
+have a **null** value.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [AllowNull()]
     [String]
     $ComputerName
 )
 ```
 
-### AllowEmptyString Validation Attribute
+### AllowEmptyString validation attribute
 
-The `AllowEmptyString` attribute allows the value of a **Mandatory** parameter
-to be an empty string (""). The following example declares a `ComputerName`
+The **AllowEmptyString** attribute allows the value of a mandatory parameter to
+be an empty string (`""`). The following example declares a **ComputerName**
 parameter that can have an empty string value.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [AllowEmptyString()]
     [String]
     $ComputerName
 )
 ```
 
-### AllowEmptyCollection Validation Attribute
+### AllowEmptyCollection validation attribute
 
-The `AllowEmptyCollection` attribute allows the value of a mandatory parameter
-to be an empty collection `@()`. The following example declares a `ComputerName`
-parameter that can have a empty collection value.
+The **AllowEmptyCollection** attribute allows the value of a mandatory
+parameter to be an empty collection `@()`. The following example declares a
+**ComputerName** parameter that can have an empty collection value.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [AllowEmptyCollection()]
     [String[]]
     $ComputerName
 )
 ```
 
-### ValidateCount Validation Attribute
+### ValidateCount validation attribute
 
-The `ValidateCount` attribute specifies the minimum and maximum number of
-parameter values that a parameter accepts. PowerShell generates an error if
-the number of parameter values in the command that calls the function is
-outside that range.
+The **ValidateCount** attribute specifies the minimum and maximum number of
+parameter values that a parameter accepts. PowerShell generates an error if the
+number of parameter values in the command that calls the function is outside
+that range.
 
-The following parameter declaration creates a ComputerName parameter that
+The following parameter declaration creates a **ComputerName** parameter that
 takes one to five parameter values.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidateCount(1,5)]
     [String[]]
     $ComputerName
 )
 ```
 
-### ValidateLength Validation Attribute
+### ValidateLength validation attribute
 
-The `ValidateLength` attribute specifies the minimum and maximum number of
+The **ValidateLength** attribute specifies the minimum and maximum number of
 characters in a parameter or variable value. PowerShell generates an error if
-the length of a value specified for a parameter or a variable is outside of
-the range.
+the length of a value specified for a parameter or a variable is outside of the
+range.
 
 In the following example, each computer name must have one to ten characters.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidateLength(1,10)]
     [String[]]
     $ComputerName
@@ -459,94 +463,94 @@ of one character in length, and a maximum of ten characters.
 [Int32][ValidateLength(1,10)]$number = 01
 ```
 
-### ValidatePattern Validation Attribute
+### ValidatePattern validation attribute
 
-The `ValidatePattern` attribute specifies a regular expression that is compared
-to the parameter or variable value. PowerShell generates an error if the value
-does not match the regular expression pattern.
+The **ValidatePattern** attribute specifies a regular expression that's
+compared to the parameter or variable value. PowerShell generates an error if
+the value doesn't match the regular expression pattern.
 
-In the following example, the parameter value must contain a four-digit number, and
-each digit must be a number zero to nine.
+In the following example, the parameter value must contain a four-digit number,
+and each digit must be a number zero to nine.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidatePattern("[0-9][0-9][0-9][0-9]")]
     [String[]]
     $ComputerName
 )
 ```
 
-In the following example, the value of the variable $number must be exactly a
+In the following example, the value of the variable `$number` must be exactly a
 four-digit number, and each digit must be a number zero to nine.
 
 ```powershell
 [Int32][ValidatePattern("^[0-9][0-9][0-9][0-9]$")]$number = 1111
 ```
 
-### ValidateRange Validation Attribute
+### ValidateRange validation attribute
 
-The `ValidateRange` attribute specifies a numeric range for each parameter or
+The **ValidateRange** attribute specifies a numeric range for each parameter or
 variable value. PowerShell generates an error if any value is outside that
-range. In the following example, the value of the `Attempts` parameter must be
-between zero and ten.
+range. In the following example, the value of the **Attempts** parameter must
+be between zero and ten.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidateRange(0,10)]
     [Int]
     $Attempts
 )
 ```
 
-In the following example, the value of the variable $number must be between
+In the following example, the value of the variable `$number` must be between
 zero and ten.
 
 ```powershell
 [Int32][ValidateRange(0,10)]$number = 5
 ```
 
-### ValidateScript Validation Attribute
+### ValidateScript validation attribute
 
-The `ValidateScript` attribute specifies a script that is used to validate a
+The **ValidateScript** attribute specifies a script that is used to validate a
 parameter or variable value. PowerShell pipes the value to the script, and
 generates an error if the script returns `$false` or if the script throws an
 exception.
 
-When you use the `ValidateScript` attribute, the value that is being
-validated is mapped to the `$_` variable. You can use the `$_` variable to refer
-to the value in the script.
+When you use the **ValidateScript** attribute, the value that's being validated
+is mapped to the `$_` variable. You can use the `$_` variable to refer to the
+value in the script.
 
-In the following example, the value of the `EventDate` parameter must be
+In the following example, the value of the **EventDate** parameter must be
 greater than or equal to the current date.
 
 ```powershell
 Param(
-    [parameter()]
+    [Parameter()]
     [ValidateScript({$_ -ge (Get-Date)})]
     [DateTime]
     $EventDate
 )
 ```
 
-In the following example, the value of the variable `$date` must be greater than
-or equal to the current date and time.
+In the following example, the value of the variable `$date` must be greater
+than or equal to the current date and time.
 
 ```powershell
 [DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
 ```
 
-### ValidateSet Attribute
+### ValidateSet attribute
 
-The `ValidateSet` attribute specifies a set of valid values for a parameter or
-variable. PowerShell generates an error if a parameter or variable value does
-not match a value in the set. In the following example, the value of the
-`Detail` parameter can only be "Low," "Average," or "High."
+The **ValidateSet** attribute specifies a set of valid values for a parameter
+or variable. PowerShell generates an error if a parameter or variable value
+doesn't match a value in the set. In the following example, the value of the
+**Detail** parameter can only be Low, Average, or High.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidateSet("Low", "Average", "High")]
     [String[]]
     $Detail
@@ -554,80 +558,80 @@ Param(
 ```
 
 In the following example, the value of the variable `$flavor` must be either
-"Chocolate", "Strawberry", or "Vanilla".
+Chocolate, Strawberry, or Vanilla.
 
 ```powershell
 [ValidateSet("Chocolate", "Strawberry", "Vanilla")]
-[String]$flavor = Strawberry
+[String]$flavor = "Strawberry"
 ```
 
-Note that the validation occurs whenever that variable is assigned even within
-the script. For example, the following results in an error at runtime:
+The validation occurs whenever that variable is assigned even within the
+script. For example, the following results in an error at runtime:
 
 ```powershell
 Param(
-    [ValidateSet("hello","world")]
+    [ValidateSet("hello", "world")]
     [String]$Message
 )
 
 $Message = "bye"
 ```
 
-### ValidateNotNull Validation Attribute
+### ValidateNotNull validation attribute
 
-The `ValidateNotNull` attribute specifies that the parameter value cannot be
+The **ValidateNotNull** attribute specifies that the parameter value can't be
 `$null`. PowerShell generates an error if the parameter value is `$null`.
 
-The `ValidateNotNull` attribute is designed to be used when the type of the
-parameter value is not specified or when the specified type will accept a
-value of `$null`. (If you specify a type that will not accept a `$null` value,
-such as a string, the `$null` value will be rejected without the
-`ValidateNotNull` attribute, because it does not match the specified type.)
+The **ValidateNotNull** attribute is designed to be used when the type of the
+parameter value isn't specified or when the specified type accepts a value of
+`$null`. If you specify a type that doesn't accept a `$null` value, such as a
+string, the `$null` value is rejected without the **ValidateNotNull**
+attribute, because it doesn't match the specified type.
 
-In the following example, the value of the `ID` parameter cannot be `$null`.
+In the following example, the value of the **ID** parameter can't be `$null`.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidateNotNull()]
-    # $ID
+    $ID
 )
 ```
 
-### ValidateNotNullOrEmpty Validation Attribute
+### ValidateNotNullOrEmpty validation attribute
 
-The `ValidateNotNullOrEmpty` attribute specifies that the parameter value cannot
-be `$null` and cannot be an empty string `""`. PowerShell generates an
-error if the parameter is used in a function call, but its value is `$null`,
-an empty string `""`, or an empty array `@()`.
+The **ValidateNotNullOrEmpty** attribute specifies that the parameter value
+can't be `$null` and can't be an empty string (`""`). PowerShell generates an
+error if the parameter is used in a function call, but its value is `$null`, an
+empty string (`""`), or an empty array `@()`.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidateNotNullOrEmpty()]
     [String[]]
     $UserName
 )
 ```
 
-## Dynamic Parameters
+## Dynamic parameters
 
 Dynamic parameters are parameters of a cmdlet, function, or script that are
 available only under certain conditions.
 
 For example, several provider cmdlets have parameters that are available only
 when the cmdlet is used in the provider drive, or in a particular path of the
-provider drive. For example, the `Encoding` parameter is available on the
-`Add-Content`, `Get-Content`, and `Set-Content` cmdlets only when it is used
-in a file system drive.
+provider drive. For example, the **Encoding** parameter is available on the
+`Add-Content`, `Get-Content`, and `Set-Content` cmdlets only when it's used in
+a file system drive.
 
 You can also create a parameter that appears only when another parameter is
 used in the function command or when another parameter has a certain value.
 
-Dynamic parameters can be very useful, but use them only when necessary,
-because they can be difficult for users to discover. To find a dynamic
-parameter, the user must be in the provider path, use the `ArgumentList`
-parameter of the `Get-Command` cmdlet, or use the Path parameter of `Get-Help`.
+Dynamic parameters can be useful, but use them only when necessary, because
+they can be difficult for users to discover. To find a dynamic parameter, the
+user must be in the provider path, use the **ArgumentList** parameter of the
+`Get-Command` cmdlet, or use the **Path** parameter of `Get-Help`.
 
 To create a dynamic parameter for a function or script, use the `DynamicParam`
 keyword.
@@ -636,24 +640,24 @@ The syntax is as follows:
 
 `DynamicParam {<statement-list>}`
 
-In the statement list, use an If statement to specify the conditions under
+In the statement list, use an `If` statement to specify the conditions under
 which the parameter is available in the function.
 
 Use the `New-Object` cmdlet to create a
-`System.Management.Automation.RuntimeDefinedParameter` object to represent the
-parameter and specify its name.
+**System.Management.Automation.RuntimeDefinedParameter** object to represent
+the parameter and specify its name.
 
-You can also use a `New-Object` command to create a
-`System.Management.Automation.ParameterAttribute` object to represent attributes
-of the parameter, such as `Mandatory`, `Position`, or `ValueFromPipeline` or its
-parameter set.
+You can use a `New-Object` command to create a
+**System.Management.Automation.ParameterAttribute** object to represent
+attributes of the parameter, such as **Mandatory**, **Position**, or
+**ValueFromPipeline** or its parameter set.
 
 The following example shows a sample function with standard parameters named
-**Name** and **Path**, and an optional dynamic parameter named **DP1**.
-The **DP1** parameter is in the PSet1 parameter set and has a type of `Int32`.
-The **DP1** parameter is available in the `Get-Sample` function
-only when the value of the **Path** parameter starts with "HKLM:",
-indicating that it is being used in the HKEY_LOCAL_MACHINE registry drive.
+**Name** and **Path**, and an optional dynamic parameter named **DP1**. The
+**DP1** parameter is in the `PSet1` parameter set and has a type of `Int32`.
+The **DP1** parameter is available in the `Get-Sample` function only when the
+value of the **Path** parameter starts with `HKLM:`, indicating that it's being
+used in the `HKEY_LOCAL_MACHINE` registry drive.
 
 ```powershell
 function Get-Sample {
@@ -685,19 +689,18 @@ function Get-Sample {
 }
 ```
 
-For more information, see "RuntimeDefinedParameter Class" in the MSDN
-(Microsoft Developer Network) library at
-[RuntimeDefinedParameter](/dotnet/api/system.management.automation.runtimedefinedparameter)
+For more information, see
+[RuntimeDefinedParameter](/dotnet/api/system.management.automation.runtimedefinedparameter).
 
-## Switch Parameters
+## Switch parameters
 
-Switch parameters are parameters with no parameter value. They are effective
-only when they are used and have only one effect.
+Switch parameters are parameters with no parameter value. They're effective
+only when they're used and have only one effect.
 
-For example, the `-NoProfile` parameter of PowerShell.exe is a switch
+For example, the **NoProfile** parameter of **powershell.exe** is a switch
 parameter.
 
-To create a switch parameter in a function, specify the Switch type in the
+To create a switch parameter in a function, specify the `Switch` type in the
 parameter definition.
 
 For example:
@@ -706,11 +709,11 @@ For example:
 Param([Switch]<ParameterName>)
 ```
 
--or-
+Or, you can use an another method:
 
 ```powershell
 Param(
-    [parameter(Mandatory=$false)]
+    [Parameter(Mandatory=$false)]
     [Switch]
     $<ParameterName>
 )
@@ -729,11 +732,13 @@ To use a Boolean parameter, the user types the parameter and a Boolean value.
 `-IncludeAll:$true`
 
 When creating switch parameters, choose the parameter name carefully. Be sure
-that the parameter name communicates the effect of the parameter to the user,
-and avoid ambiguous terms, such as Filter or Maximum, that might imply that a
+that the parameter name communicates the effect of the parameter to the user.
+Avoid ambiguous terms, such as **Filter** or **Maximum** that might imply a
 value is required.
 
 ## See also
+
+[about_Automatic_Variables](about_Automatic_Variables.md)
 
 [about_Functions](about_Functions.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,10 +1,11 @@
 ---
-ms.date:  11/28/2017
+ms.date: 05/20/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Functions_Advanced_Parameters
 ---
+
 # About Functions Advanced Parameters
 
 ## Short description
@@ -17,256 +18,258 @@ You can add parameters to the advanced functions that you write, and use
 parameter attributes and arguments to limit the parameter values that function
 users submit with the parameter.
 
-The parameters that you add to your function are available to users in
-addition to the common parameters that PowerShell adds automatically to all
-cmdlets and advanced functions. For more information about the Windows
-PowerShell common parameters, see
-[about_CommonParameters](about_CommonParameters.md).
+The parameters that you add to your function are available to users in addition
+to the common parameters that PowerShell adds automatically to all cmdlets and
+advanced functions. For more information about the PowerShell common
+parameters, see [about_CommonParameters](about_CommonParameters.md).
 
-Beginning in PowerShell 3.0, you can use splatting with @Args to represent the
-parameters in a command. This technique is valid on simple and advanced
-functions. For more information, see [about_Functions](about_Functions.md) and
-[about_Splatting](about_Splatting.md).
+Beginning in PowerShell 3.0, you can use splatting with `@Args` to represent
+the parameters in a command. Splatting is valid on simple and advanced
+functions. For more information, see [about_Functions](about_Functions.md) and [about_Splatting](about_Splatting.md).
 
-## Static Parameters
+## Static parameters
 
 Static parameters are parameters that are always available in the function.
 Most parameters in PowerShell cmdlets and scripts are static parameters.
 
-The following example shows the declaration of a ComputerName parameter that
-has the following characteristics:
+The following example shows the declaration of a **ComputerName** parameter
+that has the following characteristics:
 
-- It is mandatory (required).
+- It's mandatory (required).
 - It takes input from the pipeline.
 - It takes an array of strings as input.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ValueFromPipeline=$true)]
     [String[]]
     $ComputerName
 )
 ```
 
-## Attributes of Parameters
+## Attributes of parameters
 
 This section describes the attributes that you can add to function parameters.
 
-All attributes are optional. However, if you omit the `CmdletBinding` attribute,
-then to be recognized as an advanced function, the function must include the
-Parameter attribute.
+All attributes are optional. However, if you omit the **CmdletBinding**
+attribute, then to be recognized as an advanced function, the function must
+include the **Parameter** attribute.
 
-You can add one or multiple attributes in each parameter declaration. There is
+You can add one or multiple attributes in each parameter declaration. There's
 no limit to the number of attributes that you can add to a parameter
 declaration.
 
-### The Parameter Attribute
+### Parameter attribute
 
-The `Parameter` attribute is used to declare the attributes of function
+The **Parameter** attribute is used to declare the attributes of function
 parameters.
 
-The `Parameter` attribute is optional, and you can omit it if none of the
-parameters of your functions need attributes, but to be recognized as an
-advanced function (rather than a simple function), a function must have either
-the `CmdletBinding` attribute or the `Parameter` attribute, or both.
+The **Parameter** attribute is optional, and you can omit it if none of the
+parameters of your functions need attributes. But, to be recognized as an
+advanced function, rather than a simple function, a function must have either
+the **CmdletBinding** attribute or the **Parameter** attribute, or both.
 
-The `Parameter` attribute has arguments that define the characteristics of the
-parameter, such as whether the parameter is mandatory or optional.
+The **Parameter** attribute has arguments that define the characteristics of
+the parameter, such as whether the parameter is mandatory or optional.
 
-Use the following syntax to declare the Parameter attribute, an argument, and
-an argument value. The parentheses that enclose the argument and its value
-must follow "`Parameter`" with no intervening space.
+Use the following syntax to declare the **Parameter** attribute, an argument,
+and an argument value. The parentheses that enclose the argument and its value
+must follow **Parameter** with no intervening space.
 
 ```powershell
 Param(
-    [parameter(Argument=value)]
+    [Parameter(Argument=value)]
     $ParameterName
 )
 ```
 
 Use commas to separate arguments within the parentheses. Use the following
-syntax to declare two arguments of the `Parameter` attribute.
+syntax to declare two arguments of the **Parameter** attribute.
 
 ```powershell
 Param(
-    [parameter(Argument1=value1,
+    [Parameter(Argument1=value1,
     Argument2=value2)]
 )
 ```
 
-If you use the `Parameter` attribute without arguments (as an alternative to
-using the `CmdletBinding` attribute), the parentheses that follow the attribute
-name are still required.
+If you use the **Parameter** attribute without arguments, as an alternative to
+using the **CmdletBinding** attribute, the parentheses that follow the
+attribute name are still required.
 
 ```powershell
 Param(
-    [parameter()]
+    [Parameter()]
     $ParameterName
 )
 ```
 
-### Mandatory Argument
+### Mandatory argument
 
 The `Mandatory` argument indicates that the parameter is required. If this
-argument is not specified, the parameter is an optional parameter.
+argument isn't specified, the parameter is optional.
 
-The following example declares the `ComputerName` parameter. It uses the
+The following example declares the **ComputerName** parameter. It uses the
 `Mandatory` argument to make the parameter mandatory.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [String[]]
     $ComputerName
 )
 ```
 
-### Position Argument
+### Position argument
 
 The `Position` argument determines whether the parameter name is required when
 the parameter is used in a command. When a parameter declaration includes the
-`Position` argument, the parameter name can be omitted and PowerShell identifies
-the unnamed parameter value by its position (or order) in the list of unnamed
-parameter values in the command.
+`Position` argument, the parameter name can be omitted and PowerShell
+identifies the unnamed parameter value by its position, or order, in the list
+of unnamed parameter values in the command.
 
-If the `Position` argument is not specified, the parameter name (or a parameter
-name alias or abbreviation) must precede the parameter value whenever the
+If the `Position` argument isn't specified, the parameter name, or a parameter
+name alias or abbreviation, must precede the parameter value whenever the
 parameter is used in a command.
 
 By default, all function parameters are positional. PowerShell assigns position
 numbers to parameters in the order in which the parameters are declared in the
 function. To disable this feature, set the value of the `PositionalBinding`
-argument of the `CmdletBinding` attribute to `$False`.The `Position` argument
-takes precedence over the value of the `PositionalBinding` argument for the
-parameters on which it is declared. For more information, see
-`PositionalBinding` in [about_Functions_CmdletBindingAttribute](about_Functions_CmdletBindingAttribute.md).
+argument of the **CmdletBinding** attribute to `$False`. The `Position`
+argument takes precedence over the value of the `PositionalBinding` argument
+for the parameters on which it's declared. For more information, see
+`PositionalBinding` in
+[about_Functions_CmdletBindingAttribute](about_Functions_CmdletBindingAttribute.md).
 
-The value of the Position argument is specified as an integer. A position
-value of **"0"** represents the first position in the command, a position value
-of **"1"** represents the second position in the command, and so on.
+The value of the `Position` argument is specified as an integer. A position
+value of **0** represents the first position in the command, a position value
+of **1** represents the second position in the command, and so on.
 
 If a function has no positional parameters, PowerShell assigns positions to
 each parameter based on the order in which the parameters are declared.
-However, as a best practice, do not rely on this assignment. When you want
-parameters to be positional, use the Position argument.
+However, as a best practice, don't rely on this assignment. When you want
+parameters to be positional, use the `Position` argument.
 
 The following example declares the **ComputerName** parameter. It uses the
-Position argument with a value of **"0"**. As a result, when `-ComputerName` is
+`Position` argument with a value of **0**. As a result, when `-ComputerName` is
 omitted from command, its value must be the first or only unnamed parameter
 value in the command.
 
 ```powershell
 Param(
-    [parameter(Position=0)]
+    [Parameter(Position=0)]
     [String[]]
     $ComputerName
 )
 ```
 
 > [!NOTE]
-> When the Get-Help cmdlet displays the corresponding `Position`
-> parameter attribute, the position value is incremented by one.
+> When the `Get-Help` cmdlet displays the corresponding **Position** parameter
+> attribute, the position value is incremented by one.
 >
-> For example, a parameter with a Position argument value of **"0"**
-> has a parameter attribute of "`Position=1`"
+> For example, a parameter with a `Position` argument value of **0** has a
+> parameter attribute of **Position=1**.
 
-### ParameterSetName Argument
+### ParameterSetName argument
 
-The ParameterSetName argument specifies the parameter set to which a parameter
-belongs. If no parameter set is specified, the parameter belongs to all the
-parameter sets defined by the function. Therefore, to be unique, each
-parameter set must have at least one parameter that is not a member of any
-other parameter set.
+The `ParameterSetName` argument specifies the parameter set to which a
+parameter belongs. If no parameter set is specified, the parameter belongs to
+all the parameter sets defined by the function. Therefore, to be unique, each
+parameter set must have at least one parameter that isn't a member of any other
+parameter set.
 
-The following example declares a `ComputerName` parameter in the "Computer"
-parameter set, a `UserName` parameter in the "User" parameter set, and a
-`Summary` parameter in both parameter sets.
+> [!NOTE]
+> The parameters for a cmdlet or function can be included in a maximum of 32
+> parameter sets.
+
+The following example declares a **ComputerName** parameter in the `Computer`
+parameter set, a **UserName** parameter in the `User` parameter set, and a
+**Summary** parameter in both parameter sets.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ParameterSetName="Computer")]
     [String[]]
     $ComputerName,
 
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ParameterSetName="User")]
     [String[]]
     $UserName,
 
-    [parameter(Mandatory=$false)]
+    [Parameter(Mandatory=$false)]
     [Switch]
     $Summary
 )
 ```
 
-You can specify only one `ParameterSetName` value in each argument and only
-one `ParameterSetName` argument in each `Parameter` attribute. To indicate
-that a parameter appears in more than one parameter set, add additional
-`Parameter` attributes.
+You can specify only one `ParameterSetName` value in each argument and only one
+`ParameterSetName` argument in each **Parameter** attribute. To indicate that a
+parameter appears in more than one parameter set, add additional **Parameter**
+attributes.
 
-The following example explicitly adds the `Summary` parameter to the Computer
-and User parameter sets. The `Summary` parameter is **Mandatory** in one
-parameter set and **Optional** in the other.
+The following example explicitly adds the **Summary** parameter to the
+`Computer` and `User` parameter sets. The **Summary** parameter is optional in
+the `Computer` parameter set and mandatory in the `User` parameter set.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ParameterSetName="Computer")]
     [String[]]
     $ComputerName,
 
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ParameterSetName="User")]
     [String[]]
     $UserName,
 
-    [parameter(Mandatory=$false, ParameterSetName="Computer")]
-    [parameter(Mandatory=$true, ParameterSetName="User")]
+    [Parameter(Mandatory=$false, ParameterSetName="Computer")]
+    [Parameter(Mandatory=$true, ParameterSetName="User")]
     [Switch]
     $Summary
 )
 ```
 
-For more information about parameter sets, see "Cmdlet Parameter Sets" in the
-MSDN library at [Cmdlet Parameter Sets](/powershell/developer/cmdlet/cmdlet-parameter-sets)
+For more information about parameter sets, see [Cmdlet Parameter Sets](/powershell/developer/cmdlet/cmdlet-parameter-sets).
 
-### ValueFromPipeline Argument
+### ValueFromPipeline argument
 
-The `ValueFromPipeline` argument indicates that the parameter accepts input from
-a pipeline object. Specify this argument if the function accepts the entire
-object, not just a property of the object.
+The `ValueFromPipeline` argument indicates that the parameter accepts input
+from a pipeline object. Specify this argument if the function accepts the
+entire object, not just a property of the object.
 
-The following example declares a `ComputerName` parameter that is mandatory
-and accepts an object that is passed to the function from the pipeline.
+The following example declares a **ComputerName** parameter that's mandatory
+and accepts an object that's passed to the function from the pipeline.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ValueFromPipeline=$true)]
     [String[]]
     $ComputerName
 )
 ```
 
-### ValueFromPipelineByPropertyName Argument
+### ValueFromPipelineByPropertyName argument
 
 The `ValueFromPipelineByPropertyName` argument indicates that the parameter
 accepts input from a property of a pipeline object. The object property must
 have the same name or alias as the parameter.
 
-For example, if the function has a `ComputerName` parameter, and the piped
-object has a `ComputerName` property, the value of the `ComputerName`
-property is assigned to the `ComputerName` parameter of the function.
+For example, if the function has a **ComputerName** parameter, and the piped
+object has a **ComputerName** property, the value of the **ComputerName**
+property is assigned to the function's **ComputerName** parameter.
 
-The following example declares a `ComputerName` parameter that is mandatory
-and accepts input from the `ComputerName` property of the object that is
-passed to the function through the pipeline.
+The following example declares a **ComputerName** parameter that's mandatory
+and accepts input from the object's **ComputerName** property that's passed to
+the function through the pipeline.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true,
+    [Parameter(Mandatory=$true,
     ValueFromPipelineByPropertyName=$true)]
     [String[]]
     $ComputerName
@@ -275,29 +278,30 @@ Param(
 
 > [!NOTE]
 > A typed parameter that accepts pipeline input (`by Value`) or
-> (`by PropertyName`) enables use of **delay-bind** script blocks on the parameter.
+> (`by PropertyName`) enables use of **delay-bind** script blocks on the
+> parameter.
 >
 > The **delay-bind** script block is run automatically during
 > **ParameterBinding**. The result is bound to the parameter. Delay binding
-> does **not** work for parameters defined as type `ScriptBlock` or
-> `System.Object`, the script block is passed through
-> **without** being invoked.
+> **does not** work for parameters defined as type `ScriptBlock` or
+> `System.Object`, the script block is passed through **without** being
+> invoked.
 >
-> You can read about **delay-bind** script blocks here [about_Script_Blocks.md](about_Script_Blocks.md)
+> You can read about **delay-bind** script blocks here [about_Script_Blocks.md](about_Script_Blocks.md).
 
-### ValueFromRemainingArguments Argument
+### ValueFromRemainingArguments argument
 
-The `ValueFromRemainingArguments` argument indicates that the parameter
-accepts all of the parameters values in the command that are not assigned to
-other parameters of the function.
+The `ValueFromRemainingArguments` argument indicates that the parameter accepts
+all the parameter's values in the command that aren't assigned to other
+parameters of the function.
 
-There is a known issue for using collections with
-**ValueFromRemainingArguments** where the passed in collection is treated
-as a single element.
+There's a known issue for using collections with
+**ValueFromRemainingArguments** where the passed-in collection is treated as a
+single element.
 
-The following example demonstrates this issue. The `$Remaining` parameter
-should contain "one" at index 0 and "two" at index 1. Instead, both elements
-are combined into a single entity.
+The following example demonstrates this known issue. The **Remaining**
+parameter should contain **one** at **index 0** and **two** at **index 1**.
+Instead, both elements are combined into a single entity.
 
 ```powershell
 function Test-Remainder
@@ -326,126 +330,126 @@ Found 1 elements
 > [!NOTE]
 > This issue is resolved in PowerShell 6.2.
 
-### HelpMessage Argument
+### HelpMessage argument
 
-The `HelpMessage` argument specifies a string that contains a brief
-description of the parameter or its value. PowerShell displays this message in
-the prompt that appears when a mandatory parameter value is missing from a
-command. This argument has no effect on optional parameters.
+The `HelpMessage` argument specifies a string that contains a brief description
+of the parameter or its value. PowerShell displays this message in the prompt
+that appears when a mandatory parameter value is missing from a command. This
+argument has no effect on optional parameters.
 
-The following example declares a mandatory `ComputerName` parameter and a
+The following example declares a mandatory **ComputerName** parameter and a
 help message that explains the expected parameter value.
 
 ```powershell
 Param(
-    [parameter(mandatory=$true,
+    [Parameter(Mandatory=$true,
     HelpMessage="Enter one or more computer names separated by commas.")]
     [String[]]
     $ComputerName
 )
 ```
 
-### Alias Attribute
+### Alias attribute
 
-The `Alias` attribute establishes an alternate name for the parameter. There is
-no limit to the number of aliases that you can assign to a parameter.
+The **Alias** attribute establishes an alternate name for the parameter.
+There's no limit to the number of aliases that you can assign to a parameter.
 
-The following example shows a parameter declaration that adds the "CN" and
-"MachineName" aliases to the mandatory `ComputerName` parameter.
+The following example shows a parameter declaration that adds the **CN** and
+**MachineName** aliases to the mandatory **ComputerName** parameter.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
-    [alias("CN","MachineName")]
+    [Parameter(Mandatory=$true)]
+    [Alias("CN","MachineName")]
     [String[]]
     $ComputerName
 )
 ```
 
-### Parameter and Variable Validation Attributes
+### Parameter and variable validation attributes
 
-Validation attributes direct PowerShell to test the parameter values that
-users submit when they call the advanced function. If the parameter values
-fail the test, an error is generated and the function is not called. You can
-also use some of the validation attributes to restrict the values that users
-can specify for variables.
+Validation attributes direct PowerShell to test the parameter values that users
+submit when they call the advanced function. If the parameter values fail the
+test, an error is generated and the function isn't called. You can also use
+some of the validation attributes to restrict the values that users can specify
+for variables.
 
-### AllowNull Validation Attribute
+### AllowNull validation attribute
 
-The `AllowNull` attribute allows the value of a **Mandatory** parameter to be
-`$null`. The following example declares a `ComputerName` parameter that can have
-a Null value.
+The **AllowNull** attribute allows the value of a mandatory parameter to be
+`$null`. The following example declares a **ComputerName** parameter that can
+have a **null** value.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [AllowNull()]
     [String]
     $ComputerName
 )
 ```
 
-### AllowEmptyString Validation Attribute
+### AllowEmptyString validation attribute
 
-The `AllowEmptyString` attribute allows the value of a **Mandatory** parameter
-to be an empty string (""). The following example declares a `ComputerName`
+The **AllowEmptyString** attribute allows the value of a mandatory parameter to
+be an empty string (`""`). The following example declares a **ComputerName**
 parameter that can have an empty string value.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [AllowEmptyString()]
     [String]
     $ComputerName
 )
 ```
 
-### AllowEmptyCollection Validation Attribute
+### AllowEmptyCollection validation attribute
 
-The `AllowEmptyCollection` attribute allows the value of a mandatory parameter
-to be an empty collection `@()`. The following example declares a `ComputerName`
-parameter that can have a empty collection value.
+The **AllowEmptyCollection** attribute allows the value of a mandatory
+parameter to be an empty collection `@()`. The following example declares a
+**ComputerName** parameter that can have an empty collection value.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [AllowEmptyCollection()]
     [String[]]
     $ComputerName
 )
 ```
 
-### ValidateCount Validation Attribute
+### ValidateCount validation attribute
 
-The `ValidateCount` attribute specifies the minimum and maximum number of
-parameter values that a parameter accepts. PowerShell generates an error if
-the number of parameter values in the command that calls the function is
-outside that range.
+The **ValidateCount** attribute specifies the minimum and maximum number of
+parameter values that a parameter accepts. PowerShell generates an error if the
+number of parameter values in the command that calls the function is outside
+that range.
 
-The following parameter declaration creates a ComputerName parameter that
+The following parameter declaration creates a **ComputerName** parameter that
 takes one to five parameter values.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidateCount(1,5)]
     [String[]]
     $ComputerName
 )
 ```
 
-### ValidateLength Validation Attribute
+### ValidateLength validation attribute
 
-The `ValidateLength` attribute specifies the minimum and maximum number of
+The **ValidateLength** attribute specifies the minimum and maximum number of
 characters in a parameter or variable value. PowerShell generates an error if
-the length of a value specified for a parameter or a variable is outside of
-the range.
+the length of a value specified for a parameter or a variable is outside of the
+range.
 
 In the following example, each computer name must have one to ten characters.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidateLength(1,10)]
     [String[]]
     $ComputerName
@@ -459,94 +463,94 @@ of one character in length, and a maximum of ten characters.
 [Int32][ValidateLength(1,10)]$number = 01
 ```
 
-### ValidatePattern Validation Attribute
+### ValidatePattern validation attribute
 
-The `ValidatePattern` attribute specifies a regular expression that is compared
-to the parameter or variable value. PowerShell generates an error if the value
-does not match the regular expression pattern.
+The **ValidatePattern** attribute specifies a regular expression that's
+compared to the parameter or variable value. PowerShell generates an error if
+the value doesn't match the regular expression pattern.
 
-In the following example, the parameter value must contain a four-digit number, and
-each digit must be a number zero to nine.
+In the following example, the parameter value must contain a four-digit number,
+and each digit must be a number zero to nine.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidatePattern("[0-9][0-9][0-9][0-9]")]
     [String[]]
     $ComputerName
 )
 ```
 
-In the following example, the value of the variable $number must be exactly a
+In the following example, the value of the variable `$number` must be exactly a
 four-digit number, and each digit must be a number zero to nine.
 
 ```powershell
 [Int32][ValidatePattern("^[0-9][0-9][0-9][0-9]$")]$number = 1111
 ```
 
-### ValidateRange Validation Attribute
+### ValidateRange validation attribute
 
-The `ValidateRange` attribute specifies a numeric range for each parameter or
+The **ValidateRange** attribute specifies a numeric range for each parameter or
 variable value. PowerShell generates an error if any value is outside that
-range. In the following example, the value of the `Attempts` parameter must be
-between zero and ten.
+range. In the following example, the value of the **Attempts** parameter must
+be between zero and ten.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidateRange(0,10)]
     [Int]
     $Attempts
 )
 ```
 
-In the following example, the value of the variable $number must be between
+In the following example, the value of the variable `$number` must be between
 zero and ten.
 
 ```powershell
 [Int32][ValidateRange(0,10)]$number = 5
 ```
 
-### ValidateScript Validation Attribute
+### ValidateScript validation attribute
 
-The `ValidateScript` attribute specifies a script that is used to validate a
+The **ValidateScript** attribute specifies a script that is used to validate a
 parameter or variable value. PowerShell pipes the value to the script, and
 generates an error if the script returns `$false` or if the script throws an
 exception.
 
-When you use the `ValidateScript` attribute, the value that is being
-validated is mapped to the `$_` variable. You can use the `$_` variable to refer
-to the value in the script.
+When you use the **ValidateScript** attribute, the value that's being validated
+is mapped to the `$_` variable. You can use the `$_` variable to refer to the
+value in the script.
 
-In the following example, the value of the `EventDate` parameter must be
+In the following example, the value of the **EventDate** parameter must be
 greater than or equal to the current date.
 
 ```powershell
 Param(
-    [parameter()]
+    [Parameter()]
     [ValidateScript({$_ -ge (Get-Date)})]
     [DateTime]
     $EventDate
 )
 ```
 
-In the following example, the value of the variable `$date` must be greater than
-or equal to the current date and time.
+In the following example, the value of the variable `$date` must be greater
+than or equal to the current date and time.
 
 ```powershell
 [DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
 ```
 
-### ValidateSet Attribute
+### ValidateSet attribute
 
-The `ValidateSet` attribute specifies a set of valid values for a parameter or
-variable. PowerShell generates an error if a parameter or variable value does
-not match a value in the set. In the following example, the value of the
-`Detail` parameter can only be "Low," "Average," or "High."
+The **ValidateSet** attribute specifies a set of valid values for a parameter
+or variable. PowerShell generates an error if a parameter or variable value
+doesn't match a value in the set. In the following example, the value of the
+**Detail** parameter can only be Low, Average, or High.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidateSet("Low", "Average", "High")]
     [String[]]
     $Detail
@@ -554,80 +558,80 @@ Param(
 ```
 
 In the following example, the value of the variable `$flavor` must be either
-"Chocolate", "Strawberry", or "Vanilla".
+Chocolate, Strawberry, or Vanilla.
 
 ```powershell
 [ValidateSet("Chocolate", "Strawberry", "Vanilla")]
-[String]$flavor = Strawberry
+[String]$flavor = "Strawberry"
 ```
 
-Note that the validation occurs whenever that variable is assigned even within
-the script. For example, the following results in an error at runtime:
+The validation occurs whenever that variable is assigned even within the
+script. For example, the following results in an error at runtime:
 
 ```powershell
 Param(
-    [ValidateSet("hello","world")]
+    [ValidateSet("hello", "world")]
     [String]$Message
 )
 
 $Message = "bye"
 ```
 
-### ValidateNotNull Validation Attribute
+### ValidateNotNull validation attribute
 
-The `ValidateNotNull` attribute specifies that the parameter value cannot be
+The **ValidateNotNull** attribute specifies that the parameter value can't be
 `$null`. PowerShell generates an error if the parameter value is `$null`.
 
-The `ValidateNotNull` attribute is designed to be used when the type of the
-parameter value is not specified or when the specified type will accept a
-value of `$null`. (If you specify a type that will not accept a `$null` value,
-such as a string, the `$null` value will be rejected without the
-`ValidateNotNull` attribute, because it does not match the specified type.)
+The **ValidateNotNull** attribute is designed to be used when the type of the
+parameter value isn't specified or when the specified type accepts a value of
+`$null`. If you specify a type that doesn't accept a `$null` value, such as a
+string, the `$null` value is rejected without the **ValidateNotNull**
+attribute, because it doesn't match the specified type.
 
-In the following example, the value of the `ID` parameter cannot be `$null`.
+In the following example, the value of the **ID** parameter can't be `$null`.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidateNotNull()]
-    # $ID
+    $ID
 )
 ```
 
-### ValidateNotNullOrEmpty Validation Attribute
+### ValidateNotNullOrEmpty validation attribute
 
-The `ValidateNotNullOrEmpty` attribute specifies that the parameter value cannot
-be `$null` and cannot be an empty string `""`. PowerShell generates an
-error if the parameter is used in a function call, but its value is `$null`,
-an empty string `""`, or an empty array `@()`.
+The **ValidateNotNullOrEmpty** attribute specifies that the parameter value
+can't be `$null` and can't be an empty string (`""`). PowerShell generates an
+error if the parameter is used in a function call, but its value is `$null`, an
+empty string (`""`), or an empty array `@()`.
 
 ```powershell
 Param(
-    [parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$true)]
     [ValidateNotNullOrEmpty()]
     [String[]]
     $UserName
 )
 ```
 
-## Dynamic Parameters
+## Dynamic parameters
 
 Dynamic parameters are parameters of a cmdlet, function, or script that are
 available only under certain conditions.
 
 For example, several provider cmdlets have parameters that are available only
 when the cmdlet is used in the provider drive, or in a particular path of the
-provider drive. For example, the `Encoding` parameter is available on the
-`Add-Content`, `Get-Content`, and `Set-Content` cmdlets only when it is used
-in a file system drive.
+provider drive. For example, the **Encoding** parameter is available on the
+`Add-Content`, `Get-Content`, and `Set-Content` cmdlets only when it's used in
+a file system drive.
 
 You can also create a parameter that appears only when another parameter is
 used in the function command or when another parameter has a certain value.
 
-Dynamic parameters can be very useful, but use them only when necessary,
-because they can be difficult for users to discover. To find a dynamic
-parameter, the user must be in the provider path, use the `ArgumentList`
-parameter of the `Get-Command` cmdlet, or use the Path parameter of `Get-Help`.
+Dynamic parameters can be useful, but use them only when necessary, because
+they can be difficult for users to discover. To find a dynamic parameter, the
+user must be in the provider path, use the **ArgumentList** parameter of the
+`Get-Command` cmdlet, or use the **Path** parameter of `Get-Help`.
 
 To create a dynamic parameter for a function or script, use the `DynamicParam`
 keyword.
@@ -636,24 +640,24 @@ The syntax is as follows:
 
 `DynamicParam {<statement-list>}`
 
-In the statement list, use an If statement to specify the conditions under
+In the statement list, use an `If` statement to specify the conditions under
 which the parameter is available in the function.
 
 Use the `New-Object` cmdlet to create a
-`System.Management.Automation.RuntimeDefinedParameter` object to represent the
-parameter and specify its name.
+**System.Management.Automation.RuntimeDefinedParameter** object to represent
+the parameter and specify its name.
 
-You can also use a `New-Object` command to create a
-`System.Management.Automation.ParameterAttribute` object to represent attributes
-of the parameter, such as `Mandatory`, `Position`, or `ValueFromPipeline` or its
-parameter set.
+You can use a `New-Object` command to create a
+**System.Management.Automation.ParameterAttribute** object to represent
+attributes of the parameter, such as **Mandatory**, **Position**, or
+**ValueFromPipeline** or its parameter set.
 
 The following example shows a sample function with standard parameters named
-**Name** and **Path**, and an optional dynamic parameter named **DP1**.
-The **DP1** parameter is in the PSet1 parameter set and has a type of `Int32`.
-The **DP1** parameter is available in the `Get-Sample` function
-only when the value of the **Path** parameter starts with "HKLM:",
-indicating that it is being used in the HKEY_LOCAL_MACHINE registry drive.
+**Name** and **Path**, and an optional dynamic parameter named **DP1**. The
+**DP1** parameter is in the `PSet1` parameter set and has a type of `Int32`.
+The **DP1** parameter is available in the `Get-Sample` function only when the
+value of the **Path** parameter starts with `HKLM:`, indicating that it's being
+used in the `HKEY_LOCAL_MACHINE` registry drive.
 
 ```powershell
 function Get-Sample {
@@ -685,19 +689,18 @@ function Get-Sample {
 }
 ```
 
-For more information, see "RuntimeDefinedParameter Class" in the MSDN
-(Microsoft Developer Network) library at
-[RuntimeDefinedParameter](/dotnet/api/system.management.automation.runtimedefinedparameter)
+For more information, see
+[RuntimeDefinedParameter](/dotnet/api/system.management.automation.runtimedefinedparameter).
 
-## Switch Parameters
+## Switch parameters
 
-Switch parameters are parameters with no parameter value. They are effective
-only when they are used and have only one effect.
+Switch parameters are parameters with no parameter value. They're effective
+only when they're used and have only one effect.
 
-For example, the `-NoProfile` parameter of PowerShell.exe is a switch
+For example, the **NoProfile** parameter of **powershell.exe** is a switch
 parameter.
 
-To create a switch parameter in a function, specify the Switch type in the
+To create a switch parameter in a function, specify the `Switch` type in the
 parameter definition.
 
 For example:
@@ -706,11 +709,11 @@ For example:
 Param([Switch]<ParameterName>)
 ```
 
--or-
+Or, you can use an another method:
 
 ```powershell
 Param(
-    [parameter(Mandatory=$false)]
+    [Parameter(Mandatory=$false)]
     [Switch]
     $<ParameterName>
 )
@@ -729,11 +732,13 @@ To use a Boolean parameter, the user types the parameter and a Boolean value.
 `-IncludeAll:$true`
 
 When creating switch parameters, choose the parameter name carefully. Be sure
-that the parameter name communicates the effect of the parameter to the user,
-and avoid ambiguous terms, such as Filter or Maximum, that might imply that a
+that the parameter name communicates the effect of the parameter to the user.
+Avoid ambiguous terms, such as **Filter** or **Maximum** that might imply a
 value is required.
 
 ## See also
+
+[about_Automatic_Variables](about_Automatic_Variables.md)
 
 [about_Functions](about_Functions.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,10 +1,11 @@
 ---
-ms.date: 5/20/2019
+ms.date: 05/20/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Functions_Advanced_Parameters
 ---
+
 # About Functions Advanced Parameters
 
 ## Short description
@@ -17,26 +18,24 @@ You can add parameters to the advanced functions that you write, and use
 parameter attributes and arguments to limit the parameter values that function
 users submit with the parameter.
 
-The parameters that you add to your function are available to users in
-addition to the common parameters that PowerShell adds automatically to all
-cmdlets and advanced functions. For more information about the Windows
-PowerShell common parameters, see
-[about_CommonParameters](about_CommonParameters.md).
+The parameters that you add to your function are available to users in addition
+to the common parameters that PowerShell adds automatically to all cmdlets and
+advanced functions. For more information about the PowerShell common
+parameters, see [about_CommonParameters](about_CommonParameters.md).
 
-Beginning in PowerShell 3.0, you can use splatting with @Args to represent the
-parameters in a command. This technique is valid on simple and advanced
-functions. For more information, see [about_Functions](about_Functions.md) and
-[about_Splatting](about_Splatting.md).
+Beginning in PowerShell 3.0, you can use splatting with `@Args` to represent
+the parameters in a command. Splatting is valid on simple and advanced
+functions. For more information, see [about_Functions](about_Functions.md) and [about_Splatting](about_Splatting.md).
 
-## Static Parameters
+## Static parameters
 
 Static parameters are parameters that are always available in the function.
 Most parameters in PowerShell cmdlets and scripts are static parameters.
 
-The following example shows the declaration of a ComputerName parameter that
-has the following characteristics:
+The following example shows the declaration of a **ComputerName** parameter
+that has the following characteristics:
 
-- It is mandatory (required).
+- It's mandatory (required).
 - It takes input from the pipeline.
 - It takes an array of strings as input.
 
@@ -49,34 +48,34 @@ Param(
 )
 ```
 
-## Attributes of Parameters
+## Attributes of parameters
 
 This section describes the attributes that you can add to function parameters.
 
-All attributes are optional. However, if you omit the `CmdletBinding` attribute,
-then to be recognized as an advanced function, the function must include the
-Parameter attribute.
+All attributes are optional. However, if you omit the **CmdletBinding**
+attribute, then to be recognized as an advanced function, the function must
+include the **Parameter** attribute.
 
-You can add one or multiple attributes in each parameter declaration. There is
+You can add one or multiple attributes in each parameter declaration. There's
 no limit to the number of attributes that you can add to a parameter
 declaration.
 
-### The Parameter Attribute
+### Parameter attribute
 
-The `Parameter` attribute is used to declare the attributes of function
+The **Parameter** attribute is used to declare the attributes of function
 parameters.
 
-The `Parameter` attribute is optional, and you can omit it if none of the
-parameters of your functions need attributes, but to be recognized as an
-advanced function (rather than a simple function), a function must have either
-the `CmdletBinding` attribute or the `Parameter` attribute, or both.
+The **Parameter** attribute is optional, and you can omit it if none of the
+parameters of your functions need attributes. But, to be recognized as an
+advanced function, rather than a simple function, a function must have either
+the **CmdletBinding** attribute or the **Parameter** attribute, or both.
 
-The `Parameter` attribute has arguments that define the characteristics of the
-parameter, such as whether the parameter is mandatory or optional.
+The **Parameter** attribute has arguments that define the characteristics of
+the parameter, such as whether the parameter is mandatory or optional.
 
-Use the following syntax to declare the Parameter attribute, an argument, and
-an argument value. The parentheses that enclose the argument and its value
-must follow "`Parameter`" with no intervening space.
+Use the following syntax to declare the **Parameter** attribute, an argument,
+and an argument value. The parentheses that enclose the argument and its value
+must follow **Parameter** with no intervening space.
 
 ```powershell
 Param(
@@ -86,7 +85,7 @@ Param(
 ```
 
 Use commas to separate arguments within the parentheses. Use the following
-syntax to declare two arguments of the `Parameter` attribute.
+syntax to declare two arguments of the **Parameter** attribute.
 
 ```powershell
 Param(
@@ -95,9 +94,9 @@ Param(
 )
 ```
 
-If you use the `Parameter` attribute without arguments (as an alternative to
-using the `CmdletBinding` attribute), the parentheses that follow the attribute
-name are still required.
+If you use the **Parameter** attribute without arguments, as an alternative to
+using the **CmdletBinding** attribute, the parentheses that follow the
+attribute name are still required.
 
 ```powershell
 Param(
@@ -106,12 +105,12 @@ Param(
 )
 ```
 
-### Mandatory Argument
+### Mandatory argument
 
 The `Mandatory` argument indicates that the parameter is required. If this
-argument is not specified, the parameter is an optional parameter.
+argument isn't specified, the parameter is optional.
 
-The following example declares the `ComputerName` parameter. It uses the
+The following example declares the **ComputerName** parameter. It uses the
 `Mandatory` argument to make the parameter mandatory.
 
 ```powershell
@@ -122,37 +121,38 @@ Param(
 )
 ```
 
-### Position Argument
+### Position argument
 
 The `Position` argument determines whether the parameter name is required when
 the parameter is used in a command. When a parameter declaration includes the
-`Position` argument, the parameter name can be omitted and PowerShell identifies
-the unnamed parameter value by its position (or order) in the list of unnamed
-parameter values in the command.
+`Position` argument, the parameter name can be omitted and PowerShell
+identifies the unnamed parameter value by its position, or order, in the list
+of unnamed parameter values in the command.
 
-If the `Position` argument is not specified, the parameter name (or a parameter
-name alias or abbreviation) must precede the parameter value whenever the
+If the `Position` argument isn't specified, the parameter name, or a parameter
+name alias or abbreviation, must precede the parameter value whenever the
 parameter is used in a command.
 
 By default, all function parameters are positional. PowerShell assigns position
 numbers to parameters in the order in which the parameters are declared in the
 function. To disable this feature, set the value of the `PositionalBinding`
-argument of the `CmdletBinding` attribute to `$False`.The `Position` argument
-takes precedence over the value of the `PositionalBinding` argument for the
-parameters on which it is declared. For more information, see
-`PositionalBinding` in [about_Functions_CmdletBindingAttribute](about_Functions_CmdletBindingAttribute.md).
+argument of the **CmdletBinding** attribute to `$False`. The `Position`
+argument takes precedence over the value of the `PositionalBinding` argument
+for the parameters on which it's declared. For more information, see
+`PositionalBinding` in
+[about_Functions_CmdletBindingAttribute](about_Functions_CmdletBindingAttribute.md).
 
-The value of the Position argument is specified as an integer. A position
-value of **"0"** represents the first position in the command, a position value
-of **"1"** represents the second position in the command, and so on.
+The value of the `Position` argument is specified as an integer. A position
+value of **0** represents the first position in the command, a position value
+of **1** represents the second position in the command, and so on.
 
 If a function has no positional parameters, PowerShell assigns positions to
 each parameter based on the order in which the parameters are declared.
-However, as a best practice, do not rely on this assignment. When you want
-parameters to be positional, use the Position argument.
+However, as a best practice, don't rely on this assignment. When you want
+parameters to be positional, use the `Position` argument.
 
 The following example declares the **ComputerName** parameter. It uses the
-Position argument with a value of **"0"**. As a result, when `-ComputerName` is
+`Position` argument with a value of **0**. As a result, when `-ComputerName` is
 omitted from command, its value must be the first or only unnamed parameter
 value in the command.
 
@@ -165,23 +165,27 @@ Param(
 ```
 
 > [!NOTE]
-> When the Get-Help cmdlet displays the corresponding `Position`
-> parameter attribute, the position value is incremented by one.
+> When the `Get-Help` cmdlet displays the corresponding **Position** parameter
+> attribute, the position value is incremented by one.
 >
-> For example, a parameter with a Position argument value of **"0"**
-> has a parameter attribute of "`Position=1`"
+> For example, a parameter with a `Position` argument value of **0** has a
+> parameter attribute of **Position=1**.
 
-### ParameterSetName Argument
+### ParameterSetName argument
 
-The ParameterSetName argument specifies the parameter set to which a parameter
-belongs. If no parameter set is specified, the parameter belongs to all the
-parameter sets defined by the function. Therefore, to be unique, each
-parameter set must have at least one parameter that is not a member of any
-other parameter set.
+The `ParameterSetName` argument specifies the parameter set to which a
+parameter belongs. If no parameter set is specified, the parameter belongs to
+all the parameter sets defined by the function. Therefore, to be unique, each
+parameter set must have at least one parameter that isn't a member of any other
+parameter set.
 
-The following example declares a `ComputerName` parameter in the "Computer"
-parameter set, a `UserName` parameter in the "User" parameter set, and a
-`Summary` parameter in both parameter sets.
+> [!NOTE]
+> The parameters for a cmdlet or function can be included in a maximum of 32
+> parameter sets.
+
+The following example declares a **ComputerName** parameter in the `Computer`
+parameter set, a **UserName** parameter in the `User` parameter set, and a
+**Summary** parameter in both parameter sets.
 
 ```powershell
 Param(
@@ -201,14 +205,14 @@ Param(
 )
 ```
 
-You can specify only one `ParameterSetName` value in each argument and only
-one `ParameterSetName` argument in each `Parameter` attribute. To indicate
-that a parameter appears in more than one parameter set, add additional
-`Parameter` attributes.
+You can specify only one `ParameterSetName` value in each argument and only one
+`ParameterSetName` argument in each **Parameter** attribute. To indicate that a
+parameter appears in more than one parameter set, add additional **Parameter**
+attributes.
 
-The following example explicitly adds the `Summary` parameter to the Computer
-and User parameter sets. The `Summary` parameter is **Mandatory** in one
-parameter set and **Optional** in the other.
+The following example explicitly adds the **Summary** parameter to the
+`Computer` and `User` parameter sets. The **Summary** parameter is optional in
+the `Computer` parameter set and mandatory in the `User` parameter set.
 
 ```powershell
 Param(
@@ -229,17 +233,16 @@ Param(
 )
 ```
 
-For more information about parameter sets, see "Cmdlet Parameter Sets" in the
-MSDN library at [Cmdlet Parameter Sets](/powershell/developer/cmdlet/cmdlet-parameter-sets)
+For more information about parameter sets, see [Cmdlet Parameter Sets](/powershell/developer/cmdlet/cmdlet-parameter-sets).
 
-### ValueFromPipeline Argument
+### ValueFromPipeline argument
 
-The `ValueFromPipeline` argument indicates that the parameter accepts input from
-a pipeline object. Specify this argument if the function accepts the entire
-object, not just a property of the object.
+The `ValueFromPipeline` argument indicates that the parameter accepts input
+from a pipeline object. Specify this argument if the function accepts the
+entire object, not just a property of the object.
 
-The following example declares a `ComputerName` parameter that is mandatory
-and accepts an object that is passed to the function from the pipeline.
+The following example declares a **ComputerName** parameter that's mandatory
+and accepts an object that's passed to the function from the pipeline.
 
 ```powershell
 Param(
@@ -250,19 +253,19 @@ Param(
 )
 ```
 
-### ValueFromPipelineByPropertyName Argument
+### ValueFromPipelineByPropertyName argument
 
 The `ValueFromPipelineByPropertyName` argument indicates that the parameter
 accepts input from a property of a pipeline object. The object property must
 have the same name or alias as the parameter.
 
-For example, if the function has a `ComputerName` parameter, and the piped
-object has a `ComputerName` property, the value of the `ComputerName`
-property is assigned to the `ComputerName` parameter of the function.
+For example, if the function has a **ComputerName** parameter, and the piped
+object has a **ComputerName** property, the value of the **ComputerName**
+property is assigned to the function's **ComputerName** parameter.
 
-The following example declares a `ComputerName` parameter that is mandatory
-and accepts input from the `ComputerName` property of the object that is
-passed to the function through the pipeline.
+The following example declares a **ComputerName** parameter that's mandatory
+and accepts input from the object's **ComputerName** property that's passed to
+the function through the pipeline.
 
 ```powershell
 Param(
@@ -275,29 +278,30 @@ Param(
 
 > [!NOTE]
 > A typed parameter that accepts pipeline input (`by Value`) or
-> (`by PropertyName`) enables use of **delay-bind** script blocks on the parameter.
+> (`by PropertyName`) enables use of **delay-bind** script blocks on the
+> parameter.
 >
 > The **delay-bind** script block is run automatically during
 > **ParameterBinding**. The result is bound to the parameter. Delay binding
-> does **not** work for parameters defined as type `ScriptBlock` or
-> `System.Object`, the script block is passed through
-> **without** being invoked.
+> **does not** work for parameters defined as type `ScriptBlock` or
+> `System.Object`, the script block is passed through **without** being
+> invoked.
 >
-> You can read about **delay-bind** script blocks here [about_Script_Blocks.md](about_Script_Blocks.md)
+> You can read about **delay-bind** script blocks here [about_Script_Blocks.md](about_Script_Blocks.md).
 
-### ValueFromRemainingArguments Argument
+### ValueFromRemainingArguments argument
 
-The `ValueFromRemainingArguments` argument indicates that the parameter
-accepts all of the parameters values in the command that are not assigned to
-other parameters of the function.
+The `ValueFromRemainingArguments` argument indicates that the parameter accepts
+all the parameter's values in the command that aren't assigned to other
+parameters of the function.
 
-There is a known issue for using collections with
-**ValueFromRemainingArguments** where the passed in collection is treated
-as a single element.
+There's a known issue for using collections with
+**ValueFromRemainingArguments** where the passed-in collection is treated as a
+single element.
 
-The following example demonstrates this issue. The `$Remaining` parameter
-should contain "one" at index 0 and "two" at index 1. Instead, both elements
-are combined into a single entity.
+The following example demonstrates this known issue. The **Remaining**
+parameter should contain **one** at **index 0** and **two** at **index 1**.
+Instead, both elements are combined into a single entity.
 
 ```powershell
 function Test-Remainder
@@ -326,32 +330,32 @@ Found 1 elements
 > [!NOTE]
 > This issue is resolved in PowerShell 6.2.
 
-### HelpMessage Argument
+### HelpMessage argument
 
-The `HelpMessage` argument specifies a string that contains a brief
-description of the parameter or its value. PowerShell displays this message in
-the prompt that appears when a mandatory parameter value is missing from a
-command. This argument has no effect on optional parameters.
+The `HelpMessage` argument specifies a string that contains a brief description
+of the parameter or its value. PowerShell displays this message in the prompt
+that appears when a mandatory parameter value is missing from a command. This
+argument has no effect on optional parameters.
 
-The following example declares a mandatory `ComputerName` parameter and a
+The following example declares a mandatory **ComputerName** parameter and a
 help message that explains the expected parameter value.
 
 ```powershell
 Param(
-    [Parameter(mandatory=$true,
+    [Parameter(Mandatory=$true,
     HelpMessage="Enter one or more computer names separated by commas.")]
     [String[]]
     $ComputerName
 )
 ```
 
-### Alias Attribute
+### Alias attribute
 
-The `Alias` attribute establishes an alternate name for the parameter. There is
-no limit to the number of aliases that you can assign to a parameter.
+The **Alias** attribute establishes an alternate name for the parameter.
+There's no limit to the number of aliases that you can assign to a parameter.
 
-The following example shows a parameter declaration that adds the "CN" and
-"MachineName" aliases to the mandatory `ComputerName` parameter.
+The following example shows a parameter declaration that adds the **CN** and
+**MachineName** aliases to the mandatory **ComputerName** parameter.
 
 ```powershell
 Param(
@@ -362,19 +366,19 @@ Param(
 )
 ```
 
-### Parameter and Variable Validation Attributes
+### Parameter and variable validation attributes
 
-Validation attributes direct PowerShell to test the parameter values that
-users submit when they call the advanced function. If the parameter values
-fail the test, an error is generated and the function is not called. You can
-also use some of the validation attributes to restrict the values that users
-can specify for variables.
+Validation attributes direct PowerShell to test the parameter values that users
+submit when they call the advanced function. If the parameter values fail the
+test, an error is generated and the function isn't called. You can also use
+some of the validation attributes to restrict the values that users can specify
+for variables.
 
-### AllowNull Validation Attribute
+### AllowNull validation attribute
 
-The `AllowNull` attribute allows the value of a **Mandatory** parameter to be
-`$null`. The following example declares a `ComputerName` parameter that can have
-a Null value.
+The **AllowNull** attribute allows the value of a mandatory parameter to be
+`$null`. The following example declares a **ComputerName** parameter that can
+have a **null** value.
 
 ```powershell
 Param(
@@ -385,10 +389,10 @@ Param(
 )
 ```
 
-### AllowEmptyString Validation Attribute
+### AllowEmptyString validation attribute
 
-The `AllowEmptyString` attribute allows the value of a **Mandatory** parameter
-to be an empty string (""). The following example declares a `ComputerName`
+The **AllowEmptyString** attribute allows the value of a mandatory parameter to
+be an empty string (`""`). The following example declares a **ComputerName**
 parameter that can have an empty string value.
 
 ```powershell
@@ -400,11 +404,11 @@ Param(
 )
 ```
 
-### AllowEmptyCollection Validation Attribute
+### AllowEmptyCollection validation attribute
 
-The `AllowEmptyCollection` attribute allows the value of a mandatory parameter
-to be an empty collection `@()`. The following example declares a `ComputerName`
-parameter that can have a empty collection value.
+The **AllowEmptyCollection** attribute allows the value of a mandatory
+parameter to be an empty collection `@()`. The following example declares a
+**ComputerName** parameter that can have an empty collection value.
 
 ```powershell
 Param(
@@ -415,14 +419,14 @@ Param(
 )
 ```
 
-### ValidateCount Validation Attribute
+### ValidateCount validation attribute
 
-The `ValidateCount` attribute specifies the minimum and maximum number of
-parameter values that a parameter accepts. PowerShell generates an error if
-the number of parameter values in the command that calls the function is
-outside that range.
+The **ValidateCount** attribute specifies the minimum and maximum number of
+parameter values that a parameter accepts. PowerShell generates an error if the
+number of parameter values in the command that calls the function is outside
+that range.
 
-The following parameter declaration creates a ComputerName parameter that
+The following parameter declaration creates a **ComputerName** parameter that
 takes one to five parameter values.
 
 ```powershell
@@ -434,12 +438,12 @@ Param(
 )
 ```
 
-### ValidateLength Validation Attribute
+### ValidateLength validation attribute
 
-The `ValidateLength` attribute specifies the minimum and maximum number of
+The **ValidateLength** attribute specifies the minimum and maximum number of
 characters in a parameter or variable value. PowerShell generates an error if
-the length of a value specified for a parameter or a variable is outside of
-the range.
+the length of a value specified for a parameter or a variable is outside of the
+range.
 
 In the following example, each computer name must have one to ten characters.
 
@@ -459,14 +463,14 @@ of one character in length, and a maximum of ten characters.
 [Int32][ValidateLength(1,10)]$number = 01
 ```
 
-### ValidatePattern Validation Attribute
+### ValidatePattern validation attribute
 
-The `ValidatePattern` attribute specifies a regular expression that is compared
-to the parameter or variable value. PowerShell generates an error if the value
-does not match the regular expression pattern.
+The **ValidatePattern** attribute specifies a regular expression that's
+compared to the parameter or variable value. PowerShell generates an error if
+the value doesn't match the regular expression pattern.
 
-In the following example, the parameter value must contain a four-digit number, and
-each digit must be a number zero to nine.
+In the following example, the parameter value must contain a four-digit number,
+and each digit must be a number zero to nine.
 
 ```powershell
 Param(
@@ -484,12 +488,12 @@ four-digit number, and each digit must be a number zero to nine.
 [Int32][ValidatePattern("^[0-9][0-9][0-9][0-9]$")]$number = 1111
 ```
 
-### ValidateRange Validation Attribute
+### ValidateRange validation attribute
 
-The `ValidateRange` attribute specifies a numeric range for each parameter or
+The **ValidateRange** attribute specifies a numeric range for each parameter or
 variable value. PowerShell generates an error if any value is outside that
-range. In the following example, the value of the `Attempts` parameter must be
-between zero and ten.
+range. In the following example, the value of the **Attempts** parameter must
+be between zero and ten.
 
 ```powershell
 Param(
@@ -507,18 +511,18 @@ zero and ten.
 [Int32][ValidateRange(0,10)]$number = 5
 ```
 
-### ValidateScript Validation Attribute
+### ValidateScript validation attribute
 
-The `ValidateScript` attribute specifies a script that is used to validate a
+The **ValidateScript** attribute specifies a script that is used to validate a
 parameter or variable value. PowerShell pipes the value to the script, and
 generates an error if the script returns `$false` or if the script throws an
 exception.
 
-When you use the `ValidateScript` attribute, the value that is being
-validated is mapped to the `$_` variable. You can use the `$_` variable to refer
-to the value in the script.
+When you use the **ValidateScript** attribute, the value that's being validated
+is mapped to the `$_` variable. You can use the `$_` variable to refer to the
+value in the script.
 
-In the following example, the value of the `EventDate` parameter must be
+In the following example, the value of the **EventDate** parameter must be
 greater than or equal to the current date.
 
 ```powershell
@@ -530,19 +534,19 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$date` must be greater than
-or equal to the current date and time.
+In the following example, the value of the variable `$date` must be greater
+than or equal to the current date and time.
 
 ```powershell
 [DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
 ```
 
-### ValidateSet Attribute
+### ValidateSet attribute
 
-The `ValidateSet` attribute specifies a set of valid values for a parameter or
-variable. PowerShell generates an error if a parameter or variable value does
-not match a value in the set. In the following example, the value of the
-`Detail` parameter can only be "Low," "Average," or "High."
+The **ValidateSet** attribute specifies a set of valid values for a parameter
+or variable. PowerShell generates an error if a parameter or variable value
+doesn't match a value in the set. In the following example, the value of the
+**Detail** parameter can only be Low, Average, or High.
 
 ```powershell
 Param(
@@ -554,15 +558,15 @@ Param(
 ```
 
 In the following example, the value of the variable `$flavor` must be either
-"Chocolate", "Strawberry", or "Vanilla".
+Chocolate, Strawberry, or Vanilla.
 
 ```powershell
 [ValidateSet("Chocolate", "Strawberry", "Vanilla")]
 [String]$flavor = "Strawberry"
 ```
 
-Note that the validation occurs whenever that variable is assigned even within
-the script. For example, the following results in an error at runtime:
+The validation occurs whenever that variable is assigned even within the
+script. For example, the following results in an error at runtime:
 
 ```powershell
 Param(
@@ -573,18 +577,18 @@ Param(
 $Message = "bye"
 ```
 
-### ValidateNotNull Validation Attribute
+### ValidateNotNull validation attribute
 
-The `ValidateNotNull` attribute specifies that the parameter value cannot be
+The **ValidateNotNull** attribute specifies that the parameter value can't be
 `$null`. PowerShell generates an error if the parameter value is `$null`.
 
-The `ValidateNotNull` attribute is designed to be used when the type of the
-parameter value is not specified or when the specified type accepts a
-value of `$null`. (If you specify a type that does not accept a `$null` value,
-such as a string, the `$null` value is rejected without the
-`ValidateNotNull` attribute, because it does not match the specified type.)
+The **ValidateNotNull** attribute is designed to be used when the type of the
+parameter value isn't specified or when the specified type accepts a value of
+`$null`. If you specify a type that doesn't accept a `$null` value, such as a
+string, the `$null` value is rejected without the **ValidateNotNull**
+attribute, because it doesn't match the specified type.
 
-In the following example, the value of the `ID` parameter cannot be `$null`.
+In the following example, the value of the **ID** parameter can't be `$null`.
 
 ```powershell
 Param(
@@ -594,12 +598,12 @@ Param(
 )
 ```
 
-### ValidateNotNullOrEmpty Validation Attribute
+### ValidateNotNullOrEmpty validation attribute
 
-The `ValidateNotNullOrEmpty` attribute specifies that the parameter value cannot
-be `$null` and cannot be an empty string `""`. PowerShell generates an
-error if the parameter is used in a function call, but its value is `$null`,
-an empty string `""`, or an empty array `@()`.
+The **ValidateNotNullOrEmpty** attribute specifies that the parameter value
+can't be `$null` and can't be an empty string (`""`). PowerShell generates an
+error if the parameter is used in a function call, but its value is `$null`, an
+empty string (`""`), or an empty array `@()`.
 
 ```powershell
 Param(
@@ -610,24 +614,24 @@ Param(
 )
 ```
 
-## Dynamic Parameters
+## Dynamic parameters
 
 Dynamic parameters are parameters of a cmdlet, function, or script that are
 available only under certain conditions.
 
 For example, several provider cmdlets have parameters that are available only
 when the cmdlet is used in the provider drive, or in a particular path of the
-provider drive. For example, the `Encoding` parameter is available on the
-`Add-Content`, `Get-Content`, and `Set-Content` cmdlets only when it is used
-in a file system drive.
+provider drive. For example, the **Encoding** parameter is available on the
+`Add-Content`, `Get-Content`, and `Set-Content` cmdlets only when it's used in
+a file system drive.
 
 You can also create a parameter that appears only when another parameter is
 used in the function command or when another parameter has a certain value.
 
-Dynamic parameters can be very useful, but use them only when necessary,
-because they can be difficult for users to discover. To find a dynamic
-parameter, the user must be in the provider path, use the `ArgumentList`
-parameter of the `Get-Command` cmdlet, or use the Path parameter of `Get-Help`.
+Dynamic parameters can be useful, but use them only when necessary, because
+they can be difficult for users to discover. To find a dynamic parameter, the
+user must be in the provider path, use the **ArgumentList** parameter of the
+`Get-Command` cmdlet, or use the **Path** parameter of `Get-Help`.
 
 To create a dynamic parameter for a function or script, use the `DynamicParam`
 keyword.
@@ -636,24 +640,24 @@ The syntax is as follows:
 
 `DynamicParam {<statement-list>}`
 
-In the statement list, use an If statement to specify the conditions under
+In the statement list, use an `If` statement to specify the conditions under
 which the parameter is available in the function.
 
 Use the `New-Object` cmdlet to create a
-`System.Management.Automation.RuntimeDefinedParameter` object to represent the
-parameter and specify its name.
+**System.Management.Automation.RuntimeDefinedParameter** object to represent
+the parameter and specify its name.
 
-You can also use a `New-Object` command to create a
-`System.Management.Automation.ParameterAttribute` object to represent attributes
-of the parameter, such as `Mandatory`, `Position`, or `ValueFromPipeline` or its
-parameter set.
+You can use a `New-Object` command to create a
+**System.Management.Automation.ParameterAttribute** object to represent
+attributes of the parameter, such as **Mandatory**, **Position**, or
+**ValueFromPipeline** or its parameter set.
 
 The following example shows a sample function with standard parameters named
-**Name** and **Path**, and an optional dynamic parameter named **DP1**.
-The **DP1** parameter is in the PSet1 parameter set and has a type of `Int32`.
-The **DP1** parameter is available in the `Get-Sample` function
-only when the value of the **Path** parameter starts with "HKLM:",
-indicating that it is being used in the HKEY_LOCAL_MACHINE registry drive.
+**Name** and **Path**, and an optional dynamic parameter named **DP1**. The
+**DP1** parameter is in the `PSet1` parameter set and has a type of `Int32`.
+The **DP1** parameter is available in the `Get-Sample` function only when the
+value of the **Path** parameter starts with `HKLM:`, indicating that it's being
+used in the `HKEY_LOCAL_MACHINE` registry drive.
 
 ```powershell
 function Get-Sample {
@@ -685,19 +689,18 @@ function Get-Sample {
 }
 ```
 
-For more information, see "RuntimeDefinedParameter Class" in the MSDN
-(Microsoft Developer Network) library at
-[RuntimeDefinedParameter](/dotnet/api/system.management.automation.runtimedefinedparameter)
+For more information, see
+[RuntimeDefinedParameter](/dotnet/api/system.management.automation.runtimedefinedparameter).
 
-## Switch Parameters
+## Switch parameters
 
-Switch parameters are parameters with no parameter value. They are effective
-only when they are used and have only one effect.
+Switch parameters are parameters with no parameter value. They're effective
+only when they're used and have only one effect.
 
-For example, the `-NoProfile` parameter of PowerShell.exe is a switch
+For example, the **NoProfile** parameter of **powershell.exe** is a switch
 parameter.
 
-To create a switch parameter in a function, specify the Switch type in the
+To create a switch parameter in a function, specify the `Switch` type in the
 parameter definition.
 
 For example:
@@ -706,7 +709,7 @@ For example:
 Param([Switch]<ParameterName>)
 ```
 
--or-
+Or, you can use an another method:
 
 ```powershell
 Param(
@@ -729,20 +732,21 @@ To use a Boolean parameter, the user types the parameter and a Boolean value.
 `-IncludeAll:$true`
 
 When creating switch parameters, choose the parameter name carefully. Be sure
-that the parameter name communicates the effect of the parameter to the user,
-and avoid ambiguous terms, such as Filter or Maximum, that might imply that a
+that the parameter name communicates the effect of the parameter to the user.
+Avoid ambiguous terms, such as **Filter** or **Maximum** that might imply a
 value is required.
 
 ## ArgumentCompleter attribute
 
-The **ArgumentCompleter** attribute allows you to add tab completion values
-to a specific parameter. Like DynamicParameters, the available values are
-calculated at runtime when the user presses `<TAB>` after the parameter name.
+The **ArgumentCompleter** attribute allows you to add tab completion values to
+a specific parameter. Like **DynamicParameters**, the available values are
+calculated at runtime when the user presses <kbd>Tab</kbd> after the parameter
+name.
 
 To add an **ArgumentCompleter** attribute, you need to define a script block
 that will determine the values. The script block must take the following
-parameters in the order specified below. The parameter's names
-do not matter as the values are provided *positionally*.
+parameters in the order specified below. The parameter's names don't matter as
+the values are provided positionally.
 
 The syntax is as follows:
 
@@ -756,35 +760,35 @@ Param(
 )
 ```
 
-### The ArgumentCompleter script block
+### ArgumentCompleter script block
 
 The script block parameters are set to the following values:
 
 - `$commandName` (Position 0) - This parameter is set to the name of the
   command for which the script block is providing tab completion.
-- `$parameterName` (Position 1) - This parameter is set to the parameter
-  whose value requires tab completion.
+- `$parameterName` (Position 1) - This parameter is set to the parameter whose
+  value requires tab completion.
 - `$wordToComplete` (Position 2) - This parameter is set to value the user has
-  provided before they pressed `<TAB>`. Your script block should use this value
-  to determine tab completion values.
+  provided before they pressed <kbd>Tab</kbd>. Your script block should use
+  this value to determine tab completion values.
 - `$commandAst` (Position 3) - This parameter is set to the Abstract Syntax
-  Tree (AST) for the current input line. For more information, see
-  [Ast Class](/dotnet/api/system.management.automation.language.ast).
+  Tree (AST) for the current input line. For more information, see [Ast Class](/dotnet/api/system.management.automation.language.ast).
 - `$fakeBoundParameter` (Position 4) - This parameter is set to a hashtable
   containing the `$PSBoundParameters` for the cmdlet, before the user pressed
-  `<TAB>`. For more information, see [about_Automatic_Variables](about_Automatic_Variables.md).
+  <kbd>Tab</kbd>. For more information, see [about_Automatic_Variables](about_Automatic_Variables.md).
 
 The **ArgumentCompleter** script block must unroll the values using the
-pipeline (`ForEach-Object`, `Where-Object`, etc.), or another suitable method.
+pipeline, such as`ForEach-Object`, `Where-Object`, or another suitable method.
 Returning an array of values causes PowerShell to treat the entire array as
 **one** tab completion value.
 
-The following example adds tab completion to the `$Value` parameter.  If no
+The following example adds tab completion to the **Value** parameter. If no
 `$Type` is specified, fruits and vegetables are returned. If a `$Type` is
-specified, only values for the type are specified. In addition the `-like`
-operator ensures that if the user types
-`Test-ArgumentCompleter -Type Fruits -Value A<TAB>`, only **Apple** is
-returned.
+specified, only values for the type are specified. In addition, the `-like`
+operator ensures that if the user types the following command and uses
+<kbd>Tab</kbd> completion, only **Apple** is returned.
+
+`Test-ArgumentCompleter -Type Fruits -Value A`
 
 ```powershell
 function Test-ArgumentCompleter {
@@ -822,6 +826,8 @@ function Test-ArgumentCompleter {
 ```
 
 ## See also
+
+[about_Automatic_Variables](about_Automatic_Variables.md)
 
 [about_Functions](about_Functions.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,10 +1,11 @@
 ---
-ms.date: 5/20/2019
+ms.date: 05/20/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Functions_Advanced_Parameters
 ---
+
 # About Functions Advanced Parameters
 
 ## Short description
@@ -17,26 +18,24 @@ You can add parameters to the advanced functions that you write, and use
 parameter attributes and arguments to limit the parameter values that function
 users submit with the parameter.
 
-The parameters that you add to your function are available to users in
-addition to the common parameters that PowerShell adds automatically to all
-cmdlets and advanced functions. For more information about the Windows
-PowerShell common parameters, see
-[about_CommonParameters](about_CommonParameters.md).
+The parameters that you add to your function are available to users in addition
+to the common parameters that PowerShell adds automatically to all cmdlets and
+advanced functions. For more information about the PowerShell common
+parameters, see [about_CommonParameters](about_CommonParameters.md).
 
-Beginning in PowerShell 3.0, you can use splatting with @Args to represent the
-parameters in a command. This technique is valid on simple and advanced
-functions. For more information, see [about_Functions](about_Functions.md) and
-[about_Splatting](about_Splatting.md).
+Beginning in PowerShell 3.0, you can use splatting with `@Args` to represent
+the parameters in a command. Splatting is valid on simple and advanced
+functions. For more information, see [about_Functions](about_Functions.md) and [about_Splatting](about_Splatting.md).
 
-## Static Parameters
+## Static parameters
 
 Static parameters are parameters that are always available in the function.
 Most parameters in PowerShell cmdlets and scripts are static parameters.
 
-The following example shows the declaration of a ComputerName parameter that
-has the following characteristics:
+The following example shows the declaration of a **ComputerName** parameter
+that has the following characteristics:
 
-- It is mandatory (required).
+- It's mandatory (required).
 - It takes input from the pipeline.
 - It takes an array of strings as input.
 
@@ -49,34 +48,34 @@ Param(
 )
 ```
 
-## Attributes of Parameters
+## Attributes of parameters
 
 This section describes the attributes that you can add to function parameters.
 
-All attributes are optional. However, if you omit the `CmdletBinding` attribute,
-then to be recognized as an advanced function, the function must include the
-Parameter attribute.
+All attributes are optional. However, if you omit the **CmdletBinding**
+attribute, then to be recognized as an advanced function, the function must
+include the **Parameter** attribute.
 
-You can add one or multiple attributes in each parameter declaration. There is
+You can add one or multiple attributes in each parameter declaration. There's
 no limit to the number of attributes that you can add to a parameter
 declaration.
 
-### The Parameter Attribute
+### Parameter attribute
 
-The `Parameter` attribute is used to declare the attributes of function
+The **Parameter** attribute is used to declare the attributes of function
 parameters.
 
-The `Parameter` attribute is optional, and you can omit it if none of the
-parameters of your functions need attributes, but to be recognized as an
-advanced function (rather than a simple function), a function must have either
-the `CmdletBinding` attribute or the `Parameter` attribute, or both.
+The **Parameter** attribute is optional, and you can omit it if none of the
+parameters of your functions need attributes. But, to be recognized as an
+advanced function, rather than a simple function, a function must have either
+the **CmdletBinding** attribute or the **Parameter** attribute, or both.
 
-The `Parameter` attribute has arguments that define the characteristics of the
-parameter, such as whether the parameter is mandatory or optional.
+The **Parameter** attribute has arguments that define the characteristics of
+the parameter, such as whether the parameter is mandatory or optional.
 
-Use the following syntax to declare the Parameter attribute, an argument, and
-an argument value. The parentheses that enclose the argument and its value
-must follow "`Parameter`" with no intervening space.
+Use the following syntax to declare the **Parameter** attribute, an argument,
+and an argument value. The parentheses that enclose the argument and its value
+must follow **Parameter** with no intervening space.
 
 ```powershell
 Param(
@@ -86,7 +85,7 @@ Param(
 ```
 
 Use commas to separate arguments within the parentheses. Use the following
-syntax to declare two arguments of the `Parameter` attribute.
+syntax to declare two arguments of the **Parameter** attribute.
 
 ```powershell
 Param(
@@ -95,9 +94,9 @@ Param(
 )
 ```
 
-If you use the `Parameter` attribute without arguments (as an alternative to
-using the `CmdletBinding` attribute), the parentheses that follow the attribute
-name are still required.
+If you use the **Parameter** attribute without arguments, as an alternative to
+using the **CmdletBinding** attribute, the parentheses that follow the
+attribute name are still required.
 
 ```powershell
 Param(
@@ -106,12 +105,12 @@ Param(
 )
 ```
 
-### Mandatory Argument
+### Mandatory argument
 
 The `Mandatory` argument indicates that the parameter is required. If this
-argument is not specified, the parameter is an optional parameter.
+argument isn't specified, the parameter is optional.
 
-The following example declares the `ComputerName` parameter. It uses the
+The following example declares the **ComputerName** parameter. It uses the
 `Mandatory` argument to make the parameter mandatory.
 
 ```powershell
@@ -122,37 +121,38 @@ Param(
 )
 ```
 
-### Position Argument
+### Position argument
 
 The `Position` argument determines whether the parameter name is required when
 the parameter is used in a command. When a parameter declaration includes the
-`Position` argument, the parameter name can be omitted and PowerShell identifies
-the unnamed parameter value by its position (or order) in the list of unnamed
-parameter values in the command.
+`Position` argument, the parameter name can be omitted and PowerShell
+identifies the unnamed parameter value by its position, or order, in the list
+of unnamed parameter values in the command.
 
-If the `Position` argument is not specified, the parameter name (or a parameter
-name alias or abbreviation) must precede the parameter value whenever the
+If the `Position` argument isn't specified, the parameter name, or a parameter
+name alias or abbreviation, must precede the parameter value whenever the
 parameter is used in a command.
 
 By default, all function parameters are positional. PowerShell assigns position
 numbers to parameters in the order in which the parameters are declared in the
 function. To disable this feature, set the value of the `PositionalBinding`
-argument of the `CmdletBinding` attribute to `$False`.The `Position` argument
-takes precedence over the value of the `PositionalBinding` argument for the
-parameters on which it is declared. For more information, see
-`PositionalBinding` in [about_Functions_CmdletBindingAttribute](about_Functions_CmdletBindingAttribute.md).
+argument of the **CmdletBinding** attribute to `$False`. The `Position`
+argument takes precedence over the value of the `PositionalBinding` argument
+for the parameters on which it's declared. For more information, see
+`PositionalBinding` in
+[about_Functions_CmdletBindingAttribute](about_Functions_CmdletBindingAttribute.md).
 
-The value of the Position argument is specified as an integer. A position
-value of **"0"** represents the first position in the command, a position value
-of **"1"** represents the second position in the command, and so on.
+The value of the `Position` argument is specified as an integer. A position
+value of **0** represents the first position in the command, a position value
+of **1** represents the second position in the command, and so on.
 
 If a function has no positional parameters, PowerShell assigns positions to
 each parameter based on the order in which the parameters are declared.
-However, as a best practice, do not rely on this assignment. When you want
-parameters to be positional, use the Position argument.
+However, as a best practice, don't rely on this assignment. When you want
+parameters to be positional, use the `Position` argument.
 
 The following example declares the **ComputerName** parameter. It uses the
-Position argument with a value of **"0"**. As a result, when `-ComputerName` is
+`Position` argument with a value of **0**. As a result, when `-ComputerName` is
 omitted from command, its value must be the first or only unnamed parameter
 value in the command.
 
@@ -165,23 +165,27 @@ Param(
 ```
 
 > [!NOTE]
-> When the Get-Help cmdlet displays the corresponding `Position`
-> parameter attribute, the position value is incremented by one.
+> When the `Get-Help` cmdlet displays the corresponding **Position** parameter
+> attribute, the position value is incremented by one.
 >
-> For example, a parameter with a Position argument value of **"0"**
-> has a parameter attribute of "`Position=1`"
+> For example, a parameter with a `Position` argument value of **0** has a
+> parameter attribute of **Position=1**.
 
-### ParameterSetName Argument
+### ParameterSetName argument
 
-The ParameterSetName argument specifies the parameter set to which a parameter
-belongs. If no parameter set is specified, the parameter belongs to all the
-parameter sets defined by the function. Therefore, to be unique, each
-parameter set must have at least one parameter that is not a member of any
-other parameter set.
+The `ParameterSetName` argument specifies the parameter set to which a
+parameter belongs. If no parameter set is specified, the parameter belongs to
+all the parameter sets defined by the function. Therefore, to be unique, each
+parameter set must have at least one parameter that isn't a member of any other
+parameter set.
 
-The following example declares a `ComputerName` parameter in the "Computer"
-parameter set, a `UserName` parameter in the "User" parameter set, and a
-`Summary` parameter in both parameter sets.
+> [!NOTE]
+> The parameters for a cmdlet or function can be included in a maximum of 32
+> parameter sets.
+
+The following example declares a **ComputerName** parameter in the `Computer`
+parameter set, a **UserName** parameter in the `User` parameter set, and a
+**Summary** parameter in both parameter sets.
 
 ```powershell
 Param(
@@ -201,14 +205,14 @@ Param(
 )
 ```
 
-You can specify only one `ParameterSetName` value in each argument and only
-one `ParameterSetName` argument in each `Parameter` attribute. To indicate
-that a parameter appears in more than one parameter set, add additional
-`Parameter` attributes.
+You can specify only one `ParameterSetName` value in each argument and only one
+`ParameterSetName` argument in each **Parameter** attribute. To indicate that a
+parameter appears in more than one parameter set, add additional **Parameter**
+attributes.
 
-The following example explicitly adds the `Summary` parameter to the Computer
-and User parameter sets. The `Summary` parameter is **Mandatory** in one
-parameter set and **Optional** in the other.
+The following example explicitly adds the **Summary** parameter to the
+`Computer` and `User` parameter sets. The **Summary** parameter is optional in
+the `Computer` parameter set and mandatory in the `User` parameter set.
 
 ```powershell
 Param(
@@ -229,17 +233,16 @@ Param(
 )
 ```
 
-For more information about parameter sets, see "Cmdlet Parameter Sets" in the
-MSDN library at [Cmdlet Parameter Sets](/powershell/developer/cmdlet/cmdlet-parameter-sets)
+For more information about parameter sets, see [Cmdlet Parameter Sets](/powershell/developer/cmdlet/cmdlet-parameter-sets).
 
-### ValueFromPipeline Argument
+### ValueFromPipeline argument
 
-The `ValueFromPipeline` argument indicates that the parameter accepts input from
-a pipeline object. Specify this argument if the function accepts the entire
-object, not just a property of the object.
+The `ValueFromPipeline` argument indicates that the parameter accepts input
+from a pipeline object. Specify this argument if the function accepts the
+entire object, not just a property of the object.
 
-The following example declares a `ComputerName` parameter that is mandatory
-and accepts an object that is passed to the function from the pipeline.
+The following example declares a **ComputerName** parameter that's mandatory
+and accepts an object that's passed to the function from the pipeline.
 
 ```powershell
 Param(
@@ -250,19 +253,19 @@ Param(
 )
 ```
 
-### ValueFromPipelineByPropertyName Argument
+### ValueFromPipelineByPropertyName argument
 
 The `ValueFromPipelineByPropertyName` argument indicates that the parameter
 accepts input from a property of a pipeline object. The object property must
 have the same name or alias as the parameter.
 
-For example, if the function has a `ComputerName` parameter, and the piped
-object has a `ComputerName` property, the value of the `ComputerName`
-property is assigned to the `ComputerName` parameter of the function.
+For example, if the function has a **ComputerName** parameter, and the piped
+object has a **ComputerName** property, the value of the **ComputerName**
+property is assigned to the function's **ComputerName** parameter.
 
-The following example declares a `ComputerName` parameter that is mandatory
-and accepts input from the `ComputerName` property of the object that is
-passed to the function through the pipeline.
+The following example declares a **ComputerName** parameter that's mandatory
+and accepts input from the object's **ComputerName** property that's passed to
+the function through the pipeline.
 
 ```powershell
 Param(
@@ -275,29 +278,30 @@ Param(
 
 > [!NOTE]
 > A typed parameter that accepts pipeline input (`by Value`) or
-> (`by PropertyName`) enables use of **delay-bind** script blocks on the parameter.
+> (`by PropertyName`) enables use of **delay-bind** script blocks on the
+> parameter.
 >
 > The **delay-bind** script block is run automatically during
 > **ParameterBinding**. The result is bound to the parameter. Delay binding
-> does **not** work for parameters defined as type `ScriptBlock` or
-> `System.Object`, the script block is passed through
-> **without** being invoked.
+> **does not** work for parameters defined as type `ScriptBlock` or
+> `System.Object`, the script block is passed through **without** being
+> invoked.
 >
-> You can read about **delay-bind** script blocks here [about_Script_Blocks.md](about_Script_Blocks.md)
+> You can read about **delay-bind** script blocks here [about_Script_Blocks.md](about_Script_Blocks.md).
 
-### ValueFromRemainingArguments Argument
+### ValueFromRemainingArguments argument
 
-The `ValueFromRemainingArguments` argument indicates that the parameter
-accepts all of the parameters values in the command that are not assigned to
-other parameters of the function.
+The `ValueFromRemainingArguments` argument indicates that the parameter accepts
+all the parameter's values in the command that aren't assigned to other
+parameters of the function.
 
-There is a known issue for using collections with
-**ValueFromRemainingArguments** where the passed in collection is treated
-as a single element.
+There's a known issue for using collections with
+**ValueFromRemainingArguments** where the passed-in collection is treated as a
+single element.
 
-The following example demonstrates this issue. The `$Remaining` parameter
-should contain "one" at index 0 and "two" at index 1. Instead, both elements
-are combined into a single entity.
+The following example demonstrates this known issue. The **Remaining**
+parameter should contain **one** at **index 0** and **two** at **index 1**.
+Instead, both elements are combined into a single entity.
 
 ```powershell
 function Test-Remainder
@@ -326,32 +330,32 @@ Found 1 elements
 > [!NOTE]
 > This issue is resolved in PowerShell 6.2.
 
-### HelpMessage Argument
+### HelpMessage argument
 
-The `HelpMessage` argument specifies a string that contains a brief
-description of the parameter or its value. PowerShell displays this message in
-the prompt that appears when a mandatory parameter value is missing from a
-command. This argument has no effect on optional parameters.
+The `HelpMessage` argument specifies a string that contains a brief description
+of the parameter or its value. PowerShell displays this message in the prompt
+that appears when a mandatory parameter value is missing from a command. This
+argument has no effect on optional parameters.
 
-The following example declares a mandatory `ComputerName` parameter and a
+The following example declares a mandatory **ComputerName** parameter and a
 help message that explains the expected parameter value.
 
 ```powershell
 Param(
-    [Parameter(mandatory=$true,
+    [Parameter(Mandatory=$true,
     HelpMessage="Enter one or more computer names separated by commas.")]
     [String[]]
     $ComputerName
 )
 ```
 
-### Alias Attribute
+### Alias attribute
 
-The `Alias` attribute establishes an alternate name for the parameter. There is
-no limit to the number of aliases that you can assign to a parameter.
+The **Alias** attribute establishes an alternate name for the parameter.
+There's no limit to the number of aliases that you can assign to a parameter.
 
-The following example shows a parameter declaration that adds the "CN" and
-"MachineName" aliases to the mandatory `ComputerName` parameter.
+The following example shows a parameter declaration that adds the **CN** and
+**MachineName** aliases to the mandatory **ComputerName** parameter.
 
 ```powershell
 Param(
@@ -362,19 +366,19 @@ Param(
 )
 ```
 
-### Parameter and Variable Validation Attributes
+### Parameter and variable validation attributes
 
-Validation attributes direct PowerShell to test the parameter values that
-users submit when they call the advanced function. If the parameter values
-fail the test, an error is generated and the function is not called. You can
-also use some of the validation attributes to restrict the values that users
-can specify for variables.
+Validation attributes direct PowerShell to test the parameter values that users
+submit when they call the advanced function. If the parameter values fail the
+test, an error is generated and the function isn't called. You can also use
+some of the validation attributes to restrict the values that users can specify
+for variables.
 
-### AllowNull Validation Attribute
+### AllowNull validation attribute
 
-The `AllowNull` attribute allows the value of a **Mandatory** parameter to be
-`$null`. The following example declares a `ComputerName` parameter that can have
-a Null value.
+The **AllowNull** attribute allows the value of a mandatory parameter to be
+`$null`. The following example declares a **ComputerName** parameter that can
+have a **null** value.
 
 ```powershell
 Param(
@@ -385,10 +389,10 @@ Param(
 )
 ```
 
-### AllowEmptyString Validation Attribute
+### AllowEmptyString validation attribute
 
-The `AllowEmptyString` attribute allows the value of a **Mandatory** parameter
-to be an empty string (""). The following example declares a `ComputerName`
+The **AllowEmptyString** attribute allows the value of a mandatory parameter to
+be an empty string (`""`). The following example declares a **ComputerName**
 parameter that can have an empty string value.
 
 ```powershell
@@ -400,11 +404,11 @@ Param(
 )
 ```
 
-### AllowEmptyCollection Validation Attribute
+### AllowEmptyCollection validation attribute
 
-The `AllowEmptyCollection` attribute allows the value of a mandatory parameter
-to be an empty collection `@()`. The following example declares a `ComputerName`
-parameter that can have a empty collection value.
+The **AllowEmptyCollection** attribute allows the value of a mandatory
+parameter to be an empty collection `@()`. The following example declares a
+**ComputerName** parameter that can have an empty collection value.
 
 ```powershell
 Param(
@@ -415,14 +419,14 @@ Param(
 )
 ```
 
-### ValidateCount Validation Attribute
+### ValidateCount validation attribute
 
-The `ValidateCount` attribute specifies the minimum and maximum number of
-parameter values that a parameter accepts. PowerShell generates an error if
-the number of parameter values in the command that calls the function is
-outside that range.
+The **ValidateCount** attribute specifies the minimum and maximum number of
+parameter values that a parameter accepts. PowerShell generates an error if the
+number of parameter values in the command that calls the function is outside
+that range.
 
-The following parameter declaration creates a ComputerName parameter that
+The following parameter declaration creates a **ComputerName** parameter that
 takes one to five parameter values.
 
 ```powershell
@@ -434,12 +438,12 @@ Param(
 )
 ```
 
-### ValidateLength Validation Attribute
+### ValidateLength validation attribute
 
-The `ValidateLength` attribute specifies the minimum and maximum number of
+The **ValidateLength** attribute specifies the minimum and maximum number of
 characters in a parameter or variable value. PowerShell generates an error if
-the length of a value specified for a parameter or a variable is outside of
-the range.
+the length of a value specified for a parameter or a variable is outside of the
+range.
 
 In the following example, each computer name must have one to ten characters.
 
@@ -459,14 +463,14 @@ of one character in length, and a maximum of ten characters.
 [Int32][ValidateLength(1,10)]$number = 01
 ```
 
-### ValidatePattern Validation Attribute
+### ValidatePattern validation attribute
 
-The `ValidatePattern` attribute specifies a regular expression that is compared
-to the parameter or variable value. PowerShell generates an error if the value
-does not match the regular expression pattern.
+The **ValidatePattern** attribute specifies a regular expression that's
+compared to the parameter or variable value. PowerShell generates an error if
+the value doesn't match the regular expression pattern.
 
-In the following example, the parameter value must contain a four-digit number, and
-each digit must be a number zero to nine.
+In the following example, the parameter value must contain a four-digit number,
+and each digit must be a number zero to nine.
 
 ```powershell
 Param(
@@ -484,12 +488,12 @@ four-digit number, and each digit must be a number zero to nine.
 [Int32][ValidatePattern("^[0-9][0-9][0-9][0-9]$")]$number = 1111
 ```
 
-### ValidateRange Validation Attribute
+### ValidateRange validation attribute
 
-The `ValidateRange` attribute specifies a numeric range for each parameter or
+The **ValidateRange** attribute specifies a numeric range for each parameter or
 variable value. PowerShell generates an error if any value is outside that
-range. In the following example, the value of the `Attempts` parameter must be
-between zero and ten.
+range. In the following example, the value of the **Attempts** parameter must
+be between zero and ten.
 
 ```powershell
 Param(
@@ -507,18 +511,18 @@ zero and ten.
 [Int32][ValidateRange(0,10)]$number = 5
 ```
 
-### ValidateScript Validation Attribute
+### ValidateScript validation attribute
 
-The `ValidateScript` attribute specifies a script that is used to validate a
+The **ValidateScript** attribute specifies a script that is used to validate a
 parameter or variable value. PowerShell pipes the value to the script, and
 generates an error if the script returns `$false` or if the script throws an
 exception.
 
-When you use the `ValidateScript` attribute, the value that is being
-validated is mapped to the `$_` variable. You can use the `$_` variable to refer
-to the value in the script.
+When you use the **ValidateScript** attribute, the value that's being validated
+is mapped to the `$_` variable. You can use the `$_` variable to refer to the
+value in the script.
 
-In the following example, the value of the `EventDate` parameter must be
+In the following example, the value of the **EventDate** parameter must be
 greater than or equal to the current date.
 
 ```powershell
@@ -530,19 +534,19 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$date` must be greater than
-or equal to the current date and time.
+In the following example, the value of the variable `$date` must be greater
+than or equal to the current date and time.
 
 ```powershell
 [DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
 ```
 
-### ValidateSet Attribute
+### ValidateSet attribute
 
-The `ValidateSet` attribute specifies a set of valid values for a parameter or
-variable. PowerShell generates an error if a parameter or variable value does
-not match a value in the set. In the following example, the value of the
-`Detail` parameter can only be "Low," "Average," or "High."
+The **ValidateSet** attribute specifies a set of valid values for a parameter
+or variable. PowerShell generates an error if a parameter or variable value
+doesn't match a value in the set. In the following example, the value of the
+**Detail** parameter can only be Low, Average, or High.
 
 ```powershell
 Param(
@@ -554,15 +558,15 @@ Param(
 ```
 
 In the following example, the value of the variable `$flavor` must be either
-"Chocolate", "Strawberry", or "Vanilla".
+Chocolate, Strawberry, or Vanilla.
 
 ```powershell
 [ValidateSet("Chocolate", "Strawberry", "Vanilla")]
 [String]$flavor = "Strawberry"
 ```
 
-Note that the validation occurs whenever that variable is assigned even within
-the script. For example, the following results in an error at runtime:
+The validation occurs whenever that variable is assigned even within the
+script. For example, the following results in an error at runtime:
 
 ```powershell
 Param(
@@ -573,18 +577,18 @@ Param(
 $Message = "bye"
 ```
 
-### ValidateNotNull Validation Attribute
+### ValidateNotNull validation attribute
 
-The `ValidateNotNull` attribute specifies that the parameter value cannot be
+The **ValidateNotNull** attribute specifies that the parameter value can't be
 `$null`. PowerShell generates an error if the parameter value is `$null`.
 
-The `ValidateNotNull` attribute is designed to be used when the type of the
-parameter value is not specified or when the specified type accepts a
-value of `$null`. (If you specify a type that does not accept a `$null` value,
-such as a string, the `$null` value is rejected without the
-`ValidateNotNull` attribute, because it does not match the specified type.)
+The **ValidateNotNull** attribute is designed to be used when the type of the
+parameter value isn't specified or when the specified type accepts a value of
+`$null`. If you specify a type that doesn't accept a `$null` value, such as a
+string, the `$null` value is rejected without the **ValidateNotNull**
+attribute, because it doesn't match the specified type.
 
-In the following example, the value of the `ID` parameter cannot be `$null`.
+In the following example, the value of the **ID** parameter can't be `$null`.
 
 ```powershell
 Param(
@@ -594,12 +598,12 @@ Param(
 )
 ```
 
-### ValidateNotNullOrEmpty Validation Attribute
+### ValidateNotNullOrEmpty validation attribute
 
-The `ValidateNotNullOrEmpty` attribute specifies that the parameter value cannot
-be `$null` and cannot be an empty string `""`. PowerShell generates an
-error if the parameter is used in a function call, but its value is `$null`,
-an empty string `""`, or an empty array `@()`.
+The **ValidateNotNullOrEmpty** attribute specifies that the parameter value
+can't be `$null` and can't be an empty string (`""`). PowerShell generates an
+error if the parameter is used in a function call, but its value is `$null`, an
+empty string (`""`), or an empty array `@()`.
 
 ```powershell
 Param(
@@ -610,12 +614,12 @@ Param(
 )
 ```
 
-### ValidateDrive Validation Attribute
+### ValidateDrive validation attribute
 
-The ValidateDrive attribute specifies that the parameter value must represent
-the path, that is referring to allowed drives only. PowerShell generates
-an error if the parameter value refers to drives other than the allowed.
-Existence of the path, except for the drive itself, is not verified.
+The **ValidateDrive** attribute specifies that the parameter value must
+represent the path, that's referring to allowed drives only. PowerShell
+generates an error if the parameter value refers to drives other than the
+allowed. Existence of the path, except for the drive itself, isn't verified.
 
 If you use relative path, the current drive must be in the allowed drive list.
 
@@ -626,17 +630,17 @@ Param(
 )
 ```
 
-### ValidateUserDrive Validation Attribute
+### ValidateUserDrive validation attribute
 
-The ValidateUserDrive attribute specifies that the parameter value
-must represent the path, that is referring to `User` drive.
-PowerShell generates an error if the path refers to other drives.
-Existence of the path, except for the drive itself, is not verified.
+The **ValidateUserDrive** attribute specifies that the parameter value must
+represent the path, that is referring to `User` drive. PowerShell generates an
+error if the path refers to other drives. Existence of the path, except for the
+drive itself, isn't verified.
 
 If you use relative path, the current drive must be `User`.
 
-You can define `User` drive in Just Enough Administration (JEA)
-session configurations.
+You can define `User` drive in Just Enough Administration (JEA) session
+configurations.
 
 ```powershell
 Param(
@@ -645,24 +649,24 @@ Param(
 )
 ```
 
-## Dynamic Parameters
+## Dynamic parameters
 
 Dynamic parameters are parameters of a cmdlet, function, or script that are
 available only under certain conditions.
 
 For example, several provider cmdlets have parameters that are available only
 when the cmdlet is used in the provider drive, or in a particular path of the
-provider drive. For example, the `Encoding` parameter is available on the
-`Add-Content`, `Get-Content`, and `Set-Content` cmdlets only when it is used
-in a file system drive.
+provider drive. For example, the **Encoding** parameter is available on the
+`Add-Content`, `Get-Content`, and `Set-Content` cmdlets only when it's used in
+a file system drive.
 
 You can also create a parameter that appears only when another parameter is
 used in the function command or when another parameter has a certain value.
 
-Dynamic parameters can be very useful, but use them only when necessary,
-because they can be difficult for users to discover. To find a dynamic
-parameter, the user must be in the provider path, use the `ArgumentList`
-parameter of the `Get-Command` cmdlet, or use the Path parameter of `Get-Help`.
+Dynamic parameters can be useful, but use them only when necessary, because
+they can be difficult for users to discover. To find a dynamic parameter, the
+user must be in the provider path, use the **ArgumentList** parameter of the
+`Get-Command` cmdlet, or use the **Path** parameter of `Get-Help`.
 
 To create a dynamic parameter for a function or script, use the `DynamicParam`
 keyword.
@@ -671,24 +675,24 @@ The syntax is as follows:
 
 `DynamicParam {<statement-list>}`
 
-In the statement list, use an If statement to specify the conditions under
+In the statement list, use an `If` statement to specify the conditions under
 which the parameter is available in the function.
 
 Use the `New-Object` cmdlet to create a
-`System.Management.Automation.RuntimeDefinedParameter` object to represent the
-parameter and specify its name.
+**System.Management.Automation.RuntimeDefinedParameter** object to represent
+the parameter and specify its name.
 
-You can also use a `New-Object` command to create a
-`System.Management.Automation.ParameterAttribute` object to represent attributes
-of the parameter, such as `Mandatory`, `Position`, or `ValueFromPipeline` or its
-parameter set.
+You can use a `New-Object` command to create a
+**System.Management.Automation.ParameterAttribute** object to represent
+attributes of the parameter, such as **Mandatory**, **Position**, or
+**ValueFromPipeline** or its parameter set.
 
 The following example shows a sample function with standard parameters named
-**Name** and **Path**, and an optional dynamic parameter named **DP1**.
-The **DP1** parameter is in the PSet1 parameter set and has a type of `Int32`.
-The **DP1** parameter is available in the `Get-Sample` function
-only when the value of the **Path** parameter starts with "HKLM:",
-indicating that it is being used in the HKEY_LOCAL_MACHINE registry drive.
+**Name** and **Path**, and an optional dynamic parameter named **DP1**. The
+**DP1** parameter is in the `PSet1` parameter set and has a type of `Int32`.
+The **DP1** parameter is available in the `Get-Sample` function only when the
+value of the **Path** parameter starts with `HKLM:`, indicating that it's being
+used in the `HKEY_LOCAL_MACHINE` registry drive.
 
 ```powershell
 function Get-Sample {
@@ -720,19 +724,18 @@ function Get-Sample {
 }
 ```
 
-For more information, see "RuntimeDefinedParameter Class" in the MSDN
-(Microsoft Developer Network) library at
-[RuntimeDefinedParameter](/dotnet/api/system.management.automation.runtimedefinedparameter)
+For more information, see
+[RuntimeDefinedParameter](/dotnet/api/system.management.automation.runtimedefinedparameter).
 
-## Switch Parameters
+## Switch parameters
 
-Switch parameters are parameters with no parameter value. They are effective
-only when they are used and have only one effect.
+Switch parameters are parameters with no parameter value. They're effective
+only when they're used and have only one effect.
 
-For example, the `-NoProfile` parameter of PowerShell.exe is a switch
+For example, the **NoProfile** parameter of **powershell.exe** is a switch
 parameter.
 
-To create a switch parameter in a function, specify the Switch type in the
+To create a switch parameter in a function, specify the `Switch` type in the
 parameter definition.
 
 For example:
@@ -741,7 +744,7 @@ For example:
 Param([Switch]<ParameterName>)
 ```
 
--or-
+Or, you can use an another method:
 
 ```powershell
 Param(
@@ -764,20 +767,21 @@ To use a Boolean parameter, the user types the parameter and a Boolean value.
 `-IncludeAll:$true`
 
 When creating switch parameters, choose the parameter name carefully. Be sure
-that the parameter name communicates the effect of the parameter to the user,
-and avoid ambiguous terms, such as Filter or Maximum, that might imply that a
+that the parameter name communicates the effect of the parameter to the user.
+Avoid ambiguous terms, such as **Filter** or **Maximum** that might imply a
 value is required.
 
 ## ArgumentCompleter attribute
 
-The **ArgumentCompleter** attribute allows you to add tab completion values
-to a specific parameter. Like DynamicParameters, the available values are
-calculated at runtime when the user presses `<TAB>` after the parameter name.
+The **ArgumentCompleter** attribute allows you to add tab completion values to
+a specific parameter. Like **DynamicParameters**, the available values are
+calculated at runtime when the user presses <kbd>Tab</kbd> after the parameter
+name.
 
 To add an **ArgumentCompleter** attribute, you need to define a script block
 that will determine the values. The script block must take the following
-parameters in the order specified below. The parameter's names
-do not matter as the values are provided *positionally*.
+parameters in the order specified below. The parameter's names don't matter as
+the values are provided positionally.
 
 The syntax is as follows:
 
@@ -791,35 +795,35 @@ Param(
 )
 ```
 
-### The ArgumentCompleter script block
+### ArgumentCompleter script block
 
 The script block parameters are set to the following values:
 
 - `$commandName` (Position 0) - This parameter is set to the name of the
   command for which the script block is providing tab completion.
-- `$parameterName` (Position 1) - This parameter is set to the parameter
-  whose value requires tab completion.
+- `$parameterName` (Position 1) - This parameter is set to the parameter whose
+  value requires tab completion.
 - `$wordToComplete` (Position 2) - This parameter is set to value the user has
-  provided before they pressed `<TAB>`. Your script block should use this value
-  to determine tab completion values.
+  provided before they pressed <kbd>Tab</kbd>. Your script block should use
+  this value to determine tab completion values.
 - `$commandAst` (Position 3) - This parameter is set to the Abstract Syntax
-  Tree (AST) for the current input line. For more information, see
-  [Ast Class](/dotnet/api/system.management.automation.language.ast).
+  Tree (AST) for the current input line. For more information, see [Ast Class](/dotnet/api/system.management.automation.language.ast).
 - `$fakeBoundParameter` (Position 4) - This parameter is set to a hashtable
   containing the `$PSBoundParameters` for the cmdlet, before the user pressed
-  `<TAB>`. For more information, see [about_Automatic_Variables](about_Automatic_Variables.md).
+  <kbd>Tab</kbd>. For more information, see [about_Automatic_Variables](about_Automatic_Variables.md).
 
 The **ArgumentCompleter** script block must unroll the values using the
-pipeline (`ForEach-Object`, `Where-Object`, etc.), or another suitable method.
+pipeline, such as`ForEach-Object`, `Where-Object`, or another suitable method.
 Returning an array of values causes PowerShell to treat the entire array as
 **one** tab completion value.
 
-The following example adds tab completion to the `$Value` parameter.  If no
+The following example adds tab completion to the **Value** parameter. If no
 `$Type` is specified, fruits and vegetables are returned. If a `$Type` is
-specified, only values for the type are specified. In addition the `-like`
-operator ensures that if the user types
-`Test-ArgumentCompleter -Type Fruits -Value A<TAB>`, only **Apple** is
-returned.
+specified, only values for the type are specified. In addition, the `-like`
+operator ensures that if the user types the following command and uses
+<kbd>Tab</kbd> completion, only **Apple** is returned.
+
+`Test-ArgumentCompleter -Type Fruits -Value A`
 
 ```powershell
 function Test-ArgumentCompleter {
@@ -857,6 +861,8 @@ function Test-ArgumentCompleter {
 ```
 
 ## See also
+
+[about_Automatic_Variables](about_Automatic_Variables.md)
 
 [about_Functions](about_Functions.md)
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,10 +1,11 @@
 ---
-ms.date: 5/20/2019
+ms.date: 05/20/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Functions_Advanced_Parameters
 ---
+
 # About Functions Advanced Parameters
 
 ## Short description
@@ -17,26 +18,24 @@ You can add parameters to the advanced functions that you write, and use
 parameter attributes and arguments to limit the parameter values that function
 users submit with the parameter.
 
-The parameters that you add to your function are available to users in
-addition to the common parameters that PowerShell adds automatically to all
-cmdlets and advanced functions. For more information about the Windows
-PowerShell common parameters, see
-[about_CommonParameters](about_CommonParameters.md).
+The parameters that you add to your function are available to users in addition
+to the common parameters that PowerShell adds automatically to all cmdlets and
+advanced functions. For more information about the PowerShell common
+parameters, see [about_CommonParameters](about_CommonParameters.md).
 
-Beginning in PowerShell 3.0, you can use splatting with @Args to represent the
-parameters in a command. This technique is valid on simple and advanced
-functions. For more information, see [about_Functions](about_Functions.md) and
-[about_Splatting](about_Splatting.md).
+Beginning in PowerShell 3.0, you can use splatting with `@Args` to represent
+the parameters in a command. Splatting is valid on simple and advanced
+functions. For more information, see [about_Functions](about_Functions.md) and [about_Splatting](about_Splatting.md).
 
-## Static Parameters
+## Static parameters
 
 Static parameters are parameters that are always available in the function.
 Most parameters in PowerShell cmdlets and scripts are static parameters.
 
-The following example shows the declaration of a ComputerName parameter that
-has the following characteristics:
+The following example shows the declaration of a **ComputerName** parameter
+that has the following characteristics:
 
-- It is mandatory (required).
+- It's mandatory (required).
 - It takes input from the pipeline.
 - It takes an array of strings as input.
 
@@ -49,34 +48,34 @@ Param(
 )
 ```
 
-## Attributes of Parameters
+## Attributes of parameters
 
 This section describes the attributes that you can add to function parameters.
 
-All attributes are optional. However, if you omit the `CmdletBinding` attribute,
-then to be recognized as an advanced function, the function must include the
-Parameter attribute.
+All attributes are optional. However, if you omit the **CmdletBinding**
+attribute, then to be recognized as an advanced function, the function must
+include the **Parameter** attribute.
 
-You can add one or multiple attributes in each parameter declaration. There is
+You can add one or multiple attributes in each parameter declaration. There's
 no limit to the number of attributes that you can add to a parameter
 declaration.
 
-### The Parameter Attribute
+### Parameter attribute
 
-The `Parameter` attribute is used to declare the attributes of function
+The **Parameter** attribute is used to declare the attributes of function
 parameters.
 
-The `Parameter` attribute is optional, and you can omit it if none of the
-parameters of your functions need attributes, but to be recognized as an
-advanced function (rather than a simple function), a function must have either
-the `CmdletBinding` attribute or the `Parameter` attribute, or both.
+The **Parameter** attribute is optional, and you can omit it if none of the
+parameters of your functions need attributes. But, to be recognized as an
+advanced function, rather than a simple function, a function must have either
+the **CmdletBinding** attribute or the **Parameter** attribute, or both.
 
-The `Parameter` attribute has arguments that define the characteristics of the
-parameter, such as whether the parameter is mandatory or optional.
+The **Parameter** attribute has arguments that define the characteristics of
+the parameter, such as whether the parameter is mandatory or optional.
 
-Use the following syntax to declare the Parameter attribute, an argument, and
-an argument value. The parentheses that enclose the argument and its value
-must follow "`Parameter`" with no intervening space.
+Use the following syntax to declare the **Parameter** attribute, an argument,
+and an argument value. The parentheses that enclose the argument and its value
+must follow **Parameter** with no intervening space.
 
 ```powershell
 Param(
@@ -86,7 +85,7 @@ Param(
 ```
 
 Use commas to separate arguments within the parentheses. Use the following
-syntax to declare two arguments of the `Parameter` attribute.
+syntax to declare two arguments of the **Parameter** attribute.
 
 ```powershell
 Param(
@@ -95,9 +94,9 @@ Param(
 )
 ```
 
-If you use the `Parameter` attribute without arguments (as an alternative to
-using the `CmdletBinding` attribute), the parentheses that follow the attribute
-name are still required.
+If you use the **Parameter** attribute without arguments, as an alternative to
+using the **CmdletBinding** attribute, the parentheses that follow the
+attribute name are still required.
 
 ```powershell
 Param(
@@ -106,12 +105,12 @@ Param(
 )
 ```
 
-### Mandatory Argument
+### Mandatory argument
 
 The `Mandatory` argument indicates that the parameter is required. If this
-argument is not specified, the parameter is an optional parameter.
+argument isn't specified, the parameter is optional.
 
-The following example declares the `ComputerName` parameter. It uses the
+The following example declares the **ComputerName** parameter. It uses the
 `Mandatory` argument to make the parameter mandatory.
 
 ```powershell
@@ -122,37 +121,38 @@ Param(
 )
 ```
 
-### Position Argument
+### Position argument
 
 The `Position` argument determines whether the parameter name is required when
 the parameter is used in a command. When a parameter declaration includes the
-`Position` argument, the parameter name can be omitted and PowerShell identifies
-the unnamed parameter value by its position (or order) in the list of unnamed
-parameter values in the command.
+`Position` argument, the parameter name can be omitted and PowerShell
+identifies the unnamed parameter value by its position, or order, in the list
+of unnamed parameter values in the command.
 
-If the `Position` argument is not specified, the parameter name (or a parameter
-name alias or abbreviation) must precede the parameter value whenever the
+If the `Position` argument isn't specified, the parameter name, or a parameter
+name alias or abbreviation, must precede the parameter value whenever the
 parameter is used in a command.
 
 By default, all function parameters are positional. PowerShell assigns position
 numbers to parameters in the order in which the parameters are declared in the
 function. To disable this feature, set the value of the `PositionalBinding`
-argument of the `CmdletBinding` attribute to `$False`.The `Position` argument
-takes precedence over the value of the `PositionalBinding` argument for the
-parameters on which it is declared. For more information, see
-`PositionalBinding` in [about_Functions_CmdletBindingAttribute](about_Functions_CmdletBindingAttribute.md).
+argument of the **CmdletBinding** attribute to `$False`. The `Position`
+argument takes precedence over the value of the `PositionalBinding` argument
+for the parameters on which it's declared. For more information, see
+`PositionalBinding` in
+[about_Functions_CmdletBindingAttribute](about_Functions_CmdletBindingAttribute.md).
 
-The value of the Position argument is specified as an integer. A position
-value of **"0"** represents the first position in the command, a position value
-of **"1"** represents the second position in the command, and so on.
+The value of the `Position` argument is specified as an integer. A position
+value of **0** represents the first position in the command, a position value
+of **1** represents the second position in the command, and so on.
 
 If a function has no positional parameters, PowerShell assigns positions to
 each parameter based on the order in which the parameters are declared.
-However, as a best practice, do not rely on this assignment. When you want
-parameters to be positional, use the Position argument.
+However, as a best practice, don't rely on this assignment. When you want
+parameters to be positional, use the `Position` argument.
 
 The following example declares the **ComputerName** parameter. It uses the
-Position argument with a value of **"0"**. As a result, when `-ComputerName` is
+`Position` argument with a value of **0**. As a result, when `-ComputerName` is
 omitted from command, its value must be the first or only unnamed parameter
 value in the command.
 
@@ -165,23 +165,27 @@ Param(
 ```
 
 > [!NOTE]
-> When the Get-Help cmdlet displays the corresponding `Position`
-> parameter attribute, the position value is incremented by one.
+> When the `Get-Help` cmdlet displays the corresponding **Position** parameter
+> attribute, the position value is incremented by one.
 >
-> For example, a parameter with a Position argument value of **"0"**
-> has a parameter attribute of "`Position=1`"
+> For example, a parameter with a `Position` argument value of **0** has a
+> parameter attribute of **Position=1**.
 
-### ParameterSetName Argument
+### ParameterSetName argument
 
-The ParameterSetName argument specifies the parameter set to which a parameter
-belongs. If no parameter set is specified, the parameter belongs to all the
-parameter sets defined by the function. Therefore, to be unique, each
-parameter set must have at least one parameter that is not a member of any
-other parameter set.
+The `ParameterSetName` argument specifies the parameter set to which a
+parameter belongs. If no parameter set is specified, the parameter belongs to
+all the parameter sets defined by the function. Therefore, to be unique, each
+parameter set must have at least one parameter that isn't a member of any other
+parameter set.
 
-The following example declares a `ComputerName` parameter in the "Computer"
-parameter set, a `UserName` parameter in the "User" parameter set, and a
-`Summary` parameter in both parameter sets.
+> [!NOTE]
+> The parameters for a cmdlet or function can be included in a maximum of 32
+> parameter sets.
+
+The following example declares a **ComputerName** parameter in the `Computer`
+parameter set, a **UserName** parameter in the `User` parameter set, and a
+**Summary** parameter in both parameter sets.
 
 ```powershell
 Param(
@@ -201,14 +205,14 @@ Param(
 )
 ```
 
-You can specify only one `ParameterSetName` value in each argument and only
-one `ParameterSetName` argument in each `Parameter` attribute. To indicate
-that a parameter appears in more than one parameter set, add additional
-`Parameter` attributes.
+You can specify only one `ParameterSetName` value in each argument and only one
+`ParameterSetName` argument in each **Parameter** attribute. To indicate that a
+parameter appears in more than one parameter set, add additional **Parameter**
+attributes.
 
-The following example explicitly adds the `Summary` parameter to the Computer
-and User parameter sets. The `Summary` parameter is **Mandatory** in one
-parameter set and **Optional** in the other.
+The following example explicitly adds the **Summary** parameter to the
+`Computer` and `User` parameter sets. The **Summary** parameter is optional in
+the `Computer` parameter set and mandatory in the `User` parameter set.
 
 ```powershell
 Param(
@@ -229,17 +233,16 @@ Param(
 )
 ```
 
-For more information about parameter sets, see "Cmdlet Parameter Sets" in the
-MSDN library at [Cmdlet Parameter Sets](/powershell/developer/cmdlet/cmdlet-parameter-sets)
+For more information about parameter sets, see [Cmdlet Parameter Sets](/powershell/developer/cmdlet/cmdlet-parameter-sets).
 
-### ValueFromPipeline Argument
+### ValueFromPipeline argument
 
-The `ValueFromPipeline` argument indicates that the parameter accepts input from
-a pipeline object. Specify this argument if the function accepts the entire
-object, not just a property of the object.
+The `ValueFromPipeline` argument indicates that the parameter accepts input
+from a pipeline object. Specify this argument if the function accepts the
+entire object, not just a property of the object.
 
-The following example declares a `ComputerName` parameter that is mandatory
-and accepts an object that is passed to the function from the pipeline.
+The following example declares a **ComputerName** parameter that's mandatory
+and accepts an object that's passed to the function from the pipeline.
 
 ```powershell
 Param(
@@ -250,19 +253,19 @@ Param(
 )
 ```
 
-### ValueFromPipelineByPropertyName Argument
+### ValueFromPipelineByPropertyName argument
 
 The `ValueFromPipelineByPropertyName` argument indicates that the parameter
 accepts input from a property of a pipeline object. The object property must
 have the same name or alias as the parameter.
 
-For example, if the function has a `ComputerName` parameter, and the piped
-object has a `ComputerName` property, the value of the `ComputerName`
-property is assigned to the `ComputerName` parameter of the function.
+For example, if the function has a **ComputerName** parameter, and the piped
+object has a **ComputerName** property, the value of the **ComputerName**
+property is assigned to the function's **ComputerName** parameter.
 
-The following example declares a `ComputerName` parameter that is mandatory
-and accepts input from the `ComputerName` property of the object that is
-passed to the function through the pipeline.
+The following example declares a **ComputerName** parameter that's mandatory
+and accepts input from the object's **ComputerName** property that's passed to
+the function through the pipeline.
 
 ```powershell
 Param(
@@ -275,25 +278,26 @@ Param(
 
 > [!NOTE]
 > A typed parameter that accepts pipeline input (`by Value`) or
-> (`by PropertyName`) enables use of **delay-bind** script blocks on the parameter.
+> (`by PropertyName`) enables use of **delay-bind** script blocks on the
+> parameter.
 >
 > The **delay-bind** script block is run automatically during
 > **ParameterBinding**. The result is bound to the parameter. Delay binding
-> does **not** work for parameters defined as type `ScriptBlock` or
-> `System.Object`, the script block is passed through
-> **without** being invoked.
+> **does not** work for parameters defined as type `ScriptBlock` or
+> `System.Object`, the script block is passed through **without** being
+> invoked.
 >
-> You can read about **delay-bind** script blocks here [about_Script_Blocks.md](about_Script_Blocks.md)
+> You can read about **delay-bind** script blocks here [about_Script_Blocks.md](about_Script_Blocks.md).
 
-### ValueFromRemainingArguments Argument
+### ValueFromRemainingArguments argument
 
-The `ValueFromRemainingArguments` argument indicates that the parameter
-accepts all of the parameters values in the command that are not assigned to
-other parameters of the function.
+The `ValueFromRemainingArguments` argument indicates that the parameter accepts
+all the parameter's values in the command that aren't assigned to other
+parameters of the function.
 
-The following example declares a `$Value` parameter that is **Mandatory**
-and a `$Remaining` parameter which accepts all the remaining parameter values
-that are submitted to the function.
+The following example declares a **Value** parameter that's mandatory and a
+**Remaining** parameter that accepts all the remaining parameter values that
+are submitted to the function.
 
 ```powershell
 function Test-Remainder
@@ -321,35 +325,35 @@ Found 2 elements
 ```
 
 > [!NOTE]
-> Prior to PowerShell 6.2, the **ValueFromRemainingArguments** collection
-> was joined as single entity under index 0.
+> Prior to PowerShell 6.2, the **ValueFromRemainingArguments** collection was
+> joined as single entity under index **0**.
 
-### HelpMessage Argument
+### HelpMessage argument
 
-The `HelpMessage` argument specifies a string that contains a brief
-description of the parameter or its value. PowerShell displays this message in
-the prompt that appears when a mandatory parameter value is missing from a
-command. This argument has no effect on optional parameters.
+The `HelpMessage` argument specifies a string that contains a brief description
+of the parameter or its value. PowerShell displays this message in the prompt
+that appears when a mandatory parameter value is missing from a command. This
+argument has no effect on optional parameters.
 
-The following example declares a mandatory `ComputerName` parameter and a
+The following example declares a mandatory **ComputerName** parameter and a
 help message that explains the expected parameter value.
 
 ```powershell
 Param(
-    [Parameter(mandatory=$true,
+    [Parameter(Mandatory=$true,
     HelpMessage="Enter one or more computer names separated by commas.")]
     [String[]]
     $ComputerName
 )
 ```
 
-### Alias Attribute
+### Alias attribute
 
-The `Alias` attribute establishes an alternate name for the parameter. There is
-no limit to the number of aliases that you can assign to a parameter.
+The **Alias** attribute establishes an alternate name for the parameter.
+There's no limit to the number of aliases that you can assign to a parameter.
 
-The following example shows a parameter declaration that adds the "CN" and
-"MachineName" aliases to the mandatory `ComputerName` parameter.
+The following example shows a parameter declaration that adds the **CN** and
+**MachineName** aliases to the mandatory **ComputerName** parameter.
 
 ```powershell
 Param(
@@ -360,19 +364,19 @@ Param(
 )
 ```
 
-### Parameter and Variable Validation Attributes
+### Parameter and variable validation attributes
 
-Validation attributes direct PowerShell to test the parameter values that
-users submit when they call the advanced function. If the parameter values
-fail the test, an error is generated and the function is not called. You can
-also use some of the validation attributes to restrict the values that users
-can specify for variables.
+Validation attributes direct PowerShell to test the parameter values that users
+submit when they call the advanced function. If the parameter values fail the
+test, an error is generated and the function isn't called. You can also use
+some of the validation attributes to restrict the values that users can specify
+for variables.
 
-### AllowNull Validation Attribute
+### AllowNull validation attribute
 
-The `AllowNull` attribute allows the value of a **Mandatory** parameter to be
-`$null`. The following example declares a `ComputerName` parameter that can have
-a Null value.
+The **AllowNull** attribute allows the value of a mandatory parameter to be
+`$null`. The following example declares a **ComputerName** parameter that can
+have a **null** value.
 
 ```powershell
 Param(
@@ -383,10 +387,10 @@ Param(
 )
 ```
 
-### AllowEmptyString Validation Attribute
+### AllowEmptyString validation attribute
 
-The `AllowEmptyString` attribute allows the value of a **Mandatory** parameter
-to be an empty string (""). The following example declares a `ComputerName`
+The **AllowEmptyString** attribute allows the value of a mandatory parameter to
+be an empty string (`""`). The following example declares a **ComputerName**
 parameter that can have an empty string value.
 
 ```powershell
@@ -398,11 +402,11 @@ Param(
 )
 ```
 
-### AllowEmptyCollection Validation Attribute
+### AllowEmptyCollection validation attribute
 
-The `AllowEmptyCollection` attribute allows the value of a mandatory parameter
-to be an empty collection `@()`. The following example declares a `ComputerName`
-parameter that can have a empty collection value.
+The **AllowEmptyCollection** attribute allows the value of a mandatory
+parameter to be an empty collection `@()`. The following example declares a
+**ComputerName** parameter that can have an empty collection value.
 
 ```powershell
 Param(
@@ -413,14 +417,14 @@ Param(
 )
 ```
 
-### ValidateCount Validation Attribute
+### ValidateCount validation attribute
 
-The `ValidateCount` attribute specifies the minimum and maximum number of
-parameter values that a parameter accepts. PowerShell generates an error if
-the number of parameter values in the command that calls the function is
-outside that range.
+The **ValidateCount** attribute specifies the minimum and maximum number of
+parameter values that a parameter accepts. PowerShell generates an error if the
+number of parameter values in the command that calls the function is outside
+that range.
 
-The following parameter declaration creates a ComputerName parameter that
+The following parameter declaration creates a **ComputerName** parameter that
 takes one to five parameter values.
 
 ```powershell
@@ -432,12 +436,12 @@ Param(
 )
 ```
 
-### ValidateLength Validation Attribute
+### ValidateLength validation attribute
 
-The `ValidateLength` attribute specifies the minimum and maximum number of
+The **ValidateLength** attribute specifies the minimum and maximum number of
 characters in a parameter or variable value. PowerShell generates an error if
-the length of a value specified for a parameter or a variable is outside of
-the range.
+the length of a value specified for a parameter or a variable is outside of the
+range.
 
 In the following example, each computer name must have one to ten characters.
 
@@ -457,14 +461,14 @@ of one character in length, and a maximum of ten characters.
 [Int32][ValidateLength(1,10)]$number = 01
 ```
 
-### ValidatePattern Validation Attribute
+### ValidatePattern validation attribute
 
-The `ValidatePattern` attribute specifies a regular expression that is compared
-to the parameter or variable value. PowerShell generates an error if the value
-does not match the regular expression pattern.
+The **ValidatePattern** attribute specifies a regular expression that's
+compared to the parameter or variable value. PowerShell generates an error if
+the value doesn't match the regular expression pattern.
 
-In the following example, the parameter value must contain a four-digit number, and
-each digit must be a number zero to nine.
+In the following example, the parameter value must contain a four-digit number,
+and each digit must be a number zero to nine.
 
 ```powershell
 Param(
@@ -482,21 +486,21 @@ four-digit number, and each digit must be a number zero to nine.
 [Int32][ValidatePattern("^[0-9][0-9][0-9][0-9]$")]$number = 1111
 ```
 
-### ValidateRange Validation Attribute
+### ValidateRange validation attribute
 
-The `ValidateRange` attribute specifies a numeric range or a `ValidateRangeKind`
-enum value for each parameter or variable value. PowerShell generates an error
-if any value is outside that range.
+The **ValidateRange** attribute specifies a numeric range or a
+**ValidateRangeKind** enum value for each parameter or variable value.
+PowerShell generates an error if any value is outside that range.
 
-The `ValidateRangeKind` enum allows for the following values:
+The **ValidateRangeKind** enum allows for the following values:
 
-- `Positive` A number greater than zero
-- `Negative` A number less than zero
-- `NonPositive` A number less than or equal to zero
-- `NonNegative` A number greater than or equal to zero
+- **Positive** - A number greater than zero.
+- **Negative** - A number less than zero.
+- **NonPositive** - A number less than or equal to zero.
+- **NonNegative** - A number greater than or equal to zero.
 
-In the following example, the value of the
-`Attempts` parameter must be between zero and ten.
+In the following example, the value of the **Attempts** parameter must be
+between zero and ten.
 
 ```powershell
 Param(
@@ -514,25 +518,25 @@ zero and ten.
 [Int32][ValidateRange(0,10)]$number = 5
 ```
 
-In the following example, the value of the variable $number must be greater
+In the following example, the value of the variable `$number` must be greater
 than zero.
 
 ```powershell
 [Int32][ValidateRange("Positive")]$number = 1
 ```
 
-### ValidateScript Validation Attribute
+### ValidateScript validation attribute
 
-The `ValidateScript` attribute specifies a script that is used to validate a
+The **ValidateScript** attribute specifies a script that is used to validate a
 parameter or variable value. PowerShell pipes the value to the script, and
 generates an error if the script returns `$false` or if the script throws an
 exception.
 
-When you use the `ValidateScript` attribute, the value that is being
-validated is mapped to the `$_` variable. You can use the `$_` variable to refer
-to the value in the script.
+When you use the **ValidateScript** attribute, the value that's being validated
+is mapped to the `$_` variable. You can use the `$_` variable to refer to the
+value in the script.
 
-In the following example, the value of the `EventDate` parameter must be
+In the following example, the value of the **EventDate** parameter must be
 greater than or equal to the current date.
 
 ```powershell
@@ -544,19 +548,19 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$date` must be greater than
-or equal to the current date and time.
+In the following example, the value of the variable `$date` must be greater
+than or equal to the current date and time.
 
 ```powershell
 [DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
 ```
 
-### ValidateSet Attribute
+### ValidateSet attribute
 
-The `ValidateSet` attribute specifies a set of valid values for a parameter or
-variable. PowerShell generates an error if a parameter or variable value does
-not match a value in the set. In the following example, the value of the
-`Detail` parameter can only be "Low," "Average," or "High."
+The **ValidateSet** attribute specifies a set of valid values for a parameter
+or variable. PowerShell generates an error if a parameter or variable value
+doesn't match a value in the set. In the following example, the value of the
+**Detail** parameter can only be Low, Average, or High.
 
 ```powershell
 Param(
@@ -568,15 +572,15 @@ Param(
 ```
 
 In the following example, the value of the variable `$flavor` must be either
-"Chocolate", "Strawberry", or "Vanilla".
+Chocolate, Strawberry, or Vanilla.
 
 ```powershell
 [ValidateSet("Chocolate", "Strawberry", "Vanilla")]
 [String]$flavor = "Strawberry"
 ```
 
-Note that the validation occurs whenever that variable is assigned even within
-the script. For example, the following results in an error at runtime:
+The validation occurs whenever that variable is assigned even within the
+script. For example, the following results in an error at runtime:
 
 ```powershell
 Param(
@@ -587,12 +591,12 @@ Param(
 $Message = "bye"
 ```
 
-#### Dynamic ValidateSet Values
+#### Dynamic validateSet values
 
-You can use a `Class` to dynamically generate the values for `ValidateSet` at
-runtime. In the following example, the valid values for the variable `$Sound`
-are generated via a `Class` named `SoundNames` that checks three filesystem
-paths for available sound files:
+You can use a **Class** to dynamically generate the values for **ValidateSet**
+at runtime. In the following example, the valid values for the variable
+`$Sound` are generated via a **Class** named **SoundNames** that checks three
+filesystem paths for available sound files:
 
 ```powershell
 Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
@@ -609,7 +613,7 @@ Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
 }
 ```
 
-The `[SoundNames]` class is then implemented as a dynamic `ValidateSet` value
+The `[SoundNames]` class is then implemented as a dynamic **ValidateSet** value
 as follows:
 
 ```powershell
@@ -619,18 +623,18 @@ Param(
 )
 ```
 
-### ValidateNotNull Validation Attribute
+### ValidateNotNull validation attribute
 
-The `ValidateNotNull` attribute specifies that the parameter value cannot be
+The **ValidateNotNull** attribute specifies that the parameter value can't be
 `$null`. PowerShell generates an error if the parameter value is `$null`.
 
-The `ValidateNotNull` attribute is designed to be used when the type of the
-parameter value is not specified or when the specified type accepts a
-value of `$null`. (If you specify a type that does not accept a `$null` value,
-such as a string, the `$null` value is rejected without the
-`ValidateNotNull` attribute, because it does not match the specified type.)
+The **ValidateNotNull** attribute is designed to be used when the type of the
+parameter value isn't specified or when the specified type accepts a value of
+`$null`. If you specify a type that doesn't accept a `$null` value, such as a
+string, the `$null` value is rejected without the **ValidateNotNull**
+attribute, because it doesn't match the specified type.
 
-In the following example, the value of the `ID` parameter cannot be `$null`.
+In the following example, the value of the **ID** parameter can't be `$null`.
 
 ```powershell
 Param(
@@ -640,12 +644,12 @@ Param(
 )
 ```
 
-### ValidateNotNullOrEmpty Validation Attribute
+### ValidateNotNullOrEmpty validation attribute
 
-The `ValidateNotNullOrEmpty` attribute specifies that the parameter value cannot
-be `$null` and cannot be an empty string `""`. PowerShell generates an
-error if the parameter is used in a function call, but its value is `$null`,
-an empty string `""`, or an empty array `@()`.
+The **ValidateNotNullOrEmpty** attribute specifies that the parameter value
+can't be `$null` and can't be an empty string (`""`). PowerShell generates an
+error if the parameter is used in a function call, but its value is `$null`, an
+empty string (`""`), or an empty array `@()`.
 
 ```powershell
 Param(
@@ -656,12 +660,12 @@ Param(
 )
 ```
 
-### ValidateDrive Validation Attribute
+### ValidateDrive validation attribute
 
-The ValidateDrive attribute specifies that the parameter value must represent
-the path, that is referring to allowed drives only. PowerShell generates
-an error if the parameter value refers to drives other than the allowed.
-Existence of the path, except for the drive itself, is not verified.
+The **ValidateDrive** attribute specifies that the parameter value must
+represent the path, that's referring to allowed drives only. PowerShell
+generates an error if the parameter value refers to drives other than the
+allowed. Existence of the path, except for the drive itself, isn't verified.
 
 If you use relative path, the current drive must be in the allowed drive list.
 
@@ -672,17 +676,17 @@ Param(
 )
 ```
 
-### ValidateUserDrive Validation Attribute
+### ValidateUserDrive validation attribute
 
-The ValidateUserDrive attribute specifies that the parameter value
-must represent the path, that is referring to `User` drive.
-PowerShell generates an error if the path refers to other drives.
-Existence of the path, except for the drive itself, is not verified.
+The **ValidateUserDrive** attribute specifies that the parameter value must
+represent the path, that is referring to `User` drive. PowerShell generates an
+error if the path refers to other drives. Existence of the path, except for the
+drive itself, isn't verified.
 
 If you use relative path, the current drive must be `User`.
 
-You can define `User` drive in Just Enough Administration (JEA)
-session configurations.
+You can define `User` drive in Just Enough Administration (JEA) session
+configurations.
 
 ```powershell
 Param(
@@ -691,24 +695,24 @@ Param(
 )
 ```
 
-## Dynamic Parameters
+## Dynamic parameters
 
 Dynamic parameters are parameters of a cmdlet, function, or script that are
 available only under certain conditions.
 
 For example, several provider cmdlets have parameters that are available only
 when the cmdlet is used in the provider drive, or in a particular path of the
-provider drive. For example, the `Encoding` parameter is available on the
-`Add-Content`, `Get-Content`, and `Set-Content` cmdlets only when it is used
-in a file system drive.
+provider drive. For example, the **Encoding** parameter is available on the
+`Add-Content`, `Get-Content`, and `Set-Content` cmdlets only when it's used in
+a file system drive.
 
 You can also create a parameter that appears only when another parameter is
 used in the function command or when another parameter has a certain value.
 
-Dynamic parameters can be very useful, but use them only when necessary,
-because they can be difficult for users to discover. To find a dynamic
-parameter, the user must be in the provider path, use the `ArgumentList`
-parameter of the `Get-Command` cmdlet, or use the Path parameter of `Get-Help`.
+Dynamic parameters can be useful, but use them only when necessary, because
+they can be difficult for users to discover. To find a dynamic parameter, the
+user must be in the provider path, use the **ArgumentList** parameter of the
+`Get-Command` cmdlet, or use the **Path** parameter of `Get-Help`.
 
 To create a dynamic parameter for a function or script, use the `DynamicParam`
 keyword.
@@ -717,24 +721,24 @@ The syntax is as follows:
 
 `DynamicParam {<statement-list>}`
 
-In the statement list, use an If statement to specify the conditions under
+In the statement list, use an `If` statement to specify the conditions under
 which the parameter is available in the function.
 
 Use the `New-Object` cmdlet to create a
-`System.Management.Automation.RuntimeDefinedParameter` object to represent the
-parameter and specify its name.
+**System.Management.Automation.RuntimeDefinedParameter** object to represent
+the parameter and specify its name.
 
-You can also use a `New-Object` command to create a
-`System.Management.Automation.ParameterAttribute` object to represent attributes
-of the parameter, such as `Mandatory`, `Position`, or `ValueFromPipeline` or its
-parameter set.
+You can use a `New-Object` command to create a
+**System.Management.Automation.ParameterAttribute** object to represent
+attributes of the parameter, such as **Mandatory**, **Position**, or
+**ValueFromPipeline** or its parameter set.
 
 The following example shows a sample function with standard parameters named
-**Name** and **Path**, and an optional dynamic parameter named **DP1**.
-The **DP1** parameter is in the PSet1 parameter set and has a type of `Int32`.
-The **DP1** parameter is available in the `Get-Sample` function
-only when the value of the **Path** parameter starts with "HKLM:",
-indicating that it is being used in the HKEY_LOCAL_MACHINE registry drive.
+**Name** and **Path**, and an optional dynamic parameter named **DP1**. The
+**DP1** parameter is in the `PSet1` parameter set and has a type of `Int32`.
+The **DP1** parameter is available in the `Get-Sample` function only when the
+value of the **Path** parameter starts with `HKLM:`, indicating that it's being
+used in the `HKEY_LOCAL_MACHINE` registry drive.
 
 ```powershell
 function Get-Sample {
@@ -766,19 +770,18 @@ function Get-Sample {
 }
 ```
 
-For more information, see "RuntimeDefinedParameter Class" in the MSDN
-(Microsoft Developer Network) library at
-[RuntimeDefinedParameter](/dotnet/api/system.management.automation.runtimedefinedparameter)
+For more information, see
+[RuntimeDefinedParameter](/dotnet/api/system.management.automation.runtimedefinedparameter).
 
-## Switch Parameters
+## Switch parameters
 
-Switch parameters are parameters with no parameter value. They are effective
-only when they are used and have only one effect.
+Switch parameters are parameters with no parameter value. They're effective
+only when they're used and have only one effect.
 
-For example, the `-NoProfile` parameter of PowerShell.exe is a switch
+For example, the **NoProfile** parameter of **powershell.exe** is a switch
 parameter.
 
-To create a switch parameter in a function, specify the Switch type in the
+To create a switch parameter in a function, specify the `Switch` type in the
 parameter definition.
 
 For example:
@@ -787,7 +790,7 @@ For example:
 Param([Switch]<ParameterName>)
 ```
 
--or-
+Or, you can use an another method:
 
 ```powershell
 Param(
@@ -810,20 +813,21 @@ To use a Boolean parameter, the user types the parameter and a Boolean value.
 `-IncludeAll:$true`
 
 When creating switch parameters, choose the parameter name carefully. Be sure
-that the parameter name communicates the effect of the parameter to the user,
-and avoid ambiguous terms, such as Filter or Maximum, that might imply that a
+that the parameter name communicates the effect of the parameter to the user.
+Avoid ambiguous terms, such as **Filter** or **Maximum** that might imply a
 value is required.
 
 ## ArgumentCompleter attribute
 
-The **ArgumentCompleter** attribute allows you to add tab completion values
-to a specific parameter. Like DynamicParameters, the available values are
-calculated at runtime when the user presses `<TAB>` after the parameter name.
+The **ArgumentCompleter** attribute allows you to add tab completion values to
+a specific parameter. Like **DynamicParameters**, the available values are
+calculated at runtime when the user presses <kbd>Tab</kbd> after the parameter
+name.
 
 To add an **ArgumentCompleter** attribute, you need to define a script block
 that will determine the values. The script block must take the following
-parameters in the order specified below. The parameter's names
-do not matter as the values are provided *positionally*.
+parameters in the order specified below. The parameter's names don't matter as
+the values are provided positionally.
 
 The syntax is as follows:
 
@@ -837,35 +841,35 @@ Param(
 )
 ```
 
-### The ArgumentCompleter script block
+### ArgumentCompleter script block
 
 The script block parameters are set to the following values:
 
 - `$commandName` (Position 0) - This parameter is set to the name of the
   command for which the script block is providing tab completion.
-- `$parameterName` (Position 1) - This parameter is set to the parameter
-  whose value requires tab completion.
+- `$parameterName` (Position 1) - This parameter is set to the parameter whose
+  value requires tab completion.
 - `$wordToComplete` (Position 2) - This parameter is set to value the user has
-  provided before they pressed `<TAB>`. Your script block should use this value
-  to determine tab completion values.
+  provided before they pressed <kbd>Tab</kbd>. Your script block should use
+  this value to determine tab completion values.
 - `$commandAst` (Position 3) - This parameter is set to the Abstract Syntax
-  Tree (AST) for the current input line. For more information, see
-  [Ast Class](/dotnet/api/system.management.automation.language.ast).
+  Tree (AST) for the current input line. For more information, see [Ast Class](/dotnet/api/system.management.automation.language.ast).
 - `$fakeBoundParameter` (Position 4) - This parameter is set to a hashtable
   containing the `$PSBoundParameters` for the cmdlet, before the user pressed
-  `<TAB>`. For more information, see [about_Automatic_Variables](about_Automatic_Variables.md).
+  <kbd>Tab</kbd>. For more information, see [about_Automatic_Variables](about_Automatic_Variables.md).
 
 The **ArgumentCompleter** script block must unroll the values using the
-pipeline (`ForEach-Object`, `Where-Object`, etc.), or another suitable method.
+pipeline, such as`ForEach-Object`, `Where-Object`, or another suitable method.
 Returning an array of values causes PowerShell to treat the entire array as
 **one** tab completion value.
 
-The following example adds tab completion to the `$Value` parameter.  If no
+The following example adds tab completion to the **Value** parameter. If no
 `$Type` is specified, fruits and vegetables are returned. If a `$Type` is
-specified, only values for the type are specified. In addition the `-like`
-operator ensures that if the user types
-`Test-ArgumentCompleter -Type Fruits -Value A<TAB>`, only **Apple** is
-returned.
+specified, only values for the type are specified. In addition, the `-like`
+operator ensures that if the user types the following command and uses
+<kbd>Tab</kbd> completion, only **Apple** is returned.
+
+`Test-ArgumentCompleter -Type Fruits -Value A`
 
 ```powershell
 function Test-ArgumentCompleter {
@@ -903,6 +907,8 @@ function Test-ArgumentCompleter {
 ```
 
 ## See also
+
+[about_Automatic_Variables](about_Automatic_Variables.md)
 
 [about_Functions](about_Functions.md)
 

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,10 +1,11 @@
 ---
-ms.date: 5/20/2019
+ms.date: 05/20/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Functions_Advanced_Parameters
 ---
+
 # About Functions Advanced Parameters
 
 ## Short description
@@ -17,26 +18,24 @@ You can add parameters to the advanced functions that you write, and use
 parameter attributes and arguments to limit the parameter values that function
 users submit with the parameter.
 
-The parameters that you add to your function are available to users in
-addition to the common parameters that PowerShell adds automatically to all
-cmdlets and advanced functions. For more information about the Windows
-PowerShell common parameters, see
-[about_CommonParameters](about_CommonParameters.md).
+The parameters that you add to your function are available to users in addition
+to the common parameters that PowerShell adds automatically to all cmdlets and
+advanced functions. For more information about the PowerShell common
+parameters, see [about_CommonParameters](about_CommonParameters.md).
 
-Beginning in PowerShell 3.0, you can use splatting with @Args to represent the
-parameters in a command. This technique is valid on simple and advanced
-functions. For more information, see [about_Functions](about_Functions.md) and
-[about_Splatting](about_Splatting.md).
+Beginning in PowerShell 3.0, you can use splatting with `@Args` to represent
+the parameters in a command. Splatting is valid on simple and advanced
+functions. For more information, see [about_Functions](about_Functions.md) and [about_Splatting](about_Splatting.md).
 
-## Static Parameters
+## Static parameters
 
 Static parameters are parameters that are always available in the function.
 Most parameters in PowerShell cmdlets and scripts are static parameters.
 
-The following example shows the declaration of a ComputerName parameter that
-has the following characteristics:
+The following example shows the declaration of a **ComputerName** parameter
+that has the following characteristics:
 
-- It is mandatory (required).
+- It's mandatory (required).
 - It takes input from the pipeline.
 - It takes an array of strings as input.
 
@@ -49,34 +48,34 @@ Param(
 )
 ```
 
-## Attributes of Parameters
+## Attributes of parameters
 
 This section describes the attributes that you can add to function parameters.
 
-All attributes are optional. However, if you omit the `CmdletBinding` attribute,
-then to be recognized as an advanced function, the function must include the
-Parameter attribute.
+All attributes are optional. However, if you omit the **CmdletBinding**
+attribute, then to be recognized as an advanced function, the function must
+include the **Parameter** attribute.
 
-You can add one or multiple attributes in each parameter declaration. There is
+You can add one or multiple attributes in each parameter declaration. There's
 no limit to the number of attributes that you can add to a parameter
 declaration.
 
-### The Parameter Attribute
+### Parameter attribute
 
-The `Parameter` attribute is used to declare the attributes of function
+The **Parameter** attribute is used to declare the attributes of function
 parameters.
 
-The `Parameter` attribute is optional, and you can omit it if none of the
-parameters of your functions need attributes, but to be recognized as an
-advanced function (rather than a simple function), a function must have either
-the `CmdletBinding` attribute or the `Parameter` attribute, or both.
+The **Parameter** attribute is optional, and you can omit it if none of the
+parameters of your functions need attributes. But, to be recognized as an
+advanced function, rather than a simple function, a function must have either
+the **CmdletBinding** attribute or the **Parameter** attribute, or both.
 
-The `Parameter` attribute has arguments that define the characteristics of the
-parameter, such as whether the parameter is mandatory or optional.
+The **Parameter** attribute has arguments that define the characteristics of
+the parameter, such as whether the parameter is mandatory or optional.
 
-Use the following syntax to declare the Parameter attribute, an argument, and
-an argument value. The parentheses that enclose the argument and its value
-must follow "`Parameter`" with no intervening space.
+Use the following syntax to declare the **Parameter** attribute, an argument,
+and an argument value. The parentheses that enclose the argument and its value
+must follow **Parameter** with no intervening space.
 
 ```powershell
 Param(
@@ -86,7 +85,7 @@ Param(
 ```
 
 Use commas to separate arguments within the parentheses. Use the following
-syntax to declare two arguments of the `Parameter` attribute.
+syntax to declare two arguments of the **Parameter** attribute.
 
 ```powershell
 Param(
@@ -95,9 +94,9 @@ Param(
 )
 ```
 
-If you use the `Parameter` attribute without arguments (as an alternative to
-using the `CmdletBinding` attribute), the parentheses that follow the attribute
-name are still required.
+If you use the **Parameter** attribute without arguments, as an alternative to
+using the **CmdletBinding** attribute, the parentheses that follow the
+attribute name are still required.
 
 ```powershell
 Param(
@@ -106,12 +105,12 @@ Param(
 )
 ```
 
-### Mandatory Argument
+### Mandatory argument
 
 The `Mandatory` argument indicates that the parameter is required. If this
-argument is not specified, the parameter is an optional parameter.
+argument isn't specified, the parameter is optional.
 
-The following example declares the `ComputerName` parameter. It uses the
+The following example declares the **ComputerName** parameter. It uses the
 `Mandatory` argument to make the parameter mandatory.
 
 ```powershell
@@ -122,37 +121,38 @@ Param(
 )
 ```
 
-### Position Argument
+### Position argument
 
 The `Position` argument determines whether the parameter name is required when
 the parameter is used in a command. When a parameter declaration includes the
-`Position` argument, the parameter name can be omitted and PowerShell identifies
-the unnamed parameter value by its position (or order) in the list of unnamed
-parameter values in the command.
+`Position` argument, the parameter name can be omitted and PowerShell
+identifies the unnamed parameter value by its position, or order, in the list
+of unnamed parameter values in the command.
 
-If the `Position` argument is not specified, the parameter name (or a parameter
-name alias or abbreviation) must precede the parameter value whenever the
+If the `Position` argument isn't specified, the parameter name, or a parameter
+name alias or abbreviation, must precede the parameter value whenever the
 parameter is used in a command.
 
 By default, all function parameters are positional. PowerShell assigns position
 numbers to parameters in the order in which the parameters are declared in the
 function. To disable this feature, set the value of the `PositionalBinding`
-argument of the `CmdletBinding` attribute to `$False`.The `Position` argument
-takes precedence over the value of the `PositionalBinding` argument for the
-parameters on which it is declared. For more information, see
-`PositionalBinding` in [about_Functions_CmdletBindingAttribute](about_Functions_CmdletBindingAttribute.md).
+argument of the **CmdletBinding** attribute to `$False`. The `Position`
+argument takes precedence over the value of the `PositionalBinding` argument
+for the parameters on which it's declared. For more information, see
+`PositionalBinding` in
+[about_Functions_CmdletBindingAttribute](about_Functions_CmdletBindingAttribute.md).
 
-The value of the Position argument is specified as an integer. A position
-value of **"0"** represents the first position in the command, a position value
-of **"1"** represents the second position in the command, and so on.
+The value of the `Position` argument is specified as an integer. A position
+value of **0** represents the first position in the command, a position value
+of **1** represents the second position in the command, and so on.
 
 If a function has no positional parameters, PowerShell assigns positions to
 each parameter based on the order in which the parameters are declared.
-However, as a best practice, do not rely on this assignment. When you want
-parameters to be positional, use the Position argument.
+However, as a best practice, don't rely on this assignment. When you want
+parameters to be positional, use the `Position` argument.
 
 The following example declares the **ComputerName** parameter. It uses the
-Position argument with a value of **"0"**. As a result, when `-ComputerName` is
+`Position` argument with a value of **0**. As a result, when `-ComputerName` is
 omitted from command, its value must be the first or only unnamed parameter
 value in the command.
 
@@ -165,23 +165,27 @@ Param(
 ```
 
 > [!NOTE]
-> When the Get-Help cmdlet displays the corresponding `Position`
-> parameter attribute, the position value is incremented by one.
+> When the `Get-Help` cmdlet displays the corresponding **Position** parameter
+> attribute, the position value is incremented by one.
 >
-> For example, a parameter with a Position argument value of **"0"**
-> has a parameter attribute of "`Position=1`"
+> For example, a parameter with a `Position` argument value of **0** has a
+> parameter attribute of **Position=1**.
 
-### ParameterSetName Argument
+### ParameterSetName argument
 
-The ParameterSetName argument specifies the parameter set to which a parameter
-belongs. If no parameter set is specified, the parameter belongs to all the
-parameter sets defined by the function. Therefore, to be unique, each
-parameter set must have at least one parameter that is not a member of any
-other parameter set.
+The `ParameterSetName` argument specifies the parameter set to which a
+parameter belongs. If no parameter set is specified, the parameter belongs to
+all the parameter sets defined by the function. Therefore, to be unique, each
+parameter set must have at least one parameter that isn't a member of any other
+parameter set.
 
-The following example declares a `ComputerName` parameter in the "Computer"
-parameter set, a `UserName` parameter in the "User" parameter set, and a
-`Summary` parameter in both parameter sets.
+> [!NOTE]
+> The parameters for a cmdlet or function can be included in a maximum of 32
+> parameter sets.
+
+The following example declares a **ComputerName** parameter in the `Computer`
+parameter set, a **UserName** parameter in the `User` parameter set, and a
+**Summary** parameter in both parameter sets.
 
 ```powershell
 Param(
@@ -201,14 +205,14 @@ Param(
 )
 ```
 
-You can specify only one `ParameterSetName` value in each argument and only
-one `ParameterSetName` argument in each `Parameter` attribute. To indicate
-that a parameter appears in more than one parameter set, add additional
-`Parameter` attributes.
+You can specify only one `ParameterSetName` value in each argument and only one
+`ParameterSetName` argument in each **Parameter** attribute. To indicate that a
+parameter appears in more than one parameter set, add additional **Parameter**
+attributes.
 
-The following example explicitly adds the `Summary` parameter to the Computer
-and User parameter sets. The `Summary` parameter is **Mandatory** in one
-parameter set and **Optional** in the other.
+The following example explicitly adds the **Summary** parameter to the
+`Computer` and `User` parameter sets. The **Summary** parameter is optional in
+the `Computer` parameter set and mandatory in the `User` parameter set.
 
 ```powershell
 Param(
@@ -229,17 +233,16 @@ Param(
 )
 ```
 
-For more information about parameter sets, see "Cmdlet Parameter Sets" in the
-MSDN library at [Cmdlet Parameter Sets](/powershell/developer/cmdlet/cmdlet-parameter-sets)
+For more information about parameter sets, see [Cmdlet Parameter Sets](/powershell/developer/cmdlet/cmdlet-parameter-sets).
 
-### ValueFromPipeline Argument
+### ValueFromPipeline argument
 
-The `ValueFromPipeline` argument indicates that the parameter accepts input from
-a pipeline object. Specify this argument if the function accepts the entire
-object, not just a property of the object.
+The `ValueFromPipeline` argument indicates that the parameter accepts input
+from a pipeline object. Specify this argument if the function accepts the
+entire object, not just a property of the object.
 
-The following example declares a `ComputerName` parameter that is mandatory
-and accepts an object that is passed to the function from the pipeline.
+The following example declares a **ComputerName** parameter that's mandatory
+and accepts an object that's passed to the function from the pipeline.
 
 ```powershell
 Param(
@@ -250,19 +253,19 @@ Param(
 )
 ```
 
-### ValueFromPipelineByPropertyName Argument
+### ValueFromPipelineByPropertyName argument
 
 The `ValueFromPipelineByPropertyName` argument indicates that the parameter
 accepts input from a property of a pipeline object. The object property must
 have the same name or alias as the parameter.
 
-For example, if the function has a `ComputerName` parameter, and the piped
-object has a `ComputerName` property, the value of the `ComputerName`
-property is assigned to the `ComputerName` parameter of the function.
+For example, if the function has a **ComputerName** parameter, and the piped
+object has a **ComputerName** property, the value of the **ComputerName**
+property is assigned to the function's **ComputerName** parameter.
 
-The following example declares a `ComputerName` parameter that is mandatory
-and accepts input from the `ComputerName` property of the object that is
-passed to the function through the pipeline.
+The following example declares a **ComputerName** parameter that's mandatory
+and accepts input from the object's **ComputerName** property that's passed to
+the function through the pipeline.
 
 ```powershell
 Param(
@@ -275,25 +278,26 @@ Param(
 
 > [!NOTE]
 > A typed parameter that accepts pipeline input (`by Value`) or
-> (`by PropertyName`) enables use of **delay-bind** script blocks on the parameter.
+> (`by PropertyName`) enables use of **delay-bind** script blocks on the
+> parameter.
 >
 > The **delay-bind** script block is run automatically during
 > **ParameterBinding**. The result is bound to the parameter. Delay binding
-> does **not** work for parameters defined as type `ScriptBlock` or
-> `System.Object`, the script block is passed through
-> **without** being invoked.
+> **does not** work for parameters defined as type `ScriptBlock` or
+> `System.Object`, the script block is passed through **without** being
+> invoked.
 >
-> You can read about **delay-bind** script blocks here [about_Script_Blocks.md](about_Script_Blocks.md)
+> You can read about **delay-bind** script blocks here [about_Script_Blocks.md](about_Script_Blocks.md).
 
-### ValueFromRemainingArguments Argument
+### ValueFromRemainingArguments argument
 
-The `ValueFromRemainingArguments` argument indicates that the parameter
-accepts all of the parameters values in the command that are not assigned to
-other parameters of the function.
+The `ValueFromRemainingArguments` argument indicates that the parameter accepts
+all the parameter's values in the command that aren't assigned to other
+parameters of the function.
 
-The following example declares a `$Value` parameter that is **Mandatory**
-and a `$Remaining` parameter which accepts all the remaining parameter values
-that are submitted to the function.
+The following example declares a **Value** parameter that's mandatory and a
+**Remaining** parameter that accepts all the remaining parameter values that
+are submitted to the function.
 
 ```powershell
 function Test-Remainder
@@ -321,35 +325,35 @@ Found 2 elements
 ```
 
 > [!NOTE]
-> Prior to PowerShell 6.2, the **ValueFromRemainingArguments** collection
-> was joined as single entity under index 0.
+> Prior to PowerShell 6.2, the **ValueFromRemainingArguments** collection was
+> joined as single entity under index **0**.
 
-### HelpMessage Argument
+### HelpMessage argument
 
-The `HelpMessage` argument specifies a string that contains a brief
-description of the parameter or its value. PowerShell displays this message in
-the prompt that appears when a mandatory parameter value is missing from a
-command. This argument has no effect on optional parameters.
+The `HelpMessage` argument specifies a string that contains a brief description
+of the parameter or its value. PowerShell displays this message in the prompt
+that appears when a mandatory parameter value is missing from a command. This
+argument has no effect on optional parameters.
 
-The following example declares a mandatory `ComputerName` parameter and a
+The following example declares a mandatory **ComputerName** parameter and a
 help message that explains the expected parameter value.
 
 ```powershell
 Param(
-    [Parameter(mandatory=$true,
+    [Parameter(Mandatory=$true,
     HelpMessage="Enter one or more computer names separated by commas.")]
     [String[]]
     $ComputerName
 )
 ```
 
-### Alias Attribute
+### Alias attribute
 
-The `Alias` attribute establishes an alternate name for the parameter. There is
-no limit to the number of aliases that you can assign to a parameter.
+The **Alias** attribute establishes an alternate name for the parameter.
+There's no limit to the number of aliases that you can assign to a parameter.
 
-The following example shows a parameter declaration that adds the "CN" and
-"MachineName" aliases to the mandatory `ComputerName` parameter.
+The following example shows a parameter declaration that adds the **CN** and
+**MachineName** aliases to the mandatory **ComputerName** parameter.
 
 ```powershell
 Param(
@@ -360,19 +364,19 @@ Param(
 )
 ```
 
-### Parameter and Variable Validation Attributes
+### Parameter and variable validation attributes
 
-Validation attributes direct PowerShell to test the parameter values that
-users submit when they call the advanced function. If the parameter values
-fail the test, an error is generated and the function is not called. You can
-also use some of the validation attributes to restrict the values that users
-can specify for variables.
+Validation attributes direct PowerShell to test the parameter values that users
+submit when they call the advanced function. If the parameter values fail the
+test, an error is generated and the function isn't called. You can also use
+some of the validation attributes to restrict the values that users can specify
+for variables.
 
-### AllowNull Validation Attribute
+### AllowNull validation attribute
 
-The `AllowNull` attribute allows the value of a **Mandatory** parameter to be
-`$null`. The following example declares a `ComputerName` parameter that can have
-a Null value.
+The **AllowNull** attribute allows the value of a mandatory parameter to be
+`$null`. The following example declares a **ComputerName** parameter that can
+have a **null** value.
 
 ```powershell
 Param(
@@ -383,10 +387,10 @@ Param(
 )
 ```
 
-### AllowEmptyString Validation Attribute
+### AllowEmptyString validation attribute
 
-The `AllowEmptyString` attribute allows the value of a **Mandatory** parameter
-to be an empty string (""). The following example declares a `ComputerName`
+The **AllowEmptyString** attribute allows the value of a mandatory parameter to
+be an empty string (`""`). The following example declares a **ComputerName**
 parameter that can have an empty string value.
 
 ```powershell
@@ -398,11 +402,11 @@ Param(
 )
 ```
 
-### AllowEmptyCollection Validation Attribute
+### AllowEmptyCollection validation attribute
 
-The `AllowEmptyCollection` attribute allows the value of a mandatory parameter
-to be an empty collection `@()`. The following example declares a `ComputerName`
-parameter that can have a empty collection value.
+The **AllowEmptyCollection** attribute allows the value of a mandatory
+parameter to be an empty collection `@()`. The following example declares a
+**ComputerName** parameter that can have an empty collection value.
 
 ```powershell
 Param(
@@ -413,14 +417,14 @@ Param(
 )
 ```
 
-### ValidateCount Validation Attribute
+### ValidateCount validation attribute
 
-The `ValidateCount` attribute specifies the minimum and maximum number of
-parameter values that a parameter accepts. PowerShell generates an error if
-the number of parameter values in the command that calls the function is
-outside that range.
+The **ValidateCount** attribute specifies the minimum and maximum number of
+parameter values that a parameter accepts. PowerShell generates an error if the
+number of parameter values in the command that calls the function is outside
+that range.
 
-The following parameter declaration creates a ComputerName parameter that
+The following parameter declaration creates a **ComputerName** parameter that
 takes one to five parameter values.
 
 ```powershell
@@ -432,12 +436,12 @@ Param(
 )
 ```
 
-### ValidateLength Validation Attribute
+### ValidateLength validation attribute
 
-The `ValidateLength` attribute specifies the minimum and maximum number of
+The **ValidateLength** attribute specifies the minimum and maximum number of
 characters in a parameter or variable value. PowerShell generates an error if
-the length of a value specified for a parameter or a variable is outside of
-the range.
+the length of a value specified for a parameter or a variable is outside of the
+range.
 
 In the following example, each computer name must have one to ten characters.
 
@@ -457,14 +461,14 @@ of one character in length, and a maximum of ten characters.
 [Int32][ValidateLength(1,10)]$number = 01
 ```
 
-### ValidatePattern Validation Attribute
+### ValidatePattern validation attribute
 
-The `ValidatePattern` attribute specifies a regular expression that is compared
-to the parameter or variable value. PowerShell generates an error if the value
-does not match the regular expression pattern.
+The **ValidatePattern** attribute specifies a regular expression that's
+compared to the parameter or variable value. PowerShell generates an error if
+the value doesn't match the regular expression pattern.
 
-In the following example, the parameter value must contain a four-digit number, and
-each digit must be a number zero to nine.
+In the following example, the parameter value must contain a four-digit number,
+and each digit must be a number zero to nine.
 
 ```powershell
 Param(
@@ -482,21 +486,21 @@ four-digit number, and each digit must be a number zero to nine.
 [Int32][ValidatePattern("^[0-9][0-9][0-9][0-9]$")]$number = 1111
 ```
 
-### ValidateRange Validation Attribute
+### ValidateRange validation attribute
 
-The `ValidateRange` attribute specifies a numeric range or a `ValidateRangeKind`
-enum value for each parameter or variable value. PowerShell generates an error
-if any value is outside that range.
+The **ValidateRange** attribute specifies a numeric range or a
+**ValidateRangeKind** enum value for each parameter or variable value.
+PowerShell generates an error if any value is outside that range.
 
-The `ValidateRangeKind` enum allows for the following values:
+The **ValidateRangeKind** enum allows for the following values:
 
-- `Positive` A number greater than zero
-- `Negative` A number less than zero
-- `NonPositive` A number less than or equal to zero
-- `NonNegative` A number greater than or equal to zero
+- **Positive** - A number greater than zero.
+- **Negative** - A number less than zero.
+- **NonPositive** - A number less than or equal to zero.
+- **NonNegative** - A number greater than or equal to zero.
 
-In the following example, the value of the
-`Attempts` parameter must be between zero and ten.
+In the following example, the value of the **Attempts** parameter must be
+between zero and ten.
 
 ```powershell
 Param(
@@ -514,25 +518,25 @@ zero and ten.
 [Int32][ValidateRange(0,10)]$number = 5
 ```
 
-In the following example, the value of the variable $number must be greater
+In the following example, the value of the variable `$number` must be greater
 than zero.
 
 ```powershell
 [Int32][ValidateRange("Positive")]$number = 1
 ```
 
-### ValidateScript Validation Attribute
+### ValidateScript validation attribute
 
-The `ValidateScript` attribute specifies a script that is used to validate a
+The **ValidateScript** attribute specifies a script that is used to validate a
 parameter or variable value. PowerShell pipes the value to the script, and
 generates an error if the script returns `$false` or if the script throws an
 exception.
 
-When you use the `ValidateScript` attribute, the value that is being
-validated is mapped to the `$_` variable. You can use the `$_` variable to refer
-to the value in the script.
+When you use the **ValidateScript** attribute, the value that's being validated
+is mapped to the `$_` variable. You can use the `$_` variable to refer to the
+value in the script.
 
-In the following example, the value of the `EventDate` parameter must be
+In the following example, the value of the **EventDate** parameter must be
 greater than or equal to the current date.
 
 ```powershell
@@ -544,19 +548,19 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$date` must be greater than
-or equal to the current date and time.
+In the following example, the value of the variable `$date` must be greater
+than or equal to the current date and time.
 
 ```powershell
 [DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
 ```
 
-### ValidateSet Attribute
+### ValidateSet attribute
 
-The `ValidateSet` attribute specifies a set of valid values for a parameter or
-variable. PowerShell generates an error if a parameter or variable value does
-not match a value in the set. In the following example, the value of the
-`Detail` parameter can only be "Low," "Average," or "High."
+The **ValidateSet** attribute specifies a set of valid values for a parameter
+or variable. PowerShell generates an error if a parameter or variable value
+doesn't match a value in the set. In the following example, the value of the
+**Detail** parameter can only be Low, Average, or High.
 
 ```powershell
 Param(
@@ -568,15 +572,15 @@ Param(
 ```
 
 In the following example, the value of the variable `$flavor` must be either
-"Chocolate", "Strawberry", or "Vanilla".
+Chocolate, Strawberry, or Vanilla.
 
 ```powershell
 [ValidateSet("Chocolate", "Strawberry", "Vanilla")]
 [String]$flavor = "Strawberry"
 ```
 
-Note that the validation occurs whenever that variable is assigned even within
-the script. For example, the following results in an error at runtime:
+The validation occurs whenever that variable is assigned even within the
+script. For example, the following results in an error at runtime:
 
 ```powershell
 Param(
@@ -587,12 +591,12 @@ Param(
 $Message = "bye"
 ```
 
-#### Dynamic ValidateSet Values
+#### Dynamic validateSet values
 
-You can use a `Class` to dynamically generate the values for `ValidateSet` at
-runtime. In the following example, the valid values for the variable `$Sound`
-are generated via a `Class` named `SoundNames` that checks three filesystem
-paths for available sound files:
+You can use a **Class** to dynamically generate the values for **ValidateSet**
+at runtime. In the following example, the valid values for the variable
+`$Sound` are generated via a **Class** named **SoundNames** that checks three
+filesystem paths for available sound files:
 
 ```powershell
 Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
@@ -609,7 +613,7 @@ Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
 }
 ```
 
-The `[SoundNames]` class is then implemented as a dynamic `ValidateSet` value
+The `[SoundNames]` class is then implemented as a dynamic **ValidateSet** value
 as follows:
 
 ```powershell
@@ -619,18 +623,18 @@ Param(
 )
 ```
 
-### ValidateNotNull Validation Attribute
+### ValidateNotNull validation attribute
 
-The `ValidateNotNull` attribute specifies that the parameter value cannot be
+The **ValidateNotNull** attribute specifies that the parameter value can't be
 `$null`. PowerShell generates an error if the parameter value is `$null`.
 
-The `ValidateNotNull` attribute is designed to be used when the type of the
-parameter value is not specified or when the specified type accepts a
-value of `$null`. (If you specify a type that does not accept a `$null` value,
-such as a string, the `$null` value is rejected without the
-`ValidateNotNull` attribute, because it does not match the specified type.)
+The **ValidateNotNull** attribute is designed to be used when the type of the
+parameter value isn't specified or when the specified type accepts a value of
+`$null`. If you specify a type that doesn't accept a `$null` value, such as a
+string, the `$null` value is rejected without the **ValidateNotNull**
+attribute, because it doesn't match the specified type.
 
-In the following example, the value of the `ID` parameter cannot be `$null`.
+In the following example, the value of the **ID** parameter can't be `$null`.
 
 ```powershell
 Param(
@@ -640,12 +644,12 @@ Param(
 )
 ```
 
-### ValidateNotNullOrEmpty Validation Attribute
+### ValidateNotNullOrEmpty validation attribute
 
-The `ValidateNotNullOrEmpty` attribute specifies that the parameter value cannot
-be `$null` and cannot be an empty string `""`. PowerShell generates an
-error if the parameter is used in a function call, but its value is `$null`,
-an empty string `""`, or an empty array `@()`.
+The **ValidateNotNullOrEmpty** attribute specifies that the parameter value
+can't be `$null` and can't be an empty string (`""`). PowerShell generates an
+error if the parameter is used in a function call, but its value is `$null`, an
+empty string (`""`), or an empty array `@()`.
 
 ```powershell
 Param(
@@ -656,12 +660,12 @@ Param(
 )
 ```
 
-### ValidateDrive Validation Attribute
+### ValidateDrive validation attribute
 
-The ValidateDrive attribute specifies that the parameter value must represent
-the path, that is referring to allowed drives only. PowerShell generates
-an error if the parameter value refers to drives other than the allowed.
-Existence of the path, except for the drive itself, is not verified.
+The **ValidateDrive** attribute specifies that the parameter value must
+represent the path, that's referring to allowed drives only. PowerShell
+generates an error if the parameter value refers to drives other than the
+allowed. Existence of the path, except for the drive itself, isn't verified.
 
 If you use relative path, the current drive must be in the allowed drive list.
 
@@ -672,17 +676,17 @@ Param(
 )
 ```
 
-### ValidateUserDrive Validation Attribute
+### ValidateUserDrive validation attribute
 
-The ValidateUserDrive attribute specifies that the parameter value
-must represent the path, that is referring to `User` drive.
-PowerShell generates an error if the path refers to other drives.
-Existence of the path, except for the drive itself, is not verified.
+The **ValidateUserDrive** attribute specifies that the parameter value must
+represent the path, that is referring to `User` drive. PowerShell generates an
+error if the path refers to other drives. Existence of the path, except for the
+drive itself, isn't verified.
 
 If you use relative path, the current drive must be `User`.
 
-You can define `User` drive in Just Enough Administration (JEA)
-session configurations.
+You can define `User` drive in Just Enough Administration (JEA) session
+configurations.
 
 ```powershell
 Param(
@@ -691,24 +695,24 @@ Param(
 )
 ```
 
-## Dynamic Parameters
+## Dynamic parameters
 
 Dynamic parameters are parameters of a cmdlet, function, or script that are
 available only under certain conditions.
 
 For example, several provider cmdlets have parameters that are available only
 when the cmdlet is used in the provider drive, or in a particular path of the
-provider drive. For example, the `Encoding` parameter is available on the
-`Add-Content`, `Get-Content`, and `Set-Content` cmdlets only when it is used
-in a file system drive.
+provider drive. For example, the **Encoding** parameter is available on the
+`Add-Content`, `Get-Content`, and `Set-Content` cmdlets only when it's used in
+a file system drive.
 
 You can also create a parameter that appears only when another parameter is
 used in the function command or when another parameter has a certain value.
 
-Dynamic parameters can be very useful, but use them only when necessary,
-because they can be difficult for users to discover. To find a dynamic
-parameter, the user must be in the provider path, use the `ArgumentList`
-parameter of the `Get-Command` cmdlet, or use the Path parameter of `Get-Help`.
+Dynamic parameters can be useful, but use them only when necessary, because
+they can be difficult for users to discover. To find a dynamic parameter, the
+user must be in the provider path, use the **ArgumentList** parameter of the
+`Get-Command` cmdlet, or use the **Path** parameter of `Get-Help`.
 
 To create a dynamic parameter for a function or script, use the `DynamicParam`
 keyword.
@@ -717,24 +721,24 @@ The syntax is as follows:
 
 `DynamicParam {<statement-list>}`
 
-In the statement list, use an If statement to specify the conditions under
+In the statement list, use an `If` statement to specify the conditions under
 which the parameter is available in the function.
 
 Use the `New-Object` cmdlet to create a
-`System.Management.Automation.RuntimeDefinedParameter` object to represent the
-parameter and specify its name.
+**System.Management.Automation.RuntimeDefinedParameter** object to represent
+the parameter and specify its name.
 
-You can also use a `New-Object` command to create a
-`System.Management.Automation.ParameterAttribute` object to represent attributes
-of the parameter, such as `Mandatory`, `Position`, or `ValueFromPipeline` or its
-parameter set.
+You can use a `New-Object` command to create a
+**System.Management.Automation.ParameterAttribute** object to represent
+attributes of the parameter, such as **Mandatory**, **Position**, or
+**ValueFromPipeline** or its parameter set.
 
 The following example shows a sample function with standard parameters named
-**Name** and **Path**, and an optional dynamic parameter named **DP1**.
-The **DP1** parameter is in the PSet1 parameter set and has a type of `Int32`.
-The **DP1** parameter is available in the `Get-Sample` function
-only when the value of the **Path** parameter starts with "HKLM:",
-indicating that it is being used in the HKEY_LOCAL_MACHINE registry drive.
+**Name** and **Path**, and an optional dynamic parameter named **DP1**. The
+**DP1** parameter is in the `PSet1` parameter set and has a type of `Int32`.
+The **DP1** parameter is available in the `Get-Sample` function only when the
+value of the **Path** parameter starts with `HKLM:`, indicating that it's being
+used in the `HKEY_LOCAL_MACHINE` registry drive.
 
 ```powershell
 function Get-Sample {
@@ -766,19 +770,18 @@ function Get-Sample {
 }
 ```
 
-For more information, see "RuntimeDefinedParameter Class" in the MSDN
-(Microsoft Developer Network) library at
-[RuntimeDefinedParameter](/dotnet/api/system.management.automation.runtimedefinedparameter)
+For more information, see
+[RuntimeDefinedParameter](/dotnet/api/system.management.automation.runtimedefinedparameter).
 
-## Switch Parameters
+## Switch parameters
 
-Switch parameters are parameters with no parameter value. They are effective
-only when they are used and have only one effect.
+Switch parameters are parameters with no parameter value. They're effective
+only when they're used and have only one effect.
 
-For example, the `-NoProfile` parameter of PowerShell.exe is a switch
+For example, the **NoProfile** parameter of **powershell.exe** is a switch
 parameter.
 
-To create a switch parameter in a function, specify the Switch type in the
+To create a switch parameter in a function, specify the `Switch` type in the
 parameter definition.
 
 For example:
@@ -787,7 +790,7 @@ For example:
 Param([Switch]<ParameterName>)
 ```
 
--or-
+Or, you can use an another method:
 
 ```powershell
 Param(
@@ -810,20 +813,21 @@ To use a Boolean parameter, the user types the parameter and a Boolean value.
 `-IncludeAll:$true`
 
 When creating switch parameters, choose the parameter name carefully. Be sure
-that the parameter name communicates the effect of the parameter to the user,
-and avoid ambiguous terms, such as Filter or Maximum, that might imply that a
+that the parameter name communicates the effect of the parameter to the user.
+Avoid ambiguous terms, such as **Filter** or **Maximum** that might imply a
 value is required.
 
 ## ArgumentCompleter attribute
 
-The **ArgumentCompleter** attribute allows you to add tab completion values
-to a specific parameter. Like DynamicParameters, the available values are
-calculated at runtime when the user presses `<TAB>` after the parameter name.
+The **ArgumentCompleter** attribute allows you to add tab completion values to
+a specific parameter. Like **DynamicParameters**, the available values are
+calculated at runtime when the user presses <kbd>Tab</kbd> after the parameter
+name.
 
 To add an **ArgumentCompleter** attribute, you need to define a script block
 that will determine the values. The script block must take the following
-parameters in the order specified below. The parameter's names
-do not matter as the values are provided *positionally*.
+parameters in the order specified below. The parameter's names don't matter as
+the values are provided positionally.
 
 The syntax is as follows:
 
@@ -837,35 +841,35 @@ Param(
 )
 ```
 
-### The ArgumentCompleter script block
+### ArgumentCompleter script block
 
 The script block parameters are set to the following values:
 
 - `$commandName` (Position 0) - This parameter is set to the name of the
   command for which the script block is providing tab completion.
-- `$parameterName` (Position 1) - This parameter is set to the parameter
-  whose value requires tab completion.
+- `$parameterName` (Position 1) - This parameter is set to the parameter whose
+  value requires tab completion.
 - `$wordToComplete` (Position 2) - This parameter is set to value the user has
-  provided before they pressed `<TAB>`. Your script block should use this value
-  to determine tab completion values.
+  provided before they pressed <kbd>Tab</kbd>. Your script block should use
+  this value to determine tab completion values.
 - `$commandAst` (Position 3) - This parameter is set to the Abstract Syntax
-  Tree (AST) for the current input line. For more information, see
-  [Ast Class](/dotnet/api/system.management.automation.language.ast).
+  Tree (AST) for the current input line. For more information, see [Ast Class](/dotnet/api/system.management.automation.language.ast).
 - `$fakeBoundParameter` (Position 4) - This parameter is set to a hashtable
   containing the `$PSBoundParameters` for the cmdlet, before the user pressed
-  `<TAB>`. For more information, see [about_Automatic_Variables](about_Automatic_Variables.md).
+  <kbd>Tab</kbd>. For more information, see [about_Automatic_Variables](about_Automatic_Variables.md).
 
 The **ArgumentCompleter** script block must unroll the values using the
-pipeline (`ForEach-Object`, `Where-Object`, etc.), or another suitable method.
+pipeline, such as`ForEach-Object`, `Where-Object`, or another suitable method.
 Returning an array of values causes PowerShell to treat the entire array as
 **one** tab completion value.
 
-The following example adds tab completion to the `$Value` parameter.  If no
+The following example adds tab completion to the **Value** parameter. If no
 `$Type` is specified, fruits and vegetables are returned. If a `$Type` is
-specified, only values for the type are specified. In addition the `-like`
-operator ensures that if the user types
-`Test-ArgumentCompleter -Type Fruits -Value A<TAB>`, only **Apple** is
-returned.
+specified, only values for the type are specified. In addition, the `-like`
+operator ensures that if the user types the following command and uses
+<kbd>Tab</kbd> completion, only **Apple** is returned.
+
+`Test-ArgumentCompleter -Type Fruits -Value A`
 
 ```powershell
 function Test-ArgumentCompleter {
@@ -903,6 +907,8 @@ function Test-ArgumentCompleter {
 ```
 
 ## See also
+
+[about_Automatic_Variables](about_Automatic_Variables.md)
 
 [about_Functions](about_Functions.md)
 


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

- Fixes AB#1596270
- Fixes #4198 - Added note about limit of 32 parameter sets
- Fixes AB#1596303
- Fixes #4243 - Removed duplicated code block
- Minor copyedits, style, and paragraph reflows

cmdlet-parameter-sets.md Acrolinx scores
Original version: 88
Updated version: 98

about_Functions_Advanced_Parameters.md Acrolinx scores
Original version: 91
Updated version: 95
