### PR TITLE
Issue #4954 - Fixed cmdlet ParameterSet spacing part 1

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-EventLog.md
@@ -21,9 +21,9 @@ computers.
 
 ```
 Get-EventLog [-LogName] <String> [-ComputerName <String[]>] [-Newest <Int32>] [-After <DateTime>]
-[-Before <DateTime>] [-UserName <String[]>] [[-InstanceId] <Int64[]>] [-Index <Int32[]>]
-[-EntryType <String[]>] [-Source <String[]>] [-Message <String>] [-AsBaseObject]
-[<CommonParameters>]
+ [-Before <DateTime>] [-UserName <String[]>] [[-InstanceId] <Int64[]>] [-Index <Int32[]>]
+ [-EntryType <String[]>] [-Source <String[]>] [-Message <String>] [-AsBaseObject]
+ [<CommonParameters>]
 ```
 
 ### List

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
@@ -21,7 +21,7 @@ objects.
 
 ```
 ConvertFrom-Csv [-InputObject] <psobject[]> [[-Delimiter] <char>] [-Header <string[]>]
-[<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### UseCulture

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -20,7 +20,7 @@ Converts objects into a series of comma-separated value (CSV) strings.
 
 ```
 ConvertTo-Csv [-InputObject] <psobject> [[-Delimiter] <char>] [-NoTypeInformation]
