### PR TITLE
Fixes #4938 - fix MemberType enum value name

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Add-Member.md
@@ -1,7 +1,8 @@
 ---
-external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
+external help file: Microsoft.PowerShell.Commands.Utility.dll-help.xml
 keywords: powershell,cmdlet
 locale: en-us
+Module Name: Microsoft.PowerShell.Utility
 ms.date: 4/26/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/add-member?view=powershell-3.0&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -10,39 +11,35 @@ title: Add-Member
 # Add-Member
 
 ## SYNOPSIS
-Adds custom properties and methods to an instance of a Windows PowerShell object.
+Adds custom properties and methods to an instance of a PowerShell object.
 
 ## SYNTAX
 
 ### TypeNameSet (Default)
 
 ```
-Add-Member -InputObject <PSObject> -TypeName <String> [-PassThru]
- [<CommonParameters>]
-```
-
-### MemberSet
-
-```
-Add-Member [-MemberType] <PSMemberTypes> [-Name] <String>
- [[-Value] <Object>] [[-SecondValue] <Object>]
- -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
- [<CommonParameters>]
-```
-
-### NotePropertySingleMemberSet
-
-```
-Add-Member [-NotePropertyName] <String> [-NotePropertyValue] <Object>
- -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
- [<CommonParameters>]
+Add-Member -InputObject <PSObject> -TypeName <String> [-PassThru] [<CommonParameters>]
 ```
 
 ### NotePropertyMultiMemberSet
 
 ```
-Add-Member [-NotePropertyMembers] <IDictionary>
- -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
+Add-Member [-NotePropertyMembers] <IDictionary> -InputObject <PSObject> [-TypeName <String>]
+ [-Force] [-PassThru] [<CommonParameters>]
+```
+
+### NotePropertySingleMemberSet
+
+```
+Add-Member [-NotePropertyName] <String> [-NotePropertyValue] <Object> -InputObject <PSObject>
+ [-TypeName <String>] [-Force] [-PassThru] [<CommonParameters>]
+```
+
+### MemberSet
+
+```
+Add-Member [-MemberType] <PSMemberTypes> [-Name] <String> [[-Value] <Object>]
+ [[-SecondValue] <Object>] -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
  [<CommonParameters>]
 ```
 
@@ -125,7 +122,7 @@ $A.Size
 ### Example 3: Add a StringUse note property to a string
 
 This example adds the **StringUse** note property to a string.
-Because `Add-Member` cannot add types to **String** input objects, you can speciy the **PassThru**
+Because `Add-Member` cannot add types to **String** input objects, you can specify the **PassThru**
 parameter to generate an output object. The last command in the example displays the new property.
 
 This example uses the **NotePropertyMembers** parameter. The value of the **NotePropertyMembers**
@@ -273,7 +270,7 @@ The acceptable values for this parameter are:
 - ScriptProperty
 - CodeProperty
 - ScriptMethod
-- CopyMethod
+- CodeMethod
 
 For information about these values, see [PSMemberTypes Enumeration](/dotnet/api/system.management.automation.psmembertypes)
 in the MSDN library.
