### PR TITLE
Fixes #3113 -  update not about excludeproperty

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-Object.md
@@ -38,14 +38,13 @@ Select-Object [-InputObject <PSObject>] [-Unique] [-Wait] [-Index <Int32[]>] [<C
 
 ## DESCRIPTION
 
-The `Select-Object` cmdlet selects specified properties of an object or set of objects.
-It can also select unique objects, a specified number of objects, or objects in a specified position
-in an array.
+The `Select-Object` cmdlet selects specified properties of an object or set of objects. It can also
+select unique objects, a specified number of objects, or objects in a specified position in an
+array.
 
 To select objects from a collection, use the **First**, **Last**, **Unique**, **Skip**, and
-**Index** parameters. To select object properties, use the **Property** parameter.
-When you select properties, `Select-Object` returns new objects that have only the specified
-properties.
+**Index** parameters. To select object properties, use the **Property** parameter. When you select
+properties, `Select-Object` returns new objects that have only the specified properties.
 
 Beginning in Windows PowerShell 3.0, `Select-Object` includes an optimization feature that prevents
 commands from creating and processing objects that are not used.
@@ -53,14 +52,14 @@ commands from creating and processing objects that are not used.
 When you include a `Select-Object` command with the **First** or **Index** parameters in a command
 pipeline, PowerShell stops the command that generates the objects as soon as the selected number of
 objects is generated, even when the command that generates the objects appears before the
-`Select-Object` command in the pipeline.
-To turn off this optimizing behavior, use the **Wait** parameter.
+`Select-Object` command in the pipeline. To turn off this optimizing behavior, use the **Wait**
+parameter.
 
 ## EXAMPLES
 
 ### Example 1: Select objects by property
 
-This command creates objects that have the **Name**, **ID**, and working set (**WS**) properties of
+This example creates objects that have the **Name**, **ID**, and working set (**WS**) properties of
 process objects.
 
 ```powershell
@@ -69,25 +68,24 @@ Get-Process | Select-Object -Property ProcessName, Id, WS
 
 ### Example 2: Select objects by property and format the results
 
-This command gets information about the modules used by the processes on the computer.
-It uses `Get-Process` cmdlet to get the process on the computer.
+This example gets information about the modules used by the processes on the computer. It uses
+`Get-Process` cmdlet to get the process on the computer.
 
 It uses the `Select-Object` cmdlet to output an array of `[System.Diagnostics.ProcessModule]`
 instances as contained in the **Modules** property of each `System.Diagnostics.Process` instance
 output by `Get-Process`.
 
-The command uses the **Property** parameter of the `Select-Object` cmdlet to select the process
-names. This add a `ProcessName` `NoteProperty` to every `[System.Diagnostics.ProcessModule]`
-instance and populates it with the value of current processes **ProcessName** property.
+The **Property** parameter of the `Select-Object` cmdlet selects the process names. This add a
+`ProcessName` **NoteProperty** to every `[System.Diagnostics.ProcessModule]` instance and populates
+it with the value of current processes **ProcessName** property.
 
-The command uses the `Format-List` cmdlet to display the name and modules in of each process in a
-list.
+Finally, `Format-List` cmdlet is used to display the name and modules in of each process in a list.
 
 ```powershell
 Get-Process Explorer | Select-Object -Property ProcessName -ExpandProperty Modules | Format-List
 ```
 
-```output
+```Output
 ProcessName       : explorer
 ModuleName        : explorer.exe
 FileName          : C:\WINDOWS\explorer.exe
@@ -106,21 +104,20 @@ FileVersionInfo   : File:             C:\WINDOWS\explorer.exe
 
 ### Example 3: Select processes using the most memory
 
-This command gets the five processes that are using the most memory.
-The `Get-Process` cmdlet gets the processes on the computer.
-The `Sort-Object` cmdlet sorts the processes according to memory (working set) usage, and the
-`Select-Object` cmdlet selects only the last five members of the resulting array of objects.
+This example gets the five processes that are using the most memory. The `Get-Process` cmdlet gets
+the processes on the computer. The `Sort-Object` cmdlet sorts the processes according to memory
+(working set) usage, and the `Select-Object` cmdlet selects only the last five members of the
+resulting array of objects.
 
 The **Wait** parameter is not required in commands that include the `Sort-Object` cmdlet because
-`Sort-Object` processes all objects and then returns a collection.
-The `Select-Object` optimization is available only for commands that return objects individually as
-they are processed.
+`Sort-Object` processes all objects and then returns a collection. The `Select-Object` optimization
+is available only for commands that return objects individually as they are processed.
 
 ```powershell
 Get-Process | Sort-Object -Property WS | Select-Object -Last 5
 ```
 
-```output
+```Output
 Handles  NPM(K)    PM(K)      WS(K) VS(M)   CPU(s)     Id ProcessName
 -------  ------    -----      ----- -----   ------     -- -----------
 2866     320       33432      45764   203   222.41   1292 svchost
@@ -132,14 +129,14 @@ Handles  NPM(K)    PM(K)      WS(K) VS(M)   CPU(s)     Id ProcessName
 
 ### Example 4: Select unique characters from an array
 
-This command uses the **Unique** parameter of `Select-Object` to get unique characters from an array
+This example uses the **Unique** parameter of `Select-Object` to get unique characters from an array
 of characters.
 
 ```powershell
 "a","b","c","a","a","a" | Select-Object -Unique
 ```
 
-```output
+```Output
 a
 b
 c
@@ -147,16 +144,12 @@ c
 
 ### Example 5: Select newest and oldest events in the event log
 
-These commands gets the first (newest) and last (oldest) events in the Windows PowerShell event log.
+These example gets the first (newest) and last (oldest) events in the Windows PowerShell event log.
 
-The command uses the `Get-EventLog` cmdlet to get all events in the Windows PowerShell log.
-It saves them in the `$a` variable.
-
-The second command uses a pipeline operator (|) to send the events in `$a` to the `Select-Object`
-cmdlet.
-The `Select-Object` command uses the **Index** parameter to select events from the array of events
-in the `$a` variable. The index of the first event is 0.
-The index of the last event is the number of items in `$a` minus 1.
+`Get-EventLog` gets all events in the Windows PowerShell log and saves them in the `$a` variable.
+Then, `$a` is piped to the `Select-Object` cmdlet. The `Select-Object` command uses the **Index**
+parameter to select events from the array of events in the `$a` variable. The index of the first
+event is 0. The index of the last event is the number of items in `$a` minus 1.
 
 ```powershell
 $a = Get-EventLog -LogName "Windows PowerShell"
@@ -165,13 +158,11 @@ $a | Select-Object -Index 0, ($A.count - 1)
 
 ### Example 6: Select all but the first object
 
-This command creates a new PSSession on each of the computers listed in the Servers.txt files,
+This example creates a new PSSession on each of the computers listed in the Servers.txt files,
 except for the first one.
 
-This command uses the `Select-Object` cmdlet to select all but the first computer in a list of
-computer names.
-The resulting list of computers is set as the value of the **ComputerName** parameter of the
-`New-PSSession` cmdlet.
+`Select-Object` selects all but the first computer in a list of computer names. The resulting list
+of computers is set as the value of the **ComputerName** parameter of the `New-PSSession` cmdlet.
 
 ```powershell
 New-PSSession -ComputerName (Get-Content Servers.txt | Select-Object -Skip 1)
@@ -179,19 +170,17 @@ New-PSSession -ComputerName (Get-Content Servers.txt | Select-Object -Skip 1)
 
 ### Example 7: Rename files and select several to review
 
-This command adds a "-ro" suffix to the base names of text files that have the read-only attribute
+This example adds a "-ro" suffix to the base names of text files that have the read-only attribute
 and then displays the first five files so the user can see a sample of the effect.
 
-The command uses the **ReadOnly** dynamic parameter of the `Get-ChildItem` for FileSystem cmdlet to
-get read-only files.
-It uses a pipeline operator (|) to send the files to the `Rename-Item` cmdlet, which renames the
-file.
-It uses the **Passthru** parameter of `Rename-Item` to send the renamed files to the `Select-Object`
-cmdlet, which selects the first 5 for display.
+`Get-ChildItem` uses the **ReadOnly** dynamic parameter to get read-only files. The resulting files
+are piped to the `Rename-Item` cmdlet, which renames the file. It uses the **Passthru** parameter of
+`Rename-Item` to send the renamed files to the `Select-Object` cmdlet, which selects the first 5 for
+display.
 
 The **Wait** parameter of `Select-Object` prevents PowerShell from stopping the `Get-ChildItem`
-cmdlet after it gets the first five read-only text files.
-Without this parameter, only the first five read-only files would be renamed.
+cmdlet after it gets the first five read-only text files. Without this parameter, only the first
+five read-only files would be renamed.
 
 ```powershell
 Get-ChildItem *.txt -ReadOnly | Rename-Item -NewName {$_.BaseName + "-ro.txt"} -PassThru | Select-Object -First 5 -Wait
@@ -201,10 +190,9 @@ Get-ChildItem *.txt -ReadOnly | Rename-Item -NewName {$_.BaseName + "-ro.txt"} -
 
 This example demonstrates the intricacies of the **ExpandProperty** parameter.
 
-Note that the output generated was an array of `[System.Int32]` instances.  The instances conform to
-standard formatting rules of the **Output View**.
-This is true for any *Expanded* properties.  If the outputted objects have a specific standard
-format, the expanded property might not be visible.
+Note that the output generated was an array of `[System.Int32]` instances. The instances conform to
+standard formatting rules of the **Output View**. This is true for any *Expanded* properties. If the
+outputted objects have a specific standard format, the expanded property might not be visible.
 
 ```powershell
 # Create a custom object to use for the Select-Object example.
@@ -213,7 +201,7 @@ $object = [pscustomobject]@{Name="CustomObject";Expand=@(1,2,3,4,5)}
 $object | Select-Object -ExpandProperty Expand -Property Name
 ```
 
-```output
+```Output
 1
 2
 3
@@ -227,7 +215,7 @@ $object | Select-Object -ExpandProperty Expand -Property Name
 $object | Select-Object -ExpandProperty Expand -Property Name | Get-Member
 ```
 
-```output
+```Output
    TypeName: System.Int32
 
 Name        MemberType   Definition
@@ -276,22 +264,21 @@ New Custom Property
 
 ### Example 10: Create calculated properties for each InputObject
 
-This example demonstrates using `Select-Object` to add calculated properties to your input.
-Passing a **ScriptBlock** to the **Property** parameter causes `Select-Object` to evaluate the
-expression on each object passed and add the results to the output. Within the **ScriptBlock**, you
-can use the `$_` variable to reference the current object in the pipeline.
+This example demonstrates using `Select-Object` to add calculated properties to your input. Passing
+a **ScriptBlock** to the **Property** parameter causes `Select-Object` to evaluate the expression on
+each object passed and add the results to the output. Within the **ScriptBlock**, you can use the
+`$_` variable to reference the current object in the pipeline.
 
-By default, `Select-Object` will use the **ScriptBlock** string as the name of the property.
-Using a **Hashtable**, you can label the output of your **ScriptBlock** as a custom property
-added to each object. You can add multiple calculated properties to each object passed to
-`Select-Object`.
+By default, `Select-Object` will use the **ScriptBlock** string as the name of the property. Using a
+**Hashtable**, you can label the output of your **ScriptBlock** as a custom property added to each
+object. You can add multiple calculated properties to each object passed to `Select-Object`.
 
 ```powershell
 # Create a calculated property called $_.StartTime.DayOfWeek
 Get-Process | Select-Object -Property ProcessName,{$_.StartTime.DayOfWeek}
 ```
 
-```output
+```Output
 ProcessName  $_.StartTime.DayOfWeek
 ----         ----------------------
 alg                       Wednesday
@@ -323,9 +310,8 @@ DotNetTypes.format.ps1xml   134.9833984375  223
 
 ### -ExcludeProperty
 
-Specifies the properties that this cmdlet excludes from the operation.
-Wildcards are permitted.
-This parameter is effective only when the command also includes the **Property** parameter.
+Specifies the properties that this cmdlet excludes from the operation. Wildcards are permitted. This
+parameter is effective only when the command also includes the **Property** parameter.
 
 ```yaml
 Type: String[]
@@ -361,7 +347,7 @@ property as a **NoteProperty** to every outputted object.
 >
 > - If the expanded object has a property of the same name, an error will occur.
 > - If the *Selected* object has a property of the same name as an *Expanded* objects property, an
-> error will occur.
+>   error will occur.
 
 ```yaml
 Type: String
@@ -393,11 +379,9 @@ Accept wildcard characters: False
 
 ### -Index
 
-Selects objects from an array based on their index values.
-Enter the indexes in a comma-separated list.
-
-Indexes in an array begin with 0, where 0 represents the first value and (n-1) represents the last
-value.
+Selects objects from an array based on their index values. Enter the indexes in a comma-separated
+list. Indexes in an array begin with 0, where 0 represents the first value and (n-1) represents the
+last value.
 
 ```yaml
 Type: Int32[]
@@ -413,12 +397,12 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies objects to send to the cmdlet through the pipeline.
-This parameter enables you to pipe objects to `Select-Object`.
+Specifies objects to send to the cmdlet through the pipeline. This parameter enables you to pipe
+objects to `Select-Object`.
 
 When you pass objects to the **InputObject** parameter, instead of using the pipeline,
- `Select-Object` treats the **InputObject** as a single object, even if the value is a
-collection. It is recommended that you use the pipeline when passing collections to `Select-Object`.
+`Select-Object` treats the **InputObject** as a single object, even if the value is a collection. It
+is recommended that you use the pipeline when passing collections to `Select-Object`.
 
 ```yaml
 Type: PSObject
@@ -450,11 +434,12 @@ Accept wildcard characters: False
 
 ### -Property
 
-Specifies the properties to select.  These properties are added as **NoteProperty** members to the
+Specifies the properties to select. These properties are added as **NoteProperty** members to the
 output objects. Wildcards are permitted.
 
-The value of the **Property** parameter can be a new calculated property.
-To create a calculated, property, use a hash table.
+The value of the **Property** parameter can be a new calculated property. To create a calculated,
+property, use a hash table.
+
 Valid keys are:
 
 - Name (or Label): `<string>`
@@ -474,9 +459,9 @@ Accept wildcard characters: True
 
 ### -Skip
 
-Skips (does not select) the specified number of items.
-By default, the **Skip** parameter counts from the beginning of the array or list of objects, but if
-the command uses the **Last** parameter, it counts from the end of the list or array.
+Skips (does not select) the specified number of items. By default, the **Skip** parameter counts
+from the beginning of the array or list of objects, but if the command uses the **Last** parameter,
+it counts from the end of the list or array.
 
 Unlike the **Index** parameter, which starts counting at 0, the **Skip** parameter begins at 1.
 
@@ -516,8 +501,8 @@ Accept wildcard characters: False
 Specifies that if a subset of the input objects has identical properties and values, only a single
 member of the subset will be selected.
 
-This parameter is case-sensitive.
-As a result, strings that differ only in character casing are considered to be unique.
+This parameter is case-sensitive. As a result, strings that differ only in character casing are
+considered to be unique.
 
 ```yaml
 Type: SwitchParameter
@@ -533,12 +518,10 @@ Accept wildcard characters: False
 
 ### -Wait
 
-Indicates that the cmdlet turns off optimization.
-PowerShell runs commands in the order that they appear in the command pipeline and lets them
-generate all objects.
-By default, if you include a `Select-Object` command with the **First** or **Index** parameters in a
-command pipeline, PowerShell stops the command that generates the objects as soon as the selected
-number of objects is generated.
+Indicates that the cmdlet turns off optimization. PowerShell runs commands in the order that they
+appear in the command pipeline and lets them generate all objects. By default, if you include a
+`Select-Object` command with the **First** or **Index** parameters in a command pipeline, PowerShell
+stops the command that generates the objects as soon as the selected number of objects is generated.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -577,9 +560,8 @@ You can pipe any object to `Select-Object`.
 - The optimization feature of `Select-Object` is available only for commands that write objects to
   the pipeline as they are processed. It has no effect on commands that buffer processed objects and
   write them as a collection. Writing objects immediately is a cmdlet design best practice. For more
-  information, see Write Single Records to the Pipeline in
-  [Strongly Encouraged Development Guidelines](/powershell/developer/windows-powershell) in the
-  MSDN library.
+  information, see *Write Single Records to the Pipeline* in
+  [Strongly Encouraged Development Guidelines](/powershell/scripting/developer/windows-powershell).
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Select-Object.md
@@ -38,14 +38,13 @@ Select-Object [-InputObject <PSObject>] [-Unique] [-Wait] [-Index <Int32[]>] [<C
 
 ## DESCRIPTION
 
-The `Select-Object` cmdlet selects specified properties of an object or set of objects.
-It can also select unique objects, a specified number of objects, or objects in a specified position
-in an array.
+The `Select-Object` cmdlet selects specified properties of an object or set of objects. It can also
+select unique objects, a specified number of objects, or objects in a specified position in an
+array.
 
 To select objects from a collection, use the **First**, **Last**, **Unique**, **Skip**, and
-**Index** parameters. To select object properties, use the **Property** parameter.
-When you select properties, `Select-Object` returns new objects that have only the specified
-properties.
+**Index** parameters. To select object properties, use the **Property** parameter. When you select
+properties, `Select-Object` returns new objects that have only the specified properties.
 
 Beginning in Windows PowerShell 3.0, `Select-Object` includes an optimization feature that prevents
 commands from creating and processing objects that are not used.
@@ -53,14 +52,14 @@ commands from creating and processing objects that are not used.
 When you include a `Select-Object` command with the **First** or **Index** parameters in a command
 pipeline, PowerShell stops the command that generates the objects as soon as the selected number of
 objects is generated, even when the command that generates the objects appears before the
-`Select-Object` command in the pipeline.
-To turn off this optimizing behavior, use the **Wait** parameter.
+`Select-Object` command in the pipeline. To turn off this optimizing behavior, use the **Wait**
+parameter.
 
 ## EXAMPLES
 
 ### Example 1: Select objects by property
 
-This command creates objects that have the **Name**, **ID**, and working set (**WS**) properties of
+This example creates objects that have the **Name**, **ID**, and working set (**WS**) properties of
 process objects.
 
 ```powershell
@@ -69,25 +68,24 @@ Get-Process | Select-Object -Property ProcessName, Id, WS
 
 ### Example 2: Select objects by property and format the results
 
-This command gets information about the modules used by the processes on the computer.
-It uses `Get-Process` cmdlet to get the process on the computer.
+This example gets information about the modules used by the processes on the computer. It uses
+`Get-Process` cmdlet to get the process on the computer.
 
 It uses the `Select-Object` cmdlet to output an array of `[System.Diagnostics.ProcessModule]`
 instances as contained in the **Modules** property of each `System.Diagnostics.Process` instance
 output by `Get-Process`.
 
-The command uses the **Property** parameter of the `Select-Object` cmdlet to select the process
-names. This add a `ProcessName` `NoteProperty` to every `[System.Diagnostics.ProcessModule]`
-instance and populates it with the value of current processes **ProcessName** property.
+The **Property** parameter of the `Select-Object` cmdlet selects the process names. This add a
+`ProcessName` **NoteProperty** to every `[System.Diagnostics.ProcessModule]` instance and populates
+it with the value of current processes **ProcessName** property.
 
-The command uses the `Format-List` cmdlet to display the name and modules in of each process in a
-list.
+Finally, `Format-List` cmdlet is used to display the name and modules in of each process in a list.
 
 ```powershell
 Get-Process Explorer | Select-Object -Property ProcessName -ExpandProperty Modules | Format-List
 ```
 
-```output
+```Output
 ProcessName       : explorer
 ModuleName        : explorer.exe
 FileName          : C:\WINDOWS\explorer.exe
@@ -106,21 +104,20 @@ FileVersionInfo   : File:             C:\WINDOWS\explorer.exe
 
 ### Example 3: Select processes using the most memory
 
-This command gets the five processes that are using the most memory.
-The `Get-Process` cmdlet gets the processes on the computer.
-The `Sort-Object` cmdlet sorts the processes according to memory (working set) usage, and the
-`Select-Object` cmdlet selects only the last five members of the resulting array of objects.
+This example gets the five processes that are using the most memory. The `Get-Process` cmdlet gets
+the processes on the computer. The `Sort-Object` cmdlet sorts the processes according to memory
+(working set) usage, and the `Select-Object` cmdlet selects only the last five members of the
+resulting array of objects.
 
 The **Wait** parameter is not required in commands that include the `Sort-Object` cmdlet because
-`Sort-Object` processes all objects and then returns a collection.
-The `Select-Object` optimization is available only for commands that return objects individually as
-they are processed.
+`Sort-Object` processes all objects and then returns a collection. The `Select-Object` optimization
+is available only for commands that return objects individually as they are processed.
 
 ```powershell
 Get-Process | Sort-Object -Property WS | Select-Object -Last 5
 ```
 
-```output
+```Output
 Handles  NPM(K)    PM(K)      WS(K) VS(M)   CPU(s)     Id ProcessName
 -------  ------    -----      ----- -----   ------     -- -----------
 2866     320       33432      45764   203   222.41   1292 svchost
@@ -132,14 +129,14 @@ Handles  NPM(K)    PM(K)      WS(K) VS(M)   CPU(s)     Id ProcessName
 
 ### Example 4: Select unique characters from an array
 
-This command uses the **Unique** parameter of `Select-Object` to get unique characters from an array
+This example uses the **Unique** parameter of `Select-Object` to get unique characters from an array
 of characters.
 
 ```powershell
 "a","b","c","a","a","a" | Select-Object -Unique
 ```
 
-```output
+```Output
 a
 b
 c
@@ -147,16 +144,12 @@ c
 
 ### Example 5: Select newest and oldest events in the event log
 
-These commands gets the first (newest) and last (oldest) events in the Windows PowerShell event log.
+These example gets the first (newest) and last (oldest) events in the Windows PowerShell event log.
 
-The command uses the `Get-EventLog` cmdlet to get all events in the Windows PowerShell log.
-It saves them in the `$a` variable.
-
-The second command uses a pipeline operator (|) to send the events in `$a` to the `Select-Object`
-cmdlet.
-The `Select-Object` command uses the **Index** parameter to select events from the array of events
-in the `$a` variable. The index of the first event is 0.
-The index of the last event is the number of items in `$a` minus 1.
+`Get-EventLog` gets all events in the Windows PowerShell log and saves them in the `$a` variable.
+Then, `$a` is piped to the `Select-Object` cmdlet. The `Select-Object` command uses the **Index**
+parameter to select events from the array of events in the `$a` variable. The index of the first
+event is 0. The index of the last event is the number of items in `$a` minus 1.
 
 ```powershell
 $a = Get-EventLog -LogName "Windows PowerShell"
@@ -165,13 +158,11 @@ $a | Select-Object -Index 0, ($A.count - 1)
 
 ### Example 6: Select all but the first object
 
-This command creates a new PSSession on each of the computers listed in the Servers.txt files,
+This example creates a new PSSession on each of the computers listed in the Servers.txt files,
 except for the first one.
 
-This command uses the `Select-Object` cmdlet to select all but the first computer in a list of
-computer names.
-The resulting list of computers is set as the value of the **ComputerName** parameter of the
-`New-PSSession` cmdlet.
+`Select-Object` selects all but the first computer in a list of computer names. The resulting list
+of computers is set as the value of the **ComputerName** parameter of the `New-PSSession` cmdlet.
 
 ```powershell
 New-PSSession -ComputerName (Get-Content Servers.txt | Select-Object -Skip 1)
@@ -179,19 +170,17 @@ New-PSSession -ComputerName (Get-Content Servers.txt | Select-Object -Skip 1)
 
 ### Example 7: Rename files and select several to review
 
-This command adds a "-ro" suffix to the base names of text files that have the read-only attribute
+This example adds a "-ro" suffix to the base names of text files that have the read-only attribute
 and then displays the first five files so the user can see a sample of the effect.
 
-The command uses the **ReadOnly** dynamic parameter of the `Get-ChildItem` for FileSystem cmdlet to
-get read-only files.
-It uses a pipeline operator (|) to send the files to the `Rename-Item` cmdlet, which renames the
-file.
-It uses the **Passthru** parameter of `Rename-Item` to send the renamed files to the `Select-Object`
-cmdlet, which selects the first 5 for display.
+`Get-ChildItem` uses the **ReadOnly** dynamic parameter to get read-only files. The resulting files
+are piped to the `Rename-Item` cmdlet, which renames the file. It uses the **Passthru** parameter of
+`Rename-Item` to send the renamed files to the `Select-Object` cmdlet, which selects the first 5 for
+display.
 
 The **Wait** parameter of `Select-Object` prevents PowerShell from stopping the `Get-ChildItem`
-cmdlet after it gets the first five read-only text files.
-Without this parameter, only the first five read-only files would be renamed.
+cmdlet after it gets the first five read-only text files. Without this parameter, only the first
+five read-only files would be renamed.
 
 ```powershell
 Get-ChildItem *.txt -ReadOnly | Rename-Item -NewName {$_.BaseName + "-ro.txt"} -PassThru | Select-Object -First 5 -Wait
@@ -201,10 +190,9 @@ Get-ChildItem *.txt -ReadOnly | Rename-Item -NewName {$_.BaseName + "-ro.txt"} -
 
 This example demonstrates the intricacies of the **ExpandProperty** parameter.
 
-Note that the output generated was an array of `[System.Int32]` instances.  The instances conform to
-standard formatting rules of the **Output View**.
-This is true for any *Expanded* properties.  If the outputted objects have a specific standard
-format, the expanded property might not be visible.
+Note that the output generated was an array of `[System.Int32]` instances. The instances conform to
+standard formatting rules of the **Output View**. This is true for any *Expanded* properties. If the
+outputted objects have a specific standard format, the expanded property might not be visible.
 
 ```powershell
 # Create a custom object to use for the Select-Object example.
@@ -213,7 +201,7 @@ $object = [pscustomobject]@{Name="CustomObject";Expand=@(1,2,3,4,5)}
 $object | Select-Object -ExpandProperty Expand -Property Name
 ```
 
-```output
+```Output
 1
 2
 3
@@ -227,7 +215,7 @@ $object | Select-Object -ExpandProperty Expand -Property Name
 $object | Select-Object -ExpandProperty Expand -Property Name | Get-Member
 ```
 
-```output
+```Output
    TypeName: System.Int32
 
 Name        MemberType   Definition
@@ -276,22 +264,21 @@ New Custom Property
 
 ### Example 10: Create calculated properties for each InputObject
 
-This example demonstrates using `Select-Object` to add calculated properties to your input.
-Passing a **ScriptBlock** to the **Property** parameter causes `Select-Object` to evaluate the
-expression on each object passed and add the results to the output. Within the **ScriptBlock**, you
-can use the `$_` variable to reference the current object in the pipeline.
+This example demonstrates using `Select-Object` to add calculated properties to your input. Passing
+a **ScriptBlock** to the **Property** parameter causes `Select-Object` to evaluate the expression on
+each object passed and add the results to the output. Within the **ScriptBlock**, you can use the
+`$_` variable to reference the current object in the pipeline.
 
-By default, `Select-Object` will use the **ScriptBlock** string as the name of the property.
-Using a **Hashtable**, you can label the output of your **ScriptBlock** as a custom property
-added to each object. You can add multiple calculated properties to each object passed to
-`Select-Object`.
+By default, `Select-Object` will use the **ScriptBlock** string as the name of the property. Using a
+**Hashtable**, you can label the output of your **ScriptBlock** as a custom property added to each
+object. You can add multiple calculated properties to each object passed to `Select-Object`.
 
 ```powershell
 # Create a calculated property called $_.StartTime.DayOfWeek
 Get-Process | Select-Object -Property ProcessName,{$_.StartTime.DayOfWeek}
 ```
 
-```output
+```Output
 ProcessName  $_.StartTime.DayOfWeek
 ----         ----------------------
 alg                       Wednesday
@@ -323,9 +310,10 @@ DotNetTypes.format.ps1xml   134.9833984375  223
 
 ### -ExcludeProperty
 
-Specifies the properties that this cmdlet excludes from the operation.
-Wildcards are permitted.
-This parameter is effective only when the command also includes the **Property** parameter.
+Specifies the properties that this cmdlet excludes from the operation. Wildcards are permitted.
+
+Beginning in PowerShell 6, it is no longer required to include the **Property** parameter for
+**ExcludeProperty** to work.
 
 ```yaml
 Type: String[]
@@ -361,7 +349,7 @@ property as a **NoteProperty** to every outputted object.
 >
 > - If the expanded object has a property of the same name, an error will occur.
 > - If the *Selected* object has a property of the same name as an *Expanded* objects property, an
-> error will occur.
+>   error will occur.
 
 ```yaml
 Type: String
@@ -393,11 +381,9 @@ Accept wildcard characters: False
 
 ### -Index
 
-Selects objects from an array based on their index values.
-Enter the indexes in a comma-separated list.
-
-Indexes in an array begin with 0, where 0 represents the first value and (n-1) represents the last
-value.
+Selects objects from an array based on their index values. Enter the indexes in a comma-separated
+list. Indexes in an array begin with 0, where 0 represents the first value and (n-1) represents the
+last value.
 
 ```yaml
 Type: Int32[]
@@ -413,12 +399,12 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies objects to send to the cmdlet through the pipeline.
-This parameter enables you to pipe objects to `Select-Object`.
+Specifies objects to send to the cmdlet through the pipeline. This parameter enables you to pipe
+objects to `Select-Object`.
 
 When you pass objects to the **InputObject** parameter, instead of using the pipeline,
- `Select-Object` treats the **InputObject** as a single object, even if the value is a
-collection. It is recommended that you use the pipeline when passing collections to `Select-Object`.
+`Select-Object` treats the **InputObject** as a single object, even if the value is a collection. It
+is recommended that you use the pipeline when passing collections to `Select-Object`.
 
 ```yaml
 Type: PSObject
@@ -450,11 +436,12 @@ Accept wildcard characters: False
 
 ### -Property
 
-Specifies the properties to select.  These properties are added as **NoteProperty** members to the
+Specifies the properties to select. These properties are added as **NoteProperty** members to the
 output objects. Wildcards are permitted.
 
-The value of the **Property** parameter can be a new calculated property.
-To create a calculated, property, use a hash table.
+The value of the **Property** parameter can be a new calculated property. To create a calculated,
+property, use a hash table.
+
 Valid keys are:
 
 - Name (or Label): `<string>`
@@ -474,9 +461,9 @@ Accept wildcard characters: True
 
 ### -Skip
 
-Skips (does not select) the specified number of items.
-By default, the **Skip** parameter counts from the beginning of the array or list of objects, but if
-the command uses the **Last** parameter, it counts from the end of the list or array.
+Skips (does not select) the specified number of items. By default, the **Skip** parameter counts
+from the beginning of the array or list of objects, but if the command uses the **Last** parameter,
+it counts from the end of the list or array.
 
 Unlike the **Index** parameter, which starts counting at 0, the **Skip** parameter begins at 1.
 
@@ -516,8 +503,8 @@ Accept wildcard characters: False
 Specifies that if a subset of the input objects has identical properties and values, only a single
 member of the subset will be selected.
 
-This parameter is case-sensitive.
-As a result, strings that differ only in character casing are considered to be unique.
+This parameter is case-sensitive. As a result, strings that differ only in character casing are
+considered to be unique.
 
 ```yaml
 Type: SwitchParameter
@@ -533,12 +520,10 @@ Accept wildcard characters: False
 
 ### -Wait
 
-Indicates that the cmdlet turns off optimization.
-PowerShell runs commands in the order that they appear in the command pipeline and lets them
-generate all objects.
-By default, if you include a `Select-Object` command with the **First** or **Index** parameters in a
-command pipeline, PowerShell stops the command that generates the objects as soon as the selected
-number of objects is generated.
+Indicates that the cmdlet turns off optimization. PowerShell runs commands in the order that they
+appear in the command pipeline and lets them generate all objects. By default, if you include a
+`Select-Object` command with the **First** or **Index** parameters in a command pipeline, PowerShell
+stops the command that generates the objects as soon as the selected number of objects is generated.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -577,9 +562,8 @@ You can pipe any object to `Select-Object`.
 - The optimization feature of `Select-Object` is available only for commands that write objects to
   the pipeline as they are processed. It has no effect on commands that buffer processed objects and
   write them as a collection. Writing objects immediately is a cmdlet design best practice. For more
-  information, see Write Single Records to the Pipeline in
-  [Strongly Encouraged Development Guidelines](/powershell/developer/windows-powershell) in the
-  MSDN library.
+  information, see *Write Single Records to the Pipeline* in
+  [Strongly Encouraged Development Guidelines](/powershell/scripting/developer/windows-powershell).
 
 ## RELATED LINKS
 

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -398,6 +398,8 @@ Get-Process notepad && Stop-Process -Name notepad
 npm install || Remove-Item -Recurse ./node_modules
 ```
 
+For more information, see [About_Pipeline_Chain_Operators](About_Pipeline_Chain_Operators.md).
+
 #### Property dereferences operator `.`
 
 Accesses the properties and methods of an object.

--- a/reference/7/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Select-Object.md
@@ -38,14 +38,13 @@ Select-Object [-InputObject <PSObject>] [-Unique] [-Wait] [-Index <Int32[]>] [<C
 
 ## DESCRIPTION
 
-The `Select-Object` cmdlet selects specified properties of an object or set of objects.
-It can also select unique objects, a specified number of objects, or objects in a specified position
-in an array.
+The `Select-Object` cmdlet selects specified properties of an object or set of objects. It can also
+select unique objects, a specified number of objects, or objects in a specified position in an
+array.
 
 To select objects from a collection, use the **First**, **Last**, **Unique**, **Skip**, and
-**Index** parameters. To select object properties, use the **Property** parameter.
-When you select properties, `Select-Object` returns new objects that have only the specified
-properties.
+**Index** parameters. To select object properties, use the **Property** parameter. When you select
+properties, `Select-Object` returns new objects that have only the specified properties.
 
 Beginning in Windows PowerShell 3.0, `Select-Object` includes an optimization feature that prevents
 commands from creating and processing objects that are not used.
@@ -53,14 +52,14 @@ commands from creating and processing objects that are not used.
 When you include a `Select-Object` command with the **First** or **Index** parameters in a command
 pipeline, PowerShell stops the command that generates the objects as soon as the selected number of
 objects is generated, even when the command that generates the objects appears before the
-`Select-Object` command in the pipeline.
-To turn off this optimizing behavior, use the **Wait** parameter.
+`Select-Object` command in the pipeline. To turn off this optimizing behavior, use the **Wait**
+parameter.
 
 ## EXAMPLES
 
 ### Example 1: Select objects by property
 
-This command creates objects that have the **Name**, **ID**, and working set (**WS**) properties of
+This example creates objects that have the **Name**, **ID**, and working set (**WS**) properties of
 process objects.
 
 ```powershell
@@ -69,25 +68,24 @@ Get-Process | Select-Object -Property ProcessName, Id, WS
 
 ### Example 2: Select objects by property and format the results
 
-This command gets information about the modules used by the processes on the computer.
-It uses `Get-Process` cmdlet to get the process on the computer.
+This example gets information about the modules used by the processes on the computer. It uses
+`Get-Process` cmdlet to get the process on the computer.
 
 It uses the `Select-Object` cmdlet to output an array of `[System.Diagnostics.ProcessModule]`
 instances as contained in the **Modules** property of each `System.Diagnostics.Process` instance
 output by `Get-Process`.
 
-The command uses the **Property** parameter of the `Select-Object` cmdlet to select the process
-names. This add a `ProcessName` `NoteProperty` to every `[System.Diagnostics.ProcessModule]`
-instance and populates it with the value of current processes **ProcessName** property.
+The **Property** parameter of the `Select-Object` cmdlet selects the process names. This add a
+`ProcessName` **NoteProperty** to every `[System.Diagnostics.ProcessModule]` instance and populates
+it with the value of current processes **ProcessName** property.
 
-The command uses the `Format-List` cmdlet to display the name and modules in of each process in a
-list.
+Finally, `Format-List` cmdlet is used to display the name and modules in of each process in a list.
 
 ```powershell
 Get-Process Explorer | Select-Object -Property ProcessName -ExpandProperty Modules | Format-List
 ```
 
-```output
+```Output
 ProcessName       : explorer
 ModuleName        : explorer.exe
 FileName          : C:\WINDOWS\explorer.exe
@@ -106,21 +104,20 @@ FileVersionInfo   : File:             C:\WINDOWS\explorer.exe
 
 ### Example 3: Select processes using the most memory
 
-This command gets the five processes that are using the most memory.
-The `Get-Process` cmdlet gets the processes on the computer.
-The `Sort-Object` cmdlet sorts the processes according to memory (working set) usage, and the
-`Select-Object` cmdlet selects only the last five members of the resulting array of objects.
+This example gets the five processes that are using the most memory. The `Get-Process` cmdlet gets
+the processes on the computer. The `Sort-Object` cmdlet sorts the processes according to memory
+(working set) usage, and the `Select-Object` cmdlet selects only the last five members of the
+resulting array of objects.
 
 The **Wait** parameter is not required in commands that include the `Sort-Object` cmdlet because
-`Sort-Object` processes all objects and then returns a collection.
-The `Select-Object` optimization is available only for commands that return objects individually as
-they are processed.
+`Sort-Object` processes all objects and then returns a collection. The `Select-Object` optimization
+is available only for commands that return objects individually as they are processed.
 
 ```powershell
 Get-Process | Sort-Object -Property WS | Select-Object -Last 5
 ```
 
-```output
+```Output
 Handles  NPM(K)    PM(K)      WS(K) VS(M)   CPU(s)     Id ProcessName
 -------  ------    -----      ----- -----   ------     -- -----------
 2866     320       33432      45764   203   222.41   1292 svchost
@@ -132,14 +129,14 @@ Handles  NPM(K)    PM(K)      WS(K) VS(M)   CPU(s)     Id ProcessName
 
 ### Example 4: Select unique characters from an array
 
-This command uses the **Unique** parameter of `Select-Object` to get unique characters from an array
+This example uses the **Unique** parameter of `Select-Object` to get unique characters from an array
 of characters.
 
 ```powershell
 "a","b","c","a","a","a" | Select-Object -Unique
 ```
 
-```output
+```Output
 a
 b
 c
@@ -147,16 +144,12 @@ c
 
 ### Example 5: Select newest and oldest events in the event log
 
-These commands gets the first (newest) and last (oldest) events in the Windows PowerShell event log.
+These example gets the first (newest) and last (oldest) events in the Windows PowerShell event log.
 
-The command uses the `Get-EventLog` cmdlet to get all events in the Windows PowerShell log.
-It saves them in the `$a` variable.
-
-The second command uses a pipeline operator (|) to send the events in `$a` to the `Select-Object`
-cmdlet.
-The `Select-Object` command uses the **Index** parameter to select events from the array of events
-in the `$a` variable. The index of the first event is 0.
-The index of the last event is the number of items in `$a` minus 1.
+`Get-EventLog` gets all events in the Windows PowerShell log and saves them in the `$a` variable.
+Then, `$a` is piped to the `Select-Object` cmdlet. The `Select-Object` command uses the **Index**
+parameter to select events from the array of events in the `$a` variable. The index of the first
+event is 0. The index of the last event is the number of items in `$a` minus 1.
 
 ```powershell
 $a = Get-EventLog -LogName "Windows PowerShell"
@@ -165,13 +158,11 @@ $a | Select-Object -Index 0, ($A.count - 1)
 
 ### Example 6: Select all but the first object
 
-This command creates a new PSSession on each of the computers listed in the Servers.txt files,
+This example creates a new PSSession on each of the computers listed in the Servers.txt files,
 except for the first one.
 
-This command uses the `Select-Object` cmdlet to select all but the first computer in a list of
-computer names.
-The resulting list of computers is set as the value of the **ComputerName** parameter of the
-`New-PSSession` cmdlet.
+`Select-Object` selects all but the first computer in a list of computer names. The resulting list
+of computers is set as the value of the **ComputerName** parameter of the `New-PSSession` cmdlet.
 
 ```powershell
 New-PSSession -ComputerName (Get-Content Servers.txt | Select-Object -Skip 1)
@@ -179,19 +170,17 @@ New-PSSession -ComputerName (Get-Content Servers.txt | Select-Object -Skip 1)
 
 ### Example 7: Rename files and select several to review
 
-This command adds a "-ro" suffix to the base names of text files that have the read-only attribute
+This example adds a "-ro" suffix to the base names of text files that have the read-only attribute
 and then displays the first five files so the user can see a sample of the effect.
 
-The command uses the **ReadOnly** dynamic parameter of the `Get-ChildItem` for FileSystem cmdlet to
-get read-only files.
-It uses a pipeline operator (|) to send the files to the `Rename-Item` cmdlet, which renames the
-file.
-It uses the **Passthru** parameter of `Rename-Item` to send the renamed files to the `Select-Object`
-cmdlet, which selects the first 5 for display.
+`Get-ChildItem` uses the **ReadOnly** dynamic parameter to get read-only files. The resulting files
+are piped to the `Rename-Item` cmdlet, which renames the file. It uses the **Passthru** parameter of
+`Rename-Item` to send the renamed files to the `Select-Object` cmdlet, which selects the first 5 for
+display.
 
 The **Wait** parameter of `Select-Object` prevents PowerShell from stopping the `Get-ChildItem`
-cmdlet after it gets the first five read-only text files.
-Without this parameter, only the first five read-only files would be renamed.
+cmdlet after it gets the first five read-only text files. Without this parameter, only the first
+five read-only files would be renamed.
 
 ```powershell
 Get-ChildItem *.txt -ReadOnly | Rename-Item -NewName {$_.BaseName + "-ro.txt"} -PassThru | Select-Object -First 5 -Wait
@@ -201,10 +190,9 @@ Get-ChildItem *.txt -ReadOnly | Rename-Item -NewName {$_.BaseName + "-ro.txt"} -
 
 This example demonstrates the intricacies of the **ExpandProperty** parameter.
 
-Note that the output generated was an array of `[System.Int32]` instances.  The instances conform to
-standard formatting rules of the **Output View**.
-This is true for any *Expanded* properties.  If the outputted objects have a specific standard
-format, the expanded property might not be visible.
+Note that the output generated was an array of `[System.Int32]` instances. The instances conform to
+standard formatting rules of the **Output View**. This is true for any *Expanded* properties. If the
+outputted objects have a specific standard format, the expanded property might not be visible.
 
 ```powershell
 # Create a custom object to use for the Select-Object example.
@@ -213,7 +201,7 @@ $object = [pscustomobject]@{Name="CustomObject";Expand=@(1,2,3,4,5)}
 $object | Select-Object -ExpandProperty Expand -Property Name
 ```
 
-```output
+```Output
 1
 2
 3
@@ -227,7 +215,7 @@ $object | Select-Object -ExpandProperty Expand -Property Name
 $object | Select-Object -ExpandProperty Expand -Property Name | Get-Member
 ```
 
-```output
+```Output
    TypeName: System.Int32
 
 Name        MemberType   Definition
@@ -276,22 +264,21 @@ New Custom Property
 
 ### Example 10: Create calculated properties for each InputObject
 
-This example demonstrates using `Select-Object` to add calculated properties to your input.
-Passing a **ScriptBlock** to the **Property** parameter causes `Select-Object` to evaluate the
-expression on each object passed and add the results to the output. Within the **ScriptBlock**, you
-can use the `$_` variable to reference the current object in the pipeline.
+This example demonstrates using `Select-Object` to add calculated properties to your input. Passing
+a **ScriptBlock** to the **Property** parameter causes `Select-Object` to evaluate the expression on
+each object passed and add the results to the output. Within the **ScriptBlock**, you can use the
+`$_` variable to reference the current object in the pipeline.
 
-By default, `Select-Object` will use the **ScriptBlock** string as the name of the property.
-Using a **Hashtable**, you can label the output of your **ScriptBlock** as a custom property
-added to each object. You can add multiple calculated properties to each object passed to
-`Select-Object`.
+By default, `Select-Object` will use the **ScriptBlock** string as the name of the property. Using a
+**Hashtable**, you can label the output of your **ScriptBlock** as a custom property added to each
+object. You can add multiple calculated properties to each object passed to `Select-Object`.
 
 ```powershell
 # Create a calculated property called $_.StartTime.DayOfWeek
 Get-Process | Select-Object -Property ProcessName,{$_.StartTime.DayOfWeek}
 ```
 
-```output
+```Output
 ProcessName  $_.StartTime.DayOfWeek
 ----         ----------------------
 alg                       Wednesday
@@ -323,9 +310,10 @@ DotNetTypes.format.ps1xml   134.9833984375  223
 
 ### -ExcludeProperty
 
-Specifies the properties that this cmdlet excludes from the operation.
-Wildcards are permitted.
-This parameter is effective only when the command also includes the **Property** parameter.
+Specifies the properties that this cmdlet excludes from the operation. Wildcards are permitted.
+
+Beginning in PowerShell 6, it is no longer required to include the **Property** parameter for
+**ExcludeProperty** to work.
 
 ```yaml
 Type: String[]
@@ -361,7 +349,7 @@ property as a **NoteProperty** to every outputted object.
 >
 > - If the expanded object has a property of the same name, an error will occur.
 > - If the *Selected* object has a property of the same name as an *Expanded* objects property, an
-> error will occur.
+>   error will occur.
 
 ```yaml
 Type: String
@@ -393,11 +381,9 @@ Accept wildcard characters: False
 
 ### -Index
 
-Selects objects from an array based on their index values.
-Enter the indexes in a comma-separated list.
-
-Indexes in an array begin with 0, where 0 represents the first value and (n-1) represents the last
-value.
+Selects objects from an array based on their index values. Enter the indexes in a comma-separated
+list. Indexes in an array begin with 0, where 0 represents the first value and (n-1) represents the
+last value.
 
 ```yaml
 Type: Int32[]
@@ -413,12 +399,12 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies objects to send to the cmdlet through the pipeline.
-This parameter enables you to pipe objects to `Select-Object`.
+Specifies objects to send to the cmdlet through the pipeline. This parameter enables you to pipe
+objects to `Select-Object`.
 
 When you pass objects to the **InputObject** parameter, instead of using the pipeline,
- `Select-Object` treats the **InputObject** as a single object, even if the value is a
-collection. It is recommended that you use the pipeline when passing collections to `Select-Object`.
+`Select-Object` treats the **InputObject** as a single object, even if the value is a collection. It
+is recommended that you use the pipeline when passing collections to `Select-Object`.
 
 ```yaml
 Type: PSObject
@@ -450,11 +436,12 @@ Accept wildcard characters: False
 
 ### -Property
 
-Specifies the properties to select.  These properties are added as **NoteProperty** members to the
+Specifies the properties to select. These properties are added as **NoteProperty** members to the
 output objects. Wildcards are permitted.
 
-The value of the **Property** parameter can be a new calculated property.
-To create a calculated, property, use a hash table.
+The value of the **Property** parameter can be a new calculated property. To create a calculated,
+property, use a hash table.
+
 Valid keys are:
 
 - Name (or Label): `<string>`
@@ -474,9 +461,9 @@ Accept wildcard characters: True
 
 ### -Skip
 
-Skips (does not select) the specified number of items.
-By default, the **Skip** parameter counts from the beginning of the array or list of objects, but if
-the command uses the **Last** parameter, it counts from the end of the list or array.
+Skips (does not select) the specified number of items. By default, the **Skip** parameter counts
+from the beginning of the array or list of objects, but if the command uses the **Last** parameter,
+it counts from the end of the list or array.
 
 Unlike the **Index** parameter, which starts counting at 0, the **Skip** parameter begins at 1.
 
@@ -516,8 +503,8 @@ Accept wildcard characters: False
 Specifies that if a subset of the input objects has identical properties and values, only a single
 member of the subset will be selected.
 
-This parameter is case-sensitive.
-As a result, strings that differ only in character casing are considered to be unique.
+This parameter is case-sensitive. As a result, strings that differ only in character casing are
+considered to be unique.
 
 ```yaml
 Type: SwitchParameter
@@ -533,12 +520,10 @@ Accept wildcard characters: False
 
 ### -Wait
 
-Indicates that the cmdlet turns off optimization.
-PowerShell runs commands in the order that they appear in the command pipeline and lets them
-generate all objects.
-By default, if you include a `Select-Object` command with the **First** or **Index** parameters in a
-command pipeline, PowerShell stops the command that generates the objects as soon as the selected
-number of objects is generated.
+Indicates that the cmdlet turns off optimization. PowerShell runs commands in the order that they
+appear in the command pipeline and lets them generate all objects. By default, if you include a
+`Select-Object` command with the **First** or **Index** parameters in a command pipeline, PowerShell
+stops the command that generates the objects as soon as the selected number of objects is generated.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -577,9 +562,8 @@ You can pipe any object to `Select-Object`.
 - The optimization feature of `Select-Object` is available only for commands that write objects to
   the pipeline as they are processed. It has no effect on commands that buffer processed objects and
   write them as a collection. Writing objects immediately is a cmdlet design best practice. For more
-  information, see Write Single Records to the Pipeline in
-  [Strongly Encouraged Development Guidelines](/powershell/developer/windows-powershell) in the
-  MSDN library.
+  information, see *Write Single Records to the Pipeline* in
+  [Strongly Encouraged Development Guidelines](/powershell/scripting/developer/windows-powershell).
 
 ## RELATED LINKS
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #3113 -  update not about excludeproperty
Fixes [AB#1648258](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1648258)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
