### PR TITLE
Fixes #4671, #3768 - Added PsDscRunAsCredential and cleanup

### DIFF
--- a/dsc/reference/resources/linux/lnxArchiveResource.md
+++ b/dsc/reference/resources/linux/lnxArchiveResource.md
@@ -1,16 +1,16 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC for Linux nxArchive Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC for Linux nxArchive Resource
 ---
-
 # DSC for Linux nxArchive Resource
 
-The **nxArchive** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to unpack archive (.tar, .zip) files at a specific path on a Linux node.
+The **nxArchive** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to
+unpack archive (.tar, .zip) files at a specific path on a Linux node.
 
 ## Syntax
 
-```
+```MOF
 nxArchive <string> #ResourceName
 {
     SourcePath = <string>
@@ -24,20 +24,25 @@ nxArchive <string> #ResourceName
 
 ## Properties
 
-|  Property |  Description |
+|Property |Description |
 |---|---|
-| SourcePath| Specifies the source path of the archive file. This should be a .tar, .zip, or .tar.gz file. |
-| DestinationPath| Specifies the location where you want to ensure the archive contents are extracted.|
-| Checksum| Defines the type to use when determining whether the source archive has been updated. Values are: "ctime", "mtime", or "md5". The default value is "md5".|
-| Force| Certain file operations (such as overwriting a file or deleting a directory that is not empty) will result in an error. Using the **Force** property overrides such errors. The default value is **$false**.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the **ID** of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
-| Ensure| Determines whether to check if the content of the archive exists at the **Destination**. Set this property to "Present" to ensure the contents exist. Set it to "Absent" to ensure they do not exist. The default value is "Present".|
+|SourcePath |Specifies the source path of the archive file. This should be a .tar, .zip, or .tar.gz file. |
+|DestinationPath |Specifies the location where you want to ensure the archive contents are extracted. |
+|Checksum |Defines the type to use when determining whether the source archive has been updated. Values are: _ctime_, _mtime_, or _md5_. The default value is _md5_. |
+|Force |Certain file operations (such as overwriting a file or deleting a directory that is not empty) will result in an error. Using the **Force** property overrides such errors. The default value is _$false_. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Determines whether to check if the content of the archive exists at the **Destination**. Set this property to _Present_ to ensure the contents exist. Set it to _Absent_ to ensure they do not exist. The default value is _Present_. |
 
 ## Example
 
 The following example shows how to use the **nxArchive** resource to ensure that the contents of an archive file called `website.tar` exist and are extracted at a given destination.
 
-```
+```powershell
 Import-DSCResource -Module nx
 
 nxFile SyncArchiveFromWeb

--- a/dsc/reference/resources/linux/lnxArchiveResource.md
+++ b/dsc/reference/resources/linux/lnxArchiveResource.md
@@ -10,7 +10,7 @@ unpack archive (.tar, .zip) files at a specific path on a Linux node.
 
 ## Syntax
 
-```MOF
+```Syntax
 nxArchive <string> #ResourceName
 {
     SourcePath = <string>
@@ -28,19 +28,20 @@ nxArchive <string> #ResourceName
 |---|---|
 |SourcePath |Specifies the source path of the archive file. This should be a .tar, .zip, or .tar.gz file. |
 |DestinationPath |Specifies the location where you want to ensure the archive contents are extracted. |
-|Checksum |Defines the type to use when determining whether the source archive has been updated. Values are: _ctime_, _mtime_, or _md5_. The default value is _md5_. |
-|Force |Certain file operations (such as overwriting a file or deleting a directory that is not empty) will result in an error. Using the **Force** property overrides such errors. The default value is _$false_. |
+|Checksum |Defines the type to use when determining whether the source archive has been updated. Values are: **ctime**, **mtime**, or **md5**. The default value is **md5**. |
+|Force |Certain file operations (such as overwriting a file or deleting a directory that is not empty) will result in an error. Using the **Force** property overrides such errors. The default value is `$false`. |
 
 ## Common properties
 
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Determines whether to check if the content of the archive exists at the **Destination**. Set this property to _Present_ to ensure the contents exist. Set it to _Absent_ to ensure they do not exist. The default value is _Present_. |
+|Ensure |Determines whether to check if the content of the archive exists at the **Destination**. Set this property to **Present** to ensure the contents exist. Set it to **Absent** to ensure they do not exist. The default value is **Present**. |
 
 ## Example
 
-The following example shows how to use the **nxArchive** resource to ensure that the contents of an archive file called `website.tar` exist and are extracted at a given destination.
+The following example shows how to use the **nxArchive** resource to ensure that the contents of an
+archive file called `website.tar` exist and are extracted at a given destination.
 
 ```powershell
 Import-DSCResource -Module nx
@@ -48,16 +49,16 @@ Import-DSCResource -Module nx
 nxFile SyncArchiveFromWeb
 {
    Ensure = "Present"
-   SourcePath = “http://release.contoso.com/releases/website.tar”
+   SourcePath = "http://release.contoso.com/releases/website.tar"
    DestinationPath = "/usr/release/staging/website.tar"
    Type = "File"
-   Checksum = “mtime”
+   Checksum = "mtime"
 }
 
 nxArchive SyncWebDir
 {
-   SourcePath = “/usr/release/staging/website.tar”
-   DestinationPath = “/usr/local/apache2/htdocs/”
+   SourcePath = "/usr/release/staging/website.tar"
+   DestinationPath = "/usr/local/apache2/htdocs/"
    Force = $false
    DependsOn = "[nxFile]SyncArchiveFromWeb"
 }

--- a/dsc/reference/resources/linux/lnxEnvironmentResource.md
+++ b/dsc/reference/resources/linux/lnxEnvironmentResource.md
@@ -1,54 +1,64 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC for Linux nxEnvironment Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC for Linux nxEnvironment Resource
 ---
-
 # DSC for Linux nxEnvironment Resource
 
-The **nxEnvironment** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to manage system environment variables on a Linux node.
+The **nxEnvironment** resource in PowerShell Desired State Configuration (DSC) provides a mechanism
+to manage system environment variables on a Linux node.
 
 ## Syntax
 
-```
+```MOF
 nxEnvironment <string> #ResourceName
 {
     Name = <string>
     [ Value = <string>
-    [ Ensure = <string> { Absent | Present }  ]
     [ Path = <bool> }
     [ DependsOn = <string[]> ]
-
+    [ Ensure = <string> { Absent | Present }  ]
 }
 ```
 
 ## Properties
 
-|  Property |  Description |
+|Property |Description |
 |---|---|
-| Name| Indicates the name of the environment variable for which you want to ensure a specific state.|
-| Value| The value to assign to the environment variable.|
-| Ensure| Determines whether to check if the variable exists. Set this property to "Present" to ensure the variable exists. Set it to "Absent" to ensure the variable does not exist. The default value is "Present".|
-| Path| Defines the environment variable that is being configured. Set this property to **$true** if the variable is the **Path** variable; otherwise, set it to **$false**. The default is **$false**. If the variable being configured is the **Path** variable, the value provided through the **Value** property will be appended to the existing value.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the **ID** of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|Name |Indicates the name of the environment variable for which you want to ensure a specific state. |
+|Value |The value to assign to the environment variable. |
+|Path |Defines the environment variable that is being configured. Set this property to _$true_ if the variable is the **Path** variable; otherwise, set it to _$false_. The default is _$false_. If the variable being configured is the **Path** variable, the value provided through the **Value** property will be appended to the existing value. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Determines whether to check if the variable exists. Set this property to _Present_ to ensure the variable exists. Set it to _Absent_ to ensure the variable does not exist. The default value is _Present_. |
 
 ## Additional Information
 
-* If **Path** is absent or set to **$false**, environment variables are managed in `/etc/environment`. Your programs or scripts may require configuration to source the `/etc/environment` file to access the managed environment variables.
-* If **Path** is set to **$true**, the environment variable is managed in the file `/etc/profile.d/DSCenvironment.sh`. This file will be created if it does not exist. If **Ensure** is set to "Absent" and **Path** is set to **$true**, an existing environment variable will only be removed from `/etc/profile.d/DSCenvironment.sh` and not from other files.
+- If **Path** is absent or set to _$false_, environment variables are managed in `/etc/environment`.
+  Your programs or scripts may require configuration to source the `/etc/environment` file to access
+  the managed environment variables.
+- If **Path** is set to _$true_, the environment variable is managed in the file
+  `/etc/profile.d/DSCenvironment.sh`. This file will be created if it does not exist. If **Ensure**
+  is set to _Absent_ and **Path** is set to _$true_, an existing environment variable will only be
+  removed from `/etc/profile.d/DSCenvironment.sh` and not from other files.
 
 ## Example
 
-The following example shows how to use the **nxEnvironment** resource to ensure that **TestEnvironmentVariable** is present and has the value "Test-Value". If **TestEnvironmentVariable** is not present, it will be created.
+The following example shows how to use the **nxEnvironment** resource to ensure that
+**TestEnvironmentVariable** is present and has the value "Test-Value". If
+**TestEnvironmentVariable** is not present, it will be created.
 
-```
+```powershell
 Import-DSCResource -Module nx
-
 
 nxEnvironment EnvironmentExample
 {
-    Ensure = “Present”
-    Name = “TestEnvironmentVariable”
-    Value = “TestValue”
+    Ensure = "Present"
+    Name = "TestEnvironmentVariable"
+    Value = "TestValue"
 }
 ```

--- a/dsc/reference/resources/linux/lnxEnvironmentResource.md
+++ b/dsc/reference/resources/linux/lnxEnvironmentResource.md
@@ -10,7 +10,7 @@ to manage system environment variables on a Linux node.
 
 ## Syntax
 
-```MOF
+```Syntax
 nxEnvironment <string> #ResourceName
 {
     Name = <string>
@@ -27,23 +27,23 @@ nxEnvironment <string> #ResourceName
 |---|---|
 |Name |Indicates the name of the environment variable for which you want to ensure a specific state. |
 |Value |The value to assign to the environment variable. |
-|Path |Defines the environment variable that is being configured. Set this property to _$true_ if the variable is the **Path** variable; otherwise, set it to _$false_. The default is _$false_. If the variable being configured is the **Path** variable, the value provided through the **Value** property will be appended to the existing value. |
+|Path |Defines the environment variable that is being configured. Set this property to `$true` if the variable is the **Path** variable; otherwise, set it to `$false`. The default is `$false`. If the variable being configured is the **Path** variable, the value provided through the **Value** property will be appended to the existing value. |
 
 ## Common properties
 
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Determines whether to check if the variable exists. Set this property to _Present_ to ensure the variable exists. Set it to _Absent_ to ensure the variable does not exist. The default value is _Present_. |
+|Ensure |Determines whether to check if the variable exists. Set this property to **Present** to ensure the variable exists. Set it to **Absent** to ensure the variable does not exist. The default value is **Present**. |
 
 ## Additional Information
 
-- If **Path** is absent or set to _$false_, environment variables are managed in `/etc/environment`.
+- If **Path** is absent or set to `$false`, environment variables are managed in `/etc/environment`.
   Your programs or scripts may require configuration to source the `/etc/environment` file to access
   the managed environment variables.
-- If **Path** is set to _$true_, the environment variable is managed in the file
+- If **Path** is set to `$true`, the environment variable is managed in the file
   `/etc/profile.d/DSCenvironment.sh`. This file will be created if it does not exist. If **Ensure**
-  is set to _Absent_ and **Path** is set to _$true_, an existing environment variable will only be
+  is set to **Absent** and **Path** is set to `$true`, an existing environment variable will only be
   removed from `/etc/profile.d/DSCenvironment.sh` and not from other files.
 
 ## Example

--- a/dsc/reference/resources/linux/lnxFileLineResource.md
+++ b/dsc/reference/resources/linux/lnxFileLineResource.md
@@ -10,7 +10,7 @@ manage lines within a configuration file on a Linux node.
 
 ## Syntax
 
-```MOF
+```Syntax
 nxFileLine <string> #ResourceName
 {
     FilePath = <string>

--- a/dsc/reference/resources/linux/lnxFileLineResource.md
+++ b/dsc/reference/resources/linux/lnxFileLineResource.md
@@ -1,44 +1,50 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC for Linux nxFileLine Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC for Linux nxFileLine Resource
 ---
 # DSC for Linux nxFileLine Resource
 
-The **nxFileLine** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to manage lines within a configuration file on a Linux node.
+The **nxFileLine** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to
+manage lines within a configuration file on a Linux node.
 
 ## Syntax
 
-```
+```MOF
 nxFileLine <string> #ResourceName
 {
     FilePath = <string>
     ContainsLine = <string>
     [ DoesNotContainPattern = <string> ]
     [ DependsOn = <string[]> ]
-
 }
 ```
 
 ## Properties
 
-|  Property |  Description |
+|Property |Description |
 |---|---|
-| FilePath| The full path to the file to manage lines in on the target node.|
-| ContainsLine| A line to ensure exists in the file. This line will be appended to the file if it does not exist in the file. **ContainsLine** is mandatory, but can be set to an empty string (`ContainsLine = ""`) if it is not needed.|
-| DoesNotContainPattern| A regular expression pattern for lines that should not exist in the file. For any lines that exist in the file that match this regular expression, the line will be removed from the file.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the **ID** of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|FilePath |The full path to the file to manage lines in on the target node. |
+|ContainsLine |A line to ensure exists in the file. This line will be appended to the file if it does not exist in the file. **ContainsLine** is mandatory, but can be set to an empty string (`ContainsLine = ""`) if it is not needed. |
+|DoesNotContainPattern |A regular expression pattern for lines that should not exist in the file. For any lines that exist in the file that match this regular expression, the line will be removed from the file. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
 
 ## Example
 
-This example demonstrates using the **nxFileLine** resource to configure the `/etc/sudoers` file, ensuring that the user: monuser is configured to not requiretty.
+This example demonstrates using the **nxFileLine** resource to configure the `/etc/sudoers` file,
+ensuring that the user: monuser is configured to not requiretty.
 
 ```powershell
 Import-DscResource -Module nx
 
 nxFileLine DoNotRequireTTY
 {
-   FilePath = “/etc/sudoers”
+   FilePath = "/etc/sudoers"
    ContainsLine = 'Defaults:monuser !requiretty'
    DoesNotContainPattern = "Defaults:monuser[ ]+requiretty"
 }

--- a/dsc/reference/resources/linux/lnxFileResource.md
+++ b/dsc/reference/resources/linux/lnxFileResource.md
@@ -1,154 +1,161 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC for Linux nxFile Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC for Linux nxFile Resource
 ---
-
 # DSC for Linux nxFile Resource
 
-The **nxFile** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to manage files and directories on a Linux node.
+The **nxFile** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to
+manage files and directories on a Linux node.
 
 ## Syntax
 
-```
+```MOF
 nxFile <string> #ResourceName
 {
     DestinationPath = <string>
     [ SourcePath = <string> ]
-    [ Ensure = <string> { Absent | Present }  ]
     [ Type = <string> { directory | file | link } ]
     [ Contents = <string> ]
     [ Checksum = <string> { ctime | mtime | md5 }  ]
     [ Recurse = <bool> ]
     [ Force = <bool> ]
-    [ Links = <string> { follow | manage } ]
+    [ Links = <string> { follow | manage | ignore } ]
     [ Group = <string> ]
     [ Mode = <string> ]
     [ Owner = <string> ]
     [ DependsOn = <string[]> ]
-
+    [ Ensure = <string> { Absent | Present }  ]
 }
 ```
 
 ## Properties
 
-|  Property |  Description |
+|Property |Description |
 |---|---|
-| DestinationPath| Specifies the location where you want to ensure the state for a file or directory.|
-| SourcePath| Specifies the path from which to copy the file or folder resource. This path may be a local path, or an `http/https/ftp` URL. Remote `http/https/ftp` URLs are only supported when the value of the **Type** property is file.|
-| Ensure| Determines whether to check if the file exists. Set this property to "Present" to ensure the file exists. Set it to "Absent" to ensure the file does not exist. The default value is "Present".|
-| Type| Specifies whether the resource being configured is a directory or a file. Set this property to "directory" to indicate that the resource is a directory. Set it to "file" to indicate that the resource is a file. The default value is "file"|
-| Contents| Specifies the contents of a file, such as a particular string.|
-| Checksum| Defines the type to use when determining whether two files are the same. If **Checksum** is not specified, only the file or directory name is used for comparison. Values are: "ctime", "mtime", or "md5".|
-| Recurse| Indicates if subdirectories are included. Set this property to **$true** to indicate that you want subdirectories to be included. The default is **$false**. **Note:** This property is only valid when the **Type** property is set to directory.|
-| Force| Certain file operations (such as overwriting a file or deleting a directory that is not empty) will result in an error. Using the **Force** property overrides such errors. The default value is **$false**.|
-| Links| Specifies the desired behavior for symbolic links. Set this property to "follow" to follow symbolic links and act on the links target (for example. copy the file instead of the link). Set this property to "manage" to act on the link (for example. copy the link itself). Set this property to "ignore" to ignore symbolic links.|
-| Group| The name of the **Group** to own the file or directory.|
-| Mode| Specifies the desired permissions for the resource, in octal or symbolic notation. (for example, 777 or rwxrwxrwx). If using symbolic notation, do not provide the first character which indicates directory or file.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the **ID** of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|DestinationPath |Specifies the location where you want to ensure the state for a file or directory. |
+|SourcePath |Specifies the path from which to copy the file or folder resource. This path may be a local path, or an `http/https/ftp` URL. Remote `http/https/ftp` URLs are only supported when the value of the **Type** property is _file_. |
+|Type |Specifies whether the resource being configured is a directory or a file. Set this property to _directory_ to indicate that the resource is a directory. Set it to _file_ to indicate that the resource is a file. The default value is _file_. |
+|Contents |Specifies the contents of a file, such as a particular string. |
+|Checksum |Defines the type to use when determining whether two files are the same. If **Checksum** is not specified, only the file or directory name is used for comparison. Values are: _ctime_, _mtime_, or _md5_. |
+|Recurse |Indicates if subdirectories are included. Set this property to _$true_ to indicate that you want subdirectories to be included. The default is _$false_. This property is only valid when the **Type** property is set to _directory_. |
+|Force |Certain file operations (such as overwriting a file or deleting a directory that is not empty) will result in an error. Using the **Force** property overrides such errors. The default value is _$false_. |
+|Links |Specifies the desired behavior for symbolic links. Set this property to _follow_ to follow symbolic links and act on the links target. For example, copy the file instead of the link. Set this property to _manage_ to act on the link. For example, copy the link itself. Set this property to _ignore_ to ignore symbolic links. |
+|Group |The name of the **Group** to have permissions to the file or directory. |
+|Mode |Specifies the desired permissions for the resource, in octal or symbolic notation. For example, _777_ or _rwxrwxrwx_. If using symbolic notation, do not provide the first character which indicates directory or file. |
+|Owner |The name of the group to own the file or directory. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Determines whether to check if the file exists. Set this property to _Present_ to ensure the file exists. Set it to _Absent_ to ensure the file does not exist. The default value is _Present_. |
 
 ## Additional Information
 
+Linux and Windows use different line break characters in text files by default, and this can cause
+unexpected results when configuring some files on a Linux computer with **nxFile**. There are
+multiple ways to manage the content of a Linux file while avoiding issues caused by unexpected line
+break characters:
 
-Linux and Windows use different line break characters in text files by default, and this can cause unexpected results when configuring some files on a Linux computer with __nxFile__. There are multiple ways to manage the content of a Linux file while avoiding issues caused by unexpected line break characters:
+1. Copy the file from a remote source (http, https, or ftp)
 
-Step 1: Copy the file from a remote source (http, https, or ftp): create a file on Linux with the desired contents, and stage it on a web or ftp server accessible the node(s) you will configure. Define the __SourcePath__ property in the __nxFile__ resource with the web or ftp URL to the file.
+   Create a file on Linux with the desired contents, and stage it on a web or ftp server accessible
+   the node(s) you will configure. Define the **SourcePath** property in the **nxFile** resource
+   with the web or ftp URL to the file.
 
-```
-Import-DSCResource -Module nx
-Node $Node
-{
-nxFile resolvConf
-{
-    SourcePath = "http://10.185.85.11/conf/resolv.conf"
-    DestinationPath = "/etc/resolv.conf"
-    Mode = "644"
-    Type = "file"
+   ```powershell
+   Import-DSCResource -Module nx
 
-}
+   Node $Node
+   {
+      nxFile resolvConf
+      {
+         SourcePath = "http://10.185.85.11/conf/resolv.conf"
+         DestinationPath = "/etc/resolv.conf"
+         Mode = "644"
+         Type = "file"
+      }
+   }
+   ```
 
-}
-```
+1. Read the file contents in the PowerShell script with [Get-Content](https://technet.microsoft.com/library/hh849787.aspx)
+   after setting the **$OFS** property to use the Linux line-break character.
 
+   ```powershell
+   Import-DSCResource -Module nx
 
-Step 2: Read the file contents in the PowerShell script with [Get-Content](https://technet.microsoft.com/library/hh849787.aspx) after setting the __$OFS__ property to use the Linux line-break character.
+   Node $Node
+   {
+      $OFS = "`n"
+      $Contents = Get-Content C:\temp\resolv.conf
 
+      nxFile resolvConf
+      {
+         DestinationPath = "/etc/resolv.conf"
+         Mode = "644"
+         Type = "file"
+         Contents = "$Contents"
+      }
+   }
+   ```
 
-```
-Import-DSCResource -Module nx
-Node $Node
-{
-$OFS = "`n"
-$Contents = Get-Content C:\temp\resolv.conf
+1. Use a PowerShell function to replace Windows line breaks with Linux line-break characters.
 
-nxFile resolvConf
-{
-    DestinationPath = "/etc/resolv.conf"
-    Mode = "644"
-    Type = "file"
-    Contents = "$Contents"
-}
+   ```powershell
+   Function LinuxString($inputStr){
+      $outputStr = $inputStr.Replace("`r`n","`n")
+      $outputStr += "`n"
+      Return $outputStr
+   }
 
-}
-```
+   Import-DSCResource -Module nx
 
+   Node $Node
+   {
+      $Contents = @'
+   search contoso.com
+   domain contoso.com
+   nameserver 10.185.85.11
+   '@
+       $Contents = LinuxString $Contents
 
-Step 3: Use a PowerShell function to replace Windows line breaks with Linux line-break characters.
-
-```
-Function LinuxString($inputStr){
-    $outputStr = $inputStr.Replace("`r`n","`n")
-    $ouputStr += "`n"
-    Return $outputStr
-}
-
-Import-DSCResource -Module nx
-Node $Node
-{
-
-$Contents = @'
-search contoso.com
-domain contoso.com
-nameserver 10.185.85.11
-'@
-
-$Contents = LinuxString $Contents
-
-nxFile resolvConf
-{
-    DestinationPath = "/etc/resolv.conf"
-    Mode = "644"
-    Type = "file"
-    Contents = $Contents
-
-}
-}
-```
+      nxFile resolvConf
+      {
+         DestinationPath = "/etc/resolv.conf"
+         Mode = "644"
+         Type = "file"
+         Contents = $Contents
+      }
+   }
+   ```
 
 ## Example
 
