### PR TITLE
Update build to use Pandoc 2.7.3

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -37,6 +37,7 @@ Get-ChildItem $ReferenceDocset -Directory -Exclude $excludeList | ForEach-Object
     $job = Start-ThreadJob -Name $_.Name -ArgumentList @($SkipCabs,$pandocExePath,$PSScriptRoot,$_) -ScriptBlock {
         param($SkipCabs, $pandocExePath, $WorkingDirectory, $DocSet)
 
+        $tempDir = [System.IO.Path]::GetTempPath()
         $workingDir = Join-Path $tempDir $DocSet.Name
         $workingDir = New-Item -ItemType Directory -Path $workingDir -Force
         Set-Location $WorkingDir

--- a/build.ps1
+++ b/build.ps1
@@ -8,17 +8,18 @@ $global:ProgressPreference = 'SilentlyContinue'
 if ($ShowProgress) { $ProgressPreference = 'Continue' }
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+$tempDir = [System.IO.Path]::GetTempPath()
 
 # Pandoc source URL
-$panDocVersion = "2.0.6"
-$pandocSourceURL = "https://github.com/jgm/pandoc/releases/download/$panDocVersion/pandoc-$panDocVersion-windows.zip"
+$panDocVersion = "2.7.3"
+$pandocSourceURL = "https://github.com/jgm/pandoc/releases/download/$panDocVersion/pandoc-$panDocVersion-windows-x86_64.zip"
 
-$pandocDestinationPath = New-Item (Join-Path ([System.IO.Path]::GetTempPath()) "PanDoc") -ItemType Directory -Force
-$pandocZipPath = Join-Path $pandocDestinationPath "pandoc-$panDocVersion-windows.zip"
+$pandocDestinationPath = New-Item (Join-Path $tempDir "pandoc") -ItemType Directory -Force
+$pandocZipPath = Join-Path $pandocDestinationPath "pandoc-$panDocVersion-windows-x86_64.zip"
 Invoke-WebRequest -Uri $pandocSourceURL -OutFile $pandocZipPath
 
-Expand-Archive -Path (Join-Path $pandocDestinationPath "pandoc-$panDocVersion-windows.zip") -DestinationPath $pandocDestinationPath -Force
-$pandocExePath = Join-Path (Join-Path $pandocDestinationPath "pandoc-$panDocVersion") "pandoc.exe"
+Expand-Archive -Path $pandocZipPath -DestinationPath $pandocDestinationPath -Force
+$pandocExePath = Join-Path (Join-Path $pandocDestinationPath "pandoc-$panDocVersion-windows-x86_64") "pandoc.exe"
 
 # Install ThreadJob if not available
 $threadJob = Get-Module ThreadJob -ListAvailable
@@ -36,7 +37,6 @@ Get-ChildItem $ReferenceDocset -Directory -Exclude $excludeList | ForEach-Object
     $job = Start-ThreadJob -Name $_.Name -ArgumentList @($SkipCabs,$pandocExePath,$PSScriptRoot,$_) -ScriptBlock {
         param($SkipCabs, $pandocExePath, $WorkingDirectory, $DocSet)
 
-        $tempDir = [System.IO.Path]::GetTempPath()
         $workingDir = Join-Path $tempDir $DocSet.Name
         $workingDir = New-Item -ItemType Directory -Path $workingDir -Force
         Set-Location $WorkingDir
@@ -112,7 +112,7 @@ Get-ChildItem $ReferenceDocset -Directory -Exclude $excludeList | ForEach-Object
 
                     $pandocArgs = @(
                         "--from=gfm",
-                        "--to=plain+multiline_tables+inline_code_attributes",
+                        "--to=plain+multiline_tables",
                         "--columns=75",
                         "--output=$aboutFileOutputFullName",
                         "--quiet"

--- a/tools/build-updatedhelp.ps1
+++ b/tools/build-updatedhelp.ps1
@@ -21,6 +21,10 @@ param(
     [string]$sourceFolder
 )
 
+# Turning off the progress display, by default
+$savedProgressPreference = $global:ProgressPreference
+$global:ProgressPreference = 'SilentlyContinue'
+
 $tempDir = [System.IO.Path]::GetTempPath()
 
 # Pandoc source URL
@@ -139,3 +143,5 @@ Get-ChildItem $VersionFolder -Directory | ForEach-Object -Process {
         Write-Error -Message "PlatyPS failure: $ModuleName -- $Version" -Exception $_
     }
 }
+
+$global:ProgressPreference = $savedProgressPreference

--- a/tools/build-updatedhelp.ps1
+++ b/tools/build-updatedhelp.ps1
@@ -5,9 +5,9 @@
        cd C:\temp
        git clone https://github.com/MicrosoftDocs/PowerShell-Docs.git
 
-    2. Run make-updatedhelp.ps1 for the version folder you want to build
+    2. Run build-updatedhelp.ps1 for the version folder you want to build
 
-      .\make-updatedhelp.ps1 -sourceFolder C:\temp\PowerShell-Docs\reference\5.1 -Verbose
+      .\build-updatedhelp.ps1 -sourceFolder C:\temp\PowerShell-Docs\reference\5.1 -Verbose
 
     3. Run Update-Help  to install the newly built help
 
@@ -68,7 +68,7 @@ function Get-ContentWithoutHeader {
         }
     }
     if ($end -gt $start) {
-        Write-Output ($doc[$end..$($doc.count)] -join "`r`n")
+        Write-Output ($doc[$end..$($doc.count)] -join ([Environment]::Newline))
     }
     else {
         Write-Output ($doc -join "`r`n")

--- a/tools/make-updatedhelp.ps1
+++ b/tools/make-updatedhelp.ps1
@@ -1,0 +1,141 @@
+<#
+    Usage:
+
+    1. Clone the docs respository
+       cd C:\temp
+       git clone https://github.com/MicrosoftDocs/PowerShell-Docs.git
+
+    2. Run make-updatedhelp.ps1 for the version folder you want to build
+
+      .\make-updatedhelp.ps1 -sourceFolder C:\temp\PowerShell-Docs\reference\5.1 -Verbose
+
+    3. Run Update-Help  to install the newly built help
+
+       Update-Help -SourcePath c:\temp\updatablehelp\5.1 -Recurse -Force
+#>
+
+
+param(
+    [Parameter(Mandatory=$true)]
+    [ValidateScript({ Test-Path $_ })]
+    [string]$sourceFolder
+)
+
+$tempDir = [System.IO.Path]::GetTempPath()
+
+# Pandoc source URL
+$panDocVersion = "2.7.3"
+$pandocSourceURL = "https://github.com/jgm/pandoc/releases/download/$panDocVersion/pandoc-$panDocVersion-windows-x86_64.zip"
+
+$docToolsPath = New-Item (Join-Path $tempDir "doctools") -ItemType Directory -Force
+$pandocZipPath = Join-Path $docToolsPath "pandoc-$panDocVersion-windows-x86_64.zip"
+Write-Verbose "Downloading Pandoc..."
+Invoke-WebRequest -Uri $pandocSourceURL -OutFile $pandocZipPath
+
+Expand-Archive -Path $pandocZipPath -DestinationPath $docToolsPath -Force
+$pandocExePath = Join-Path $docToolsPath "pandoc-$panDocVersion-windows-x86_64\pandoc.exe"
+
+$platyPSversion = "0.14.0"
+Write-Verbose "Downloading platyPS..."
+Save-Module -Name platyPS -Repository PSGallery -Force -Path $docToolsPath -RequiredVersion $platyPSversion
+Import-Module -FullyQualifiedName $docToolsPath\platyPS\$platyPSversion\platyPS.psd1
+
+$DocSet = Get-Item $sourceFolder
+$WorkingDirectory = $PWD
+
+function Get-ContentWithoutHeader {
+    param(
+        $path
+    )
+
+    $doc = Get-Content $path -Encoding UTF8
+    $start = $end = -1
+
+    # search the first 30 lines for the Yaml header
+    # no yaml header in our docset will ever be that long
+
+    for ($x = 0; $x -lt 30; $x++) {
+        if ($doc[$x] -eq '---') {
+            if ($start -eq -1) {
+                $start = $x
+            }
+            else {
+                if ($end -eq -1) {
+                    $end = $x + 1
+                    break
+                }
+            }
+        }
+    }
+    if ($end -gt $start) {
+        Write-Output ($doc[$end..$($doc.count)] -join "`r`n")
+    }
+    else {
+        Write-Output ($doc -join "`r`n")
+    }
+}
+
+$Version = $DocSet.Name
+Write-Verbose "Version = $Version"
+
+$VersionFolder = $DocSet.FullName
+Write-Verbose "VersionFolder = $VersionFolder"
+
+# For each of the directories, go through each module folder
+Get-ChildItem $VersionFolder -Directory | ForEach-Object -Process {
+    $ModuleName = $_.Name
+    Write-Verbose "ModuleName = $ModuleName"
+
+    $ModulePath = Join-Path $VersionFolder $ModuleName
+    Write-Verbose "ModulePath = $ModulePath"
+
+    $LandingPage = Join-Path $ModulePath "$ModuleName.md"
+    Write-Verbose "LandingPage = $LandingPage"
+
+    $MamlOutputFolder = Join-Path "$WorkingDirectory\maml" "$Version\$ModuleName"
+    Write-Verbose "MamlOutputFolder = $MamlOutputFolder"
+
+    $CabOutputFolder = Join-Path "$WorkingDirectory\updatablehelp" "$Version\$ModuleName"
+    Write-Verbose "CabOutputFolder = $CabOutputFolder"
+
+    if (-not (Test-Path $MamlOutputFolder)) {
+        New-Item $MamlOutputFolder -ItemType Directory -Force > $null
+    }
+
+    # Process the about topics if any
+    $AboutFolder = Join-Path $ModulePath "About"
+
+    if (Test-Path $AboutFolder) {
+        Write-Verbose "AboutFolder = $AboutFolder"
+        Get-ChildItem "$aboutfolder/about_*.md" | ForEach-Object {
+            $aboutFileFullName = $_.FullName
+            $aboutFileOutputName = "$($_.BaseName).help.txt"
+            $aboutFileOutputFullName = Join-Path $MamlOutputFolder $aboutFileOutputName
+
+            $pandocArgs = @(
+                "--from=gfm",
+                "--to=plain+multiline_tables",
+                "--columns=75",
+                "--output=$aboutFileOutputFullName",
+                "--quiet"
+            )
+
+            Get-ContentWithoutHeader $aboutFileFullName | & $pandocExePath $pandocArgs
+        }
+    }
+
+    try {
+        # For each module, create a single maml help file
+        # Adding warningaction=stop to throw errors for all warnings, erroraction=stop to make them terminating errors
+        New-ExternalHelp -Path $ModulePath -OutputPath $MamlOutputFolder -Force -WarningAction Stop -ErrorAction Stop
+
+        # For each module, create update-help help files (cab and helpinfo.xml files)
+        $cabInfo = New-ExternalHelpCab -CabFilesFolder $MamlOutputFolder -LandingPagePath $LandingPage -OutputFolder $CabOutputFolder
+
+        # Only output the cab fileinfo object
+        if ($cabInfo.Count -eq 8) { $cabInfo[-1].FullName }
+    }
+    catch {
+        Write-Error -Message "PlatyPS failure: $ModuleName -- $Version" -Exception $_
+    }
+}


### PR DESCRIPTION
Updated build to use Pandoc 2.7.3

Added tools/build-updatedhelp.ps1 - This script can be used to build the updateable help for a single version folder. Using this script, a user could build and install any version of help they need.

Usage:

1. Clone the docs respository

   ```
    cd C:\temp
    git clone https://github.com/MicrosoftDocs/PowerShell-Docs.git
   ```

2. Run build-updatedhelp.ps1 for the version folder you want to build

   ```
    .\build-updatedhelp.ps1 -sourceFolder C:\temp\PowerShell-Docs\reference\5.1 -Verbose
   ```

3. Run Update-Help  to install the newly built help

   ```
    Update-Help -SourcePath c:\temp\updatablehelp\5.1 -Recurse -Force
   ```
