### PR TITLE
Related to #4877 - Fixed spelling error

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -5,6 +5,7 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Regular_Expressions
 ---
+
 # About Regular Expressions
 
 ## Short description
@@ -14,8 +15,9 @@ Describes regular expressions in PowerShell.
 
 > [!NOTE]
 > This article will show you the syntax and methods for using regular
-> expressions in PowerShell, not all syntax is discussed. For a more
-> complete reference, see the [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference).
+> expressions in PowerShell, not all syntax is discussed. For a more complete
+> reference, see the
+> [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference).
 
 A regular expression is a pattern used to match text. It can be made up of
 literal characters, operators, and other constructs.
@@ -40,8 +42,8 @@ shown above has a different way to force case sensitivity.
 
 ### Character literals
 
-A regular expression can be a literal character or a string.
-This causes the engine to match the text specified exactly.
+A regular expression can be a literal character or a string. The expression
+causes the engine to match the text specified exactly.
 
 ```powershell
 # This statement returns true because book contains the string "oo"
@@ -50,8 +52,8 @@ This causes the engine to match the text specified exactly.
 
 ### Character classes
 
-While character literals work if you know the exact pattern, character
-classes allow you to be less specific.
+While character literals work if you know the exact pattern, character classes
+allow you to be less specific.
 
 #### Character groups
 
@@ -63,14 +65,14 @@ while `[^character group]` only matches characters NOT in the group.
 "big" -match "b[iou]g"
 ```
 
-If your list of characters to match includes the hyphen character (-), it must be at the beginning
-or end of the list to distinguish it from a character range expression.
+If your list of characters to match includes the hyphen character (`-`), it
+must be at the beginning or end of the list to distinguish it from a character
+range expression.
 
 #### Character ranges
 
-A pattern can also be a range of characters. This can be alphabetic
-`[A-Z]`, numeric `[0-9]`, or even ASCII-based `[ -~]` (all printable
-characters).
+A pattern can also be a range of characters. The characters can be alphabetic `[A-Z]`,
+numeric `[0-9]`, or even ASCII-based `[ -~]` (all printable characters).
 
 ```powershell
 # This expression returns true if the pattern matches any 2 digit number.
@@ -79,8 +81,8 @@ characters).
 
 #### Numbers
 
-The `\d` character class will match any decimal digit.  Conversely, `\D`
-will match any non-decimal digit.
+The `\d` character class will match any decimal digit. Conversely, `\D` will
+match any non-decimal digit.
 
 ```powershell
 # This expression returns true if it matches a server name.
@@ -90,8 +92,8 @@ will match any non-decimal digit.
 
 #### Word characters
 
-The `\w` character class will match any word character `[a-zA-Z_0-9]`.
-To match any non-word character, use `\W`.
+The `\w` character class will match any word character `[a-zA-Z_0-9]`. To match
+any non-word character, use `\W`.
 
 ```powershell
 # This expression returns true.
@@ -101,8 +103,8 @@ To match any non-word character, use `\W`.
 
 #### Wildcards
 
-The period (`.`) is a wildcard character in regular expressions. It will
-match any character except a newline (`\n`).
+The period (`.`) is a wildcard character in regular expressions. It will match
+any character except a newline (`\n`).
 
 ```powershell
 # This expression returns true.
@@ -112,7 +114,7 @@ match any character except a newline (`\n`).
 
 #### Whitespace
 
-Whitespace is matched using the `\s` character class.  Any non-whitespace
+Whitespace is matched using the `\s` character class. Any non-whitespace
 character is matched using `\S`. Literal space characters `' '` can also be
 used.
 
@@ -124,10 +126,10 @@ used.
 
 ### Quantifiers
 
-Quantifiers control how many instances of each element should be present in
-the input string.
+Quantifiers control how many instances of each element should be present in the
+input string.
 
-These are a few of the quantifiers are available in PowerShell.
+The following are a few of the quantifiers available in PowerShell:
 
 |Quantifier  |Description  |
 |---------|---------|
@@ -136,15 +138,15 @@ These are a few of the quantifiers are available in PowerShell.
 |`?`|Zero or one time.|
 |`{n,m}`|At least `n`, but no more than `m` times.|
 
-The asterisk `*` matches the previous element Zero or more times. This means
-that even an input string without the element would be a match.
+The asterisk (`*`) matches the previous element zero or more times. The result
+is that even an input string without the element would be a match.
 
 ```powershell
 # This returns true for all account name strings even if the name is absent.
 "ACCOUNT NAME:    Administrator" -match "ACCOUNT NAME:\s*\w*"
 ```
 
-The plus sign `+` matches the previous element One or more times.
+The plus sign (`+`) matches the previous element one or more times.
 
 ```powershell
 # This returns true if it matches any server name.
@@ -155,7 +157,7 @@ The question mark `?` matches the previous element zero or one time. Like
 asterisk `*`, it will even match strings where the element is absent.
 
 ```powershell
-# This returns true for any server name, even ones without dashes.
+# This returns true for any server name, even server names without dashes.
 "SERVER01" -match "[A-Z]+-?\d\d"
 ```
 
@@ -179,9 +181,9 @@ optional.
 Anchors allow you to cause a match to succeed or fail based on the matches
 position within the input string.
 
-The two commonly used anchors are `^` and `$`. The carat `^` matches the
-start of a string, and `$`, which matches the end of a string. This allows
-you to match your text at a specific position while also discarding unwanted
+The two commonly used anchors are `^` and `$`. The caret `^` matches the start
+of a string, and `$`, which matches the end of a string. The anchors allow you
+to match your text at a specific position while also discarding unwanted
 characters.
 
 ```powershell
@@ -190,12 +192,12 @@ characters.
 "fishing" -match "^fish$"
 ```
 
-When using anchors in powershell, you should understand the difference
-between **Singleline** and **Multiline** regular expression options.
+When using anchors in powershell, you should understand the difference between
+**Singleline** and **Multiline** regular expression options.
 
-- **Multiline**: Multiline mode forces `^` and `$` to match the beginning
-  end of every LINE instead of the beginning and end of the input string.
-- **Singleline**: Singleline mode treats the input string as a *SingleLine*.
+- **Multiline**: Multiline mode forces `^` and `$` to match the beginning end
+  of every LINE instead of the beginning and end of the input string.
+- **Singleline**: Singleline mode treats the input string as a **SingleLine**.
   It forces the `.` character to match every character (including newlines),
   instead of matching every character EXCEPT the newline `\n`.
 
@@ -204,13 +206,13 @@ To read more about these options and how to use them, visit the
 
 ### Escaping characters
 
-The backslash `\` is used to escape characters so they are not parsed by the
+The backslash (`\`) is used to escape characters so they aren't parsed by the
 regular expression engine.
 
 The following characters are reserved: `[]().\^$|?*+{}`.
 
-You will need to escape these characters in your patterns to match
-them in your input strings.
+You'll need to escape these characters in your patterns to match them in your
+input strings.
 
 ```powershell
 # This returns true and matches numbers with at least 2 digits of precision.
@@ -224,21 +226,21 @@ There`s a static method of the regex class that can escape text for you.
 [regex]::escape("3.\d{2,}")
 ```
 
-```output
+```Output
 3\.\\d\{2,}
 ```
 
 > [!NOTE]
-> This escapes all reserved regular expression characters, including
-> existing backslashes used in character classes.  Be sure to only use it on
-> the portion of your pattern that you need to escape.
+> This escapes all reserved regular expression characters, including existing
+> backslashes used in character classes. Be sure to only use it on the portion
+> of your pattern that you need to escape.
 
 #### Other character escapes
 
 There are also reserved character escapes that you can use to match special
 character types.
 
-The following are a few commonly used character escapes.
+The following are a few commonly used character escapes:
 
 |Character Escape  |Description  |
 |---------|---------|
@@ -248,26 +250,31 @@ The following are a few commonly used character escapes.
 
 ### Groups, Captures, and Substitutions
 
-Grouping constructs separate a input string into substrings that can be
+Grouping constructs separate an input string into substrings that can be
 captured or ignored. Grouped substrings are called subexpressions. By default
-subexpressions are captured in numbered groups, though you can assign names
-to them as well.
+subexpressions are captured in numbered groups, though you can assign names to
+them as well.
 
-A grouping construct is a regular expression surrounded by
-parenthesis. Any text matched by the by the enclosed regular expression is
-captured. The following example will break the input text into two capturing
-groups.
+A grouping construct is a regular expression surrounded by parentheses. Any
+text matched by the enclosed regular expression is captured. The following
+example will break the input text into two capturing groups.
 
 ```powershell
 "The last logged on user was CONTOSO\jsmith" -match "(.+was )(.+)"
+```
+
+```Output
 True
 ```
 
-Use the `$Matches` **Hashtable** automatic variable to retrieve
-captured text. The text representing the entire match is stored at key `0`.
+Use the `$Matches` **Hashtable** automatic variable to retrieve captured text.
+The text representing the entire match is stored at key `0`.
 
 ```powershell
 $Matches.0
+```
+
+```Output
 The last logged on user was CONTOSO\jsmith
 ```
 
@@ -277,7 +284,9 @@ contains just the username.
 
 ```powershell
 $Matches
+```
 
+```Output
 Name                           Value
 ----                           -----
 2                              CONTOSO\jsmith
@@ -289,7 +298,7 @@ Name                           Value
 > The `0` key is an **Integer**. You can use any **Hashtable** method to access
 > the value stored.
 >
-> ```powershell
+> ```
 > PS> "Good Dog" -match "Dog"
 > True
 >
@@ -306,13 +315,13 @@ Name                           Value
 #### Named Captures
 
 By default, captures are stored in ascending numeric order, from left to right.
-You can also assign a *name* to a capturing group. This *name* becomes a key
-on the `$Matches` **Hashtable** automatic variable.
+You can also assign a **name** to a capturing group. This **name** becomes a
+key on the `$Matches` **Hashtable** automatic variable.
 
-Inside a capturing group, use `?<keyname>` to store captured data under
-a named key.
+Inside a capturing group, use `?<keyname>` to store captured data under a named
+key.
 
-```powershell
+```
 PS> $string = "The last logged on user was CONTOSO\jsmith"
 PS> $string -match "was (?<domain>.+)\\(?<user>.+)"
 True
