### PR TITLE
Add the bold tag to 'IgnorePatternWhitespace' in about_Split

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Split.md
@@ -204,7 +204,7 @@ The RegexMatch options are:
   operator is specified.
 - **CultureInvariant**: Ignores cultural differences in language
   when evaluting the delimiter. Valid only with RegexMatch.
-- IgnorePatternWhitespace: Ignores unescaped whitespace and
+- **IgnorePatternWhitespace**: Ignores unescaped whitespace and
   comments marked with the number sign (#). Valid only with
   RegexMatch.
 - **Multiline**: Multiline mode forces `^` and `$` to match the beginning

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Split.md
@@ -205,7 +205,7 @@ The RegexMatch options are:
   operator is specified.
 - **CultureInvariant**: Ignores cultural differences in language
   when evaluting the delimiter. Valid only with RegexMatch.
-- IgnorePatternWhitespace: Ignores unescaped whitespace and
+- **IgnorePatternWhitespace**: Ignores unescaped whitespace and
   comments marked with the number sign (#). Valid only with
   RegexMatch.
 - **Multiline**: Multiline mode forces `^` and `$` to match the beginning

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Split.md
@@ -203,7 +203,7 @@ The RegexMatch options are:
   operator is specified.
 - **CultureInvariant**: Ignores cultural differences in language
   when evaluting the delimiter. Valid only with RegexMatch.
-- IgnorePatternWhitespace: Ignores unescaped whitespace and
+- **IgnorePatternWhitespace**: Ignores unescaped whitespace and
   comments marked with the number sign (#). Valid only with
   RegexMatch.
 - **Multiline**: Multiline mode forces `^` and `$` to match the beginning

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
@@ -205,7 +205,7 @@ The RegexMatch options are:
   operator is specified.
 - **CultureInvariant**: Ignores cultural differences in language
   when evaluting the delimiter. Valid only with RegexMatch.
-- IgnorePatternWhitespace: Ignores unescaped whitespace and
+- **IgnorePatternWhitespace**: Ignores unescaped whitespace and
   comments marked with the number sign (#). Valid only with
   RegexMatch.
 - **Multiline**: Multiline mode forces `^` and `$` to match the beginning

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Split.md
@@ -203,7 +203,7 @@ The RegexMatch options are:
   operator is specified.
 - **CultureInvariant**: Ignores cultural differences in language
   when evaluting the delimiter. Valid only with RegexMatch.
-- IgnorePatternWhitespace: Ignores unescaped whitespace and
+- **IgnorePatternWhitespace**: Ignores unescaped whitespace and
   comments marked with the number sign (#). Valid only with
   RegexMatch.
 - **Multiline**: Multiline mode forces `^` and `$` to match the beginning

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Split.md
@@ -203,7 +203,7 @@ The RegexMatch options are:
   operator is specified.
 - **CultureInvariant**: Ignores cultural differences in language
   when evaluting the delimiter. Valid only with RegexMatch.
-- IgnorePatternWhitespace: Ignores unescaped whitespace and
+- **IgnorePatternWhitespace**: Ignores unescaped whitespace and
   comments marked with the number sign (#). Valid only with
   RegexMatch.
 - **Multiline**: Multiline mode forces `^` and `$` to match the beginning


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->