@@ -291,7 +288,7 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: True
+Accept wildcard characters: False
 ```
 
 ### -Name
@@ -305,80 +302,6 @@ Aliases:
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -PassThru
-
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
-
-For most objects, `Add-Member` adds the new members to the input object.
-However, when the input object is a string, `Add-Member` cannot add the member to the input object.
-For these objects, use the **PassThru** parameter to create an output object.
-
-In Windows PowerShell 2.0, `Add-Member` added members only to the **PSObject** wrapper of objects,
-not to the object.
-Use the **PassThru** parameter to create an output object for any object that has a **PSObject**
-wrapper.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -SecondValue
-
-Specifies optional additional information about **AliasProperty**, **ScriptProperty**,
-**CodeProperty**, or **CodeMethod** members.
-
-If used when adding an **AliasProperty**, this parameter must be a data type.
-A conversion to the specified data type is added to the value of the **AliasProperty**.
-
-For example, if you add an **AliasProperty** that provides an alternate name for a string property,
-you can also specify a **SecondValue** parameter of **System.Int32** to indicate that the value of
-that string property should be converted to an integer when accessed by using the corresponding
-**AliasProperty**.
-
-You can use the **SecondValue** parameter to specify an additional **ScriptBlock** when adding a
-**ScriptProperty** member. The first **ScriptBlock**, specified in the **Value** parameter, is
-used to get the value of a variable. The second **ScriptBlock**, specified in the
-**SecondValue** parameter, is used to set the value of a variable.
-
-```yaml
-Type: Object
-Parameter Sets: MemberSet
-Aliases:
-
-Required: False
-Position: 3
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Value
-
-Specifies the initial value of the added member.
-If you add an **AliasProperty**, **CodeProperty**, **ScriptProperty** or **CodeMethod** member, you
-can supply optional, additional information by using the **SecondValue** parameter.
-
-```yaml
-Type: Object
-Parameter Sets: MemberSet
-Aliases:
-
-Required: False
-Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -444,6 +367,80 @@ Aliases:
 
 Required: True
 Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+
+Returns an object representing the item with which you are working.
+By default, this cmdlet does not generate any output.
+
+For most objects, `Add-Member` adds the new members to the input object.
+However, when the input object is a string, `Add-Member` cannot add the member to the input object.
+For these objects, use the **PassThru** parameter to create an output object.
+
+In Windows PowerShell 2.0, `Add-Member` added members only to the **PSObject** wrapper of objects,
+not to the object.
+Use the **PassThru** parameter to create an output object for any object that has a **PSObject**
+wrapper.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SecondValue
+
+Specifies optional additional information about **AliasProperty**, **ScriptProperty**,
+**CodeProperty**, or **CodeMethod** members.
+
+If used when adding an **AliasProperty**, this parameter must be a data type.
+A conversion to the specified data type is added to the value of the **AliasProperty**.
+
+For example, if you add an **AliasProperty** that provides an alternate name for a string property,
+you can also specify a **SecondValue** parameter of **System.Int32** to indicate that the value of
+that string property should be converted to an integer when accessed by using the corresponding
+**AliasProperty**.
+
+You can use the **SecondValue** parameter to specify an additional **ScriptBlock** when adding a
+**ScriptProperty** member. The first **ScriptBlock**, specified in the **Value** parameter, is
+used to get the value of a variable. The second **ScriptBlock**, specified in the
+**SecondValue** parameter, is used to set the value of a variable.
+
+```yaml
+Type: Object
+Parameter Sets: MemberSet
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Value
+
+Specifies the initial value of the added member.
+If you add an **AliasProperty**, **CodeProperty**, **ScriptProperty** or **CodeMethod** member, you
+can supply optional, additional information by using the **SecondValue** parameter.
+
+```yaml
+Type: Object
+Parameter Sets: MemberSet
+Aliases:
+
+Required: False
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/reference/4.0/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Add-Member.md
@@ -1,7 +1,8 @@
 ---
-external help file: PSITPro4_Utility.xml
+external help file: Microsoft.PowerShell.Commands.Utility.dll-help.xml
 keywords: powershell,cmdlet
 locale: en-us
+Module Name: Microsoft.PowerShell.Utility
 ms.date: 4/26/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/add-member?view=powershell-4.0&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -17,32 +18,28 @@ Adds custom properties and methods to an instance of a PowerShell object.
 ### TypeNameSet (Default)
 
 ```
