### PR TITLE
Fixes #4954 - Fixed cmdlet ParameterSet spacing part 2

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Update-Help.md
@@ -20,16 +20,16 @@ Downloads and installs the newest help files on your computer.
 
 ```
 Update-Help [[-Module] <String[]>] [-FullyQualifiedModule <ModuleSpecification[]>]
-[[-SourcePath] <String[]>] [-Recurse] [[-UICulture] <CultureInfo[]>] [-Credential <PSCredential>]
-[-UseDefaultCredentials] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-SourcePath] <String[]>] [-Recurse] [[-UICulture] <CultureInfo[]>] [-Credential <PSCredential>]
+ [-UseDefaultCredentials] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPath
 
 ```
 Update-Help [[-Module] <String[]>] [-FullyQualifiedModule <ModuleSpecification[]>]
-[-LiteralPath <String[]>] [-Recurse] [[-UICulture] <CultureInfo[]>] [-Credential <PSCredential>]
-[-UseDefaultCredentials] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-LiteralPath <String[]>] [-Recurse] [[-UICulture] <CultureInfo[]>] [-Credential <PSCredential>]
+ [-UseDefaultCredentials] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -251,7 +251,7 @@ foreach ($mModule in $Modules)
     if (Test-Path $mdir\*helpinfo.xml)
     {
         $mName=$mModule.Name
-        $mNodes = dir $mdir\*helpinfo.xml -ErrorAction SilentlyContinue | 
+        $mNodes = dir $mdir\*helpinfo.xml -ErrorAction SilentlyContinue |
             Select-Xml -Namespace $HelpInfoNamespace -XPath "//helpInfo:UICulture"
         foreach ($mNode in $mNodes)
         {
@@ -572,15 +572,15 @@ Only members of the Administrators group on the computer can update help for the
 modules, the commands that are installed together with PowerShell, and for modules in the
 `$PSHOME\Modules` folder. If you don't have permission to update help files, you can read the help
 files online. For example, `Get-Help Update-Help -Online`.
-  
+
 Modules are the smallest unit of updatable help. You can't update help for a particular cmdlet. To
 find the module that contains a particular cmdlet, use the **ModuleName** property of the
 `Get-Command` cmdlet, for example, `(Get-Command Update-Help).ModuleName`.
-  
+
 Because help files are installed in the module directory, the `Update-Help` cmdlet can install
 updated help file only for modules that are installed on the computer. However, the `Save-Help`
 cmdlet can save help for modules that aren't installed on the computer.
-  
+
 If `Update-Help` can't find updated help files for a module, or can't find updated help in the
 specified language, it continues silently without displaying an error message. To see status and
 progress details, use the **Verbose** parameter.
@@ -596,7 +596,7 @@ for HTTP and port 443 for HTTPS.
 
 `Update-Help` supports all modules and the PowerShell Core snap-ins. It doesn't support any other
 snap-ins.
-  
+
 To update help for a module in a location that isn't listed in the `$env:PSModulePath` environment
 variable, import the module into the current session and then run an `Update-Help` command. Run
 `Update-Help` without parameters or use the **Module** parameter to specify the module name. The

--- a/reference/5.1/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
@@ -19,49 +19,49 @@ Gets events from event logs and event tracing log files on local and remote comp
 
 ```
 Get-WinEvent [[-LogName] <String[]>] [-MaxEvents <Int64>] [-ComputerName <String>]
-[-Credential <PSCredential>] [-FilterXPath <String>] [-Force] [-Oldest] [<CommonParameters>]
+ [-Credential <PSCredential>] [-FilterXPath <String>] [-Force] [-Oldest] [<CommonParameters>]
 ```
 
 ### ListLogSet
 
 ```
 Get-WinEvent [-ListLog] <String[]> [-ComputerName <String>] [-Credential <PSCredential>] [-Force]
-[<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### ListProviderSet
 
 ```
 Get-WinEvent [-ListProvider] <String[]> [-ComputerName <String>] [-Credential <PSCredential>]
-[<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### GetProviderSet
 
 ```
 Get-WinEvent [-ProviderName] <String[]> [-MaxEvents <Int64>] [-ComputerName <String>]
-[-Credential <PSCredential>] [-FilterXPath <String>] [-Force] [-Oldest] [<CommonParameters>]
+ [-Credential <PSCredential>] [-FilterXPath <String>] [-Force] [-Oldest] [<CommonParameters>]
 ```
 
 ### FileSet
 
 ```
 Get-WinEvent [-Path] <String[]> [-MaxEvents <Int64>] [-Credential <PSCredential>]
-[-FilterXPath <String>] [-Oldest] [<CommonParameters>]
+ [-FilterXPath <String>] [-Oldest] [<CommonParameters>]
 ```
 
 ### HashQuerySet
 
 ```
 Get-WinEvent [-MaxEvents <Int64>] [-ComputerName <String>] [-Credential <PSCredential>]
-[-FilterHashtable] <Hashtable[]> [-Force] [-Oldest] [<CommonParameters>]
+ [-FilterHashtable] <Hashtable[]> [-Force] [-Oldest] [<CommonParameters>]
 ```
 
 ### XmlQuerySet
 
 ```
-Get-WinEvent [-MaxEvents <Int64>] [-ComputerName <String>] [-Credential <PSCredential>] [-FilterXml]
-<XmlDocument> [-Oldest] [<CommonParameters>]
+Get-WinEvent [-MaxEvents <Int64>] [-ComputerName <String>] [-Credential <PSCredential>]
+ [-FilterXml] <XmlDocument> [-Oldest] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Add-Content.md
@@ -17,19 +17,19 @@ Adds content to the specified items, such as adding words to a file.
 ### Path (Default)
 
 ```
-Add-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>] [-Include
-<string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf] [-Confirm]
-[-UseTransaction] [-NoNewline] [-Encoding <FileSystemCmdletProviderEncoding>] [-Stream <string>]
-[<CommonParameters>]
+Add-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>]
+ [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
+ [-Confirm] [-UseTransaction] [-NoNewline] [-Encoding <FileSystemCmdletProviderEncoding>]
+ [-Stream <string>] [<CommonParameters>]
 ```
 
 ### LiteralPath
 
 ```
-Add-Content [-Value] <Object[]> -LiteralPath <string[]> [-PassThru] [-Filter <string>] [-Include
-<string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf] [-Confirm]
-[-UseTransaction] [-NoNewline] [-Encoding <FileSystemCmdletProviderEncoding>] [-Stream <string>]
-[<CommonParameters>]
+Add-Content [-Value] <Object[]> -LiteralPath <string[]> [-PassThru] [-Filter <string>]
+ [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
+ [-Confirm] [-UseTransaction] [-NoNewline] [-Encoding <FileSystemCmdletProviderEncoding>]
+ [-Stream <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Content.md
@@ -18,18 +18,18 @@ Writes new content or replaces existing content in a file.
 
 ```
 Set-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>]
-[-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
-[-Confirm] [-UseTransaction] [-NoNewline] [-Encoding <FileSystemCmdletProviderEncoding>]
-[-Stream <string>] [<CommonParameters>]
+ [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
+ [-Confirm] [-UseTransaction] [-NoNewline] [-Encoding <FileSystemCmdletProviderEncoding>]
+ [-Stream <string>] [<CommonParameters>]
 ```
 
 ### LiteralPath
 
 ```
 Set-Content [-Value] <Object[]> -LiteralPath <string[]> [-PassThru] [-Filter <string>]
-[-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
-[-Confirm] [-UseTransaction] [-NoNewline] [-Encoding <FileSystemCmdletProviderEncoding>]
-[-Stream <string>] [<CommonParameters>]
+ [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
+ [-Confirm] [-UseTransaction] [-NoNewline] [-Encoding <FileSystemCmdletProviderEncoding>]
+ [-Stream <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -20,7 +20,7 @@ Sets the PowerShell execution policies for Windows computers.
 
 ```
 Set-ExecutionPolicy [-ExecutionPolicy] <ExecutionPolicy> [[-Scope] <ExecutionPolicyScope>] [-Force]
-[-WhatIf] [-Confirm] [<CommonParameters>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/6/Microsoft.PowerShell.Core/Update-Help.md
@@ -20,18 +20,18 @@ Downloads and installs the newest help files on your computer.
 
 ```
 Update-Help [[-Module] <String[]>] [-FullyQualifiedModule <ModuleSpecification[]>]
-[[-SourcePath] <String[]>] [-Recurse] [[-UICulture] <CultureInfo[]>] [-Credential <PSCredential>]
-[-UseDefaultCredentials] [-Force] [-Scope <UpdateHelpScope>] [-WhatIf] [-Confirm]
-[<CommonParameters>]
+ [[-SourcePath] <String[]>] [-Recurse] [[-UICulture] <CultureInfo[]>] [-Credential <PSCredential>]
+ [-UseDefaultCredentials] [-Force] [-Scope <UpdateHelpScope>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### LiteralPath
 
 ```
 Update-Help [[-Module] <String[]>] [-FullyQualifiedModule <ModuleSpecification[]>]
-[-LiteralPath <String[]>] [-Recurse] [[-UICulture] <CultureInfo[]>] [-Credential <PSCredential>]
-[-UseDefaultCredentials] [-Force] [-Scope <UpdateHelpScope>] [-WhatIf] [-Confirm]
-[<CommonParameters>]
+ [-LiteralPath <String[]>] [-Recurse] [[-UICulture] <CultureInfo[]>] [-Credential <PSCredential>]
+ [-UseDefaultCredentials] [-Force] [-Scope <UpdateHelpScope>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -211,7 +211,7 @@ foreach ($mModule in $Modules)
     if (Test-Path $mdir\*helpinfo.xml)
     {
         $mName=$mModule.Name
-        $mNodes = dir $mdir\*helpinfo.xml -ErrorAction SilentlyContinue | 
+        $mNodes = dir $mdir\*helpinfo.xml -ErrorAction SilentlyContinue |
             Select-Xml -Namespace $HelpInfoNamespace -XPath "//helpInfo:UICulture"
         foreach ($mNode in $mNodes)
         {
@@ -559,15 +559,15 @@ Only members of the Administrators group on the computer can update help for the
 modules, the commands that are installed together with PowerShell, and for modules in the
 `$PSHOME\Modules` folder. If you don't have permission to update help files, you can read the help
 files online. For example, `Get-Help Update-Help -Online`.
-  
+
 Modules are the smallest unit of updatable help. You can't update help for a particular cmdlet. To
 find the module that contains a particular cmdlet, use the **ModuleName** property of the
 `Get-Command` cmdlet, for example, `(Get-Command Update-Help).ModuleName`.
-  
+
 Because help files are installed in the module directory, the `Update-Help` cmdlet can install
 updated help file only for modules that are installed on the computer. However, the `Save-Help`
 cmdlet can save help for modules that aren't installed on the computer.
-  
+
 If `Update-Help` can't find updated help files for a module, or can't find updated help in the
 specified language, it continues silently without displaying an error message. To see status and
 progress details, use the **Verbose** parameter.
@@ -583,7 +583,7 @@ for HTTP and port 443 for HTTPS.
 
 `Update-Help` supports all modules and the PowerShell Core snap-ins. It doesn't support any other
 snap-ins.
-  
+
 To update help for a module in a location that isn't listed in the `$env:PSModulePath` environment
 variable, import the module into the current session and then run an `Update-Help` command. Run
 `Update-Help` without parameters or use the **Module** parameter to specify the module name. The

--- a/reference/6/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
+++ b/reference/6/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
@@ -19,49 +19,49 @@ Gets events from event logs and event tracing log files on local and remote comp
 
 ```
 Get-WinEvent [[-LogName] <String[]>] [-MaxEvents <Int64>] [-ComputerName <String>]
-[-Credential <PSCredential>] [-FilterXPath <String>] [-Force] [-Oldest] [<CommonParameters>]
+ [-Credential <PSCredential>] [-FilterXPath <String>] [-Force] [-Oldest] [<CommonParameters>]
 ```
 
 ### ListLogSet
 
 ```
 Get-WinEvent [-ListLog] <String[]> [-ComputerName <String>] [-Credential <PSCredential>] [-Force]
-[<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### ListProviderSet
 
 ```
 Get-WinEvent [-ListProvider] <String[]> [-ComputerName <String>] [-Credential <PSCredential>]
-[<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### GetProviderSet
 
 ```
 Get-WinEvent [-ProviderName] <String[]> [-MaxEvents <Int64>] [-ComputerName <String>]
-[-Credential <PSCredential>] [-FilterXPath <String>] [-Force] [-Oldest] [<CommonParameters>]
+ [-Credential <PSCredential>] [-FilterXPath <String>] [-Force] [-Oldest] [<CommonParameters>]
 ```
 
 ### FileSet
 
 ```
 Get-WinEvent [-Path] <String[]> [-MaxEvents <Int64>] [-Credential <PSCredential>]
-[-FilterXPath <String>] [-Oldest] [<CommonParameters>]
+ [-FilterXPath <String>] [-Oldest] [<CommonParameters>]
 ```
 
 ### HashQuerySet
 
 ```
 Get-WinEvent [-MaxEvents <Int64>] [-ComputerName <String>] [-Credential <PSCredential>]
-[-FilterHashtable] <Hashtable[]> [-Force] [-Oldest] [<CommonParameters>]
+ [-FilterHashtable] <Hashtable[]> [-Force] [-Oldest] [<CommonParameters>]
 ```
 
 ### XmlQuerySet
 
 ```
-Get-WinEvent [-MaxEvents <Int64>] [-ComputerName <String>] [-Credential <PSCredential>] [-FilterXml]
-<XmlDocument> [-Oldest] [<CommonParameters>]
+Get-WinEvent [-MaxEvents <Int64>] [-ComputerName <String>] [-Credential <PSCredential>]
+ [-FilterXml] <XmlDocument> [-Oldest] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/6/Microsoft.PowerShell.Management/Add-Content.md
@@ -27,9 +27,9 @@ Add-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>
 
 ```
 Add-Content [-Value] <Object[]> -LiteralPath <string[]> [-PassThru] [-Filter <string>]
-[-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
-[-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
-[<CommonParameters>]
+ [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
+ [-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/6/Microsoft.PowerShell.Management/Add-Content.md
@@ -18,9 +18,9 @@ Adds content to the specified items, such as adding words to a file.
 
 ```
 Add-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>]
-[-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
-[-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
-[<CommonParameters>]
+ [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
+ [-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
+ [<CommonParameters>]
 ```
 
 ### LiteralPath

--- a/reference/6/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Content.md
@@ -18,18 +18,18 @@ Writes new content or replaces existing content in a file.
 
 ```
 Set-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>]
-[-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
-[-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>][-AsByteStream] [-Stream <string>]
-[<CommonParameters>]
+ [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>][-AsByteStream] [-Stream <string>]
+ [<CommonParameters>]
 ```
 
 ### LiteralPath
 
 ```
 Set-Content [-Value] <Object[]> -LiteralPath <string[]> [-PassThru] [-Filter <string>]
-[-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
-[-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>][-AsByteStream] [-Stream <string>]
-[<CommonParameters>]
+ [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>][-AsByteStream] [-Stream <string>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Content.md
@@ -19,7 +19,7 @@ Writes new content or replaces existing content in a file.
 ```
 Set-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>]
  [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
- [-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>][-AsByteStream] [-Stream <string>]
+ [-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
  [<CommonParameters>]
 ```
 
@@ -28,7 +28,7 @@ Set-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>
 ```
 Set-Content [-Value] <Object[]> -LiteralPath <string[]> [-PassThru] [-Filter <string>]
  [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
- [-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>][-AsByteStream] [-Stream <string>]
+ [-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
  [<CommonParameters>]
 ```
 

--- a/reference/6/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/6/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -20,7 +20,7 @@ Sets the PowerShell execution policies for Windows computers.
 
 ```
 Set-ExecutionPolicy [-ExecutionPolicy] <ExecutionPolicy> [[-Scope] <ExecutionPolicyScope>] [-Force]
-[-WhatIf] [-Confirm] [<CommonParameters>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/7/Microsoft.PowerShell.Core/Start-Job.md
@@ -551,7 +551,8 @@ Accept wildcard characters: False
 
 ### -WorkingDirectory
 
-Specifies the initial working directory(location) of the background job. If it is not specified it defaults to `$HOME`.
+Specifies the initial working directory (location) of the background job. If it's not specified it
+defaults to `$HOME`.
 
  ```yaml
 Type: String

--- a/reference/7/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/7/Microsoft.PowerShell.Core/Start-Job.md
@@ -20,8 +20,9 @@ Starts a PowerShell background job.
 
 ```
 Start-Job [-Name <String>] [-ScriptBlock] <ScriptBlock> [-Credential <PSCredential>]
- [-Authentication <AuthenticationMechanism>] [[-InitializationScript] <ScriptBlock>] [WorkingDirectory <String>] [-RunAs32]
- [-PSVersion <Version>] [-InputObject <PSObject>] [-ArgumentList <Object[]>] [<CommonParameters>]
+ [-Authentication <AuthenticationMechanism>] [[-InitializationScript] <ScriptBlock>]
+ [WorkingDirectory <String>] [-RunAs32] [-PSVersion <Version>] [-InputObject <PSObject>]
+ [-ArgumentList <Object[]>] [<CommonParameters>]
 ```
 
 ### DefinitionName
@@ -35,16 +36,18 @@ Start-Job [-DefinitionName] <String> [[-DefinitionPath] <String>] [[-Type] <Stri
 
 ```
 Start-Job [-Name <String>] [-Credential <PSCredential>] [-FilePath] <String>
- [-Authentication <AuthenticationMechanism>] [[-InitializationScript] <ScriptBlock>] [WorkingDirectory <String>] [-RunAs32]
- [-PSVersion <Version>] [-InputObject <PSObject>] [-ArgumentList <Object[]>] [<CommonParameters>]
+ [-Authentication <AuthenticationMechanism>] [[-InitializationScript] <ScriptBlock>]
+ [WorkingDirectory <String>] [-RunAs32] [-PSVersion <Version>] [-InputObject <PSObject>]
+ [-ArgumentList <Object[]>] [<CommonParameters>]
 ```
 
 ### LiteralFilePathComputerName
 
 ```
 Start-Job [-Name <String>] [-Credential <PSCredential>] -LiteralPath <String>
- [-Authentication <AuthenticationMechanism>] [[-InitializationScript] <ScriptBlock>] [WorkingDirectory <String>] [-RunAs32]
- [-PSVersion <Version>] [-InputObject <PSObject>] [-ArgumentList <Object[]>] [<CommonParameters>]
+ [-Authentication <AuthenticationMechanism>] [[-InitializationScript] <ScriptBlock>]
+ [WorkingDirectory <String>] [-RunAs32] [-PSVersion <Version>] [-InputObject <PSObject>]
+ [-ArgumentList <Object[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/7/Microsoft.PowerShell.Core/Update-Help.md
@@ -20,18 +20,18 @@ Downloads and installs the newest help files on your computer.
 
 ```
 Update-Help [[-Module] <String[]>] [-FullyQualifiedModule <ModuleSpecification[]>]
-[[-SourcePath] <String[]>] [-Recurse] [[-UICulture] <CultureInfo[]>] [-Credential <PSCredential>]
-[-UseDefaultCredentials] [-Force] [-Scope <UpdateHelpScope>] [-WhatIf] [-Confirm]
-[<CommonParameters>]
+ [[-SourcePath] <String[]>] [-Recurse] [[-UICulture] <CultureInfo[]>] [-Credential <PSCredential>]
+ [-UseDefaultCredentials] [-Force] [-Scope <UpdateHelpScope>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### LiteralPath
 
 ```
 Update-Help [[-Module] <String[]>] [-FullyQualifiedModule <ModuleSpecification[]>]
-[-LiteralPath <String[]>] [-Recurse] [[-UICulture] <CultureInfo[]>] [-Credential <PSCredential>]
-[-UseDefaultCredentials] [-Force] [-Scope <UpdateHelpScope>] [-WhatIf] [-Confirm]
-[<CommonParameters>]
+ [-LiteralPath <String[]>] [-Recurse] [[-UICulture] <CultureInfo[]>] [-Credential <PSCredential>]
+ [-UseDefaultCredentials] [-Force] [-Scope <UpdateHelpScope>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -211,7 +211,7 @@ foreach ($mModule in $Modules)
     if (Test-Path $mdir\*helpinfo.xml)
     {
         $mName=$mModule.Name
-        $mNodes = dir $mdir\*helpinfo.xml -ErrorAction SilentlyContinue | 
+        $mNodes = dir $mdir\*helpinfo.xml -ErrorAction SilentlyContinue |
             Select-Xml -Namespace $HelpInfoNamespace -XPath "//helpInfo:UICulture"
         foreach ($mNode in $mNodes)
         {
@@ -559,15 +559,15 @@ Only members of the Administrators group on the computer can update help for the
 modules, the commands that are installed together with PowerShell, and for modules in the
 `$PSHOME\Modules` folder. If you don't have permission to update help files, you can read the help
 files online. For example, `Get-Help Update-Help -Online`.
-  
+
 Modules are the smallest unit of updatable help. You can't update help for a particular cmdlet. To
 find the module that contains a particular cmdlet, use the **ModuleName** property of the
 `Get-Command` cmdlet, for example, `(Get-Command Update-Help).ModuleName`.
-  
+
 Because help files are installed in the module directory, the `Update-Help` cmdlet can install
 updated help file only for modules that are installed on the computer. However, the `Save-Help`
 cmdlet can save help for modules that aren't installed on the computer.
-  
+
 If `Update-Help` can't find updated help files for a module, or can't find updated help in the
 specified language, it continues silently without displaying an error message. To see status and
 progress details, use the **Verbose** parameter.
@@ -583,7 +583,7 @@ for HTTP and port 443 for HTTPS.
 
 `Update-Help` supports all modules and the PowerShell Core snap-ins. It doesn't support any other
 snap-ins.
-  
+
 To update help for a module in a location that isn't listed in the `$env:PSModulePath` environment
 variable, import the module into the current session and then run an `Update-Help` command. Run
 `Update-Help` without parameters or use the **Module** parameter to specify the module name. The

--- a/reference/7/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
+++ b/reference/7/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
@@ -19,28 +19,28 @@ Gets events from event logs and event tracing log files on local and remote comp
 
 ```
 Get-WinEvent [[-LogName] <String[]>] [-MaxEvents <Int64>] [-ComputerName <String>]
-[-Credential <PSCredential>] [-FilterXPath <String>] [-Force] [-Oldest] [<CommonParameters>]
+ [-Credential <PSCredential>] [-FilterXPath <String>] [-Force] [-Oldest] [<CommonParameters>]
 ```
 
 ### ListLogSet
 
 ```
 Get-WinEvent [-ListLog] <String[]> [-ComputerName <String>] [-Credential <PSCredential>] [-Force]
-[<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### ListProviderSet
 
 ```
 Get-WinEvent [-ListProvider] <String[]> [-ComputerName <String>] [-Credential <PSCredential>]
-[<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### GetProviderSet
 
 ```
 Get-WinEvent [-ProviderName] <String[]> [-MaxEvents <Int64>] [-ComputerName <String>]
-[-Credential <PSCredential>] [-FilterXPath <String>] [-Force] [-Oldest] [<CommonParameters>]
+ [-Credential <PSCredential>] [-FilterXPath <String>] [-Force] [-Oldest] [<CommonParameters>]
 ```
 
 ### FileSet
@@ -54,14 +54,14 @@ Get-WinEvent [-Path] <String[]> [-MaxEvents <Int64>] [-Credential <PSCredential>
 
 ```
 Get-WinEvent [-MaxEvents <Int64>] [-ComputerName <String>] [-Credential <PSCredential>]
-[-FilterHashtable] <Hashtable[]> [-Force] [-Oldest] [<CommonParameters>]
+ [-FilterHashtable] <Hashtable[]> [-Force] [-Oldest] [<CommonParameters>]
 ```
 
 ### XmlQuerySet
 
 ```
-Get-WinEvent [-MaxEvents <Int64>] [-ComputerName <String>] [-Credential <PSCredential>] [-FilterXml]
-<XmlDocument> [-Oldest] [<CommonParameters>]
+Get-WinEvent [-MaxEvents <Int64>] [-ComputerName <String>] [-Credential <PSCredential>]
+ [-FilterXml] <XmlDocument> [-Oldest] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
+++ b/reference/7/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
@@ -47,7 +47,7 @@ Get-WinEvent [-ProviderName] <String[]> [-MaxEvents <Int64>] [-ComputerName <Str
 
 ```
 Get-WinEvent [-Path] <String[]> [-MaxEvents <Int64>] [-Credential <PSCredential>]
-[-FilterXPath <String>] [-Oldest] [<CommonParameters>]
+ [-FilterXPath <String>] [-Oldest] [<CommonParameters>]
 ```
 
 ### HashQuerySet

--- a/reference/7/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/7/Microsoft.PowerShell.Management/Add-Content.md
@@ -18,18 +18,18 @@ Adds content to the specified items, such as adding words to a file.
 
 ```
 Add-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>]
-[-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
-[-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
-[<CommonParameters>]
+ [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
+ [-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
+ [<CommonParameters>]
 ```
 
 ### LiteralPath
 
 ```
 Add-Content [-Value] <Object[]> -LiteralPath <string[]> [-PassThru] [-Filter <string>]
-[-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
-[-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
-[<CommonParameters>]
+ [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf]
+ [-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/7/Microsoft.PowerShell.Management/Set-Content.md
@@ -18,18 +18,18 @@ Writes new content or replaces existing content in a file.
 
 ```
 Set-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>]
-[-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
-[-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>][-AsByteStream] [-Stream <string>]
-[<CommonParameters>]
+ [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>][-AsByteStream] [-Stream <string>]
+ [<CommonParameters>]
 ```
 
 ### LiteralPath
 
 ```
 Set-Content [-Value] <Object[]> -LiteralPath <string[]> [-PassThru] [-Filter <string>]
-[-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
-[-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>][-AsByteStream] [-Stream <string>]
-[<CommonParameters>]
+ [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>][-AsByteStream] [-Stream <string>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/7/Microsoft.PowerShell.Management/Set-Content.md
@@ -19,7 +19,7 @@ Writes new content or replaces existing content in a file.
 ```
 Set-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>]
  [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
- [-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>][-AsByteStream] [-Stream <string>]
+ [-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
  [<CommonParameters>]
 ```
 
@@ -28,7 +28,7 @@ Set-Content [-Path] <string[]> [-Value] <Object[]> [-PassThru] [-Filter <string>
 ```
 Set-Content [-Value] <Object[]> -LiteralPath <string[]> [-PassThru] [-Filter <string>]
  [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
- [-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>][-AsByteStream] [-Stream <string>]
+ [-WhatIf] [-Confirm] [-NoNewline] [-Encoding <Encoding>] [-AsByteStream] [-Stream <string>]
  [<CommonParameters>]
 ```
 

--- a/reference/7/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/7/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -20,7 +20,7 @@ Sets the PowerShell execution policies for Windows computers.
 
 ```
 Set-ExecutionPolicy [-ExecutionPolicy] <ExecutionPolicy> [[-Scope] <ExecutionPolicyScope>] [-Force]
-[-WhatIf] [-Confirm] [<CommonParameters>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Part 2 of 2 to fix ParameterSet spacing.

- Fixes [AB#1617150](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1617150)
- Fixes #4954
- Related PR: #4960

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content
- [ ] Version 5.0 content
- [ ] Version 4.0 content
- [ ] Version 3.0 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