@@ -333,9 +342,9 @@ jsmith
 ```
 
 The following example stores the latest **SuccessAudit** from the Windows
-Security Log. The provided regular expression extracts the username and
-domain from the message and stores them under **N** and **D** keys for
-*name* and *domain*.
+Security Log. The provided regular expression extracts the username and domain
+from the message and stores them under the keys: **N** for name and **D** for
+domain.
 
 ```powershell
 $log = (Get-EventLog -LogName Security -Newest 1 -InstanceId 4689).message
@@ -343,7 +352,7 @@ $r = '(?s).*Account Name:\s*(?<N>.*).*Account Domain:\s*(?<D>[A-Z,0-9]*)'
 $log -match $r
 ```
 
-```output
+```Output
 True
 ```
 
@@ -351,7 +360,7 @@ True
 $Matches
 ```
 
-```output
+```Output
 Name                           Value
 ----                           -----
 D                              CONTOSO
@@ -359,73 +368,75 @@ N                              jsmith
 0                              A process has exited....
 ```
 
-For more information, see [Grouping Constructs in Regular Expressions](/dotnet/standard/base-types/grouping-constructs-in-regular-expressions).
+For more information, see
+[Grouping Constructs in Regular Expressions](/dotnet/standard/base-types/grouping-constructs-in-regular-expressions).
 
 #### Substitutions in Regular Expressions
 
 Using the regular expressions with the `-replace` operator allows you to
 dynamically replace text using captured text. Capturing groups can be
-referenced in the \<substitute\> string. This is done by using the `$`
-character before the group identifier.
+referenced in the \<substitute\> string. The substitution is done by using the
+`$` character before the group identifier.
 
 `<input> -replace <original>, <substitute>`
 
-Two of the ways to reference capturing groups is by **Number** and by **Name**
+Two ways to reference capturing groups are by **Number** and by **Name**.
 
-- By **Number** -
-  Capturing Groups are numbered from left to right.
+- By **Number** - Capturing Groups are numbered from left to right.
 
   ```powershell
   "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
   ```
 
-  ```output
+  ```Output
   John.D.Smith@contoso.com
   ```
 
-- By **Name** -
-  Capturing Groups can also be referenced by name.
+- By **Name** - Capturing Groups can also be referenced by name.
 
   ```powershell
   "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
   ```
 
-  ```output
+  ```Output
   FABRIKAM\Administrator
   ```
 
-The `$&` expression represents all of the text matched.
+The `$&` expression represents all the text matched.
 
 ```powershell
 "Gobble" -replace "Gobble", "$& $&"
 ```
 
-```output
+```Output
 Gobble Gobble
 ```
 
 > [!WARNING]
-> Since the `$` character is used in string expansion, you will need to use
+> Since the `$` character is used in string expansion, you'll need to use
 > literal strings with substitution, or escape the `$` character.
+>
 > ```powershell
 > 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
 > ```
 >
-> ```output
+> ```Output
 > Hello Universe
 > ```
 >
-> Additionally, sicne the `$` character is used in substitution, you will need
+> Additionally, since the `$` character is used in substitution, you will need
 > to escape any instances in your string.
 >
 > ```powershell
 > '5.72' -replace '(.+)', '$$$1'
 > ```
-> ```output
+>
+> ```Output
 > $5.72
 > ```
 
-For more information, see [Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions).
+For more information, see
+[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions).
 
 ## See also
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -5,6 +5,7 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Regular_Expressions
 ---
+
 # About Regular Expressions
 
 ## Short description
@@ -14,8 +15,9 @@ Describes regular expressions in PowerShell.
 
 > [!NOTE]
 > This article will show you the syntax and methods for using regular
-> expressions in PowerShell, not all syntax is discussed. For a more
-> complete reference, see the [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference).
+> expressions in PowerShell, not all syntax is discussed. For a more complete
+> reference, see the
+> [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference).
 
 A regular expression is a pattern used to match text. It can be made up of
 literal characters, operators, and other constructs.
@@ -40,8 +42,8 @@ shown above has a different way to force case sensitivity.
 
 ### Character literals
 
-A regular expression can be a literal character or a string.
-This causes the engine to match the text specified exactly.
+A regular expression can be a literal character or a string. The expression
+causes the engine to match the text specified exactly.
 
 ```powershell
 # This statement returns true because book contains the string "oo"
@@ -50,8 +52,8 @@ This causes the engine to match the text specified exactly.
 
 ### Character classes
 
-While character literals work if you know the exact pattern, character
-classes allow you to be less specific.
+While character literals work if you know the exact pattern, character classes
+allow you to be less specific.
 
 #### Character groups
 
@@ -63,14 +65,14 @@ while `[^character group]` only matches characters NOT in the group.
 "big" -match "b[iou]g"
 ```
 
-If your list of characters to match includes the hyphen character (-), it must be at the beginning
-or end of the list to distinguish it from a character range expression.
+If your list of characters to match includes the hyphen character (`-`), it
+must be at the beginning or end of the list to distinguish it from a character
+range expression.
 
 #### Character ranges
 
-A pattern can also be a range of characters. This can be alphabetic
-`[A-Z]`, numeric `[0-9]`, or even ASCII-based `[ -~]` (all printable
-characters).
+A pattern can also be a range of characters. The characters can be alphabetic `[A-Z]`,
+numeric `[0-9]`, or even ASCII-based `[ -~]` (all printable characters).
 
 ```powershell
 # This expression returns true if the pattern matches any 2 digit number.
@@ -79,8 +81,8 @@ characters).
 
 #### Numbers
 
-The `\d` character class will match any decimal digit.  Conversely, `\D`
-will match any non-decimal digit.
+The `\d` character class will match any decimal digit. Conversely, `\D` will
+match any non-decimal digit.
 
 ```powershell
 # This expression returns true if it matches a server name.
@@ -90,8 +92,8 @@ will match any non-decimal digit.
 
 #### Word characters
 
-The `\w` character class will match any word character `[a-zA-Z_0-9]`.
-To match any non-word character, use `\W`.
+The `\w` character class will match any word character `[a-zA-Z_0-9]`. To match
+any non-word character, use `\W`.
 
 ```powershell
 # This expression returns true.
@@ -101,8 +103,8 @@ To match any non-word character, use `\W`.
 
 #### Wildcards
 
-The period (`.`) is a wildcard character in regular expressions. It will
-match any character except a newline (`\n`).
+The period (`.`) is a wildcard character in regular expressions. It will match
+any character except a newline (`\n`).
 
 ```powershell
 # This expression returns true.
@@ -112,7 +114,7 @@ match any character except a newline (`\n`).
 
 #### Whitespace
 
-Whitespace is matched using the `\s` character class.  Any non-whitespace
+Whitespace is matched using the `\s` character class. Any non-whitespace
 character is matched using `\S`. Literal space characters `' '` can also be
 used.
 
@@ -124,10 +126,10 @@ used.
 
 ### Quantifiers
 
-Quantifiers control how many instances of each element should be present in
-the input string.
+Quantifiers control how many instances of each element should be present in the
+input string.
 
-These are a few of the quantifiers are available in PowerShell.
+The following are a few of the quantifiers available in PowerShell:
 
 |Quantifier  |Description  |
 |---------|---------|
@@ -136,15 +138,15 @@ These are a few of the quantifiers are available in PowerShell.
 |`?`|Zero or one time.|
 |`{n,m}`|At least `n`, but no more than `m` times.|
 
-The asterisk `*` matches the previous element Zero or more times. This means
-that even an input string without the element would be a match.
+The asterisk (`*`) matches the previous element zero or more times. The result
+is that even an input string without the element would be a match.
 
 ```powershell
 # This returns true for all account name strings even if the name is absent.
 "ACCOUNT NAME:    Administrator" -match "ACCOUNT NAME:\s*\w*"
 ```
 
-The plus sign `+` matches the previous element One or more times.
+The plus sign (`+`) matches the previous element one or more times.
 
 ```powershell
 # This returns true if it matches any server name.
@@ -155,7 +157,7 @@ The question mark `?` matches the previous element zero or one time. Like
 asterisk `*`, it will even match strings where the element is absent.
 
 ```powershell
-# This returns true for any server name, even ones without dashes.
+# This returns true for any server name, even server names without dashes.
 "SERVER01" -match "[A-Z]+-?\d\d"
 ```
 
@@ -179,9 +181,9 @@ optional.
 Anchors allow you to cause a match to succeed or fail based on the matches
 position within the input string.
 
-The two commonly used anchors are `^` and `$`. The carat `^` matches the
-start of a string, and `$`, which matches the end of a string. This allows
-you to match your text at a specific position while also discarding unwanted
+The two commonly used anchors are `^` and `$`. The caret `^` matches the start
+of a string, and `$`, which matches the end of a string. The anchors allow you
+to match your text at a specific position while also discarding unwanted
 characters.
 
 ```powershell
@@ -190,12 +192,12 @@ characters.
 "fishing" -match "^fish$"
 ```
 
-When using anchors in powershell, you should understand the difference
-between **Singleline** and **Multiline** regular expression options.
+When using anchors in powershell, you should understand the difference between
+**Singleline** and **Multiline** regular expression options.
 
-- **Multiline**: Multiline mode forces `^` and `$` to match the beginning
-  end of every LINE instead of the beginning and end of the input string.
-- **Singleline**: Singleline mode treats the input string as a *SingleLine*.
+- **Multiline**: Multiline mode forces `^` and `$` to match the beginning end
+  of every LINE instead of the beginning and end of the input string.
+- **Singleline**: Singleline mode treats the input string as a **SingleLine**.
   It forces the `.` character to match every character (including newlines),
   instead of matching every character EXCEPT the newline `\n`.
 
@@ -204,13 +206,13 @@ To read more about these options and how to use them, visit the
 
 ### Escaping characters
 
-The backslash `\` is used to escape characters so they are not parsed by the
+The backslash (`\`) is used to escape characters so they aren't parsed by the
 regular expression engine.
 
 The following characters are reserved: `[]().\^$|?*+{}`.
 
-You will need to escape these characters in your patterns to match
-them in your input strings.
+You'll need to escape these characters in your patterns to match them in your
+input strings.
 
 ```powershell
 # This returns true and matches numbers with at least 2 digits of precision.