-Add-Member -InputObject <PSObject> -TypeName <String> [-PassThru]
- [<CommonParameters>]
-```
-
-### MemberSet
-
-```
-Add-Member [-MemberType] <PSMemberTypes> [-Name] <String>
- [[-Value] <Object>] [[-SecondValue] <Object>]
- -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
- [<CommonParameters>]
-```
-
-### NotePropertySingleMemberSet
-
-```
-Add-Member [-NotePropertyName] <String> [-NotePropertyValue] <Object>
- -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
- [<CommonParameters>]
+Add-Member -InputObject <PSObject> -TypeName <String> [-PassThru] [<CommonParameters>]
 ```
 
 ### NotePropertyMultiMemberSet
 
 ```
-Add-Member [-NotePropertyMembers] <IDictionary>
- -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
+Add-Member [-NotePropertyMembers] <IDictionary> -InputObject <PSObject> [-TypeName <String>]
+ [-Force] [-PassThru] [<CommonParameters>]
+```
+
+### NotePropertySingleMemberSet
+
+```
+Add-Member [-NotePropertyName] <String> [-NotePropertyValue] <Object> -InputObject <PSObject>
+ [-TypeName <String>] [-Force] [-PassThru] [<CommonParameters>]
+```
+
+### MemberSet
+
+```
+Add-Member [-MemberType] <PSMemberTypes> [-Name] <String> [[-Value] <Object>]
+ [[-SecondValue] <Object>] -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
  [<CommonParameters>]
 ```
 
@@ -125,7 +122,7 @@ $A.Size
 ### Example 3: Add a StringUse note property to a string
 
 This example adds the **StringUse** note property to a string.
-Because `Add-Member` cannot add types to **String** input objects, you can speciy the **PassThru**
+Because `Add-Member` cannot add types to **String** input objects, you can specify the **PassThru**
 parameter to generate an output object. The last command in the example displays the new property.
 
 This example uses the **NotePropertyMembers** parameter. The value of the **NotePropertyMembers**
@@ -214,7 +211,7 @@ $Asset | Get-Member
 
 ```Output
    TypeName: Asset
-   
+
 Name        MemberType   Definition
 ----        ----------   ----------
 Equals      Method       bool Equals(System.Object obj)
@@ -235,7 +232,7 @@ You cannot use the **Force** parameter to replace a standard member of a type.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: MemberSet, NotePropertySingleMemberSet, NotePropertyMultiMemberSet
+Parameter Sets: NotePropertyMultiMemberSet, NotePropertySingleMemberSet, MemberSet
 Aliases:
 
 Required: False
@@ -273,7 +270,7 @@ The acceptable values for this parameter are:
 - ScriptProperty
 - CodeProperty
 - ScriptMethod
-- CopyMethod
+- CodeMethod
 
 For information about these values, see [PSMemberTypes Enumeration](/dotnet/api/system.management.automation.psmembertypes)
 in the MSDN library.
@@ -305,80 +302,6 @@ Aliases:
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -PassThru
-
-Returns an object representing the item with which you are working.
-By default, this cmdlet does not generate any output.
-
-For most objects, `Add-Member` adds the new members to the input object.
-However, when the input object is a string, `Add-Member` cannot add the member to the input object.
-For these objects, use the **PassThru** parameter to create an output object.
-
-In Windows PowerShell 2.0, `Add-Member` added members only to the **PSObject** wrapper of objects,
-not to the object.
-Use the **PassThru** parameter to create an output object for any object that has a **PSObject**
-wrapper.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -SecondValue
-
-Specifies optional additional information about **AliasProperty**, **ScriptProperty**,
-**CodeProperty**, or **CodeMethod** members.
-
-If used when adding an **AliasProperty**, this parameter must be a data type.
-A conversion to the specified data type is added to the value of the **AliasProperty**.
-
-For example, if you add an **AliasProperty** that provides an alternate name for a string property,
-you can also specify a **SecondValue** parameter of **System.Int32** to indicate that the value of
-that string property should be converted to an integer when accessed by using the corresponding
-**AliasProperty**.
-
-You can use the **SecondValue** parameter to specify an additional **ScriptBlock** when adding a
-**ScriptProperty** member. The first **ScriptBlock**, specified in the **Value** parameter, is
-used to get the value of a variable. The second **ScriptBlock**, specified in the
-**SecondValue** parameter, is used to set the value of a variable.
-
-```yaml
-Type: Object
-Parameter Sets: MemberSet
-Aliases:
-
-Required: False
-Position: 3
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Value
-
-Specifies the initial value of the added member.
-If you add an **AliasProperty**, **CodeProperty**, **ScriptProperty** or **CodeMethod** member, you
-can supply optional, additional information by using the **SecondValue** parameter.
-
-```yaml
-Type: Object
-Parameter Sets: MemberSet
-Aliases:
-
-Required: False
-Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -444,6 +367,80 @@ Aliases:
 
 Required: True
 Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+
