### PR TITLE
Specify other allowed name characters

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -212,7 +212,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies the name of a new alias. An alias name can contain alphanumeric characters. Alias names
+Specifies the name of a new alias. An alias name can contain alphanumeric characters and hyphens. Alias names
 cannot be numeric, such as 123.
 
 ```yaml


### PR DESCRIPTION
Indicates that hyphens are allowed, too. If more characters are allowed, they should also be specified.