### PR TITLE
Fixes #5086 - incorrect parameter name

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
@@ -19,8 +19,8 @@ Sends ICMP echo request packets, or pings, to one or more computers.
 ### Default (Default)
 
 ```
-Test-Connection [-ComputerName] <String[]> [-AsJob] [-DcomAuthentication <AuthenticationLevel>]
- [-WsmanAuthentication <String>] [-Protocol <String>] [-BufferSize <Int32>] [-Count <Int32>]
+Test-Connection [-AsJob] [-DcomAuthentication <AuthenticationLevel>] [-WsmanAuthentication <String>]
+ [-Protocol <String>] [-BufferSize <Int32>] [-ComputerName] <String[]> [-Count <Int32>]
  [-Impersonation <ImpersonationLevel>] [-ThrottleLimit <Int32>] [-TimeToLive <Int32>]
  [-Delay <Int32>] [<CommonParameters>]
 ```
@@ -28,18 +28,17 @@ Test-Connection [-ComputerName] <String[]> [-AsJob] [-DcomAuthentication <Authen
 ### Source
 
 ```
-Test-Connection [-ComputerName] <String[]> [-Source] <String[]> [-AsJob]
- [-DcomAuthentication <AuthenticationLevel>] [-WsmanAuthentication <String>] [-Protocol <String>]
- [-BufferSize <Int32>] [-Count <Int32>] [-Credential <PSCredential>]
- [-Impersonation <ImpersonationLevel>] [-ThrottleLimit <Int32>] [-TimeToLive <Int32>]
- [-Delay <Int32>] [<CommonParameters>]
+Test-Connection [-AsJob] [-DcomAuthentication <AuthenticationLevel>] [-WsmanAuthentication <String>]
+ [-Protocol <String>] [-BufferSize <Int32>] [-ComputerName] <String[]> [-Count <Int32>]
+ [-Credential <PSCredential>] [-Source] <String[]> [-Impersonation <ImpersonationLevel>]
+ [-ThrottleLimit <Int32>] [-TimeToLive <Int32>] [-Delay <Int32>] [<CommonParameters>]
 ```
 
 ### Quiet
 
 ```
-Test-Connection [-ComputerName] <String[]> [-DcomAuthentication <AuthenticationLevel>]
- [-WsmanAuthentication <String>] [-Protocol <String>] [-BufferSize <Int32>] [-Count <Int32>]
+Test-Connection [-DcomAuthentication <AuthenticationLevel>] [-WsmanAuthentication <String>]
+ [-Protocol <String>] [-BufferSize <Int32>] [-ComputerName] <String[]> [-Count <Int32>]
  [-Impersonation <ImpersonationLevel>] [-TimeToLive <Int32>] [-Delay <Int32>] [-Quiet]
  [<CommonParameters>]
 ```
@@ -109,7 +108,7 @@ sends a ping test to a remote computer.
 Test-Connection -ComputerName Server01 -Count 3 -Delay 2 -TTL 255 -BufferSize 256 -ThrottleLimit 32
 ```
 
-`Test-Connection` uses the **TargetName** parameter to specify Server01. The **Count** parameter
+`Test-Connection` uses the **ComputerName** parameter to specify Server01. The **Count** parameter
 specifies three pings are sent to the Server01 computer with a **Delay** of 2-second intervals.
 
 You might use these options when the ping response is expected to take longer than usual, either

--- a/reference/6/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/6/Microsoft.PowerShell.Management/Test-Connection.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 10/09/2019
+ms.date: 11/12/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/test-connection?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Test-Connection
@@ -18,38 +18,38 @@ Sends ICMP echo request packets, or pings, to one or more computers.
 ### PingCount (Default)
 
 ```
-Test-Connection [-TargetName] <String[]> [-Ping] [-IPv4] [-IPv6] [-ResolveDestination]
- [-Source <String>] [-MaxHops <Int32>] [-Count <Int32>] [-Delay <Int32>] [-BufferSize <Int32>]
- [-DontFragment] [-TimeoutSeconds <Int32>] [-Quiet] [<CommonParameters>]
+Test-Connection [-Ping] [-IPv4] [-IPv6] [-ResolveDestination] [-Source <String>] [-MaxHops <Int32>]
+ [-Count <Int32>] [-Delay <Int32>] [-BufferSize <Int32>] [-DontFragment] [-TimeoutSeconds <Int32>]
+ [-TargetName] <String[]> [-Quiet] [<CommonParameters>]
 ```
 
 ### PingContinues
 
 ```
-Test-Connection [-TargetName] <String[]> [-Ping] [-IPv4] [-IPv6] [-ResolveDestination]
- [-Source <String>] [-MaxHops <Int32>] [-Delay <Int32>] [-BufferSize <Int32>] [-DontFragment]
- [-Continues] [-TimeoutSeconds <Int32>] [-Quiet] [<CommonParameters>]
+Test-Connection [-Ping] [-IPv4] [-IPv6] [-ResolveDestination] [-Source <String>] [-MaxHops <Int32>]
+ [-Delay <Int32>] [-BufferSize <Int32>] [-DontFragment] [-Continues] [-TimeoutSeconds <Int32>]
+ [-TargetName] <String[]> [-Quiet] [<CommonParameters>]
 ```
 
 ### DetectionOfMTUSize
 
 ```
-Test-Connection [-TargetName] <String[]> -MTUSizeDetect [-IPv4] [-IPv6] [-ResolveDestination]
- [-TimeoutSeconds <Int32>] [-Quiet] [<CommonParameters>]
+Test-Connection [-IPv4] [-IPv6] [-ResolveDestination] [-TimeoutSeconds <Int32>]
+ [-TargetName] <String[]> -MTUSizeDetect [-Quiet] [<CommonParameters>]
 ```
 
 ### TraceRoute
 
 ```
-Test-Connection [-TargetName] <String[]> -Traceroute [-IPv4] [-IPv6] [-ResolveDestination]
- [-Source <String>] [-MaxHops <Int32>] [-TimeoutSeconds <Int32>] [-Quiet] [<CommonParameters>]
+Test-Connection [-IPv4] [-IPv6] [-ResolveDestination] [-Source <String>] [-MaxHops <Int32>]
+ [-TimeoutSeconds <Int32>] [-TargetName] <String[]> -Traceroute [-Quiet] [<CommonParameters>]
 ```
 
 ### ConnectionByTCPPort
 
 ```
-Test-Connection [-TargetName] <String[]> -TCPPort <Int32> [-IPv4] [-IPv6] [-ResolveDestination]
- [-Source <String>] [-TimeoutSeconds <Int32>] [-Quiet] [<CommonParameters>]
+Test-Connection [-IPv4] [-IPv6] [-ResolveDestination] [-Source <String>] [-TimeoutSeconds <Int32>]
+ [-TargetName] <String[]> -TCPPort <Int32> [-Quiet] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/7/Microsoft.PowerShell.Management/Test-Connection.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 10/09/2019
+ms.date: 11/12/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/test-connection?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Test-Connection
@@ -18,38 +18,38 @@ Sends ICMP echo request packets, or pings, to one or more computers.
 ### DefaultPing (Default)
 
 ```
-Test-Connection [-TargetName] <String[]> [-Ping] [-IPv4] [-IPv6] [-ResolveDestination]
- [-Source <String>] [-MaxHops <Int32>] [-Count <Int32>] [-Delay <Int32>] [-BufferSize <Int32>]
- [-DontFragment] [-TimeoutSeconds <Int32>] [-Quiet] [<CommonParameters>]
+Test-Connection [-Ping] [-IPv4] [-IPv6] [-ResolveDestination] [-Source <String>] [-MaxHops <Int32>]
+ [-Count <Int32>] [-Delay <Int32>] [-BufferSize <Int32>] [-DontFragment] [-TimeoutSeconds <Int32>]
+ [-TargetName] <String[]> [-Quiet] [<CommonParameters>]
 ```
 
 ### RepeatPing
 
 ```
-Test-Connection [-TargetName] <String[]> [-Ping] [-IPv4] [-IPv6] [-ResolveDestination]
- [-Source <String>] [-MaxHops <Int32>] [-Delay <Int32>] [-BufferSize <Int32>] [-DontFragment]
- [-Continues] [-TimeoutSeconds <Int32>] [-Quiet] [<CommonParameters>]
-```
-
-### TraceRoute
-
-```
-Test-Connection [-TargetName] <String[]> -Traceroute [-IPv4] [-IPv6] [-ResolveDestination]
- [-Source <String>] [-MaxHops <Int32>] [-TimeoutSeconds <Int32>] [-Quiet] [<CommonParameters>]
+Test-Connection [-Ping] [-IPv4] [-IPv6] [-ResolveDestination] [-Source <String>] [-MaxHops <Int32>]
+ [-Delay <Int32>] [-BufferSize <Int32>] [-DontFragment] [-Continues] [-TimeoutSeconds <Int32>]
+ [-TargetName] <String[]> [-Quiet] [<CommonParameters>]
 ```
 
 ### MtuSizeDetect
 
 ```
-Test-Connection [-TargetName] <String[]> -MTUSizeDetect [-IPv4] [-IPv6] [-ResolveDestination]
- [-TimeoutSeconds <Int32>] [-Quiet] [<CommonParameters>]
+Test-Connection [-IPv4] [-IPv6] [-ResolveDestination] [-TimeoutSeconds <Int32>]
+ [-TargetName] <String[]> -MTUSizeDetect [-Quiet] [<CommonParameters>]
+```
+
+### TraceRoute
+
+```
+Test-Connection [-IPv4] [-IPv6] [-ResolveDestination] [-Source <String>] [-MaxHops <Int32>]
+ [-TimeoutSeconds <Int32>] [-TargetName] <String[]> -Traceroute [-Quiet] [<CommonParameters>]
 ```
 
 ### TcpPort
 
 ```
-Test-Connection [-TargetName] <String[]> -TCPPort <Int32> [-IPv4] [-IPv6] [-ResolveDestination]
- [-Source <String>] [-TimeoutSeconds <Int32>] [-Quiet] [<CommonParameters>]
+Test-Connection [-IPv4] [-IPv6] [-ResolveDestination] [-Source <String>] [-TimeoutSeconds <Int32>]
+ [-TargetName] <String[]> -TCPPort <Int32> [-Quiet] [<CommonParameters>]
 ```
 
 ## DESCRIPTION


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #5086 - incorrect parameter name
Fixes [AB#1645587](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1645587)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7 content
- [ ] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
