### PR TITLE
Fixes #4765 - new multiline continuation support

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -65,7 +65,7 @@ Get-ChildItem -Path *.txt |
 ```
 
 This pipeline consists of four commands in the specified order. The following
-illustration shows the output from each command as it is passed to the next
+illustration shows the output from each command as it's passed to the next
 command in the pipeline.
 
 ```
@@ -226,10 +226,10 @@ to associate the piped objects with a parameter of the receiving cmdlet.
 PowerShell's parameter binding component associates the input objects with
 cmdlet parameters according to the following criteria:
 
-- The parameter must accept input from a pipeline
+- The parameter must accept input from a pipeline.
 - The parameter must accept the type of object being sent or a type that can be
-  converted to the expected type
-- The parameter was not used in the command
+  converted to the expected type.
+- The parameter wasn't used in the command.
 
 For example, the `Start-Service` cmdlet has many parameters, but only two of
 them, **Name** and **InputObject** accept pipeline input. The **Name**
@@ -248,7 +248,7 @@ article.
 ### One-at-a-time processing
 
 Piping objects to a command is much like using a parameter of the command to
-submit the objects. Let look at a pipeline example. In this example, we use a
+submit the objects. Let's look at a pipeline example. In this example, we use a
 pipeline to display a table of service objects.
 
 ```powershell
@@ -416,29 +416,22 @@ The results of the trace are lengthy, but they show the values being bound to
 the `Get-Item` cmdlet and then the named values being bound to the
 `Move-ItemProperty` cmdlet.
 
-```
+```Output
 ...
-
 BIND NAMED cmd line args [`Move-ItemProperty`]
 BIND arg [HKLM:\Software\MyCompany\design] to parameter [Path]
-
 ...
-
 BIND arg [product] to parameter [Name]
-
 ...
-
 BIND POSITIONAL cmd line args [`Move-ItemProperty`]
-
 ...
 ```
 
 Finally, it shows that the attempt to bind the path to the **Destination**
 parameter of `Move-ItemProperty` failed.
 
-```
+```Output
 ...
-
 BIND PIPELINE object to parameters: [`Move-ItemProperty`]
 PIPELINE object TYPE = [Microsoft.Win32.RegistryKey]
 RESTORING pipeline parameter's original values
@@ -446,13 +439,12 @@ Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO
 COERCION
 Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO
 COERCION
-
 ...
 ```
 
 Use the `Get-Help` cmdlet to view the attributes of the **Destination** parameter.
 
-```
+```Output
 Get-Help Move-ItemProperty -Parameter Destination
 
 -Destination <String>
@@ -479,7 +471,7 @@ doesn't have a **Destination** property. That explains why the command failed.
 
 The **Path** parameter accepts pipeline input by name or by value.
 
-```
+```Output
 Get-Help Move-ItemProperty -Parameter Path
 
 -Path <String[]>

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -1,5 +1,5 @@
 ﻿---
-ms.date:  02/14/2018
+ms.date:  09/27/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -7,20 +7,20 @@ title:  about_pipelines
 ---
 # About Pipelines
 
-## Short Description
+## Short description
 
 Combining commands into pipelines in the PowerShell
 
-## Long Description
+## Long description
 
 A pipeline is a series of commands connected by pipeline operators (`|`)
 (ASCII 124). Each pipeline operator sends the results of the preceding command
 to the next command.
 
-You can use pipelines to send the objects that are output by one command to be
-used as input to another command for processing. And you can send the output
-of that command to yet another command. The result is a very powerful command
-chain or "pipeline" that is comprised of a series of simple commands.
+The output of the first command can be sent for processing as input to the
+second command. And that output can be sent to yet another command. The result
+is a complex command chain or _pipeline_ that is composed of a series of
+simple commands.
 
 For example,
 
@@ -33,9 +33,9 @@ In this example, the objects that `Command-1` emits are sent to `Command-2`.
 processes the objects and send them down the pipeline. Because there are no
 more commands in the pipeline, the results are displayed at the console.
 
-In a pipeline, the commands are processed from left to right in the order that
-they appear. The processing is handled as a single operation and output is
-displayed as it is generated.
+In a pipeline, the commands are processed in order from left to right. The
+processing is handled as a single operation and output is displayed as it's
+generated.
 
 Here is a simple example. The following command gets the Notepad process and
 then stops it.
@@ -49,67 +49,45 @@ Get-Process notepad | Stop-Process
 The first command uses the `Get-Process` cmdlet to get an object representing
 the Notepad process. It uses a pipeline operator (`|`) to send the process
 object to the `Stop-Process` cmdlet, which stops the Notepad process. Notice
-that the `Stop-Process` command does not have a **Name** or **ID** parameter to
+that the `Stop-Process` command doesn't have a **Name** or **ID** parameter to
 specify the process, because the specified process is submitted through the
 pipeline.
 
-Here is a practical example. This command pipeline gets the text files in the
-current directory, selects only the files that are more than 10,000 bytes
-long, sorts them by length, and displays the name and length of each file in a
-table.
+This pipeline example gets the text files in the current directory, selects
+only the files that are more than 10,000 bytes long, sorts them by length, and
+displays the name and length of each file in a table.
 
 ```powershell
-Get-ChildItem -Path *.txt | Where-Object {$_.length -gt 10000} |
-Sort-Object -Property length | Format-Table -Property name, length
+Get-ChildItem -Path *.txt |
+  Where-Object {$_.length -gt 10000} |
+    Sort-Object -Property length |
+      Format-Table -Property name, length
 ```
 
-This pipeline is comprised of four commands in the specified order. The
-command is written horizontally, but we will show the process vertically in
-the following graphic.
-
-`Get-ChildItem` `-Path` *.txt
+This pipeline consists of four commands in the specified order. The following
+illustration shows the output from each command as it is passed to the next
+command in the pipeline.
 
 ```
-|
-|   (FileInfo objects for *.txt)
-|
+Get-ChildItem -Path *.txt
+| (FileInfo objects for *.txt)
 V
-```
-
-`Where-Object` {$_.length `-gt` 10000}
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|
+Where-Object {$_.length -gt 10000}
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
 V
-```
-
-`Sort-Object` `-Property` Length
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|   (    Sorted by length      )
-|
+Sort-Object -Property Length
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
+| (     Sorted by length     )
 V
-```
-
-`Format-Table` `-Property` name, length
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|   (    Sorted by length      )
-|   (  Formatted in a table    )
-|
+Format-Table -Property name, length
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
+| (     Sorted by length     )
+| (   Formatted in a table   )
 V
-```
 
-```output
 Name                       Length
 ----                       ------
 tmp1.txt                    82920
@@ -117,33 +95,23 @@ tmp2.txt                   114000
 tmp3.txt                   114000
 ```
 
-## Using Pipelines
+## Using pipelines
 
-The PowerShell cmdlets were designed to be used in pipelines. For example, you
-can usually pipe the results of a **Get** cmdlet to an action cmdlet (such as a
-**Set**, **Start**, **Stop**, or **Rename** cmdlet) for the same noun.
+Most PowerShell cmdlets are designed to support pipelines. In most cases, you
+can _pipe_ the results of a **Get** cmdlet to another cmdlet of the same noun.
+For example, you can pipe the output of the `Get-Service` cmdlet to the
+`Start-Service` or `Stop-Service` cmdlets.
 
-For example, you can pipe any service from the `Get-Service` cmdlet to the
-`Start-Service` or `Stop-Service` cmdlets (although disabled services cannot
-be restarted in this way).
-
-This command pipeline starts the WMI service on the computer:
-
-For example,
+This example pipeline starts the WMI service on the computer:
 
 ```powershell
 Get-Service wmi | Start-Service
 ```
 
-The cmdlets that get and set objects of the PowerShell providers, such as the
-**Item** and **ItemProperty** cmdlets, are also designed to be used in pipelines.
-
-For example, you can pipe the results of a `Get-Item` or `Get-ChildItem`
-command in the PowerShell registry provider to the `New-ItemProperty` cmdlet.
-This command adds a new registry entry, **NoOfEmployees**, with a value of 8124,
+For another example, you can pipe the output of `Get-Item` or `Get-ChildItem`
+within the PowerShell registry provider to the `New-ItemProperty` cmdlet. This
+example adds a new registry entry, **NoOfEmployees**, with a value of **8124**,
 to the **MyCompany** registry key.
-
-For example,
 
 ```powershell
 Get-Item -Path HKLM:\Software\MyCompany |
@@ -151,27 +119,20 @@ Get-Item -Path HKLM:\Software\MyCompany |
 ```
 
 Many of the utility cmdlets, such as `Get-Member`, `Where-Object`,
-`Sort-Object`, `Group-Object`, and `Measure-Object` are used almost
-exclusively in pipelines. You can pipe any objects to these cmdlets.
-
-For example, you can pipe all of the processes on the computer to the
-`Sort-Object` command and have them sorted by the number of handles in the
-process.
-
-For example,
+`Sort-Object`, `Group-Object`, and `Measure-Object` are used almost exclusively
+in pipelines. You can pipe any object type to these cmdlets. This example shows
+how to sort all the processes on the computer by the number of open handles in
+each process.
 
 ```powershell
 Get-Process | Sort-Object -Property handles
 ```
 
-Also, you can pipe any objects to the formatting cmdlets, such as
-`Format-List` and `Format-Table`, the Export cmdlets, such as `Export-Clixml`
-and `Export-CSV`, and the Out cmdlets, such as `Out-Printer`.
+You can pipe objects to the formatting, export, and output cmdlets, such as
+`Format-List`, `Format-Table`, `Export-Clixml`, `Export-CSV`, and `Out-File`.
 
-For example, you can pipe the "Winlogon" process to the `Format-List` cmdlet to
-display all of the properties of the process in a list.
-
-For example,
+This example shows how to use the `Format-List` cmdlet to display a list of
+properties for a process object.
 
 ```powershell
 Get-Process winlogon | Format-List -Property *
@@ -180,86 +141,149 @@ Get-Process winlogon | Format-List -Property *
 With a bit of practice, you'll find that combining simple commands into
 pipelines saves time and typing, and makes your scripting more efficient.
 
-## How Pipelines Work
+## How pipelines work
 
-When you "pipe" objects, that is send the objects in the output of one command
-to another command, PowerShell tries to associate the piped objects with one
-of the parameters of the receiving cmdlet.
+This section explains how input objects are bound to cmdlet parameters and
+processed during pipeline execution.
 
-To do so, the PowerShell "parameter binding" component, which associates input
-objects with cmdlet parameters, tries to find a parameter that meets the
-following criteria:
+### Accepts pipeline input
 
-- The parameter must accept input from a pipeline (not all do).
-- The parameter must accept the type of object being sent or a type that the
-  object can be converted to.
-- The parameter must not already be used in the command.
+To support pipelining, the receiving cmdlet must have a parameter that accepts
+pipeline input. Use the `Get-Help` command with the **Full** or **Parameter**
+options to determine which parameters of a cmdlet accept pipeline input.
 
-For example, the `Start-Service` cmdlet has many parameters, but only two of
-them, `-Name` and `-InputObject` accept pipeline input. The `-Name` parameter
-takes strings and the `-InputObject` parameter takes service objects.
-Therefore, you can pipe strings and service objects (and objects with
-properties that can be converted to string and service objects) to
-`Start-Service`.
-
-If the parameter binding component of PowerShell cannot associate the piped
-objects with a parameter of the receiving cmdlet, the command fails and
-PowerShell prompts you for the missing parameter values.
-
-You cannot force the parameter binding component to associate the piped
-objects with a particular parameter. You cannot even suggest a parameter.
-Instead, the logic of the component manages the piping as efficiently as
-possible.
-
-## One-At-A-Time Processing
-
-Piping objects to a command is much like using a parameter of the command to
-submit the objects.
-
-For example, piping objects representing the services on the computer to a
-`Format-Table` command, such as:
+For example, to determine which of the parameters of the `Start-Service`
+cmdlet accepts pipeline input, type:
 
 ```powershell
-Get-Service | Format-Table -Property name, dependentservices
+Get-Help Start-Service -Full
 ```
 
-is much like saving the service objects in a variable and using the
-**InputObject** parameter of `Format-Table` to submit the service object.
+or
 
-For example,
+```powershell
+Get-Help Start-Service -Parameter *
+```
+
+The help for the `Start-Service` cmdlet shows that only the **InputObject** and
+**Name** parameters accept pipeline input.
+
+```Output
+-InputObject <ServiceController[]>
+Specifies ServiceController objects representing the services to be started.
+Enter a variable that contains the objects, or type a command or expression
+that gets the objects.
+
+Required?                    true
+Position?                    0
+Default value                None
+Accept pipeline input?       True (ByValue)
+Accept wildcard characters?  false
+
+-Name <String[]>
+Specifies the service names for the service to be started.
+
+The parameter name is optional. You can use Name or its alias, ServiceName,
+or you can omit the parameter name.
+
+Required?                    true
+Position?                    0
+Default value                None
+Accept pipeline input?       True (ByPropertyName, ByValue)
+Accept wildcard characters?  false
+```
+
+When you send objects through the pipeline to `Start-Service`, PowerShell
+attempts to associate the objects with the **InputObject** and **Name**
+parameters.
+
+### Methods of accepting pipeline input
+
+Cmdlets parameters can accept pipeline input in one of two different ways:
+
+- **ByValue**: The parameter accepts values that match the expected .NET type
+  or that can be converted to that type.
+
+  For example, the **Name** parameter of `Start-Service` accepts pipeline input
+  by value. It can accept string objects or objects that can be converted to
+  strings.
+
+- **ByPropertyName**: The parameter accepts input only when the input object
+  has a property of the same name as the parameter.
+
+  For example, the Name parameter of `Start-Service` can accept objects that
+  have a **Name** property. To list the properties of an object, pipe it to
+  `Get-Member`.
+
+Some parameters can accept objects by both value or property name, making it
+easier to take input from the pipeline.
+
+### Parameter binding
+
+When you pipe objects from one command to another command, PowerShell attempts
+to associate the piped objects with a parameter of the receiving cmdlet.
+
+PowerShell's parameter binding component associates the input objects with
+cmdlet parameters according to the following criteria:
+
+- The parameter must accept input from a pipeline
+- The parameter must accept the type of object being sent or a type that can be
+  converted to the expected type
+- The parameter was not used in the command
+
+For example, the `Start-Service` cmdlet has many parameters, but only two of
+them, **Name** and **InputObject** accept pipeline input. The **Name**
+parameter takes strings and the **InputObject** parameter takes service
+objects. Therefore, you can pipe strings, service objects, and objects with
+properties that can be converted to string or service objects.
+
+PowerShell manages parameter binding as efficiently as possible. You can't
+suggest or force the PowerShell to bind to a specific parameter. The command
+fails if PowerShell can't bind the piped objects.
+
+For more information about troubleshooting binding errors, see
+[Investigating Pipeline Errors](#investigating-pipeline-errors) later in this
+article.
+
+### One-at-a-time processing
+
+Piping objects to a command is much like using a parameter of the command to
+submit the objects. Let look at a pipeline example. In this example, we use a
+pipeline to display a table of service objects.
+
+```powershell
+Get-Service | Format-Table -Property Name, DependentServices
+```
+
+Functionally, this is like using the **InputObject** parameter of `Format-Table`
+to submit the object collection.
+
+For example, we can save the collection of services to a variable that is
+passed using the **InputObject** parameter.
 
 ```powershell
 $services = Get-Service
-Format-Table -InputObject $services -Property name, dependentservices
+Format-Table -InputObject $services -Property Name, DependentServices
 ```
 
-or imbedding the command in the parameter value
-
-For example,
+Or we can embed the command in the **InputObject** parameter.
 
 ```powershell
-Format-Table -InputObject (Get-Service wmi) -Property name,dependentservices
+Format-Table -InputObject (Get-Service) -Property Name, DependentServices
 ```
 
-However, there is an important difference. When you pipe multiple objects to a
+However, there's an important difference. When you pipe multiple objects to a
 command, PowerShell sends the objects to the command one at a time. When you
-use a command parameter, the objects are sent as a single array object.
+use a command parameter, the objects are sent as a single array object. This
+minor difference has significant consequences.
 
-This seemingly technical difference can have interesting, and sometimes
-useful, consequences.
+When executing a pipeline, PowerShell automatically enumerates any type that
+implements the `IEnumerable` interface and sends the members through the
+pipeline one at a time. The exception is `[hashtable]`, which requires a call
+to the `GetEnumerator()` method.
 
-For example, if you pipe multiple process objects from the `Get-Process`
-cmdlet to the `Get-Member` cmdlet, PowerShell sends each process object, one
-at a time, to `Get-Member`. `Get-Member` displays the .NET class (type) of the
-process objects, and their properties and methods.
-
-PowerShell automatically enumerates any type that implements the `IEnumerable`
-interface and sends the members through the pipeline one at a time. The
-exception is `[hashtable]`, which requires a call to the `GetEnumerator()`
-method.
-
-In the example below, an array and a hashtable are piped to the `Measure-Object`
-cmdlet, which counts the number of objects received from the pipeline. The array
+In the following examples, an array and a hashtable are piped to the `Measure-Object`
+cmdlet to count the number of objects received from the pipeline. The array
 has multiple members, and the hashtable has multiple key-value pairs. Only the
 array is enumerated one at a time.
 
@@ -289,14 +313,10 @@ Minimum  :
 Property :
 ```
 
-> [!NOTE]
-> `Get-Member` eliminates duplicates, so if the objects are all of the
-> same type, it displays only one object type.
-
-In this case, `Get-Member` displays the properties and methods of each process
-object, that is, a System.Diagnostics.Process object.
-
-For example,
+Similarly, if you pipe multiple process objects from the `Get-Process` cmdlet
+to the `Get-Member` cmdlet, PowerShell sends each process object, one at a
+time, to `Get-Member`. `Get-Member` displays the .NET class (type) of the
+process objects, and their properties and methods.
 
 ```powershell
 Get-Process | Get-Member
@@ -313,9 +333,13 @@ NPM       AliasProperty  NPM = NonpagedSystemMemorySize
 ...
 ```
 
+> [!NOTE]
+> `Get-Member` eliminates duplicates, so if the objects are all of the same
+> type, it only displays one object type.
+
 However, if you use the **InputObject** parameter of `Get-Member`, then
 `Get-Member` receives an array of **System.Diagnostics.Process** objects as a