@@ -224,21 +226,21 @@ There`s a static method of the regex class that can escape text for you.
 [regex]::escape("3.\d{2,}")
 ```
 
-```output
+```Output
 3\.\\d\{2,}
 ```
 
 > [!NOTE]
-> This escapes all reserved regular expression characters, including
-> existing backslashes used in character classes.  Be sure to only use it on
-> the portion of your pattern that you need to escape.
+> This escapes all reserved regular expression characters, including existing
+> backslashes used in character classes. Be sure to only use it on the portion
+> of your pattern that you need to escape.
 
 #### Other character escapes
 
 There are also reserved character escapes that you can use to match special
 character types.
 
-The following are a few commonly used character escapes.
+The following are a few commonly used character escapes:
 
 |Character Escape  |Description  |
 |---------|---------|
@@ -248,26 +250,31 @@ The following are a few commonly used character escapes.
 
 ### Groups, Captures, and Substitutions
 
-Grouping constructs separate a input string into substrings that can be
+Grouping constructs separate an input string into substrings that can be
 captured or ignored. Grouped substrings are called subexpressions. By default
-subexpressions are captured in numbered groups, though you can assign names
-to them as well.
+subexpressions are captured in numbered groups, though you can assign names to
+them as well.
 
-A grouping construct is a regular expression surrounded by
-parenthesis. Any text matched by the by the enclosed regular expression is
-captured. The following example will break the input text into two capturing
-groups.
+A grouping construct is a regular expression surrounded by parentheses. Any
+text matched by the enclosed regular expression is captured. The following
+example will break the input text into two capturing groups.
 
 ```powershell
 "The last logged on user was CONTOSO\jsmith" -match "(.+was )(.+)"
+```
+
+```Output
 True
 ```
 
-Use the `$Matches` **Hashtable** automatic variable to retrieve
-captured text. The text representing the entire match is stored at key `0`.
+Use the `$Matches` **Hashtable** automatic variable to retrieve captured text.
+The text representing the entire match is stored at key `0`.
 
 ```powershell
 $Matches.0
+```
+
+```Output
 The last logged on user was CONTOSO\jsmith
 ```
 
@@ -277,7 +284,9 @@ contains just the username.
 
 ```powershell
 $Matches
+```
 
+```Output
 Name                           Value
 ----                           -----
 2                              CONTOSO\jsmith
@@ -289,7 +298,7 @@ Name                           Value
 > The `0` key is an **Integer**. You can use any **Hashtable** method to access
 > the value stored.
 >
-> ```powershell
+> ```
 > PS> "Good Dog" -match "Dog"
 > True
 >
@@ -306,13 +315,13 @@ Name                           Value
 #### Named Captures
 
 By default, captures are stored in ascending numeric order, from left to right.
-You can also assign a *name* to a capturing group. This *name* becomes a key
-on the `$Matches` **Hashtable** automatic variable.
+You can also assign a **name** to a capturing group. This **name** becomes a
+key on the `$Matches` **Hashtable** automatic variable.
 
-Inside a capturing group, use `?<keyname>` to store captured data under
-a named key.
+Inside a capturing group, use `?<keyname>` to store captured data under a named
+key.
 
-```powershell
+```
 PS> $string = "The last logged on user was CONTOSO\jsmith"
 PS> $string -match "was (?<domain>.+)\\(?<user>.+)"
 True
@@ -333,9 +342,9 @@ jsmith
 ```
 
 The following example stores the latest **SuccessAudit** from the Windows
-Security Log. The provided regular expression extracts the username and
-domain from the message and stores them under **N** and **D** keys for
-*name* and *domain*.
+Security Log. The provided regular expression extracts the username and domain
+from the message and stores them under the keys: **N** for name and **D** for
+domain.
 
 ```powershell
 $log = (Get-EventLog -LogName Security -Newest 1 -InstanceId 4689).message
@@ -343,7 +352,7 @@ $r = '(?s).*Account Name:\s*(?<N>.*).*Account Domain:\s*(?<D>[A-Z,0-9]*)'
 $log -match $r
 ```
 
-```output
+```Output
 True
 ```
 
@@ -351,7 +360,7 @@ True
 $Matches
 ```
 
-```output
+```Output
 Name                           Value
 ----                           -----
 D                              CONTOSO
@@ -359,73 +368,75 @@ N                              jsmith
 0                              A process has exited....
 ```
 
-For more information, see [Grouping Constructs in Regular Expressions](/dotnet/standard/base-types/grouping-constructs-in-regular-expressions).
+For more information, see
+[Grouping Constructs in Regular Expressions](/dotnet/standard/base-types/grouping-constructs-in-regular-expressions).
 
 #### Substitutions in Regular Expressions
 
 Using the regular expressions with the `-replace` operator allows you to
 dynamically replace text using captured text. Capturing groups can be
-referenced in the \<substitute\> string. This is done by using the `$`
-character before the group identifier.
+referenced in the \<substitute\> string. The substitution is done by using the
+`$` character before the group identifier.
 
 `<input> -replace <original>, <substitute>`
 
-Two of the ways to reference capturing groups is by **Number** and by **Name**
+Two ways to reference capturing groups are by **Number** and by **Name**.
 
-- By **Number** -
-  Capturing Groups are numbered from left to right.
+- By **Number** - Capturing Groups are numbered from left to right.
 
   ```powershell
   "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
   ```
 
-  ```output
+  ```Output
   John.D.Smith@contoso.com
   ```
 
-- By **Name** -
-  Capturing Groups can also be referenced by name.
+- By **Name** - Capturing Groups can also be referenced by name.
 
   ```powershell
   "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
   ```
 
-  ```output
+  ```Output
   FABRIKAM\Administrator
   ```
 
-The `$&` expression represents all of the text matched.
+The `$&` expression represents all the text matched.
 
 ```powershell
 "Gobble" -replace "Gobble", "$& $&"
 ```
 
-```output
+```Output
 Gobble Gobble
 ```
 
 > [!WARNING]
-> Since the `$` character is used in string expansion, you will need to use
+> Since the `$` character is used in string expansion, you'll need to use
 > literal strings with substitution, or escape the `$` character.
+>
 > ```powershell
 > 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
 > ```
 >
-> ```output
+> ```Output
 > Hello Universe
 > ```
 >
-> Additionally, sicne the `$` character is used in substitution, you will need
+> Additionally, since the `$` character is used in substitution, you will need
 > to escape any instances in your string.
 >
 > ```powershell
 > '5.72' -replace '(.+)', '$$$1'
 > ```
-> ```output
+>
+> ```Output
 > $5.72
 > ```
 
-For more information, see [Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions).
+For more information, see
+[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions).
 
 ## See also
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -5,6 +5,7 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Regular_Expressions
 ---
+
 # About Regular Expressions
 
 ## Short description
@@ -14,8 +15,9 @@ Describes regular expressions in PowerShell.
 
 > [!NOTE]
 > This article will show you the syntax and methods for using regular
-> expressions in PowerShell, not all syntax is discussed. For a more
-> complete reference, see the [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference).
+> expressions in PowerShell, not all syntax is discussed. For a more complete
+> reference, see the
+> [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference).
 
 A regular expression is a pattern used to match text. It can be made up of
 literal characters, operators, and other constructs.
@@ -40,8 +42,8 @@ shown above has a different way to force case sensitivity.
 
 ### Character literals
 
-A regular expression can be a literal character or a string.
-This causes the engine to match the text specified exactly.
+A regular expression can be a literal character or a string. The expression
+causes the engine to match the text specified exactly.
 
 ```powershell
 # This statement returns true because book contains the string "oo"
@@ -50,8 +52,8 @@ This causes the engine to match the text specified exactly.
 
 ### Character classes
 
-While character literals work if you know the exact pattern, character
-classes allow you to be less specific.
+While character literals work if you know the exact pattern, character classes
+allow you to be less specific.
 
 #### Character groups
 
@@ -63,14 +65,14 @@ while `[^character group]` only matches characters NOT in the group.
 "big" -match "b[iou]g"
 ```
 
-If your list of characters to match includes the hyphen character (-), it must be at the beginning
-or end of the list to distinguish it from a character range expression.
+If your list of characters to match includes the hyphen character (`-`), it
+must be at the beginning or end of the list to distinguish it from a character
+range expression.
 
 #### Character ranges
 
-A pattern can also be a range of characters. This can be alphabetic
-`[A-Z]`, numeric `[0-9]`, or even ASCII-based `[ -~]` (all printable
-characters).
+A pattern can also be a range of characters. The characters can be alphabetic `[A-Z]`,
+numeric `[0-9]`, or even ASCII-based `[ -~]` (all printable characters).
 
 ```powershell
 # This expression returns true if the pattern matches any 2 digit number.
@@ -79,8 +81,8 @@ characters).
 
 #### Numbers
 
-The `\d` character class will match any decimal digit.  Conversely, `\D`
-will match any non-decimal digit.
+The `\d` character class will match any decimal digit. Conversely, `\D` will
+match any non-decimal digit.
 
 ```powershell
 # This expression returns true if it matches a server name.
@@ -90,8 +92,8 @@ will match any non-decimal digit.
 
 #### Word characters
 
-The `\w` character class will match any word character `[a-zA-Z_0-9]`.
-To match any non-word character, use `\W`.
+The `\w` character class will match any word character `[a-zA-Z_0-9]`. To match
+any non-word character, use `\W`.
 
 ```powershell
 # This expression returns true.
@@ -101,8 +103,8 @@ To match any non-word character, use `\W`.
 
 #### Wildcards
 
