### PR TITLE
Removed unrequited ticks in the code example

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -316,7 +316,7 @@ display. You can still use the **Format** cmdlets to display the **PsComputerNam
 of the affected objects.
 
 ```powershell
-`Invoke-Command` -ComputerName S1, S2 -ScriptBlock {Get-Process PowerShell}
+Invoke-Command -ComputerName S1, S2 -ScriptBlock {Get-Process PowerShell}
 ```
 
 ```Output

--- a/reference/4.0/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -305,7 +305,7 @@ display. You can still use the **Format** cmdlets to display the **PsComputerNam
 of the affected objects.
 
 ```powershell
-`Invoke-Command` -ComputerName S1, S2 -ScriptBlock {Get-Process PowerShell}
+Invoke-Command -ComputerName S1, S2 -ScriptBlock {Get-Process PowerShell}
 ```
 
 ```Output

--- a/reference/5.0/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -348,7 +348,7 @@ display. You can still use the **Format** cmdlets to display the **PsComputerNam
 of the affected objects.
 
 ```powershell
-`Invoke-Command` -ComputerName S1, S2 -ScriptBlock {Get-Process PowerShell}
+Invoke-Command -ComputerName S1, S2 -ScriptBlock {Get-Process PowerShell}
 ```
 
 ```Output

--- a/reference/5.1/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -364,7 +364,7 @@ display. You can still use the **Format** cmdlets to display the **PsComputerNam
 of the affected objects.
 
 ```powershell
-`Invoke-Command` -ComputerName S1, S2 -ScriptBlock {Get-Process PowerShell}
+Invoke-Command -ComputerName S1, S2 -ScriptBlock {Get-Process PowerShell}
 ```
 
 ```Output

--- a/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -404,7 +404,7 @@ display. You can still use the **Format** cmdlets to display the **PsComputerNam
 of the affected objects.
 
 ```powershell
-`Invoke-Command` -ComputerName S1, S2 -ScriptBlock {Get-Process PowerShell}
+Invoke-Command -ComputerName S1, S2 -ScriptBlock {Get-Process PowerShell}
 ```
 
 ```Output

--- a/reference/7/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/7/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -404,7 +404,7 @@ display. You can still use the **Format** cmdlets to display the **PsComputerNam
 of the affected objects.
 
 ```powershell
-`Invoke-Command` -ComputerName S1, S2 -ScriptBlock {Get-Process PowerShell}
+Invoke-Command -ComputerName S1, S2 -ScriptBlock {Get-Process PowerShell}
 ```
 
 ```Output


### PR DESCRIPTION
There is no need of placing command within ticks symbols if it's already placed in the code block. It breaks the output on the web page.

It's a cosmetic change. 

![image](https://user-images.githubusercontent.com/26633375/65323800-2c9feb00-dbcc-11e9-8aae-3cfa167a4c91.png)

Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
