### PR TITLE
Fix Get-Command -ShowCommandInfo

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-Command.md
@@ -517,14 +517,7 @@ Accept wildcard characters: True
 
 Indicates that this cmdlet displays command information.
 
-For more information about the method that PowerShell uses to select the command to run when
-multiple commands have the same name, see [about_Command_Precedence](About/about_Command_Precedence.md).
-For information about module-qualified command names and running commands that do not run by default
-because of a name conflict, see [about_Modules](About/about_Modules.md).
-
-This parameter was introduced in Windows PowerShell 3.0.
-
-In Windows PowerShell 2.0, `Get-Command` gets all commands by default.
+This parameter was introduced in Windows PowerShell 5.0.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-Command.md
@@ -517,14 +517,7 @@ Accept wildcard characters: True
 
 Indicates that this cmdlet displays command information.
 
-For more information about the method that PowerShell uses to select the command to run when
-multiple commands have the same name, see [about_Command_Precedence](About/about_Command_Precedence.md).
-For information about module-qualified command names and running commands that do not run by default
-because of a name conflict, see [about_Modules](About/about_Modules.md).
-
-This parameter was introduced in Windows PowerShell 3.0.
-
-In Windows PowerShell 2.0, `Get-Command` gets all commands by default.
+This parameter was introduced in Windows PowerShell 5.0.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/6/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Command.md
@@ -532,14 +532,7 @@ Accept wildcard characters: True
 
 Indicates that this cmdlet displays command information.
 
-For more information about the method that PowerShell uses to select the command to run when
-multiple commands have the same name, see [about_Command_Precedence](About/about_Command_Precedence.md).
-For information about module-qualified command names and running commands that do not run by default
-because of a name conflict, see [about_Modules](About/about_Modules.md).
-
-This parameter was introduced in Windows PowerShell 3.0.
-
-In Windows PowerShell 2.0, `Get-Command` gets all commands by default.
+This parameter was introduced in Windows PowerShell 5.0.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/7/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/7/Microsoft.PowerShell.Core/Get-Command.md
@@ -532,14 +532,7 @@ Accept wildcard characters: True
 
 Indicates that this cmdlet displays command information.
 
-For more information about the method that PowerShell uses to select the command to run when
-multiple commands have the same name, see [about_Command_Precedence](About/about_Command_Precedence.md).
-For information about module-qualified command names and running commands that do not run by default
-because of a name conflict, see [about_Modules](About/about_Modules.md).
-
-This parameter was introduced in Windows PowerShell 3.0.
-
-In Windows PowerShell 2.0, `Get-Command` gets all commands by default.
+This parameter was introduced in Windows PowerShell 5.0.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
* `Get-Command -ShowCommandInfo` was [introduced in v5.0](https://docs.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-windows-powershell-50), not v3.0
* "For more information..." and "In Windows PowerShell 2.0..." are meaningless copy/paste texts from `-All` param

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in the above versions of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