-The period (`.`) is a wildcard character in regular expressions. It will
-match any character except a newline (`\n`).
+The period (`.`) is a wildcard character in regular expressions. It will match
+any character except a newline (`\n`).
 
 ```powershell
 # This expression returns true.
@@ -112,7 +114,7 @@ match any character except a newline (`\n`).
 
 #### Whitespace
 
-Whitespace is matched using the `\s` character class.  Any non-whitespace
+Whitespace is matched using the `\s` character class. Any non-whitespace
 character is matched using `\S`. Literal space characters `' '` can also be
 used.
 
@@ -124,10 +126,10 @@ used.
 
 ### Quantifiers
 
-Quantifiers control how many instances of each element should be present in
-the input string.
+Quantifiers control how many instances of each element should be present in the
+input string.
 
-These are a few of the quantifiers are available in PowerShell.
+The following are a few of the quantifiers available in PowerShell:
 
 |Quantifier  |Description  |
 |---------|---------|
@@ -136,15 +138,15 @@ These are a few of the quantifiers are available in PowerShell.
 |`?`|Zero or one time.|
 |`{n,m}`|At least `n`, but no more than `m` times.|
 
-The asterisk `*` matches the previous element Zero or more times. This means
-that even an input string without the element would be a match.
+The asterisk (`*`) matches the previous element zero or more times. The result
+is that even an input string without the element would be a match.
 
 ```powershell
 # This returns true for all account name strings even if the name is absent.
 "ACCOUNT NAME:    Administrator" -match "ACCOUNT NAME:\s*\w*"
 ```
 
-The plus sign `+` matches the previous element One or more times.
+The plus sign (`+`) matches the previous element one or more times.
 
 ```powershell
 # This returns true if it matches any server name.
@@ -155,7 +157,7 @@ The question mark `?` matches the previous element zero or one time. Like
 asterisk `*`, it will even match strings where the element is absent.
 
 ```powershell
-# This returns true for any server name, even ones without dashes.
+# This returns true for any server name, even server names without dashes.
 "SERVER01" -match "[A-Z]+-?\d\d"
 ```
 
@@ -179,9 +181,9 @@ optional.
 Anchors allow you to cause a match to succeed or fail based on the matches
 position within the input string.
 
-The two commonly used anchors are `^` and `$`. The carat `^` matches the
-start of a string, and `$`, which matches the end of a string. This allows
-you to match your text at a specific position while also discarding unwanted
+The two commonly used anchors are `^` and `$`. The caret `^` matches the start
+of a string, and `$`, which matches the end of a string. The anchors allow you
+to match your text at a specific position while also discarding unwanted
 characters.
 
 ```powershell
@@ -190,12 +192,12 @@ characters.
 "fishing" -match "^fish$"
 ```
 
-When using anchors in powershell, you should understand the difference
-between **Singleline** and **Multiline** regular expression options.
+When using anchors in powershell, you should understand the difference between
+**Singleline** and **Multiline** regular expression options.
 
-- **Multiline**: Multiline mode forces `^` and `$` to match the beginning
-  end of every LINE instead of the beginning and end of the input string.
-- **Singleline**: Singleline mode treats the input string as a *SingleLine*.
+- **Multiline**: Multiline mode forces `^` and `$` to match the beginning end
+  of every LINE instead of the beginning and end of the input string.
+- **Singleline**: Singleline mode treats the input string as a **SingleLine**.
   It forces the `.` character to match every character (including newlines),
   instead of matching every character EXCEPT the newline `\n`.
 
@@ -204,13 +206,13 @@ To read more about these options and how to use them, visit the
 
 ### Escaping characters
 
-The backslash `\` is used to escape characters so they are not parsed by the
+The backslash (`\`) is used to escape characters so they aren't parsed by the
 regular expression engine.
 
 The following characters are reserved: `[]().\^$|?*+{}`.
 
-You will need to escape these characters in your patterns to match
-them in your input strings.
+You'll need to escape these characters in your patterns to match them in your
+input strings.
 
 ```powershell
 # This returns true and matches numbers with at least 2 digits of precision.
@@ -224,21 +226,21 @@ There`s a static method of the regex class that can escape text for you.
 [regex]::escape("3.\d{2,}")
 ```
 
-```output
+```Output
 3\.\\d\{2,}
 ```
 
 > [!NOTE]
-> This escapes all reserved regular expression characters, including
-> existing backslashes used in character classes.  Be sure to only use it on
-> the portion of your pattern that you need to escape.
+> This escapes all reserved regular expression characters, including existing
+> backslashes used in character classes. Be sure to only use it on the portion
+> of your pattern that you need to escape.
 
 #### Other character escapes
 
 There are also reserved character escapes that you can use to match special
 character types.
 
-The following are a few commonly used character escapes.
+The following are a few commonly used character escapes:
 
 |Character Escape  |Description  |
 |---------|---------|
@@ -248,26 +250,31 @@ The following are a few commonly used character escapes.
 
 ### Groups, Captures, and Substitutions
 
-Grouping constructs separate a input string into substrings that can be
+Grouping constructs separate an input string into substrings that can be
 captured or ignored. Grouped substrings are called subexpressions. By default
-subexpressions are captured in numbered groups, though you can assign names
-to them as well.
+subexpressions are captured in numbered groups, though you can assign names to
+them as well.
 
-A grouping construct is a regular expression surrounded by
-parenthesis. Any text matched by the by the enclosed regular expression is
-captured. The following example will break the input text into two capturing
-groups.
+A grouping construct is a regular expression surrounded by parentheses. Any
+text matched by the enclosed regular expression is captured. The following
+example will break the input text into two capturing groups.
 
 ```powershell
 "The last logged on user was CONTOSO\jsmith" -match "(.+was )(.+)"
+```
+
+```Output
 True
 ```
 
-Use the `$Matches` **Hashtable** automatic variable to retrieve
-captured text. The text representing the entire match is stored at key `0`.
+Use the `$Matches` **Hashtable** automatic variable to retrieve captured text.
+The text representing the entire match is stored at key `0`.
 
 ```powershell
 $Matches.0
+```
+
+```Output
 The last logged on user was CONTOSO\jsmith
 ```
 
@@ -277,7 +284,9 @@ contains just the username.
 
 ```powershell
 $Matches
+```
 
+```Output
 Name                           Value
 ----                           -----
 2                              CONTOSO\jsmith
@@ -289,7 +298,7 @@ Name                           Value
 > The `0` key is an **Integer**. You can use any **Hashtable** method to access
 > the value stored.
 >
-> ```powershell
+> ```
 > PS> "Good Dog" -match "Dog"
 > True
 >
@@ -306,13 +315,13 @@ Name                           Value
 #### Named Captures
 
 By default, captures are stored in ascending numeric order, from left to right.
-You can also assign a *name* to a capturing group. This *name* becomes a key
-on the `$Matches` **Hashtable** automatic variable.
+You can also assign a **name** to a capturing group. This **name** becomes a
+key on the `$Matches` **Hashtable** automatic variable.
 
-Inside a capturing group, use `?<keyname>` to store captured data under
-a named key.
+Inside a capturing group, use `?<keyname>` to store captured data under a named
+key.
 
-```powershell
+```
 PS> $string = "The last logged on user was CONTOSO\jsmith"
 PS> $string -match "was (?<domain>.+)\\(?<user>.+)"
 True
@@ -333,9 +342,9 @@ jsmith
 ```
 
 The following example stores the latest **SuccessAudit** from the Windows
-Security Log. The provided regular expression extracts the username and
-domain from the message and stores them under **N** and **D** keys for
-*name* and *domain*.
+Security Log. The provided regular expression extracts the username and domain
+from the message and stores them under the keys: **N** for name and **D** for
+domain.
 
 ```powershell
 $log = (Get-EventLog -LogName Security -Newest 1 -InstanceId 4689).message
@@ -343,7 +352,7 @@ $r = '(?s).*Account Name:\s*(?<N>.*).*Account Domain:\s*(?<D>[A-Z,0-9]*)'
 $log -match $r
 ```
 
-```output
+```Output
 True
 ```
 
@@ -351,7 +360,7 @@ True
 $Matches
 ```
 
-```output
+```Output
 Name                           Value
 ----                           -----
 D                              CONTOSO
@@ -359,73 +368,75 @@ N                              jsmith
 0                              A process has exited....
 ```
 
-For more information, see [Grouping Constructs in Regular Expressions](/dotnet/standard/base-types/grouping-constructs-in-regular-expressions).
+For more information, see
+[Grouping Constructs in Regular Expressions](/dotnet/standard/base-types/grouping-constructs-in-regular-expressions).
 
 #### Substitutions in Regular Expressions
 
 Using the regular expressions with the `-replace` operator allows you to
 dynamically replace text using captured text. Capturing groups can be
-referenced in the \<substitute\> string. This is done by using the `$`
-character before the group identifier.
+referenced in the \<substitute\> string. The substitution is done by using the
+`$` character before the group identifier.
 
 `<input> -replace <original>, <substitute>`
 
-Two of the ways to reference capturing groups is by **Number** and by **Name**
+Two ways to reference capturing groups are by **Number** and by **Name**.
 
-- By **Number** -
-  Capturing Groups are numbered from left to right.
+- By **Number** - Capturing Groups are numbered from left to right.
 
   ```powershell
   "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
   ```
 
-  ```output
+  ```Output
   John.D.Smith@contoso.com
   ```
 
-- By **Name** -
-  Capturing Groups can also be referenced by name.
+- By **Name** - Capturing Groups can also be referenced by name.
 
   ```powershell
   "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
   ```
 
-  ```output
+  ```Output
   FABRIKAM\Administrator
   ```
 
-The `$&` expression represents all of the text matched.
+The `$&` expression represents all the text matched.
 
 ```powershell
 "Gobble" -replace "Gobble", "$& $&"
 ```
 
-```output
+```Output
 Gobble Gobble
 ```
 
 > [!WARNING]
-> Since the `$` character is used in string expansion, you will need to use
+> Since the `$` character is used in string expansion, you'll need to use
 > literal strings with substitution, or escape the `$` character.
+>
 > ```powershell
 > 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
 > ```
 >
-> ```output
+> ```Output
 > Hello Universe
 > ```
 >
-> Additionally, sicne the `$` character is used in substitution, you will need
+> Additionally, since the `$` character is used in substitution, you will need
 > to escape any instances in your string.
 >
 > ```powershell
 > '5.72' -replace '(.+)', '$$$1'
 > ```
