### PR TITLE
Fixes #5024 - use 8.3 name instead of hardlink

### DIFF
--- a/reference/docs-conceptual/learn/remoting/SSH-Remoting-in-PowerShell-Core.md
+++ b/reference/docs-conceptual/learn/remoting/SSH-Remoting-in-PowerShell-Core.md
@@ -78,25 +78,27 @@ an SSH subsystem to host a PowerShell process on the remote computer. And, you m
    Create the SSH subsystem that hosts a PowerShell process on the remote computer:
 
    ```
-   Subsystem powershell c:/program files/powershell/6/pwsh.exe -sshs -NoLogo -NoProfile
+   Subsystem powershell c:/progra~1/powershell/6/pwsh.exe -sshs -NoLogo -NoProfile
    ```
 
    > [!NOTE]
-   > There's a bug in OpenSSH for Windows that prevents spaces from working in subsystem executable
-   > paths. For more information, see this [GitHub issue](https://github.com/PowerShell/Win32-OpenSSH/issues/784).
-
-   A solution is to create a symbolic link to the PowerShell installation directory that doesn't
-   include spaces:
-
-   ```powershell
-   New-Item -ItemType SymbolicLink -Path "C:\pwshdir" -Value "C:\Program Files\PowerShell\6"
-   ```
-
-   Use the symbolic link path to the PowerShell executable in the subsystem:
-
-   ```
-   Subsystem powershell C:\pwshdir\pwsh.exe -sshs -NoLogo -NoProfile
-   ```
+   > You must use the 8.3 short name for an file paths that contain spaces. There's a bug in OpenSSH
+   > for Windows that prevents spaces from working in subsystem executable paths. For more
+   > information, see this [GitHub issue](https://github.com/PowerShell/Win32-OpenSSH/issues/784).
+   >
+   > The 8.3 short name for the `Program Files` folder in Windows is usually `Progra~1`. However,
+   > you can use the following command to make sure:
+   >
+   > ```powershell
+   > Get-CimInstance Win32_Directory -Filter 'Name="C:\\Program Files"' |
+   >   Select-Object EightDotThreeFileName
+   > ```
+   >
+   > ```Output
+   > EightDotThreeFileName
+   > ---------------------
+   > c:\progra~1
+   > ```
 
    Optionally, enable key authentication:
 

--- a/reference/docs-conceptual/learn/remoting/SSH-Remoting-in-PowerShell-Core.md
+++ b/reference/docs-conceptual/learn/remoting/SSH-Remoting-in-PowerShell-Core.md
@@ -82,8 +82,8 @@ an SSH subsystem to host a PowerShell process on the remote computer. And, you m
    ```
 
    > [!NOTE]
-   > You must use the 8.3 short name for an file paths that contain spaces. There's a bug in OpenSSH
-   > for Windows that prevents spaces from working in subsystem executable paths. For more
+   > You must use the 8.3 short name for any file paths that contain spaces. There's a bug in
+   > OpenSSH for Windows that prevents spaces from working in subsystem executable paths. For more
    > information, see this [GitHub issue](https://github.com/PowerShell/Win32-OpenSSH/issues/784).
    >
    > The 8.3 short name for the `Program Files` folder in Windows is usually `Progra~1`. However,


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #5024 - use 8.3 name instead of hardlink
Fixes [AB#1638206](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1638206)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [x] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