+Returns an object representing the item with which you are working.
+By default, this cmdlet does not generate any output.
+
+For most objects, `Add-Member` adds the new members to the input object.
+However, when the input object is a string, `Add-Member` cannot add the member to the input object.
+For these objects, use the **PassThru** parameter to create an output object.
+
+In Windows PowerShell 2.0, `Add-Member` added members only to the **PSObject** wrapper of objects,
+not to the object.
+Use the **PassThru** parameter to create an output object for any object that has a **PSObject**
+wrapper.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SecondValue
+
+Specifies optional additional information about **AliasProperty**, **ScriptProperty**,
+**CodeProperty**, or **CodeMethod** members.
+
+If used when adding an **AliasProperty**, this parameter must be a data type.
+A conversion to the specified data type is added to the value of the **AliasProperty**.
+
+For example, if you add an **AliasProperty** that provides an alternate name for a string property,
+you can also specify a **SecondValue** parameter of **System.Int32** to indicate that the value of
+that string property should be converted to an integer when accessed by using the corresponding
+**AliasProperty**.
+
+You can use the **SecondValue** parameter to specify an additional **ScriptBlock** when adding a
+**ScriptProperty** member. The first **ScriptBlock**, specified in the **Value** parameter, is
+used to get the value of a variable. The second **ScriptBlock**, specified in the
+**SecondValue** parameter, is used to set the value of a variable.
+
+```yaml
+Type: Object
+Parameter Sets: MemberSet
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Value
+
+Specifies the initial value of the added member.
+If you add an **AliasProperty**, **CodeProperty**, **ScriptProperty** or **CodeMethod** member, you
+can supply optional, additional information by using the **SecondValue** parameter.
+
+```yaml
+Type: Object
+Parameter Sets: MemberSet
+Aliases:
+
+Required: False
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/reference/5.0/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Add-Member.md
@@ -1,7 +1,8 @@
 ---
-external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
+external help file: Microsoft.PowerShell.Commands.Utility.dll-help.xml
 keywords: powershell,cmdlet
 locale: en-us
+Module Name: Microsoft.PowerShell.Utility
 ms.date: 4/26/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/add-member?view=powershell-5.0&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -17,32 +18,28 @@ Adds custom properties and methods to an instance of a PowerShell object.
 ### TypeNameSet (Default)
 
 ```
-Add-Member -InputObject <PSObject> -TypeName <String> [-PassThru]
- [<CommonParameters>]
-```
-
-### MemberSet
-
-```
-Add-Member [-MemberType] <PSMemberTypes> [-Name] <String>
- [[-Value] <Object>] [[-SecondValue] <Object>]
- -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
- [<CommonParameters>]
-```
-
-### NotePropertySingleMemberSet
-
-```
-Add-Member [-NotePropertyName] <String> [-NotePropertyValue] <Object>
- -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
- [<CommonParameters>]
+Add-Member -InputObject <PSObject> -TypeName <String> [-PassThru] [<CommonParameters>]
 ```
 
 ### NotePropertyMultiMemberSet
 
 ```
-Add-Member [-NotePropertyMembers] <IDictionary>
- -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
+Add-Member [-NotePropertyMembers] <IDictionary> -InputObject <PSObject> [-TypeName <String>]
+ [-Force] [-PassThru] [<CommonParameters>]
+```
+
+### NotePropertySingleMemberSet
+
+```
+Add-Member [-NotePropertyName] <String> [-NotePropertyValue] <Object> -InputObject <PSObject>
+ [-TypeName <String>] [-Force] [-PassThru] [<CommonParameters>]
+```
+
+### MemberSet
+
+```
+Add-Member [-MemberType] <PSMemberTypes> [-Name] <String> [[-Value] <Object>]
+ [[-SecondValue] <Object>] -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
  [<CommonParameters>]
 ```
 