-> ```output
+>
+> ```Output
 > $5.72
 > ```
 
-For more information, see [Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions).
+For more information, see
+[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions).
 
 ## See also
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -5,6 +5,7 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Regular_Expressions
 ---
+
 # About Regular Expressions
 
 ## Short description
@@ -14,8 +15,9 @@ Describes regular expressions in PowerShell.
 
 > [!NOTE]
 > This article will show you the syntax and methods for using regular
-> expressions in PowerShell, not all syntax is discussed. For a more
-> complete reference, see the [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference).
+> expressions in PowerShell, not all syntax is discussed. For a more complete
+> reference, see the
+> [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference).
 
 A regular expression is a pattern used to match text. It can be made up of
 literal characters, operators, and other constructs.
@@ -40,8 +42,8 @@ shown above has a different way to force case sensitivity.
 
 ### Character literals
 
-A regular expression can be a literal character or a string.
-This causes the engine to match the text specified exactly.
+A regular expression can be a literal character or a string. The expression
+causes the engine to match the text specified exactly.
 
 ```powershell
 # This statement returns true because book contains the string "oo"
@@ -50,8 +52,8 @@ This causes the engine to match the text specified exactly.
 
 ### Character classes
 
-While character literals work if you know the exact pattern, character
-classes allow you to be less specific.
+While character literals work if you know the exact pattern, character classes
+allow you to be less specific.
 
 #### Character groups
 
@@ -63,14 +65,14 @@ while `[^character group]` only matches characters NOT in the group.
 "big" -match "b[iou]g"
 ```
 
-If your list of characters to match includes the hyphen character (-), it must be at the beginning
-or end of the list to distinguish it from a character range expression.
+If your list of characters to match includes the hyphen character (`-`), it
+must be at the beginning or end of the list to distinguish it from a character
+range expression.
 
 #### Character ranges
 
-A pattern can also be a range of characters. This can be alphabetic
-`[A-Z]`, numeric `[0-9]`, or even ASCII-based `[ -~]` (all printable
-characters).
+A pattern can also be a range of characters. The characters can be alphabetic `[A-Z]`,
+numeric `[0-9]`, or even ASCII-based `[ -~]` (all printable characters).
 
 ```powershell
 # This expression returns true if the pattern matches any 2 digit number.
@@ -79,8 +81,8 @@ characters).
 
 #### Numbers
 
-The `\d` character class will match any decimal digit.  Conversely, `\D`
-will match any non-decimal digit.
+The `\d` character class will match any decimal digit. Conversely, `\D` will
+match any non-decimal digit.
 
 ```powershell
 # This expression returns true if it matches a server name.
@@ -90,8 +92,8 @@ will match any non-decimal digit.
 
 #### Word characters
 
-The `\w` character class will match any word character `[a-zA-Z_0-9]`.
-To match any non-word character, use `\W`.
+The `\w` character class will match any word character `[a-zA-Z_0-9]`. To match
+any non-word character, use `\W`.
 
 ```powershell
 # This expression returns true.
@@ -101,8 +103,8 @@ To match any non-word character, use `\W`.
 
 #### Wildcards
 
-The period (`.`) is a wildcard character in regular expressions. It will
-match any character except a newline (`\n`).
+The period (`.`) is a wildcard character in regular expressions. It will match
+any character except a newline (`\n`).
 
 ```powershell
 # This expression returns true.
@@ -112,7 +114,7 @@ match any character except a newline (`\n`).
 
 #### Whitespace
 
-Whitespace is matched using the `\s` character class.  Any non-whitespace
+Whitespace is matched using the `\s` character class. Any non-whitespace
 character is matched using `\S`. Literal space characters `' '` can also be
 used.
 
@@ -124,10 +126,10 @@ used.
 
 ### Quantifiers
 
-Quantifiers control how many instances of each element should be present in
-the input string.
+Quantifiers control how many instances of each element should be present in the
+input string.
 
-These are a few of the quantifiers are available in PowerShell.
+The following are a few of the quantifiers available in PowerShell:
 
 |Quantifier  |Description  |
 |---------|---------|
@@ -136,15 +138,15 @@ These are a few of the quantifiers are available in PowerShell.
 |`?`|Zero or one time.|
 |`{n,m}`|At least `n`, but no more than `m` times.|
 
-The asterisk `*` matches the previous element Zero or more times. This means
-that even an input string without the element would be a match.
+The asterisk (`*`) matches the previous element zero or more times. The result
+is that even an input string without the element would be a match.
 
 ```powershell
 # This returns true for all account name strings even if the name is absent.
 "ACCOUNT NAME:    Administrator" -match "ACCOUNT NAME:\s*\w*"
 ```
 
-The plus sign `+` matches the previous element One or more times.
+The plus sign (`+`) matches the previous element one or more times.
 
 ```powershell
 # This returns true if it matches any server name.
@@ -155,7 +157,7 @@ The question mark `?` matches the previous element zero or one time. Like
 asterisk `*`, it will even match strings where the element is absent.
 
 ```powershell
-# This returns true for any server name, even ones without dashes.
+# This returns true for any server name, even server names without dashes.
 "SERVER01" -match "[A-Z]+-?\d\d"
 ```
 
@@ -179,9 +181,9 @@ optional.
 Anchors allow you to cause a match to succeed or fail based on the matches
 position within the input string.
 
-The two commonly used anchors are `^` and `$`. The carat `^` matches the
-start of a string, and `$`, which matches the end of a string. This allows
-you to match your text at a specific position while also discarding unwanted
+The two commonly used anchors are `^` and `$`. The caret `^` matches the start
+of a string, and `$`, which matches the end of a string. The anchors allow you
+to match your text at a specific position while also discarding unwanted
 characters.
 
 ```powershell
@@ -190,12 +192,12 @@ characters.
 "fishing" -match "^fish$"
 ```
 
-When using anchors in powershell, you should understand the difference
-between **Singleline** and **Multiline** regular expression options.
+When using anchors in powershell, you should understand the difference between
+**Singleline** and **Multiline** regular expression options.
 
-- **Multiline**: Multiline mode forces `^` and `$` to match the beginning
-  end of every LINE instead of the beginning and end of the input string.
-- **Singleline**: Singleline mode treats the input string as a *SingleLine*.
+- **Multiline**: Multiline mode forces `^` and `$` to match the beginning end
+  of every LINE instead of the beginning and end of the input string.
+- **Singleline**: Singleline mode treats the input string as a **SingleLine**.
   It forces the `.` character to match every character (including newlines),
   instead of matching every character EXCEPT the newline `\n`.
 
@@ -204,13 +206,13 @@ To read more about these options and how to use them, visit the
 
 ### Escaping characters
 
-The backslash `\` is used to escape characters so they are not parsed by the
+The backslash (`\`) is used to escape characters so they aren't parsed by the
 regular expression engine.
 
 The following characters are reserved: `[]().\^$|?*+{}`.
 
-You will need to escape these characters in your patterns to match
-them in your input strings.
+You'll need to escape these characters in your patterns to match them in your
+input strings.
 
 ```powershell
 # This returns true and matches numbers with at least 2 digits of precision.
@@ -224,21 +226,21 @@ There`s a static method of the regex class that can escape text for you.
 [regex]::escape("3.\d{2,}")
 ```
 
-```output
+```Output
 3\.\\d\{2,}
 ```
 
 > [!NOTE]
-> This escapes all reserved regular expression characters, including
-> existing backslashes used in character classes.  Be sure to only use it on
-> the portion of your pattern that you need to escape.
+> This escapes all reserved regular expression characters, including existing
+> backslashes used in character classes. Be sure to only use it on the portion
+> of your pattern that you need to escape.
 
 #### Other character escapes
 
 There are also reserved character escapes that you can use to match special
 character types.
 
-The following are a few commonly used character escapes.
+The following are a few commonly used character escapes:
 
 |Character Escape  |Description  |
 |---------|---------|
@@ -248,26 +250,31 @@ The following are a few commonly used character escapes.
 
 ### Groups, Captures, and Substitutions
 
-Grouping constructs separate a input string into substrings that can be
+Grouping constructs separate an input string into substrings that can be
 captured or ignored. Grouped substrings are called subexpressions. By default
-subexpressions are captured in numbered groups, though you can assign names
-to them as well.
+subexpressions are captured in numbered groups, though you can assign names to
+them as well.
 
-A grouping construct is a regular expression surrounded by
-parenthesis. Any text matched by the by the enclosed regular expression is
-captured. The following example will break the input text into two capturing
-groups.
+A grouping construct is a regular expression surrounded by parentheses. Any
+text matched by the enclosed regular expression is captured. The following
+example will break the input text into two capturing groups.
 
 ```powershell
 "The last logged on user was CONTOSO\jsmith" -match "(.+was )(.+)"
+```
+
+```Output
 True
 ```
 
-Use the `$Matches` **Hashtable** automatic variable to retrieve
-captured text. The text representing the entire match is stored at key `0`.
+Use the `$Matches` **Hashtable** automatic variable to retrieve captured text.
+The text representing the entire match is stored at key `0`.
 
 ```powershell
 $Matches.0
+```
+
+```Output
 The last logged on user was CONTOSO\jsmith
 ```
 
@@ -277,7 +284,9 @@ contains just the username.
 
 ```powershell
 $Matches
+```
 
+```Output
 Name                           Value
 ----                           -----
 2                              CONTOSO\jsmith
@@ -289,7 +298,7 @@ Name                           Value
 > The `0` key is an **Integer**. You can use any **Hashtable** method to access
 > the value stored.
 >
-> ```powershell
+> ```
 > PS> "Good Dog" -match "Dog"
 > True
 >
@@ -306,13 +315,13 @@ Name                           Value
 #### Named Captures
 
 By default, captures are stored in ascending numeric order, from left to right.
-You can also assign a *name* to a capturing group. This *name* becomes a key
-on the `$Matches` **Hashtable** automatic variable.
+You can also assign a **name** to a capturing group. This **name** becomes a
+key on the `$Matches` **Hashtable** automatic variable.
 
-Inside a capturing group, use `?<keyname>` to store captured data under
-a named key.
+Inside a capturing group, use `?<keyname>` to store captured data under a named
+key.
 
-```powershell
+```
 PS> $string = "The last logged on user was CONTOSO\jsmith"
 PS> $string -match "was (?<domain>.+)\\(?<user>.+)"
 True
