### PR TITLE
Fixes #5031 - remove unnecessary $() example

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Function_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Function_Provider.md
@@ -168,7 +168,7 @@ it displays the time before the path.
 
 ```powershell
 Set-Item -Path Function:prompt -Value {
-  'PS '+ $(Get-Date -Format t) + " " + $(Get-Location) + '> '
+  'PS '+ (Get-Date -Format t) + " " + (Get-Location) + '> '
   }
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Item.md
@@ -57,7 +57,7 @@ Set-Item -Path env:UserRole -Value "Administrator"
 This command changes the prompt function so that it displays the time before the path.
 
 ```powershell
-Set-Item -Path function:prompt -Value {'PS '+ $(Get-Date -Format t) + " " + $(Get-Location) + '> '}
+Set-Item -Path function:prompt -Value {'PS '+ (Get-Date -Format t) + " " + (Get-Location) + '> '}
 ```
 
 ### Example 4: Set options for your prompt function

--- a/reference/5.1/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -55,7 +55,7 @@ different between the files. `Testfile1.txt` is the **reference** object (`<=`) 
 Lines with content that appear in both files aren't displayed.
 
 ```powershell
-Compare-Object -ReferenceObject $(Get-Content -Path C:\Test\Testfile1.txt) -DifferenceObject $(Get-Content -Path C:\Test\Testfile2.txt)
+Compare-Object -ReferenceObject (Get-Content -Path C:\Test\Testfile1.txt) -DifferenceObject (Get-Content -Path C:\Test\Testfile2.txt)
 ```
 
 ```Output
@@ -77,8 +77,8 @@ The **SideIndicator** specifies if the line appears in the `Testfile1.txt` **ref
 
 ```powershell
 $objects = @{
-  ReferenceObject = $(Get-Content -Path C:\Test\Testfile1.txt)
-  DifferenceObject = $(Get-Content -Path C:\Test\Testfile2.txt)
+  ReferenceObject = (Get-Content -Path C:\Test\Testfile1.txt)
+  DifferenceObject = (Get-Content -Path C:\Test\Testfile2.txt)
 }
 Compare-Object @objects -IncludeEqual
 ```
@@ -103,8 +103,8 @@ contained in both files, as shown by the **SideIndicator** (`==`).
 
 ```powershell
 $objects = @{
-  ReferenceObject = $(Get-Content -Path C:\Test\Testfile1.txt)
-  DifferenceObject = $(Get-Content -Path C:\Test\Testfile2.txt)
+  ReferenceObject = (Get-Content -Path C:\Test\Testfile1.txt)
+  DifferenceObject = (Get-Content -Path C:\Test\Testfile2.txt)
 }
 Compare-Object @objects -IncludeEqual -ExcludeDifferent
 ```

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Function_Provider.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Function_Provider.md
@@ -167,7 +167,7 @@ it displays the time before the path.
 
 ```powershell
 Set-Item -Path Function:prompt -Value {
-  'PS '+ $(Get-Date -Format t) + " " + $(Get-Location) + '> '
+  'PS '+ (Get-Date -Format t) + " " + (Get-Location) + '> '
   }
 ```
 

--- a/reference/6/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Item.md
@@ -57,7 +57,7 @@ Set-Item -Path env:UserRole -Value "Administrator"
 This command changes the prompt function so that it displays the time before the path.
 
 ```powershell
-Set-Item -Path function:prompt -Value {'PS '+ $(Get-Date -Format t) + " " + $(Get-Location) + '> '}
+Set-Item -Path function:prompt -Value {'PS '+ (Get-Date -Format t) + " " + (Get-Location) + '> '}
 ```
 
 ### Example 4: Set options for your prompt function