@@ -125,7 +122,7 @@ $A.Size
 ### Example 3: Add a StringUse note property to a string
 
 This example adds the **StringUse** note property to a string.
-Because `Add-Member` cannot add types to **String** input objects, you can speciy the **PassThru**
+Because `Add-Member` cannot add types to **String** input objects, you can specify the **PassThru**
 parameter to generate an output object. The last command in the example displays the new property.
 
 This example uses the **NotePropertyMembers** parameter. The value of the **NotePropertyMembers**
@@ -214,7 +211,7 @@ $Asset | Get-Member
 
 ```Output
    TypeName: Asset
-   
+
 Name        MemberType   Definition
 ----        ----------   ----------
 Equals      Method       bool Equals(System.Object obj)
@@ -235,7 +232,7 @@ You cannot use the **Force** parameter to replace a standard member of a type.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: MemberSet, NotePropertySingleMemberSet, NotePropertyMultiMemberSet
+Parameter Sets: NotePropertyMultiMemberSet, NotePropertySingleMemberSet, MemberSet
 Aliases:
 
 Required: False
@@ -273,7 +270,7 @@ The acceptable values for this parameter are:
 - ScriptProperty
 - CodeProperty
 - ScriptMethod
-- CopyMethod
+- CodeMethod
 
 For information about these values, see [PSMemberTypes Enumeration](/dotnet/api/system.management.automation.psmembertypes)
 in the MSDN library.
@@ -431,6 +428,24 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Value
+
+Specifies the initial value of the added member.
+If you add an **AliasProperty**, **CodeProperty**, **ScriptProperty** or **CodeMethod** member, you
+can supply optional, additional information by using the **SecondValue** parameter.
+
+```yaml
+Type: Object
+Parameter Sets: MemberSet
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -TypeName
 
 Specifies a name for the type.
@@ -448,24 +463,6 @@ Aliases:
 
 Required: True (TypeNameSet), False (NotePropertyMultiMemberSet, NotePropertySingleMemberSet, MemberSet)
 Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Value
-
-Specifies the initial value of the added member.
-If you add an **AliasProperty**, **CodeProperty**, **ScriptProperty** or **CodeMethod** member, you
-can supply optional, additional information by using the **SecondValue** parameter.
-
-```yaml
-Type: Object
-Parameter Sets: MemberSet
-Aliases:
-
-Required: False
-Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/reference/5.1/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Add-Member.md
@@ -21,11 +21,11 @@ Adds custom properties and methods to an instance of a PowerShell object.
 Add-Member -InputObject <PSObject> -TypeName <String> [-PassThru] [<CommonParameters>]
 ```
 
-### MemberSet
+### NotePropertyMultiMemberSet
 
 ```
-Add-Member -InputObject <PSObject> [-MemberType] <PSMemberTypes> [-Name] <String> [[-Value] <Object>]
- [[-SecondValue] <Object>] [-TypeName <String>] [-Force] [-PassThru] [<CommonParameters>]
+Add-Member -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
+ [-NotePropertyMembers] <IDictionary> [<CommonParameters>]
 ```
 
 ### NotePropertySingleMemberSet
