### PR TITLE
Make it clear on install docs that Kali and Arch are unsupported community packages

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
@@ -566,7 +566,7 @@ sudo dnf remove powershell
 ## Arch Linux
 
 > [!NOTE]
-> Arch support is experimental.
+> Arch support is not officially supported by Microsoft and is maintained by the community.
 
 PowerShell is available from the [Arch Linux][] User Repository (AUR).
 
@@ -632,6 +632,9 @@ sudo snap remove powershell-preview
 ```
 
 ## Kali
+
+> [!NOTE]
+> Kali support is not officially supported by Microsoft and is maintained by the community.
 
 ### Installation - Kali
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Per our conversation in shiproom, Kali and Arch are unsupported (not just experimental) and community-owned, and we should be clear as such. 

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [x] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
