### PR TITLE
Add Debian 8 to list of supported versions

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
@@ -7,7 +7,7 @@ ms.date: 07/19/2019
 # Installing PowerShell Core on Linux
 
 Supports [Ubuntu 16.04][u16], [Ubuntu 18.04][u1804], [Ubuntu 18.10][u1810], [Ubuntu 19.04][u1904],
- [Debian 9][deb9], [CentOS 7][cos], [Red Hat Enterprise Linux (RHEL) 7][rhel7],
+ [Debian 8][deb8],  [Debian 9][deb9], [CentOS 7][cos], [Red Hat Enterprise Linux (RHEL) 7][rhel7],
  [openSUSE 42.3][opensuse], [openSUSE Leap 15][opensuse], [Fedora 27][fedora], [Fedora 28][fedora],
  and [Arch Linux][arch].
 
@@ -23,6 +23,7 @@ All packages are available on our GitHub [releases][] page. After the package is
 [u1804]: #ubuntu-1804
 [u1810]: #ubuntu-1810
 [u1904]: #ubuntu-1904
+[deb8]: #debian-8
 [deb9]: #debian-9
 [cos]: #centos-7
 [rhel7]: #red-hat-enterprise-linux-rhel-7


### PR DESCRIPTION
It was already present in the list further down; this merely adds it to the header.

Unsure about the "version(s)" info below - I honestly don't understand how that part works. (I can't see any separate branches for these versions, so maybe there's some other magic going on here... 😄) 

Version(s) of document impacted
------------------------------
- [ ] Impacts 7 document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