@@ -333,9 +342,9 @@ jsmith
 ```
 
 The following example stores the latest **SuccessAudit** from the Windows
-Security Log. The provided regular expression extracts the username and
-domain from the message and stores them under **N** and **D** keys for
-*name* and *domain*.
+Security Log. The provided regular expression extracts the username and domain
+from the message and stores them under the keys: **N** for name and **D** for
+domain.
 
 ```powershell
 $log = (Get-EventLog -LogName Security -Newest 1 -InstanceId 4689).message
@@ -343,7 +352,7 @@ $r = '(?s).*Account Name:\s*(?<N>.*).*Account Domain:\s*(?<D>[A-Z,0-9]*)'
 $log -match $r
 ```
 
-```output
+```Output
 True
 ```
 
@@ -351,7 +360,7 @@ True
 $Matches
 ```
 
-```output
+```Output
 Name                           Value
 ----                           -----
 D                              CONTOSO
@@ -359,73 +368,75 @@ N                              jsmith
 0                              A process has exited....
 ```
 
-For more information, see [Grouping Constructs in Regular Expressions](/dotnet/standard/base-types/grouping-constructs-in-regular-expressions).
+For more information, see
+[Grouping Constructs in Regular Expressions](/dotnet/standard/base-types/grouping-constructs-in-regular-expressions).
 
 #### Substitutions in Regular Expressions
 
 Using the regular expressions with the `-replace` operator allows you to
 dynamically replace text using captured text. Capturing groups can be
-referenced in the \<substitute\> string. This is done by using the `$`
-character before the group identifier.
+referenced in the \<substitute\> string. The substitution is done by using the
+`$` character before the group identifier.
 
 `<input> -replace <original>, <substitute>`
 
-Two of the ways to reference capturing groups is by **Number** and by **Name**
+Two ways to reference capturing groups are by **Number** and by **Name**.
 
-- By **Number** -
-  Capturing Groups are numbered from left to right.
+- By **Number** - Capturing Groups are numbered from left to right.
 
   ```powershell
   "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
   ```
 
-  ```output
+  ```Output
   John.D.Smith@contoso.com
   ```
 
-- By **Name** -
-  Capturing Groups can also be referenced by name.
+- By **Name** - Capturing Groups can also be referenced by name.
 
   ```powershell
   "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
   ```
 
-  ```output
+  ```Output
   FABRIKAM\Administrator
   ```
 
-The `$&` expression represents all of the text matched.
+The `$&` expression represents all the text matched.
 
 ```powershell
 "Gobble" -replace "Gobble", "$& $&"
 ```
 
-```output
+```Output
 Gobble Gobble
 ```
 
 > [!WARNING]
-> Since the `$` character is used in string expansion, you will need to use
+> Since the `$` character is used in string expansion, you'll need to use
 > literal strings with substitution, or escape the `$` character.
+>
 > ```powershell
 > 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
 > ```
 >
-> ```output
+> ```Output
 > Hello Universe
 > ```
 >
-> Additionally, sicne the `$` character is used in substitution, you will need
+> Additionally, since the `$` character is used in substitution, you will need
 > to escape any instances in your string.
 >
 > ```powershell
 > '5.72' -replace '(.+)', '$$$1'
 > ```
-> ```output
+>
+> ```Output
 > $5.72
 > ```
 
-For more information, see [Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions).
+For more information, see
+[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions).
 
 ## See also
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -5,6 +5,7 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Regular_Expressions
 ---
+
 # About Regular Expressions
 
 ## Short description
@@ -14,8 +15,9 @@ Describes regular expressions in PowerShell.
 
 > [!NOTE]
 > This article will show you the syntax and methods for using regular
-> expressions in PowerShell, not all syntax is discussed. For a more
-> complete reference, see the [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference).
+> expressions in PowerShell, not all syntax is discussed. For a more complete
+> reference, see the
+> [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference).
 
 A regular expression is a pattern used to match text. It can be made up of
 literal characters, operators, and other constructs.
@@ -40,8 +42,8 @@ shown above has a different way to force case sensitivity.
 
 ### Character literals
 
-A regular expression can be a literal character or a string.
-This causes the engine to match the text specified exactly.
+A regular expression can be a literal character or a string. The expression
+causes the engine to match the text specified exactly.
 
 ```powershell
 # This statement returns true because book contains the string "oo"
@@ -50,8 +52,8 @@ This causes the engine to match the text specified exactly.
 
 ### Character classes
 
-While character literals work if you know the exact pattern, character
-classes allow you to be less specific.
+While character literals work if you know the exact pattern, character classes
+allow you to be less specific.
 
 #### Character groups
 
@@ -63,14 +65,14 @@ while `[^character group]` only matches characters NOT in the group.
 "big" -match "b[iou]g"
 ```
 
-If your list of characters to match includes the hyphen character (-), it must be at the beginning
-or end of the list to distinguish it from a character range expression.
+If your list of characters to match includes the hyphen character (`-`), it
+must be at the beginning or end of the list to distinguish it from a character
+range expression.
 
 #### Character ranges
 
-A pattern can also be a range of characters. This can be alphabetic
-`[A-Z]`, numeric `[0-9]`, or even ASCII-based `[ -~]` (all printable
-characters).
+A pattern can also be a range of characters. The characters can be alphabetic `[A-Z]`,
+numeric `[0-9]`, or even ASCII-based `[ -~]` (all printable characters).
 
 ```powershell
 # This expression returns true if the pattern matches any 2 digit number.
@@ -79,8 +81,8 @@ characters).
 
 #### Numbers
 
-The `\d` character class will match any decimal digit.  Conversely, `\D`
-will match any non-decimal digit.
+The `\d` character class will match any decimal digit. Conversely, `\D` will
+match any non-decimal digit.
 
 ```powershell
 # This expression returns true if it matches a server name.
@@ -90,8 +92,8 @@ will match any non-decimal digit.
 
 #### Word characters
 
-The `\w` character class will match any word character `[a-zA-Z_0-9]`.
-To match any non-word character, use `\W`.
+The `\w` character class will match any word character `[a-zA-Z_0-9]`. To match
+any non-word character, use `\W`.
 
 ```powershell
 # This expression returns true.
@@ -101,8 +103,8 @@ To match any non-word character, use `\W`.
 
 #### Wildcards
 
-The period (`.`) is a wildcard character in regular expressions. It will
-match any character except a newline (`\n`).
+The period (`.`) is a wildcard character in regular expressions. It will match
+any character except a newline (`\n`).
 
 ```powershell
 # This expression returns true.
@@ -112,7 +114,7 @@ match any character except a newline (`\n`).
 
 #### Whitespace
 
-Whitespace is matched using the `\s` character class.  Any non-whitespace
+Whitespace is matched using the `\s` character class. Any non-whitespace
 character is matched using `\S`. Literal space characters `' '` can also be
 used.
 
@@ -124,10 +126,10 @@ used.
 
 ### Quantifiers
 
-Quantifiers control how many instances of each element should be present in
-the input string.
+Quantifiers control how many instances of each element should be present in the
+input string.
 
-These are a few of the quantifiers are available in PowerShell.
+The following are a few of the quantifiers available in PowerShell:
 
 |Quantifier  |Description  |
 |---------|---------|
@@ -136,15 +138,15 @@ These are a few of the quantifiers are available in PowerShell.
 |`?`|Zero or one time.|
 |`{n,m}`|At least `n`, but no more than `m` times.|
 
-The asterisk `*` matches the previous element Zero or more times. This means
-that even an input string without the element would be a match.
+The asterisk (`*`) matches the previous element zero or more times. The result
+is that even an input string without the element would be a match.
 
 ```powershell
 # This returns true for all account name strings even if the name is absent.
 "ACCOUNT NAME:    Administrator" -match "ACCOUNT NAME:\s*\w*"
 ```
 
-The plus sign `+` matches the previous element One or more times.
+The plus sign (`+`) matches the previous element one or more times.
 
 ```powershell
 # This returns true if it matches any server name.
@@ -155,7 +157,7 @@ The question mark `?` matches the previous element zero or one time. Like
 asterisk `*`, it will even match strings where the element is absent.
 
 ```powershell
-# This returns true for any server name, even ones without dashes.
+# This returns true for any server name, even server names without dashes.
 "SERVER01" -match "[A-Z]+-?\d\d"
 ```
 
@@ -179,9 +181,9 @@ optional.
 Anchors allow you to cause a match to succeed or fail based on the matches
 position within the input string.
 
-The two commonly used anchors are `^` and `$`. The carat `^` matches the
-start of a string, and `$`, which matches the end of a string. This allows
-you to match your text at a specific position while also discarding unwanted
+The two commonly used anchors are `^` and `$`. The caret `^` matches the start
+of a string, and `$`, which matches the end of a string. The anchors allow you
+to match your text at a specific position while also discarding unwanted
 characters.
 
 ```powershell
@@ -190,12 +192,12 @@ characters.
 "fishing" -match "^fish$"
 ```
 
-When using anchors in powershell, you should understand the difference
-between **Singleline** and **Multiline** regular expression options.
+When using anchors in powershell, you should understand the difference between
+**Singleline** and **Multiline** regular expression options.
 
-- **Multiline**: Multiline mode forces `^` and `$` to match the beginning
-  end of every LINE instead of the beginning and end of the input string.
-- **Singleline**: Singleline mode treats the input string as a *SingleLine*.
+- **Multiline**: Multiline mode forces `^` and `$` to match the beginning end
+  of every LINE instead of the beginning and end of the input string.
+- **Singleline**: Singleline mode treats the input string as a **SingleLine**.
   It forces the `.` character to match every character (including newlines),
   instead of matching every character EXCEPT the newline `\n`.
 
@@ -204,13 +206,13 @@ To read more about these options and how to use them, visit the
 
 ### Escaping characters
 
-The backslash `\` is used to escape characters so they are not parsed by the
+The backslash (`\`) is used to escape characters so they aren't parsed by the
 regular expression engine.
 
 The following characters are reserved: `[]().\^$|?*+{}`.
 
-You will need to escape these characters in your patterns to match
-them in your input strings.
+You'll need to escape these characters in your patterns to match them in your
+input strings.
 
 ```powershell
 # This returns true and matches numbers with at least 2 digits of precision.
@@ -224,21 +226,21 @@ There`s a static method of the regex class that can escape text for you.
 [regex]::escape("3.\d{2,}")
 ```
 
