### PR TITLE
Fix ArgumentCompleter attribute example

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -753,7 +753,7 @@ The syntax is as follows:
 Param(
     [Parameter(Mandatory)]
     [ArgumentCompleter({
-        param ($commandName, $wordToComplete, $commandAst, $fakeBoundParameter)
+        param ($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
         # Perform calculation of tab completed values here.
     })]
 )

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -788,7 +788,7 @@ The syntax is as follows:
 Param(
     [Parameter(Mandatory)]
     [ArgumentCompleter({
-        param ($commandName, $wordToComplete, $commandAst, $fakeBoundParameter)
+        param ($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
         # Perform calculation of tab completed values here.
     })]
 )

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -834,7 +834,7 @@ The syntax is as follows:
 Param(
     [Parameter(Mandatory)]
     [ArgumentCompleter({
-        param ($commandName, $wordToComplete, $commandAst, $fakeBoundParameter)
+        param ($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
         # Perform calculation of tab completed values here.
     })]
 )

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -834,7 +834,7 @@ The syntax is as follows:
 Param(
     [Parameter(Mandatory)]
     [ArgumentCompleter({
-        param ($commandName, $wordToComplete, $commandAst, $fakeBoundParameter)
+        param ($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
         # Perform calculation of tab completed values here.
     })]
 )

--- a/reference/7/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_If.md
@@ -81,7 +81,6 @@ else {
 To further refine this example, you can use the Elseif statement to display
 a message when the value of $a is equal to 2. As the next example shows:
 
-
 ```powershell
 if ($a -gt 2) {
     Write-Host "The value $a is greater than 2."
@@ -94,6 +93,31 @@ else {
         " was not created or initialized.")
 }
 ```
+
+### Using the ternary operator syntax
+
+PowerShell 7.0 introduced a new syntax using the ternary operator. It follows the C# ternary
+operator syntax:
+
+```Syntax
+<condition> ? <if-true> : <if-false>
+```
+
+The ternary operator behaves like the simplified `if-else` statement. The `<condition>` expression
+is evaluated and the result is converted to a boolean to determine which branch should be evaluated
+next:
+
+- The `<if-true>` expression is executed if the `<condition>` expression is true
+- The `<if-false>` expression is executed if the `<condition>` expression is false
+
+For example:
+
+```powershell
+$message = (Test-Path $path) ? "Path exists" : "Path not found"
+```
+
+In this example, the value of `$message` is "Path exists" when `Test-Path` returns `$true`. When
+`Test-Path` returns `$false`, the value of `$message` is "Path not found".
 
 ## SEE ALSO
 

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -442,6 +442,13 @@ $($x * 23)
 $(Get-WmiObject win32_Directory)
 ```
 
+#### Ternary operator `? <if-true> : <if-false>`
+
+You can use the ternary operator as a replacement for the `if-else` statement in
+simple conditional cases. The ternary operator was introduced in PowerShell 7.0.
+
+For more information, see [about_If](about_If.md).
+
 ## See also
 
 [about_Arithmetic_Operators](about_Arithmetic_Operators.md)


### PR DESCRIPTION
Add missing $parameterName argument to ArgumentCompleter attribute example.
Without this argument, the sample doesn't work.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 5.0 of PowerShell
- [x] This issue only shows up in version 5.0, 5.1, 6, 7 of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