-single unit, and it displays the properties of an array of objects. (Note the
+single unit. It displays the properties of an array of objects. (Note the
 array symbol (`[]`) after the **System.Object** type name.)
 
 For example,
@@ -335,9 +359,9 @@ Clone              Method        System.Object Clone()
 ...
 ```
 
-This result might not be what you intended, but after you understand it, you
-can use it. For example, an array of process objects has a **Count** property
-that you can use to count the number of processes on the computer.
+This result might not be what you intended. But after you understand it, you
+can use it. For example, all array objects have a **Count** property. You can
+use that to count the number of processes running on the computer.
 
 For example,
 
@@ -345,135 +369,47 @@ For example,
 (Get-Process).count
 ```
 
-This distinction can be important, so remember that when you pipe objects to a
-cmdlet, they are delivered one at a time.
+It's important to remember that objects sent down the pipeline are delivered
+one at a time.
 
-## Accepts Pipeline Input
+## Investigating pipeline errors
 
-In order to receive objects in a pipeline, the receiving cmdlet must have a
-parameter that accepts pipeline input. You can use a `Get-Help` command with
-the **Full** or **Parameter** parameters to determine which, if any, of a
-cmdlet's parameters accepts pipeline input.
+When PowerShell can't associate the piped objects with a parameter of the
+receiving cmdlet, the command fails.
 
-In the `Get-Help` default display, the "Accept pipeline input?" item appears
-in a table of parameter attributes. This table is displayed only when you use
-the **Full** or **Parameter** parameters of the `Get-Help` cmdlet.
-
-For example, to determine which of the parameters of the `Start-Service`
-cmdlet accepts pipeline input, type:
+In the following example, we try to move a registry entry from one registry
+key to another. The `Get-Item` cmdlet gets the destination path, which
+is then piped to the `Move-ItemProperty` cmdlet. The `Move-ItemProperty`
+command specifies the current path and name of the registry entry to be moved.
 
 ```powershell
-Get-Help Start-Service -Full
-```
-
-or
-
-```powershell
-Get-Help Start-Service -Parameter *
-```
-
-For example, the help for the `Start-Service` cmdlet shows that the
-**InputObject** and **Name** parameters accept pipeline input ("true"). All
-other parameters have a value of "false" in the "Accept pipeline input?" row.
-
-```
--InputObject <ServiceController[]>
-Specifies ServiceController objects representing the services to be started.
-Enter a variable that contains the objects, or type a command or expression
-that gets the objects.
-
-Required?                    true
-Position?                    0
-Default value                None
-Accept pipeline input?       True (ByValue)
-Accept wildcard characters?  false
-
--Name <String[]>
-Specifies the service names for the service to be started.
-
-The parameter name is optional. You can use Name or its alias, ServiceName,
-or you can omit the parameter name.
-
-Required?                    true
-Position?                    0
-Default value                None
-Accept pipeline input?       True (ByPropertyName, ByValue)
-Accept wildcard characters?  false
-```
-
-This means that you can send objects (PsObjects) through the pipeline to the
-`Where-Object` cmdlet and PowerShell will associate the object with the
-**InputObject** and **Name** parameters.
-
-## Methods Of Accepting Pipeline Input
-
-Cmdlets parameters can accept pipeline input in one of two different ways:
-
-- **ByValue**: Parameters that accept input "by value" can accept piped objects
-  that have the same .NET type as their parameter value or objects that can be
-  converted to that type.
-
-  For example, the Name parameter of `Start-Service` accepts pipeline input by
-  value. It can accept string objects or objects that can be converted to
-  strings.
-
-- **ByPropertyName**: Parameters that accept input "by property name" can accept
-  piped objects only when a property of the object has the same name as the
-  parameter.
-
-  For example, the Name parameter of `Start-Service` can accept objects that
-  have a Name property. To list the properties of an object, pipe it to
-  `Get-Member`.
-
-Some parameters can accept objects by value or by property name. These
-parameters are designed to take input from the pipeline easily.
-
-## Investigating Pipeline Errors
-
-If a command fails because of a pipeline error, you can investigate the
-failure and rewrite the command.
-
-For example, the following command tries to move a registry entry from one
-registry key to another by using the `Get-Item` cmdlet to get the destination
-path and then piping the path to the `Move-ItemProperty` cmdlet.
-
-Specifically, the command uses the `Get-Item` cmdlet to get the destination
-path. It uses a pipeline operator to send the result to the
-`Move-ItemProperty` cmdlet. The `Move-ItemProperty` command specifies the
-current path and name of the registry entry to be moved.
-
-For example,
-
-```powershell
-Get-Item -Path HKLM:\software\mycompany\sales |
-Move-ItemProperty -Path HKLM:\software\mycompany\design -Name product
+Get-Item -Path HKLM:\Software\MyCompany\sales |
+Move-ItemProperty -Path HKLM:\Software\MyCompany\design -Name product
 ```
 
 The command fails and PowerShell displays the following error
 message:
 
-```output
-Move-ItemProperty : The input object cannot be bound to any parameters for
-the command either because the command does not take pipeline input or the
+```Output
+Move-ItemProperty : The input object can't be bound to any parameters for
+the command either because the command doesn't take pipeline input or the
 input and its properties do not match any of the parameters that take
 pipeline input.
 At line:1 char:23
-+ $a | Move-ItemProperty <<<<  -Path HKLM:\software\mycompany\design -Name p
++ $a | Move-ItemProperty <<<<  -Path HKLM:\Software\MyCompany\design -Name p
 ```
 
-To investigate, use the `Trace-Command` cmdlet to trace the Parameter Binding
-component of PowerShell. The following command traces the Parameter Binding
-component while the command is processing. It uses the `-PSHost` parameter to
-display the results at the console and the `-filepath` command to send them to
-the `debug.txt` file for later reference.
-
-For example,
+To investigate, use the `Trace-Command` cmdlet to trace the parameter binding
+component of PowerShell. The following example traces parameter binding while
+the pipeline is executing. The **PSHost** parameter displays the trace results
+in the console and the **FilePath** parameter send the trace results to the
+`debug.txt` file for later reference.
 
 ```powershell
-Trace-Command -Name parameterbinding -Expression {
-  Get-Item -Path HKLM:\software\mycompany\sales |
-    Move-ItemProperty -Path HKLM:\software\mycompany\design -Name product} `
- -PSHost -FilePath debug.txt
+Trace-Command -Name ParameterBinding -PSHost -FilePath debug.txt -Expression {
+  Get-Item -Path HKLM:\Software\MyCompany\sales |
+    Move-ItemProperty -Path HKLM:\Software\MyCompany\design -Name product
+}
 ```
 
 The results of the trace are lengthy, but they show the values being bound to
@@ -484,7 +420,7 @@ the `Get-Item` cmdlet and then the named values being bound to the
 ...
 
 BIND NAMED cmd line args [`Move-ItemProperty`]
-BIND arg [HKLM:\software\mycompany\design] to parameter [Path]
+BIND arg [HKLM:\Software\MyCompany\design] to parameter [Path]
 
 ...
 
@@ -506,26 +442,19 @@ parameter of `Move-ItemProperty` failed.
 BIND PIPELINE object to parameters: [`Move-ItemProperty`]
 PIPELINE object TYPE = [Microsoft.Win32.RegistryKey]
 RESTORING pipeline parameter's original values
-Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO CO
-ERCION
-Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO COE
-RCION
+Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO
+COERCION
+Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO
+COERCION
 
 ...
 ```
 
-To investigate the failure, use the `Get-Help` cmdlet to view the attributes
-of the **Destination** parameter. The following command gets detailed
-information about the **Destination** parameter.
+Use the `Get-Help` cmdlet to view the attributes of the **Destination** parameter.
 
-```powershell
+```
 Get-Help Move-ItemProperty -Parameter Destination
-```
 
-The results show that **Destination** takes pipeline input only "by property
-name". That is, the piped object must have a property named **Destination**.
-
-```
 -Destination <String>
     Specifies the path to the destination location.
 
@@ -536,59 +465,78 @@ name". That is, the piped object must have a property named **Destination**.
     Accept wildcard characters?  false
 ```
 
-To see the properties of the object being piped to the `Move-ItemProperty`
-cmdlet, pipe it to the `Get-Member` cmdlet. The following command pipes the
-results of the first part of the command to the `Get-Member` cmdlet.
+The results show that **Destination** takes pipeline input only "by property
+name". Therefore, the piped object must have a property named **Destination**.
 
-For example,
+Use `Get-Member` to see the properties of the object coming from `Get-Item`.
 
 ```powershell
-Get-Item -Path HKLM:\software\mycompany\sales | Get-Member
+Get-Item -Path HKLM:\Software\MyCompany\sales | Get-Member
 ```
 
-The output shows that the item is a **Microsoft.Win32.RegistryKey** that does
-not have a **Destination** property. That explains why the command failed.
+The output shows that the item is a **Microsoft.Win32.RegistryKey** object that
+doesn't have a **Destination** property. That explains why the command failed.
+
+The **Path** parameter accepts pipeline input by name or by value.
+
+```
+Get-Help Move-ItemProperty -Parameter Path
+
+-Path <String[]>
+    Specifies the path to the current location of the property. Wildcard
+    characters are permitted.
+
+    Required?                    true
+    Position?                    0
+    Default value                None
+    Accept pipeline input?       True (ByPropertyName, ByValue)
+    Accept wildcard characters?  true
+```
 
 To fix the command, we must specify the destination in the `Move-ItemProperty`
-cmdlet. We can use a `Get-ItemProperty` command to get the path, but the name
-and destination must be specified in the `Move-ItemProperty` part of the
-command.
+cmdlet and use `Get-Item` to get the **Path** of the item we want to move.
 
 For example,
 
 ```powershell
-Get-Item -Path HKLM:\software\mycompany\design |
-Move-ItemProperty -Destination HKLM:\software\mycompany\sales -Name product
+Get-Item -Path HKLM:\Software\MyCompany\design |
+Move-ItemProperty -Destination HKLM:\Software\MyCompany\sales -Name product
 ```
 
-To verify that the command worked, use a `Get-ItemProperty` command:
+## Intrinsic line continuation
 
-For example,
+As already discussed, a pipeline is a series of commands connected by pipeline
+operators (`|`), usually written on a single line. However, for
+readability, PowerShell allows you to split the pipeline across multiple lines.
+When a pipe operator is the last token on the line, the PowerShell parser joins
+the next line to current command to continue the construction of the pipeline.
+
+For example, the following single-line pipeline:
 
 ```powershell
-Get-ItemProperty HKLM:\software\mycompany\sales
+Command-1 | Command-2 | Command-3
 ```
 
-The results show that the **Product** registry entry was moved to the **Sales**
-key.
+can be written as:
 
-```Output
-PSPath       : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\softwa
-re\mycompany\sales
-PSParentPath : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\softwa
-re\mycompany
-PSChildName  : sales
-PSDrive      : HKLM
-PSProvider   : Microsoft.PowerShell.Core\Registry
-Product      : 18
+```powershell
+Command-1 |
+  Command-2 |
+    Command-3
 ```
+
+The leading spaces on the subsequent lines are not significant. The indentation
+enhances readability.
 
 ## See Also
 
-[about_objects](about_objects.md)
+[about_PSReadLine](../../PSReadLine/About/about_PSReadLine.md)
 
-[about_parameters](about_parameters.md)
+[about_Objects](about_objects.md)
 
-[about_command_syntax](about_command_syntax.md)
+[about_Parameters](about_parameters.md)
 
-[about_foreach](about_foreach.md)
+[about_Command_Syntax](about_command_syntax.md)
+
+[about_ForEach](about_foreach.md)
+

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  02/14/2018
+ms.date:  09/27/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -7,20 +7,20 @@ title:  about_pipelines
 ---
 # About Pipelines
 
-## Short Description
+## Short description
 
 Combining commands into pipelines in the PowerShell
 
-## Long Description
+## Long description
 
 A pipeline is a series of commands connected by pipeline operators (`|`)
 (ASCII 124). Each pipeline operator sends the results of the preceding command
 to the next command.
 
-You can use pipelines to send the objects that are output by one command to be
-used as input to another command for processing. And you can send the output
-of that command to yet another command. The result is a very powerful command
-chain or "pipeline" that is comprised of a series of simple commands.
+The output of the first command can be sent for processing as input to the
+second command. And that output can be sent to yet another command. The result
+is a complex command chain or _pipeline_ that is composed of a series of
+simple commands.
 
 For example,
 
@@ -33,9 +33,9 @@ In this example, the objects that `Command-1` emits are sent to `Command-2`.
 processes the objects and send them down the pipeline. Because there are no
 more commands in the pipeline, the results are displayed at the console.
 
-In a pipeline, the commands are processed from left to right in the order that
-they appear. The processing is handled as a single operation and output is
-displayed as it is generated.
+In a pipeline, the commands are processed in order from left to right. The
+processing is handled as a single operation and output is displayed as it's
+generated.
 
 Here is a simple example. The following command gets the Notepad process and
 then stops it.
@@ -49,67 +49,45 @@ Get-Process notepad | Stop-Process
 The first command uses the `Get-Process` cmdlet to get an object representing
 the Notepad process. It uses a pipeline operator (`|`) to send the process
 object to the `Stop-Process` cmdlet, which stops the Notepad process. Notice
-that the `Stop-Process` command does not have a **Name** or **ID** parameter to
+that the `Stop-Process` command doesn't have a **Name** or **ID** parameter to
 specify the process, because the specified process is submitted through the
 pipeline.
 
-Here is a practical example. This command pipeline gets the text files in the
-current directory, selects only the files that are more than 10,000 bytes
-long, sorts them by length, and displays the name and length of each file in a
-table.
+This pipeline example gets the text files in the current directory, selects
+only the files that are more than 10,000 bytes long, sorts them by length, and
+displays the name and length of each file in a table.
 
 ```powershell
-Get-ChildItem -Path *.txt | Where-Object {$_.length -gt 10000} |
-Sort-Object -Property length | Format-Table -Property name, length
+Get-ChildItem -Path *.txt |
+  Where-Object {$_.length -gt 10000} |
+    Sort-Object -Property length |
+      Format-Table -Property name, length
 ```
 
-This pipeline is comprised of four commands in the specified order. The
-command is written horizontally, but we will show the process vertically in
-the following graphic.
-
-`Get-ChildItem` `-Path` *.txt
+This pipeline consists of four commands in the specified order. The following
+illustration shows the output from each command as it is passed to the next
+command in the pipeline.
 
 ```
-|
-|   (FileInfo objects for *.txt)
-|
+Get-ChildItem -Path *.txt
+| (FileInfo objects for *.txt)
 V
-```
-
-`Where-Object` {$_.length `-gt` 10000}
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|
+Where-Object {$_.length -gt 10000}
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
 V
-```
-
-`Sort-Object` `-Property` Length
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|   (    Sorted by length      )
-|
+Sort-Object -Property Length
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
+| (     Sorted by length     )
 V
-```
-
-`Format-Table` `-Property` name, length
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|   (    Sorted by length      )
-|   (  Formatted in a table    )
-|
+Format-Table -Property name, length
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
+| (     Sorted by length     )
+| (   Formatted in a table   )
 V
-```
 
-```output
 Name                       Length
 ----                       ------
 tmp1.txt                    82920
@@ -117,33 +95,23 @@ tmp2.txt                   114000
 tmp3.txt                   114000
 ```
 
-## Using Pipelines
+## Using pipelines
 
-The PowerShell cmdlets were designed to be used in pipelines. For example, you
-can usually pipe the results of a **Get** cmdlet to an action cmdlet (such as a
-**Set**, **Start**, **Stop**, or **Rename** cmdlet) for the same noun.
+Most PowerShell cmdlets are designed to support pipelines. In most cases, you
+can _pipe_ the results of a **Get** cmdlet to another cmdlet of the same noun.
+For example, you can pipe the output of the `Get-Service` cmdlet to the
+`Start-Service` or `Stop-Service` cmdlets.
 
-For example, you can pipe any service from the `Get-Service` cmdlet to the
-`Start-Service` or `Stop-Service` cmdlets (although disabled services cannot
-be restarted in this way).
-
-This command pipeline starts the WMI service on the computer:
-
-For example,
+This example pipeline starts the WMI service on the computer:
 
 ```powershell
 Get-Service wmi | Start-Service
 ```
 
-The cmdlets that get and set objects of the PowerShell providers, such as the
-**Item** and **ItemProperty** cmdlets, are also designed to be used in pipelines.
-
-For example, you can pipe the results of a `Get-Item` or `Get-ChildItem`
-command in the PowerShell registry provider to the `New-ItemProperty` cmdlet.
-This command adds a new registry entry, **NoOfEmployees**, with a value of 8124,
+For another example, you can pipe the output of `Get-Item` or `Get-ChildItem`
+within the PowerShell registry provider to the `New-ItemProperty` cmdlet. This
+example adds a new registry entry, **NoOfEmployees**, with a value of **8124**,
 to the **MyCompany** registry key.
-
-For example,
 
 ```powershell
 Get-Item -Path HKLM:\Software\MyCompany |
@@ -151,27 +119,20 @@ Get-Item -Path HKLM:\Software\MyCompany |
 ```
 
 Many of the utility cmdlets, such as `Get-Member`, `Where-Object`,
-`Sort-Object`, `Group-Object`, and `Measure-Object` are used almost
-exclusively in pipelines. You can pipe any objects to these cmdlets.
-
-For example, you can pipe all of the processes on the computer to the
-`Sort-Object` command and have them sorted by the number of handles in the
-process.
-
-For example,
+`Sort-Object`, `Group-Object`, and `Measure-Object` are used almost exclusively
+in pipelines. You can pipe any object type to these cmdlets. This example shows
+how to sort all the processes on the computer by the number of open handles in
+each process.
 
 ```powershell
 Get-Process | Sort-Object -Property handles
 ```
 
-Also, you can pipe any objects to the formatting cmdlets, such as
-`Format-List` and `Format-Table`, the Export cmdlets, such as `Export-Clixml`
-and `Export-CSV`, and the Out cmdlets, such as `Out-Printer`.
+You can pipe objects to the formatting, export, and output cmdlets, such as
+`Format-List`, `Format-Table`, `Export-Clixml`, `Export-CSV`, and `Out-File`.
 
-For example, you can pipe the "Winlogon" process to the `Format-List` cmdlet to
-display all of the properties of the process in a list.
-
-For example,
+This example shows how to use the `Format-List` cmdlet to display a list of
+properties for a process object.
 
 ```powershell
 Get-Process winlogon | Format-List -Property *
@@ -180,86 +141,149 @@ Get-Process winlogon | Format-List -Property *
 With a bit of practice, you'll find that combining simple commands into
 pipelines saves time and typing, and makes your scripting more efficient.
 
-## How Pipelines Work
+## How pipelines work
 
-When you "pipe" objects, that is send the objects in the output of one command
-to another command, PowerShell tries to associate the piped objects with one
-of the parameters of the receiving cmdlet.
+This section explains how input objects are bound to cmdlet parameters and
+processed during pipeline execution.
 
-To do so, the PowerShell "parameter binding" component, which associates input
-objects with cmdlet parameters, tries to find a parameter that meets the
-following criteria:
+### Accepts pipeline input
 
-- The parameter must accept input from a pipeline (not all do).
-- The parameter must accept the type of object being sent or a type that the
-  object can be converted to.
-- The parameter must not already be used in the command.
+To support pipelining, the receiving cmdlet must have a parameter that accepts
+pipeline input. Use the `Get-Help` command with the **Full** or **Parameter**
+options to determine which parameters of a cmdlet accept pipeline input.
 
-For example, the `Start-Service` cmdlet has many parameters, but only two of
-them, `-Name` and `-InputObject` accept pipeline input. The `-Name` parameter
-takes strings and the `-InputObject` parameter takes service objects.
-Therefore, you can pipe strings and service objects (and objects with
-properties that can be converted to string and service objects) to
-`Start-Service`.
-
-If the parameter binding component of PowerShell cannot associate the piped
-objects with a parameter of the receiving cmdlet, the command fails and
-PowerShell prompts you for the missing parameter values.
-
-You cannot force the parameter binding component to associate the piped
-objects with a particular parameter. You cannot even suggest a parameter.
-Instead, the logic of the component manages the piping as efficiently as
-possible.
-
-## One-At-A-Time Processing
-
-Piping objects to a command is much like using a parameter of the command to
-submit the objects.
-
-For example, piping objects representing the services on the computer to a
-`Format-Table` command, such as:
+For example, to determine which of the parameters of the `Start-Service`
+cmdlet accepts pipeline input, type:
 
 ```powershell
-Get-Service | Format-Table -Property name, dependentservices
+Get-Help Start-Service -Full
 ```
 
-is much like saving the service objects in a variable and using the
-**InputObject** parameter of `Format-Table` to submit the service object.
+or
 
-For example,
+```powershell
+Get-Help Start-Service -Parameter *
+```
+
+The help for the `Start-Service` cmdlet shows that only the **InputObject** and
+**Name** parameters accept pipeline input.
+
+```Output
+-InputObject <ServiceController[]>
+Specifies ServiceController objects representing the services to be started.
+Enter a variable that contains the objects, or type a command or expression
+that gets the objects.
+
+Required?                    true
+Position?                    0
+Default value                None
+Accept pipeline input?       True (ByValue)
+Accept wildcard characters?  false
+
+-Name <String[]>
+Specifies the service names for the service to be started.
+
+The parameter name is optional. You can use Name or its alias, ServiceName,
+or you can omit the parameter name.
+
+Required?                    true
+Position?                    0
+Default value                None
+Accept pipeline input?       True (ByPropertyName, ByValue)
+Accept wildcard characters?  false
+```
+
+When you send objects through the pipeline to `Start-Service`, PowerShell
+attempts to associate the objects with the **InputObject** and **Name**
+parameters.
+
+### Methods of accepting pipeline input
+
+Cmdlets parameters can accept pipeline input in one of two different ways:
+
+- **ByValue**: The parameter accepts values that match the expected .NET type
+  or that can be converted to that type.
+
+  For example, the **Name** parameter of `Start-Service` accepts pipeline input
+  by value. It can accept string objects or objects that can be converted to
+  strings.
+
+- **ByPropertyName**: The parameter accepts input only when the input object
+  has a property of the same name as the parameter.
+
+  For example, the Name parameter of `Start-Service` can accept objects that
+  have a **Name** property. To list the properties of an object, pipe it to
+  `Get-Member`.
+
+Some parameters can accept objects by both value or property name, making it
+easier to take input from the pipeline.
+
+### Parameter binding
+
+When you pipe objects from one command to another command, PowerShell attempts
+to associate the piped objects with a parameter of the receiving cmdlet.
+
+PowerShell's parameter binding component associates the input objects with
+cmdlet parameters according to the following criteria:
+
+- The parameter must accept input from a pipeline
+- The parameter must accept the type of object being sent or a type that can be
+  converted to the expected type
+- The parameter was not used in the command
+
+For example, the `Start-Service` cmdlet has many parameters, but only two of
+them, **Name** and **InputObject** accept pipeline input. The **Name**
+parameter takes strings and the **InputObject** parameter takes service
+objects. Therefore, you can pipe strings, service objects, and objects with
+properties that can be converted to string or service objects.
+
+PowerShell manages parameter binding as efficiently as possible. You can't
+suggest or force the PowerShell to bind to a specific parameter. The command
+fails if PowerShell can't bind the piped objects.
+
+For more information about troubleshooting binding errors, see
+[Investigating Pipeline Errors](#investigating-pipeline-errors) later in this
+article.
+
+### One-at-a-time processing
+
+Piping objects to a command is much like using a parameter of the command to
+submit the objects. Let look at a pipeline example. In this example, we use a
+pipeline to display a table of service objects.
+
+```powershell
+Get-Service | Format-Table -Property Name, DependentServices
+```
+
+Functionally, this is like using the **InputObject** parameter of `Format-Table`
+to submit the object collection.
+
+For example, we can save the collection of services to a variable that is
+passed using the **InputObject** parameter.
 
 ```powershell
 $services = Get-Service
-Format-Table -InputObject $services -Property name, dependentservices
+Format-Table -InputObject $services -Property Name, DependentServices
 ```
 
-or imbedding the command in the parameter value
-
-For example,
+Or we can embed the command in the **InputObject** parameter.
 
 ```powershell
-Format-Table -InputObject (Get-Service wmi) -Property name,dependentservices
+Format-Table -InputObject (Get-Service) -Property Name, DependentServices
 ```
 
-However, there is an important difference. When you pipe multiple objects to a
+However, there's an important difference. When you pipe multiple objects to a
 command, PowerShell sends the objects to the command one at a time. When you
-use a command parameter, the objects are sent as a single array object.
+use a command parameter, the objects are sent as a single array object. This
+minor difference has significant consequences.
 
-This seemingly technical difference can have interesting, and sometimes
-useful, consequences.
+When executing a pipeline, PowerShell automatically enumerates any type that
+implements the `IEnumerable` interface and sends the members through the
+pipeline one at a time. The exception is `[hashtable]`, which requires a call
+to the `GetEnumerator()` method.
 
-For example, if you pipe multiple process objects from the `Get-Process`
-cmdlet to the `Get-Member` cmdlet, PowerShell sends each process object, one
-at a time, to `Get-Member`. `Get-Member` displays the .NET class (type) of the
-process objects, and their properties and methods.
-
-PowerShell automatically enumerates any type that implements the `IEnumerable`
-interface and sends the members through the pipeline one at a time. The
-exception is `[hashtable]`, which requires a call to the `GetEnumerator()`
-method.
-
-In the example below, an array and a hashtable are piped to the `Measure-Object`
-cmdlet, which counts the number of objects received from the pipeline. The array
+In the following examples, an array and a hashtable are piped to the `Measure-Object`
+cmdlet to count the number of objects received from the pipeline. The array
 has multiple members, and the hashtable has multiple key-value pairs. Only the
 array is enumerated one at a time.
 
@@ -289,14 +313,10 @@ Minimum  :
 Property :
 ```
 
-> [!NOTE]
-> `Get-Member` eliminates duplicates, so if the objects are all of the
-> same type, it displays only one object type.
-
-In this case, `Get-Member` displays the properties and methods of each process
-object, that is, a System.Diagnostics.Process object.
-
-For example,
+Similarly, if you pipe multiple process objects from the `Get-Process` cmdlet
+to the `Get-Member` cmdlet, PowerShell sends each process object, one at a
+time, to `Get-Member`. `Get-Member` displays the .NET class (type) of the
+process objects, and their properties and methods.
 
 ```powershell
 Get-Process | Get-Member
@@ -313,9 +333,13 @@ NPM       AliasProperty  NPM = NonpagedSystemMemorySize
 ...
 ```
 
+> [!NOTE]
+> `Get-Member` eliminates duplicates, so if the objects are all of the same
+> type, it only displays one object type.
+
 However, if you use the **InputObject** parameter of `Get-Member`, then
 `Get-Member` receives an array of **System.Diagnostics.Process** objects as a
-single unit, and it displays the properties of an array of objects. (Note the
+single unit. It displays the properties of an array of objects. (Note the
 array symbol (`[]`) after the **System.Object** type name.)
 
 For example,
@@ -335,9 +359,9 @@ Clone              Method        System.Object Clone()
 ...
 ```
 
-This result might not be what you intended, but after you understand it, you
-can use it. For example, an array of process objects has a **Count** property
-that you can use to count the number of processes on the computer.
+This result might not be what you intended. But after you understand it, you
+can use it. For example, all array objects have a **Count** property. You can
+use that to count the number of processes running on the computer.
 
 For example,
 
@@ -345,135 +369,47 @@ For example,
 (Get-Process).count
 ```
 
-This distinction can be important, so remember that when you pipe objects to a
-cmdlet, they are delivered one at a time.
+It's important to remember that objects sent down the pipeline are delivered
+one at a time.
 
-## Accepts Pipeline Input
+## Investigating pipeline errors
 
-In order to receive objects in a pipeline, the receiving cmdlet must have a
-parameter that accepts pipeline input. You can use a `Get-Help` command with
-the **Full** or **Parameter** parameters to determine which, if any, of a
-cmdlet's parameters accepts pipeline input.
+When PowerShell can't associate the piped objects with a parameter of the
+receiving cmdlet, the command fails.
 
-In the `Get-Help` default display, the "Accept pipeline input?" item appears
-in a table of parameter attributes. This table is displayed only when you use
-the **Full** or **Parameter** parameters of the `Get-Help` cmdlet.
-
-For example, to determine which of the parameters of the `Start-Service`
-cmdlet accepts pipeline input, type:
+In the following example, we try to move a registry entry from one registry
+key to another. The `Get-Item` cmdlet gets the destination path, which
+is then piped to the `Move-ItemProperty` cmdlet. The `Move-ItemProperty`
+command specifies the current path and name of the registry entry to be moved.
 
 ```powershell
-Get-Help Start-Service -Full
-```
-
-or
-
-```powershell
-Get-Help Start-Service -Parameter *
-```
-
-For example, the help for the `Start-Service` cmdlet shows that the
-**InputObject** and **Name** parameters accept pipeline input ("true"). All
-other parameters have a value of "false" in the "Accept pipeline input?" row.
-
-```
--InputObject <ServiceController[]>
-Specifies ServiceController objects representing the services to be started.
-Enter a variable that contains the objects, or type a command or expression
-that gets the objects.
-
-Required?                    true
-Position?                    0
-Default value                None
-Accept pipeline input?       True (ByValue)
-Accept wildcard characters?  false
-
--Name <String[]>
-Specifies the service names for the service to be started.
-
-The parameter name is optional. You can use Name or its alias, ServiceName,
-or you can omit the parameter name.
-
-Required?                    true
-Position?                    0
-Default value                None
-Accept pipeline input?       True (ByPropertyName, ByValue)
-Accept wildcard characters?  false
-```
-
-This means that you can send objects (PsObjects) through the pipeline to the
-`Where-Object` cmdlet and PowerShell will associate the object with the
-**InputObject** and **Name** parameters.
-
-## Methods Of Accepting Pipeline Input
-
-Cmdlets parameters can accept pipeline input in one of two different ways:
-
-- **ByValue**: Parameters that accept input "by value" can accept piped objects
-  that have the same .NET type as their parameter value or objects that can be
-  converted to that type.
-
-  For example, the Name parameter of `Start-Service` accepts pipeline input by
-  value. It can accept string objects or objects that can be converted to
-  strings.
-
-- **ByPropertyName**: Parameters that accept input "by property name" can accept
-  piped objects only when a property of the object has the same name as the
-  parameter.
-
-  For example, the Name parameter of `Start-Service` can accept objects that
-  have a Name property. To list the properties of an object, pipe it to
-  `Get-Member`.
-
-Some parameters can accept objects by value or by property name. These
-parameters are designed to take input from the pipeline easily.
-
-## Investigating Pipeline Errors
-
-If a command fails because of a pipeline error, you can investigate the
-failure and rewrite the command.
-
-For example, the following command tries to move a registry entry from one
-registry key to another by using the `Get-Item` cmdlet to get the destination
-path and then piping the path to the `Move-ItemProperty` cmdlet.
-
-Specifically, the command uses the `Get-Item` cmdlet to get the destination
-path. It uses a pipeline operator to send the result to the
-`Move-ItemProperty` cmdlet. The `Move-ItemProperty` command specifies the
-current path and name of the registry entry to be moved.
-
-For example,
-
-```powershell
-Get-Item -Path HKLM:\software\mycompany\sales |
-Move-ItemProperty -Path HKLM:\software\mycompany\design -Name product
+Get-Item -Path HKLM:\Software\MyCompany\sales |
+Move-ItemProperty -Path HKLM:\Software\MyCompany\design -Name product
 ```
 
 The command fails and PowerShell displays the following error
 message:
 
-```output
-Move-ItemProperty : The input object cannot be bound to any parameters for
-the command either because the command does not take pipeline input or the
+```Output
+Move-ItemProperty : The input object can't be bound to any parameters for
+the command either because the command doesn't take pipeline input or the
 input and its properties do not match any of the parameters that take
 pipeline input.
 At line:1 char:23
-+ $a | Move-ItemProperty <<<<  -Path HKLM:\software\mycompany\design -Name p
++ $a | Move-ItemProperty <<<<  -Path HKLM:\Software\MyCompany\design -Name p
 ```
 
-To investigate, use the `Trace-Command` cmdlet to trace the Parameter Binding
-component of PowerShell. The following command traces the Parameter Binding
-component while the command is processing. It uses the `-PSHost` parameter to
-display the results at the console and the `-filepath` command to send them to
-the `debug.txt` file for later reference.
-
-For example,
+To investigate, use the `Trace-Command` cmdlet to trace the parameter binding
+component of PowerShell. The following example traces parameter binding while
+the pipeline is executing. The **PSHost** parameter displays the trace results
+in the console and the **FilePath** parameter send the trace results to the
+`debug.txt` file for later reference.
 
 ```powershell
-Trace-Command -Name parameterbinding -Expression {
-  Get-Item -Path HKLM:\software\mycompany\sales |
-    Move-ItemProperty -Path HKLM:\software\mycompany\design -Name product} `
- -PSHost -FilePath debug.txt
+Trace-Command -Name ParameterBinding -PSHost -FilePath debug.txt -Expression {
+  Get-Item -Path HKLM:\Software\MyCompany\sales |
+    Move-ItemProperty -Path HKLM:\Software\MyCompany\design -Name product
+}
 ```
 
 The results of the trace are lengthy, but they show the values being bound to
@@ -484,7 +420,7 @@ the `Get-Item` cmdlet and then the named values being bound to the
 ...
 
 BIND NAMED cmd line args [`Move-ItemProperty`]
-BIND arg [HKLM:\software\mycompany\design] to parameter [Path]
+BIND arg [HKLM:\Software\MyCompany\design] to parameter [Path]
 
 ...
 
@@ -506,26 +442,19 @@ parameter of `Move-ItemProperty` failed.
 BIND PIPELINE object to parameters: [`Move-ItemProperty`]
 PIPELINE object TYPE = [Microsoft.Win32.RegistryKey]
 RESTORING pipeline parameter's original values
-Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO CO
-ERCION
-Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO COE
-RCION
+Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO
+COERCION
+Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO
+COERCION
 
 ...
 ```
 
-To investigate the failure, use the `Get-Help` cmdlet to view the attributes
-of the **Destination** parameter. The following command gets detailed
-information about the **Destination** parameter.
+Use the `Get-Help` cmdlet to view the attributes of the **Destination** parameter.
 
-```powershell
+```
 Get-Help Move-ItemProperty -Parameter Destination
-```
 
-The results show that **Destination** takes pipeline input only "by property
-name". That is, the piped object must have a property named **Destination**.
-
-```
 -Destination <String>
     Specifies the path to the destination location.
 
@@ -536,59 +465,78 @@ name". That is, the piped object must have a property named **Destination**.
     Accept wildcard characters?  false
 ```
 
-To see the properties of the object being piped to the `Move-ItemProperty`
-cmdlet, pipe it to the `Get-Member` cmdlet. The following command pipes the
-results of the first part of the command to the `Get-Member` cmdlet.
+The results show that **Destination** takes pipeline input only "by property
+name". Therefore, the piped object must have a property named **Destination**.
 
-For example,
+Use `Get-Member` to see the properties of the object coming from `Get-Item`.
 
 ```powershell
-Get-Item -Path HKLM:\software\mycompany\sales | Get-Member
+Get-Item -Path HKLM:\Software\MyCompany\sales | Get-Member
 ```
 
-The output shows that the item is a **Microsoft.Win32.RegistryKey** that does
-not have a **Destination** property. That explains why the command failed.
+The output shows that the item is a **Microsoft.Win32.RegistryKey** object that
+doesn't have a **Destination** property. That explains why the command failed.
+
+The **Path** parameter accepts pipeline input by name or by value.
+
+```
+Get-Help Move-ItemProperty -Parameter Path
+
+-Path <String[]>
+    Specifies the path to the current location of the property. Wildcard
+    characters are permitted.
+
+    Required?                    true
+    Position?                    0
+    Default value                None
+    Accept pipeline input?       True (ByPropertyName, ByValue)
+    Accept wildcard characters?  true
+```
 
 To fix the command, we must specify the destination in the `Move-ItemProperty`
-cmdlet. We can use a `Get-ItemProperty` command to get the path, but the name
-and destination must be specified in the `Move-ItemProperty` part of the
-command.
+cmdlet and use `Get-Item` to get the **Path** of the item we want to move.
 
 For example,
 
 ```powershell
-Get-Item -Path HKLM:\software\mycompany\design |
-Move-ItemProperty -Destination HKLM:\software\mycompany\sales -Name product
+Get-Item -Path HKLM:\Software\MyCompany\design |
+Move-ItemProperty -Destination HKLM:\Software\MyCompany\sales -Name product
 ```
 
-To verify that the command worked, use a `Get-ItemProperty` command:
+## Intrinsic line continuation
 
-For example,
+As already discussed, a pipeline is a series of commands connected by pipeline
+operators (`|`), usually written on a single line. However, for
+readability, PowerShell allows you to split the pipeline across multiple lines.
+When a pipe operator is the last token on the line, the PowerShell parser joins
+the next line to current command to continue the construction of the pipeline.
+
+For example, the following single-line pipeline:
 
 ```powershell
-Get-ItemProperty HKLM:\software\mycompany\sales
+Command-1 | Command-2 | Command-3
 ```
 
-The results show that the **Product** registry entry was moved to the **Sales**
-key.
+can be written as:
 
-```Output
-PSPath       : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\softwa
-re\mycompany\sales
-PSParentPath : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\softwa
-re\mycompany
-PSChildName  : sales
-PSDrive      : HKLM
-PSProvider   : Microsoft.PowerShell.Core\Registry
-Product      : 18
+```powershell
+Command-1 |
+  Command-2 |
+    Command-3
 ```
+
+The leading spaces on the subsequent lines are not significant. The indentation
+enhances readability.
 
 ## See Also
 
-[about_objects](about_objects.md)
+[about_PSReadLine](../../PSReadLine/About/about_PSReadLine.md)
 
-[about_parameters](about_parameters.md)
+[about_Objects](about_objects.md)
 
-[about_command_syntax](about_command_syntax.md)
+[about_Parameters](about_parameters.md)
 
-[about_foreach](about_foreach.md)
+[about_Command_Syntax](about_command_syntax.md)
+
+[about_ForEach](about_foreach.md)
+

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -65,7 +65,7 @@ Get-ChildItem -Path *.txt |
 ```
 
 This pipeline consists of four commands in the specified order. The following
-illustration shows the output from each command as it is passed to the next
+illustration shows the output from each command as it's passed to the next
 command in the pipeline.
 
 ```
@@ -226,10 +226,10 @@ to associate the piped objects with a parameter of the receiving cmdlet.
 PowerShell's parameter binding component associates the input objects with
 cmdlet parameters according to the following criteria:
 
-- The parameter must accept input from a pipeline
+- The parameter must accept input from a pipeline.
 - The parameter must accept the type of object being sent or a type that can be
-  converted to the expected type
-- The parameter was not used in the command
+  converted to the expected type.
+- The parameter wasn't used in the command.
 
 For example, the `Start-Service` cmdlet has many parameters, but only two of
 them, **Name** and **InputObject** accept pipeline input. The **Name**
@@ -248,7 +248,7 @@ article.
 ### One-at-a-time processing
 
 Piping objects to a command is much like using a parameter of the command to
-submit the objects. Let look at a pipeline example. In this example, we use a
+submit the objects. Let's look at a pipeline example. In this example, we use a
 pipeline to display a table of service objects.
 
 ```powershell
@@ -416,29 +416,22 @@ The results of the trace are lengthy, but they show the values being bound to
 the `Get-Item` cmdlet and then the named values being bound to the
 `Move-ItemProperty` cmdlet.
 
-```
+```Output
 ...
-
 BIND NAMED cmd line args [`Move-ItemProperty`]
 BIND arg [HKLM:\Software\MyCompany\design] to parameter [Path]
-
 ...
-
 BIND arg [product] to parameter [Name]
-
 ...
-
 BIND POSITIONAL cmd line args [`Move-ItemProperty`]
-
 ...
 ```
 
 Finally, it shows that the attempt to bind the path to the **Destination**
 parameter of `Move-ItemProperty` failed.
 
-```
+```Output
 ...
-
 BIND PIPELINE object to parameters: [`Move-ItemProperty`]
 PIPELINE object TYPE = [Microsoft.Win32.RegistryKey]
 RESTORING pipeline parameter's original values
@@ -446,13 +439,12 @@ Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO
 COERCION
 Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO
 COERCION
-
 ...
 ```
 
 Use the `Get-Help` cmdlet to view the attributes of the **Destination** parameter.
 
-```
+```Output
 Get-Help Move-ItemProperty -Parameter Destination
 
 -Destination <String>
@@ -479,7 +471,7 @@ doesn't have a **Destination** property. That explains why the command failed.
 
 The **Path** parameter accepts pipeline input by name or by value.
 
-```
+```Output
 Get-Help Move-ItemProperty -Parameter Path
 
 -Path <String[]>

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  02/14/2018
+ms.date:  09/27/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -7,20 +7,20 @@ title:  about_pipelines
 ---
 # About Pipelines
 
-## Short Description
+## Short description
 
 Combining commands into pipelines in the PowerShell
 
-## Long Description
+## Long description
 
 A pipeline is a series of commands connected by pipeline operators (`|`)
 (ASCII 124). Each pipeline operator sends the results of the preceding command
 to the next command.
 
-You can use pipelines to send the objects that are output by one command to be
-used as input to another command for processing. And you can send the output
-of that command to yet another command. The result is a very powerful command
-chain or "pipeline" that is comprised of a series of simple commands.
+The output of the first command can be sent for processing as input to the
+second command. And that output can be sent to yet another command. The result
+is a complex command chain or _pipeline_ that is composed of a series of
+simple commands.
 
 For example,
 
@@ -33,9 +33,9 @@ In this example, the objects that `Command-1` emits are sent to `Command-2`.
 processes the objects and send them down the pipeline. Because there are no
 more commands in the pipeline, the results are displayed at the console.
 
-In a pipeline, the commands are processed from left to right in the order that
-they appear. The processing is handled as a single operation and output is
-displayed as it is generated.
+In a pipeline, the commands are processed in order from left to right. The
+processing is handled as a single operation and output is displayed as it's
+generated.
 
 Here is a simple example. The following command gets the Notepad process and
 then stops it.
@@ -49,67 +49,45 @@ Get-Process notepad | Stop-Process
 The first command uses the `Get-Process` cmdlet to get an object representing
 the Notepad process. It uses a pipeline operator (`|`) to send the process
 object to the `Stop-Process` cmdlet, which stops the Notepad process. Notice
-that the `Stop-Process` command does not have a **Name** or **ID** parameter to
+that the `Stop-Process` command doesn't have a **Name** or **ID** parameter to
 specify the process, because the specified process is submitted through the
 pipeline.
 
-Here is a practical example. This command pipeline gets the text files in the
-current directory, selects only the files that are more than 10,000 bytes
-long, sorts them by length, and displays the name and length of each file in a
-table.
+This pipeline example gets the text files in the current directory, selects
+only the files that are more than 10,000 bytes long, sorts them by length, and
+displays the name and length of each file in a table.
 
 ```powershell
-Get-ChildItem -Path *.txt | Where-Object {$_.length -gt 10000} |
-Sort-Object -Property length | Format-Table -Property name, length
+Get-ChildItem -Path *.txt |
+  Where-Object {$_.length -gt 10000} |
+    Sort-Object -Property length |
+      Format-Table -Property name, length
 ```
 
-This pipeline is comprised of four commands in the specified order. The
-command is written horizontally, but we will show the process vertically in
-the following graphic.
-
-`Get-ChildItem` `-Path` *.txt
+This pipeline consists of four commands in the specified order. The following
+illustration shows the output from each command as it is passed to the next
+command in the pipeline.
 
 ```
-|
-|   (FileInfo objects for *.txt)
-|
+Get-ChildItem -Path *.txt
+| (FileInfo objects for *.txt)
 V
-```
-
-`Where-Object` {$_.length `-gt` 10000}
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|
+Where-Object {$_.length -gt 10000}
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
 V
-```
-
-`Sort-Object` `-Property` Length
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|   (    Sorted by length      )
-|
+Sort-Object -Property Length
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
+| (     Sorted by length     )
 V
-```
-
-`Format-Table` `-Property` name, length
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|   (    Sorted by length      )
-|   (  Formatted in a table    )
-|
+Format-Table -Property name, length
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
+| (     Sorted by length     )
+| (   Formatted in a table   )
 V
-```
 
-```output
 Name                       Length
 ----                       ------
 tmp1.txt                    82920
@@ -117,33 +95,23 @@ tmp2.txt                   114000
 tmp3.txt                   114000
 ```
 
-## Using Pipelines
+## Using pipelines
 
-The PowerShell cmdlets were designed to be used in pipelines. For example, you
-can usually pipe the results of a **Get** cmdlet to an action cmdlet (such as a
-**Set**, **Start**, **Stop**, or **Rename** cmdlet) for the same noun.
+Most PowerShell cmdlets are designed to support pipelines. In most cases, you
+can _pipe_ the results of a **Get** cmdlet to another cmdlet of the same noun.
+For example, you can pipe the output of the `Get-Service` cmdlet to the
+`Start-Service` or `Stop-Service` cmdlets.
 
-For example, you can pipe any service from the `Get-Service` cmdlet to the
-`Start-Service` or `Stop-Service` cmdlets (although disabled services cannot
-be restarted in this way).
-
-This command pipeline starts the WMI service on the computer:
-
-For example,
+This example pipeline starts the WMI service on the computer:
 
 ```powershell
 Get-Service wmi | Start-Service
 ```
 
-The cmdlets that get and set objects of the PowerShell providers, such as the
-**Item** and **ItemProperty** cmdlets, are also designed to be used in pipelines.
-
-For example, you can pipe the results of a `Get-Item` or `Get-ChildItem`
-command in the PowerShell registry provider to the `New-ItemProperty` cmdlet.
-This command adds a new registry entry, **NoOfEmployees**, with a value of 8124,
+For another example, you can pipe the output of `Get-Item` or `Get-ChildItem`
+within the PowerShell registry provider to the `New-ItemProperty` cmdlet. This
+example adds a new registry entry, **NoOfEmployees**, with a value of **8124**,
 to the **MyCompany** registry key.
-
-For example,
 
 ```powershell
 Get-Item -Path HKLM:\Software\MyCompany |
@@ -151,27 +119,20 @@ Get-Item -Path HKLM:\Software\MyCompany |
 ```
 
 Many of the utility cmdlets, such as `Get-Member`, `Where-Object`,
-`Sort-Object`, `Group-Object`, and `Measure-Object` are used almost
-exclusively in pipelines. You can pipe any objects to these cmdlets.
-
-For example, you can pipe all of the processes on the computer to the
-`Sort-Object` command and have them sorted by the number of handles in the
-process.
-
-For example,
+`Sort-Object`, `Group-Object`, and `Measure-Object` are used almost exclusively
+in pipelines. You can pipe any object type to these cmdlets. This example shows
+how to sort all the processes on the computer by the number of open handles in
+each process.
 
 ```powershell
 Get-Process | Sort-Object -Property handles
 ```
 
-Also, you can pipe any objects to the formatting cmdlets, such as
-`Format-List` and `Format-Table`, the Export cmdlets, such as `Export-Clixml`
-and `Export-CSV`, and the Out cmdlets, such as `Out-Printer`.
+You can pipe objects to the formatting, export, and output cmdlets, such as
+`Format-List`, `Format-Table`, `Export-Clixml`, `Export-CSV`, and `Out-File`.
 
-For example, you can pipe the "Winlogon" process to the `Format-List` cmdlet to
-display all of the properties of the process in a list.
-
-For example,
+This example shows how to use the `Format-List` cmdlet to display a list of
+properties for a process object.
 
 ```powershell
 Get-Process winlogon | Format-List -Property *
@@ -180,86 +141,149 @@ Get-Process winlogon | Format-List -Property *
 With a bit of practice, you'll find that combining simple commands into
 pipelines saves time and typing, and makes your scripting more efficient.
 
-## How Pipelines Work
+## How pipelines work
 
-When you "pipe" objects, that is send the objects in the output of one command
-to another command, PowerShell tries to associate the piped objects with one
-of the parameters of the receiving cmdlet.
+This section explains how input objects are bound to cmdlet parameters and
+processed during pipeline execution.
 
-To do so, the PowerShell "parameter binding" component, which associates input
-objects with cmdlet parameters, tries to find a parameter that meets the
-following criteria:
+### Accepts pipeline input
 
-- The parameter must accept input from a pipeline (not all do).
-- The parameter must accept the type of object being sent or a type that the
-  object can be converted to.
-- The parameter must not already be used in the command.
+To support pipelining, the receiving cmdlet must have a parameter that accepts
+pipeline input. Use the `Get-Help` command with the **Full** or **Parameter**
+options to determine which parameters of a cmdlet accept pipeline input.
 
-For example, the `Start-Service` cmdlet has many parameters, but only two of
-them, `-Name` and `-InputObject` accept pipeline input. The `-Name` parameter
-takes strings and the `-InputObject` parameter takes service objects.
-Therefore, you can pipe strings and service objects (and objects with
-properties that can be converted to string and service objects) to
-`Start-Service`.
-
-If the parameter binding component of PowerShell cannot associate the piped
-objects with a parameter of the receiving cmdlet, the command fails and
-PowerShell prompts you for the missing parameter values.
-
-You cannot force the parameter binding component to associate the piped
-objects with a particular parameter. You cannot even suggest a parameter.
-Instead, the logic of the component manages the piping as efficiently as
-possible.
-
-## One-At-A-Time Processing
-
-Piping objects to a command is much like using a parameter of the command to
-submit the objects.
-
-For example, piping objects representing the services on the computer to a
-`Format-Table` command, such as:
+For example, to determine which of the parameters of the `Start-Service`
+cmdlet accepts pipeline input, type:
 
 ```powershell
-Get-Service | Format-Table -Property name, dependentservices
+Get-Help Start-Service -Full
 ```
 
-is much like saving the service objects in a variable and using the
-**InputObject** parameter of `Format-Table` to submit the service object.
+or
 
-For example,
+```powershell
+Get-Help Start-Service -Parameter *
+```
+
+The help for the `Start-Service` cmdlet shows that only the **InputObject** and
+**Name** parameters accept pipeline input.
+
+```Output
+-InputObject <ServiceController[]>
+Specifies ServiceController objects representing the services to be started.
+Enter a variable that contains the objects, or type a command or expression
+that gets the objects.
+
+Required?                    true
+Position?                    0
+Default value                None
+Accept pipeline input?       True (ByValue)
+Accept wildcard characters?  false
+
+-Name <String[]>
+Specifies the service names for the service to be started.
+
+The parameter name is optional. You can use Name or its alias, ServiceName,
+or you can omit the parameter name.
+
+Required?                    true
+Position?                    0
+Default value                None
+Accept pipeline input?       True (ByPropertyName, ByValue)
+Accept wildcard characters?  false
+```
+
+When you send objects through the pipeline to `Start-Service`, PowerShell
+attempts to associate the objects with the **InputObject** and **Name**
+parameters.
+
+### Methods of accepting pipeline input
+
+Cmdlets parameters can accept pipeline input in one of two different ways:
+
+- **ByValue**: The parameter accepts values that match the expected .NET type
+  or that can be converted to that type.
+
+  For example, the **Name** parameter of `Start-Service` accepts pipeline input
+  by value. It can accept string objects or objects that can be converted to
+  strings.
+
+- **ByPropertyName**: The parameter accepts input only when the input object
+  has a property of the same name as the parameter.
+
+  For example, the Name parameter of `Start-Service` can accept objects that
+  have a **Name** property. To list the properties of an object, pipe it to
+  `Get-Member`.
+
+Some parameters can accept objects by both value or property name, making it
+easier to take input from the pipeline.
+
+### Parameter binding
+
+When you pipe objects from one command to another command, PowerShell attempts
+to associate the piped objects with a parameter of the receiving cmdlet.
+
+PowerShell's parameter binding component associates the input objects with
+cmdlet parameters according to the following criteria:
+
+- The parameter must accept input from a pipeline
+- The parameter must accept the type of object being sent or a type that can be
+  converted to the expected type
+- The parameter was not used in the command
+
+For example, the `Start-Service` cmdlet has many parameters, but only two of
+them, **Name** and **InputObject** accept pipeline input. The **Name**
+parameter takes strings and the **InputObject** parameter takes service
+objects. Therefore, you can pipe strings, service objects, and objects with
+properties that can be converted to string or service objects.
+
+PowerShell manages parameter binding as efficiently as possible. You can't
+suggest or force the PowerShell to bind to a specific parameter. The command
+fails if PowerShell can't bind the piped objects.
+
+For more information about troubleshooting binding errors, see
+[Investigating Pipeline Errors](#investigating-pipeline-errors) later in this
+article.
+
+### One-at-a-time processing
+
+Piping objects to a command is much like using a parameter of the command to
+submit the objects. Let look at a pipeline example. In this example, we use a
+pipeline to display a table of service objects.
+
+```powershell
+Get-Service | Format-Table -Property Name, DependentServices
+```
+
+Functionally, this is like using the **InputObject** parameter of `Format-Table`
+to submit the object collection.
+
+For example, we can save the collection of services to a variable that is
+passed using the **InputObject** parameter.
 
 ```powershell
 $services = Get-Service
-Format-Table -InputObject $services -Property name, dependentservices
+Format-Table -InputObject $services -Property Name, DependentServices
 ```
 
-or imbedding the command in the parameter value
-
-For example,
+Or we can embed the command in the **InputObject** parameter.
 
 ```powershell
-Format-Table -InputObject (Get-Service wmi) -Property name,dependentservices
+Format-Table -InputObject (Get-Service) -Property Name, DependentServices
 ```
 
-However, there is an important difference. When you pipe multiple objects to a
+However, there's an important difference. When you pipe multiple objects to a
 command, PowerShell sends the objects to the command one at a time. When you
-use a command parameter, the objects are sent as a single array object.
+use a command parameter, the objects are sent as a single array object. This
+minor difference has significant consequences.
 
-This seemingly technical difference can have interesting, and sometimes
-useful, consequences.
+When executing a pipeline, PowerShell automatically enumerates any type that
+implements the `IEnumerable` interface and sends the members through the
+pipeline one at a time. The exception is `[hashtable]`, which requires a call
+to the `GetEnumerator()` method.
 
-For example, if you pipe multiple process objects from the `Get-Process`
-cmdlet to the `Get-Member` cmdlet, PowerShell sends each process object, one
-at a time, to `Get-Member`. `Get-Member` displays the .NET class (type) of the
-process objects, and their properties and methods.
-
-PowerShell automatically enumerates any type that implements the `IEnumerable`
-interface and sends the members through the pipeline one at a time. The
-exception is `[hashtable]`, which requires a call to the `GetEnumerator()`
-method.
-
-In the example below, an array and a hashtable are piped to the `Measure-Object`
-cmdlet, which counts the number of objects received from the pipeline. The array
+In the following examples, an array and a hashtable are piped to the `Measure-Object`
+cmdlet to count the number of objects received from the pipeline. The array
 has multiple members, and the hashtable has multiple key-value pairs. Only the
 array is enumerated one at a time.
 
@@ -289,14 +313,10 @@ Minimum  :
 Property :
 ```
 
-> [!NOTE]
-> `Get-Member` eliminates duplicates, so if the objects are all of the
-> same type, it displays only one object type.
-
-In this case, `Get-Member` displays the properties and methods of each process
-object, that is, a System.Diagnostics.Process object.
-
-For example,
+Similarly, if you pipe multiple process objects from the `Get-Process` cmdlet
+to the `Get-Member` cmdlet, PowerShell sends each process object, one at a
+time, to `Get-Member`. `Get-Member` displays the .NET class (type) of the
+process objects, and their properties and methods.
 
 ```powershell
 Get-Process | Get-Member
@@ -313,9 +333,13 @@ NPM       AliasProperty  NPM = NonpagedSystemMemorySize
 ...
 ```
 
+> [!NOTE]
+> `Get-Member` eliminates duplicates, so if the objects are all of the same
+> type, it only displays one object type.
+
 However, if you use the **InputObject** parameter of `Get-Member`, then
 `Get-Member` receives an array of **System.Diagnostics.Process** objects as a
-single unit, and it displays the properties of an array of objects. (Note the
+single unit. It displays the properties of an array of objects. (Note the
 array symbol (`[]`) after the **System.Object** type name.)
 
 For example,
@@ -335,9 +359,9 @@ Clone              Method        System.Object Clone()
 ...
 ```
 
-This result might not be what you intended, but after you understand it, you
-can use it. For example, an array of process objects has a **Count** property
-that you can use to count the number of processes on the computer.
+This result might not be what you intended. But after you understand it, you
+can use it. For example, all array objects have a **Count** property. You can
+use that to count the number of processes running on the computer.
 
 For example,
 
@@ -345,135 +369,47 @@ For example,
 (Get-Process).count
 ```
 
-This distinction can be important, so remember that when you pipe objects to a
-cmdlet, they are delivered one at a time.
+It's important to remember that objects sent down the pipeline are delivered
+one at a time.
 
-## Accepts Pipeline Input
+## Investigating pipeline errors
 
-In order to receive objects in a pipeline, the receiving cmdlet must have a
-parameter that accepts pipeline input. You can use a `Get-Help` command with
-the **Full** or **Parameter** parameters to determine which, if any, of a
-cmdlet's parameters accepts pipeline input.
+When PowerShell can't associate the piped objects with a parameter of the
+receiving cmdlet, the command fails.
 
-In the `Get-Help` default display, the "Accept pipeline input?" item appears
-in a table of parameter attributes. This table is displayed only when you use
-the **Full** or **Parameter** parameters of the `Get-Help` cmdlet.
-
-For example, to determine which of the parameters of the `Start-Service`
-cmdlet accepts pipeline input, type:
+In the following example, we try to move a registry entry from one registry
+key to another. The `Get-Item` cmdlet gets the destination path, which
+is then piped to the `Move-ItemProperty` cmdlet. The `Move-ItemProperty`
+command specifies the current path and name of the registry entry to be moved.
 
 ```powershell
-Get-Help Start-Service -Full
-```
-
-or
-
-```powershell
-Get-Help Start-Service -Parameter *
-```
-
-For example, the help for the `Start-Service` cmdlet shows that the
-**InputObject** and **Name** parameters accept pipeline input ("true"). All
-other parameters have a value of "false" in the "Accept pipeline input?" row.
-
-```
--InputObject <ServiceController[]>
-Specifies ServiceController objects representing the services to be started.
-Enter a variable that contains the objects, or type a command or expression
-that gets the objects.
-
-Required?                    true
-Position?                    0
-Default value                None
-Accept pipeline input?       True (ByValue)
-Accept wildcard characters?  false
-
--Name <String[]>
-Specifies the service names for the service to be started.
-
-The parameter name is optional. You can use Name or its alias, ServiceName,
-or you can omit the parameter name.
-
-Required?                    true
-Position?                    0
-Default value                None
-Accept pipeline input?       True (ByPropertyName, ByValue)
-Accept wildcard characters?  false
-```
-
-This means that you can send objects (PsObjects) through the pipeline to the
-`Where-Object` cmdlet and PowerShell will associate the object with the
-**InputObject** and **Name** parameters.
-
-## Methods Of Accepting Pipeline Input
-
-Cmdlets parameters can accept pipeline input in one of two different ways:
-
-- **ByValue**: Parameters that accept input "by value" can accept piped objects
-  that have the same .NET type as their parameter value or objects that can be
-  converted to that type.
-
-  For example, the Name parameter of `Start-Service` accepts pipeline input by
-  value. It can accept string objects or objects that can be converted to
-  strings.
-
-- **ByPropertyName**: Parameters that accept input "by property name" can accept
-  piped objects only when a property of the object has the same name as the
-  parameter.
-
-  For example, the Name parameter of `Start-Service` can accept objects that
-  have a Name property. To list the properties of an object, pipe it to
-  `Get-Member`.
-
-Some parameters can accept objects by value or by property name. These
-parameters are designed to take input from the pipeline easily.
-
-## Investigating Pipeline Errors
-
-If a command fails because of a pipeline error, you can investigate the
-failure and rewrite the command.
-
-For example, the following command tries to move a registry entry from one
-registry key to another by using the `Get-Item` cmdlet to get the destination
-path and then piping the path to the `Move-ItemProperty` cmdlet.
-
-Specifically, the command uses the `Get-Item` cmdlet to get the destination
-path. It uses a pipeline operator to send the result to the
-`Move-ItemProperty` cmdlet. The `Move-ItemProperty` command specifies the
-current path and name of the registry entry to be moved.
-
-For example,
-
-```powershell
-Get-Item -Path HKLM:\software\mycompany\sales |
-Move-ItemProperty -Path HKLM:\software\mycompany\design -Name product
+Get-Item -Path HKLM:\Software\MyCompany\sales |
+Move-ItemProperty -Path HKLM:\Software\MyCompany\design -Name product
 ```
 
 The command fails and PowerShell displays the following error
 message:
 
-```output
-Move-ItemProperty : The input object cannot be bound to any parameters for
-the command either because the command does not take pipeline input or the
+```Output
+Move-ItemProperty : The input object can't be bound to any parameters for
+the command either because the command doesn't take pipeline input or the
 input and its properties do not match any of the parameters that take
 pipeline input.
 At line:1 char:23
-+ $a | Move-ItemProperty <<<<  -Path HKLM:\software\mycompany\design -Name p
++ $a | Move-ItemProperty <<<<  -Path HKLM:\Software\MyCompany\design -Name p
 ```
 
-To investigate, use the `Trace-Command` cmdlet to trace the Parameter Binding
-component of PowerShell. The following command traces the Parameter Binding
-component while the command is processing. It uses the `-PSHost` parameter to
-display the results at the console and the `-filepath` command to send them to
-the `debug.txt` file for later reference.
-
-For example,
+To investigate, use the `Trace-Command` cmdlet to trace the parameter binding
+component of PowerShell. The following example traces parameter binding while
+the pipeline is executing. The **PSHost** parameter displays the trace results
+in the console and the **FilePath** parameter send the trace results to the
+`debug.txt` file for later reference.
 
 ```powershell
-Trace-Command -Name parameterbinding -Expression {
-  Get-Item -Path HKLM:\software\mycompany\sales |
-    Move-ItemProperty -Path HKLM:\software\mycompany\design -Name product} `
- -PSHost -FilePath debug.txt
+Trace-Command -Name ParameterBinding -PSHost -FilePath debug.txt -Expression {
+  Get-Item -Path HKLM:\Software\MyCompany\sales |
+    Move-ItemProperty -Path HKLM:\Software\MyCompany\design -Name product
+}
 ```
 
 The results of the trace are lengthy, but they show the values being bound to
@@ -484,7 +420,7 @@ the `Get-Item` cmdlet and then the named values being bound to the
 ...
 
 BIND NAMED cmd line args [`Move-ItemProperty`]
-BIND arg [HKLM:\software\mycompany\design] to parameter [Path]
+BIND arg [HKLM:\Software\MyCompany\design] to parameter [Path]
 
 ...
 
@@ -506,26 +442,19 @@ parameter of `Move-ItemProperty` failed.
 BIND PIPELINE object to parameters: [`Move-ItemProperty`]
 PIPELINE object TYPE = [Microsoft.Win32.RegistryKey]
 RESTORING pipeline parameter's original values
-Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO CO
-ERCION
-Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO COE
-RCION
+Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO
+COERCION
+Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO
+COERCION
 
 ...
 ```
 
-To investigate the failure, use the `Get-Help` cmdlet to view the attributes
-of the **Destination** parameter. The following command gets detailed
-information about the **Destination** parameter.
+Use the `Get-Help` cmdlet to view the attributes of the **Destination** parameter.
 
-```powershell
+```
 Get-Help Move-ItemProperty -Parameter Destination
-```
 
-The results show that **Destination** takes pipeline input only "by property
-name". That is, the piped object must have a property named **Destination**.
-
-```
 -Destination <String>
     Specifies the path to the destination location.
 
@@ -536,59 +465,78 @@ name". That is, the piped object must have a property named **Destination**.
     Accept wildcard characters?  false
 ```
 
-To see the properties of the object being piped to the `Move-ItemProperty`
-cmdlet, pipe it to the `Get-Member` cmdlet. The following command pipes the
-results of the first part of the command to the `Get-Member` cmdlet.
+The results show that **Destination** takes pipeline input only "by property
+name". Therefore, the piped object must have a property named **Destination**.
 
-For example,
+Use `Get-Member` to see the properties of the object coming from `Get-Item`.
 
 ```powershell
-Get-Item -Path HKLM:\software\mycompany\sales | Get-Member
+Get-Item -Path HKLM:\Software\MyCompany\sales | Get-Member
 ```
 
-The output shows that the item is a **Microsoft.Win32.RegistryKey** that does
-not have a **Destination** property. That explains why the command failed.
+The output shows that the item is a **Microsoft.Win32.RegistryKey** object that
+doesn't have a **Destination** property. That explains why the command failed.
+
+The **Path** parameter accepts pipeline input by name or by value.
+
+```
+Get-Help Move-ItemProperty -Parameter Path
+
+-Path <String[]>
+    Specifies the path to the current location of the property. Wildcard
+    characters are permitted.
+
+    Required?                    true
+    Position?                    0
+    Default value                None
+    Accept pipeline input?       True (ByPropertyName, ByValue)
+    Accept wildcard characters?  true
+```
 
 To fix the command, we must specify the destination in the `Move-ItemProperty`
-cmdlet. We can use a `Get-ItemProperty` command to get the path, but the name
-and destination must be specified in the `Move-ItemProperty` part of the
-command.
+cmdlet and use `Get-Item` to get the **Path** of the item we want to move.
 
 For example,
 
 ```powershell
-Get-Item -Path HKLM:\software\mycompany\design |
-Move-ItemProperty -Destination HKLM:\software\mycompany\sales -Name product
+Get-Item -Path HKLM:\Software\MyCompany\design |
+Move-ItemProperty -Destination HKLM:\Software\MyCompany\sales -Name product
 ```
 
-To verify that the command worked, use a `Get-ItemProperty` command:
+## Intrinsic line continuation
 
-For example,
+As already discussed, a pipeline is a series of commands connected by pipeline
+operators (`|`), usually written on a single line. However, for
+readability, PowerShell allows you to split the pipeline across multiple lines.
+When a pipe operator is the last token on the line, the PowerShell parser joins
+the next line to current command to continue the construction of the pipeline.
+
+For example, the following single-line pipeline:
 
 ```powershell
-Get-ItemProperty HKLM:\software\mycompany\sales
+Command-1 | Command-2 | Command-3
 ```
 
-The results show that the **Product** registry entry was moved to the **Sales**
-key.
+can be written as:
 
-```Output
-PSPath       : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\softwa
-re\mycompany\sales
-PSParentPath : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\softwa
-re\mycompany
-PSChildName  : sales
-PSDrive      : HKLM
-PSProvider   : Microsoft.PowerShell.Core\Registry
-Product      : 18
+```powershell
+Command-1 |
+  Command-2 |
+    Command-3
 ```
+
+The leading spaces on the subsequent lines are not significant. The indentation
+enhances readability.
 
 ## See Also
 
-[about_objects](about_objects.md)
+[about_PSReadLine](../../PSReadLine/About/about_PSReadLine.md)
 
-[about_parameters](about_parameters.md)
+[about_Objects](about_objects.md)
 
-[about_command_syntax](about_command_syntax.md)
+[about_Parameters](about_parameters.md)
 
-[about_foreach](about_foreach.md)
+[about_Command_Syntax](about_command_syntax.md)
+
+[about_ForEach](about_foreach.md)
+

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -65,7 +65,7 @@ Get-ChildItem -Path *.txt |
 ```
 
 This pipeline consists of four commands in the specified order. The following
-illustration shows the output from each command as it is passed to the next
+illustration shows the output from each command as it's passed to the next
 command in the pipeline.
 
 ```
@@ -226,10 +226,10 @@ to associate the piped objects with a parameter of the receiving cmdlet.
 PowerShell's parameter binding component associates the input objects with
 cmdlet parameters according to the following criteria:
 
-- The parameter must accept input from a pipeline
+- The parameter must accept input from a pipeline.
 - The parameter must accept the type of object being sent or a type that can be
-  converted to the expected type
-- The parameter was not used in the command
+  converted to the expected type.
+- The parameter wasn't used in the command.
 
 For example, the `Start-Service` cmdlet has many parameters, but only two of
 them, **Name** and **InputObject** accept pipeline input. The **Name**
@@ -248,7 +248,7 @@ article.
 ### One-at-a-time processing
 
 Piping objects to a command is much like using a parameter of the command to
-submit the objects. Let look at a pipeline example. In this example, we use a
+submit the objects. Let's look at a pipeline example. In this example, we use a
 pipeline to display a table of service objects.
 
 ```powershell
@@ -416,29 +416,22 @@ The results of the trace are lengthy, but they show the values being bound to
 the `Get-Item` cmdlet and then the named values being bound to the
 `Move-ItemProperty` cmdlet.
 
-```
+```Output
 ...
-
 BIND NAMED cmd line args [`Move-ItemProperty`]
 BIND arg [HKLM:\Software\MyCompany\design] to parameter [Path]
-
 ...
-
 BIND arg [product] to parameter [Name]
-
 ...
-
 BIND POSITIONAL cmd line args [`Move-ItemProperty`]
-
 ...
 ```
 
 Finally, it shows that the attempt to bind the path to the **Destination**
 parameter of `Move-ItemProperty` failed.
 
-```
+```Output
 ...
-
 BIND PIPELINE object to parameters: [`Move-ItemProperty`]
 PIPELINE object TYPE = [Microsoft.Win32.RegistryKey]
 RESTORING pipeline parameter's original values
@@ -446,13 +439,12 @@ Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO
 COERCION
 Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO
 COERCION
-
 ...
 ```
 
 Use the `Get-Help` cmdlet to view the attributes of the **Destination** parameter.
 
-```
+```Output
 Get-Help Move-ItemProperty -Parameter Destination
 
 -Destination <String>
@@ -479,7 +471,7 @@ doesn't have a **Destination** property. That explains why the command failed.
 
 The **Path** parameter accepts pipeline input by name or by value.
 
-```
+```Output
 Get-Help Move-ItemProperty -Parameter Path
 
 -Path <String[]>

--- a/reference/5.0/PSReadline/About/about_PSReadline.md
+++ b/reference/5.0/PSReadline/About/about_PSReadline.md
@@ -607,6 +607,15 @@ The contents of the kill ring are cleared.
 This is similar to Yank, but uses the system clipboard instead of the kill
 ring.
 
+ [!IMPORTANT]
+> When using the **Paste** function, the entire contents of the clipboard
+> buffer is pasted into the input buffer of PSReadLine. The input buffer is
+> then passed to the PowerShell parser. Input pasted using the console
+> application's **right-click** paste method is copied to the input buffer one
+> character at a time. The input buffer is passed to the parser when a newline
+> character is copied. Therefore, the input is parsed one line at a time. The
+> difference between paste methods results in different execution behavior.
+
 ### YankLastArg
 
 - Cmd: `<Alt+.>`

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  02/14/2018
+ms.date:  09/27/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -7,20 +7,20 @@ title:  about_pipelines
 ---
 # About Pipelines
 
-## Short Description
+## Short description
 
 Combining commands into pipelines in the PowerShell
 
-## Long Description
+## Long description
 
 A pipeline is a series of commands connected by pipeline operators (`|`)
 (ASCII 124). Each pipeline operator sends the results of the preceding command
 to the next command.
 
-You can use pipelines to send the objects that are output by one command to be
-used as input to another command for processing. And you can send the output
-of that command to yet another command. The result is a very powerful command
-chain or "pipeline" that is comprised of a series of simple commands.
+The output of the first command can be sent for processing as input to the
+second command. And that output can be sent to yet another command. The result
+is a complex command chain or _pipeline_ that is composed of a series of
+simple commands.
 
 For example,
 
@@ -33,9 +33,9 @@ In this example, the objects that `Command-1` emits are sent to `Command-2`.
 processes the objects and send them down the pipeline. Because there are no
 more commands in the pipeline, the results are displayed at the console.
 
-In a pipeline, the commands are processed from left to right in the order that
-they appear. The processing is handled as a single operation and output is
-displayed as it is generated.
+In a pipeline, the commands are processed in order from left to right. The
+processing is handled as a single operation and output is displayed as it's
+generated.
 
 Here is a simple example. The following command gets the Notepad process and
 then stops it.
@@ -49,67 +49,45 @@ Get-Process notepad | Stop-Process
 The first command uses the `Get-Process` cmdlet to get an object representing
 the Notepad process. It uses a pipeline operator (`|`) to send the process
 object to the `Stop-Process` cmdlet, which stops the Notepad process. Notice
-that the `Stop-Process` command does not have a **Name** or **ID** parameter to
+that the `Stop-Process` command doesn't have a **Name** or **ID** parameter to
 specify the process, because the specified process is submitted through the
 pipeline.
 
-Here is a practical example. This command pipeline gets the text files in the
-current directory, selects only the files that are more than 10,000 bytes
-long, sorts them by length, and displays the name and length of each file in a
-table.
+This pipeline example gets the text files in the current directory, selects
+only the files that are more than 10,000 bytes long, sorts them by length, and
+displays the name and length of each file in a table.
 
 ```powershell
-Get-ChildItem -Path *.txt | Where-Object {$_.length -gt 10000} |
-Sort-Object -Property length | Format-Table -Property name, length
+Get-ChildItem -Path *.txt |
+  Where-Object {$_.length -gt 10000} |
+    Sort-Object -Property length |
+      Format-Table -Property name, length
 ```
 
-This pipeline is comprised of four commands in the specified order. The
-command is written horizontally, but we will show the process vertically in
-the following graphic.
-
-`Get-ChildItem` `-Path` *.txt
+This pipeline consists of four commands in the specified order. The following
+illustration shows the output from each command as it is passed to the next
+command in the pipeline.
 
 ```
-|
-|   (FileInfo objects for *.txt)
-|
+Get-ChildItem -Path *.txt
+| (FileInfo objects for *.txt)
 V
-```
-
-`Where-Object` {$_.length `-gt` 10000}
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|
+Where-Object {$_.length -gt 10000}
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
 V
-```
-
-`Sort-Object` `-Property` Length
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|   (    Sorted by length      )
-|
+Sort-Object -Property Length
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
+| (     Sorted by length     )
 V
-```
-
-`Format-Table` `-Property` name, length
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|   (    Sorted by length      )
-|   (  Formatted in a table    )
-|
+Format-Table -Property name, length
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
+| (     Sorted by length     )
+| (   Formatted in a table   )
 V
-```
 
-```output
 Name                       Length
 ----                       ------
 tmp1.txt                    82920
@@ -117,33 +95,23 @@ tmp2.txt                   114000
 tmp3.txt                   114000
 ```
 
-## Using Pipelines
+## Using pipelines
 
-The PowerShell cmdlets were designed to be used in pipelines. For example, you
-can usually pipe the results of a **Get** cmdlet to an action cmdlet (such as a
-**Set**, **Start**, **Stop**, or **Rename** cmdlet) for the same noun.
+Most PowerShell cmdlets are designed to support pipelines. In most cases, you
+can _pipe_ the results of a **Get** cmdlet to another cmdlet of the same noun.
+For example, you can pipe the output of the `Get-Service` cmdlet to the
+`Start-Service` or `Stop-Service` cmdlets.
 
-For example, you can pipe any service from the `Get-Service` cmdlet to the
-`Start-Service` or `Stop-Service` cmdlets (although disabled services cannot
-be restarted in this way).
-
-This command pipeline starts the WMI service on the computer:
-
-For example,
+This example pipeline starts the WMI service on the computer:
 
 ```powershell
 Get-Service wmi | Start-Service
 ```
 
-The cmdlets that get and set objects of the PowerShell providers, such as the
-**Item** and **ItemProperty** cmdlets, are also designed to be used in pipelines.
-
-For example, you can pipe the results of a `Get-Item` or `Get-ChildItem`
-command in the PowerShell registry provider to the `New-ItemProperty` cmdlet.
-This command adds a new registry entry, **NoOfEmployees**, with a value of 8124,
+For another example, you can pipe the output of `Get-Item` or `Get-ChildItem`
+within the PowerShell registry provider to the `New-ItemProperty` cmdlet. This
+example adds a new registry entry, **NoOfEmployees**, with a value of **8124**,
 to the **MyCompany** registry key.
-
-For example,
 
 ```powershell
 Get-Item -Path HKLM:\Software\MyCompany |
@@ -151,27 +119,20 @@ Get-Item -Path HKLM:\Software\MyCompany |
 ```
 
 Many of the utility cmdlets, such as `Get-Member`, `Where-Object`,
-`Sort-Object`, `Group-Object`, and `Measure-Object` are used almost
-exclusively in pipelines. You can pipe any objects to these cmdlets.
-
-For example, you can pipe all of the processes on the computer to the
-`Sort-Object` command and have them sorted by the number of handles in the
-process.
-
-For example,
+`Sort-Object`, `Group-Object`, and `Measure-Object` are used almost exclusively
+in pipelines. You can pipe any object type to these cmdlets. This example shows
+how to sort all the processes on the computer by the number of open handles in
+each process.
 
 ```powershell
 Get-Process | Sort-Object -Property handles
 ```
 
-Also, you can pipe any objects to the formatting cmdlets, such as
-`Format-List` and `Format-Table`, the Export cmdlets, such as `Export-Clixml`
-and `Export-CSV`, and the Out cmdlets, such as `Out-Printer`.
+You can pipe objects to the formatting, export, and output cmdlets, such as
+`Format-List`, `Format-Table`, `Export-Clixml`, `Export-CSV`, and `Out-File`.
 
-For example, you can pipe the "Winlogon" process to the `Format-List` cmdlet to
-display all of the properties of the process in a list.
-
-For example,
+This example shows how to use the `Format-List` cmdlet to display a list of
+properties for a process object.
 
 ```powershell
 Get-Process winlogon | Format-List -Property *
@@ -180,86 +141,149 @@ Get-Process winlogon | Format-List -Property *
 With a bit of practice, you'll find that combining simple commands into
 pipelines saves time and typing, and makes your scripting more efficient.
 
-## How Pipelines Work
+## How pipelines work
 
-When you "pipe" objects, that is send the objects in the output of one command
-to another command, PowerShell tries to associate the piped objects with one
-of the parameters of the receiving cmdlet.
+This section explains how input objects are bound to cmdlet parameters and
+processed during pipeline execution.
 
-To do so, the PowerShell "parameter binding" component, which associates input
-objects with cmdlet parameters, tries to find a parameter that meets the
-following criteria:
+### Accepts pipeline input
 
-- The parameter must accept input from a pipeline (not all do).
-- The parameter must accept the type of object being sent or a type that the
-  object can be converted to.
-- The parameter must not already be used in the command.
+To support pipelining, the receiving cmdlet must have a parameter that accepts
+pipeline input. Use the `Get-Help` command with the **Full** or **Parameter**
+options to determine which parameters of a cmdlet accept pipeline input.
 
-For example, the `Start-Service` cmdlet has many parameters, but only two of
-them, `-Name` and `-InputObject` accept pipeline input. The `-Name` parameter
-takes strings and the `-InputObject` parameter takes service objects.
-Therefore, you can pipe strings and service objects (and objects with
-properties that can be converted to string and service objects) to
-`Start-Service`.
-
-If the parameter binding component of PowerShell cannot associate the piped
-objects with a parameter of the receiving cmdlet, the command fails and
-PowerShell prompts you for the missing parameter values.
-
-You cannot force the parameter binding component to associate the piped
-objects with a particular parameter. You cannot even suggest a parameter.
-Instead, the logic of the component manages the piping as efficiently as
-possible.
-
-## One-At-A-Time Processing
-
-Piping objects to a command is much like using a parameter of the command to
-submit the objects.
-
-For example, piping objects representing the services on the computer to a
-`Format-Table` command, such as:
+For example, to determine which of the parameters of the `Start-Service`
+cmdlet accepts pipeline input, type:
 
 ```powershell
-Get-Service | Format-Table -Property name, dependentservices
+Get-Help Start-Service -Full
 ```
 
-is much like saving the service objects in a variable and using the
-**InputObject** parameter of `Format-Table` to submit the service object.
+or
 
-For example,
+```powershell
+Get-Help Start-Service -Parameter *
+```
+
+The help for the `Start-Service` cmdlet shows that only the **InputObject** and
+**Name** parameters accept pipeline input.
+
+```Output
+-InputObject <ServiceController[]>
+Specifies ServiceController objects representing the services to be started.
+Enter a variable that contains the objects, or type a command or expression
+that gets the objects.
+
+Required?                    true
+Position?                    0
+Default value                None
+Accept pipeline input?       True (ByValue)
+Accept wildcard characters?  false
+
+-Name <String[]>
+Specifies the service names for the service to be started.
+
+The parameter name is optional. You can use Name or its alias, ServiceName,
+or you can omit the parameter name.
+
+Required?                    true
+Position?                    0
+Default value                None
+Accept pipeline input?       True (ByPropertyName, ByValue)
+Accept wildcard characters?  false
+```
+
+When you send objects through the pipeline to `Start-Service`, PowerShell
+attempts to associate the objects with the **InputObject** and **Name**
+parameters.
+
+### Methods of accepting pipeline input
+
+Cmdlets parameters can accept pipeline input in one of two different ways:
+
+- **ByValue**: The parameter accepts values that match the expected .NET type
+  or that can be converted to that type.
+
+  For example, the **Name** parameter of `Start-Service` accepts pipeline input
+  by value. It can accept string objects or objects that can be converted to
+  strings.
+
+- **ByPropertyName**: The parameter accepts input only when the input object
+  has a property of the same name as the parameter.
+
+  For example, the Name parameter of `Start-Service` can accept objects that
+  have a **Name** property. To list the properties of an object, pipe it to
+  `Get-Member`.
+
+Some parameters can accept objects by both value or property name, making it
+easier to take input from the pipeline.
+
+### Parameter binding
+
+When you pipe objects from one command to another command, PowerShell attempts
+to associate the piped objects with a parameter of the receiving cmdlet.
+
+PowerShell's parameter binding component associates the input objects with
+cmdlet parameters according to the following criteria:
+
+- The parameter must accept input from a pipeline
+- The parameter must accept the type of object being sent or a type that can be
+  converted to the expected type
+- The parameter was not used in the command
+
+For example, the `Start-Service` cmdlet has many parameters, but only two of
+them, **Name** and **InputObject** accept pipeline input. The **Name**
+parameter takes strings and the **InputObject** parameter takes service
+objects. Therefore, you can pipe strings, service objects, and objects with
+properties that can be converted to string or service objects.
+
+PowerShell manages parameter binding as efficiently as possible. You can't
+suggest or force the PowerShell to bind to a specific parameter. The command
+fails if PowerShell can't bind the piped objects.
+
+For more information about troubleshooting binding errors, see
+[Investigating Pipeline Errors](#investigating-pipeline-errors) later in this
+article.
+
+### One-at-a-time processing
+
+Piping objects to a command is much like using a parameter of the command to
+submit the objects. Let look at a pipeline example. In this example, we use a
+pipeline to display a table of service objects.
+
+```powershell
+Get-Service | Format-Table -Property Name, DependentServices
+```
+
+Functionally, this is like using the **InputObject** parameter of `Format-Table`
+to submit the object collection.
+
+For example, we can save the collection of services to a variable that is
+passed using the **InputObject** parameter.
 
 ```powershell
 $services = Get-Service
-Format-Table -InputObject $services -Property name, dependentservices
+Format-Table -InputObject $services -Property Name, DependentServices
 ```
 
-or imbedding the command in the parameter value
-
-For example,
+Or we can embed the command in the **InputObject** parameter.
 
 ```powershell
-Format-Table -InputObject (Get-Service wmi) -Property name,dependentservices
+Format-Table -InputObject (Get-Service) -Property Name, DependentServices
 ```
 
-However, there is an important difference. When you pipe multiple objects to a
+However, there's an important difference. When you pipe multiple objects to a
 command, PowerShell sends the objects to the command one at a time. When you
-use a command parameter, the objects are sent as a single array object.
+use a command parameter, the objects are sent as a single array object. This
+minor difference has significant consequences.
 
-This seemingly technical difference can have interesting, and sometimes
-useful, consequences.
+When executing a pipeline, PowerShell automatically enumerates any type that
+implements the `IEnumerable` interface and sends the members through the
+pipeline one at a time. The exception is `[hashtable]`, which requires a call
+to the `GetEnumerator()` method.
 
-For example, if you pipe multiple process objects from the `Get-Process`
-cmdlet to the `Get-Member` cmdlet, PowerShell sends each process object, one
-at a time, to `Get-Member`. `Get-Member` displays the .NET class (type) of the
-process objects, and their properties and methods.
-
-PowerShell automatically enumerates any type that implements the `IEnumerable`
-interface and sends the members through the pipeline one at a time. The
-exception is `[hashtable]`, which requires a call to the `GetEnumerator()`
-method.
-
-In the example below, an array and a hashtable are piped to the `Measure-Object`
-cmdlet, which counts the number of objects received from the pipeline. The array
+In the following examples, an array and a hashtable are piped to the `Measure-Object`
+cmdlet to count the number of objects received from the pipeline. The array
 has multiple members, and the hashtable has multiple key-value pairs. Only the
 array is enumerated one at a time.
 
@@ -289,14 +313,10 @@ Minimum  :
 Property :
 ```
 
-> [!NOTE]
-> `Get-Member` eliminates duplicates, so if the objects are all of the
-> same type, it displays only one object type.
-
-In this case, `Get-Member` displays the properties and methods of each process
-object, that is, a System.Diagnostics.Process object.
-
-For example,
+Similarly, if you pipe multiple process objects from the `Get-Process` cmdlet
+to the `Get-Member` cmdlet, PowerShell sends each process object, one at a
+time, to `Get-Member`. `Get-Member` displays the .NET class (type) of the
+process objects, and their properties and methods.
 
 ```powershell
 Get-Process | Get-Member
@@ -313,9 +333,13 @@ NPM       AliasProperty  NPM = NonpagedSystemMemorySize
 ...
 ```
 
+> [!NOTE]
+> `Get-Member` eliminates duplicates, so if the objects are all of the same
+> type, it only displays one object type.
+
 However, if you use the **InputObject** parameter of `Get-Member`, then
 `Get-Member` receives an array of **System.Diagnostics.Process** objects as a
-single unit, and it displays the properties of an array of objects. (Note the
+single unit. It displays the properties of an array of objects. (Note the
 array symbol (`[]`) after the **System.Object** type name.)
 
 For example,
@@ -335,9 +359,9 @@ Clone              Method        System.Object Clone()
 ...
 ```
 
-This result might not be what you intended, but after you understand it, you
-can use it. For example, an array of process objects has a **Count** property
-that you can use to count the number of processes on the computer.
+This result might not be what you intended. But after you understand it, you
+can use it. For example, all array objects have a **Count** property. You can
+use that to count the number of processes running on the computer.
 
 For example,
 
@@ -345,135 +369,47 @@ For example,
 (Get-Process).count
 ```
 
-This distinction can be important, so remember that when you pipe objects to a
-cmdlet, they are delivered one at a time.
+It's important to remember that objects sent down the pipeline are delivered
+one at a time.
 
-## Accepts Pipeline Input
+## Investigating pipeline errors
 
-In order to receive objects in a pipeline, the receiving cmdlet must have a
-parameter that accepts pipeline input. You can use a `Get-Help` command with
-the **Full** or **Parameter** parameters to determine which, if any, of a
-cmdlet's parameters accepts pipeline input.
+When PowerShell can't associate the piped objects with a parameter of the
+receiving cmdlet, the command fails.
 
-In the `Get-Help` default display, the "Accept pipeline input?" item appears
-in a table of parameter attributes. This table is displayed only when you use
-the **Full** or **Parameter** parameters of the `Get-Help` cmdlet.
-
-For example, to determine which of the parameters of the `Start-Service`
-cmdlet accepts pipeline input, type:
+In the following example, we try to move a registry entry from one registry
+key to another. The `Get-Item` cmdlet gets the destination path, which
+is then piped to the `Move-ItemProperty` cmdlet. The `Move-ItemProperty`
+command specifies the current path and name of the registry entry to be moved.
 
 ```powershell
-Get-Help Start-Service -Full
-```
-
-or
-
-```powershell
-Get-Help Start-Service -Parameter *
-```
-
-For example, the help for the `Start-Service` cmdlet shows that the
-**InputObject** and **Name** parameters accept pipeline input ("true"). All
-other parameters have a value of "false" in the "Accept pipeline input?" row.
-
-```
--InputObject <ServiceController[]>
-Specifies ServiceController objects representing the services to be started.
-Enter a variable that contains the objects, or type a command or expression
-that gets the objects.
-
-Required?                    true
-Position?                    0
-Default value                None
-Accept pipeline input?       True (ByValue)
-Accept wildcard characters?  false
-
--Name <String[]>
-Specifies the service names for the service to be started.
-
-The parameter name is optional. You can use Name or its alias, ServiceName,
-or you can omit the parameter name.
-
-Required?                    true
-Position?                    0
-Default value                None
-Accept pipeline input?       True (ByPropertyName, ByValue)
-Accept wildcard characters?  false
-```
-
-This means that you can send objects (PsObjects) through the pipeline to the
-`Where-Object` cmdlet and PowerShell will associate the object with the
-**InputObject** and **Name** parameters.
-
-## Methods Of Accepting Pipeline Input
-
-Cmdlets parameters can accept pipeline input in one of two different ways:
-
-- **ByValue**: Parameters that accept input "by value" can accept piped objects
-  that have the same .NET type as their parameter value or objects that can be
-  converted to that type.
-
-  For example, the Name parameter of `Start-Service` accepts pipeline input by
-  value. It can accept string objects or objects that can be converted to
-  strings.
-
-- **ByPropertyName**: Parameters that accept input "by property name" can accept
-  piped objects only when a property of the object has the same name as the
-  parameter.
-
-  For example, the Name parameter of `Start-Service` can accept objects that
-  have a Name property. To list the properties of an object, pipe it to
-  `Get-Member`.
-
-Some parameters can accept objects by value or by property name. These
-parameters are designed to take input from the pipeline easily.
-
-## Investigating Pipeline Errors
-
-If a command fails because of a pipeline error, you can investigate the
-failure and rewrite the command.
-
-For example, the following command tries to move a registry entry from one
-registry key to another by using the `Get-Item` cmdlet to get the destination
-path and then piping the path to the `Move-ItemProperty` cmdlet.
-
-Specifically, the command uses the `Get-Item` cmdlet to get the destination
-path. It uses a pipeline operator to send the result to the
-`Move-ItemProperty` cmdlet. The `Move-ItemProperty` command specifies the
-current path and name of the registry entry to be moved.
-
-For example,
-
-```powershell
-Get-Item -Path HKLM:\software\mycompany\sales |
-Move-ItemProperty -Path HKLM:\software\mycompany\design -Name product
+Get-Item -Path HKLM:\Software\MyCompany\sales |
+Move-ItemProperty -Path HKLM:\Software\MyCompany\design -Name product
 ```
 
 The command fails and PowerShell displays the following error
 message:
 
-```output
-Move-ItemProperty : The input object cannot be bound to any parameters for
-the command either because the command does not take pipeline input or the
+```Output
+Move-ItemProperty : The input object can't be bound to any parameters for
+the command either because the command doesn't take pipeline input or the
 input and its properties do not match any of the parameters that take
 pipeline input.
 At line:1 char:23
-+ $a | Move-ItemProperty <<<<  -Path HKLM:\software\mycompany\design -Name p
++ $a | Move-ItemProperty <<<<  -Path HKLM:\Software\MyCompany\design -Name p
 ```
 
-To investigate, use the `Trace-Command` cmdlet to trace the Parameter Binding
-component of PowerShell. The following command traces the Parameter Binding
-component while the command is processing. It uses the `-PSHost` parameter to
-display the results at the console and the `-filepath` command to send them to
-the `debug.txt` file for later reference.
-
-For example,
+To investigate, use the `Trace-Command` cmdlet to trace the parameter binding
+component of PowerShell. The following example traces parameter binding while
+the pipeline is executing. The **PSHost** parameter displays the trace results
+in the console and the **FilePath** parameter send the trace results to the
+`debug.txt` file for later reference.
 
 ```powershell
-Trace-Command -Name parameterbinding -Expression {
-  Get-Item -Path HKLM:\software\mycompany\sales |
-    Move-ItemProperty -Path HKLM:\software\mycompany\design -Name product} `
- -PSHost -FilePath debug.txt
+Trace-Command -Name ParameterBinding -PSHost -FilePath debug.txt -Expression {
+  Get-Item -Path HKLM:\Software\MyCompany\sales |
+    Move-ItemProperty -Path HKLM:\Software\MyCompany\design -Name product
+}
 ```
 
 The results of the trace are lengthy, but they show the values being bound to
@@ -484,7 +420,7 @@ the `Get-Item` cmdlet and then the named values being bound to the
 ...
 
 BIND NAMED cmd line args [`Move-ItemProperty`]
-BIND arg [HKLM:\software\mycompany\design] to parameter [Path]
+BIND arg [HKLM:\Software\MyCompany\design] to parameter [Path]
 
 ...
 
@@ -506,26 +442,19 @@ parameter of `Move-ItemProperty` failed.
 BIND PIPELINE object to parameters: [`Move-ItemProperty`]
 PIPELINE object TYPE = [Microsoft.Win32.RegistryKey]
 RESTORING pipeline parameter's original values
-Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO CO
-ERCION
-Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO COE
-RCION
+Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO
+COERCION
+Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO
+COERCION
 
 ...
 ```
 
-To investigate the failure, use the `Get-Help` cmdlet to view the attributes
-of the **Destination** parameter. The following command gets detailed
-information about the **Destination** parameter.
+Use the `Get-Help` cmdlet to view the attributes of the **Destination** parameter.
 
-```powershell
+```
 Get-Help Move-ItemProperty -Parameter Destination
-```
 
-The results show that **Destination** takes pipeline input only "by property
-name". That is, the piped object must have a property named **Destination**.
-
-```
 -Destination <String>
     Specifies the path to the destination location.
 
@@ -536,59 +465,78 @@ name". That is, the piped object must have a property named **Destination**.
     Accept wildcard characters?  false
 ```
 
-To see the properties of the object being piped to the `Move-ItemProperty`
-cmdlet, pipe it to the `Get-Member` cmdlet. The following command pipes the
-results of the first part of the command to the `Get-Member` cmdlet.
+The results show that **Destination** takes pipeline input only "by property
+name". Therefore, the piped object must have a property named **Destination**.
 
-For example,
+Use `Get-Member` to see the properties of the object coming from `Get-Item`.
 
 ```powershell
-Get-Item -Path HKLM:\software\mycompany\sales | Get-Member
+Get-Item -Path HKLM:\Software\MyCompany\sales | Get-Member
 ```
 
-The output shows that the item is a **Microsoft.Win32.RegistryKey** that does
-not have a **Destination** property. That explains why the command failed.
+The output shows that the item is a **Microsoft.Win32.RegistryKey** object that
+doesn't have a **Destination** property. That explains why the command failed.
+
+The **Path** parameter accepts pipeline input by name or by value.
+
+```
+Get-Help Move-ItemProperty -Parameter Path
+
+-Path <String[]>
+    Specifies the path to the current location of the property. Wildcard
+    characters are permitted.
+
+    Required?                    true
+    Position?                    0
+    Default value                None
+    Accept pipeline input?       True (ByPropertyName, ByValue)
+    Accept wildcard characters?  true
+```
 
 To fix the command, we must specify the destination in the `Move-ItemProperty`
-cmdlet. We can use a `Get-ItemProperty` command to get the path, but the name
-and destination must be specified in the `Move-ItemProperty` part of the
-command.
+cmdlet and use `Get-Item` to get the **Path** of the item we want to move.
 
 For example,
 
 ```powershell
-Get-Item -Path HKLM:\software\mycompany\design |
-Move-ItemProperty -Destination HKLM:\software\mycompany\sales -Name product
+Get-Item -Path HKLM:\Software\MyCompany\design |
+Move-ItemProperty -Destination HKLM:\Software\MyCompany\sales -Name product
 ```
 
-To verify that the command worked, use a `Get-ItemProperty` command:
+## Intrinsic line continuation
 
-For example,
+As already discussed, a pipeline is a series of commands connected by pipeline
+operators (`|`), usually written on a single line. However, for
+readability, PowerShell allows you to split the pipeline across multiple lines.
+When a pipe operator is the last token on the line, the PowerShell parser joins
+the next line to current command to continue the construction of the pipeline.
+
+For example, the following single-line pipeline:
 
 ```powershell
-Get-ItemProperty HKLM:\software\mycompany\sales
+Command-1 | Command-2 | Command-3
 ```
 
-The results show that the **Product** registry entry was moved to the **Sales**
-key.
+can be written as:
 
-```Output
-PSPath       : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\softwa
-re\mycompany\sales
-PSParentPath : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\softwa
-re\mycompany
-PSChildName  : sales
-PSDrive      : HKLM
-PSProvider   : Microsoft.PowerShell.Core\Registry
-Product      : 18
+```powershell
+Command-1 |
+  Command-2 |
+    Command-3
 ```
+
+The leading spaces on the subsequent lines are not significant. The indentation
+enhances readability.
 
 ## See Also
 
-[about_objects](about_objects.md)
+[about_PSReadLine](../../PSReadLine/About/about_PSReadLine.md)
 
-[about_parameters](about_parameters.md)
+[about_Objects](about_objects.md)
 
-[about_command_syntax](about_command_syntax.md)
+[about_Parameters](about_parameters.md)
 
-[about_foreach](about_foreach.md)
+[about_Command_Syntax](about_command_syntax.md)
+
+[about_ForEach](about_foreach.md)
+

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -65,7 +65,7 @@ Get-ChildItem -Path *.txt |
 ```
 
 This pipeline consists of four commands in the specified order. The following
-illustration shows the output from each command as it is passed to the next
+illustration shows the output from each command as it's passed to the next
 command in the pipeline.
 
 ```
@@ -226,10 +226,10 @@ to associate the piped objects with a parameter of the receiving cmdlet.
 PowerShell's parameter binding component associates the input objects with
 cmdlet parameters according to the following criteria:
 
-- The parameter must accept input from a pipeline
+- The parameter must accept input from a pipeline.
 - The parameter must accept the type of object being sent or a type that can be
-  converted to the expected type
-- The parameter was not used in the command
+  converted to the expected type.
+- The parameter wasn't used in the command.
 
 For example, the `Start-Service` cmdlet has many parameters, but only two of
 them, **Name** and **InputObject** accept pipeline input. The **Name**
@@ -248,7 +248,7 @@ article.
 ### One-at-a-time processing
 
 Piping objects to a command is much like using a parameter of the command to
-submit the objects. Let look at a pipeline example. In this example, we use a
+submit the objects. Let's look at a pipeline example. In this example, we use a
 pipeline to display a table of service objects.
 
 ```powershell
@@ -416,29 +416,22 @@ The results of the trace are lengthy, but they show the values being bound to
 the `Get-Item` cmdlet and then the named values being bound to the
 `Move-ItemProperty` cmdlet.
 
-```
+```Output
 ...
-
 BIND NAMED cmd line args [`Move-ItemProperty`]
 BIND arg [HKLM:\Software\MyCompany\design] to parameter [Path]
-
 ...
-
 BIND arg [product] to parameter [Name]
-
 ...
-
 BIND POSITIONAL cmd line args [`Move-ItemProperty`]
-
 ...
 ```
 
 Finally, it shows that the attempt to bind the path to the **Destination**
 parameter of `Move-ItemProperty` failed.
 
-```
+```Output
 ...
-
 BIND PIPELINE object to parameters: [`Move-ItemProperty`]
 PIPELINE object TYPE = [Microsoft.Win32.RegistryKey]
 RESTORING pipeline parameter's original values
@@ -446,13 +439,12 @@ Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO
 COERCION
 Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO
 COERCION
-
 ...
 ```
 
 Use the `Get-Help` cmdlet to view the attributes of the **Destination** parameter.
 
-```
+```Output
 Get-Help Move-ItemProperty -Parameter Destination
 
 -Destination <String>
@@ -479,7 +471,7 @@ doesn't have a **Destination** property. That explains why the command failed.
 
 The **Path** parameter accepts pipeline input by name or by value.
 
-```
+```Output
 Get-Help Move-ItemProperty -Parameter Path
 
 -Path <String[]>

--- a/reference/5.1/PSReadline/About/about_PSReadline.md
+++ b/reference/5.1/PSReadline/About/about_PSReadline.md
@@ -607,6 +607,15 @@ The contents of the kill ring are cleared.
 This is similar to Yank, but uses the system clipboard instead of the kill
 ring.
 
+ [!IMPORTANT]
+> When using the **Paste** function, the entire contents of the clipboard
+> buffer is pasted into the input buffer of PSReadLine. The input buffer is
+> then passed to the PowerShell parser. Input pasted using the console
+> application's **right-click** paste method is copied to the input buffer one
+> character at a time. The input buffer is passed to the parser when a newline
+> character is copied. Therefore, the input is parsed one line at a time. The
+> difference between paste methods results in different execution behavior.
+
 ### YankLastArg
 
 - Cmd: `<Alt+.>`

--- a/reference/6/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  02/14/2018
+ms.date:  09/27/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -7,20 +7,20 @@ title:  about_pipelines
 ---
 # About Pipelines
 
-## Short Description
+## Short description
 
 Combining commands into pipelines in the PowerShell
 
-## Long Description
+## Long description
 
 A pipeline is a series of commands connected by pipeline operators (`|`)
 (ASCII 124). Each pipeline operator sends the results of the preceding command
 to the next command.
 
-You can use pipelines to send the objects that are output by one command to be
-used as input to another command for processing. And you can send the output
-of that command to yet another command. The result is a very powerful command
-chain or "pipeline" that is comprised of a series of simple commands.
+The output of the first command can be sent for processing as input to the
+second command. And that output can be sent to yet another command. The result
+is a complex command chain or _pipeline_ that is composed of a series of
+simple commands.
 
 For example,
 
@@ -33,9 +33,9 @@ In this example, the objects that `Command-1` emits are sent to `Command-2`.
 processes the objects and send them down the pipeline. Because there are no
 more commands in the pipeline, the results are displayed at the console.
 
-In a pipeline, the commands are processed from left to right in the order that
-they appear. The processing is handled as a single operation and output is
-displayed as it is generated.
+In a pipeline, the commands are processed in order from left to right. The
+processing is handled as a single operation and output is displayed as it's
+generated.
 
 Here is a simple example. The following command gets the Notepad process and
 then stops it.
@@ -49,67 +49,45 @@ Get-Process notepad | Stop-Process
 The first command uses the `Get-Process` cmdlet to get an object representing
 the Notepad process. It uses a pipeline operator (`|`) to send the process
 object to the `Stop-Process` cmdlet, which stops the Notepad process. Notice
-that the `Stop-Process` command does not have a **Name** or **ID** parameter to
+that the `Stop-Process` command doesn't have a **Name** or **ID** parameter to
 specify the process, because the specified process is submitted through the
 pipeline.
 
-Here is a practical example. This command pipeline gets the text files in the
-current directory, selects only the files that are more than 10,000 bytes
-long, sorts them by length, and displays the name and length of each file in a
-table.
+This pipeline example gets the text files in the current directory, selects
+only the files that are more than 10,000 bytes long, sorts them by length, and
+displays the name and length of each file in a table.
 
 ```powershell
-Get-ChildItem -Path *.txt | Where-Object {$_.length -gt 10000} |
-Sort-Object -Property length | Format-Table -Property name, length
+Get-ChildItem -Path *.txt |
+  Where-Object {$_.length -gt 10000} |
+    Sort-Object -Property length |
+      Format-Table -Property name, length
 ```
 
-This pipeline is comprised of four commands in the specified order. The
-command is written horizontally, but we will show the process vertically in
-the following graphic.
-
-`Get-ChildItem` `-Path` *.txt
+This pipeline consists of four commands in the specified order. The following
+illustration shows the output from each command as it is passed to the next
+command in the pipeline.
 
 ```
-|
-|   (FileInfo objects for *.txt)
-|
+Get-ChildItem -Path *.txt
+| (FileInfo objects for *.txt)
 V
-```
-
-`Where-Object` {$_.length `-gt` 10000}
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|
+Where-Object {$_.length -gt 10000}
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
 V
-```
-
-`Sort-Object` `-Property` Length
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|   (    Sorted by length      )
-|
+Sort-Object -Property Length
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
+| (     Sorted by length     )
 V
-```
-
-`Format-Table` `-Property` name, length
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|   (    Sorted by length      )
-|   (  Formatted in a table    )
-|
+Format-Table -Property name, length
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
+| (     Sorted by length     )
+| (   Formatted in a table   )
 V
-```
 
-```output
 Name                       Length
 ----                       ------
 tmp1.txt                    82920
@@ -117,33 +95,23 @@ tmp2.txt                   114000
 tmp3.txt                   114000
 ```
 
-## Using Pipelines
+## Using pipelines
 
-The PowerShell cmdlets were designed to be used in pipelines. For example, you
-can usually pipe the results of a **Get** cmdlet to an action cmdlet (such as a
-**Set**, **Start**, **Stop**, or **Rename** cmdlet) for the same noun.
+Most PowerShell cmdlets are designed to support pipelines. In most cases, you
+can _pipe_ the results of a **Get** cmdlet to another cmdlet of the same noun.
+For example, you can pipe the output of the `Get-Service` cmdlet to the
+`Start-Service` or `Stop-Service` cmdlets.
 
-For example, you can pipe any service from the `Get-Service` cmdlet to the
-`Start-Service` or `Stop-Service` cmdlets (although disabled services cannot
-be restarted in this way).
-
-This command pipeline starts the WMI service on the computer:
-
-For example,
+This example pipeline starts the WMI service on the computer:
 
 ```powershell
 Get-Service wmi | Start-Service
 ```
 
-The cmdlets that get and set objects of the PowerShell providers, such as the
-**Item** and **ItemProperty** cmdlets, are also designed to be used in pipelines.
-
-For example, you can pipe the results of a `Get-Item` or `Get-ChildItem`
-command in the PowerShell registry provider to the `New-ItemProperty` cmdlet.
-This command adds a new registry entry, **NoOfEmployees**, with a value of 8124,
+For another example, you can pipe the output of `Get-Item` or `Get-ChildItem`
+within the PowerShell registry provider to the `New-ItemProperty` cmdlet. This
+example adds a new registry entry, **NoOfEmployees**, with a value of **8124**,
 to the **MyCompany** registry key.
-
-For example,
 
 ```powershell
 Get-Item -Path HKLM:\Software\MyCompany |
@@ -151,27 +119,20 @@ Get-Item -Path HKLM:\Software\MyCompany |
 ```
 
 Many of the utility cmdlets, such as `Get-Member`, `Where-Object`,
-`Sort-Object`, `Group-Object`, and `Measure-Object` are used almost
-exclusively in pipelines. You can pipe any objects to these cmdlets.
-
-For example, you can pipe all of the processes on the computer to the
-`Sort-Object` command and have them sorted by the number of handles in the
-process.
-
-For example,
+`Sort-Object`, `Group-Object`, and `Measure-Object` are used almost exclusively
+in pipelines. You can pipe any object type to these cmdlets. This example shows
+how to sort all the processes on the computer by the number of open handles in
+each process.
 
 ```powershell
 Get-Process | Sort-Object -Property handles
 ```
 
-Also, you can pipe any objects to the formatting cmdlets, such as
-`Format-List` and `Format-Table`, the Export cmdlets, such as `Export-Clixml`
-and `Export-CSV`, and the Out cmdlets, such as `Out-Printer`.
+You can pipe objects to the formatting, export, and output cmdlets, such as
+`Format-List`, `Format-Table`, `Export-Clixml`, `Export-CSV`, and `Out-File`.
 
-For example, you can pipe the "Winlogon" process to the `Format-List` cmdlet to
-display all of the properties of the process in a list.
-
-For example,
+This example shows how to use the `Format-List` cmdlet to display a list of
+properties for a process object.
 
 ```powershell
 Get-Process winlogon | Format-List -Property *
@@ -180,86 +141,149 @@ Get-Process winlogon | Format-List -Property *
 With a bit of practice, you'll find that combining simple commands into
 pipelines saves time and typing, and makes your scripting more efficient.
 
-## How Pipelines Work
+## How pipelines work
 
-When you "pipe" objects, that is send the objects in the output of one command
-to another command, PowerShell tries to associate the piped objects with one
-of the parameters of the receiving cmdlet.
+This section explains how input objects are bound to cmdlet parameters and
+processed during pipeline execution.
 
-To do so, the PowerShell "parameter binding" component, which associates input
-objects with cmdlet parameters, tries to find a parameter that meets the
-following criteria:
+### Accepts pipeline input
 
-- The parameter must accept input from a pipeline (not all do).
-- The parameter must accept the type of object being sent or a type that the
-  object can be converted to.
-- The parameter must not already be used in the command.
+To support pipelining, the receiving cmdlet must have a parameter that accepts
+pipeline input. Use the `Get-Help` command with the **Full** or **Parameter**
+options to determine which parameters of a cmdlet accept pipeline input.
 
-For example, the `Start-Service` cmdlet has many parameters, but only two of
-them, `-Name` and `-InputObject` accept pipeline input. The `-Name` parameter
-takes strings and the `-InputObject` parameter takes service objects.
-Therefore, you can pipe strings and service objects (and objects with
-properties that can be converted to string and service objects) to
-`Start-Service`.
-
-If the parameter binding component of PowerShell cannot associate the piped
-objects with a parameter of the receiving cmdlet, the command fails and
-PowerShell prompts you for the missing parameter values.
-
-You cannot force the parameter binding component to associate the piped
-objects with a particular parameter. You cannot even suggest a parameter.
-Instead, the logic of the component manages the piping as efficiently as
-possible.
-
-## One-At-A-Time Processing
-
-Piping objects to a command is much like using a parameter of the command to
-submit the objects.
-
-For example, piping objects representing the services on the computer to a
-`Format-Table` command, such as:
+For example, to determine which of the parameters of the `Start-Service`
+cmdlet accepts pipeline input, type:
 
 ```powershell
-Get-Service | Format-Table -Property name, dependentservices
+Get-Help Start-Service -Full
 ```
 
-is much like saving the service objects in a variable and using the
-**InputObject** parameter of `Format-Table` to submit the service object.
+or
 
-For example,
+```powershell
+Get-Help Start-Service -Parameter *
+```
+
+The help for the `Start-Service` cmdlet shows that only the **InputObject** and
+**Name** parameters accept pipeline input.
+
+```Output
+-InputObject <ServiceController[]>
+Specifies ServiceController objects representing the services to be started.
+Enter a variable that contains the objects, or type a command or expression
+that gets the objects.
+
+Required?                    true
+Position?                    0
+Default value                None
+Accept pipeline input?       True (ByValue)
+Accept wildcard characters?  false
+
+-Name <String[]>
+Specifies the service names for the service to be started.
+
+The parameter name is optional. You can use Name or its alias, ServiceName,
+or you can omit the parameter name.
+
+Required?                    true
+Position?                    0
+Default value                None
+Accept pipeline input?       True (ByPropertyName, ByValue)
+Accept wildcard characters?  false
+```
+
+When you send objects through the pipeline to `Start-Service`, PowerShell
+attempts to associate the objects with the **InputObject** and **Name**
+parameters.
+
+### Methods of accepting pipeline input
+
+Cmdlets parameters can accept pipeline input in one of two different ways:
+
+- **ByValue**: The parameter accepts values that match the expected .NET type
+  or that can be converted to that type.
+
+  For example, the **Name** parameter of `Start-Service` accepts pipeline input
+  by value. It can accept string objects or objects that can be converted to
+  strings.
+
+- **ByPropertyName**: The parameter accepts input only when the input object
+  has a property of the same name as the parameter.
+
+  For example, the Name parameter of `Start-Service` can accept objects that
+  have a **Name** property. To list the properties of an object, pipe it to
+  `Get-Member`.
+
+Some parameters can accept objects by both value or property name, making it
+easier to take input from the pipeline.
+
+### Parameter binding
+
+When you pipe objects from one command to another command, PowerShell attempts
+to associate the piped objects with a parameter of the receiving cmdlet.
+
+PowerShell's parameter binding component associates the input objects with
+cmdlet parameters according to the following criteria:
+
+- The parameter must accept input from a pipeline
+- The parameter must accept the type of object being sent or a type that can be
+  converted to the expected type
+- The parameter was not used in the command
+
+For example, the `Start-Service` cmdlet has many parameters, but only two of
+them, **Name** and **InputObject** accept pipeline input. The **Name**
+parameter takes strings and the **InputObject** parameter takes service
+objects. Therefore, you can pipe strings, service objects, and objects with
+properties that can be converted to string or service objects.
+
+PowerShell manages parameter binding as efficiently as possible. You can't
+suggest or force the PowerShell to bind to a specific parameter. The command
+fails if PowerShell can't bind the piped objects.
+
+For more information about troubleshooting binding errors, see
+[Investigating Pipeline Errors](#investigating-pipeline-errors) later in this
+article.
+
+### One-at-a-time processing
+
+Piping objects to a command is much like using a parameter of the command to
+submit the objects. Let look at a pipeline example. In this example, we use a
+pipeline to display a table of service objects.
+
+```powershell
+Get-Service | Format-Table -Property Name, DependentServices
+```
+
+Functionally, this is like using the **InputObject** parameter of `Format-Table`
+to submit the object collection.
+
+For example, we can save the collection of services to a variable that is
+passed using the **InputObject** parameter.
 
 ```powershell
 $services = Get-Service
-Format-Table -InputObject $services -Property name, dependentservices
+Format-Table -InputObject $services -Property Name, DependentServices
 ```
 
-or imbedding the command in the parameter value
-
-For example,
+Or we can embed the command in the **InputObject** parameter.
 
 ```powershell
-Format-Table -InputObject (Get-Service wmi) -Property name,dependentservices
+Format-Table -InputObject (Get-Service) -Property Name, DependentServices
 ```
 
-However, there is an important difference. When you pipe multiple objects to a
+However, there's an important difference. When you pipe multiple objects to a
 command, PowerShell sends the objects to the command one at a time. When you
-use a command parameter, the objects are sent as a single array object.
+use a command parameter, the objects are sent as a single array object. This
+minor difference has significant consequences.
 
-This seemingly technical difference can have interesting, and sometimes
-useful, consequences.
+When executing a pipeline, PowerShell automatically enumerates any type that
+implements the `IEnumerable` interface and sends the members through the
+pipeline one at a time. The exception is `[hashtable]`, which requires a call
+to the `GetEnumerator()` method.
 
-For example, if you pipe multiple process objects from the `Get-Process`
-cmdlet to the `Get-Member` cmdlet, PowerShell sends each process object, one
-at a time, to `Get-Member`. `Get-Member` displays the .NET class (type) of the
-process objects, and their properties and methods.
-
-PowerShell automatically enumerates any type that implements the `IEnumerable`
-interface and sends the members through the pipeline one at a time. The
-exception is `[hashtable]`, which requires a call to the `GetEnumerator()`
-method.
-
-In the example below, an array and a hashtable are piped to the `Measure-Object`
-cmdlet, which counts the number of objects received from the pipeline. The array
+In the following examples, an array and a hashtable are piped to the `Measure-Object`
+cmdlet to count the number of objects received from the pipeline. The array
 has multiple members, and the hashtable has multiple key-value pairs. Only the
 array is enumerated one at a time.
 
@@ -289,14 +313,10 @@ Minimum  :
 Property :
 ```
 
-> [!NOTE]
-> `Get-Member` eliminates duplicates, so if the objects are all of the
-> same type, it displays only one object type.
-
-In this case, `Get-Member` displays the properties and methods of each process
-object, that is, a System.Diagnostics.Process object.
-
-For example,
+Similarly, if you pipe multiple process objects from the `Get-Process` cmdlet
+to the `Get-Member` cmdlet, PowerShell sends each process object, one at a
+time, to `Get-Member`. `Get-Member` displays the .NET class (type) of the
+process objects, and their properties and methods.
 
 ```powershell
 Get-Process | Get-Member
@@ -313,9 +333,13 @@ NPM       AliasProperty  NPM = NonpagedSystemMemorySize
 ...
 ```
 
+> [!NOTE]
+> `Get-Member` eliminates duplicates, so if the objects are all of the same
+> type, it only displays one object type.
+
 However, if you use the **InputObject** parameter of `Get-Member`, then
 `Get-Member` receives an array of **System.Diagnostics.Process** objects as a
-single unit, and it displays the properties of an array of objects. (Note the
+single unit. It displays the properties of an array of objects. (Note the
 array symbol (`[]`) after the **System.Object** type name.)
 
 For example,
@@ -335,9 +359,9 @@ Clone              Method        System.Object Clone()
 ...
 ```
 
-This result might not be what you intended, but after you understand it, you
-can use it. For example, an array of process objects has a **Count** property
-that you can use to count the number of processes on the computer.
+This result might not be what you intended. But after you understand it, you
+can use it. For example, all array objects have a **Count** property. You can
+use that to count the number of processes running on the computer.
 
 For example,
 
@@ -345,135 +369,47 @@ For example,
 (Get-Process).count
 ```
 
-This distinction can be important, so remember that when you pipe objects to a
-cmdlet, they are delivered one at a time.
+It's important to remember that objects sent down the pipeline are delivered
+one at a time.
 
-## Accepts Pipeline Input
+## Investigating pipeline errors
 
-In order to receive objects in a pipeline, the receiving cmdlet must have a
-parameter that accepts pipeline input. You can use a `Get-Help` command with
-the **Full** or **Parameter** parameters to determine which, if any, of a
-cmdlet's parameters accepts pipeline input.
+When PowerShell can't associate the piped objects with a parameter of the
+receiving cmdlet, the command fails.
 
-In the `Get-Help` default display, the "Accept pipeline input?" item appears
-in a table of parameter attributes. This table is displayed only when you use
-the **Full** or **Parameter** parameters of the `Get-Help` cmdlet.
-
-For example, to determine which of the parameters of the `Start-Service`
-cmdlet accepts pipeline input, type:
+In the following example, we try to move a registry entry from one registry
+key to another. The `Get-Item` cmdlet gets the destination path, which
+is then piped to the `Move-ItemProperty` cmdlet. The `Move-ItemProperty`
+command specifies the current path and name of the registry entry to be moved.
 
 ```powershell
-Get-Help Start-Service -Full
-```
-
-or
-
-```powershell
-Get-Help Start-Service -Parameter *
-```
-
-For example, the help for the `Start-Service` cmdlet shows that the
-**InputObject** and **Name** parameters accept pipeline input ("true"). All
-other parameters have a value of "false" in the "Accept pipeline input?" row.
-
-```
--InputObject <ServiceController[]>
-Specifies ServiceController objects representing the services to be started.
-Enter a variable that contains the objects, or type a command or expression
-that gets the objects.
-
-Required?                    true
-Position?                    0
-Default value                None
-Accept pipeline input?       True (ByValue)
-Accept wildcard characters?  false
-
--Name <String[]>
-Specifies the service names for the service to be started.
-
-The parameter name is optional. You can use Name or its alias, ServiceName,
-or you can omit the parameter name.
-
-Required?                    true
-Position?                    0
-Default value                None
-Accept pipeline input?       True (ByPropertyName, ByValue)
-Accept wildcard characters?  false
-```
-
-This means that you can send objects (PsObjects) through the pipeline to the
-`Where-Object` cmdlet and PowerShell will associate the object with the
-**InputObject** and **Name** parameters.
-
-## Methods Of Accepting Pipeline Input
-
-Cmdlets parameters can accept pipeline input in one of two different ways:
-
-- **ByValue**: Parameters that accept input "by value" can accept piped objects
-  that have the same .NET type as their parameter value or objects that can be
-  converted to that type.
-
-  For example, the Name parameter of `Start-Service` accepts pipeline input by
-  value. It can accept string objects or objects that can be converted to
-  strings.
-
-- **ByPropertyName**: Parameters that accept input "by property name" can accept
-  piped objects only when a property of the object has the same name as the
-  parameter.
-
-  For example, the Name parameter of `Start-Service` can accept objects that
-  have a Name property. To list the properties of an object, pipe it to
-  `Get-Member`.
-
-Some parameters can accept objects by value or by property name. These
-parameters are designed to take input from the pipeline easily.
-
-## Investigating Pipeline Errors
-
-If a command fails because of a pipeline error, you can investigate the
-failure and rewrite the command.
-
-For example, the following command tries to move a registry entry from one
-registry key to another by using the `Get-Item` cmdlet to get the destination
-path and then piping the path to the `Move-ItemProperty` cmdlet.
-
-Specifically, the command uses the `Get-Item` cmdlet to get the destination
-path. It uses a pipeline operator to send the result to the
-`Move-ItemProperty` cmdlet. The `Move-ItemProperty` command specifies the
-current path and name of the registry entry to be moved.
-
-For example,
-
-```powershell
-Get-Item -Path HKLM:\software\mycompany\sales |
-Move-ItemProperty -Path HKLM:\software\mycompany\design -Name product
+Get-Item -Path HKLM:\Software\MyCompany\sales |
+Move-ItemProperty -Path HKLM:\Software\MyCompany\design -Name product
 ```
 
 The command fails and PowerShell displays the following error
 message:
 
-```output
-Move-ItemProperty : The input object cannot be bound to any parameters for
-the command either because the command does not take pipeline input or the
+```Output
+Move-ItemProperty : The input object can't be bound to any parameters for
+the command either because the command doesn't take pipeline input or the
 input and its properties do not match any of the parameters that take
 pipeline input.
 At line:1 char:23
-+ $a | Move-ItemProperty <<<<  -Path HKLM:\software\mycompany\design -Name p
++ $a | Move-ItemProperty <<<<  -Path HKLM:\Software\MyCompany\design -Name p
 ```
 
-To investigate, use the `Trace-Command` cmdlet to trace the Parameter Binding
-component of PowerShell. The following command traces the Parameter Binding
-component while the command is processing. It uses the `-PSHost` parameter to
-display the results at the console and the `-filepath` command to send them to
-the `debug.txt` file for later reference.
-
-For example,
+To investigate, use the `Trace-Command` cmdlet to trace the parameter binding
+component of PowerShell. The following example traces parameter binding while
+the pipeline is executing. The **PSHost** parameter displays the trace results
+in the console and the **FilePath** parameter send the trace results to the
+`debug.txt` file for later reference.
 
 ```powershell
-Trace-Command -Name parameterbinding -Expression {
-  Get-Item -Path HKLM:\software\mycompany\sales |
-    Move-ItemProperty -Path HKLM:\software\mycompany\design -Name product} `
- -PSHost -FilePath debug.txt
+Trace-Command -Name ParameterBinding -PSHost -FilePath debug.txt -Expression {
+  Get-Item -Path HKLM:\Software\MyCompany\sales |
+    Move-ItemProperty -Path HKLM:\Software\MyCompany\design -Name product
+}
 ```
 
 The results of the trace are lengthy, but they show the values being bound to
@@ -484,7 +420,7 @@ the `Get-Item` cmdlet and then the named values being bound to the
 ...
 
 BIND NAMED cmd line args [`Move-ItemProperty`]
-BIND arg [HKLM:\software\mycompany\design] to parameter [Path]
+BIND arg [HKLM:\Software\MyCompany\design] to parameter [Path]
 
 ...
 
@@ -506,26 +442,19 @@ parameter of `Move-ItemProperty` failed.
 BIND PIPELINE object to parameters: [`Move-ItemProperty`]
 PIPELINE object TYPE = [Microsoft.Win32.RegistryKey]
 RESTORING pipeline parameter's original values
-Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO CO
-ERCION
-Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO COE
-RCION
+Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO
+COERCION
+Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO
+COERCION
 
 ...
 ```
 
-To investigate the failure, use the `Get-Help` cmdlet to view the attributes
-of the **Destination** parameter. The following command gets detailed
-information about the **Destination** parameter.
+Use the `Get-Help` cmdlet to view the attributes of the **Destination** parameter.
 
-```powershell
+```
 Get-Help Move-ItemProperty -Parameter Destination
-```
 
-The results show that **Destination** takes pipeline input only "by property
-name". That is, the piped object must have a property named **Destination**.
-
-```
 -Destination <String>
     Specifies the path to the destination location.
 
@@ -536,59 +465,78 @@ name". That is, the piped object must have a property named **Destination**.
     Accept wildcard characters?  false
 ```
 
-To see the properties of the object being piped to the `Move-ItemProperty`
-cmdlet, pipe it to the `Get-Member` cmdlet. The following command pipes the
-results of the first part of the command to the `Get-Member` cmdlet.
+The results show that **Destination** takes pipeline input only "by property
+name". Therefore, the piped object must have a property named **Destination**.
 
-For example,
+Use `Get-Member` to see the properties of the object coming from `Get-Item`.
 
 ```powershell
-Get-Item -Path HKLM:\software\mycompany\sales | Get-Member
+Get-Item -Path HKLM:\Software\MyCompany\sales | Get-Member
 ```
 
-The output shows that the item is a **Microsoft.Win32.RegistryKey** that does
-not have a **Destination** property. That explains why the command failed.
+The output shows that the item is a **Microsoft.Win32.RegistryKey** object that
+doesn't have a **Destination** property. That explains why the command failed.
+
+The **Path** parameter accepts pipeline input by name or by value.
+
+```
+Get-Help Move-ItemProperty -Parameter Path
+
+-Path <String[]>
+    Specifies the path to the current location of the property. Wildcard
+    characters are permitted.
+
+    Required?                    true
+    Position?                    0
+    Default value                None
+    Accept pipeline input?       True (ByPropertyName, ByValue)
+    Accept wildcard characters?  true
+```
 
 To fix the command, we must specify the destination in the `Move-ItemProperty`
-cmdlet. We can use a `Get-ItemProperty` command to get the path, but the name
-and destination must be specified in the `Move-ItemProperty` part of the
-command.
+cmdlet and use `Get-Item` to get the **Path** of the item we want to move.
 
 For example,
 
 ```powershell
-Get-Item -Path HKLM:\software\mycompany\design |
-Move-ItemProperty -Destination HKLM:\software\mycompany\sales -Name product
+Get-Item -Path HKLM:\Software\MyCompany\design |
+Move-ItemProperty -Destination HKLM:\Software\MyCompany\sales -Name product
 ```
 
-To verify that the command worked, use a `Get-ItemProperty` command:
+## Intrinsic line continuation
 
-For example,
+As already discussed, a pipeline is a series of commands connected by pipeline
+operators (`|`), usually written on a single line. However, for
+readability, PowerShell allows you to split the pipeline across multiple lines.
+When a pipe operator is the last token on the line, the PowerShell parser joins
+the next line to current command to continue the construction of the pipeline.
+
+For example, the following single-line pipeline:
 
 ```powershell
-Get-ItemProperty HKLM:\software\mycompany\sales
+Command-1 | Command-2 | Command-3
 ```
 
-The results show that the **Product** registry entry was moved to the **Sales**
-key.
+can be written as:
 
-```Output
-PSPath       : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\softwa
-re\mycompany\sales
-PSParentPath : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\softwa
-re\mycompany
-PSChildName  : sales
-PSDrive      : HKLM
-PSProvider   : Microsoft.PowerShell.Core\Registry
-Product      : 18
+```powershell
+Command-1 |
+  Command-2 |
+    Command-3
 ```
+
+The leading spaces on the subsequent lines are not significant. The indentation
+enhances readability.
 
 ## See Also
 
-[about_objects](about_objects.md)
+[about_PSReadLine](../../PSReadLine/About/about_PSReadLine.md)
 
-[about_parameters](about_parameters.md)
+[about_Objects](about_objects.md)
 
-[about_command_syntax](about_command_syntax.md)
+[about_Parameters](about_parameters.md)
 
-[about_foreach](about_foreach.md)
+[about_Command_Syntax](about_command_syntax.md)
+
+[about_ForEach](about_foreach.md)
+

--- a/reference/6/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -65,7 +65,7 @@ Get-ChildItem -Path *.txt |
 ```
 
 This pipeline consists of four commands in the specified order. The following
-illustration shows the output from each command as it is passed to the next
+illustration shows the output from each command as it's passed to the next
 command in the pipeline.
 
 ```
@@ -226,10 +226,10 @@ to associate the piped objects with a parameter of the receiving cmdlet.
 PowerShell's parameter binding component associates the input objects with
 cmdlet parameters according to the following criteria:
 
-- The parameter must accept input from a pipeline
+- The parameter must accept input from a pipeline.
 - The parameter must accept the type of object being sent or a type that can be
-  converted to the expected type
-- The parameter was not used in the command
+  converted to the expected type.
+- The parameter wasn't used in the command.
 
 For example, the `Start-Service` cmdlet has many parameters, but only two of
 them, **Name** and **InputObject** accept pipeline input. The **Name**
@@ -248,7 +248,7 @@ article.
 ### One-at-a-time processing
 
 Piping objects to a command is much like using a parameter of the command to
-submit the objects. Let look at a pipeline example. In this example, we use a
+submit the objects. Let's look at a pipeline example. In this example, we use a
 pipeline to display a table of service objects.
 
 ```powershell
@@ -416,29 +416,22 @@ The results of the trace are lengthy, but they show the values being bound to
 the `Get-Item` cmdlet and then the named values being bound to the
 `Move-ItemProperty` cmdlet.
 
-```
+```Output
 ...
-
 BIND NAMED cmd line args [`Move-ItemProperty`]
 BIND arg [HKLM:\Software\MyCompany\design] to parameter [Path]
-
 ...
-
 BIND arg [product] to parameter [Name]
-
 ...
-
 BIND POSITIONAL cmd line args [`Move-ItemProperty`]
-
 ...
 ```
 
 Finally, it shows that the attempt to bind the path to the **Destination**
 parameter of `Move-ItemProperty` failed.
 
-```
+```Output
 ...
-
 BIND PIPELINE object to parameters: [`Move-ItemProperty`]
 PIPELINE object TYPE = [Microsoft.Win32.RegistryKey]
 RESTORING pipeline parameter's original values
@@ -446,13 +439,12 @@ Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO
 COERCION
 Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO
 COERCION
-
 ...
 ```
 
 Use the `Get-Help` cmdlet to view the attributes of the **Destination** parameter.
 
-```
+```Output
 Get-Help Move-ItemProperty -Parameter Destination
 
 -Destination <String>
@@ -479,7 +471,7 @@ doesn't have a **Destination** property. That explains why the command failed.
 
 The **Path** parameter accepts pipeline input by name or by value.
 
-```
+```Output
 Get-Help Move-ItemProperty -Parameter Path
 
 -Path <String[]>

--- a/reference/6/PSReadLine/About/about_PSReadLine.md
+++ b/reference/6/PSReadLine/About/about_PSReadLine.md
@@ -248,6 +248,15 @@ Paste text from the system clipboard.
 - Vi insert mode: `<Ctrl+v>`
 - Vi command mode: `<Ctrl+v>`
 
+> [!IMPORTANT]
+> When using the **Paste** function, the entire contents of the clipboard
+> buffer is pasted into the input buffer of PSReadLine. The input buffer is
+> then passed to the PowerShell parser. Input pasted using the console
+> application's **right-click** paste method is copied to the input buffer one
+> character at a time. The input buffer is passed to the parser when a newline
+> character is copied. Therefore, the input is parsed one line at a time. The
+> difference between paste methods results in different execution behavior.
+
 ### PasteAfter
 
 Paste the clipboard after the cursor, moving the cursor to the end of the

--- a/reference/7/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -65,7 +65,7 @@ Get-ChildItem -Path *.txt |
 ```
 
 This pipeline consists of four commands in the specified order. The following
-illustration shows the output from each command as it is passed to the next
+illustration shows the output from each command as it's passed to the next
 command in the pipeline.
 
 ```
@@ -226,10 +226,10 @@ to associate the piped objects with a parameter of the receiving cmdlet.
 PowerShell's parameter binding component associates the input objects with
 cmdlet parameters according to the following criteria:
 
-- The parameter must accept input from a pipeline
+- The parameter must accept input from a pipeline.
 - The parameter must accept the type of object being sent or a type that can be
-  converted to the expected type
-- The parameter was not used in the command
+  converted to the expected type.
+- The parameter wasn't used in the command.
 
 For example, the `Start-Service` cmdlet has many parameters, but only two of
 them, **Name** and **InputObject** accept pipeline input. The **Name**
@@ -248,7 +248,7 @@ article.
 ### One-at-a-time processing
 
 Piping objects to a command is much like using a parameter of the command to
-submit the objects. Let look at a pipeline example. In this example, we use a
+submit the objects. Let's look at a pipeline example. In this example, we use a
 pipeline to display a table of service objects.
 
 ```powershell
@@ -416,29 +416,22 @@ The results of the trace are lengthy, but they show the values being bound to
 the `Get-Item` cmdlet and then the named values being bound to the
 `Move-ItemProperty` cmdlet.
 
-```
+```Output
 ...
-
 BIND NAMED cmd line args [`Move-ItemProperty`]
 BIND arg [HKLM:\Software\MyCompany\design] to parameter [Path]
-
 ...
-
 BIND arg [product] to parameter [Name]
-
 ...
-
 BIND POSITIONAL cmd line args [`Move-ItemProperty`]
-
 ...
 ```
 
 Finally, it shows that the attempt to bind the path to the **Destination**
 parameter of `Move-ItemProperty` failed.
 
-```
+```Output
 ...
-
 BIND PIPELINE object to parameters: [`Move-ItemProperty`]
 PIPELINE object TYPE = [Microsoft.Win32.RegistryKey]
 RESTORING pipeline parameter's original values
@@ -446,13 +439,12 @@ Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO
 COERCION
 Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO
 COERCION
-
 ...
 ```
 
 Use the `Get-Help` cmdlet to view the attributes of the **Destination** parameter.
 
-```
+```Output
 Get-Help Move-ItemProperty -Parameter Destination
 
 -Destination <String>
@@ -479,7 +471,7 @@ doesn't have a **Destination** property. That explains why the command failed.
 
 The **Path** parameter accepts pipeline input by name or by value.
 
-```
+```Output
 Get-Help Move-ItemProperty -Parameter Path
 
 -Path <String[]>
@@ -564,3 +556,4 @@ Get-Process | Where-Object CPU | Where-Object Path
 [about_Command_Syntax](about_command_syntax.md)
 
 [about_ForEach](about_foreach.md)
+

--- a/reference/7/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  02/14/2018
+ms.date:  09/27/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -7,20 +7,20 @@ title:  about_pipelines
 ---
 # About Pipelines
 
-## Short Description
+## Short description
 
 Combining commands into pipelines in the PowerShell
 
-## Long Description
+## Long description
 
 A pipeline is a series of commands connected by pipeline operators (`|`)
 (ASCII 124). Each pipeline operator sends the results of the preceding command
 to the next command.
 
-You can use pipelines to send the objects that are output by one command to be
-used as input to another command for processing. And you can send the output
-of that command to yet another command. The result is a very powerful command
-chain or "pipeline" that is comprised of a series of simple commands.
+The output of the first command can be sent for processing as input to the
+second command. And that output can be sent to yet another command. The result
+is a complex command chain or _pipeline_ that is composed of a series of
+simple commands.
 
 For example,
 
@@ -33,9 +33,9 @@ In this example, the objects that `Command-1` emits are sent to `Command-2`.
 processes the objects and send them down the pipeline. Because there are no
 more commands in the pipeline, the results are displayed at the console.
 
-In a pipeline, the commands are processed from left to right in the order that
-they appear. The processing is handled as a single operation and output is
-displayed as it is generated.
+In a pipeline, the commands are processed in order from left to right. The
+processing is handled as a single operation and output is displayed as it's
+generated.
 
 Here is a simple example. The following command gets the Notepad process and
 then stops it.
@@ -49,67 +49,45 @@ Get-Process notepad | Stop-Process
 The first command uses the `Get-Process` cmdlet to get an object representing
 the Notepad process. It uses a pipeline operator (`|`) to send the process
 object to the `Stop-Process` cmdlet, which stops the Notepad process. Notice
-that the `Stop-Process` command does not have a **Name** or **ID** parameter to
+that the `Stop-Process` command doesn't have a **Name** or **ID** parameter to
 specify the process, because the specified process is submitted through the
 pipeline.
 
-Here is a practical example. This command pipeline gets the text files in the
-current directory, selects only the files that are more than 10,000 bytes
-long, sorts them by length, and displays the name and length of each file in a
-table.
+This pipeline example gets the text files in the current directory, selects
+only the files that are more than 10,000 bytes long, sorts them by length, and
+displays the name and length of each file in a table.
 
 ```powershell
-Get-ChildItem -Path *.txt | Where-Object {$_.length -gt 10000} |
-Sort-Object -Property length | Format-Table -Property name, length
+Get-ChildItem -Path *.txt |
+  Where-Object {$_.length -gt 10000} |
+    Sort-Object -Property length |
+      Format-Table -Property name, length
 ```
 
-This pipeline is comprised of four commands in the specified order. The
-command is written horizontally, but we will show the process vertically in
-the following graphic.
-
-`Get-ChildItem` `-Path` *.txt
+This pipeline consists of four commands in the specified order. The following
+illustration shows the output from each command as it is passed to the next
+command in the pipeline.
 
 ```
-|
-|   (FileInfo objects for *.txt)
-|
+Get-ChildItem -Path *.txt
+| (FileInfo objects for *.txt)
 V
-```
-
-`Where-Object` {$_.length `-gt` 10000}
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|
+Where-Object {$_.length -gt 10000}
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
 V
-```
-
-`Sort-Object` `-Property` Length
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|   (    Sorted by length      )
-|
+Sort-Object -Property Length
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
+| (     Sorted by length     )
 V
-```
-
-`Format-Table` `-Property` name, length
-
-```
-|
-|   (FileInfo objects for *.txt)
-|   (     Length > 10000       )
-|   (    Sorted by length      )
-|   (  Formatted in a table    )
-|
+Format-Table -Property name, length
+| (FileInfo objects for *.txt)
+| (      Length > 10000      )
+| (     Sorted by length     )
+| (   Formatted in a table   )
 V
-```
 
-```output
 Name                       Length
 ----                       ------
 tmp1.txt                    82920
@@ -117,33 +95,23 @@ tmp2.txt                   114000
 tmp3.txt                   114000
 ```
 
-## Using Pipelines
+## Using pipelines
 
-The PowerShell cmdlets were designed to be used in pipelines. For example, you
-can usually pipe the results of a **Get** cmdlet to an action cmdlet (such as a
-**Set**, **Start**, **Stop**, or **Rename** cmdlet) for the same noun.
+Most PowerShell cmdlets are designed to support pipelines. In most cases, you
+can _pipe_ the results of a **Get** cmdlet to another cmdlet of the same noun.
+For example, you can pipe the output of the `Get-Service` cmdlet to the
+`Start-Service` or `Stop-Service` cmdlets.
 
-For example, you can pipe any service from the `Get-Service` cmdlet to the
-`Start-Service` or `Stop-Service` cmdlets (although disabled services cannot
-be restarted in this way).
-
-This command pipeline starts the WMI service on the computer:
-
-For example,
+This example pipeline starts the WMI service on the computer:
 
 ```powershell
 Get-Service wmi | Start-Service
 ```
 
-The cmdlets that get and set objects of the PowerShell providers, such as the
-**Item** and **ItemProperty** cmdlets, are also designed to be used in pipelines.
-
-For example, you can pipe the results of a `Get-Item` or `Get-ChildItem`
-command in the PowerShell registry provider to the `New-ItemProperty` cmdlet.
-This command adds a new registry entry, **NoOfEmployees**, with a value of 8124,
+For another example, you can pipe the output of `Get-Item` or `Get-ChildItem`
+within the PowerShell registry provider to the `New-ItemProperty` cmdlet. This
+example adds a new registry entry, **NoOfEmployees**, with a value of **8124**,
 to the **MyCompany** registry key.
-
-For example,
 
 ```powershell
 Get-Item -Path HKLM:\Software\MyCompany |
@@ -151,27 +119,20 @@ Get-Item -Path HKLM:\Software\MyCompany |
 ```
 
 Many of the utility cmdlets, such as `Get-Member`, `Where-Object`,
-`Sort-Object`, `Group-Object`, and `Measure-Object` are used almost
-exclusively in pipelines. You can pipe any objects to these cmdlets.
-
-For example, you can pipe all of the processes on the computer to the
-`Sort-Object` command and have them sorted by the number of handles in the
-process.
-
-For example,
+`Sort-Object`, `Group-Object`, and `Measure-Object` are used almost exclusively
+in pipelines. You can pipe any object type to these cmdlets. This example shows
+how to sort all the processes on the computer by the number of open handles in
+each process.
 
 ```powershell
 Get-Process | Sort-Object -Property handles
 ```
 
-Also, you can pipe any objects to the formatting cmdlets, such as
-`Format-List` and `Format-Table`, the Export cmdlets, such as `Export-Clixml`
-and `Export-CSV`, and the Out cmdlets, such as `Out-Printer`.
+You can pipe objects to the formatting, export, and output cmdlets, such as
+`Format-List`, `Format-Table`, `Export-Clixml`, `Export-CSV`, and `Out-File`.
 
-For example, you can pipe the "Winlogon" process to the `Format-List` cmdlet to
-display all of the properties of the process in a list.
-
-For example,
+This example shows how to use the `Format-List` cmdlet to display a list of
+properties for a process object.
 
 ```powershell
 Get-Process winlogon | Format-List -Property *
@@ -180,86 +141,149 @@ Get-Process winlogon | Format-List -Property *
 With a bit of practice, you'll find that combining simple commands into
 pipelines saves time and typing, and makes your scripting more efficient.
 
-## How Pipelines Work
+## How pipelines work
 
-When you "pipe" objects, that is send the objects in the output of one command
-to another command, PowerShell tries to associate the piped objects with one
-of the parameters of the receiving cmdlet.
+This section explains how input objects are bound to cmdlet parameters and
+processed during pipeline execution.
 
-To do so, the PowerShell "parameter binding" component, which associates input
-objects with cmdlet parameters, tries to find a parameter that meets the
-following criteria:
+### Accepts pipeline input
 
-- The parameter must accept input from a pipeline (not all do).
-- The parameter must accept the type of object being sent or a type that the
-  object can be converted to.
-- The parameter must not already be used in the command.
+To support pipelining, the receiving cmdlet must have a parameter that accepts
+pipeline input. Use the `Get-Help` command with the **Full** or **Parameter**
+options to determine which parameters of a cmdlet accept pipeline input.
 
-For example, the `Start-Service` cmdlet has many parameters, but only two of
-them, `-Name` and `-InputObject` accept pipeline input. The `-Name` parameter
-takes strings and the `-InputObject` parameter takes service objects.
-Therefore, you can pipe strings and service objects (and objects with
-properties that can be converted to string and service objects) to
-`Start-Service`.
-
-If the parameter binding component of PowerShell cannot associate the piped
-objects with a parameter of the receiving cmdlet, the command fails and
-PowerShell prompts you for the missing parameter values.
-
-You cannot force the parameter binding component to associate the piped
-objects with a particular parameter. You cannot even suggest a parameter.
-Instead, the logic of the component manages the piping as efficiently as
-possible.
-
-## One-At-A-Time Processing
-
-Piping objects to a command is much like using a parameter of the command to
-submit the objects.
-
-For example, piping objects representing the services on the computer to a
-`Format-Table` command, such as:
+For example, to determine which of the parameters of the `Start-Service`
+cmdlet accepts pipeline input, type:
 
 ```powershell
-Get-Service | Format-Table -Property name, dependentservices
+Get-Help Start-Service -Full
 ```
 
-is much like saving the service objects in a variable and using the
-**InputObject** parameter of `Format-Table` to submit the service object.
+or
 
-For example,
+```powershell
+Get-Help Start-Service -Parameter *
+```
+
+The help for the `Start-Service` cmdlet shows that only the **InputObject** and
+**Name** parameters accept pipeline input.
+
+```Output
+-InputObject <ServiceController[]>
+Specifies ServiceController objects representing the services to be started.
+Enter a variable that contains the objects, or type a command or expression
+that gets the objects.
+
+Required?                    true
+Position?                    0
+Default value                None
+Accept pipeline input?       True (ByValue)
+Accept wildcard characters?  false
+
+-Name <String[]>
+Specifies the service names for the service to be started.
+
+The parameter name is optional. You can use Name or its alias, ServiceName,
+or you can omit the parameter name.
+
+Required?                    true
+Position?                    0
+Default value                None
+Accept pipeline input?       True (ByPropertyName, ByValue)
+Accept wildcard characters?  false
+```
+
+When you send objects through the pipeline to `Start-Service`, PowerShell
+attempts to associate the objects with the **InputObject** and **Name**
+parameters.
+
+### Methods of accepting pipeline input
+
+Cmdlets parameters can accept pipeline input in one of two different ways:
+
+- **ByValue**: The parameter accepts values that match the expected .NET type
+  or that can be converted to that type.
+
+  For example, the **Name** parameter of `Start-Service` accepts pipeline input
+  by value. It can accept string objects or objects that can be converted to
+  strings.
+
+- **ByPropertyName**: The parameter accepts input only when the input object
+  has a property of the same name as the parameter.
+
+  For example, the Name parameter of `Start-Service` can accept objects that
+  have a **Name** property. To list the properties of an object, pipe it to
+  `Get-Member`.
+
+Some parameters can accept objects by both value or property name, making it
+easier to take input from the pipeline.
+
+### Parameter binding
+
+When you pipe objects from one command to another command, PowerShell attempts
+to associate the piped objects with a parameter of the receiving cmdlet.
+
+PowerShell's parameter binding component associates the input objects with
+cmdlet parameters according to the following criteria:
+
+- The parameter must accept input from a pipeline
+- The parameter must accept the type of object being sent or a type that can be
+  converted to the expected type
+- The parameter was not used in the command
+
+For example, the `Start-Service` cmdlet has many parameters, but only two of
+them, **Name** and **InputObject** accept pipeline input. The **Name**
+parameter takes strings and the **InputObject** parameter takes service
+objects. Therefore, you can pipe strings, service objects, and objects with
+properties that can be converted to string or service objects.
+
+PowerShell manages parameter binding as efficiently as possible. You can't
+suggest or force the PowerShell to bind to a specific parameter. The command
+fails if PowerShell can't bind the piped objects.
+
+For more information about troubleshooting binding errors, see
+[Investigating Pipeline Errors](#investigating-pipeline-errors) later in this
+article.
+
+### One-at-a-time processing
+
+Piping objects to a command is much like using a parameter of the command to
+submit the objects. Let look at a pipeline example. In this example, we use a
+pipeline to display a table of service objects.
+
+```powershell
+Get-Service | Format-Table -Property Name, DependentServices
+```
+
+Functionally, this is like using the **InputObject** parameter of `Format-Table`
+to submit the object collection.
+
+For example, we can save the collection of services to a variable that is
+passed using the **InputObject** parameter.
 
 ```powershell
 $services = Get-Service
-Format-Table -InputObject $services -Property name, dependentservices
+Format-Table -InputObject $services -Property Name, DependentServices
 ```
 
-or imbedding the command in the parameter value
-
-For example,
+Or we can embed the command in the **InputObject** parameter.
 
 ```powershell
-Format-Table -InputObject (Get-Service wmi) -Property name,dependentservices
+Format-Table -InputObject (Get-Service) -Property Name, DependentServices
 ```
 
-However, there is an important difference. When you pipe multiple objects to a
+However, there's an important difference. When you pipe multiple objects to a
 command, PowerShell sends the objects to the command one at a time. When you
-use a command parameter, the objects are sent as a single array object.
+use a command parameter, the objects are sent as a single array object. This
+minor difference has significant consequences.
 
-This seemingly technical difference can have interesting, and sometimes
-useful, consequences.
+When executing a pipeline, PowerShell automatically enumerates any type that
+implements the `IEnumerable` interface and sends the members through the
+pipeline one at a time. The exception is `[hashtable]`, which requires a call
+to the `GetEnumerator()` method.
 
-For example, if you pipe multiple process objects from the `Get-Process`
-cmdlet to the `Get-Member` cmdlet, PowerShell sends each process object, one
-at a time, to `Get-Member`. `Get-Member` displays the .NET class (type) of the
-process objects, and their properties and methods.
-
-PowerShell automatically enumerates any type that implements the `IEnumerable`
-interface and sends the members through the pipeline one at a time. The
-exception is `[hashtable]`, which requires a call to the `GetEnumerator()`
-method.
-
-In the example below, an array and a hashtable are piped to the `Measure-Object`
-cmdlet, which counts the number of objects received from the pipeline. The array
+In the following examples, an array and a hashtable are piped to the `Measure-Object`
+cmdlet to count the number of objects received from the pipeline. The array
 has multiple members, and the hashtable has multiple key-value pairs. Only the
 array is enumerated one at a time.
 
@@ -289,14 +313,10 @@ Minimum  :
 Property :
 ```
 
-> [!NOTE]
-> `Get-Member` eliminates duplicates, so if the objects are all of the
-> same type, it displays only one object type.
-
-In this case, `Get-Member` displays the properties and methods of each process
-object, that is, a System.Diagnostics.Process object.
-
-For example,
+Similarly, if you pipe multiple process objects from the `Get-Process` cmdlet
+to the `Get-Member` cmdlet, PowerShell sends each process object, one at a
+time, to `Get-Member`. `Get-Member` displays the .NET class (type) of the
+process objects, and their properties and methods.
 
 ```powershell
 Get-Process | Get-Member
@@ -313,9 +333,13 @@ NPM       AliasProperty  NPM = NonpagedSystemMemorySize
 ...
 ```
 
+> [!NOTE]
+> `Get-Member` eliminates duplicates, so if the objects are all of the same
+> type, it only displays one object type.
+
 However, if you use the **InputObject** parameter of `Get-Member`, then
 `Get-Member` receives an array of **System.Diagnostics.Process** objects as a
-single unit, and it displays the properties of an array of objects. (Note the
+single unit. It displays the properties of an array of objects. (Note the
 array symbol (`[]`) after the **System.Object** type name.)
 
 For example,
@@ -335,9 +359,9 @@ Clone              Method        System.Object Clone()
 ...
 ```
 
-This result might not be what you intended, but after you understand it, you
-can use it. For example, an array of process objects has a **Count** property
-that you can use to count the number of processes on the computer.
+This result might not be what you intended. But after you understand it, you
+can use it. For example, all array objects have a **Count** property. You can
+use that to count the number of processes running on the computer.
 
 For example,
 
@@ -345,135 +369,47 @@ For example,
 (Get-Process).count
 ```
 
-This distinction can be important, so remember that when you pipe objects to a
-cmdlet, they are delivered one at a time.
+It's important to remember that objects sent down the pipeline are delivered
+one at a time.
 
-## Accepts Pipeline Input
+## Investigating pipeline errors
 
-In order to receive objects in a pipeline, the receiving cmdlet must have a
-parameter that accepts pipeline input. You can use a `Get-Help` command with
-the **Full** or **Parameter** parameters to determine which, if any, of a
-cmdlet's parameters accepts pipeline input.
+When PowerShell can't associate the piped objects with a parameter of the
+receiving cmdlet, the command fails.
 
-In the `Get-Help` default display, the "Accept pipeline input?" item appears
-in a table of parameter attributes. This table is displayed only when you use
-the **Full** or **Parameter** parameters of the `Get-Help` cmdlet.
-
-For example, to determine which of the parameters of the `Start-Service`
-cmdlet accepts pipeline input, type:
+In the following example, we try to move a registry entry from one registry
+key to another. The `Get-Item` cmdlet gets the destination path, which
+is then piped to the `Move-ItemProperty` cmdlet. The `Move-ItemProperty`
+command specifies the current path and name of the registry entry to be moved.
 
 ```powershell
-Get-Help Start-Service -Full
-```
-
-or
-
-```powershell
-Get-Help Start-Service -Parameter *
-```
-
-For example, the help for the `Start-Service` cmdlet shows that the
-**InputObject** and **Name** parameters accept pipeline input ("true"). All
-other parameters have a value of "false" in the "Accept pipeline input?" row.
-
-```
--InputObject <ServiceController[]>
-Specifies ServiceController objects representing the services to be started.
-Enter a variable that contains the objects, or type a command or expression
-that gets the objects.
-
-Required?                    true
-Position?                    0
-Default value                None
-Accept pipeline input?       True (ByValue)
-Accept wildcard characters?  false
-
--Name <String[]>
-Specifies the service names for the service to be started.
-
-The parameter name is optional. You can use Name or its alias, ServiceName,
-or you can omit the parameter name.
-
-Required?                    true
-Position?                    0
-Default value                None
-Accept pipeline input?       True (ByPropertyName, ByValue)
-Accept wildcard characters?  false
-```
-
-This means that you can send objects (PsObjects) through the pipeline to the
-`Where-Object` cmdlet and PowerShell will associate the object with the
-**InputObject** and **Name** parameters.
-
-## Methods Of Accepting Pipeline Input
-
-Cmdlets parameters can accept pipeline input in one of two different ways:
-
-- **ByValue**: Parameters that accept input "by value" can accept piped objects
-  that have the same .NET type as their parameter value or objects that can be
-  converted to that type.
-
-  For example, the Name parameter of `Start-Service` accepts pipeline input by
-  value. It can accept string objects or objects that can be converted to
-  strings.
-
-- **ByPropertyName**: Parameters that accept input "by property name" can accept
-  piped objects only when a property of the object has the same name as the
-  parameter.
-
-  For example, the Name parameter of `Start-Service` can accept objects that
-  have a Name property. To list the properties of an object, pipe it to
-  `Get-Member`.
-
-Some parameters can accept objects by value or by property name. These
-parameters are designed to take input from the pipeline easily.
-
-## Investigating Pipeline Errors
-
-If a command fails because of a pipeline error, you can investigate the
-failure and rewrite the command.
-
-For example, the following command tries to move a registry entry from one
-registry key to another by using the `Get-Item` cmdlet to get the destination
-path and then piping the path to the `Move-ItemProperty` cmdlet.
-
-Specifically, the command uses the `Get-Item` cmdlet to get the destination
-path. It uses a pipeline operator to send the result to the
-`Move-ItemProperty` cmdlet. The `Move-ItemProperty` command specifies the
-current path and name of the registry entry to be moved.
-
-For example,
-
-```powershell
-Get-Item -Path HKLM:\software\mycompany\sales |
-Move-ItemProperty -Path HKLM:\software\mycompany\design -Name product
+Get-Item -Path HKLM:\Software\MyCompany\sales |
+Move-ItemProperty -Path HKLM:\Software\MyCompany\design -Name product
 ```
 
 The command fails and PowerShell displays the following error
 message:
 
-```output
-Move-ItemProperty : The input object cannot be bound to any parameters for
-the command either because the command does not take pipeline input or the
+```Output
+Move-ItemProperty : The input object can't be bound to any parameters for
+the command either because the command doesn't take pipeline input or the
 input and its properties do not match any of the parameters that take
 pipeline input.
 At line:1 char:23
-+ $a | Move-ItemProperty <<<<  -Path HKLM:\software\mycompany\design -Name p
++ $a | Move-ItemProperty <<<<  -Path HKLM:\Software\MyCompany\design -Name p
 ```
 
-To investigate, use the `Trace-Command` cmdlet to trace the Parameter Binding
-component of PowerShell. The following command traces the Parameter Binding
-component while the command is processing. It uses the `-PSHost` parameter to
-display the results at the console and the `-filepath` command to send them to
-the `debug.txt` file for later reference.
-
-For example,
+To investigate, use the `Trace-Command` cmdlet to trace the parameter binding
+component of PowerShell. The following example traces parameter binding while
+the pipeline is executing. The **PSHost** parameter displays the trace results
+in the console and the **FilePath** parameter send the trace results to the
+`debug.txt` file for later reference.
 
 ```powershell
-Trace-Command -Name parameterbinding -Expression {
-  Get-Item -Path HKLM:\software\mycompany\sales |
-    Move-ItemProperty -Path HKLM:\software\mycompany\design -Name product} `
- -PSHost -FilePath debug.txt
+Trace-Command -Name ParameterBinding -PSHost -FilePath debug.txt -Expression {
+  Get-Item -Path HKLM:\Software\MyCompany\sales |
+    Move-ItemProperty -Path HKLM:\Software\MyCompany\design -Name product
+}
 ```
 
 The results of the trace are lengthy, but they show the values being bound to
@@ -484,7 +420,7 @@ the `Get-Item` cmdlet and then the named values being bound to the
 ...
 
 BIND NAMED cmd line args [`Move-ItemProperty`]
-BIND arg [HKLM:\software\mycompany\design] to parameter [Path]
+BIND arg [HKLM:\Software\MyCompany\design] to parameter [Path]
 
 ...
 
@@ -506,26 +442,19 @@ parameter of `Move-ItemProperty` failed.
 BIND PIPELINE object to parameters: [`Move-ItemProperty`]
 PIPELINE object TYPE = [Microsoft.Win32.RegistryKey]
 RESTORING pipeline parameter's original values
-Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO CO
-ERCION
-Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO COE
-RCION
+Parameter [Destination] PIPELINE INPUT ValueFromPipelineByPropertyName NO
+COERCION
+Parameter [Credential] PIPELINE INPUT ValueFromPipelineByPropertyName NO
+COERCION
 
 ...
 ```
 
-To investigate the failure, use the `Get-Help` cmdlet to view the attributes
-of the **Destination** parameter. The following command gets detailed
-information about the **Destination** parameter.
+Use the `Get-Help` cmdlet to view the attributes of the **Destination** parameter.
 
-```powershell
+```
 Get-Help Move-ItemProperty -Parameter Destination
-```
 
-The results show that **Destination** takes pipeline input only "by property
-name". That is, the piped object must have a property named **Destination**.
-
-```
 -Destination <String>
     Specifies the path to the destination location.
 
@@ -536,59 +465,102 @@ name". That is, the piped object must have a property named **Destination**.
     Accept wildcard characters?  false
 ```
 
-To see the properties of the object being piped to the `Move-ItemProperty`
-cmdlet, pipe it to the `Get-Member` cmdlet. The following command pipes the
-results of the first part of the command to the `Get-Member` cmdlet.
+The results show that **Destination** takes pipeline input only "by property
+name". Therefore, the piped object must have a property named **Destination**.
 
-For example,
+Use `Get-Member` to see the properties of the object coming from `Get-Item`.
 
 ```powershell
-Get-Item -Path HKLM:\software\mycompany\sales | Get-Member
+Get-Item -Path HKLM:\Software\MyCompany\sales | Get-Member
 ```
 
-The output shows that the item is a **Microsoft.Win32.RegistryKey** that does
-not have a **Destination** property. That explains why the command failed.
+The output shows that the item is a **Microsoft.Win32.RegistryKey** object that
+doesn't have a **Destination** property. That explains why the command failed.
+
+The **Path** parameter accepts pipeline input by name or by value.
+
+```
+Get-Help Move-ItemProperty -Parameter Path
+
+-Path <String[]>
+    Specifies the path to the current location of the property. Wildcard
+    characters are permitted.
+
+    Required?                    true
+    Position?                    0
+    Default value                None
+    Accept pipeline input?       True (ByPropertyName, ByValue)
+    Accept wildcard characters?  true
+```
 
 To fix the command, we must specify the destination in the `Move-ItemProperty`
-cmdlet. We can use a `Get-ItemProperty` command to get the path, but the name
-and destination must be specified in the `Move-ItemProperty` part of the
-command.
+cmdlet and use `Get-Item` to get the **Path** of the item we want to move.
 
 For example,
 
 ```powershell
-Get-Item -Path HKLM:\software\mycompany\design |
-Move-ItemProperty -Destination HKLM:\software\mycompany\sales -Name product
+Get-Item -Path HKLM:\Software\MyCompany\design |
+Move-ItemProperty -Destination HKLM:\Software\MyCompany\sales -Name product
 ```
 
-To verify that the command worked, use a `Get-ItemProperty` command:
+## Intrinsic line continuation
 
-For example,
+As already discussed, a pipeline is a series of commands connected by pipeline
+operators (`|`), usually written on a single line. However, for
+readability, PowerShell allows you to split the pipeline across multiple lines.
+When a pipe operator is the last token on the line, the PowerShell parser joins
+the next line to current command to continue the construction of the pipeline.
+
+For example, the following single-line pipeline:
 
 ```powershell
-Get-ItemProperty HKLM:\software\mycompany\sales
+Command-1 | Command-2 | Command-3
 ```
 
-The results show that the **Product** registry entry was moved to the **Sales**
-key.
+can be written as:
 
-```Output
-PSPath       : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\softwa
-re\mycompany\sales
-PSParentPath : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\softwa
-re\mycompany
-PSChildName  : sales
-PSDrive      : HKLM
-PSProvider   : Microsoft.PowerShell.Core\Registry
-Product      : 18
+```powershell
+Command-1 |
+  Command-2 |
+    Command-3
 ```
+
+The leading spaces on the subsequent lines are not significant. The indentation
+enhances readability.
+
+PowerShell 7 adds support for continuation of pipelines with the pipeline
+character at the beginning of a line. The following examples show how you could
+use this new functionality.
+
+```powershell
+# Wrapping with a pipe at the beginning of a line (no backtick required)
+Get-Process | Where-Object CPU | Where-Object Path
+    | Get-Item | Where-Object FullName -match "AppData"
+    | Sort-Object FullName -Unique
+
+# Wrapping with a pipe on a line by itself
+Get-Process | Where-Object CPU | Where-Object Path
+    |
+    Get-Item | Where-Object FullName -match "AppData"
+    |
+    Sort-Object FullName -Unique
+```
+
+> [!IMPORTANT]
+> When working interactively in the shell, pasting code with pipelines at the
+> beginning of a line only when using <kbd>Ctrl</kbd>+<kbd>V</kbd> to paste.
+> Right-click paste operations insert the lines one at a time. Since the line
+> does not end with a pipeline character, PowerShell considers the input to be
+> complete and executes that line as entered.
 
 ## See Also
 
-[about_objects](about_objects.md)
+[about_PSReadLine](../../PSReadLine/About/about_PSReadLine.md)
 
-[about_parameters](about_parameters.md)
+[about_Objects](about_objects.md)
 
-[about_command_syntax](about_command_syntax.md)
+[about_Parameters](about_parameters.md)
 
-[about_foreach](about_foreach.md)
+[about_Command_Syntax](about_command_syntax.md)
+
+[about_ForEach](about_foreach.md)

--- a/reference/7/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7/PSReadLine/About/about_PSReadLine.md
@@ -248,6 +248,15 @@ Paste text from the system clipboard.
 - Vi insert mode: `<Ctrl+v>`
 - Vi command mode: `<Ctrl+v>`
 
+> [!IMPORTANT]
+> When using the **Paste** function, the entire contents of the clipboard
+> buffer is pasted into the input buffer of PSReadLine. The input buffer is
+> then passed to the PowerShell parser. Input pasted using the console
+> application's **right-click** paste method is copied to the input buffer one
+> character at a time. The input buffer is passed to the parser when a newline
+> character is copied. Therefore, the input is parsed one line at a time. The
+> difference between paste methods results in different execution behavior.
+
 ### PasteAfter
 
 Paste the clipboard after the cursor, moving the cursor to the end of the


### PR DESCRIPTION
Fixes #4765 - new multiline continuation support
- about_pipelines
   - added note about pasting
   - cleaned up style, grammar, Acrolinx (86/96) for all versions
   - added v7 changes
- about_PSReadLine.md
   - added note about pasting to all versions

Fixes [AB#1607250](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1607250)

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