--- a/reference/6/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -55,7 +55,7 @@ different between the files. `Testfile1.txt` is the **reference** object (`<=`) 
 Lines with content that appear in both files aren't displayed.
 
 ```powershell
-Compare-Object -ReferenceObject $(Get-Content -Path C:\Test\Testfile1.txt) -DifferenceObject $(Get-Content -Path C:\Test\Testfile2.txt)
+Compare-Object -ReferenceObject (Get-Content -Path C:\Test\Testfile1.txt) -DifferenceObject (Get-Content -Path C:\Test\Testfile2.txt)
 ```
 
 ```Output
@@ -77,8 +77,8 @@ The **SideIndicator** specifies if the line appears in the `Testfile1.txt` **ref
 
 ```powershell
 $objects = @{
-  ReferenceObject = $(Get-Content -Path C:\Test\Testfile1.txt)
-  DifferenceObject = $(Get-Content -Path C:\Test\Testfile2.txt)
+  ReferenceObject = (Get-Content -Path C:\Test\Testfile1.txt)
+  DifferenceObject = (Get-Content -Path C:\Test\Testfile2.txt)
 }
 Compare-Object @objects -IncludeEqual
 ```
@@ -103,8 +103,8 @@ contained in both files, as shown by the **SideIndicator** (`==`).
 
 ```powershell
 $objects = @{
-  ReferenceObject = $(Get-Content -Path C:\Test\Testfile1.txt)
-  DifferenceObject = $(Get-Content -Path C:\Test\Testfile2.txt)
+  ReferenceObject = (Get-Content -Path C:\Test\Testfile1.txt)
+  DifferenceObject = (Get-Content -Path C:\Test\Testfile2.txt)
 }
 Compare-Object @objects -IncludeEqual -ExcludeDifferent
 ```

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Function_Provider.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Function_Provider.md
@@ -167,7 +167,7 @@ it displays the time before the path.
 
 ```powershell
 Set-Item -Path Function:prompt -Value {
-  'PS '+ $(Get-Date -Format t) + " " + $(Get-Location) + '> '
+  'PS '+ (Get-Date -Format t) + " " + (Get-Location) + '> '
   }
 ```
 

--- a/reference/7/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/7/Microsoft.PowerShell.Management/Set-Item.md
@@ -57,7 +57,7 @@ Set-Item -Path env:UserRole -Value "Administrator"
 This command changes the prompt function so that it displays the time before the path.
 
 ```powershell
-Set-Item -Path function:prompt -Value {'PS '+ $(Get-Date -Format t) + " " + $(Get-Location) + '> '}
+Set-Item -Path function:prompt -Value {'PS '+ (Get-Date -Format t) + " " + (Get-Location) + '> '}
 ```
 
 ### Example 4: Set options for your prompt function

--- a/reference/7/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -55,7 +55,7 @@ different between the files. `Testfile1.txt` is the **reference** object (`<=`) 
 Lines with content that appear in both files aren't displayed.
 
 ```powershell
-Compare-Object -ReferenceObject $(Get-Content -Path C:\Test\Testfile1.txt) -DifferenceObject $(Get-Content -Path C:\Test\Testfile2.txt)
+Compare-Object -ReferenceObject (Get-Content -Path C:\Test\Testfile1.txt) -DifferenceObject (Get-Content -Path C:\Test\Testfile2.txt)
 ```
 
 ```Output
@@ -77,8 +77,8 @@ The **SideIndicator** specifies if the line appears in the `Testfile1.txt` **ref
 
 ```powershell
 $objects = @{
-  ReferenceObject = $(Get-Content -Path C:\Test\Testfile1.txt)
-  DifferenceObject = $(Get-Content -Path C:\Test\Testfile2.txt)
+  ReferenceObject = (Get-Content -Path C:\Test\Testfile1.txt)
+  DifferenceObject = (Get-Content -Path C:\Test\Testfile2.txt)
 }
 Compare-Object @objects -IncludeEqual
 ```
@@ -103,8 +103,8 @@ contained in both files, as shown by the **SideIndicator** (`==`).
 
 ```powershell
 $objects = @{
-  ReferenceObject = $(Get-Content -Path C:\Test\Testfile1.txt)
-  DifferenceObject = $(Get-Content -Path C:\Test\Testfile2.txt)
+  ReferenceObject = (Get-Content -Path C:\Test\Testfile1.txt)
+  DifferenceObject = (Get-Content -Path C:\Test\Testfile2.txt)
 }
 Compare-Object @objects -IncludeEqual -ExcludeDifferent
 ```


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #5031 - remove unnecessary $() example
Fixes [AB#1652216](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1652216)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