-```output
+```Output
 3\.\\d\{2,}
 ```
 
 > [!NOTE]
-> This escapes all reserved regular expression characters, including
-> existing backslashes used in character classes.  Be sure to only use it on
-> the portion of your pattern that you need to escape.
+> This escapes all reserved regular expression characters, including existing
+> backslashes used in character classes. Be sure to only use it on the portion
+> of your pattern that you need to escape.
 
 #### Other character escapes
 
 There are also reserved character escapes that you can use to match special
 character types.
 
-The following are a few commonly used character escapes.
+The following are a few commonly used character escapes:
 
 |Character Escape  |Description  |
 |---------|---------|
@@ -248,26 +250,31 @@ The following are a few commonly used character escapes.
 
 ### Groups, Captures, and Substitutions
 
-Grouping constructs separate a input string into substrings that can be
+Grouping constructs separate an input string into substrings that can be
 captured or ignored. Grouped substrings are called subexpressions. By default
-subexpressions are captured in numbered groups, though you can assign names
-to them as well.
+subexpressions are captured in numbered groups, though you can assign names to
+them as well.
 
-A grouping construct is a regular expression surrounded by
-parenthesis. Any text matched by the by the enclosed regular expression is
-captured. The following example will break the input text into two capturing
-groups.
+A grouping construct is a regular expression surrounded by parentheses. Any
+text matched by the enclosed regular expression is captured. The following
+example will break the input text into two capturing groups.
 
 ```powershell
 "The last logged on user was CONTOSO\jsmith" -match "(.+was )(.+)"
+```
+
+```Output
 True
 ```
 
-Use the `$Matches` **Hashtable** automatic variable to retrieve
-captured text. The text representing the entire match is stored at key `0`.
+Use the `$Matches` **Hashtable** automatic variable to retrieve captured text.
+The text representing the entire match is stored at key `0`.
 
 ```powershell
 $Matches.0
+```
+
+```Output
 The last logged on user was CONTOSO\jsmith
 ```
 
@@ -277,7 +284,9 @@ contains just the username.
 
 ```powershell
 $Matches
+```
 
+```Output
 Name                           Value
 ----                           -----
 2                              CONTOSO\jsmith
@@ -289,7 +298,7 @@ Name                           Value
 > The `0` key is an **Integer**. You can use any **Hashtable** method to access
 > the value stored.
 >
-> ```powershell
+> ```
 > PS> "Good Dog" -match "Dog"
 > True
 >
@@ -306,13 +315,13 @@ Name                           Value
 #### Named Captures
 
 By default, captures are stored in ascending numeric order, from left to right.
-You can also assign a *name* to a capturing group. This *name* becomes a key
-on the `$Matches` **Hashtable** automatic variable.
+You can also assign a **name** to a capturing group. This **name** becomes a
+key on the `$Matches` **Hashtable** automatic variable.
 
-Inside a capturing group, use `?<keyname>` to store captured data under
-a named key.
+Inside a capturing group, use `?<keyname>` to store captured data under a named
+key.
 
-```powershell
+```
 PS> $string = "The last logged on user was CONTOSO\jsmith"
 PS> $string -match "was (?<domain>.+)\\(?<user>.+)"
 True
@@ -332,18 +341,18 @@ PS> $Matches.user
 jsmith
 ```
 
-The following example stores the latest **SuccessAudit** from the Windows
-Security Log. The provided regular expression extracts the username and
-domain from the message and stores them under **N** and **D** keys for
-*name* and *domain*.
+The following example stores the message from the newest log entry in the
+Windows Security Log. The provided regular expression extracts the username and
+domain from the message and stores them under the keys: **N** for name and
+**D** for domain.
 
 ```powershell
-$log = (Get-EventLog -LogName Security -Newest 1 -InstanceId 4689).message
+$log = (Get-WinEvent -LogName Security -MaxEvents 1).message
 $r = '(?s).*Account Name:\s*(?<N>.*).*Account Domain:\s*(?<D>[A-Z,0-9]*)'
 $log -match $r
 ```
 
-```output
+```Output
 True
 ```
 
@@ -351,7 +360,7 @@ True
 $Matches
 ```
 
-```output
+```Output
 Name                           Value
 ----                           -----
 D                              CONTOSO
@@ -359,59 +368,59 @@ N                              jsmith
 0                              A process has exited....
 ```
 
-For more information, see [Grouping Constructs in Regular Expressions](/dotnet/standard/base-types/grouping-constructs-in-regular-expressions).
+For more information, see
+[Grouping Constructs in Regular Expressions](/dotnet/standard/base-types/grouping-constructs-in-regular-expressions).
 
 #### Substitutions in Regular Expressions
 
 Using the regular expressions with the `-replace` operator allows you to
 dynamically replace text using captured text. Capturing groups can be
-referenced in the \<substitute\> string. This is done by using the `$`
-character before the group identifier.
+referenced in the \<substitute\> string. The substitution is done by using the
+`$` character before the group identifier.
 
 `<input> -replace <original>, <substitute>`
 
-Two of the ways to reference capturing groups is by **Number** and by **Name**
+Two ways to reference capturing groups are by **Number** and by **Name**.
 
-- By **Number** -
-  Capturing Groups are numbered from left to right.
+- By **Number** - Capturing Groups are numbered from left to right.
 
   ```powershell
   "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
   ```
 
-  ```output
+  ```Output
   John.D.Smith@contoso.com
   ```
 
-- By **Name** -
-  Capturing Groups can also be referenced by name.
+- By **Name** - Capturing Groups can also be referenced by name.
 
   ```powershell
   "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
   ```
 
-  ```output
+  ```Output
   FABRIKAM\Administrator
   ```
 
-The `$&` expression represents all of the text matched.
+The `$&` expression represents all the text matched.
 
 ```powershell
 "Gobble" -replace "Gobble", "$& $&"
 ```
 
-```output
+```Output
 Gobble Gobble
 ```
 
 > [!WARNING]
-> Since the `$` character is used in string expansion, you will need to use
+> Since the `$` character is used in string expansion, you'll need to use
 > literal strings with substitution, or escape the `$` character.
+>
 > ```powershell
 > 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
 > ```
 >
-> ```output
+> ```Output
 > Hello Universe
 > ```
 >
@@ -421,11 +430,13 @@ Gobble Gobble
 > ```powershell
 > '5.72' -replace '(.+)', '$$$1'
 > ```
-> ```output
+>
+> ```Output
 > $5.72
 > ```
 
-For more information, see [Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions).
+For more information, see
+[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions).
 
 ## See also
 

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -5,6 +5,7 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Regular_Expressions
 ---
+
 # About Regular Expressions
 
 ## Short description
@@ -14,8 +15,9 @@ Describes regular expressions in PowerShell.
 
 > [!NOTE]
 > This article will show you the syntax and methods for using regular
-> expressions in PowerShell, not all syntax is discussed. For a more
-> complete reference, see the [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference).
+> expressions in PowerShell, not all syntax is discussed. For a more complete
+> reference, see the
+> [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference).
 
 A regular expression is a pattern used to match text. It can be made up of
 literal characters, operators, and other constructs.
@@ -40,8 +42,8 @@ shown above has a different way to force case sensitivity.
 
 ### Character literals
 
-A regular expression can be a literal character or a string.
-This causes the engine to match the text specified exactly.
+A regular expression can be a literal character or a string. The expression
+causes the engine to match the text specified exactly.
 
 ```powershell
 # This statement returns true because book contains the string "oo"
@@ -50,8 +52,8 @@ This causes the engine to match the text specified exactly.
 
 ### Character classes
 
-While character literals work if you know the exact pattern, character
-classes allow you to be less specific.
+While character literals work if you know the exact pattern, character classes
+allow you to be less specific.
 
 #### Character groups
 
@@ -63,14 +65,14 @@ while `[^character group]` only matches characters NOT in the group.
 "big" -match "b[iou]g"
 ```
 
-If your list of characters to match includes the hyphen character (-), it must be at the beginning
-or end of the list to distinguish it from a character range expression.
+If your list of characters to match includes the hyphen character (`-`), it
+must be at the beginning or end of the list to distinguish it from a character
+range expression.
 
 #### Character ranges
 
-A pattern can also be a range of characters. This can be alphabetic
-`[A-Z]`, numeric `[0-9]`, or even ASCII-based `[ -~]` (all printable
-characters).
+A pattern can also be a range of characters. The characters can be alphabetic `[A-Z]`,
+numeric `[0-9]`, or even ASCII-based `[ -~]` (all printable characters).
 
 ```powershell
 # This expression returns true if the pattern matches any 2 digit number.
@@ -79,8 +81,8 @@ characters).
 
 #### Numbers
 
-The `\d` character class will match any decimal digit.  Conversely, `\D`
-will match any non-decimal digit.
+The `\d` character class will match any decimal digit. Conversely, `\D` will
+match any non-decimal digit.
 
 ```powershell
 # This expression returns true if it matches a server name.
@@ -90,8 +92,8 @@ will match any non-decimal digit.
 
 #### Word characters
 
-The `\w` character class will match any word character `[a-zA-Z_0-9]`.
-To match any non-word character, use `\W`.
+The `\w` character class will match any word character `[a-zA-Z_0-9]`. To match
+any non-word character, use `\W`.
 
 ```powershell
 # This expression returns true.
@@ -101,8 +103,8 @@ To match any non-word character, use `\W`.
 
 #### Wildcards
 
