### PR TITLE
Separate two examples in Measure-Command

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -104,6 +104,10 @@ TotalSeconds      : 0.0122672
 TotalMilliseconds : 12.2672
 ```
 
+### Example 4: Displaying output of measured command
+
+To display output of expression in `Measure-Command` you can use a pipe to `Out-Default`.
+
 ```powershell
 # Perform the same operation as above adding Out-Default to every execution.
 # This will show that the ScriptBlock is in fact executing for every item.

--- a/reference/4.0/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -104,6 +104,10 @@ TotalSeconds      : 0.0122672
 TotalMilliseconds : 12.2672
 ```
 
+### Example 4: Displaying output of measured command
+
+To display output of expression in `Measure-Command` you can use a pipe to `Out-Default`.
+
 ```powershell
 # Perform the same operation as above adding Out-Default to every execution.
 # This will show that the ScriptBlock is in fact executing for every item.

--- a/reference/5.0/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -104,6 +104,10 @@ TotalSeconds      : 0.0122672
 TotalMilliseconds : 12.2672
 ```
 
+### Example 4: Displaying output of measured command
+
+To display output of expression in `Measure-Command` you can use a pipe to `Out-Default`.
+
 ```powershell
 # Perform the same operation as above adding Out-Default to every execution.
 # This will show that the ScriptBlock is in fact executing for every item.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -104,6 +104,10 @@ TotalSeconds      : 0.0122672
 TotalMilliseconds : 12.2672
 ```
 
+### Example 4: Displaying output of measured command
+
+To display output of expression in `Measure-Command` you can use a pipe to `Out-Default`.
+
 ```powershell
 # Perform the same operation as above adding Out-Default to every execution.
 # This will show that the ScriptBlock is in fact executing for every item.

--- a/reference/6/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -104,6 +104,10 @@ TotalSeconds      : 0.0122672
 TotalMilliseconds : 12.2672
 ```
 
+### Example 4: Displaying output of measured command
+
+To display output of expression in `Measure-Command` you can use a pipe to `Out-Default`.
+
 ```powershell
 # Perform the same operation as above adding Out-Default to every execution.
 # This will show that the ScriptBlock is in fact executing for every item.

--- a/reference/7/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -104,6 +104,10 @@ TotalSeconds      : 0.0122672
 TotalMilliseconds : 12.2672
 ```
 
+### Example 4: Displaying output of measured command
+
+To display output of expression in `Measure-Command` you can use a pipe to `Out-Default`.
+
 ```powershell
 # Perform the same operation as above adding Out-Default to every execution.
 # This will show that the ScriptBlock is in fact executing for every item.


### PR DESCRIPTION
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

I believe showing output of `Measure-Command` is an important use case that's being easily overlooked in the docs now because it's hidden under a different title. I suggest adding a separate title so it's crystal-clear how to do that for people who have a use case like that.

See e. g. https://github.com/PowerShell/PowerShell/issues/2289 for feature request.