### PR TITLE
Fix a few sentences in contributing docs

### DIFF
--- a/contributing/6-UPDATING-REFERENCE.md
+++ b/contributing/6-UPDATING-REFERENCE.md
@@ -19,16 +19,16 @@ errors that must be fixed before we can accept your contribution.
 ## Formatting About_ files
 
 `About_*` files are now processed by [Pandoc][], instead of PlatyPS. `About_*` files are formatted
-for the best compatibility across with all versions of PowerShell and with the publishing tools. For
+for the best compatibility across all versions of PowerShell and with the publishing tools. For
 details, see [issue #1806][issue1806]. Please do not alter the formatting of `about_*` files without
-checking in with a repo maintainer.
+checking with a repo maintainer.
 
 Basic formatting guidelines:
 
 - Limit lines to 80 characters
-- Code blocks and table are limited to 76 characters - Pandoc indents these by 4 spaces during
+- Code blocks and tables are limited to 76 characters - Pandoc indents these by 4 spaces during
   conversion
-- Tables need fit within 76 characters
+- Tables need to fit within 76 characters
   - Manually wrap contents of cells across multiple lines
   - Use opening and closing `|` characters on each line
   - See a working example in [about_Comparison_Operators][about-example]


### PR DESCRIPTION
# PR Summary
Fix a few sentences in Contributing - Update reference doc

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [ ] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
