### PR TITLE
Update PSModulePath docs to also work for non-Windows systems and not be specific to Windows PowerShell any more

### DIFF
--- a/reference/docs-conceptual/developer/module/modifying-the-psmodulepath-installation-path.md
+++ b/reference/docs-conceptual/developer/module/modifying-the-psmodulepath-installation-path.md
@@ -11,9 +11,9 @@ caps.latest.revision: 15
 ---
 # Modifying the PSModulePath Installation Path
 
-The `PSModulePath` environment variable stores the paths to the locations of the modules that are installed on disk. Windows PowerShell uses this variable to locate modules when the user does not specify the full path to a module. The paths in this variable are searched in the order in which they appear.
+The `PSModulePath` environment variable stores the paths to the locations of the modules that are installed on disk. PowerShell uses this variable to locate modules when the user does not specify the full path to a module. The paths in this variable are searched in the order in which they appear.
 
-When Windows PowerShell starts, `PSModulePath` is created as a system environment variable with the following default value: `$home\Documents\WindowsPowerShell\Modules; $pshome\Modules`.
+When PowerShell starts, `PSModulePath` is created as a system environment variable with the following default value: `$HOME\Documents\PowerShell\Modules; $PSHOME\Modules` or `$HOME\Documents\WindowsPowerShell\Modules; $PSHOME\Modules` for Windows PowerShell.
 
 ## To view the PSModulePath variable
 
@@ -27,27 +27,25 @@ To add paths to this variable, use one of the following methods:
 
 - To add a temporary value that is available only for the current session, run the following command at the command line:
 
-  `$env:PSModulePath = $env:PSModulePath + ";c:\ModulePath"`
+  `$env:PSModulePath = $env:PSModulePath + "$([System.IO.Path]::PathSeparator)$MyModulePath"`
 
-- To add a persistent value that is available whenever a session is opened, add the following command to a Windows PowerShell profile:
+- To add a persistent value that is available whenever a session is opened, add the above command to a PowerShell profile file (`$PROFILE`)>
 
-  `$env:PSModulePath = $env:PSModulePath + ";c:\ModulePath"`
-
-  For more information about profiles, see [about_Profiles](/powershell/module/microsoft.powershell.core/about/about_profiles) in the Microsoft TechNet library.
+  For more information about profiles, see [about_Profiles](/powershell/module/microsoft.powershell.core/about/about_profiles).
 
 - To add a persistent variable to the registry, create a new user environment variable called `PSModulePath` using the Environment Variables Editor in the **System Properties** dialog box.
 
-- To add a persistent variable by using a script, use the **SetEnvironmentVariable** method on the Environment class. For example, the following script adds the "C:\Program Files\Fabrikam\Module path to the value of the PSModulePath environment variable for the computer. To add the path to the user PSModulePath environment variable, set the target to "User".
+- To add a persistent variable by using a script, use the .Net method [SetEnvironmentVariable](https://docs.microsoft.com/dotnet/api/system.environment.setenvironmentvariable) on the [System.Environment](https://docs.microsoft.com/en-us/dotnet/api/system.environment) class. For example, the following script adds the `C:\Program Files\Fabrikam\Module` path to the value of the `PSModulePath` environment variable for the computer. To add the path to the user `PSModulePath` environment variable, set the target to "User".
 
   ```powershell
   $CurrentValue = [Environment]::GetEnvironmentVariable("PSModulePath", "Machine")
-  [Environment]::SetEnvironmentVariable("PSModulePath", $CurrentValue + ";C:\Program Files\Fabrikam\Modules", "Machine")
+  [Environment]::SetEnvironmentVariable("PSModulePath", $CurrentValue + [System.IO.Path]::PathSeparator + "C:\Program Files\Fabrikam\Modules", "Machine")
 
   ```
 
 ## To remove locations from the PSModulePath
 
-You can remove paths from the variable using similar methods: for example, `$env:PSModulePath = $env:PSModulePath -replace ";c:\\ModulePath"` will remove the **c:\ModulePath** path from the current session.
+You can remove paths from the variable using similar methods: for example, `$env:PSModulePath = $env:PSModulePath -replace "$([System.IO.Path]::PathSeparator)c:\\ModulePath"` will remove the **c:\ModulePath** path from the current session.
 
 ## See Also
 

--- a/reference/docs-conceptual/developer/module/modifying-the-psmodulepath-installation-path.md
+++ b/reference/docs-conceptual/developer/module/modifying-the-psmodulepath-installation-path.md
@@ -35,7 +35,7 @@ To add paths to this variable, use one of the following methods:
 
 - To add a persistent variable to the registry, create a new user environment variable called `PSModulePath` using the Environment Variables Editor in the **System Properties** dialog box.
 
-- To add a persistent variable by using a script, use the .Net method [SetEnvironmentVariable](https://docs.microsoft.com/dotnet/api/system.environment.setenvironmentvariable) on the [System.Environment](https://docs.microsoft.com/en-us/dotnet/api/system.environment) class. For example, the following script adds the `C:\Program Files\Fabrikam\Module` path to the value of the `PSModulePath` environment variable for the computer. To add the path to the user `PSModulePath` environment variable, set the target to "User".
+- To add a persistent variable by using a script, use the .Net method [SetEnvironmentVariable](https://docs.microsoft.com/dotnet/api/system.environment.setenvironmentvariable) on the [System.Environment](https://docs.microsoft.com/dotnet/api/system.environment) class. For example, the following script adds the `C:\Program Files\Fabrikam\Module` path to the value of the `PSModulePath` environment variable for the computer. To add the path to the user `PSModulePath` environment variable, set the target to "User".
 
   ```powershell
   $CurrentValue = [Environment]::GetEnvironmentVariable("PSModulePath", "Machine")


### PR DESCRIPTION
# PR Summary

Update PSModulePath docs to also work for non-Windows systems (Path separators are colons and not semicolons on Unix, therefore using a generic API that will work on both Windows and Unix) and not be specific to Windows PowerShell any more. Some more tidying as well.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [x] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