@@ -35,11 +35,11 @@ Add-Member -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru] [-N
  [-NotePropertyValue] <Object> [<CommonParameters>]
 ```
 
-### NotePropertyMultiMemberSet
+### MemberSet
 
 ```
-Add-Member -InputObject <PSObject> [-TypeName <String>] [-Force] [-PassThru]
- [-NotePropertyMembers] <IDictionary> [<CommonParameters>]
+Add-Member -InputObject <PSObject> [-MemberType] <PSMemberTypes> [-Name] <String> [[-Value] <Object>]
+ [[-SecondValue] <Object>] [-TypeName <String>] [-Force] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -121,7 +121,7 @@ $A.Size
 ### Example 3: Add a StringUse note property to a string
 
 This example adds the **StringUse** note property to a string.
-Because `Add-Member` cannot add types to **String** input objects, you can speciy the **PassThru**
+Because `Add-Member` cannot add types to **String** input objects, you can specify the **PassThru**
 parameter to generate an output object. The last command in the example displays the new property.
 
 This example uses the **NotePropertyMembers** parameter. The value of the **NotePropertyMembers**
@@ -210,7 +210,7 @@ $Asset | Get-Member
 
 ```Output
    TypeName: Asset
-   
+
 Name        MemberType   Definition
 ----        ----------   ----------
 Equals      Method       bool Equals(System.Object obj)
@@ -231,7 +231,7 @@ You cannot use the **Force** parameter to replace a standard member of a type.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: MemberSet, NotePropertySingleMemberSet, NotePropertyMultiMemberSet
+Parameter Sets: NotePropertyMultiMemberSet, NotePropertySingleMemberSet, MemberSet
 Aliases:
 
 Required: False
@@ -269,7 +269,7 @@ The acceptable values for this parameter are:
 - ScriptProperty
 - CodeProperty
 - ScriptMethod
-- CopyMethod
+- CodeMethod
 
 For information about these values, see [PSMemberTypes Enumeration](/dotnet/api/system.management.automation.psmembertypes)
 in the MSDN library.
@@ -427,6 +427,24 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Value
+
+Specifies the initial value of the added member.
+If you add an **AliasProperty**, **CodeProperty**, **ScriptProperty** or **CodeMethod** member, you
+can supply optional, additional information by using the **SecondValue** parameter.
+
+```yaml
+Type: Object
+Parameter Sets: MemberSet
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -TypeName
 
 Specifies a name for the type.
@@ -444,24 +462,6 @@ Aliases:
 
 Required: True (TypeNameSet), False (NotePropertyMultiMemberSet, NotePropertySingleMemberSet, MemberSet)
 Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Value
-
-Specifies the initial value of the added member.
-If you add an **AliasProperty**, **CodeProperty**, **ScriptProperty** or **CodeMethod** member, you
-can supply optional, additional information by using the **SecondValue** parameter.
-
-```yaml
-Type: Object
-Parameter Sets: MemberSet
-Aliases:
-
-Required: False
-Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/reference/6/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Add-Member.md
@@ -269,7 +269,7 @@ The acceptable values for this parameter are:
 - ScriptProperty
 - CodeProperty
 - ScriptMethod
-- CopyMethod
+- CodeMethod
 
 For information about these values, see [PSMemberTypes Enumeration](/dotnet/api/system.management.automation.psmembertypes)
 in the MSDN library.

--- a/reference/7/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Add-Member.md
@@ -269,7 +269,7 @@ The acceptable values for this parameter are:
 - ScriptProperty
 - CodeProperty
 - ScriptMethod
-- CopyMethod
+- CodeMethod
 
 For information about these values, see [PSMemberTypes Enumeration](/dotnet/api/system.management.automation.psmembertypes)
 in the MSDN library.


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #4938 - fix MemberType enum value name
Fixes [AB#1616303](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1616303)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content
- [x] Version 5.0 content
- [x] Version 4.0 content
- [x] Version 3.0 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
