### PR TITLE
Add terminal command for a Preview release

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
@@ -17,7 +17,7 @@ the Linux [`tar.gz` archive][tar], but you would need to set up the necessary de
 the OS in separate steps.
 
 All packages are available on our GitHub [releases][] page. After the package is installed, run
-`pwsh` from a terminal.
+`pwsh` from a terminal. Run `pwsh-preview` if you installed a [Preview release][#installing-preview-releases].
 
 [u16]: #ubuntu-1604
 [u1804]: #ubuntu-1804

--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
@@ -17,7 +17,7 @@ the Linux [`tar.gz` archive][tar], but you would need to set up the necessary de
 the OS in separate steps.
 
 All packages are available on our GitHub [releases][] page. After the package is installed, run
-`pwsh` from a terminal. Run `pwsh-preview` if you installed a [Preview release][#installing-preview-releases].
+`pwsh` from a terminal. Run `pwsh-preview` if you installed a [Preview release](#installing-preview-releases).
 
 [u16]: #ubuntu-1604
 [u1804]: #ubuntu-1804


### PR DESCRIPTION
Instructs to run `pwsh-terminal` if a PowerShell Preview release was installed.
Related issue: https://github.com/PowerShell/PowerShell/issues/10713

This could also be mentioned in a documentation block for a preview version for each supported OS (see [Snap instructions](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md#snap-package) for example.)

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 7 document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