-[<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### UseCulture

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -20,16 +20,16 @@ file.
 
 ```
 Export-Csv [[-Path] <string>] [[-Delimiter] <char>] -InputObject <psobject> [-LiteralPath <string>]
-[-Force] [-NoClobber] [-Encoding <string>] [-Append] [-NoTypeInformation] [-WhatIf] [-Confirm]
-[<CommonParameters>]
+ [-Force] [-NoClobber] [-Encoding <string>] [-Append] [-NoTypeInformation] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### UseCulture
 
 ```
 Export-Csv [[-Path] <string>] -InputObject <psobject> [-LiteralPath <string>] [-Force] [-NoClobber]
-[-Encoding <string>] [-Append] [-UseCulture] [-NoTypeInformation] [-WhatIf] [-Confirm]
-[<CommonParameters>]
+ [-Encoding <string>] [-Append] [-UseCulture] [-NoTypeInformation] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -17,9 +17,10 @@ Exports commands from another session and saves them in a PowerShell module.
 
 ```
 Export-PSSession [-Session] <PSSession> [-OutputModule] <string> [[-CommandName] <string[]>]
-[[-FormatTypeName] <string[]>] [-Force] [-Encoding <string>] [-AllowClobber] [-ArgumentList
-<Object[]>] [-CommandType <CommandTypes>] [-Module <string[]>] [-FullyQualifiedModule
-<ModuleSpecification[]>] [-Certificate <X509Certificate2>] [<CommonParameters>]
+ [[-FormatTypeName] <string[]>] [-Force] [-Encoding <string>] [-AllowClobber]
+ [-ArgumentList <Object[]>] [-CommandType <CommandTypes>] [-Module <string[]>]
+ [-FullyQualifiedModule <ModuleSpecification[]>] [-Certificate <X509Certificate2>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-Csv.md
@@ -18,15 +18,15 @@ Creates table-like custom objects from the items in a comma-separated value (CSV
 ### Delimiter (Default)
 
 ```
-Import-Csv [[-Path] <string[]>] [[-Delimiter] <char>] [-LiteralPath <string[]>] [-Header
-<string[]>] [-Encoding <string>] [<CommonParameters>]
+Import-Csv [[-Path] <string[]>] [[-Delimiter] <char>] [-LiteralPath <string[]>] [-Header <string[]>]
+ [-Encoding <string>] [<CommonParameters>]
 ```
 
 ### UseCulture
 
 ```
 Import-Csv [[-Path] <string[]>] -UseCulture [-LiteralPath <string[]>] [-Header <string[]>]
-[-Encoding <string>] [<CommonParameters>]
+ [-Encoding <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-File.md
@@ -19,14 +19,14 @@ Sends output to a file.
 
 ```
 Out-File [-FilePath] <string> [[-Encoding] <string>] [-Append] [-Force] [-NoClobber] [-Width <int>]
-[-NoNewline] [-InputObject <psobject>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-NoNewline] [-InputObject <psobject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
 Out-File [[-Encoding] <string>] -LiteralPath <string> [-Append] [-Force] [-NoClobber] [-Width <int>]
-[-NoNewline] [-InputObject <psobject>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-NoNewline] [-InputObject <psobject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -20,7 +20,7 @@ Creates or changes an alias for a cmdlet or other command in the current PowerSh
 
 ```
 Set-Alias [-Name] <string> [-Value] <string> [-Description <string>] [-Option <ScopedItemOptions>]
-[-PassThru] [-Scope <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-PassThru] [-Scope <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -20,7 +20,7 @@ Sorts objects by property values.
 
 ```
 Sort-Object [[-Property] <Object[]>] [-Descending] [-Unique] [-InputObject <psobject>]
-[-Culture <string>] [-CaseSensitive] [<CommonParameters>]
+ [-Culture <string>] [-CaseSensitive] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
@@ -20,7 +20,7 @@ objects.
 
 ```
 ConvertFrom-Csv [-InputObject] <psobject[]> [[-Delimiter] <char>] [-Header <string[]>]
-[<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### UseCulture

--- a/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -19,14 +19,14 @@ Converts objects into a series of character-separated value (CSV) strings.
 
 ```
 ConvertTo-Csv [-InputObject] <psobject> [[-Delimiter] <char>] [-IncludeTypeInformation]
-[-NoTypeInformation] [<CommonParameters>]
+ [-NoTypeInformation] [<CommonParameters>]
 ```
 
 ### UseCulture
 
 ```
 ConvertTo-Csv [-InputObject] <psobject> [-UseCulture] [-IncludeTypeInformation]
-[-NoTypeInformation] [<CommonParameters>]
+ [-NoTypeInformation] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -20,16 +20,16 @@ file.
 
 ```
 Export-Csv [[-Path] <string>] [[-Delimiter] <char>] -InputObject <psobject> [-LiteralPath <string>]
-[-Force] [-NoClobber] [-Encoding <Encoding>] [-Append] [-IncludeTypeInformation]
-[-NoTypeInformation] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Force] [-NoClobber] [-Encoding <Encoding>] [-Append] [-IncludeTypeInformation]
+ [-NoTypeInformation] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### UseCulture
 
 ```
 Export-Csv [[-Path] <string>] -InputObject <psobject> [-LiteralPath <string>] [-Force] [-NoClobber]
-[-Encoding <Encoding>] [-Append] [-UseCulture] [-IncludeTypeInformation] [-NoTypeInformation]
-[-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Encoding <Encoding>] [-Append] [-UseCulture] [-IncludeTypeInformation] [-NoTypeInformation]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -17,10 +17,10 @@ Exports commands from another session and saves them in a PowerShell module.
 
 ```
 Export-PSSession [-Session] <PSSession> [-OutputModule] <string> [[-CommandName] <string[]>]
-[[-FormatTypeName] <string[]>] [-Force] [-Encoding <Encoding>] [-AllowClobber]
-[-ArgumentList <Object[]>] [-CommandType <CommandTypes>] [-Module <string[]>]
-[-FullyQualifiedModule <ModuleSpecification[]>] [-Certificate <X509Certificate2>]
-[<CommonParameters>]
+ [[-FormatTypeName] <string[]>] [-Force] [-Encoding <Encoding>] [-AllowClobber]
+ [-ArgumentList <Object[]>] [-CommandType <CommandTypes>] [-Module <string[]>]
+ [-FullyQualifiedModule <ModuleSpecification[]>] [-Certificate <X509Certificate2>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Out-File.md
@@ -20,14 +20,14 @@ Sends output to a file.
 
 ```
 Out-File [-FilePath] <string> [[-Encoding] <Encoding>] [-Append] [-Force] [-NoClobber]
-[-Width <int>] [-NoNewline] [-InputObject <psobject>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Width <int>] [-NoNewline] [-InputObject <psobject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
 Out-File [[-Encoding] <Encoding>] -LiteralPath <string> [-Append] [-Force] [-NoClobber]
-[-Width <int>] [-NoNewline] [-InputObject <psobject>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Width <int>] [-NoNewline] [-InputObject <psobject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -20,7 +20,7 @@ Creates or changes an alias for a cmdlet or other command in the current PowerSh
 
 ```
 Set-Alias [-Name] <string> [-Value] <string> [-Description <string>] [-Option <ScopedItemOptions>]
-[-PassThru] [-Scope <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-PassThru] [-Scope <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
+++ b/reference/7/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
@@ -20,7 +20,7 @@ objects.
 
 ```
 ConvertFrom-Csv [-InputObject] <psobject[]> [[-Delimiter] <char>] [-Header <string[]>]
-[<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### UseCulture

--- a/reference/7/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -17,10 +17,10 @@ Exports commands from another session and saves them in a PowerShell module.
 
 ```
 Export-PSSession [-Session] <PSSession> [-OutputModule] <string> [[-CommandName] <string[]>]
-[[-FormatTypeName] <string[]>] [-Force] [-Encoding <Encoding>] [-AllowClobber]
-[-ArgumentList <Object[]>] [-CommandType <CommandTypes>] [-Module <string[]>]
-[-FullyQualifiedModule <ModuleSpecification[]>] [-Certificate <X509Certificate2>]
-[<CommonParameters>]
+ [[-FormatTypeName] <string[]>] [-Force] [-Encoding <Encoding>] [-AllowClobber]
+ [-ArgumentList <Object[]>] [-CommandType <CommandTypes>] [-Module <string[]>]
+ [-FullyQualifiedModule <ModuleSpecification[]>] [-Certificate <X509Certificate2>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Out-File.md
@@ -20,14 +20,14 @@ Sends output to a file.
 
 ```
 Out-File [-FilePath] <string> [[-Encoding] <Encoding>] [-Append] [-Force] [-NoClobber]
-[-Width <int>] [-NoNewline] [-InputObject <psobject>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Width <int>] [-NoNewline] [-InputObject <psobject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
 Out-File [[-Encoding] <Encoding>] -LiteralPath <string> [-Append] [-Force] [-NoClobber]
-[-Width <int>] [-NoNewline] [-InputObject <psobject>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Width <int>] [-NoNewline] [-InputObject <psobject>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -20,7 +20,7 @@ Creates or changes an alias for a cmdlet or other command in the current PowerSh
 
 ```
 Set-Alias [-Name] <string> [-Value] <string> [-Description <string>] [-Option <ScopedItemOptions>]
-[-PassThru] [-Scope <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-PassThru] [-Scope <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Part 1 of 2 to fix ParameterSet spacing.

- Related to [AB#1617150](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1617150)
- Related to #4954

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content
- [ ] Version 5.0 content
- [ ] Version 4.0 content
- [ ] Version 3.0 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