-The following example ensures that the directory `/opt/mydir` exists, and that a file with specified contents exists this directory.
+The following example ensures that the directory `/opt/mydir` exists, and that a file with specified
+contents exists this directory.
 
-```
+```powershell
 Import-DSCResource -Module nx
 
 Node $node {
-nxFile DirectoryExample
-{
-   Ensure = "Present"
-   DestinationPath = "/opt/mydir"
-   Type = "Directory"
-}
+    nxFile DirectoryExample
+    {
+        Ensure = "Present"
+        DestinationPath = "/opt/mydir"
+        Type = "Directory"
+    }
 
-nxFile FileExample
-{
-    Ensure = "Present"
-    Destinationpath = "/opt/mydir/myfile"
-    Contents=@"
+    nxFile FileExample
+    {
+        Ensure = "Present"
+        Destinationpath = "/opt/mydir/myfile"
+        Contents=@"
 #!/bin/bash`necho "hello world"`n
 "@
-    Mode = “755”
-    DependsOn = "[nxFile]DirectoryExample"
-}
+        Mode = “755”
+        DependsOn = "[nxFile]DirectoryExample"
+    }
 }
 ```

--- a/dsc/reference/resources/linux/lnxFileResource.md
+++ b/dsc/reference/resources/linux/lnxFileResource.md
@@ -10,7 +10,7 @@ manage files and directories on a Linux node.
 
 ## Syntax
 
-```MOF
+```Syntax
 nxFile <string> #ResourceName
 {
     DestinationPath = <string>
@@ -34,15 +34,15 @@ nxFile <string> #ResourceName
 |Property |Description |
 |---|---|
 |DestinationPath |Specifies the location where you want to ensure the state for a file or directory. |
-|SourcePath |Specifies the path from which to copy the file or folder resource. This path may be a local path, or an `http/https/ftp` URL. Remote `http/https/ftp` URLs are only supported when the value of the **Type** property is _file_. |
-|Type |Specifies whether the resource being configured is a directory or a file. Set this property to _directory_ to indicate that the resource is a directory. Set it to _file_ to indicate that the resource is a file. The default value is _file_. |
+|SourcePath |Specifies the path from which to copy the file or folder resource. This path may be a local path, or an `http/https/ftp` URL. Remote `http/https/ftp` URLs are only supported when the value of the **Type** property is **file**. |
+|Type |Specifies whether the resource being configured is a directory or a file. Set this property to **directory** to indicate that the resource is a directory. Set it to **file** to indicate that the resource is a file. The default value is **file**. |
 |Contents |Specifies the contents of a file, such as a particular string. |
-|Checksum |Defines the type to use when determining whether two files are the same. If **Checksum** is not specified, only the file or directory name is used for comparison. Values are: _ctime_, _mtime_, or _md5_. |
-|Recurse |Indicates if subdirectories are included. Set this property to _$true_ to indicate that you want subdirectories to be included. The default is _$false_. This property is only valid when the **Type** property is set to _directory_. |
-|Force |Certain file operations (such as overwriting a file or deleting a directory that is not empty) will result in an error. Using the **Force** property overrides such errors. The default value is _$false_. |
-|Links |Specifies the desired behavior for symbolic links. Set this property to _follow_ to follow symbolic links and act on the links target. For example, copy the file instead of the link. Set this property to _manage_ to act on the link. For example, copy the link itself. Set this property to _ignore_ to ignore symbolic links. |
+|Checksum |Defines the type to use when determining whether two files are the same. If **Checksum** is not specified, only the file or directory name is used for comparison. Values are: **ctime**, **mtime**, or **md5**. |
+|Recurse |Indicates if subdirectories are included. Set this property to `$true` to indicate that you want subdirectories to be included. The default is `$false`. This property is only valid when the **Type** property is set to **directory**. |
+|Force |Certain file operations (such as overwriting a file or deleting a directory that is not empty) will result in an error. Using the **Force** property overrides such errors. The default value is `$false`. |
+|Links |Specifies the desired behavior for symbolic links. Set this property to **follow** to follow symbolic links and act on the links target. For example, copy the file instead of the link. Set this property to **manage** to act on the link. For example, copy the link itself. Set this property to **ignore** to ignore symbolic links. |
 |Group |The name of the **Group** to have permissions to the file or directory. |
-|Mode |Specifies the desired permissions for the resource, in octal or symbolic notation. For example, _777_ or _rwxrwxrwx_. If using symbolic notation, do not provide the first character which indicates directory or file. |
+|Mode |Specifies the desired permissions for the resource, in octal or symbolic notation. For example, **777** or **rwxrwxrwx**. If using symbolic notation, do not provide the first character which indicates directory or file. |
 |Owner |The name of the group to own the file or directory. |
 
 ## Common properties
@@ -50,7 +50,7 @@ nxFile <string> #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Determines whether to check if the file exists. Set this property to _Present_ to ensure the file exists. Set it to _Absent_ to ensure the file does not exist. The default value is _Present_. |
+|Ensure |Determines whether to check if the file exists. Set this property to **Present** to ensure the file exists. Set it to **Absent** to ensure the file does not exist. The default value is **Present**. |
 
 ## Additional Information
 
@@ -154,7 +154,7 @@ Node $node {
         Contents=@"
 #!/bin/bash`necho "hello world"`n
 "@
-        Mode = “755”
+        Mode = "755"
         DependsOn = "[nxFile]DirectoryExample"
     }
 }

--- a/dsc/reference/resources/linux/lnxGroupResource.md
+++ b/dsc/reference/resources/linux/lnxGroupResource.md
@@ -10,7 +10,7 @@ manage local groups on a Linux node.
 
 ## Syntax
 
-```MOF
+```Syntax
 nxGroup <string> #ResourceName
 {
     GroupName = <string>
@@ -38,7 +38,7 @@ nxGroup <string> #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Determines whether to check if the group exists. Set this property to _Present_ to ensure the group exists. Set it to _Absent_ to ensure the group does not exist. The default value is _Present_. |
+|Ensure |Determines whether to check if the group exists. Set this property to **Present** to ensure the group exists. Set it to **Absent** to ensure the group does not exist. The default value is **Present**. |
 
 ## Example
 

--- a/dsc/reference/resources/linux/lnxGroupResource.md
+++ b/dsc/reference/resources/linux/lnxGroupResource.md
@@ -1,37 +1,44 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC for Linux nxGroup Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC for Linux nxGroup Resource
 ---
 # DSC for Linux nxGroup Resource
 
-The **nxGroup** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to manage local groups on a Linux node.
+The **nxGroup** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to
+manage local groups on a Linux node.
 
 ## Syntax
 
-```
+```MOF
 nxGroup <string> #ResourceName
 {
     GroupName = <string>
-    [ Ensure = <string> { Absent | Present } ]
     [ Members = <string[]> ]
     [ MembersToInclude = <string[]> ]
     [ MembersToExclude = <string[]> ]
+    [ PreferredGroupID = <string> ]
     [ DependsOn = <string[]> ]
+    [ Ensure = <string> { Absent | Present } ]
 }
 ```
 
 ## Properties
 
-|  Property |  Description |
+|Property |Description |
 |---|---|
-| GroupName| Specifies the name of the group for which you want to ensure a specific state.|
-| Ensure| Determines whether to check if the group exists. Set this property to "Present" to ensure the group exists. Set it to "Absent" to ensure the group does not exist. The default value is "Present".|
-| Members| Specifies the members that form the group.|
-| MembersToInclude| Specifies the users who you want to ensure are members of the group.|
-| MembersToExclude| Specifies the users who you want to ensure are not members of the group.|
-| PreferredGroupID| Sets the group id to the provided value if possible. If the group id is currently in use, the next available group id is used.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the **ID** of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = '[ResourceType]ResourceName'`.|
+|GroupName |Specifies the name of the group for which you want to ensure a specific state. |
+|Members |Specifies the members that form the group. |
+|MembersToInclude |Specifies the users who you want to ensure are members of the group. |
+|MembersToExclude |Specifies the users who you want to ensure are not members of the group. |
+|PreferredGroupID |Sets the group id to the provided value if possible. If the group id is currently in use, the next available group id is used. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Determines whether to check if the group exists. Set this property to _Present_ to ensure the group exists. Set it to _Absent_ to ensure the group does not exist. The default value is _Present_. |
 
 ## Example
 
@@ -40,7 +47,8 @@ The following example ensures that the user 'monuser' exists and is a member of 
 ```powershell
 Import-DSCResource -Module nx
 