-The period (`.`) is a wildcard character in regular expressions. It will
-match any character except a newline (`\n`).
+The period (`.`) is a wildcard character in regular expressions. It will match
+any character except a newline (`\n`).
 
 ```powershell
 # This expression returns true.
@@ -112,7 +114,7 @@ match any character except a newline (`\n`).
 
 #### Whitespace
 
-Whitespace is matched using the `\s` character class.  Any non-whitespace
+Whitespace is matched using the `\s` character class. Any non-whitespace
 character is matched using `\S`. Literal space characters `' '` can also be
 used.
 
@@ -124,10 +126,10 @@ used.
 
 ### Quantifiers
 
-Quantifiers control how many instances of each element should be present in
-the input string.
+Quantifiers control how many instances of each element should be present in the
+input string.
 
-These are a few of the quantifiers are available in PowerShell.
+The following are a few of the quantifiers available in PowerShell:
 
 |Quantifier  |Description  |
 |---------|---------|
@@ -136,15 +138,15 @@ These are a few of the quantifiers are available in PowerShell.
 |`?`|Zero or one time.|
 |`{n,m}`|At least `n`, but no more than `m` times.|
 
-The asterisk `*` matches the previous element Zero or more times. This means
-that even an input string without the element would be a match.
+The asterisk (`*`) matches the previous element zero or more times. The result
+is that even an input string without the element would be a match.
 
 ```powershell
 # This returns true for all account name strings even if the name is absent.
 "ACCOUNT NAME:    Administrator" -match "ACCOUNT NAME:\s*\w*"
 ```
 
-The plus sign `+` matches the previous element One or more times.
+The plus sign (`+`) matches the previous element one or more times.
 
 ```powershell
 # This returns true if it matches any server name.
@@ -155,7 +157,7 @@ The question mark `?` matches the previous element zero or one time. Like
 asterisk `*`, it will even match strings where the element is absent.
 
 ```powershell
-# This returns true for any server name, even ones without dashes.
+# This returns true for any server name, even server names without dashes.
 "SERVER01" -match "[A-Z]+-?\d\d"
 ```
 
@@ -179,9 +181,9 @@ optional.
 Anchors allow you to cause a match to succeed or fail based on the matches
 position within the input string.
 
-The two commonly used anchors are `^` and `$`. The carat `^` matches the
-start of a string, and `$`, which matches the end of a string. This allows
-you to match your text at a specific position while also discarding unwanted
+The two commonly used anchors are `^` and `$`. The caret `^` matches the start
+of a string, and `$`, which matches the end of a string. The anchors allow you
+to match your text at a specific position while also discarding unwanted
 characters.
 
 ```powershell
@@ -190,12 +192,12 @@ characters.
 "fishing" -match "^fish$"
 ```
 
-When using anchors in powershell, you should understand the difference
-between **Singleline** and **Multiline** regular expression options.
+When using anchors in powershell, you should understand the difference between
+**Singleline** and **Multiline** regular expression options.
 
-- **Multiline**: Multiline mode forces `^` and `$` to match the beginning
-  end of every LINE instead of the beginning and end of the input string.
-- **Singleline**: Singleline mode treats the input string as a *SingleLine*.
+- **Multiline**: Multiline mode forces `^` and `$` to match the beginning end
+  of every LINE instead of the beginning and end of the input string.
+- **Singleline**: Singleline mode treats the input string as a **SingleLine**.
   It forces the `.` character to match every character (including newlines),
   instead of matching every character EXCEPT the newline `\n`.
 
@@ -204,13 +206,13 @@ To read more about these options and how to use them, visit the
 
 ### Escaping characters
 
-The backslash `\` is used to escape characters so they are not parsed by the
+The backslash (`\`) is used to escape characters so they aren't parsed by the
 regular expression engine.
 
 The following characters are reserved: `[]().\^$|?*+{}`.
 
-You will need to escape these characters in your patterns to match
-them in your input strings.
+You'll need to escape these characters in your patterns to match them in your
+input strings.
 
 ```powershell
 # This returns true and matches numbers with at least 2 digits of precision.
@@ -224,21 +226,21 @@ There`s a static method of the regex class that can escape text for you.
 [regex]::escape("3.\d{2,}")
 ```
 
-```output
+```Output
 3\.\\d\{2,}
 ```
 
 > [!NOTE]
-> This escapes all reserved regular expression characters, including
-> existing backslashes used in character classes.  Be sure to only use it on
-> the portion of your pattern that you need to escape.
+> This escapes all reserved regular expression characters, including existing
+> backslashes used in character classes. Be sure to only use it on the portion
+> of your pattern that you need to escape.
 
 #### Other character escapes
 
 There are also reserved character escapes that you can use to match special
 character types.
 
-The following are a few commonly used character escapes.
+The following are a few commonly used character escapes:
 
 |Character Escape  |Description  |
 |---------|---------|
@@ -248,26 +250,31 @@ The following are a few commonly used character escapes.
 
 ### Groups, Captures, and Substitutions
 
-Grouping constructs separate a input string into substrings that can be
+Grouping constructs separate an input string into substrings that can be
 captured or ignored. Grouped substrings are called subexpressions. By default
-subexpressions are captured in numbered groups, though you can assign names
-to them as well.
+subexpressions are captured in numbered groups, though you can assign names to
+them as well.
 
-A grouping construct is a regular expression surrounded by
-parenthesis. Any text matched by the by the enclosed regular expression is
-captured. The following example will break the input text into two capturing
-groups.
+A grouping construct is a regular expression surrounded by parentheses. Any
+text matched by the enclosed regular expression is captured. The following
+example will break the input text into two capturing groups.
 
 ```powershell
 "The last logged on user was CONTOSO\jsmith" -match "(.+was )(.+)"
+```
+
+```Output
 True
 ```
 
-Use the `$Matches` **Hashtable** automatic variable to retrieve
-captured text. The text representing the entire match is stored at key `0`.
+Use the `$Matches` **Hashtable** automatic variable to retrieve captured text.
+The text representing the entire match is stored at key `0`.
 
 ```powershell
 $Matches.0
+```
+
+```Output
 The last logged on user was CONTOSO\jsmith
 ```
 
@@ -277,7 +284,9 @@ contains just the username.
 
 ```powershell
 $Matches
+```
 
+```Output
 Name                           Value
 ----                           -----
 2                              CONTOSO\jsmith
@@ -289,7 +298,7 @@ Name                           Value
 > The `0` key is an **Integer**. You can use any **Hashtable** method to access
 > the value stored.
 >
-> ```powershell
+> ```
 > PS> "Good Dog" -match "Dog"
 > True
 >
@@ -306,13 +315,13 @@ Name                           Value
 #### Named Captures
 
 By default, captures are stored in ascending numeric order, from left to right.
-You can also assign a *name* to a capturing group. This *name* becomes a key
-on the `$Matches` **Hashtable** automatic variable.
+You can also assign a **name** to a capturing group. This **name** becomes a
+key on the `$Matches` **Hashtable** automatic variable.
 
-Inside a capturing group, use `?<keyname>` to store captured data under
-a named key.
+Inside a capturing group, use `?<keyname>` to store captured data under a named
+key.
 
-```powershell
+```
 PS> $string = "The last logged on user was CONTOSO\jsmith"
 PS> $string -match "was (?<domain>.+)\\(?<user>.+)"
 True
@@ -332,18 +341,18 @@ PS> $Matches.user
 jsmith
 ```
 
-The following example stores the latest **SuccessAudit** from the Windows
-Security Log. The provided regular expression extracts the username and
-domain from the message and stores them under **N** and **D** keys for
-*name* and *domain*.
+The following example stores the message from the newest log entry in the
+Windows Security Log. The provided regular expression extracts the username and
+domain from the message and stores them under the keys: **N** for name and
+**D** for domain.
 
 ```powershell
-$log = (Get-EventLog -LogName Security -Newest 1 -InstanceId 4689).message
+$log = (Get-WinEvent -LogName Security -MaxEvents 1).message
 $r = '(?s).*Account Name:\s*(?<N>.*).*Account Domain:\s*(?<D>[A-Z,0-9]*)'
 $log -match $r
 ```
 
-```output
+```Output
 True
 ```
 
@@ -351,7 +360,7 @@ True
 $Matches
 ```
 
-```output
+```Output
 Name                           Value
 ----                           -----
 D                              CONTOSO
@@ -359,73 +368,75 @@ N                              jsmith
 0                              A process has exited....
 ```
 
-For more information, see [Grouping Constructs in Regular Expressions](/dotnet/standard/base-types/grouping-constructs-in-regular-expressions).
+For more information, see
+[Grouping Constructs in Regular Expressions](/dotnet/standard/base-types/grouping-constructs-in-regular-expressions).
 
 #### Substitutions in Regular Expressions
 
 Using the regular expressions with the `-replace` operator allows you to
 dynamically replace text using captured text. Capturing groups can be
-referenced in the \<substitute\> string. This is done by using the `$`
-character before the group identifier.
+referenced in the \<substitute\> string. The substitution is done by using the
+`$` character before the group identifier.
 
 `<input> -replace <original>, <substitute>`
 
-Two of the ways to reference capturing groups is by **Number** and by **Name**
+Two ways to reference capturing groups are by **Number** and by **Name**.
 
-- By **Number** -
-  Capturing Groups are numbered from left to right.
+- By **Number** - Capturing Groups are numbered from left to right.
 
   ```powershell
   "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
   ```
 
-  ```output
+  ```Output
   John.D.Smith@contoso.com
   ```
 
-- By **Name** -
-  Capturing Groups can also be referenced by name.
+- By **Name** - Capturing Groups can also be referenced by name.
 
   ```powershell
   "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
   ```
 
-  ```output
+  ```Output
   FABRIKAM\Administrator
   ```
 
-The `$&` expression represents all of the text matched.
+The `$&` expression represents all the text matched.
 
 ```powershell
 "Gobble" -replace "Gobble", "$& $&"
 ```
 
-```output
+```Output
 Gobble Gobble
 ```
 
 > [!WARNING]
-> Since the `$` character is used in string expansion, you will need to use
+> Since the `$` character is used in string expansion, you'll need to use
 > literal strings with substitution, or escape the `$` character.
+>
 > ```powershell
 > 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
 > ```
 >
-> ```output
+> ```Output
 > Hello Universe
 > ```
 >
-> Additionally, sicne the `$` character is used in substitution, you will need
+> Additionally, since the `$` character is used in substitution, you will need
 > to escape any instances in your string.
 >
 > ```powershell
 > '5.72' -replace '(.+)', '$$$1'
 > ```
-> ```output
+>
+> ```Output
 > $5.72
 > ```
 
-For more information, see [Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions).
+For more information, see
+[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions).
 
 ## See also
 


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

- Fixes [AB#1610243](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1610243)
- Related to #4877
- Fixed spelling error in 3.0, 4.0, 5.0, 5.1, and 7
- Copyedits, style, paragraph reflows in all versions

Acrolinx scores
Original version: 88
Updated version: 97