### PR TITLE
Fixes #4966 - Updated the ArgumentCompleter attribute content

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -26,7 +26,8 @@ parameters, see [about_CommonParameters](about_CommonParameters.md).
 
 Beginning in PowerShell 3.0, you can use splatting with `@Args` to represent
 the parameters in a command. Splatting is valid on simple and advanced
-functions. For more information, see [about_Functions](about_Functions.md) and [about_Splatting](about_Splatting.md).
+functions. For more information, see [about_Functions](about_Functions.md) and
+[about_Splatting](about_Splatting.md).
 
 ## Static parameters
 
@@ -164,13 +165,6 @@ Param(
     $ComputerName
 )
 ```
-
-> [!NOTE]
-> When the `Get-Help` cmdlet displays the corresponding **Position** parameter
-> attribute, the position value is incremented by one.
->
-> For example, a parameter with a `Position` argument value of **0** has a
-> parameter attribute of **Position=1**.
 
 ### ParameterSetName argument
 
@@ -544,9 +538,10 @@ than or equal to the current date and time.
 ### ValidateSet attribute
 
 The **ValidateSet** attribute specifies a set of valid values for a parameter
-or variable. PowerShell generates an error if a parameter or variable value
-doesn't match a value in the set. In the following example, the value of the
-**Detail** parameter can only be Low, Average, or High.
+or variable and enables tab completion. PowerShell generates an error if a
+parameter or variable value doesn't match a value in the set. In the following
+example, the value of the **Detail** parameter can only be Low, Average, or
+High.
 
 ```powershell
 Param(
@@ -774,12 +769,13 @@ value is required.
 ## ArgumentCompleter attribute
 
 The **ArgumentCompleter** attribute allows you to add tab completion values to
-a specific parameter. Like **DynamicParameters**, the available values are
-calculated at runtime when the user presses <kbd>Tab</kbd> after the parameter
-name.
+a specific parameter. An **ArgumentCompleter** attribute must be defined for
+each parameter that needs tab completion. Similar to **DynamicParameters**, the
+available values are calculated at runtime when the user presses <kbd>Tab</kbd>
+after the parameter name.
 
 To add an **ArgumentCompleter** attribute, you need to define a script block
-that will determine the values. The script block must take the following
+that determines the values. The script block must take the following
 parameters in the order specified below. The parameter's names don't matter as
 the values are provided positionally.
 
@@ -789,7 +785,11 @@ The syntax is as follows:
 Param(
     [Parameter(Mandatory)]
     [ArgumentCompleter({
-        param ($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+        param ( $commandName,
+                $parameterName,
+                $wordToComplete,
+                $commandAst,
+                $fakeBoundParameters )
         # Perform calculation of tab completed values here.
     })]
 )
@@ -807,21 +807,25 @@ The script block parameters are set to the following values:
   provided before they pressed <kbd>Tab</kbd>. Your script block should use
   this value to determine tab completion values.
 - `$commandAst` (Position 3) - This parameter is set to the Abstract Syntax
-  Tree (AST) for the current input line. For more information, see [Ast Class](/dotnet/api/system.management.automation.language.ast).
-- `$fakeBoundParameter` (Position 4) - This parameter is set to a hashtable
+  Tree (AST) for the current input line. For more information, see
+  [Ast Class](/dotnet/api/system.management.automation.language.ast).
+- `$fakeBoundParameters` (Position 4) - This parameter is set to a hashtable
   containing the `$PSBoundParameters` for the cmdlet, before the user pressed
-  <kbd>Tab</kbd>. For more information, see [about_Automatic_Variables](about_Automatic_Variables.md).
+  <kbd>Tab</kbd>. For more information, see
+  [about_Automatic_Variables](about_Automatic_Variables.md).
 
 The **ArgumentCompleter** script block must unroll the values using the
-pipeline, such as`ForEach-Object`, `Where-Object`, or another suitable method.
+pipeline, such as `ForEach-Object`, `Where-Object`, or another suitable method.
 Returning an array of values causes PowerShell to treat the entire array as
 **one** tab completion value.
 
-The following example adds tab completion to the **Value** parameter. If no
-`$Type` is specified, fruits and vegetables are returned. If a `$Type` is
-specified, only values for the type are specified. In addition, the `-like`
-operator ensures that if the user types the following command and uses
-<kbd>Tab</kbd> completion, only **Apple** is returned.
+The following example adds tab completion to the **Value** parameter. If only
+the **Value** parameter is specified, all possible values, or arguments, for
+**Value** are displayed. When the **Type** parameter is specified, the
+**Value** parameter only displays the possible values for that type.
+
+In addition, the `-like` operator ensures that if the user types the following
+command and uses <kbd>Tab</kbd> completion, only **Apple** is returned.
 
 `Test-ArgumentCompleter -Type Fruits -Value A`
 
@@ -829,10 +833,10 @@ operator ensures that if the user types the following command and uses
 function Test-ArgumentCompleter {
 [CmdletBinding()]
  param (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory=$true)]
         [ValidateSet('Fruits', 'Vegetables')]
         $Type,
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory=$true)]
         [ArgumentCompleter( {
             param ( $commandName,
                     $parameterName,

--- a/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -8,6 +8,7 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: Register-ArgumentCompleter
 ---
+
 # Register-ArgumentCompleter
 
 ## SYNOPSIS
@@ -18,14 +19,15 @@ Registers a custom argument completer.
 ### NativeSet
 
 ```
-Register-ArgumentCompleter -CommandName <String[]> -ScriptBlock <ScriptBlock> [-Native] [<CommonParameters>]
+Register-ArgumentCompleter -CommandName <String[]> -ScriptBlock <ScriptBlock> [-Native]
+ [<CommonParameters>]
 ```
 
 ### PowerShellSet
 
 ```
-Register-ArgumentCompleter [-CommandName <String[]>] -ParameterName <String> -ScriptBlock <ScriptBlock>
- [<CommonParameters>]
+Register-ArgumentCompleter [-CommandName <String[]>] -ParameterName <String>
+ -ScriptBlock <ScriptBlock> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -54,19 +56,19 @@ $scriptBlock = {
 Register-ArgumentCompleter -CommandName Set-TimeZone -ParameterName Id -ScriptBlock $scriptBlock
 ```
 
-The first command creates a script block which takes the required parameters which are passed
-in when the user presses `<TAB>`. For more information, see the **ScriptBlock** parameter
+The first command creates a script block which takes the required parameters which are passed in
+when the user presses <kbd>Tab</kbd>. For more information, see the **ScriptBlock** parameter
 description.
 
-Within the script block, the available values for **Id** are retrieved using the
-`Get-TimeZone` cmdlet. The **Id** property for each Time Zone is piped to the `Where-Object` cmdlet.
-The `Where-Object` cmdlet filters out any ids that do not start with the value provided by
-`$wordToComplete`, which represents the text the user typed before they pressed `<TAB>`. The
+Within the script block, the available values for **Id** are retrieved using the `Get-TimeZone`
+cmdlet. The **Id** property for each Time Zone is piped to the `Where-Object` cmdlet. The
+`Where-Object` cmdlet filters out any ids that do not start with the value provided by
+`$wordToComplete`, which represents the text the user typed before they pressed <kbd>Tab</kbd>. The
 filtered ids are piped to the `For-EachObject` cmdlet which encloses each value in quotes, should
 the value contain spaces.
 
 The second command registers the argument completer by passing the scriptblock, the
-**ParameterName** "Id" and the **CommandName** `Set-TimeZone`.
+**ParameterName** **Id** and the **CommandName** `Set-TimeZone`.
 
 ### Example 2: Add details to your tab completion values
 
@@ -87,8 +89,8 @@ $s = {
 Register-ArgumentCompleter -CommandName dotnet -Native -ScriptBlock $s
 ```
 
-The first command creates a script block which takes the required parameters which are passed
-in when the user presses `<TAB>`. For more information, see the **ScriptBlock** parameter
+The first command creates a script block which takes the required parameters which are passed in
+when the user presses <kbd>Tab</kbd>. For more information, see the **ScriptBlock** parameter
 description.
 
 Within the script block, the first command retrieves all running services using the `Where-Object`
@@ -102,10 +104,11 @@ The **CompletionResult** object allows you to provide additional details to each
 - **completionText** (String) - The text to be used as the auto completion result. This is the value
   sent to the command.
 - **listItemText** (String) - The text to be displayed in a list, such as when the user presses
-  `<Ctrl>+<Space>`. This is used for display only and is not passed to the command when selected.
+  <kbd>Ctrl</kbd>+<kbd>Space</kbd>. This is used for display only and is not passed to the command
+  when selected.
 - **resultType** ([CompletionResultType](/dotnet/api/system.management.automation.completionresulttype)) - The type of completion result.
 - **toolTip** (String) - The text for the tooltip with details to be displayed about the object.
-  This is visible when the user selects an item after pressing `<Ctrl>+<Space>`.
+  This is visible when the user selects an item after pressing <kbd>Ctrl</kbd>+<kbd>Space</kbd>.
 
 The last command demonstrates that stopped services can still be passed in manually to the
 `Stop-Service` cmdlet. The tab completion is the only aspect affected.
@@ -128,13 +131,13 @@ $scriptblock = {
 Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock $scriptblock
 ```
 
-The first command creates a script block which takes the required parameters which are passed
-in when the user presses `<TAB>`. For more information, see the **ScriptBlock** parameter
+The first command creates a script block which takes the required parameters which are passed in
+when the user presses <kbd>Tab</kbd>. For more information, see the **ScriptBlock** parameter
 description.
 
 Within the script block, the `dotnet complete` command is used to perform the tab completion.
 The results are piped to the `ForEach-Object` cmdlet which use the **new** static method of the
-[`[System.Management.Automation.CompletionResult]`](/dotnet/api/system.management.automation.completionresult) class
+[System.Management.Automation.CompletionResult](/dotnet/api/system.management.automation.completionresult) class
 to create a new **CompletionResult** object for each value.
 
 ## PARAMETERS
@@ -193,38 +196,38 @@ Accept wildcard characters: False
 ### -ScriptBlock
 
 Specifies the commands to run to perform tab completion. The script block you provide should return
-the values complete the input. The script block must unroll the values using the pipeline
+the values that complete the input. The script block must unroll the values using the pipeline
 (`ForEach-Object`, `Where-Object`, etc.), or another suitable method. Returning an array of values
 causes PowerShell to treat the entire array as **one** tab completion value.
 
-The script block should also accept the following parameters in the order specified below. The names
-of the parameters are not important because PowerShell passes in the values *positionally*.
+The script block must accept the following parameters in the order specified below. The names of the
+parameters aren't important because PowerShell passes in the values by position.
 
 - `$commandName` (Position 0) - This parameter is set to the name of the
   command for which the script block is providing tab completion.
 - `$parameterName` (Position 1) - This parameter is set to the parameter
   whose value requires tab completion.
-- `$wordToComplete` (Position 2) - This parameter is set to value the user has
-  provided before they pressed `<TAB>`. Your script block should use this value
-  to determine tab completion values.
+- `$wordToComplete` (Position 2) - This parameter is set to value the user has provided before they
+  pressed <kbd>Tab</kbd>. Your script block should use this value to determine tab completion
+  values.
 - `$commandAst` (Position 3) - This parameter is set to the Abstract Syntax
   Tree (AST) for the current input line. For more information, see
   [Ast Class](/dotnet/api/system.management.automation.language.ast).
-- `$fakeBoundParameter` (Position 4) - This parameter is set to a hashtable
-  containing the `$PSBoundParameters` for the cmdlet, before the user pressed
-  `<TAB>`. For more information, see [about_Automatic_Variables](./About/about_Automatic_Variables.md).
+- `$fakeBoundParameters` (Position 4) - This parameter is set to a hashtable containing the
+  `$PSBoundParameters` for the cmdlet, before the user pressed <kbd>Tab</kbd>. For more information,
+  see [about_Automatic_Variables](./About/about_Automatic_Variables.md).
 
-When you specify the **Native** parameter, the script block should take the following parameters in
-the specified order. The names of the parameters are not important because PowerShell
-passes in the values *positionally*.
+When you specify the **Native** parameter, the script block must take the following parameters in
+the specified order. The names of the parameters aren't important because PowerShell passes in the
+values by position.
 
 - `$commandName` (Position 0) - This parameter is set to the name of the
   command for which the script block is providing tab completion.
 - `$wordToComplete` (Position 1) - This parameter is set to value the user has
-  provided before they pressed `<TAB>`. Your script block should use this value
+  provided before they pressed <kbd>Tab</kbd>. Your script block should use this value
   to determine tab completion values.
-- `$cursorPosition` (Position 2) - This parameter is set to the position of the cursor when the
-  user pressed `<TAB>`.
+- `$cursorPosition` (Position 2) - This parameter is set to the position of the cursor when the user
+  pressed <kbd>Tab</kbd>.
 
 You can also provide an **ArgumentCompleter** as a parameter attribute. For more information, see
 [about_Functions_Advanced_Parameters](./About/about_Functions_Advanced_Parameters.md).

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -26,7 +26,8 @@ parameters, see [about_CommonParameters](about_CommonParameters.md).
 
 Beginning in PowerShell 3.0, you can use splatting with `@Args` to represent
 the parameters in a command. Splatting is valid on simple and advanced
-functions. For more information, see [about_Functions](about_Functions.md) and [about_Splatting](about_Splatting.md).
+functions. For more information, see [about_Functions](about_Functions.md) and
+[about_Splatting](about_Splatting.md).
 
 ## Static parameters
 
@@ -164,13 +165,6 @@ Param(
     $ComputerName
 )
 ```
-
-> [!NOTE]
-> When the `Get-Help` cmdlet displays the corresponding **Position** parameter
-> attribute, the position value is incremented by one.
->
-> For example, a parameter with a `Position` argument value of **0** has a
-> parameter attribute of **Position=1**.
 
 ### ParameterSetName argument
 
@@ -558,9 +552,10 @@ than or equal to the current date and time.
 ### ValidateSet attribute
 
 The **ValidateSet** attribute specifies a set of valid values for a parameter
-or variable. PowerShell generates an error if a parameter or variable value
-doesn't match a value in the set. In the following example, the value of the
-**Detail** parameter can only be Low, Average, or High.
+or variable and enables tab completion. PowerShell generates an error if a
+parameter or variable value doesn't match a value in the set. In the following
+example, the value of the **Detail** parameter can only be Low, Average, or
+High.
 
 ```powershell
 Param(
@@ -820,12 +815,13 @@ value is required.
 ## ArgumentCompleter attribute
 
 The **ArgumentCompleter** attribute allows you to add tab completion values to
-a specific parameter. Like **DynamicParameters**, the available values are
-calculated at runtime when the user presses <kbd>Tab</kbd> after the parameter
-name.
+a specific parameter. An **ArgumentCompleter** attribute must be defined for
+each parameter that needs tab completion. Similar to **DynamicParameters**, the
+available values are calculated at runtime when the user presses <kbd>Tab</kbd>
+after the parameter name.
 
 To add an **ArgumentCompleter** attribute, you need to define a script block
-that will determine the values. The script block must take the following
+that determines the values. The script block must take the following
 parameters in the order specified below. The parameter's names don't matter as
 the values are provided positionally.
 
@@ -835,7 +831,11 @@ The syntax is as follows:
 Param(
     [Parameter(Mandatory)]
     [ArgumentCompleter({
-        param ($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+        param ( $commandName,
+                $parameterName,
+                $wordToComplete,
+                $commandAst,
+                $fakeBoundParameters )
         # Perform calculation of tab completed values here.
     })]
 )
@@ -853,21 +853,25 @@ The script block parameters are set to the following values:
   provided before they pressed <kbd>Tab</kbd>. Your script block should use
   this value to determine tab completion values.
 - `$commandAst` (Position 3) - This parameter is set to the Abstract Syntax
-  Tree (AST) for the current input line. For more information, see [Ast Class](/dotnet/api/system.management.automation.language.ast).
-- `$fakeBoundParameter` (Position 4) - This parameter is set to a hashtable
+  Tree (AST) for the current input line. For more information, see
+  [Ast Class](/dotnet/api/system.management.automation.language.ast).
+- `$fakeBoundParameters` (Position 4) - This parameter is set to a hashtable
   containing the `$PSBoundParameters` for the cmdlet, before the user pressed
-  <kbd>Tab</kbd>. For more information, see [about_Automatic_Variables](about_Automatic_Variables.md).
+  <kbd>Tab</kbd>. For more information, see
+  [about_Automatic_Variables](about_Automatic_Variables.md).
 
 The **ArgumentCompleter** script block must unroll the values using the
-pipeline, such as`ForEach-Object`, `Where-Object`, or another suitable method.
+pipeline, such as `ForEach-Object`, `Where-Object`, or another suitable method.
 Returning an array of values causes PowerShell to treat the entire array as
 **one** tab completion value.
 
-The following example adds tab completion to the **Value** parameter. If no
-`$Type` is specified, fruits and vegetables are returned. If a `$Type` is
-specified, only values for the type are specified. In addition, the `-like`
-operator ensures that if the user types the following command and uses
-<kbd>Tab</kbd> completion, only **Apple** is returned.
+The following example adds tab completion to the **Value** parameter. If only
+the **Value** parameter is specified, all possible values, or arguments, for
+**Value** are displayed. When the **Type** parameter is specified, the
+**Value** parameter only displays the possible values for that type.
+
+In addition, the `-like` operator ensures that if the user types the following
+command and uses <kbd>Tab</kbd> completion, only **Apple** is returned.
 
 `Test-ArgumentCompleter -Type Fruits -Value A`
 
@@ -875,10 +879,10 @@ operator ensures that if the user types the following command and uses
 function Test-ArgumentCompleter {
 [CmdletBinding()]
  param (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory=$true)]
         [ValidateSet('Fruits', 'Vegetables')]
         $Type,
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory=$true)]
         [ArgumentCompleter( {
             param ( $commandName,
                     $parameterName,

--- a/reference/6/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/6/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -8,6 +8,7 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: Register-ArgumentCompleter
 ---
+
 # Register-ArgumentCompleter
 
 ## SYNOPSIS
@@ -18,14 +19,15 @@ Registers a custom argument completer.
 ### NativeSet
 
 ```
-Register-ArgumentCompleter -CommandName <String[]> -ScriptBlock <ScriptBlock> [-Native] [<CommonParameters>]
+Register-ArgumentCompleter -CommandName <String[]> -ScriptBlock <ScriptBlock> [-Native]
+ [<CommonParameters>]
 ```
 
 ### PowerShellSet
 
 ```
-Register-ArgumentCompleter [-CommandName <String[]>] -ParameterName <String> -ScriptBlock <ScriptBlock>
- [<CommonParameters>]
+Register-ArgumentCompleter [-CommandName <String[]>] -ParameterName <String>
+ -ScriptBlock <ScriptBlock> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -54,19 +56,19 @@ $scriptBlock = {
 Register-ArgumentCompleter -CommandName Set-TimeZone -ParameterName Id -ScriptBlock $scriptBlock
 ```
 
-The first command creates a script block which takes the required parameters which are passed
-in when the user presses `<TAB>`. For more information, see the **ScriptBlock** parameter
+The first command creates a script block which takes the required parameters which are passed in
+when the user presses <kbd>Tab</kbd>. For more information, see the **ScriptBlock** parameter
 description.
 
-Within the script block, the available values for **Id** are retrieved using the
-`Get-TimeZone` cmdlet. The **Id** property for each Time Zone is piped to the `Where-Object` cmdlet.
-The `Where-Object` cmdlet filters out any ids that do not start with the value provided by
-`$wordToComplete`, which represents the text the user typed before they pressed `<TAB>`. The
+Within the script block, the available values for **Id** are retrieved using the `Get-TimeZone`
+cmdlet. The **Id** property for each Time Zone is piped to the `Where-Object` cmdlet. The
+`Where-Object` cmdlet filters out any ids that do not start with the value provided by
+`$wordToComplete`, which represents the text the user typed before they pressed <kbd>Tab</kbd>. The
 filtered ids are piped to the `For-EachObject` cmdlet which encloses each value in quotes, should
 the value contain spaces.
 
 The second command registers the argument completer by passing the scriptblock, the
-**ParameterName** "Id" and the **CommandName** `Set-TimeZone`.
+**ParameterName** **Id** and the **CommandName** `Set-TimeZone`.
 
 ### Example 2: Add details to your tab completion values
 
@@ -87,8 +89,8 @@ $s = {
 Register-ArgumentCompleter -CommandName Stop-Service -ParameterName Name -ScriptBlock $s
 ```
 
-The first command creates a script block which takes the required parameters which are passed
-in when the user presses `<TAB>`. For more information, see the **ScriptBlock** parameter
+The first command creates a script block which takes the required parameters which are passed in
+when the user presses <kbd>Tab</kbd>. For more information, see the **ScriptBlock** parameter
 description.
 
 Within the script block, the first command retrieves all running services using the `Where-Object`
@@ -102,10 +104,11 @@ The **CompletionResult** object allows you to provide additional details to each
 - **completionText** (String) - The text to be used as the auto completion result. This is the value
   sent to the command.
 - **listItemText** (String) - The text to be displayed in a list, such as when the user presses
-  `<Ctrl>+<Space>`. This is used for display only and is not passed to the command when selected.
+  <kbd>Ctrl</kbd>+<kbd>Space</kbd>. This is used for display only and is not passed to the command
+  when selected.
 - **resultType** ([CompletionResultType](/dotnet/api/system.management.automation.completionresulttype)) - The type of completion result.
 - **toolTip** (String) - The text for the tooltip with details to be displayed about the object.
-  This is visible when the user selects an item after pressing `<Ctrl>+<Space>`.
+  This is visible when the user selects an item after pressing <kbd>Ctrl</kbd>+<kbd>Space</kbd>.
 
 The last command demonstrates that stopped services can still be passed in manually to the
 `Stop-Service` cmdlet. The tab completion is the only aspect affected.
@@ -128,8 +131,8 @@ $scriptblock = {
 Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock $scriptblock
 ```
 
-The first command creates a script block which takes the required parameters which are passed
-in when the user presses `<TAB>`. For more information, see the **ScriptBlock** parameter
+The first command creates a script block which takes the required parameters which are passed in
+when the user presses <kbd>Tab</kbd>. For more information, see the **ScriptBlock** parameter
 description.
 
 Within the script block, the `dotnet complete` command is used to perform the tab completion.
@@ -197,34 +200,34 @@ the values that complete the input. The script block must unroll the values usin
 (`ForEach-Object`, `Where-Object`, etc.), or another suitable method. Returning an array of values
 causes PowerShell to treat the entire array as **one** tab completion value.
 
-The script block must accept the following parameters in the order specified below. The names
-of the parameters are not important because PowerShell passes in the values *positionally*.
+The script block must accept the following parameters in the order specified below. The names of the
+parameters aren't important because PowerShell passes in the values by position.
 
 - `$commandName` (Position 0) - This parameter is set to the name of the
   command for which the script block is providing tab completion.
 - `$parameterName` (Position 1) - This parameter is set to the parameter
   whose value requires tab completion.
-- `$wordToComplete` (Position 2) - This parameter is set to value the user has
-  provided before they pressed `<TAB>`. Your script block should use this value
-  to determine tab completion values.
+- `$wordToComplete` (Position 2) - This parameter is set to value the user has provided before they
+  pressed <kbd>Tab</kbd>. Your script block should use this value to determine tab completion
+  values.
 - `$commandAst` (Position 3) - This parameter is set to the Abstract Syntax
   Tree (AST) for the current input line. For more information, see
   [Ast Class](/dotnet/api/system.management.automation.language.ast).
-- `$fakeBoundParameter` (Position 4) - This parameter is set to a hashtable
-  containing the `$PSBoundParameters` for the cmdlet, before the user pressed
-  `<TAB>`. For more information, see [about_Automatic_Variables](./About/about_Automatic_Variables.md).
+- `$fakeBoundParameters` (Position 4) - This parameter is set to a hashtable containing the
+  `$PSBoundParameters` for the cmdlet, before the user pressed <kbd>Tab</kbd>. For more information,
+  see [about_Automatic_Variables](./About/about_Automatic_Variables.md).
 
-When you specify the **Native** parameter, selecting the `NativeSet` parameter set for this command,
-the script block must take the following parameters in the specified order. The names of the
-parameters are not important because PowerShell passes in the values *positionally*.
+When you specify the **Native** parameter, the script block must take the following parameters in
+the specified order. The names of the parameters aren't important because PowerShell passes in the
+values by position.
 
 - `$commandName` (Position 0) - This parameter is set to the name of the
   command for which the script block is providing tab completion.
 - `$wordToComplete` (Position 1) - This parameter is set to value the user has
-  provided before they pressed `<TAB>`. Your script block should use this value
+  provided before they pressed <kbd>Tab</kbd>. Your script block should use this value
   to determine tab completion values.
-- `$cursorPosition` (Position 2) - This parameter is set to the position of the cursor when the
-  user pressed `<TAB>`.
+- `$cursorPosition` (Position 2) - This parameter is set to the position of the cursor when the user
+  pressed <kbd>Tab</kbd>.
 
 You can also provide an **ArgumentCompleter** as a parameter attribute. For more information, see
 [about_Functions_Advanced_Parameters](./About/about_Functions_Advanced_Parameters.md).

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -26,7 +26,8 @@ parameters, see [about_CommonParameters](about_CommonParameters.md).
 
 Beginning in PowerShell 3.0, you can use splatting with `@Args` to represent
 the parameters in a command. Splatting is valid on simple and advanced
-functions. For more information, see [about_Functions](about_Functions.md) and [about_Splatting](about_Splatting.md).
+functions. For more information, see [about_Functions](about_Functions.md) and
+[about_Splatting](about_Splatting.md).
 
 ## Static parameters
 
@@ -164,13 +165,6 @@ Param(
     $ComputerName
 )
 ```
-
-> [!NOTE]
-> When the `Get-Help` cmdlet displays the corresponding **Position** parameter
-> attribute, the position value is incremented by one.
->
-> For example, a parameter with a `Position` argument value of **0** has a
-> parameter attribute of **Position=1**.
 
 ### ParameterSetName argument
 
@@ -558,9 +552,10 @@ than or equal to the current date and time.
 ### ValidateSet attribute
 
 The **ValidateSet** attribute specifies a set of valid values for a parameter
-or variable. PowerShell generates an error if a parameter or variable value
-doesn't match a value in the set. In the following example, the value of the
-**Detail** parameter can only be Low, Average, or High.
+or variable and enables tab completion. PowerShell generates an error if a
+parameter or variable value doesn't match a value in the set. In the following
+example, the value of the **Detail** parameter can only be Low, Average, or
+High.
 
 ```powershell
 Param(
@@ -820,12 +815,13 @@ value is required.
 ## ArgumentCompleter attribute
 
 The **ArgumentCompleter** attribute allows you to add tab completion values to
-a specific parameter. Like **DynamicParameters**, the available values are
-calculated at runtime when the user presses <kbd>Tab</kbd> after the parameter
-name.
+a specific parameter. An **ArgumentCompleter** attribute must be defined for
+each parameter that needs tab completion. Similar to **DynamicParameters**, the
+available values are calculated at runtime when the user presses <kbd>Tab</kbd>
+after the parameter name.
 
 To add an **ArgumentCompleter** attribute, you need to define a script block
-that will determine the values. The script block must take the following
+that determines the values. The script block must take the following
 parameters in the order specified below. The parameter's names don't matter as
 the values are provided positionally.
 
@@ -835,7 +831,11 @@ The syntax is as follows:
 Param(
     [Parameter(Mandatory)]
     [ArgumentCompleter({
-        param ($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+        param ( $commandName,
+                $parameterName,
+                $wordToComplete,
+                $commandAst,
+                $fakeBoundParameters )
         # Perform calculation of tab completed values here.
     })]
 )
@@ -853,21 +853,25 @@ The script block parameters are set to the following values:
   provided before they pressed <kbd>Tab</kbd>. Your script block should use
   this value to determine tab completion values.
 - `$commandAst` (Position 3) - This parameter is set to the Abstract Syntax
-  Tree (AST) for the current input line. For more information, see [Ast Class](/dotnet/api/system.management.automation.language.ast).
-- `$fakeBoundParameter` (Position 4) - This parameter is set to a hashtable
+  Tree (AST) for the current input line. For more information, see
+  [Ast Class](/dotnet/api/system.management.automation.language.ast).
+- `$fakeBoundParameters` (Position 4) - This parameter is set to a hashtable
   containing the `$PSBoundParameters` for the cmdlet, before the user pressed
-  <kbd>Tab</kbd>. For more information, see [about_Automatic_Variables](about_Automatic_Variables.md).
+  <kbd>Tab</kbd>. For more information, see
+  [about_Automatic_Variables](about_Automatic_Variables.md).
 
 The **ArgumentCompleter** script block must unroll the values using the
-pipeline, such as`ForEach-Object`, `Where-Object`, or another suitable method.
+pipeline, such as `ForEach-Object`, `Where-Object`, or another suitable method.
 Returning an array of values causes PowerShell to treat the entire array as
 **one** tab completion value.
 
-The following example adds tab completion to the **Value** parameter. If no
-`$Type` is specified, fruits and vegetables are returned. If a `$Type` is
-specified, only values for the type are specified. In addition, the `-like`
-operator ensures that if the user types the following command and uses
-<kbd>Tab</kbd> completion, only **Apple** is returned.
+The following example adds tab completion to the **Value** parameter. If only
+the **Value** parameter is specified, all possible values, or arguments, for
+**Value** are displayed. When the **Type** parameter is specified, the
+**Value** parameter only displays the possible values for that type.
+
+In addition, the `-like` operator ensures that if the user types the following
+command and uses <kbd>Tab</kbd> completion, only **Apple** is returned.
 
 `Test-ArgumentCompleter -Type Fruits -Value A`
 
@@ -875,10 +879,10 @@ operator ensures that if the user types the following command and uses
 function Test-ArgumentCompleter {
 [CmdletBinding()]
  param (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory=$true)]
         [ValidateSet('Fruits', 'Vegetables')]
         $Type,
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory=$true)]
         [ArgumentCompleter( {
             param ( $commandName,
                     $parameterName,

--- a/reference/7/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/7/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -8,6 +8,7 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: Register-ArgumentCompleter
 ---
+
 # Register-ArgumentCompleter
 
 ## SYNOPSIS
@@ -18,14 +19,15 @@ Registers a custom argument completer.
 ### NativeSet
 
 ```
-Register-ArgumentCompleter -CommandName <String[]> -ScriptBlock <ScriptBlock> [-Native] [<CommonParameters>]
+Register-ArgumentCompleter -CommandName <String[]> -ScriptBlock <ScriptBlock> [-Native]
+ [<CommonParameters>]
 ```
 
 ### PowerShellSet
 
 ```
-Register-ArgumentCompleter [-CommandName <String[]>] -ParameterName <String> -ScriptBlock <ScriptBlock>
- [<CommonParameters>]
+Register-ArgumentCompleter [-CommandName <String[]>] -ParameterName <String>
+ -ScriptBlock <ScriptBlock> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -54,19 +56,19 @@ $scriptBlock = {
 Register-ArgumentCompleter -CommandName Set-TimeZone -ParameterName Id -ScriptBlock $scriptBlock
 ```
 
-The first command creates a script block which takes the required parameters which are passed
-in when the user presses `<TAB>`. For more information, see the **ScriptBlock** parameter
+The first command creates a script block which takes the required parameters which are passed in
+when the user presses <kbd>Tab</kbd>. For more information, see the **ScriptBlock** parameter
 description.
 
-Within the script block, the available values for **Id** are retrieved using the
-`Get-TimeZone` cmdlet. The **Id** property for each Time Zone is piped to the `Where-Object` cmdlet.
-The `Where-Object` cmdlet filters out any ids that do not start with the value provided by
-`$wordToComplete`, which represents the text the user typed before they pressed `<TAB>`. The
+Within the script block, the available values for **Id** are retrieved using the `Get-TimeZone`
+cmdlet. The **Id** property for each Time Zone is piped to the `Where-Object` cmdlet. The
+`Where-Object` cmdlet filters out any ids that do not start with the value provided by
+`$wordToComplete`, which represents the text the user typed before they pressed <kbd>Tab</kbd>. The
 filtered ids are piped to the `For-EachObject` cmdlet which encloses each value in quotes, should
 the value contain spaces.
 
 The second command registers the argument completer by passing the scriptblock, the
-**ParameterName** "Id" and the **CommandName** `Set-TimeZone`.
+**ParameterName** **Id** and the **CommandName** `Set-TimeZone`.
 
 ### Example 2: Add details to your tab completion values
 
@@ -87,8 +89,8 @@ $s = {
 Register-ArgumentCompleter -CommandName Stop-Service -ParameterName Name -ScriptBlock $s
 ```
 
-The first command creates a script block which takes the required parameters which are passed
-in when the user presses `<TAB>`. For more information, see the **ScriptBlock** parameter
+The first command creates a script block which takes the required parameters which are passed in
+when the user presses <kbd>Tab</kbd>. For more information, see the **ScriptBlock** parameter
 description.
 
 Within the script block, the first command retrieves all running services using the `Where-Object`
@@ -102,10 +104,11 @@ The **CompletionResult** object allows you to provide additional details to each
 - **completionText** (String) - The text to be used as the auto completion result. This is the value
   sent to the command.
 - **listItemText** (String) - The text to be displayed in a list, such as when the user presses
-  `<Ctrl>+<Space>`. This is used for display only and is not passed to the command when selected.
+  <kbd>Ctrl</kbd>+<kbd>Space</kbd>. This is used for display only and is not passed to the command
+  when selected.
 - **resultType** ([CompletionResultType](/dotnet/api/system.management.automation.completionresulttype)) - The type of completion result.
 - **toolTip** (String) - The text for the tooltip with details to be displayed about the object.
-  This is visible when the user selects an item after pressing `<Ctrl>+<Space>`.
+  This is visible when the user selects an item after pressing <kbd>Ctrl</kbd>+<kbd>Space</kbd>.
 
 The last command demonstrates that stopped services can still be passed in manually to the
 `Stop-Service` cmdlet. The tab completion is the only aspect affected.
@@ -128,8 +131,8 @@ $scriptblock = {
 Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock $scriptblock
 ```
 
-The first command creates a script block which takes the required parameters which are passed
-in when the user presses `<TAB>`. For more information, see the **ScriptBlock** parameter
+The first command creates a script block which takes the required parameters which are passed in
+when the user presses <kbd>Tab</kbd>. For more information, see the **ScriptBlock** parameter
 description.
 
 Within the script block, the `dotnet complete` command is used to perform the tab completion.
@@ -197,34 +200,34 @@ the values that complete the input. The script block must unroll the values usin
 (`ForEach-Object`, `Where-Object`, etc.), or another suitable method. Returning an array of values
 causes PowerShell to treat the entire array as **one** tab completion value.
 
-The script block must accept the following parameters in the order specified below. The names
-of the parameters are not important because PowerShell passes in the values *positionally*.
+The script block must accept the following parameters in the order specified below. The names of the
+parameters aren't important because PowerShell passes in the values by position.
 
 - `$commandName` (Position 0) - This parameter is set to the name of the
   command for which the script block is providing tab completion.
 - `$parameterName` (Position 1) - This parameter is set to the parameter
   whose value requires tab completion.
-- `$wordToComplete` (Position 2) - This parameter is set to value the user has
-  provided before they pressed `<TAB>`. Your script block should use this value
-  to determine tab completion values.
+- `$wordToComplete` (Position 2) - This parameter is set to value the user has provided before they
+  pressed <kbd>Tab</kbd>. Your script block should use this value to determine tab completion
+  values.
 - `$commandAst` (Position 3) - This parameter is set to the Abstract Syntax
   Tree (AST) for the current input line. For more information, see
   [Ast Class](/dotnet/api/system.management.automation.language.ast).
-- `$fakeBoundParameter` (Position 4) - This parameter is set to a hashtable
-  containing the `$PSBoundParameters` for the cmdlet, before the user pressed
-  `<TAB>`. For more information, see [about_Automatic_Variables](./About/about_Automatic_Variables.md).
+- `$fakeBoundParameters` (Position 4) - This parameter is set to a hashtable containing the
+  `$PSBoundParameters` for the cmdlet, before the user pressed <kbd>Tab</kbd>. For more information,
+  see [about_Automatic_Variables](./About/about_Automatic_Variables.md).
 
-When you specify the **Native** parameter, selecting the `NativeSet` parameter set for this command,
-the script block must take the following parameters in the specified order. The names of the
-parameters are not important because PowerShell passes in the values *positionally*.
+When you specify the **Native** parameter, the script block must take the following parameters in
+the specified order. The names of the parameters aren't important because PowerShell passes in the
+values by position.
 
 - `$commandName` (Position 0) - This parameter is set to the name of the
   command for which the script block is providing tab completion.
 - `$wordToComplete` (Position 1) - This parameter is set to value the user has
-  provided before they pressed `<TAB>`. Your script block should use this value
+  provided before they pressed <kbd>Tab</kbd>. Your script block should use this value
   to determine tab completion values.
-- `$cursorPosition` (Position 2) - This parameter is set to the position of the cursor when the
-  user pressed `<TAB>`.
+- `$cursorPosition` (Position 2) - This parameter is set to the position of the cursor when the user
+  pressed <kbd>Tab</kbd>.
 
 You can also provide an **ArgumentCompleter** as a parameter attribute. For more information, see
 [about_Functions_Advanced_Parameters](./About/about_Functions_Advanced_Parameters.md).


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

- Fixes [AB#1620502](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1620502)
- Fixes #4966
- minor Copyedits, style, paragraph reflows
- Removed the `[!NOTE]` about `Get-Help` from the section: **Position argument**
- `Register-ArgumentCompleter`: updated parameter name to `$fakeBoundParameters`, minor copyedits

about_Functions_Advanced_Parameters scores
Original version: 95
Updated version: 95

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