-Node $node {
+Node $node
+{
     nxUser UserExample {
        UserName = 'monuser'
        Description = 'Monitoring user'

--- a/dsc/reference/resources/linux/lnxPackageResource.md
+++ b/dsc/reference/resources/linux/lnxPackageResource.md
@@ -10,7 +10,7 @@ manage packages on a Linux node.
 
 ## Syntax
 
-```MOF
+```Syntax
 nxPackage <string> #ResourceName
 {
     Name = <string>
@@ -29,8 +29,8 @@ nxPackage <string> #ResourceName
 |Property |Description |
 |---|---|
 |Name |The name of the package for which you want to ensure a specific state. |
-|PackageManager |Supported values are _yum_, _apt_, and _zypper_. Specifies the package manager to use when installing packages. If **FilePath** is specified, the provided path will be used to install the package. Otherwise, a Package Manager will be used to install the package from a pre-configured repository. If neither **PackageManager** nor **FilePath** are provided, the default package manager for the system will be used. |
-|PackageGroup |If _$true_, the **Name** is expected to be the name of a package group for use with a **PackageManager**. **PackageGroup** is not valid when providing a **FilePath**. |
+|PackageManager |Supported values are **yum**, **apt**, and **zypper**. Specifies the package manager to use when installing packages. If **FilePath** is specified, the provided path will be used to install the package. Otherwise, a Package Manager will be used to install the package from a pre-configured repository. If neither **PackageManager** nor **FilePath** are provided, the default package manager for the system will be used. |
+|PackageGroup |If `$true`, the **Name** is expected to be the name of a package group for use with a **PackageManager**. **PackageGroup** is not valid when providing a **FilePath**. |
 |Arguments |A string of arguments that will be passed to the package exactly as provided. |
 |ReturnCode |The expected return code. If the actual return code does not match the expected value provided here, the configuration will return an error. |
 |FilePath |The file path where the package resides. |
@@ -40,7 +40,7 @@ nxPackage <string> #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Determines whether to check if the package exists. Set this property to _Present_ to ensure the package exists. Set it to _Absent_ to ensure the package does not exist. The default value is _Present_. |
+|Ensure |Determines whether to check if the package exists. Set this property to **Present** to ensure the package exists. Set it to **Absent** to ensure the package does not exist. The default value is **Present**. |
 
 ## Example
 

--- a/dsc/reference/resources/linux/lnxPackageResource.md
+++ b/dsc/reference/resources/linux/lnxPackageResource.md
@@ -1,56 +1,62 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC for Linux nxPackage Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC for Linux nxPackage Resource
 ---
-
 # DSC for Linux nxPackage Resource
 
-The **nxPackage** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to manage packages on a Linux node.
+The **nxPackage** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to
+manage packages on a Linux node.
 
 ## Syntax
 
-```
+```MOF
 nxPackage <string> #ResourceName
 {
     Name = <string>
-    [ Ensure = <string> { Absent | Present }  ]
     [ PackageManager = <string> { Yum | Apt | Zypper } ]
     [ PackageGroup = <bool>]
     [ Arguments = <string> ]
     [ ReturnCode = <uint32> ]
-    [ LogPath = <string> ]
+    [ FilePath = <string> ]
     [ DependsOn = <string[]> ]
-
+    [ Ensure = <string> { Absent | Present }  ]
 }
 ```
 
 ## Properties
 
-|  Property |  Description |
+|Property |Description |
 |---|---|
-| Name| The name of the package for which you want to ensure a specific state.|
-| Ensure| Determines whether to check if the package exists. Set this property to "Present" to ensure the package exists. Set it to "Absent" to ensure the package does not exist. The default value is "Present".|
-| PackageManager| Supported values are "yum", "apt", and "zypper". Specifies the package manager to use when installing packages. If **FilePath** is specified, the provided path will be used to install the package. Otherwise, a Package Manager will be used to install the package from a pre-configured repository. If neither **PackageManager** nor **FilePath** are provided, the default package manager for the system will be used.|
-| FilePath| The file path where the package resides|
-| PackageGroup| If **$true**, the **Name** is expected to be the name of a package group for use with a **PackageManager**. **PacakgeGroup** is not valid when providing a **FilePath**.|
-| Arguments| A string of arguments that will be passed to the package exactly as provided.|
-| ReturnCode| The expected return code. If the actual return code does not match the expected value provided here, the configuration will return an error.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the **ID** of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|Name |The name of the package for which you want to ensure a specific state. |
+|PackageManager |Supported values are _yum_, _apt_, and _zypper_. Specifies the package manager to use when installing packages. If **FilePath** is specified, the provided path will be used to install the package. Otherwise, a Package Manager will be used to install the package from a pre-configured repository. If neither **PackageManager** nor **FilePath** are provided, the default package manager for the system will be used. |
+|PackageGroup |If _$true_, the **Name** is expected to be the name of a package group for use with a **PackageManager**. **PackageGroup** is not valid when providing a **FilePath**. |
+|Arguments |A string of arguments that will be passed to the package exactly as provided. |
+|ReturnCode |The expected return code. If the actual return code does not match the expected value provided here, the configuration will return an error. |
+|FilePath |The file path where the package resides. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Determines whether to check if the package exists. Set this property to _Present_ to ensure the package exists. Set it to _Absent_ to ensure the package does not exist. The default value is _Present_. |
 
 ## Example
 
-The following example ensures that the package named "httpd" is installed on a Linux computer, using the “Yum” package manager.
+The following example ensures that the package named "httpd" is installed on a Linux computer, using
+the "Yum" package manager.
 
-```
+```powershell
 Import-DSCResource -Module nx
 
-Node $node {
-nxPackage httpd
+Node $node
 {
-    Name = "httpd"
-    Ensure = "Present"
-    PackageManager = "Yum"
-}
+    nxPackage httpd
+    {
+        Name = "httpd"
+        Ensure = "Present"
+        PackageManager = "Yum"
+    }
 }
 ```

--- a/dsc/reference/resources/linux/lnxScriptResource.md
+++ b/dsc/reference/resources/linux/lnxScriptResource.md
@@ -10,7 +10,7 @@ run Linux scripts on a Linux node.
 
 ## Syntax
 
-```MOF
+```Syntax
 nxScript <string> #ResourceName
 {
     GetScript = <string>

--- a/dsc/reference/resources/linux/lnxScriptResource.md
+++ b/dsc/reference/resources/linux/lnxScriptResource.md
@@ -1,16 +1,16 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC for Linux nxScript Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC for Linux nxScript Resource
 ---
-
 # DSC for Linux nxScript Resource
 
-The **nxScript** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to run Linux scripts on a Linux node.
+The **nxScript** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to
+run Linux scripts on a Linux node.
 
 ## Syntax
 
-```
+```MOF
 nxScript <string> #ResourceName
 {
     GetScript = <string>
@@ -19,30 +19,36 @@ nxScript <string> #ResourceName
     [ User = <string> ]
     [ Group = <string> ]
     [ DependsOn = <string[]> ]
-
 }
 ```
 
 ## Properties
 
-|  Property |  Description |
+|Property |Description |
 |---|---|
-| GetScript| Provides a script to return current status of the machine.  This script runs when you invoke the [GetDscConfiguration.py](https://github.com/Microsoft/PowerShell-DSC-for-Linux#performing-dsc-operations-from-the-linux-computer) script. The script must begin with a shebang, such as #!/bin/bash.|
-| SetScript| Provides a script that puts the machine in the correct state. When you invoke the [StartDscConfiguration.py](https://github.com/Microsoft/PowerShell-DSC-for-Linux#performing-dsc-operations-from-the-linux-computer) script, the **TestScript** runs first. If the **TestScript** block returns an exit code other than 0, the **SetScript** block will run. If the **TestScript** returns an exit code of 0, the **SetScript** will not run. The script must begin with a shebang, such as `#!/bin/bash`.|
-| TestScript| Provides a script that evaluates whether the node is currently in the correct state. When you invoke the [StartDscConfiguration.py](https://github.com/Microsoft/PowerShell-DSC-for-Linux#performing-dsc-operations-from-the-linux-computer) script, this script runs. If it returns an exit code other than 0, the SetScript will run. If it returns an exit code of 0, the **SetScript** will not run. The **TestScript** also runs when you invoke the [TestDscConfiguration](https://github.com/Microsoft/PowerShell-DSC-for-Linux#performing-dsc-operations-from-the-linux-computer) script. However, in this case, the **SetScript** will not run, no matter what exit code is returned from the **TestScript**. The **TestScript** must contain content and must return an exit code of 0 if the actual configuration matches the current desired state configuration, and an exit code other than 0 if it does not match. (The current desired state configuration is the last configuration enacted on the node that is using DSC). The script must begin with a shebang, such as 1#!/bin/bash.1|
-| User| The user to run the script as.|
-| Group| The group to run the script as.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the **ID** of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|GetScript |Provides a script to return current status of the machine. This script runs when you invoke the [GetDscConfiguration.py](https://github.com/Microsoft/PowerShell-DSC-for-Linux#performing-dsc-operations-from-the-linux-computer) script. The script must begin with a shebang, such as `#!/bin/bash`. |
+|SetScript |Provides a script that puts the machine in the correct state. When you invoke the [StartDscConfiguration.py](https://github.com/Microsoft/PowerShell-DSC-for-Linux#performing-dsc-operations-from-the-linux-computer) script, the **TestScript** runs first. If the **TestScript** block returns an exit code other than 0, the **SetScript** block will run. If the **TestScript** returns an exit code of 0, the **SetScript** will not run. The script must begin with a shebang, such as `#!/bin/bash`. |
+|TestScript |Provides a script that evaluates whether the node is currently in the correct state. When you invoke the [StartDscConfiguration.py](https://github.com/Microsoft/PowerShell-DSC-for-Linux#performing-dsc-operations-from-the-linux-computer) script, this script runs. If it returns an exit code other than 0, the **SetScript** will run. If it returns an exit code of 0, the **SetScript** will not run. The **TestScript** also runs when you invoke the [TestDscConfiguration](https://github.com/Microsoft/PowerShell-DSC-for-Linux#performing-dsc-operations-from-the-linux-computer) script. However, in this case, the **SetScript** will not run, no matter what exit code is returned from the **TestScript**. The **TestScript** must contain content and must return an exit code of 0 if the actual configuration matches the current desired state configuration, and an exit code other than 0 if it does not match. The current desired state configuration is the last configuration enacted on the node that is using DSC. The script must begin with a shebang, such as `#!/bin/bash`. |
+|User |The user to run the script as. |
+|Group |The group to run the script as. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
 
 ## Example
 
-The following example demonstrates the use of the **nxScript** resource to perform additional configuration management.
+The following example demonstrates the use of the **nxScript** resource to perform additional
+configuration management.
 
-```
+```powershell
 Import-DSCResource -Module nx
 
-Node $node {
-nxScript KeepDirEmpty{
+Node $node
+{
+    nxScript KeepDirEmpty {
 
     GetScript = @"
 #!/bin/bash
@@ -64,6 +70,6 @@ else
     exit 0
 fi
 '@
-}
+    }
 }
 ```

--- a/dsc/reference/resources/linux/lnxServiceResource.md
+++ b/dsc/reference/resources/linux/lnxServiceResource.md
@@ -1,15 +1,16 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC for Linux nxService Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC for Linux nxService Resource
 ---
 # DSC for Linux nxService Resource
 
-The **nxService** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to manage services on a Linux node.
+The **nxService** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to
+manage services on a Linux node.
 
 ## Syntax
 
-```
+```MOF
 nxService <string> #ResourceName
 {
     Name = <string>
@@ -22,26 +23,35 @@ nxService <string> #ResourceName
 
 ## Properties
 
-| Property | Description |
+|Property |Description |
 |---|---|
-| Name| The name of the service/daemon to configure.|
-| Controller| The type of service controller to use when configuring the service.|
-| Enabled| Indicates whether the service starts on boot.|
-| State| Indicates whether the service is running. Set this property to "Stopped" to ensure that the service is not running. Set it to "Running" to ensure that the service is not running.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the **ID** of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|Name |The name of the service/daemon to configure. |
+|Controller |The type of service controller to use when configuring the service. |
+|Enabled |Indicates whether the service starts on boot. |
+|State |Indicates whether the service is running. Set this property to _Stopped_ to ensure that the service is not running. Set it to _Running_ to ensure that the service is running. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
 
 ## Additional Information
 
-The **nxService** resource will not create a service definition or script for the service if it does not exist. You can use the PowerShell Desired State Configuration **nxFile** Resource resource to manage the existence or contents of the service definition file or script.
+The **nxService** resource will not create a service definition or script for the service if it does
+not exist. You can use the PowerShell Desired State Configuration **nxFile** Resource resource to
+manage the existence or contents of the service definition file or script.
 
 ## Example
 
-The following example shows configuration of the 'httpd' service (for Apache HTTP Server), registered with the **SystemD** service controller.
+The following example shows configuration of the 'httpd' service (for Apache HTTP Server),
+registered with the **SystemD** service controller.
 
 ```powershell
 Import-DSCResource -Module nx
 
-Node $node {
+Node $node
+{
     #Apache Service
     nxService ApacheService {
         Name = 'httpd'

--- a/dsc/reference/resources/linux/lnxServiceResource.md
+++ b/dsc/reference/resources/linux/lnxServiceResource.md
@@ -10,7 +10,7 @@ manage services on a Linux node.
 
 ## Syntax
 
-```MOF
+```Syntax
 nxService <string> #ResourceName
 {
     Name = <string>
@@ -28,7 +28,7 @@ nxService <string> #ResourceName
 |Name |The name of the service/daemon to configure. |
 |Controller |The type of service controller to use when configuring the service. |
 |Enabled |Indicates whether the service starts on boot. |
-|State |Indicates whether the service is running. Set this property to _Stopped_ to ensure that the service is not running. Set it to _Running_ to ensure that the service is running. |
+|State |Indicates whether the service is running. Set this property to **Stopped** to ensure that the service is not running. Set it to **Running** to ensure that the service is running. |
 
 ## Common properties
 

--- a/dsc/reference/resources/linux/lnxSshAuthorizedKeysResource.md
+++ b/dsc/reference/resources/linux/lnxSshAuthorizedKeysResource.md
@@ -1,51 +1,56 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC for Linux nxSshAuthorizedKeys Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC for Linux nxSshAuthorizedKeys Resource
 ---
-
 # DSC for Linux nxSshAuthorizedKeys Resource
 
-The **nxAuthorizedKeys** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to manage authorized ssh keys for a specified user.
+The **nxAuthorizedKeys** resource in PowerShell Desired State Configuration (DSC) provides a
+mechanism to manage authorized ssh keys for a specified user.
 
 ## Syntax
 
-```
+```MOF
 nxAuthorizedKeys <string> #ResourceName
 {
     KeyComment = <string>
-    [ Ensure = <string> { Absent | Present }  ]
     [ Username = <string> ]
     [ Key = <string> ]
     [ DependsOn = <string[]> ]
-
+    [ Ensure = <string> { Absent | Present }  ]
 }
 ```
 
 ## Properties
 
-|  Property |  Description |
+|Property |Description |
 |---|---|
-| KeyComment| A unique comment for the key. This is used to uniquely identify keys.|
-| Ensure| Specifies whether the key is defined. Set this property to "Absent" to ensure the key does not exist in the user’s authorized keys file. Set it to "Present" to ensure the key is defined in the user’s authorized key file.|
-| Username| The username to manage ssh authorized keys for. If not defined, the default user is "root".|
-| Key| The contents of the key. This is required if **Ensure** is set to "Present".|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the **ID** of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|KeyComment |A unique comment for the key. This is used to uniquely identify keys. |
+|Username |The username to manage ssh authorized keys for. If not defined, the default user is _root_. |
+|Key |The contents of the key. This is required if **Ensure** is set to _Present_.|
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Specifies whether the key is defined. Set this property to _Absent_ to ensure the key does not exist in the user's authorized keys file. Set it to _Present_ to ensure the key is defined in the user's authorized key file. |
 
 ## Example
 
 The following example defines a public ssh authorized key for the user "monuser".
 
-```
+```powershell
 Import-DSCResource -Module nx
 
-Node $node {
-
-nxSshAuthorizedKeys myKey{
-   KeyComment = "myKey"
-   Ensure = "Present"
-   Key = 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEA0b+0xSd07QXRifm3FXj7Pn/DblA6QI5VAkDm6OivFzj3U6qGD1VJ6AAxWPCyMl/qhtpRtxZJDu/TxD8AyZNgc8aN2CljN1hOMbBRvH2q5QPf/nCnnJRaGsrxIqZjyZdYo9ZEEzjZUuMDM5HI1LA9B99k/K6PK2Bc1NLivpu7nbtVG2tLOQs+GefsnHuetsRMwo/+c3LtwYm9M0XfkGjYVCLO4CoFuSQpvX6AB3TedUy6NZ0iuxC0kRGg1rIQTwSRcw+McLhslF0drs33fw6tYdzlLBnnzimShMuiDWiT37WqCRovRGYrGCaEFGTG2e0CN8Co8nryXkyWc6NSDNpMzw== rsa-key-20150401'
-   UserName = "monuser"
-}
+Node $node
+{
+    nxSshAuthorizedKeys myKey
+    {
+        KeyComment = "myKey"
+        Ensure = "Present"
+        Key = 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEA0b+0xSd07QXRifm3FXj7Pn/DblA6QI5VAkDm6OivFzj3U6qGD1VJ6AAxWPCyMl/qhtpRtxZJDu/TxD8AyZNgc8aN2CljN1hOMbBRvH2q5QPf/nCnnJRaGsrxIqZjyZdYo9ZEEzjZUuMDM5HI1LA9B99k/K6PK2Bc1NLivpu7nbtVG2tLOQs+GefsnHuetsRMwo/+c3LtwYm9M0XfkGjYVCLO4CoFuSQpvX6AB3TedUy6NZ0iuxC0kRGg1rIQTwSRcw+McLhslF0drs33fw6tYdzlLBnnzimShMuiDWiT37WqCRovRGYrGCaEFGTG2e0CN8Co8nryXkyWc6NSDNpMzw== rsa-key-20150401'
+        UserName = "monuser"
+    }
 }
 ```

--- a/dsc/reference/resources/linux/lnxSshAuthorizedKeysResource.md
+++ b/dsc/reference/resources/linux/lnxSshAuthorizedKeysResource.md
@@ -10,7 +10,7 @@ mechanism to manage authorized ssh keys for a specified user.
 
 ## Syntax
 
-```MOF
+```Syntax
 nxAuthorizedKeys <string> #ResourceName
 {
     KeyComment = <string>
@@ -26,15 +26,15 @@ nxAuthorizedKeys <string> #ResourceName
 |Property |Description |
 |---|---|
 |KeyComment |A unique comment for the key. This is used to uniquely identify keys. |
-|Username |The username to manage ssh authorized keys for. If not defined, the default user is _root_. |
-|Key |The contents of the key. This is required if **Ensure** is set to _Present_.|
+|Username |The username to manage ssh authorized keys for. If not defined, the default user is **root**. |
+|Key |The contents of the key. This is required if **Ensure** is set to **Present**.|
 
 ## Common properties
 
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Specifies whether the key is defined. Set this property to _Absent_ to ensure the key does not exist in the user's authorized keys file. Set it to _Present_ to ensure the key is defined in the user's authorized key file. |
+|Ensure |Specifies whether the key is defined. Set this property to **Absent** to ensure the key does not exist in the user's authorized keys file. Set it to **Present** to ensure the key is defined in the user's authorized key file. |
 
 ## Example
 

--- a/dsc/reference/resources/linux/lnxUserResource.md
+++ b/dsc/reference/resources/linux/lnxUserResource.md
@@ -1,20 +1,19 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC for Linux nxUser Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC for Linux nxUser Resource
 ---
-
 # DSC for Linux nxUser Resource
 
-The **nxUser** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to manage local users on a Linux node.
+The **nxUser** resource in PowerShell Desired State Configuration (DSC) provides a mechanism to
+manage local users on a Linux node.
 
 ## Syntax
 
-```
+```MOF
 nxUser <string> #ResourceName
 {
     UserName = <string>
-    [ Ensure = <string> { Absent | Present }  ]
     [ FullName = <string> ]
     [ Description = <string> ]
     [ Password = <string> ]
@@ -23,46 +22,52 @@ nxUser <string> #ResourceName
     [ HomeDirectory = <string> ]
     [ GroupID = <string> ]
     [ DependsOn = <string[]> ]
-
+    [ Ensure = <string> { Absent | Present }  ]
 }
 ```
 
 ## Properties
 
-|  Property |  Indicates the account name for which you want to ensure a specific state. |
+|Property |Indicates the account name for which you want to ensure a specific state. |
 |---|---|
-| UserName| Specifies the location where you want to ensure the state for a file or directory.|
-| Ensure| Specifies whether the account exists. Set this property to "Present" to ensure that the account exists, and set it to "Absent" to ensure that the account does not exist.|
-| FullName| A string that contains the full name to use for the user account.|
-| Description| The description for the user account.|
-| Password| The hash of the users password in the appropriate form for the Linux computer. Typically, this is a salted SHA-256, or SHA-512 hash. On Debian and Ubuntu Linux, this value can be generated with the mkpasswd command. For other Linux distros, the crypt method of Python’s Crypt library can be used to generate the hash.|
-| Disabled| Indicates whether the account is enabled. Set this property to **$true** to ensure that this account is disabled, and set it to **$false** to ensure that it is enabled.|
-| PasswordChangeRequired| Indicates whether the user can change the password. Set this property to **$true** to ensure that the user cannot change the password, and set it to **$false** to allow the user to change the password. The default value is **$false**. This property is only evaluated if the user account did not exist previously and is being created.|
-| HomeDirectory| The home directory for the user.|
-| GroupID| The primary group ID for the user.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is "ResourceName" and its type is "ResourceType", the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|UserName |Specifies the location where you want to ensure the state for a file or directory. |
+|FullName |A string that contains the full name to use for the user account. |
+|Description |The description for the user account. |
+|Password |The hash of the users password in the appropriate form for the Linux computer. Typically, this is a salted SHA-256, or SHA-512 hash. On Debian and Ubuntu Linux, this value can be generated with the `mkpasswd` command. For other Linux distros, the crypt method of Python's Crypt library can be used to generate the hash. |
+|Disabled |Indicates whether the account is enabled. Set this property to _$true_ to ensure that this account is disabled, and set it to _$false_ to ensure that it is enabled. |
+|PasswordChangeRequired |Indicates whether the user can change the password. Set this property to _$true_ to ensure that the user cannot change the password, and set it to _$false_ to allow the user to change the password. The default value is _$false_. This property is only evaluated if the user account did not exist previously and is being created. |
+|HomeDirectory |The home directory for the user. |
+|GroupID |The primary group ID for the user. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Specifies whether the account exists. Set this property to _Present_ to ensure that the account exists, and set it to _Absent_ to ensure that the account does not exist. |
 
 ## Example
 
 The following example ensures that the user "monuser" exists and is a member of the group "DBusers".
 
-```
+```powershell
 Import-DSCResource -Module nx
 
-Node $node {
-nxUser UserExample{
-   UserName = "monuser"
-   Description = "Monitoring user"
-   Password  =    '$6$fZAne/Qc$MZejMrOxDK0ogv9SLiBP5J5qZFBvXLnDu8HY1Oy7ycX.Y3C7mGPUfeQy3A82ev3zIabhDQnj2ayeuGn02CqE/0'
-   Ensure = "Present"
-   HomeDirectory = "/home/monuser"
-}
+Node $node
+{
+   nxUser UserExample{
+      UserName = "monuser"
+      Description = "Monitoring user"
+      Password  =    '$6$fZAne/Qc$MZejMrOxDK0ogv9SLiBP5J5qZFBvXLnDu8HY1Oy7ycX.Y3C7mGPUfeQy3A82ev3zIabhDQnj2ayeuGn02CqE/0'
+      Ensure = "Present"
+      HomeDirectory = "/home/monuser"
+   }
 
-nxGroup GroupExample{
-   GroupName = "DBusers"
-   Ensure = "Present"
-   MembersToInclude = "monuser"
-   DependsOn = "[nxUser]UserExample"
-}
+   nxGroup GroupExample{
+      GroupName = "DBusers"
+      Ensure = "Present"
+      MembersToInclude = "monuser"
+      DependsOn = "[nxUser]UserExample"
+   }
 }
 ```

--- a/dsc/reference/resources/linux/lnxUserResource.md
+++ b/dsc/reference/resources/linux/lnxUserResource.md
@@ -10,7 +10,7 @@ manage local users on a Linux node.
 
 ## Syntax
 
-```MOF
+```Syntax
 nxUser <string> #ResourceName
 {
     UserName = <string>
@@ -34,8 +34,8 @@ nxUser <string> #ResourceName
 |FullName |A string that contains the full name to use for the user account. |
 |Description |The description for the user account. |
 |Password |The hash of the users password in the appropriate form for the Linux computer. Typically, this is a salted SHA-256, or SHA-512 hash. On Debian and Ubuntu Linux, this value can be generated with the `mkpasswd` command. For other Linux distros, the crypt method of Python's Crypt library can be used to generate the hash. |
-|Disabled |Indicates whether the account is enabled. Set this property to _$true_ to ensure that this account is disabled, and set it to _$false_ to ensure that it is enabled. |
-|PasswordChangeRequired |Indicates whether the user can change the password. Set this property to _$true_ to ensure that the user cannot change the password, and set it to _$false_ to allow the user to change the password. The default value is _$false_. This property is only evaluated if the user account did not exist previously and is being created. |
+|Disabled |Indicates whether the account is enabled. Set this property to `$true` to ensure that this account is disabled, and set it to `$false` to ensure that it is enabled. |
+|PasswordChangeRequired |Indicates whether the user can change the password. Set this property to `$true` to ensure that the user cannot change the password, and set it to `$false` to allow the user to change the password. The default value is `$false`. This property is only evaluated if the user account did not exist previously and is being created. |
 |HomeDirectory |The home directory for the user. |
 |GroupID |The primary group ID for the user. |
 
@@ -44,7 +44,7 @@ nxUser <string> #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Specifies whether the account exists. Set this property to _Present_ to ensure that the account exists, and set it to _Absent_ to ensure that the account does not exist. |
+|Ensure |Specifies whether the account exists. Set this property to **Present** to ensure that the account exists, and set it to **Absent** to ensure that the account does not exist. |
 
 ## Example
 

--- a/dsc/reference/resources/packagemanagement/PackageManagementDscResource.md
+++ b/dsc/reference/resources/packagemanagement/PackageManagementDscResource.md
@@ -92,7 +92,7 @@ Configuration PackageTest
         Ensure      = "Present"
         Name        = "psgallery"
         ProviderName= "PowerShellGet"
-        SourceLocation   = "https://www.powershellgallery.com/api/v2/"
+        SourceLocation   = "https://www.powershellgallery.com/api/v2"
         InstallationPolicy ="Trusted"
     }
 

--- a/dsc/reference/resources/packagemanagement/PackageManagementDscResource.md
+++ b/dsc/reference/resources/packagemanagement/PackageManagementDscResource.md
@@ -17,7 +17,7 @@ requires the **PackageManagement** module, available from [http://PowerShellGall
 
 ## Syntax
 
-```MOF
+```Syntax
 PackageManagement [string] #ResourceName
 {
     Name = [string]
@@ -54,14 +54,14 @@ The following table lists options for the AdditionalParameters property.
 |Parameter |Description |
 |---|---|
 |DestinationPath |Used by providers such as the built-in Nuget Provider. Specifies a file location where you want the package to be installed. |
-|InstallationPolicy |Used by providers such as the built-in Nuget Provider. Determines whether you trust the package's source. One of: _Untrusted_ or _Trusted_. |
+|InstallationPolicy |Used by providers such as the built-in Nuget Provider. Determines whether you trust the package's source. One of: **Untrusted** or **Trusted**. |
 
 ## Common properties
 
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Determines whether the package is to be installed or uninstalled. The default value is _Present_. |
+|Ensure |Determines whether the package is to be installed or uninstalled. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/packagemanagement/PackageManagementDscResource.md
+++ b/dsc/reference/resources/packagemanagement/PackageManagementDscResource.md
@@ -1,62 +1,79 @@
 ---
-ms.date:  06/20/2018
-keywords:  dsc,powershell,configuration,setup
-title:  DSC PackageManagement Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC PackageManagement Resource
 ---
 # DSC PackageManagement Resource
 
 Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0, Windows PowerShell 5.1
 
-The **PackageManagement** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to install or uninstall Package Management packages on a target node. This resource requires the **PackageManagement** module, available from [http://PowerShellGallery.com](http://PowerShellGallery.com).
+The **PackageManagement** resource in Windows PowerShell Desired State Configuration (DSC) provides
+a mechanism to install or uninstall Package Management packages on a target node. This resource
+requires the **PackageManagement** module, available from [http://PowerShellGallery.com](http://PowerShellGallery.com).
 
 > [!IMPORTANT]
-> The **PackageManagement** module should be at least version 1.1.7.0 for the following property information to be correct.
+> The **PackageManagement** module should be at least version 1.1.7.0 for the following property
+> information to be correct.
 
 ## Syntax
 
-```
+```MOF
 PackageManagement [string] #ResourceName
 {
     Name = [string]
-    [AdditionalParameters = [HashTable]]
-    [DependsOn = [string[]]]
-    [Ensure = [string]{ Absent | Present }]
-    [MaximumVersion = [string]]
-    [MinimumVersion = [string]]
-    [ProviderName = [string]]
-    [PsDscRunAsCredential = [PSCredential]]
-    [RequiredVersion = [string]]
-    [Source = [string]]
-    [SourceCredential = [PSCredential]]
+    [ AdditionalParameters = [HashTable] ]
+    [ MaximumVersion = [string] ]
+    [ MinimumVersion = [string] ]
+    [ ProviderName = [string] ]
+    [ RequiredVersion = [string] ]
+    [ Source = [string] ]
+    [ SourceCredential = [PSCredential] ]
+    [ DependsOn = [string[]] ]
+    [ Ensure = [string]{ Absent | Present } ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-| Property | Description |
-| --- | --- |
-| Name| Specifies the name of the Package to be installed or uninstalled.|
-| AdditionalParameters| Provider specific hashtable of parameters that would be passed to `Get-Package -AdditionalArguments`. For example, for NuGet provider you can pass additional parameters like DestinationPath.|
-| Ensure| Determines whether the package is to be installed or uninstalled.|
-| MaximumVersion|Specifies the maximum allowed version of the package that you want to find. If you do not add this parameter, the resource finds the highest available version of the package.|
-| MinimumVersion|Specifies the minimum allowed version of the package that you want to find. If you do not add this parameter, the resource finds the highest available version of the package that also satisfies any maximum specified version specified by the _MaximumVersion_ parameter.|
-| ProviderName| Specifies a package provider name to which to scope your package search. You can get package provider names by running the `Get-PackageProvider` cmdlet.|
-| RequiredVersion| Specifies the exact version of the package that you want to install. If you do not specify this parameter, this DSC resource installs the newest available version of the package that also satisfies any maximum version specified by the _MaximumVersion_ parameter.|
-| Source| Specifies the name of the package source where the package can be found. This can either be a URI or a source registered with `Register-PackageSource` or PackageManagementSource DSC resource.|
-| SourceCredential | Specifies a user account that has rights to install a package for a specified package provider or source.|
+|Property |Description |
+|---|---|
+|Name |Specifies the name of the Package to be installed or uninstalled. |
+|AdditionalParameters |Provider specific hashtable of parameters that would be passed to `Get-Package -AdditionalArguments`. For example, for NuGet provider you can pass additional parameters like DestinationPath. |
+|MaximumVersion |Specifies the maximum allowed version of the package that you want to find. If you do not add this parameter, the resource finds the highest available version of the package. |
+|MinimumVersion |Specifies the minimum allowed version of the package that you want to find. If you do not add this parameter, the resource finds the highest available version of the package that also satisfies any maximum specified version specified by the **MaximumVersion** parameter. |
+|ProviderName |Specifies a package provider name to which to scope your package search. You can get package provider names by running the `Get-PackageProvider` cmdlet. |
+|RequiredVersion |Specifies the exact version of the package that you want to install. If you do not specify this parameter, this DSC resource installs the newest available version of the package that also satisfies any maximum version specified by the **MaximumVersion** parameter. |
+|Source |Specifies the name of the package source where the package can be found. This can either be a URI or a source registered with `Register-PackageSource` or PackageManagementSource DSC resource. |
+|SourceCredential |Specifies a user account that has rights to install a package for a specified package provider or source. |
 
 ## Additional Parameters
 
 The following table lists options for the AdditionalParameters property.
 
-| Parameter | Description |
-| --- | --- |
-| DestinationPath| Used by providers such as the built-in Nuget Provider. Specifies a file location where you want the package to be installed.|
-| InstallationPolicy| Used by providers such as the built-in Nuget Provider. Determines whether you trust the package's source. One of: `Untrusted`, `Trusted`.|
+|Parameter |Description |
+|---|---|
+|DestinationPath |Used by providers such as the built-in Nuget Provider. Specifies a file location where you want the package to be installed. |
+|InstallationPolicy |Used by providers such as the built-in Nuget Provider. Determines whether you trust the package's source. One of: _Untrusted_ or _Trusted_. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Determines whether the package is to be installed or uninstalled. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 
-This example installs the **JQuery** NuGet package and **GistProvider** PowerShell module using the **PackageManagement** DSC resource. This example first ensures the required package sources are available then defines the expected state of the **JQuery** and **GistProvider** packages (NuGet and PowerShell, respectively).
+This example installs the **JQuery** NuGet package and **GistProvider** PowerShell module using the
+**PackageManagement** DSC resource. This example first ensures the required package sources are
+available then defines the expected state of the **JQuery** and **GistProvider** packages (NuGet and
+PowerShell, respectively).
 
 ```powershell
 Configuration PackageTest

--- a/dsc/reference/resources/packagemanagement/PackageManagementSourceDscResource.md
+++ b/dsc/reference/resources/packagemanagement/PackageManagementSourceDscResource.md
@@ -1,47 +1,64 @@
 ---
-ms.date:  06/20/2018
-keywords:  dsc,powershell,configuration,setup
-title:  DSC PackageManagementSource Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC PackageManagementSource Resource
 ---
 # DSC PackageManagementSource Resource
 
-> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0, Windows PowerShell 5.1
+> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
-The **PackageManagementSource** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to register or unregister Package Management sources on a target node. **Package Management sources registered in this way are registered under the System context, usable by the System account or by the DSC engine.** This resource requires the **PackageManagement** module, available from http://PowerShellGallery.com.
+The **PackageManagementSource** resource in Windows PowerShell Desired State Configuration (DSC)
+provides a mechanism to register or unregister Package Management sources on a target node.
+**Package Management sources registered in this way are registered under the System context, usable
+by the System account or by the DSC engine.** This resource requires the **PackageManagement**
+module, available from the [PowerShell Gallery](https://PowerShellGallery.com).
 
 > [!IMPORTANT]
-> The **PackageManagement** module should be at least version 1.1.7.0 for the following property information to be correct.
+> The **PackageManagement** module should be at least version 1.1.7.0 for the following property
+> information to be correct.
 
 ## Syntax
 
-```
+```MOF
 PackageManagementSource [String] #ResourceName
 {
     Name = [string]
     ProviderName = [string]
     SourceLocation = [string]
-    [DependsOn = [string[]]]
-    [Ensure = [string]{ Absent | Present }]
-    [InstallationPolicy = [string]{ Trusted | Untrusted }]
-    [PsDscRunAsCredential = [PSCredential]]
-    [SourceCredential = [PSCredential]]
+    [ InstallationPolicy = [string]{ Trusted | Untrusted } ]
+    [ SourceCredential = [PSCredential] ]
+    [ DependsOn = [string[]] ]
+    [ Ensure = [string]{ Absent | Present } ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| Name| Specifies the name of the package source to be registered or unregistered on your system.|
-| ProviderName| Specifies the name of the OneGet provider through which you can interop with the package source.|
-| SourceLocation| Specifies the URI of the package source.|
-| Ensure| Determines whether the package source is to be registered or unregistered.|
-| InstallationPolicy| Used by providers such as the built-in Nuget Provider. Determines whether you trust the package's source. One of: "Untrusted", "Trusted".|
-| SourceCredential| Provides access to the package on a remote source.|
+|Name |Specifies the name of the package source to be registered or unregistered on your system. |
+|ProviderName |Specifies the name of the OneGet provider through which you can interop with the package source. |
+|SourceLocation |Specifies the URI of the package source. |
+|InstallationPolicy |Used by providers such as the built-in Nuget Provider. Determines whether you trust the package's source. One of: _Untrusted_ or _Trusted_. |
+|SourceCredential |Provides access to the package on a remote source. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Determines whether the package source is to be registered or unregistered. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 
-This example registers the http://nuget.org package source using the **PackageManagementSource** DSC resource.
+This example registers the `https://nuget.org` package source using the **PackageManagementSource**
+DSC resource.
 
 ```powershell
 Configuration PackageManagementSourceTest
@@ -51,7 +68,7 @@ Configuration PackageManagementSourceTest
         Ensure      = "Present"
         Name        = "MyNuget"
         ProviderName= "Nuget"
-        SourceLocation   = "http://nuget.org/api/v2/"
+        SourceLocation   = "https://api.nuget.org/api/v3/"
         InstallationPolicy ="Trusted"
     }
 }

--- a/dsc/reference/resources/packagemanagement/PackageManagementSourceDscResource.md
+++ b/dsc/reference/resources/packagemanagement/PackageManagementSourceDscResource.md
@@ -19,7 +19,7 @@ module, available from the [PowerShell Gallery](https://PowerShellGallery.com).
 
 ## Syntax
 
-```MOF
+```Syntax
 PackageManagementSource [String] #ResourceName
 {
     Name = [string]
@@ -40,7 +40,7 @@ PackageManagementSource [String] #ResourceName
 |Name |Specifies the name of the package source to be registered or unregistered on your system. |
 |ProviderName |Specifies the name of the OneGet provider through which you can interop with the package source. |
 |SourceLocation |Specifies the URI of the package source. |
-|InstallationPolicy |Used by providers such as the built-in Nuget Provider. Determines whether you trust the package's source. One of: _Untrusted_ or _Trusted_. |
+|InstallationPolicy |Used by providers such as the built-in Nuget Provider. Determines whether you trust the package's source. One of: **Untrusted** or **Trusted**. |
 |SourceCredential |Provides access to the package on a remote source. |
 
 ## Common properties
@@ -48,7 +48,7 @@ PackageManagementSource [String] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Determines whether the package source is to be registered or unregistered. The default value is _Present_. |
+|Ensure |Determines whether the package source is to be registered or unregistered. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/windows/archiveResource.md
+++ b/dsc/reference/resources/windows/archiveResource.md
@@ -1,48 +1,61 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC Archive Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC Archive Resource
 ---
-
 # DSC Archive Resource
 
-> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0
+> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
-The Archive resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to unpack archive (.zip) files at a specific path.
+The Archive resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to
+unpack archive (.zip) files at a specific path.
 
 ## Syntax
+
 ```MOF
 Archive [string] #ResourceName
 {
     Destination = [string]
     Path = [string]
     [ Checksum = [string] { CreatedDate | ModifiedDate | SHA-1 | SHA-256 | SHA-512 } ]
-    [ DependsOn = [string[]] ]
-    [ Ensure = [string] { Absent | Present } ]
     [ Force = [bool] ]
     [ Validate = [bool] ]
+    [ Ensure = [string] { Absent | Present } ]
+    [ DependsOn = [string[]] ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| Destination| Specifies the location where you want to ensure the archive contents are extracted.|
-| Path| Specifies the source path of the archive file.|
-| __Checksum__| Defines the type to use when determining whether two files are the same. If __Checksum__ is not specified, only the file or directory name is used for comparison. Valid values include: SHA-1, SHA-256, SHA-512, createdDate, modifiedDate, none (default). If you specify __Checksum__ without __Validate__, the configuration will fail.|
-| Ensure| Determines whether to check if the content of the archive exists at the __Destination__. Set this property to __Present__ to ensure the contents exist. Set it to __Absent__ to ensure they do not exist. The default value is __Present__.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is __ResourceType__, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
-| Validate| Uses the Checksum property to determine if the archive matches the signature. If you specify Checksum without Validate, the configuration will fail. If you specify Validate without Checksum, a SHA-256 checksum is used by default.|
-| Force| Certain file operations (such as overwriting a file or deleting a directory that is not empty) will result in an error. Using the Force property overrides such errors. The default value is False.|
+|Destination |Specifies the location where you want to ensure the archive contents are extracted. |
+|Path |Specifies the source path of the archive file. |
+|Checksum |Defines the type to use when determining whether two files are the same. If **Checksum** is not specified, only the file or directory name is used for comparison. Valid values include: _SHA-1_, _SHA-256_, _SHA-512_, _createdDate_, _modifiedDate_. If you specify **Checksum** without **Validate**, the configuration will fail. |
+|Force |Certain file operations (such as overwriting a file or deleting a directory that is not empty) will result in an error. Using the **Force** property overrides such errors. The default value is _False_. |
+|Validate| Uses the **Checksum** property to determine if the archive matches the signature. If you specify **Checksum** without **Validate**, the configuration will fail. If you specify **Validate** without **Checksum**, a _SHA-256_ **Checksum** is used by default. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Determines whether to check if the content of the archive exists at the **Destination**. Set this property to _Present_ to ensure the contents exist. Set it to _Absent_ to ensure they do not exist. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 
-The following example shows how to use the Archive resource to ensure that the contents of an archive file called Test.zip exist and are extracted at a given destination.
+The following example shows how to use the Archive resource to ensure that the contents of an
+archive file called `Test.zip` exist and are extracted at a given destination.
 
-```
+```powershell
 Archive ArchiveExample {
-    Ensure = "Present"  # You can also set Ensure to "Absent"
+    Ensure = "Present"
     Path = "C:\Users\Public\Documents\Test.zip"
     Destination = "C:\Users\Public\Documents\ExtractionPath"
 }

--- a/dsc/reference/resources/windows/archiveResource.md
+++ b/dsc/reference/resources/windows/archiveResource.md
@@ -12,7 +12,7 @@ unpack archive (.zip) files at a specific path.
 
 ## Syntax
 
-```MOF
+```Syntax
 Archive [string] #ResourceName
 {
     Destination = [string]
@@ -32,8 +32,8 @@ Archive [string] #ResourceName
 |---|---|
 |Destination |Specifies the location where you want to ensure the archive contents are extracted. |
 |Path |Specifies the source path of the archive file. |
-|Checksum |Defines the type to use when determining whether two files are the same. If **Checksum** is not specified, only the file or directory name is used for comparison. Valid values include: _SHA-1_, _SHA-256_, _SHA-512_, _createdDate_, _modifiedDate_. If you specify **Checksum** without **Validate**, the configuration will fail. |
-|Force |Certain file operations (such as overwriting a file or deleting a directory that is not empty) will result in an error. Using the **Force** property overrides such errors. The default value is _False_. |
+|Checksum |Defines the type to use when determining whether two files are the same. If **Checksum** is not specified, only the file or directory name is used for comparison. Valid values include: **SHA-1**, **SHA-256**, **SHA-512**, **createdDate**, **modifiedDate**. If you specify **Checksum** without **Validate**, the configuration will fail. |
+|Force |Certain file operations (such as overwriting a file or deleting a directory that is not empty) will result in an error. Using the **Force** property overrides such errors. The default value is **False**. |
 |Validate| Uses the **Checksum** property to determine if the archive matches the signature. If you specify **Checksum** without **Validate**, the configuration will fail. If you specify **Validate** without **Checksum**, a _SHA-256_ **Checksum** is used by default. |
 
 ## Common properties
@@ -41,7 +41,7 @@ Archive [string] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Determines whether to check if the content of the archive exists at the **Destination**. Set this property to _Present_ to ensure the contents exist. Set it to _Absent_ to ensure they do not exist. The default value is _Present_. |
+|Ensure |Determines whether to check if the content of the archive exists at the **Destination**. Set this property to **Present** to ensure the contents exist. Set it to **Absent** to ensure they do not exist. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/windows/environmentResource.md
+++ b/dsc/reference/resources/windows/environmentResource.md
@@ -12,7 +12,7 @@ mechanism to manage system environment variables.
 
 ## Syntax
 
-```MOF
+```Syntax
 Environment [string] #ResourceName
 {
     Name = [string]
@@ -29,7 +29,7 @@ Environment [string] #ResourceName
 |Property |Description |
 |---|---|
 |Name |Indicates the name of the environment variable for which you want to ensure a specific state. |
-|Path |Defines the environment variable that is being configured. Set this property to _$true_ if the variable is the **Path** variable; otherwise, set it to _$false_. The default is _$false_. If the variable being configured is the **Path** variable, the value provided through the **Value** property will be appended to the existing value. |
+|Path |Defines the environment variable that is being configured. Set this property to `$true` if the variable is the **Path** variable; otherwise, set it to `$false`. The default is `$false`. If the variable being configured is the **Path** variable, the value provided through the **Value** property will be appended to the existing value. |
 |Value |The value to assign to the environment variable. |
 
 ## Common properties
@@ -37,7 +37,7 @@ Environment [string] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Indicates if a variable exists. Set this property to _Present_ to create the environment variable if it does not exist or to ensure that its value matches what is provided through the **Value** property if the variable already exists. Set it to _Absent_ to delete the variable if it exists. |
+|Ensure |Indicates if a variable exists. Set this property to **Present** to create the environment variable if it does not exist or to ensure that its value matches what is provided through the **Value** property if the variable already exists. Set it to **Absent** to delete the variable if it exists. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/windows/environmentResource.md
+++ b/dsc/reference/resources/windows/environmentResource.md
@@ -1,40 +1,53 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC Environment Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC Environment Resource
 ---
-
 # DSC Environment Resource
 
-> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0
+> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
-The __Environment__ resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to manage system environment variables.
+The **Environment** resource in Windows PowerShell Desired State Configuration (DSC) provides a
+mechanism to manage system environment variables.
 
 ## Syntax
-``` mof
+
+```MOF
 Environment [string] #ResourceName
 {
     Name = [string]
-    [ Ensure = [string] { Absent | Present }  ]
     [ Path = [bool] ]
-    [ DependsOn = [string[]] ]
     [ Value = [string] ]
+    [ DependsOn = [string[]] ]
+    [ Ensure = [string] { Absent | Present }  ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| Name| Indicates the name of the environment variable for which you want to ensure a specific state.|
-| Ensure| Indicates if a variable exists. Set this property to __Present__ to create the environment variable if it does not exist or to ensure that its value matches what is provided through the __Value__ property if the variable already exists. Set it to __Absent__ to delete the variable if it exists.|
-| Path| Defines the environment variable that is being configured. Set this property to __$true__ if the variable is the __Path__ variable; otherwise, set it to __$false__. The default is __$false__. If the variable being configured is the __Path__ variable, the value provided through the __Value__ property will be appended to the existing value.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is __ResourceName__ and its type is __ResourceType__, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
-| Value| The value to assign to the environment variable.|
+|Name |Indicates the name of the environment variable for which you want to ensure a specific state. |
+|Path |Defines the environment variable that is being configured. Set this property to _$true_ if the variable is the **Path** variable; otherwise, set it to _$false_. The default is _$false_. If the variable being configured is the **Path** variable, the value provided through the **Value** property will be appended to the existing value. |
+|Value |The value to assign to the environment variable. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Indicates if a variable exists. Set this property to _Present_ to create the environment variable if it does not exist or to ensure that its value matches what is provided through the **Value** property if the variable already exists. Set it to _Absent_ to delete the variable if it exists. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 
-The following example ensures that __TestEnvironmentVariable__ is present and it has the value __TestValue__. If it is not present, it creates it.
+The following example ensures that TestEnvironmentVariable is present and it has the value
+_TestValue_. If it is not present, it creates it.
 
 ```powershell
 Environment EnvironmentExample

--- a/dsc/reference/resources/windows/fileResource.md
+++ b/dsc/reference/resources/windows/fileResource.md
@@ -13,7 +13,7 @@ accessible by the target Node.
 
 ## Syntax
 
-```MOF
+```Syntax
 File [string] #ResourceName
 {
     DestinationPath = [string]
@@ -36,16 +36,16 @@ File [string] #ResourceName
 
 |Property |Description |
 |---|---|
-|DestinationPath |The location, on the target node, you want to ensure is _Present_ or _Absent_ with **Ensure**. |
+|DestinationPath |The location, on the target node, you want to ensure is **Present** or **Absent** with **Ensure**. |
 |Attributes |The desired state of the attributes for the targeted file or directory. Valid values are _Archive_, _Hidden_, _ReadOnly_, and _System_. |
-|Checksum |The checksum type to use when determining whether two files are the same. Valid values include: _SHA-1_, _SHA-256_, _SHA-512_, _createdDate_, _modifiedDate_. |
-|Contents |Only valid when used with **Type** _File_. Indicates the contents to **Ensure** are _Present_ or _Absent_ from the targeted file. |
+|Checksum |The checksum type to use when determining whether two files are the same. Valid values include: **SHA-1**, **SHA-256**, **SHA-512**, **createdDate**, **modifiedDate**. |
+|Contents |Only valid when used with **Type** **File**. Indicates the contents to **Ensure** are **Present** or **Absent** from the targeted file. |
 |Credential |The credentials that are required to access resources, such as source files. |
-|Force |Overrides access operations that would result in an error (such as overwriting a file or deleting a directory that is not empty). Default value is _$false_. |
-|Recurse |Only valid when used with **Type** _Directory_. Performs the state operation recursively to all subdirectories. Default value is _$false_. |
+|Force |Overrides access operations that would result in an error (such as overwriting a file or deleting a directory that is not empty). Default value is `$false`. |
+|Recurse |Only valid when used with **Type** **Directory**. Performs the state operation recursively to all subdirectories. Default value is `$false`. |
 |SourcePath |The path from which to copy the file or folder resource. |
-|Type |The type of resource being configured. Valid values are _Directory_ and _File_. Default value is _File_. |
-|MatchSource |Determines if the resource should monitor for new files added to the source directory after the initial copy. A value of _$true_ indicates that, after the initial copy, any new source files should be copied to the destination. If set to _$false_, the resource caches the contents of the source directory and ignores any files added after the initial copy. Default value is _$false_. |
+|Type |The type of resource being configured. Valid values are **Directory** and **File**. Default value is **File**. |
+|MatchSource |Determines if the resource should monitor for new files added to the source directory after the initial copy. A value of `$true` indicates that, after the initial copy, any new source files should be copied to the destination. If set to `$false`, the resource caches the contents of the source directory and ignores any files added after the initial copy. Default value is `$false`. |
 
 > [!WARNING]
 > If you do not specify a value for **Credential** or **PSRunAsCredential**, the resource will use
@@ -59,7 +59,7 @@ File [string] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Determines whether the file and **Contents** at the **Destination** should exist or not. Set this property to _Present_ to ensure the file exists. Set it to _Absent_ to ensure they do not exist. The default value is _Present_. |
+|Ensure |Determines whether the file and **Contents** at the **Destination** should exist or not. Set this property to **Present** to ensure the file exists. Set it to **Absent** to ensure they do not exist. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]
@@ -69,14 +69,14 @@ File [string] #ResourceName
 ### Additional information
 
 - When you only specify a **DestinationPath**, the resource ensures that the path exists if
-  _Present_ or does not exist if _Absent_.
+  **Present** or does not exist if **Absent**.
 - When you specify a **SourcePath** and a **DestinationPath** with a **Type** value of
   **Directory**, the resource copies source directory to the destination path. The properties
   **Recurse**, **Force**, and **MatchSource** change the type of copy operation performed, while
   **Credential** determines which account to use to access the source directory.
-- If you specified a value of _ReadOnly_ for the **Attributes** property alongside a
-  **DestinationPath**, **Ensure** _Present_ would create the path specified, while **Contents**
-  would set the contents of the file. An **Ensure** _Absent_ setting would ignore the **Attributes**
+- If you specified a value of **ReadOnly** for the **Attributes** property alongside a
+  **DestinationPath**, **Ensure** **Present** would create the path specified, while **Contents**
+  would set the contents of the file. An **Ensure** **Absent** setting would ignore the **Attributes**
   property entirely, and remove any file at the specified path.
 
 ## Example

--- a/dsc/reference/resources/windows/fileResource.md
+++ b/dsc/reference/resources/windows/fileResource.md
@@ -1,18 +1,19 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC File Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC File Resource
 ---
-
 # DSC File Resource
 
-> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0
+> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
-The File resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to manage files and folders on the target node. The **DestinationPath** and **SourcePath** must both be accessible by the target Node.
+The **File** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism
+to manage files and folders on the target node. **DestinationPath** and **SourcePath** must both be
+accessible by the target Node.
 
 ## Syntax
 
-```
+```MOF
 File [string] #ResourceName
 {
     DestinationPath = [string]
@@ -20,60 +21,79 @@ File [string] #ResourceName
     [ Checksum = [string] { CreatedDate | ModifiedDate | SHA-1 | SHA-256 | SHA-512 } ]
     [ Contents = [string] ]
     [ Credential = [PSCredential] ]
-    [ Ensure = [string] { Absent | Present } ]
     [ Force = [bool] ]
     [ Recurse = [bool] ]
-    [ DependsOn = [string[]] ]
     [ SourcePath = [string] ]
     [ Type = [string] { Directory | File } ]
     [ MatchSource = [bool] ]
+    [ DependsOn = [string[]] ]
+    [ Ensure = [string] { Absent | Present } ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|Property       |Description                                                                   |Required|Default|
-|---------------|------------------------------------------------------------------------------|--------|-------|
-|DestinationPath|The location, on the target node, you want to ensure is `Present` or `Absent`.|Yes|No|
-|Attributes     |The desired state of the attributes for the targeted file or directory. Valid values are **Archive**, **Hidden**, **ReadOnly**, and **System**.|No|None|
-|Checksum      |The checksum type to use when determining whether two files are the same. Valid values include: SHA-1, SHA-256, SHA-512, createdDate, modifiedDate.|No|Only the file or directory name is compared.|
-|Contents       |Only valid when used with `File` type. Indicates the contents to Ensure are `Present` or `Absent` from the targeted file. |No|None|
-|Credential     |The credentials that are required to access resources, such as source files.|No|The target node's Computer Account. (*see note*)|
-|Ensure         |The desired state of the target file or directory. |No|**Present**|
-|Force          |Overrides access operations that would result in an error (such as overwriting a file or deleting a directory that is not empty).|No|`$false`|
-|Recurse        |Only valid when used with `Directory` type. Performs the state operation recursively to all subdirectories.|No|`$false`|
-|DependsOn      |Sets a dependency on specified resource(s). This resource will only execute after successful execution of any dependent resources. You can specify dependent resources using the syntax `"[ResourceType]ResourceName"`. See [about_DependsOn](../../../configurations/resource-depends-on.md)|No|None|
-|SourcePath     |The path from which to copy the file or folder resource.|No|None|
-|Type           |The type of resource being configured. Valid values are `Directory` and `File`.|No|`File`|
-|MatchSource    |Determines if the resource should monitor for new files added to the source directory after the initial copy. A value of `$true` indicates that, after the initial copy, any new source files should be copied to the destination. If set to `$False`, the resource caches the contents of the source directory and ignores any files added after the initial copy.|No|`$false`|
+|Property |Description |
+|---|---|
+|DestinationPath |The location, on the target node, you want to ensure is _Present_ or _Absent_ with **Ensure**. |
+|Attributes |The desired state of the attributes for the targeted file or directory. Valid values are _Archive_, _Hidden_, _ReadOnly_, and _System_. |
+|Checksum |The checksum type to use when determining whether two files are the same. Valid values include: _SHA-1_, _SHA-256_, _SHA-512_, _createdDate_, _modifiedDate_. |
+|Contents |Only valid when used with **Type** _File_. Indicates the contents to **Ensure** are _Present_ or _Absent_ from the targeted file. |
+|Credential |The credentials that are required to access resources, such as source files. |
+|Force |Overrides access operations that would result in an error (such as overwriting a file or deleting a directory that is not empty). Default value is _$false_. |
+|Recurse |Only valid when used with **Type** _Directory_. Performs the state operation recursively to all subdirectories. Default value is _$false_. |
+|SourcePath |The path from which to copy the file or folder resource. |
+|Type |The type of resource being configured. Valid values are _Directory_ and _File_. Default value is _File_. |
+|MatchSource |Determines if the resource should monitor for new files added to the source directory after the initial copy. A value of _$true_ indicates that, after the initial copy, any new source files should be copied to the destination. If set to _$false_, the resource caches the contents of the source directory and ignores any files added after the initial copy. Default value is _$false_. |
 
 > [!WARNING]
-> If you do not specify a value for `Credential` or `PSRunAsCredential` (PS V.5), the resource will use the computer account of the target node to access the `SourcePath`.  When the `SourcePath` is a UNC share, this could result in an "Access Denied" error. Please ensure your permissions are set accordingly, or use the `Credential` or `PSRunAsCredential` properties to specify the account that should be used.
+> If you do not specify a value for **Credential** or **PSRunAsCredential**, the resource will use
+> the computer account of the target node to access the **SourcePath**. When the **SourcePath** is a
+> UNC share, this could result in an "Access Denied" error. Please ensure your permissions are set
+> accordingly, or use the **Credential** or **PSRunAsCredential** properties to specify the account
+> that should be used.
 
-## Present vs. Absent
+## Common properties
 
-Each DSC resource performs different operations based on the value you specify for the `Ensure` property. The values you specify for the above properties determines the state operation performed.
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Determines whether the file and **Contents** at the **Destination** should exist or not. Set this property to _Present_ to ensure the file exists. Set it to _Absent_ to ensure they do not exist. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
-### Existence
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
-When you only specify a `DestinationPath`, the resource ensures that the path exists (`Present`) or does not exist (`Absent`).
+### Additional information
 
-### Copy Operations
-
-When you specify a `SourcePath` and a `DestinationPath` with a `Type` value of **Directory**, the resource copies source directory to the destination path. The properties `Recurse`, `Force`, and `MatchSource` change the type of copy operation performed, while `Credential` determines which account to use to access the source directory.
-
-### Limitations
-
-If you specified a value of `ReadOnly` for the `Attributes` property alongside a `DestinationPath`, `Ensure = "Present"` would create the path specified, while `Contents` would set the contents of the file.  An `Absent` state operation would ignore the `Attributes` property entirely, and remove any file at the specified path.
+- When you only specify a **DestinationPath**, the resource ensures that the path exists if
+  _Present_ or does not exist if _Absent_.
+- When you specify a **SourcePath** and a **DestinationPath** with a **Type** value of
+  **Directory**, the resource copies source directory to the destination path. The properties
+  **Recurse**, **Force**, and **MatchSource** change the type of copy operation performed, while
+  **Credential** determines which account to use to access the source directory.
+- If you specified a value of _ReadOnly_ for the **Attributes** property alongside a
+  **DestinationPath**, **Ensure** _Present_ would create the path specified, while **Contents**
+  would set the contents of the file. An **Ensure** _Absent_ setting would ignore the **Attributes**
+  property entirely, and remove any file at the specified path.
 
 ## Example
 
-The following example copies a directory and its subdirectories from a pull server to a target node using the File Resource. If the operation succeeds, the Log resource writes a confirmation message to the event log.
+The following example copies a directory and its subdirectories from a pull server to a target node
+using the File Resource. If the operation succeeds, the Log resource writes a confirmation message
+to the event log.
 
-The source directory is a UNC path (`\\PullServer\DemoSource`) shared from the Pull Server. The `Recurse` property ensures that all subdirectories are copied as well.
+The source directory is a UNC path (`\\PullServer\DemoSource`) shared from the Pull Server. The
+**Recurse** property ensures that all subdirectories are copied as well.
 
 > [!IMPORTANT]
-> The LCM on the target Node executes in the context of the local system account by default. To grant access to the **SourcePath**, give the target Node's computer account appropriate permissions. The **Credential** and **PSDSCRunAsCredential** (v5) both change the context the LCM uses to access the **SourcePath**. You still need to grant access to the account that will be used to access the **SourcePath**.
+> The LCM on the target Node executes in the context of the local system account by default. To
+> grant access to the **SourcePath**, give the target Node's computer account appropriate
+> permissions. The **Credential** and **PSDSCRunAsCredential** both change the context the LCM uses
+> to access the **SourcePath**. You still need to grant access to the account that will be used to
+> access the **SourcePath**.
 
 ```powershell
 Configuration FileResourceDemo

--- a/dsc/reference/resources/windows/groupResource.md
+++ b/dsc/reference/resources/windows/groupResource.md
@@ -1,45 +1,56 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC Group Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC Group Resource
 ---
-
 # DSC Group Resource
 
-> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0
+> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
-The Group resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to manage local groups on the target node.
+The **Group** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism
+to manage local groups on the target node.
 
 ## Syntax
 
-```
+```MOF
 Group [string] #ResourceName
 {
-    GroupName          = [string]
-    [ Credential       = [PSCredential] ]
-    [ Description      = [string[]] ]
-    [ Ensure           = [string] { Absent | Present }  ]
-    [ Members          = [string[]] ]
+    GroupName = [string]
+    [ Credential = [PSCredential] ]
+    [ Description = [string[]] ]
+    [ Members = [string[]] ]
     [ MembersToExclude = [string[]] ]
     [ MembersToInclude = [string[]] ]
-    [ DependsOn        = [string[]] ]
+    [ DependsOn = [string[]] ]
+    [ Ensure = [string] { Absent | Present }  ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| GroupName| The name of the group for which you want to ensure a specific state.|
-| Credential| The credentials required to access remote resources. **Note**: This account must have the appropriate Active Directory permissions to add all non-local accounts to the group; otherwise, an error occurs when the configuration is executed on the target node.
-| Description| The description of the group.|
-| Ensure| Indicates if the group exists. Set this property to "Absent" to ensure that the group does not exist. Setting it to "Present" (the default value) ensures that the group exists.|
-| Members| Use this property to replace the current group membership with the specified members. The value of this property is an array of strings of the form *Domain*\\*UserName*. If you set this property in a configuration, do not use either the **MembersToExclude** or **MembersToInclude** property. Doing so generates an error.|
-| MembersToExclude| Use this property to remove members from the existing membership of the group. The value of this property is an array of strings of the form *Domain*\\*UserName*. If you set this property in a configuration, do not use the **Members** property. Doing so generates an error.|
-| MembersToInclude| Use this property to add members to the existing membership of the group. The value of this property is an array of strings of the form *Domain*\\*UserName*. If you set this property in a configuration, do not use the **Members** property. Doing so will generate an error.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is __ResourceName__ and its type is __ResourceType__, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"``.|
+|GroupName |The name of the group for which you want to ensure a specific state. |
+|Credential |The credentials required to access remote resources. This account must have the appropriate Active Directory permissions to add all non-local accounts to the group; otherwise, an error occurs when the configuration is executed on the target node.
+|Description |The description of the group. |
+|Members |Use this property to replace the current group membership with the specified members. The value of this property is an array of strings of the form `Domain\UserName`. If you set this property in a configuration, do not use either the **MembersToExclude** or **MembersToInclude** property. Doing so generates an error. |
+|MembersToExclude |Use this property to remove members from the existing membership of the group. The value of this property is an array of strings of the form `Domain\UserName`. If you set this property in a configuration, do not use the **Members** property. Doing so generates an error. |
+|MembersToInclude |Use this property to add members to the existing membership of the group. The value of this property is an array of strings of the form `Domain\UserName`. If you set this property in a configuration, do not use the **Members** property. Doing so will generate an error. |
 
-## Example 1
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Indicates if the group exists. Set this property to _Absent_ to ensure that the group does not exist. Setting it to _Present_ ensures that the group exists. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
+
+## Example 1: Ensure group is not present
 
 The following example shows how to ensure that a group called "TestGroup" is absent.
 
@@ -53,11 +64,13 @@ Group GroupExample
 }
 ```
 
-## Example 2
+## Example 2: Add domain user to local group
 
-The following example shows how to add an Active Directory User to the local administrators group as part of a Multi-Machine Lab build where you are already using a PSCredential for the Local Administrator account.
-As this is also used for the Domain Admin Account (after Domain promotion), we then need to convert this existing PSCredential to a Domain Friendly credential.
-Then we can add a Domain User to the Local Administrators Group on the Member server.
+The following example shows how to add an Active Directory User to the local administrators group as
+part of a Multi-Machine Lab build where you are already using a PSCredential for the Local
+Administrator account. As this is also used for the Domain Admin Account (after Domain promotion),
+we then need to convert this existing PSCredential to a Domain Friendly credential. Then we can add
+a Domain User to the Local Administrators Group on the Member server.
 
 ```powershell
 @{
@@ -87,18 +100,19 @@ Group AddADUserToLocalAdminGroup {
 
 ## Example 3
 
-The following example shows how to ensure a local group, TigerTeamAdmins, on the server TigerTeamSource.Contoso.Com does not contain a particular domain account, Contoso\JerryG.
+The following example shows how to ensure a local group, TigerTeamAdmins, on the server
+TigerTeamSource.Contoso.Com does not contain a particular domain account, Contoso\JerryG.
 
 ```powershell
 Configuration SecureTigerTeamSource {
-  Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
+    Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
 
-  Node TigerTeamSource.Contoso.Com {
-    Group TigerTeamAdmins {
-       GroupName        = 'TigerTeamAdmins'
-       Ensure           = 'Present'
-       MembersToExclude = "Contoso\JerryG"
+    Node TigerTeamSource.Contoso.Com {
+        Group TigerTeamAdmins {
+            GroupName        = 'TigerTeamAdmins'
+            Ensure           = 'Present'
+            MembersToExclude = "Contoso\JerryG"
+        }
     }
-  }
 }
 ```

--- a/dsc/reference/resources/windows/groupResource.md
+++ b/dsc/reference/resources/windows/groupResource.md
@@ -12,7 +12,7 @@ to manage local groups on the target node.
 
 ## Syntax
 
-```MOF
+```Syntax
 Group [string] #ResourceName
 {
     GroupName = [string]
@@ -43,7 +43,7 @@ Group [string] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Indicates if the group exists. Set this property to _Absent_ to ensure that the group does not exist. Setting it to _Present_ ensures that the group exists. The default value is _Present_. |
+|Ensure |Indicates if the group exists. Set this property to **Absent** to ensure that the group does not exist. Setting it to **Present** ensures that the group exists. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]
@@ -58,7 +58,7 @@ The following example shows how to ensure that a group called "TestGroup" is abs
 Group GroupExample
 {
     # This removes TestGroup, if present
-    # To create a new group, set Ensure to "Present“
+    # To create a new group, set Ensure to "Present"
     Ensure = "Absent"
     GroupName = "TestGroup"
 }

--- a/dsc/reference/resources/windows/groupSetResource.md
+++ b/dsc/reference/resources/windows/groupSetResource.md
@@ -1,47 +1,65 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-description:  Provides a mechanism to manage local groups on the target node.
-title:  DSC GroupSet Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+description: Provides a mechanism to manage local groups on the target node.
+title: DSC GroupSet Resource
 ---
 # DSC GroupSet Resource
 
-> Applies To: Windows PowerShell 5.0
+> Applies To: Windows PowerShell 5.x
 
-The **GroupSet** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to manage local groups on the target node. This resource is a
-[composite resource](../../../resources/authoringResourceComposite.md) that calls the [Group resource](groupResource.md) for each group specified in the `GroupName` parameter.
+The **GroupSet** resource in Windows PowerShell Desired State Configuration (DSC) provides a
+mechanism to manage local groups on the target node. This resource is a [composite resource](../../../resources/authoringResourceComposite.md)
+that calls the [Group resource](groupResource.md) for each group specified in the `GroupName`
+parameter.
 
-Use this resource when you want to add and/or remove the same list of members to more than one group, remove more than one group, or add more than one group with the same list of members.
+Use this resource when you want to add and/or remove the same list of members to more than one
+group, remove more than one group, or add more than one group with the same list of members.
 
 ## Syntax
 
-```
+```MOF
 Group [string] #ResourceName
 {
     GroupName = [string[]]
-    [ Ensure = [string] { Absent | Present }  ]
+    [ Members = [string[]] ]
+    [ Description = [string[]] ]
     [ MembersToInclude = [string[]] ]
     [ MembersToExclude = [string[]] ]
     [ Credential = [PSCredential] ]
     [ DependsOn = [string[]] ]
+    [ Ensure = [string] { Absent | Present }  ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| GroupName| The names of the groups for which you want to ensure a specific state.|
-| MembersToExclude| Use this property to remove members from the existing membership of the groups. The value of this property is an array of strings of the form *Domain*\\*UserName*. If you set this property in a configuration, do not use the **Members** property. Doing so will generate an error.|
-| Credential| The credentials required to access remote resources. **Note**: This account must have the appropriate Active Directory permissions to add all non-local accounts to the group; otherwise, an error will occur.
-| Ensure| Indicates whether the groups exist. Set this property to "Absent" to ensure that the groups do not exist. Setting it to "Present" (the default value) ensures that the groups exist.|
-| Members| Use this property to replace the current group membership with the specified members. The value of this property is an array of strings of the form *Domain*\\*UserName*. If you set this property in a configuration, do not use either the **MembersToExclude** or **MembersToInclude** property. Doing so will generate an error.|
-| MembersToInclude| Use this property to add members to the existing membership of the group. The value of this property is an array of strings of the form *Domain*\\*UserName*. If you set this property in a configuration, do not use the **Members** property. Doing so will generate an error.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is __ResourceName__ and its type is __ResourceType__, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"``.|
+|GroupName |The names of the groups for which you want to ensure a specific state. |
+|Members |Use this property to replace the current group membership with the specified members. The value of this property is an array of strings of the form `Domain\UserName`. If you set this property in a configuration, do not use either the **MembersToExclude** or **MembersToInclude** property. Doing so will generate an error. |
+|Description |The description of the group. |
+|MembersToInclude |Use this property to add members to the existing membership of the group. The value of this property is an array of strings of the form `Domain\UserName`. If you set this property in a configuration, do not use the **Members** property. Doing so will generate an error. |
+|MembersToExclude |Use this property to remove members from the existing membership of the groups. The value of this property is an array of strings of the form `Domain\UserName`. If you set this property in a configuration, do not use the **Members** property. Doing so will generate an error. |
+|Credential |The credentials required to access remote resources. This account must have the appropriate Active Directory permissions to add all non-local accounts to the group; otherwise, an error will occur. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Indicates whether the groups exist. Set this property to _Absent_ to ensure that the groups do not exist. Setting it to _Present_ ensures that the groups exist. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example 1: Ensuring Groups are present
 
-The following example shows how to ensure that two groups called "myGroup" and "myOtherGroup" are present.
+The following example shows how to ensure that two groups called "myGroup" and "myOtherGroup" are
+present.
 
 ```powershell
 configuration GroupSetTest
@@ -73,4 +91,5 @@ GroupSetTest -ConfigurationData $cd
 ```
 
 > [!NOTE]
-> This example uses plaintext credentials for simplicity. For information about how to encrypt credentials in the configuration MOF file, see [Securing the MOF File](../../../pull-server/secureMOF.md).
+> This example uses plaintext credentials for simplicity. For information about how to encrypt
+> credentials in the configuration MOF file, see [Securing the MOF File](../../../pull-server/secureMOF.md).

--- a/dsc/reference/resources/windows/groupSetResource.md
+++ b/dsc/reference/resources/windows/groupSetResource.md
@@ -18,7 +18,7 @@ group, remove more than one group, or add more than one group with the same list
 
 ## Syntax
 
-```MOF
+```Syntax
 Group [string] #ResourceName
 {
     GroupName = [string[]]
@@ -49,7 +49,7 @@ Group [string] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Indicates whether the groups exist. Set this property to _Absent_ to ensure that the groups do not exist. Setting it to _Present_ ensures that the groups exist. The default value is _Present_. |
+|Ensure |Indicates whether the groups exist. Set this property to **Absent** to ensure that the groups do not exist. Setting it to **Present** ensures that the groups exist. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/windows/logResource.md
+++ b/dsc/reference/resources/windows/logResource.md
@@ -1,40 +1,55 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC Log Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC Log Resource
 ---
 # DSC Log Resource
 
-> _Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0_
+> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
-The __Log__ resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to write messages to the Microsoft-Windows-Desired State Configuration/Analytic event log.
+The **Log** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to
+write messages to the Microsoft-Windows-Desired State Configuration/Analytic event log.
 
-```
-Syntax
+## Syntax
 
+```MOF
 Log [string] #ResourceName
 {
     Message = [string]
     [ DependsOn = [string[]] ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 > [!NOTE]
-> By default only the Operational logs for DSC are enabled. Before the Analytic log will be available or visible, it must be enabled. For more information, see [Where are DSC Event Logs?](../../../troubleshooting/troubleshooting.md#where-are-dsc-event-logs).
+> By default only the Operational logs for DSC are enabled. Before the Analytic log will be
+> available or visible, it must be enabled. For more information, see [Where are DSC Event Logs?](../../../troubleshooting/troubleshooting.md#where-are-dsc-event-logs).
 
 ## Properties
 
-| Property | Description |
-| --- | --- |
-| Message| Indicates the message you want to write to the Microsoft-Windows-Desired State Configuration/Analytic event log.|
-| DependsOn | Indicates that the configuration of another resource must run before this log message gets written. For example, if the ID of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = '[ResourceType]ResourceName'`.|
+|Property |Description |
+|---|---|
+|Message |Indicates the message you want to write to the Microsoft-Windows-Desired State Configuration/Analytic event log. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 
-The following example shows how to include a message in the Microsoft-Windows-Desired State Configuration/Analytic event log.
+The following example shows how to include a message in the Microsoft-Windows-Desired State
+Configuration/Analytic event log.
 
 > [!NOTE]
-> If you run [Test-DscConfiguration](https://technet.microsoft.com/en-us/library/dn407382.aspx) with this resource configured, it will always return **$false**.
+> If you run [Test-DscConfiguration](https://technet.microsoft.com/en-us/library/dn407382.aspx) with
+> this resource configured, it will always return **$false**.
 
 ```powershell
 Configuration logResourceTest

--- a/dsc/reference/resources/windows/logResource.md
+++ b/dsc/reference/resources/windows/logResource.md
@@ -12,7 +12,7 @@ write messages to the Microsoft-Windows-Desired State Configuration/Analytic eve
 
 ## Syntax
 
-```MOF
+```Syntax
 Log [string] #ResourceName
 {
     Message = [string]

--- a/dsc/reference/resources/windows/packageResource.md
+++ b/dsc/reference/resources/windows/packageResource.md
@@ -13,7 +13,7 @@ target node.
 
 ## Syntax
 
-```MOF
+```Syntax
 Package [string] #ResourceName
 {
     Name = [string]
@@ -46,7 +46,7 @@ Package [string] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Indicates if the package is installed. Set this property to _Absent_ to ensure the package is not installed (or uninstall the package if it is installed). Set it to _Present_ to ensure the package is installed. The default value is _Present_. |
+|Ensure |Indicates if the package is installed. Set this property to **Absent** to ensure the package is not installed (or uninstall the package if it is installed). Set it to **Present** to ensure the package is installed. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/windows/packageResource.md
+++ b/dsc/reference/resources/windows/packageResource.md
@@ -1,17 +1,19 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC Package Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC Package Resource
 ---
 # DSC Package Resource
 
-_Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0_
+> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
-The **Package** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to install or uninstall packages, such as Windows Installer and setup.exe packages, on a target node.
+The **Package** resource in Windows PowerShell Desired State Configuration (DSC) provides a
+mechanism to install or uninstall packages, such as Windows Installer and setup.exe packages, on a
+target node.
 
 ## Syntax
 
-```
+```MOF
 Package [string] #ResourceName
 {
     Name = [string]
@@ -19,30 +21,42 @@ Package [string] #ResourceName
     ProductId = [string]
     [ Arguments = [string] ]
     [ Credential = [PSCredential] ]
-    [ Ensure = [string] { Absent | Present }  ]
     [ LogPath = [string] ]
-    [ DependsOn = [string[]] ]
     [ ReturnCode = [UInt32[]] ]
+    [ DependsOn = [string[]] ]
+    [ Ensure = [string] { Absent | Present }  ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-| Property | Description |
-| --- | --- |
-| Name| Indicates the name of the package for which you want to ensure a specific state.|
-| Path| Indicates the path where the package resides.|
-| ProductId| Indicates the product ID that uniquely identifies the package.|
-| Arguments| Lists a string of arguments that will be passed to the package exactly as provided.|
-| Credential| Provides access to the package on a remote source. This property is not used to install the package. The package is always installed on the local system.|
-| Ensure| Indicates if the package is installed. Set this property to "Absent" to ensure the package is not installed (or uninstall the package if it is installed). Set it to "Present" (the default value) to ensure the package is installed.|
-| LogPath| Indicates the full path where you want the provider to save a log file to install or uninstall the package.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
-| ReturnCode| Indicates the expected return code. If the actual return code does not match the expected value provided here, the configuration will return an error.|
+|Property |Description |
+|---|---|
+|Name |Indicates the name of the package for which you want to ensure a specific state. |
+|Path |Indicates the path where the package resides. |
+|ProductId |Indicates the product ID that uniquely identifies the package. |
+|Arguments |Lists a string of arguments that will be passed to the package exactly as provided. |
+|Credential |Provides access to the package on a remote source. This property is not used to install the package. The package is always installed on the local system. |
+|LogPath |Indicates the full path where you want the provider to save a log file to install or uninstall the package. |
+|ReturnCode |Indicates the expected return code. If the actual return code does not match the expected value provided here, the configuration will return an error. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Indicates if the package is installed. Set this property to _Absent_ to ensure the package is not installed (or uninstall the package if it is installed). Set it to _Present_ to ensure the package is installed. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 
-This example runs the .msi installer that is located at the specified path and has the specified product ID.
+This example runs the .msi installer that is located at the specified path and has the specified
+product ID.
 
 ```powershell
 Configuration PackageTest

--- a/dsc/reference/resources/windows/processSetResource.md
+++ b/dsc/reference/resources/windows/processSetResource.md
@@ -12,7 +12,7 @@ mechanism to configure processes on a target node.
 
 ## Syntax
 
-```MOF
+```Syntax
 ProcessSet [string] #ResourceName
 {
     Path = [string]
@@ -43,7 +43,7 @@ ProcessSet [string] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Specifies whether the processes exists. Set this property to _Present_ to ensure that the process exists. Otherwise, set it to _Absent_. The default value is _Present_. |
+|Ensure |Specifies whether the processes exists. Set this property to **Present** to ensure that the process exists. Otherwise, set it to **Absent**. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/windows/processSetResource.md
+++ b/dsc/reference/resources/windows/processSetResource.md
@@ -1,44 +1,51 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC ProcessSet Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC ProcessSet Resource
 ---
-# DSC WindowsProcess Resource
+# DSC ProcessSet Resource
 
-_Applies To: Windows PowerShell 5.0_
+> Applies To: Windows PowerShell 5.x
 
 The **ProcessSet** resource in Windows PowerShell Desired State Configuration (DSC) provides a
-mechanism to configure processes on a target node. This resource is a [composite resource](../../../resources/authoringResourceComposite.md)
-that calls the [WindowsProcess resource](windowsProcessResource.md) for each group specified in the
-`GroupName` parameter.
+mechanism to configure processes on a target node.
 
 ## Syntax
 
-```
-WindowsProcess [string] #ResourceName
+```MOF
+ProcessSet [string] #ResourceName
 {
-    Arguments = [string]
     Path = [string]
     [ Credential = [PSCredential] ]
-    [ Ensure = [string] { Absent | Present }  ]
     [ StandardOutputPath = [string] ]
     [ StandardErrorPath = [string] ]
     [ StandardInputPath = [string] ]
     [ WorkingDirectory = [string] ]
     [ DependsOn = [string[]] ]
+    [ Ensure = [string] { Absent | Present }  ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-| Property | Description |
-| --- | --- |
-| Arguments| A string that contains arguments to pass to the process as-is. If you need to pass several arguments, put them all in this string.|
-| Path| The paths to the process executables. If these are the names of the executable files (not fully qualified paths), the DSC resource will search the environment **Path** variable (`$env:Path`) to find the files. If the values of this property are fully qualified paths, DSC will not use the **Path** environment variable to find the files, and will throw an error if any of the paths do not exist. Relative paths are not allowed.|
-| Credential| Indicates the credentials for starting the process.|
-| Ensure| Specifies whether the processes exists. Set this property to "Present" to ensure that the process exists. Otherwise, set it to "Absent". The default is "Present".|
-| StandardErrorPath| The path to which the processes write standard error. Any existing file there will be overwritten.|
-| StandardInputPath| The stream from which the process receives standard input.|
-| StandardOutputPath| The path of the file to which the processes write standard output. Any existing file there will be overwritten.|
-| WorkingDirectory| The location used as the current working directory for the processes.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is **ResourceName** and its type is **_ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"` .|
+|Property |Description |
+|---|---|
+|Path |The path to the process executable. If these are the names of the executable files (not fully qualified paths), the DSC resource will search the environment `$env:Path` variable to find the files. If the values of this property are fully qualified paths, DSC will not use the `$env:Path` environment variable to find the files, and will throw an error if any of the paths do not exist. Relative paths are not allowed. |
+|Credential |Indicates the credentials for starting the process. |
+|StandardErrorPath |The path to which the processes write standard error. Any existing file there will be overwritten. |
+|StandardInputPath |The stream from which the process receives standard input. |
+|StandardOutputPath |The path of the file to which the processes write standard output. Any existing file there will be overwritten. |
+|WorkingDirectory |The location used as the current working directory for the processes. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Specifies whether the processes exists. Set this property to _Present_ to ensure that the process exists. Otherwise, set it to _Absent_. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).

--- a/dsc/reference/resources/windows/registryResource.md
+++ b/dsc/reference/resources/windows/registryResource.md
@@ -1,43 +1,54 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC Registry Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC Registry Resource
 ---
 # DSC Registry Resource
 
-_Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0_
+> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
 The **Registry** resource in Windows PowerShell Desired State Configuration (DSC) provides a
 mechanism to manage registry keys and values on a target node.
 
 ## Syntax
 
-```
+```MOF
 Registry [string] #ResourceName
 {
     Key = [string]
     ValueName = [string]
-    [ Ensure = [string] { Present | Absent }  ]
     [ Force =  [bool]   ]
     [ Hex = [bool] ]
-    [ DependsOn = [string[]] ]
     [ ValueData = [string[]] ]
     [ ValueType = [string] { Binary | Dword | ExpandString | MultiString | Qword | String }  ]
+    [ DependsOn = [string[]] ]
+    [ Ensure = [string] { Present | Absent }  ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-| Property | Description |
-| --- | --- |
-| Key| Indicates the path of the registry key for which you want to ensure a specific state. This path must include the hive.|
-| ValueName| Indicates the name of the registry value. To add or remove a registry key, specify this property as an empty string without specifying ValueType or ValueData. To modify or remove the default value of a registry key, specify this property as an empty string while also specifying ValueType or ValueData.|
-| Ensure| Indicates if the key and value exist. To ensure that they do, set this property to "Present". To ensure that they do not exist, set the property to "Absent". The default value is "Present".|
-| Force| If the specified registry key is present, **Force** overwrites it with the new value. If deleting a registry key with subkeys, this needs to be **$true** |
-| Hex| Indicates if data will be expressed in hexadecimal format. If specified, the DWORD/QWORD value data is presented in hexadecimal format. Not valid for other types. The default value is **$false**.|
-| DependsOn| Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
-| ValueData| The data for the registry value.|
-| ValueType| Indicates the type of the value. The supported types are: String (REG_SZ), Binary (REG-BINARY), Dword 32-bit (REG_DWORD), Qword 64-bit (REG_QWORD), Multi-string (REG_MULTI_SZ), Expandable string (REG_EXPAND_SZ) |
+|Property |Description |
+|---|---|
+|Key |Indicates the path of the registry key for which you want to ensure a specific state. This path must include the hive. |
+|ValueName |Indicates the name of the registry value. To add or remove a registry key, specify this property as an empty string without specifying **ValueType** or **ValueData**. To modify or remove the default value of a registry key, specify this property as an empty string while also specifying **ValueType** or **ValueData**. |
+|Force |If the specified registry key is present, **Force** overwrites it with the new value. If deleting a registry key with subkeys, this needs to be _$true_. |
+|Hex |Indicates if data will be expressed in hexadecimal format. If specified, the DWORD/QWORD value data is presented in hexadecimal format. Not valid for other types. The default value is _$false_. |
+|ValueData |The data for the registry value. |
+|ValueType |Indicates the type of the value. The supported types are: _String_ (REG_SZ), _Binary_ (REG-BINARY), _Dword_ (32-bit REG_DWORD), _Qword_ (64-bit REG_QWORD), _MultiString_ (REG_MULTI_SZ), _ExpandString_ (REG_EXPAND_SZ). |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Indicates if the key and value exist. To ensure that they do, set this property to _Present_. To ensure that they do not exist, set the property to _Absent_. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 

--- a/dsc/reference/resources/windows/registryResource.md
+++ b/dsc/reference/resources/windows/registryResource.md
@@ -12,7 +12,7 @@ mechanism to manage registry keys and values on a target node.
 
 ## Syntax
 
-```MOF
+```Syntax
 Registry [string] #ResourceName
 {
     Key = [string]
@@ -33,17 +33,17 @@ Registry [string] #ResourceName
 |---|---|
 |Key |Indicates the path of the registry key for which you want to ensure a specific state. This path must include the hive. |
 |ValueName |Indicates the name of the registry value. To add or remove a registry key, specify this property as an empty string without specifying **ValueType** or **ValueData**. To modify or remove the default value of a registry key, specify this property as an empty string while also specifying **ValueType** or **ValueData**. |
-|Force |If the specified registry key is present, **Force** overwrites it with the new value. If deleting a registry key with subkeys, this needs to be _$true_. |
-|Hex |Indicates if data will be expressed in hexadecimal format. If specified, the DWORD/QWORD value data is presented in hexadecimal format. Not valid for other types. The default value is _$false_. |
+|Force |If the specified registry key is present, **Force** overwrites it with the new value. If deleting a registry key with subkeys, this needs to be `$true`. |
+|Hex |Indicates if data will be expressed in hexadecimal format. If specified, the DWORD/QWORD value data is presented in hexadecimal format. Not valid for other types. The default value is `$false`. |
 |ValueData |The data for the registry value. |
-|ValueType |Indicates the type of the value. The supported types are: _String_ (REG_SZ), _Binary_ (REG-BINARY), _Dword_ (32-bit REG_DWORD), _Qword_ (64-bit REG_QWORD), _MultiString_ (REG_MULTI_SZ), _ExpandString_ (REG_EXPAND_SZ). |
+|ValueType |Indicates the type of the value. The supported types are: **String** (REG_SZ), **Binary** (REG-BINARY), **Dword** (32-bit REG_DWORD), **Qword** (64-bit REG_QWORD), **MultiString** (REG_MULTI_SZ), **ExpandString** (REG_EXPAND_SZ). |
 
 ## Common properties
 
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Indicates if the key and value exist. To ensure that they do, set this property to _Present_. To ensure that they do not exist, set the property to _Absent_. The default value is _Present_. |
+|Ensure |Indicates if the key and value exist. To ensure that they do, set this property to **Present**. To ensure that they do not exist, set the property to **Absent**. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/windows/scriptResource.md
+++ b/dsc/reference/resources/windows/scriptResource.md
@@ -1,17 +1,20 @@
 ---
-ms.date:  08/24/2018
-keywords:  dsc,powershell,configuration,setup
-title:  DSC Script Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC Script Resource
 ---
 # DSC Script Resource
 
 > Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
-The **Script** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to run Windows PowerShell script blocks on target nodes. The **Script** resource uses `GetScript`, `SetScript`, and `TestScript` properties that contain script blocks you define to perform the corresponding DSC state operations.
+The **Script** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism
+to run Windows PowerShell script blocks on target nodes. The **Script** resource uses **GetScript**,
+**SetScript**, and **TestScript** properties that contain script blocks you define to perform the
+corresponding DSC state operations.
 
 ## Syntax
 
-```
+```MOF
 Script [string] #ResourceName
 {
     GetScript = [string]
@@ -19,45 +22,71 @@ Script [string] #ResourceName
     TestScript = [string]
     [ Credential = [PSCredential] ]
     [ DependsOn = [string[]] ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 > [!NOTE]
-> The `GetScript`, `TestScript`, and `SetScript` blocks are stored as strings.
+> **GetScript**, **TestScript**, and **SetScript** blocks are stored as strings.
 
 ## Properties
 
-|Property|Description|
-|--------|-----------|
-|GetScript|A script block that returns the current state of the Node.|
-|SetScript|A script block that DSC uses to enforce compliance when the Node is not in the desired state.|
-|TestScript|A script block that determines if the Node is in the desired state.|
-|Credential| Indicates the credentials to use for running this script, if credentials are required.|
-|DependsOn| Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.
+|Property |Description |
+|---|---|
+|GetScript |A script block that returns the current state of the Node. |
+|SetScript |A script block that DSC uses to enforce compliance when the Node is not in the desired state. |
+|TestScript |A script block that determines if the Node is in the desired state. |
+|Credential |Indicates the credentials to use for running this script, if credentials are required. |
 
-### GetScript
+## Common properties
 
-DSC does not use the output from `GetScript`. The [Get-DscConfiguration](/powershell/module/PSDesiredStateConfiguration/Get-DscConfiguration) cmdlet executes the `GetScript` to retrieve a node's current state. A return value is not required from `GetScript`. If you specify a return value, it must be a `hashtable` containing a **Result** key whose value is a `String`.
-
-### TestScript
-
-The `TestScript` is executed by DSC to determine if the `SetScript` should be run. If the `TestScript` returns `$false`, DSC executes the `SetScript` to bring the node back to the desired state. It must return a `boolean` value. A result of `$true` indicates that the node is compliant and `SetScript` should not executed.
-
-The [Test-DscConfiguration](/powershell/module/PSDesiredStateConfiguration/Test-DscConfiguration) cmdlet, executes the `TestScript` to retrieve the nodes compliance with the  **Script** resources. However, in this case, the `SetScript` does not run, no matter what the `TestScript` block returns.
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]
-> All output from your `TestScript` is part of its return value. PowerShell interprets unsuppressed output as non-zero, which means that your `TestScript` will return `$true` regardless of your node's state.
-> This results in unpredictable results, false positives, and causes difficulty during troubleshooting.
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
-### SetScript
+### Additional information
 
-The `SetScript` modifies the node to enforce the desired state. It is called by DSC if the `TestScript` script block returns `$false`. The `SetScript` should have no return value.
+#### GetScript
+
+DSC does not use the output from **GetScript**. The [Get-DscConfiguration](/powershell/module/PSDesiredStateConfiguration/Get-DscConfiguration)
+cmdlet executes **GetScript** to retrieve a node's current state. A return value is not required
+from **GetScript**. If you specify a return value, it must be a hashtable containing a **Result**
+key whose value is a String.
+
+#### TestScript
+
+**TestScript** is executed by DSC to determine if **SetScript** should be run. If **TestScript**
+returns `$false`, DSC executes **SetScript** to bring the node back to the desired state. It must
+return a boolean value. A result of `$true` indicates that the node is compliant and **SetScript**
+should not executed.
+
+The [Test-DscConfiguration](/powershell/module/PSDesiredStateConfiguration/Test-DscConfiguration)
+cmdlet, executes **TestScript** to retrieve the nodes compliance with the **Script** resources.
+However, in this case, **SetScript** does not run, no matter what **TestScript** block returns.
+
+> [!NOTE]
+> All output from your **TestScript** is part of its return value. PowerShell interprets
+> unsuppressed output as non-zero, which means that your **TestScript** will return `$true`
+> regardless of your node's state. This results in unpredictable results, false positives, and
+> causes difficulty during troubleshooting.
+
+#### SetScript
+
+**SetScript** modifies the node to enforce the desired state. It is called by DSC if the
+**TestScript** script block returns `$false`. The **SetScript** should have no return value.
 
 ## Examples
 
 ### Example 1: Write sample text using a Script resource
 
-This example tests for the existence of `C:\TempFolder\TestFile.txt` on each node. If it does not exist, it creates it using the `SetScript`. The `GetScript` returns the contents of the file, and its return value is not used.
+This example tests for the existence of `C:\TempFolder\TestFile.txt` on each node. If it does not
+exist, it creates it using the `SetScript`. The `GetScript` returns the contents of the file, and
+its return value is not used.
 
 ```powershell
 Configuration ScriptTest
@@ -82,7 +111,11 @@ Configuration ScriptTest
 
 ### Example 2: Compare version information using a Script resource
 
-This example retrieves the *compliant* version information from a text file on the authoring computer and stores it in the `$version` variable. When generating the node's MOF file, DSC replaces the `$using:version` variables in each script block with the value of the `$version` variable. During execution, the *compliant* version is stored in a text file on each Node and compared and updated on subsequent executions.
+This example retrieves the *compliant* version information from a text file on the authoring
+computer and stores it in the `$version` variable. When generating the node's MOF file, DSC replaces
+the `$using:version` variables in each script block with the value of the `$version` variable.
+During execution, the *compliant* version is stored in a text file on each Node and compared and
+updated on subsequent executions.
 
 ```powershell
 $version = Get-Content 'version.txt'

--- a/dsc/reference/resources/windows/scriptResource.md
+++ b/dsc/reference/resources/windows/scriptResource.md
@@ -14,7 +14,7 @@ corresponding DSC state operations.
 
 ## Syntax
 
-```MOF
+```Syntax
 Script [string] #ResourceName
 {
     GetScript = [string]

--- a/dsc/reference/resources/windows/serviceResource.md
+++ b/dsc/reference/resources/windows/serviceResource.md
@@ -12,7 +12,7 @@ mechanism to manage services on the target node.
 
 ## Syntax
 
-```MOF
+```Syntax
 Service [string] #ResourceName
 {
     Name = [string]
@@ -34,10 +34,10 @@ Service [string] #ResourceName
 |Property |Description |
 |---|---|
 |Name |Indicates the service name. Note that sometimes this is different from the display name. You can get a list of the services and their current state with the `Get-Service` cmdlet. |
-|BuiltInAccount |Indicates the sign-in account to use for the service. The values that are allowed for this property are: _LocalService_, _LocalSystem_, and _NetworkService_. |
+|BuiltInAccount |Indicates the sign-in account to use for the service. The values that are allowed for this property are: **LocalService**, **LocalSystem**, and **NetworkService**. |
 |Credential |Indicates credentials for the account that the service will run under. This property and the **BuiltinAccount** property cannot be used together. |
-|StartupType |Indicates the startup type for the service. The values that are allowed for this property are: _Automatic_, _Disabled_, and _Manual_. |
-|State |Indicates the state you want to ensure for the service. The values are: _Running_ or _Stopped_. |
+|StartupType |Indicates the startup type for the service. The values that are allowed for this property are: **Automatic**, **Disabled**, and **Manual**. |
+|State |Indicates the state you want to ensure for the service. The values are: **Running** or **Stopped**. |
 |Description |Indicates the description of the target service. |
 |DisplayName |Indicates the display name of the target service. |
 |Path |Indicates the path to the binary file for a new service. |
@@ -47,7 +47,7 @@ Service [string] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Indicates whether the target service exists on the system. Set this property to _Absent_ to ensure that the target service does not exist. Setting it to _Present_ ensures that target service exists. The default value is _Present_. |
+|Ensure |Indicates whether the target service exists on the system. Set this property to **Absent** to ensure that the target service does not exist. Setting it to **Present** ensures that target service exists. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/windows/serviceResource.md
+++ b/dsc/reference/resources/windows/serviceResource.md
@@ -1,48 +1,58 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC Service Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC Service Resource
 ---
-
 # DSC Service Resource
 
-> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0
+> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
-
-The **Service** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to manage services on the target node.
+The **Service** resource in Windows PowerShell Desired State Configuration (DSC) provides a
+mechanism to manage services on the target node.
 
 ## Syntax
 
-```
+```MOF
 Service [string] #ResourceName
 {
     Name = [string]
     [ BuiltInAccount = [string] { LocalService | LocalSystem | NetworkService }  ]
     [ Credential = [PSCredential] ]
-    [ DependsOn = [string[]] ]
     [ StartupType = [string] { Automatic | Disabled | Manual }  ]
     [ State = [string] { Running | Stopped }  ]
     [ Description = [string] ]
     [ DisplayName = [string] ]
-    [ Ensure = [string] { Absent | Present } ]
     [ Path = [string] ]
+    [ DependsOn = [string[]] ]
+    [ Ensure = [string] { Absent | Present } ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| Name| Indicates the service name. Note that sometimes this is different from the display name. You can get a list of the services and their current state with the Get-Service cmdlet.|
-| BuiltInAccount| Indicates the sign-in account to use for the service. The values that are allowed for this property are: **LocalService**, **LocalSystem**, and **NetworkService**.|
-| Credential| Indicates credentials for the account that the service will run under. This property and the __BuiltinAccount__ property cannot be used together.|
-| DependsOn| Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is __ResourceName__ and its type is __ResourceType__, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
-| StartupType| Indicates the startup type for the service. The values that are allowed for this property are: **Automatic**, **Disabled**, and **Manual**|
-| State| Indicates the state you want to ensure for the service.|
-| Description | Indicates the description of the target service.|
-| DisplayName | Indicates the display name of the target service.|
-| Ensure | Indicates whether the target service exists on the system. Set this property to **Absent** to ensure that the target service does not exist. Setting it to **Present** (the default value) ensures that target service exists.|
-| Path | Indicates the path to the binary file for a new service.|
+|Name |Indicates the service name. Note that sometimes this is different from the display name. You can get a list of the services and their current state with the `Get-Service` cmdlet. |
+|BuiltInAccount |Indicates the sign-in account to use for the service. The values that are allowed for this property are: _LocalService_, _LocalSystem_, and _NetworkService_. |
+|Credential |Indicates credentials for the account that the service will run under. This property and the **BuiltinAccount** property cannot be used together. |
+|StartupType |Indicates the startup type for the service. The values that are allowed for this property are: _Automatic_, _Disabled_, and _Manual_. |
+|State |Indicates the state you want to ensure for the service. The values are: _Running_ or _Stopped_. |
+|Description |Indicates the description of the target service. |
+|DisplayName |Indicates the display name of the target service. |
+|Path |Indicates the path to the binary file for a new service. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Indicates whether the target service exists on the system. Set this property to _Absent_ to ensure that the target service does not exist. Setting it to _Present_ ensures that target service exists. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 

--- a/dsc/reference/resources/windows/serviceSetResource.md
+++ b/dsc/reference/resources/windows/serviceSetResource.md
@@ -16,7 +16,7 @@ Use this resource when you want to configure a number of services to the same st
 
 ## Syntax
 
-```MOF
+```Syntax
 ServiceSet [string] #ResourceName
 {
     Name = [string[]]
@@ -35,9 +35,9 @@ ServiceSet [string] #ResourceName
 |Property |Description |
 |---|---|
 |Name |Indicates the service names. Note that sometimes this is different from the display names. You can get a list of the services and their current state with the `Get-Service` cmdlet. |
-|StartupType |Indicates the startup type for the services. The values that are allowed for this property are: _Automatic_, _Disabled_, and _Manual_. |
-|BuiltInAccount |Indicates the sign-in account to use for the services. The values that are allowed for this property are: _LocalService_, _LocalSystem_, and _NetworkService_. |
-|State |Indicates the state you want to ensure for the services: _Stopped_ or _Running_. |
+|StartupType |Indicates the startup type for the services. The values that are allowed for this property are: **Automatic**, **Disabled**, and **Manual**. |
+|BuiltInAccount |Indicates the sign-in account to use for the services. The values that are allowed for this property are: **LocalService**, **LocalSystem**, and **NetworkService**. |
+|State |Indicates the state you want to ensure for the services: **Stopped** or **Running**. |
 |Credential |Indicates credentials for the account that the service resource will run under. This property and the **BuiltinAccount** property cannot be used together. |
 
 ## Common properties
@@ -45,7 +45,7 @@ ServiceSet [string] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Indicates whether the services exist on the system. Set this property to _Absent_ to ensure that the services do not exist. Setting it to _Present_ ensures that target services exist. The default value is _Present_. |
+|Ensure |Indicates whether the services exist on the system. Set this property to **Absent** to ensure that the services do not exist. Setting it to **Present** ensures that target services exist. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/windows/serviceSetResource.md
+++ b/dsc/reference/resources/windows/serviceSetResource.md
@@ -1,47 +1,56 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC ServiceSet Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC ServiceSet Resource
 ---
-
 # DSC ServiceSet Resource
 
-> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0
+> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
-The **ServiceSet** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to manage services on the target node. This resource is a
-[composite resource](../../../resources/authoringResourceComposite.md) that calls the [Service resource](serviceResource.md) for each service specified in the `Name` property.
+The **ServiceSet** resource in Windows PowerShell Desired State Configuration (DSC) provides a
+mechanism to manage services on the target node. This resource is a [composite resource](../../../resources/authoringResourceComposite.md)
+that calls the [Service resource](serviceResource.md) for each service specified in the **Name**
+property.
 
 Use this resource when you want to configure a number of services to the same state.
 
 ## Syntax
 
-```
-Service [string] #ResourceName
+```MOF
+ServiceSet [string] #ResourceName
 {
     Name = [string[]]
     [ StartupType = [string] { Automatic | Disabled | Manual }  ]
     [ BuiltInAccount = [string] { LocalService | LocalSystem | NetworkService }  ]
     [ State = [string] { Running | Stopped }  ]
-    [ Ensure = [string] { Absent | Present }  ]
     [ Credential = [PSCredential] ]
     [ DependsOn = [string[]] ]
-
+    [ Ensure = [string] { Absent | Present }  ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| Name| Indicates the service names. Note that sometimes this is different from the display names. You can get a list of the services and their current state with the [Get-Service](https://technet.microsoft.com/library/hh849804.aspx) cmdlet.|
-| StartupType| Indicates the startup type for the service. The values that are allowed for this property are: **Automatic**, **Disabled**, and **Manual**|
-| BuiltInAccount| Indicates the sign-in account to use for the services. The values that are allowed for this property are: **LocalService**, **LocalSystem**, and **NetworkService**.|
-| State| Indicates the state you want to ensure for the services: **Stopped** or **Running**.|
-| Ensure| Indicates whether the services exist on the system. Set this property to **Absent** to ensure that the services do not exist. Setting it to **Present** (the default value) ensures that target services exist.|
-| Credential| Indicates credentials for the account that the service resource will run under. This property and the **BuiltinAccount** property cannot be used together.|
-| DependsOn| Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is *ResourceName* and its type is *ResourceType*, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|Name |Indicates the service names. Note that sometimes this is different from the display names. You can get a list of the services and their current state with the `Get-Service` cmdlet. |
+|StartupType |Indicates the startup type for the services. The values that are allowed for this property are: _Automatic_, _Disabled_, and _Manual_. |
+|BuiltInAccount |Indicates the sign-in account to use for the services. The values that are allowed for this property are: _LocalService_, _LocalSystem_, and _NetworkService_. |
+|State |Indicates the state you want to ensure for the services: _Stopped_ or _Running_. |
+|Credential |Indicates credentials for the account that the service resource will run under. This property and the **BuiltinAccount** property cannot be used together. |
 
+## Common properties
 
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Indicates whether the services exist on the system. Set this property to _Absent_ to ensure that the services do not exist. Setting it to _Present_ ensures that target services exist. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 
@@ -53,7 +62,6 @@ configuration ServiceSetTest
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Node localhost
     {
-
         ServiceSet ServiceSetExample
         {
             Name        = @("TermService", "Audiosrv")

--- a/dsc/reference/resources/windows/userResource.md
+++ b/dsc/reference/resources/windows/userResource.md
@@ -1,46 +1,58 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC User Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC User Resource
 ---
 # DSC User Resource
 
-Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0
+> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
-The **User** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to manage local user accounts on the target node.
+The **User** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism
+to manage local user accounts on the target node.
 
 ## Syntax
 
-```
+```MOF
 User [string] #ResourceName
 {
     UserName = [string]
     [ Description = [string] ]
     [ Disabled = [bool] ]
-    [ Ensure = [string] { Absent | Present }  ]
     [ FullName = [string] ]
     [ Password = [PSCredential] ]
     [ PasswordChangeNotAllowed = [bool] ]
     [ PasswordChangeRequired = [bool] ]
     [ PasswordNeverExpires = [bool] ]
     [ DependsOn = [string[]] ]
+    [ Ensure = [string] { Absent | Present }  ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| UserName| Indicates the account name for which you want to ensure a specific state.|
-| Description| Indicates the description you want to use for the user account.|
-| Disabled| Indicates if the account is enabled. Set this property to `$true` to ensure that this account is disabled, and set it to `$false` to ensure that it is enabled.|
-| Ensure| Indicates if the account exists. Set this property to "Present" to ensure that the account exists, and set it to "Absent" to ensure that the account does not exist.|
-| FullName| Represents a string with the full name you want to use for the user account.|
-| Password| Indicates the password you want to use for this account. |
-| PasswordChangeNotAllowed| Indicates if the user can change the password. Set this property to `$true` to ensure that the user cannot change the password, and set it to `$false` to allow the user to change the password. The default value is `$false`.|
-| PasswordChangeRequired| Indicates if the user must change the password at the next sign in. Set this property to `$true` if the user must change the password. The default value is `$true`.|
-| PasswordNeverExpires| Indicates if the password will expire. To ensure that the password for this account will never expire, set this property to `$true`, and set it to `$false` if the password will expire. The default value is `$false`.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|UserName |Indicates the account name for which you want to ensure a specific state. |
+|Description |Indicates the description you want to use for the user account. |
+|Disabled |Indicates if the account is enabled. Set this property to _$true_ to ensure that this account is disabled, and set it to _$false_ to ensure that it is enabled. |
+|FullName |Represents a string with the full name you want to use for the user account. |
+|Password |Indicates the password you want to use for this account. |
+|PasswordChangeNotAllowed |Indicates if the user can change the password. Set this property to _$true_ to ensure that the user cannot change the password, and set it to _$false_ to allow the user to change the password. The default value is _$false_. |
+|PasswordChangeRequired |Indicates if the user must change the password at the next sign in. Set this property to _$true_ if the user must change the password. The default value is _$true_. |
+|PasswordNeverExpires |Indicates if the password will expire. To ensure that the password for this account will never expire, set this property to _$true_. Set it to _$false_ if the password will expire. The default value is _$false_. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Indicates if the account exists. Set this property to _Present_ to ensure that the account exists, and set it to _Absent_ to ensure that the account does not exist. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 

--- a/dsc/reference/resources/windows/userResource.md
+++ b/dsc/reference/resources/windows/userResource.md
@@ -12,7 +12,7 @@ to manage local user accounts on the target node.
 
 ## Syntax
 
-```MOF
+```Syntax
 User [string] #ResourceName
 {
     UserName = [string]
@@ -35,19 +35,19 @@ User [string] #ResourceName
 |---|---|
 |UserName |Indicates the account name for which you want to ensure a specific state. |
 |Description |Indicates the description you want to use for the user account. |
-|Disabled |Indicates if the account is enabled. Set this property to _$true_ to ensure that this account is disabled, and set it to _$false_ to ensure that it is enabled. |
+|Disabled |Indicates if the account is enabled. Set this property to `$true` to ensure that this account is disabled, and set it to `$false` to ensure that it is enabled. |
 |FullName |Represents a string with the full name you want to use for the user account. |
 |Password |Indicates the password you want to use for this account. |
-|PasswordChangeNotAllowed |Indicates if the user can change the password. Set this property to _$true_ to ensure that the user cannot change the password, and set it to _$false_ to allow the user to change the password. The default value is _$false_. |
-|PasswordChangeRequired |Indicates if the user must change the password at the next sign in. Set this property to _$true_ if the user must change the password. The default value is _$true_. |
-|PasswordNeverExpires |Indicates if the password will expire. To ensure that the password for this account will never expire, set this property to _$true_. Set it to _$false_ if the password will expire. The default value is _$false_. |
+|PasswordChangeNotAllowed |Indicates if the user can change the password. Set this property to `$true` to ensure that the user cannot change the password, and set it to `$false` to allow the user to change the password. The default value is `$false`. |
+|PasswordChangeRequired |Indicates if the user must change the password at the next sign in. Set this property to `$true` if the user must change the password. The default value is `$true`. |
+|PasswordNeverExpires |Indicates if the password will expire. To ensure that the password for this account will never expire, set this property to `$true`. Set it to `$false` if the password will expire. The default value is `$false`. |
 
 ## Common properties
 
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Indicates if the account exists. Set this property to _Present_ to ensure that the account exists, and set it to _Absent_ to ensure that the account does not exist. The default value is _Present_. |
+|Ensure |Indicates if the account exists. Set this property to **Present** to ensure that the account exists, and set it to **Absent** to ensure that the account does not exist. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/windows/waitForAllResource.md
+++ b/dsc/reference/resources/windows/waitForAllResource.md
@@ -20,7 +20,7 @@ state on all target nodes defined in the **NodeName** property.
 
 ## Syntax
 
-```MOF
+```Syntax
 WaitForAll [string] #ResourceName
 {
     ResourceName = [string]

--- a/dsc/reference/resources/windows/waitForAllResource.md
+++ b/dsc/reference/resources/windows/waitForAllResource.md
@@ -1,47 +1,58 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC WaitForAll Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC WaitForAll Resource
 ---
-
 # DSC WaitForAll Resource
 
-> Applies To: Windows PowerShell 5.0 and later
+> Applies To: Windows PowerShell 5.x
 
 The **WaitForAll** Desired State Configuration (DSC) resource can be used within a node block in a [DSC configuration](../../../configurations/configurations.md)
 to specify dependencies on configurations on other nodes.
 
-This resource succeeds if the resource specified by the **ResourceName** property is in the desired state on all target nodes defined in the **NodeName** property.
+This resource succeeds if the resource specified by the **ResourceName** property is in the desired
+state on all target nodes defined in the **NodeName** property.
 
 > [!NOTE]
-> **WaitForAll** resource uses Windows Remote Management to check the state of other Nodes.
-> For more information about port and security requirements for WinRM, see
+> **WaitForAll** resource uses Windows Remote Management to check the state of other Nodes. For more
+> information about port and security requirements for WinRM, see
 > [PowerShell Remoting Security Considerations](/powershell/scripting/learn/remoting/winrmsecurity?view=powershell-6).
 
 ## Syntax
 
-```
+```MOF
 WaitForAll [string] #ResourceName
 {
     ResourceName = [string]
-    NodeName = [string]
+    NodeName = [string[]]
     [ RetryIntervalSec = [Uint64] ]
     [ RetryCount = [Uint32] ]
     [ ThrottleLimit = [Uint32]]
     [ DependsOn = [string[]] ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| ResourceName| The resource name to depend on. If this resource belongs to a different configuration, format the name as "[__ResourceType__]__ResourceName__::[__ConfigurationName__]::[__ConfigurationName__]"|
-| NodeName| The target nodes of the resource to depend on.|
-| RetryIntervalSec| The number of seconds before retrying. Minimum is 1.|
-| RetryCount| The maximum number of times to retry.|
-| ThrottleLimit| Number of machines to connect simultaneously. Default is new-cimsession default.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is __ResourceName__ and its type is __ResourceType__, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|ResourceName |The resource name to depend on. If this resource belongs to a different configuration, format the name as `[ResourceType]ResourceName::[ConfigurationName]::[ConfigurationName]`. |
+|NodeName |The target nodes of the resource to depend on. |
+|RetryIntervalSec |The number of seconds before retrying. Minimum is 1. |
+|RetryCount |The maximum number of times to retry. |
+|ThrottleLimit |Number of machines to connect simultaneously. Default is `New-CimSession` default. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 

--- a/dsc/reference/resources/windows/waitForAnyResource.md
+++ b/dsc/reference/resources/windows/waitForAnyResource.md
@@ -1,47 +1,58 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC WaitForAny Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC WaitForAny Resource
 ---
-
 # DSC WaitForAny Resource
 
-> Applies To: Windows PowerShell 5.1 and later
+> Applies To: Windows PowerShell 5.1
 
 The **WaitForAny** Desired State Configuration (DSC) resource can be used within a node block in a [DSC configuration](../../../configurations/configurations.md)
 to specify dependencies on configurations on other nodes.
 
-This resource succeeds if the resource specified by the **ResourceName** property is in the desired state on any target nodes defined in the **NodeName** property.
+This resource succeeds if the resource specified by the **ResourceName** property is in the desired
+state on any target nodes defined in the **NodeName** property.
 
 > [!NOTE]
-> **WaitForAny** resource uses Windows Remote Management to check the state of other Nodes.
-> For more information about port and security requirements for WinRM, see
+> **WaitForAny** resource uses Windows Remote Management to check the state of other Nodes. For more
+> information about port and security requirements for WinRM, see
 > [PowerShell Remoting Security Considerations](/powershell/scripting/learn/remoting/winrmsecurity?view=powershell-6).
 
 ## Syntax
 
-```
+```MOF
 WaitForAny [string] #ResourceName
 {
     ResourceName = [string]
-    NodeName = [string]
+    NodeName = [string[]]
     [ RetryIntervalSec = [Uint64] ]
     [ RetryCount = [Uint32] ]
     [ ThrottleLimit = [Uint32]]
     [ DependsOn = [string[]] ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| ResourceName| The resource name to depend on. If this resource belongs to a different configuration, format the name as "[__ResourceType__]__ResourceName__::[__ConfigurationName__]::[__ConfigurationName__]"|
-| NodeName| The target nodes of the resource to depend on.|
-| RetryIntervalSec| The number of seconds before retrying. Minimum is 1.|
-| RetryCount| The maximum number of times to retry.|
-| ThrottleLimit| Number of machines to connect simultaneously. Default is new-cimsession default.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is __ResourceName__ and its type is __ResourceType__, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|ResourceName |The resource name to depend on. If this resource belongs to a different configuration, format the name as `[ResourceType]ResourceName::[ConfigurationName]::[ConfigurationName]`. |
+|NodeName |The target nodes of the resource to depend on. |
+|RetryIntervalSec |The number of seconds before retrying. Minimum is 1. |
+|RetryCount |The maximum number of times to retry. |
+|ThrottleLimit |Number of machines to connect simultaneously. Default is `New-CimSession` default. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 

--- a/dsc/reference/resources/windows/waitForAnyResource.md
+++ b/dsc/reference/resources/windows/waitForAnyResource.md
@@ -20,7 +20,7 @@ state on any target nodes defined in the **NodeName** property.
 
 ## Syntax
 
-```MOF
+```Syntax
 WaitForAny [string] #ResourceName
 {
     ResourceName = [string]

--- a/dsc/reference/resources/windows/waitForSomeResource.md
+++ b/dsc/reference/resources/windows/waitForSomeResource.md
@@ -21,7 +21,7 @@ property.
 
 ## Syntax
 
-```MOF
+```Syntax
 WaitForSome [String] #ResourceName
 {
     NodeCount = [UInt32]

--- a/dsc/reference/resources/windows/waitForSomeResource.md
+++ b/dsc/reference/resources/windows/waitForSomeResource.md
@@ -1,52 +1,61 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC WaitForSome Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC WaitForSome Resource
 ---
-
 # DSC WaitForSome Resource
 
-> Applies To: Windows PowerShell 5.0 and later
+> Applies To: Windows PowerShell 5.x
 
 The **WaitForSome** Desired State Configuration (DSC) resource can be used within a node block in a [DSC configuration](../../../configurations/configurations.md)
 to specify dependencies on configurations on other nodes.
 
-This resource succeeds if the resource specified by the **ResourceName** property is in the desired state on a minimum number of nodes
-(specified by **NodeCount**) defined by the **NodeName** property.
+This resource succeeds if the resource specified by the **ResourceName** property is in the desired
+state on a minimum number of nodes (specified by **NodeCount**) defined by the **NodeName**
+property.
 
 > [!NOTE]
-> **WaitForSome** resource uses Windows Remote Management to check the state of other Nodes.
-> For more information about port and security requirements for WinRM, see
+> **WaitForSome** resource uses Windows Remote Management to check the state of other Nodes. For
+> more information about port and security requirements for WinRM, see
 > [PowerShell Remoting Security Considerations](/powershell/scripting/learn/remoting/winrmsecurity?view=powershell-6).
 
 ## Syntax
 
-```
+```MOF
 WaitForSome [String] #ResourceName
 {
     NodeCount = [UInt32]
     NodeName = [string[]]
     ResourceName = [string]
-    [DependsOn = [string[]]]
-    [PsDscRunAsCredential = [PSCredential]]
-    [RetryCount = [UInt32]]
-    [RetryIntervalSec = [UInt64]]
-    [ThrottleLimit = [UInt32]]
+    [ RetryCount = [UInt32] ]
+    [ RetryIntervalSec = [UInt64] ]
+    [ ThrottleLimit = [UInt32] ]
+    [ DependsOn = [string[]] ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| NodeCount| The minimum number of nodes that must be in the desired state for this resource to succeed.|
-| NodeName| The target nodes of the resource to depend on.|
-| ResourceName| The resource name to depend on. If this resource belongs to a different configuration, format the name as "[__ResourceType__]__ResourceName__::[__ConfigurationName__]::[__ConfigurationName__]"|
-| RetryIntervalSec| The number of seconds before retrying. Minimum is 1.|
-| RetryCount| The maximum number of times to retry.|
-| ThrottleLimit| Number of machines to connect simultaneously. Default is new-cimsession default.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is __ResourceName__ and its type is __ResourceType__, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
-| PsDscRunAsCredential | See [Using DSC with User Credentials](https://docs.microsoft.com/powershell/dsc/runasuser) |
+|NodeCount |The minimum number of nodes that must be in the desired state for this resource to succeed. |
+|NodeName |The target nodes of the resource to depend on. |
+|ResourceName |The resource name to depend on. If this resource belongs to a different configuration, format the name as `[ResourceType]ResourceName::[ConfigurationName]::[ConfigurationName]`. |
+|RetryIntervalSec |The number of seconds before retrying. Minimum is 1. |
+|RetryCount |The maximum number of times to retry. |
+|ThrottleLimit |Number of machines to connect simultaneously. Default is `New-CimSession` default. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 

--- a/dsc/reference/resources/windows/windowsFeatureSetResource.md
+++ b/dsc/reference/resources/windows/windowsFeatureSetResource.md
@@ -1,31 +1,32 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC WindowsFeatureSet Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC WindowsFeatureSet Resource
 ---
-
 # DSC WindowsFeatureSet Resource
 
-> Applies To: Windows PowerShell 5.0
+> Applies To: Windows PowerShell 5.x
 
-The **WindowsFeatureSet** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to ensure that roles and features are added or removed on a target node.
-This resource is a [composite resource](../../../resources/authoringResourceComposite.md) that calls the [WindowsFeature resource](windowsfeatureResource.md) for each feature specified in the `Name` property.
+The **WindowsFeatureSet** resource in Windows PowerShell Desired State Configuration (DSC) provides
+a mechanism to ensure that roles and features are added or removed on a target node. This resource
+is a [composite resource](../../../resources/authoringResourceComposite.md) that calls the [WindowsFeature resource](windowsfeatureResource.md)
+for each feature specified in the **Name** property.
 
 Use this resource when you want to configure a number of Windows Features to the same state.
 
 ## Syntax
 
-```
+```MOF
 WindowsFeatureSet [string] #ResourceName
 {
     Name = [string[]]
-    [ Ensure = [string] { Absent | Present }  ]
     [ Source = [string] ]
-    [ IncludeAllSubFeature = [bool] ]
+    [ IncludeAllSubFeature = [Boolean] ]
     [ Credential = [PSCredential] ]
     [ LogPath = [string] ]
     [ DependsOn = [string[]] ]
-
+    [ Ensure = [string] { Absent | Present }  ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
@@ -33,17 +34,28 @@ WindowsFeatureSet [string] #ResourceName
 
 |  Property  |  Description   |
 |---|---|
-| Name| The names of the roles or features that you want to ensure are added or removed. This is the same as the **Name** property of the [Get-WindowsFeature](/powershell/module/servermanager/get-windowsfeature?view=winserver2012r2-ps) cmdlet, and not the display name of the roles or features.|
-| Credential| The credentials to use to add or remove the roles or features.|
-| Ensure| Indicates whether the roles or features are added. To ensure that the roles or features are added, set this property to "Present" To ensure that the roles or features are removed, set the property to "Absent".|
-| IncludeAllSubFeature| Set this property to **$true** to include all required subfeatures with of the features you specify with the **Name** property.|
-| LogPath| The path to a log file where you want the resource provider to log the operation.|
-| DependsOn| Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is __ResourceName__ and its type is __ResourceType__, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
-| Source| Indicates the location of the source file to use for installation, if necessary.|
+|Name |The names of the roles or features that you want to ensure are added or removed. This is the same as the **Name** property of the [Get-WindowsFeature](/powershell/module/servermanager/get-windowsfeature?view=winserver2012r2-ps) cmdlet, and not the display name of the roles or features. |
+|Source |Indicates the location of the source file to use for installation, if necessary. |
+|IncludeAllSubFeature |Set this property to _$true_ to include all required subfeatures with of the features you specify with the **Name** property. |
+|Credential |The credentials to use to add or remove the roles or features. |
+|LogPath |The path to a log file where you want the resource provider to log the operation. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Indicates whether the roles or features are added. To ensure that the roles or features are added, set this property to _Present_. To ensure that the roles or features are removed, set the property to _Absent_. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
 
-The following configuration ensures that the **Web-Server** (IIS) and **SMTP Server** features, and all subfeatures of each, are installed.
+The following configuration ensures that the **Web-Server** (IIS) and **SMTP Server** features, and
+all subfeatures of each, are installed.
 
 ```powershell
 configuration FeatureSetTest

--- a/dsc/reference/resources/windows/windowsFeatureSetResource.md
+++ b/dsc/reference/resources/windows/windowsFeatureSetResource.md
@@ -16,7 +16,7 @@ Use this resource when you want to configure a number of Windows Features to the
 
 ## Syntax
 
-```MOF
+```Syntax
 WindowsFeatureSet [string] #ResourceName
 {
     Name = [string[]]
@@ -36,7 +36,7 @@ WindowsFeatureSet [string] #ResourceName
 |---|---|
 |Name |The names of the roles or features that you want to ensure are added or removed. This is the same as the **Name** property of the [Get-WindowsFeature](/powershell/module/servermanager/get-windowsfeature?view=winserver2012r2-ps) cmdlet, and not the display name of the roles or features. |
 |Source |Indicates the location of the source file to use for installation, if necessary. |
-|IncludeAllSubFeature |Set this property to _$true_ to include all required subfeatures with of the features you specify with the **Name** property. |
+|IncludeAllSubFeature |Set this property to `$true` to include all required subfeatures with of the features you specify with the **Name** property. |
 |Credential |The credentials to use to add or remove the roles or features. |
 |LogPath |The path to a log file where you want the resource provider to log the operation. |
 
@@ -45,7 +45,7 @@ WindowsFeatureSet [string] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Indicates whether the roles or features are added. To ensure that the roles or features are added, set this property to _Present_. To ensure that the roles or features are removed, set the property to _Absent_. The default value is _Present_. |
+|Ensure |Indicates whether the roles or features are added. To ensure that the roles or features are added, set this property to **Present**. To ensure that the roles or features are removed, set the property to **Absent**. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/windows/windowsOptionalFeatureResource.md
+++ b/dsc/reference/resources/windows/windowsOptionalFeatureResource.md
@@ -1,41 +1,51 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC WindowsOptionalFeature Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC WindowsOptionalFeature Resource
 ---
-
 # DSC WindowsOptionalFeature Resource
 
-> Applies To: Windows PowerShell 5.0
+> Applies To: Windows PowerShell 5.x
 
-The **WindowsOptionalFeature** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to ensure that optional features are enabled on a target node.
+The **WindowsOptionalFeature** resource in Windows PowerShell Desired State Configuration (DSC)
+provides a mechanism to ensure that optional features are enabled on a target node.
 
 ## Syntax
 
-```
+```MOF
 WindowsOptionalFeature [string] #ResourceName
 {
     Name = [string]
-    [ Ensure = [string] { Enable | Disable }  ]
-    [ Source = [string] ]
+    [ Source = [string[]] ]
     [ NoWindowsUpdateCheck = [bool] ]
     [ RemoveFilesOnDisable = [bool] ]
     [ LogLevel = [string] { ErrorsOnly | ErrorsAndWarning | ErrorsAndWarningAndInformation }  ]
     [ LogPath = [string] ]
     [ DependsOn = [string[]] ]
-
+    [ Ensure = [string] { Enable | Disable }  ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| Name| Indicates the name of the feature that you want to ensure is enabled or disabled.|
-| Ensure| Specifies whether the feature is enabled. To ensure that the feature is enabled, set this property to "Enable" To ensure that the feature is disabled, set the property to "Disable".|
-| Source| Not implemented.|
-| NoWindowsUpdateCheck| Specifies whether DISM contacts Windows Update (WU) when searching for the source files to enable a feature. If $true, DISM does not contact WU.|
-| RemoveFilesOnDisable| Set to **$true** to remove all files associated with the feature when it is disabled (that is, when **Ensure** is set to "Absent").|
-| LogLevel| The maximum output level shown in the logs. The accepted values are: "ErrorsOnly" (only errors are logged), "ErrorsAndWarning" (errors and warnings are logged), and "ErrorsAndWarningAndInformation" (errors, warnings, and debug information are logged).|
-| LogPath| The path to a log file where you want the resource provider to log the operation.|
-| DependsOn| Specifies that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is __ResourceName__ and its type is __ResourceType__, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|Name |Indicates the name of the feature that you want to ensure is enabled or disabled. |
+|Source |Not implemented. |
+|NoWindowsUpdateCheck |Specifies whether DISM contacts Windows Update (WU) when searching for the source files to enable a feature. If _$true_, DISM does not contact WU. |
+|RemoveFilesOnDisable |Set to _$true_ to remove all files associated with the feature when **Ensure** is set to _Absent_. |
+|LogLevel |The maximum output level shown in the logs. The accepted values are: _ErrorsOnly_, _ErrorsAndWarning_, and _ErrorsAndWarningAndInformation_. |
+|LogPath |The path to a log file where you want the resource provider to log the operation. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Specifies whether the feature is enabled. To ensure that the feature is enabled, set this property to _Enable_. To ensure that the feature is disabled, set the property to _Disable_. The default value is _Enable_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).

--- a/dsc/reference/resources/windows/windowsOptionalFeatureResource.md
+++ b/dsc/reference/resources/windows/windowsOptionalFeatureResource.md
@@ -12,7 +12,7 @@ provides a mechanism to ensure that optional features are enabled on a target no
 
 ## Syntax
 
-```MOF
+```Syntax
 WindowsOptionalFeature [string] #ResourceName
 {
     Name = [string]
@@ -33,9 +33,9 @@ WindowsOptionalFeature [string] #ResourceName
 |---|---|
 |Name |Indicates the name of the feature that you want to ensure is enabled or disabled. |
 |Source |Not implemented. |
-|NoWindowsUpdateCheck |Specifies whether DISM contacts Windows Update (WU) when searching for the source files to enable a feature. If _$true_, DISM does not contact WU. |
-|RemoveFilesOnDisable |Set to _$true_ to remove all files associated with the feature when **Ensure** is set to _Absent_. |
-|LogLevel |The maximum output level shown in the logs. The accepted values are: _ErrorsOnly_, _ErrorsAndWarning_, and _ErrorsAndWarningAndInformation_. |
+|NoWindowsUpdateCheck |Specifies whether DISM contacts Windows Update (WU) when searching for the source files to enable a feature. If `$true`, DISM does not contact WU. |
+|RemoveFilesOnDisable |Set to `$true` to remove all files associated with the feature when **Ensure** is set to **Absent**. |
+|LogLevel |The maximum output level shown in the logs. The accepted values are: **ErrorsOnly**, **ErrorsAndWarning**, and **ErrorsAndWarningAndInformation**. |
 |LogPath |The path to a log file where you want the resource provider to log the operation. |
 
 ## Common properties

--- a/dsc/reference/resources/windows/windowsOptionalFeatureSetResource.md
+++ b/dsc/reference/resources/windows/windowsOptionalFeatureSetResource.md
@@ -16,7 +16,7 @@ Use this resource when you want to configure a number of Windows optional featur
 
 ## Syntax
 
-```MOF
+```Syntax
 WindowsOptionalFeatureSet [string] #ResourceName
 {
     Name = [string[]]
@@ -37,9 +37,9 @@ WindowsOptionalFeatureSet [string] #ResourceName
 |---|---|
 |Name |Indicates the name of the features that you want to ensure are enabled or disabled. |
 |Source |Not implemented. |
-|NoWindowsUpdateCheck |Specifies whether DISM contacts Windows Update (WU) when searching for the source files to enable features. If _$true_, DISM does not contact WU. |
-|RemoveFilesOnDisable |Set to _$true_ to remove all files associated with the features when **Ensure** is set to _Absent_. |
-|LogLevel |The maximum output level shown in the logs. The accepted values are: _ErrorsOnly_, _ErrorsAndWarning_, and _ErrorsAndWarningAndInformation_. |
+|NoWindowsUpdateCheck |Specifies whether DISM contacts Windows Update (WU) when searching for the source files to enable features. If `$true`, DISM does not contact WU. |
+|RemoveFilesOnDisable |Set to `$true` to remove all files associated with the features when **Ensure** is set to **Absent**. |
+|LogLevel |The maximum output level shown in the logs. The accepted values are: **ErrorsOnly**, **ErrorsAndWarning**, and **ErrorsAndWarningAndInformation**. |
 |LogPath |The path to a log file where you want the resource provider to log the operation. |
 
 ## Common properties
@@ -47,7 +47,7 @@ WindowsOptionalFeatureSet [string] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Specifies whether the features are enabled. To ensure that the features are enabled, set this property to _Enable_. To ensure that the features are disabled, set the property to _Disable_. The default value is _Enable_. |
+|Ensure |Specifies whether the features are enabled. To ensure that the features are enabled, set this property to **Enable**. To ensure that the features are disabled, set the property to **Disable**. The default value is **Enable**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/windows/windowsOptionalFeatureSetResource.md
+++ b/dsc/reference/resources/windows/windowsOptionalFeatureSetResource.md
@@ -1,45 +1,55 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC WindowsOptionalFeatureSet Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC WindowsOptionalFeatureSet Resource
 ---
-
 # DSC WindowsOptionalFeatureSet Resource
 
-> Applies To: Windows PowerShell 5.0
+> Applies To: Windows PowerShell 5.x
 
-The **WindowsOptionalFeatureSet** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to ensure that optional features are enabled on a target node.
-This resource is a [composite resource](../../../resources/authoringResourceComposite.md) that calls the [WindowsOptionalFeature resource](windowsOptionalFeatureResource.md) for each feature specified in
-the `Name` property.
+The **WindowsOptionalFeatureSet** resource in Windows PowerShell Desired State Configuration (DSC)
+provides a mechanism to ensure that optional features are enabled on a target node. This resource is
+a [composite resource](../../../resources/authoringResourceComposite.md) that calls the [WindowsOptionalFeature resource](windowsOptionalFeatureResource.md)
+for each feature specified in the **Name** property.
 
 Use this resource when you want to configure a number of Windows optional features to the same state.
 
 ## Syntax
 
-```
-WindowsOptionalFeature [string] #ResourceName
+```MOF
+WindowsOptionalFeatureSet [string] #ResourceName
 {
     Name = [string[]]
-    [ Ensure = [string] { Enable | Disable }  ]
     [ Source = [string] ]
     [ RemoveFilesOnDisable = [bool] ]
     [ LogPath = [string] ]
     [ NoWindowsUpdateCheck = [bool] ]
     [ LogLevel = [string] { ErrorsOnly | ErrorsAndWarning | ErrorsAndWarningAndInformation }  ]
     [ DependsOn = [string[]] ]
-
+    [ Ensure = [string] { Enable | Disable }  ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| Name| Indicates the name of the features that you want to ensure are enabled or disabled.|
-| Ensure| Specifies whether the features are enabled. To ensure that the features are enabled, set this property to "Enable" To ensure that the features are disabled, set the property to "Disable".|
-| Source| Not implemented.|
-| NoWindowsUpdateCheck| Specifies whether DISM contacts Windows Update (WU) when searching for the source files to enable features. If $true, DISM does not contact WU.|
-| RemoveFilesOnDisable| Set to **$true** to remove all files associated with the features when they are disabled (that is, when **Ensure** is set to "Absent").|
-| LogLevel| The maximum output level shown in the logs. The accepted values are: "ErrorsOnly" (only errors are logged), "ErrorsAndWarning" (errors and warnings are logged), and "ErrorsAndWarningAndInformation" (errors, warnings, and debug information are logged).|
-| LogPath| The path to a log file where you want the resource provider to log the operation.|
-| DependsOn| Specifies that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is __ResourceName__ and its type is __ResourceType__, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
+|Name |Indicates the name of the features that you want to ensure are enabled or disabled. |
+|Source |Not implemented. |
+|NoWindowsUpdateCheck |Specifies whether DISM contacts Windows Update (WU) when searching for the source files to enable features. If _$true_, DISM does not contact WU. |
+|RemoveFilesOnDisable |Set to _$true_ to remove all files associated with the features when **Ensure** is set to _Absent_. |
+|LogLevel |The maximum output level shown in the logs. The accepted values are: _ErrorsOnly_, _ErrorsAndWarning_, and _ErrorsAndWarningAndInformation_. |
+|LogPath |The path to a log file where you want the resource provider to log the operation. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Specifies whether the features are enabled. To ensure that the features are enabled, set this property to _Enable_. To ensure that the features are disabled, set the property to _Disable_. The default value is _Enable_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).

--- a/dsc/reference/resources/windows/windowsPackageCabResource.md
+++ b/dsc/reference/resources/windows/windowsPackageCabResource.md
@@ -1,45 +1,51 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC WindowsPackageCab Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC WindowsPackageCab Resource
 ---
-
 # DSC WindowsPackageCab Resource
 
-> Applies To: Windows PowerShell 5.1 and later
+> Applies To: Windows PowerShell 5.1
 
-The **WindowsPackageCab** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to install or uninstall
-Windows cabinet (.cab) packages on a target node.
+The **WindowsPackageCab** resource in Windows PowerShell Desired State Configuration (DSC) provides
+a mechanism to install or uninstall Windows cabinet (.cab) packages on a target node.
 
 The target node must have the DISM PowerShell module installed. For information, see
-[Use DISM in Windows PowerShell](https://msdn.microsoft.com/en-us/windows/hardware/commercialize/manufacture/desktop/use-dism-in-windows-powershell-s14).
-
+[Use DISM in Windows PowerShell](/windows-hardware/manufacture/desktop/use-dism-in-windows-powershell-s14).
 
 ## Syntax
 
-```
+```MOF
 {
     Name = [string]
-    Ensure = [string] { Absent | Present }
     SourcePath = [string]
     [ LogPath = [string] ]
     [ DependsOn = [string[]] ]
+    Ensure = [string] { Absent | Present }
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| Name| Indicates the name of the package for you want to ensure a specific state.|
-| Ensure| Indicates if the package is installed. Set this property to "Absent" to ensure the package is not installed (or uninstall the package if it is installed). Set it to "Present" (the default value) to ensure the package is installed.|
-| Path| Indicates the path where the package resides.|
-| LogPath| Indicates the full path where you want the provider to save a log file to install or uninstall the package.|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"``.|
+|Name |Indicates the name of the package for you want to ensure a specific state. |
+|SourcePath |Indicates the path where the package resides. |
+|LogPath |Indicates the full path where you want the provider to save a log file to install or uninstall the package. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Indicates if the package is installed. Set this property to _Absent_ to ensure the package is not installed (or uninstall the package if it is installed). Set it to _Present_ to ensure the package is installed. **Ensure** is a required property on the **WindowsPackageCab** resource. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 ## Example
 
-The following example configuration takes input parameters, and ensures that the .cab file specified by the `$Name` parameter is installed.
+The following example configuration takes input parameters, and ensures that the .cab file specified
+by the `$Name` parameter is installed.
 
 ```powershell
 Configuration Sample_WindowsPackageCab

--- a/dsc/reference/resources/windows/windowsPackageCabResource.md
+++ b/dsc/reference/resources/windows/windowsPackageCabResource.md
@@ -15,7 +15,7 @@ The target node must have the DISM PowerShell module installed. For information,
 
 ## Syntax
 
-```MOF
+```Syntax
 {
     Name = [string]
     SourcePath = [string]
@@ -39,7 +39,7 @@ The target node must have the DISM PowerShell module installed. For information,
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Indicates if the package is installed. Set this property to _Absent_ to ensure the package is not installed (or uninstall the package if it is installed). Set it to _Present_ to ensure the package is installed. **Ensure** is a required property on the **WindowsPackageCab** resource. |
+|Ensure |Indicates if the package is installed. Set this property to **Absent** to ensure the package is not installed (or uninstall the package if it is installed). Set it to **Present** to ensure the package is installed. **Ensure** is a required property on the **WindowsPackageCab** resource. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 ## Example

--- a/dsc/reference/resources/windows/windowsProcessResource.md
+++ b/dsc/reference/resources/windows/windowsProcessResource.md
@@ -1,42 +1,49 @@
 ---
-ms.date:  06/12/2017
+ms.date: 09/20/2019
 keywords:  dsc,powershell,configuration,setup
 title:  DSC WindowsProcess Resource
 ---
 # DSC WindowsProcess Resource
 
-_Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0_
+> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
 The **WindowsProcess** resource in Windows PowerShell Desired State Configuration (DSC) provides a
 mechanism to configure processes on a target node.
 
 ## Syntax
 
-```
+```MOF
 WindowsProcess [string] #ResourceName
 {
     Arguments = [string]
     Path = [string]
     [ Credential = [PSCredential] ]
-    [ Ensure = [string] { Absent | Present }  ]
-    [ DependsOn = [string[]] ]
     [ StandardErrorPath = [string] ]
     [ StandardInputPath = [string] ]
     [ StandardOutputPath = [string] ]
     [ WorkingDirectory = [string] ]
+    [ DependsOn = [string[]] ]
+    [ Ensure = [string] { Absent | Present }  ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-| Property | Description |
-| --- | --- |
-| Arguments| Indicates a string of arguments to pass to the process as-is. If you need to pass several arguments, put them all in this string.|
-| Path| The path to the process executable. If this the file name of the executable (not the fully qualified path), the DSC resource will search the environment **Path** variable (`$env:Path`) to find the executable file. If the value of this property is a fully qualified path, DSC will not use the **Path** environment variable to find the file, and will throw an error if the path does not exist. Relative paths are not allowed.|
-| Credential| Indicates the credentials for starting the process.|
-| Ensure| Indicates if the process exists. Set this property to "Present" to ensure that the process exists. Otherwise, set it to "Absent". The default is "Present".|
-| DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is **ResourceName** and its type is **ResourceType**, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"` .|
-| StandardErrorPath| Indicates the directory path to write the standard error. Any existing file there will be overwritten.|
-| StandardInputPath| Indicates the standard input location.|
-| StandardOutputPath| Indicates the location to write the standard output. Any existing file there will be overwritten.|
-| WorkingDirectory| Indicates the location that will be used as the current working directory for the process.|
+|Property |Description |
+|---|---|
+|Arguments |Indicates a string of arguments to pass to the process as-is. If you need to pass several arguments, put them all in this string. |
+|Path |The path to the process executable. If this the file name of the executable (not the fully qualified path), the DSC resource will search the environment `$env:Path` variable to find the executable file. If the value of this property is a fully qualified path, DSC will not use the `$env:Path` variable to find the file, and will throw an error if the path does not exist. Relative paths are not allowed. |
+|Credential |Indicates the credentials for starting the process. |
+|StandardErrorPath |Indicates the directory path to write the standard error. Any existing file there will be overwritten. |
+|StandardInputPath |Indicates the standard input location. |
+|StandardOutputPath |Indicates the location to write the standard output. Any existing file there will be overwritten. |
+|WorkingDirectory |Indicates the location that will be used as the current working directory for the process. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Indicates if the process exists. Set this property to _Present_ to ensure that the process exists. Otherwise, set it to _Absent_. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |

--- a/dsc/reference/resources/windows/windowsProcessResource.md
+++ b/dsc/reference/resources/windows/windowsProcessResource.md
@@ -12,7 +12,7 @@ mechanism to configure processes on a target node.
 
 ## Syntax
 
-```MOF
+```Syntax
 WindowsProcess [string] #ResourceName
 {
     Arguments = [string]
@@ -45,5 +45,5 @@ WindowsProcess [string] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Indicates if the process exists. Set this property to _Present_ to ensure that the process exists. Otherwise, set it to _Absent_. The default value is _Present_. |
+|Ensure |Indicates if the process exists. Set this property to **Present** to ensure that the process exists. Otherwise, set it to **Absent**. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |

--- a/dsc/reference/resources/windows/windowsfeatureResource.md
+++ b/dsc/reference/resources/windows/windowsfeatureResource.md
@@ -12,7 +12,7 @@ mechanism to ensure that roles and features are added or removed on a target nod
 
 ## Syntax
 
-```MOF
+```Syntax
 WindowsFeature [string] #ResourceName
 {
     Name = [string]
@@ -32,7 +32,7 @@ WindowsFeature [string] #ResourceName
 |---|---|
 |Name |Indicates the name of the role or feature that you want to ensure is added or removed. This is the same as the **Name** property from the [Get-WindowsFeature](/powershell/module/servermanager/Get-WindowsFeature) cmdlet, and not the display name of the role or feature. |
 |Credential |Indicates the credentials to use to add or remove the role or feature. |
-|IncludeAllSubFeature |Set this property to _$true_ to ensure the state of all required subfeatures with the state of the feature you specify with the **Name** property. |
+|IncludeAllSubFeature |Set this property to `$true` to ensure the state of all required subfeatures with the state of the feature you specify with the **Name** property. |
 |LogPath |Indicates the path to a log file where you want the resource provider to log the operation. |
 |Source |Indicates the location of the source file to use for installation, if necessary. |
 
@@ -41,7 +41,7 @@ WindowsFeature [string] #ResourceName
 |Property |Description |
 |---|---|
 |DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
-|Ensure |Indicates if the role or feature is added. To ensure that the role or feature is added, set this property to _Present_. To ensure that the role or feature is removed, set the property to _Absent_. The default value is _Present_. |
+|Ensure |Indicates if the role or feature is added. To ensure that the role or feature is added, set this property to **Present**. To ensure that the role or feature is removed, set the property to **Absent**. The default value is **Present**. |
 |PsDscRunAsCredential |Sets the credential for running the entire resource as. |
 
 > [!NOTE]

--- a/dsc/reference/resources/windows/windowsfeatureResource.md
+++ b/dsc/reference/resources/windows/windowsfeatureResource.md
@@ -1,43 +1,55 @@
 ---
-ms.date:  06/12/2017
-keywords:  dsc,powershell,configuration,setup
-title:  DSC WindowsFeature Resource
+ms.date: 09/20/2019
+keywords: dsc,powershell,configuration,setup
+title: DSC WindowsFeature Resource
 ---
-
 # DSC WindowsFeature Resource
 
-> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.0
+> Applies To: Windows PowerShell 4.0, Windows PowerShell 5.x
 
-The **WindowsFeature** resource in Windows PowerShell Desired State Configuration (DSC) provides a mechanism to ensure that roles and features are added or removed on a target node.
+The **WindowsFeature** resource in Windows PowerShell Desired State Configuration (DSC) provides a
+mechanism to ensure that roles and features are added or removed on a target node.
 
 ## Syntax
 
-```
+```MOF
 WindowsFeature [string] #ResourceName
 {
     Name = [string]
     [ Credential = [PSCredential] ]
-    [ Ensure = [string] { Absent | Present }  ]
     [ IncludeAllSubFeature = [bool] ]
     [ LogPath = [string] ]
-    [ DependsOn = [string[]] ]
     [ Source = [string] ]
+    [ DependsOn = [string[]] ]
+    [ Ensure = [string] { Absent | Present }  ]
+    [ PsDscRunAsCredential = [PSCredential] ]
 }
 ```
 
 ## Properties
 
-|  Property  |  Description   |
+|Property |Description |
 |---|---|
-| Name| Indicates the name of the role or feature that you want to ensure is added or removed. This is the same as the __Name__ property from the [Get-WindowsFeature](/powershell/module/servermanager/Get-WindowsFeature) cmdlet, and not the display name of the role or feature.|
-| Credential| Indicates the credentials to use to add or remove the role or feature.|
-| Ensure| Indicates if the role or feature is added. To ensure that the role or feature is added, set this property to "Present" To ensure that the role or feature is removed, set the property to "Absent".|
-| IncludeAllSubFeature| Set this property to __$true__ to ensure the state of all required subfeatures with the state of the feature you specify with the __Name__ property.|
-| LogPath| Indicates the path to a log file where you want the resource provider to log the operation.|
-| DependsOn| Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is __ResourceName__ and its type is __ResourceType__, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`.|
-| Source| Indicates the location of the source file to use for installation, if necessary.|
+|Name |Indicates the name of the role or feature that you want to ensure is added or removed. This is the same as the **Name** property from the [Get-WindowsFeature](/powershell/module/servermanager/Get-WindowsFeature) cmdlet, and not the display name of the role or feature. |
+|Credential |Indicates the credentials to use to add or remove the role or feature. |
+|IncludeAllSubFeature |Set this property to _$true_ to ensure the state of all required subfeatures with the state of the feature you specify with the **Name** property. |
+|LogPath |Indicates the path to a log file where you want the resource provider to log the operation. |
+|Source |Indicates the location of the source file to use for installation, if necessary. |
+
+## Common properties
+
+|Property |Description |
+|---|---|
+|DependsOn |Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is ResourceName and its type is ResourceType, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"`. |
+|Ensure |Indicates if the role or feature is added. To ensure that the role or feature is added, set this property to _Present_. To ensure that the role or feature is removed, set the property to _Absent_. The default value is _Present_. |
+|PsDscRunAsCredential |Sets the credential for running the entire resource as. |
+
+> [!NOTE]
+> The **PsDscRunAsCredential** common property was added in WMF 5.0 to allow running any DSC
+> resource in the context of other credentials. For more information, see [Use Credentials with DSC Resources](../../../configurations/runasuser.md).
 
 ## Example
+
 ```powershell
 WindowsFeature RoleExample
 {


### PR DESCRIPTION
Fixes #4671
Fixes #3768
Fixes [AB#1602294](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1602294)

Reviewed all DSC Resources.  Cleaned up tables, markdown, fixed syntax issues, broke out 'Common properties', and provided a link to details on PsDscRunAsCredential.