### PR TITLE
Add is and isnot operators to comparison operators section

### DIFF
--- a/reference/7/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -51,6 +51,9 @@ expressions, and (`-like`, `-notlike`) use wildcards `*`.
 Containment comparison operators determine whether a test value appears in a
 reference set (`-in`, `-notin`, `-contains`, `-notcontains`).
 
+Type comparison operators (`-is`, `-isnot`) determine whether an object is
+of a given type.
+
 Bitwise comparison operators (`-bAND`, `-bOR`, `-bXOR`, `-bNOT`) manipulate
 the bit patterns in values.
 


### PR DESCRIPTION
Version(s) of document impacted
------------------------------
- [X] Impacts 7 document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [X] This PR partially fixes the issue, and issue #4890 tracks the remaining work
