### PR TITLE
Fixes #5186 - qualify ForEach() and Where() syntax

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 06/09/2017
+ms.date: 12/04/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_arrays?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Arrays
@@ -26,27 +26,26 @@ To create and initialize an array, assign multiple values to a variable. The
 values stored in the array are delimited with a comma and separated from the
 variable name by the assignment operator (=).
 
-For example, to create an array named $A that contains the seven numeric (int)
+For example, to create an array named `$A` that contains the seven numeric (int)
 values of 22, 5, 10, 8, 12, 9, and 80, type:
 
 ```powershell
 $A = 22,5,10,8,12,9,80
 ```
 
-You can also create and initialize an array by using the range operator (..).
-For example, to create and initialize an array named "$B" that contains the
-values 5 through 8, type:
+You can also create and initialize an array by using the range operator (`..`).
+The following example creates an array named containing the values 5 through 8.
 
 ```powershell
 $B = 5..8
 ```
 
-As a result, $B contains four values: 5, 6, 7, and 8.
+As a result, `$B` contains four values: 5, 6, 7, and 8.
 
-When no data type is specified, PowerShell creates each array as an
-object array (type: System.Object[]). To determine the data type of an array,
-use the GetType() method. For example, to determine the data type of the $a
-array, type:
+When no data type is specified, PowerShell creates each array as an object
+array (**System.Object[]**). To determine the data type of an array, use the
+GetType() method. For example, to determine the data type of the `$a` array,
+type:
 
 ```powershell
 $a.GetType()
@@ -54,19 +53,20 @@ $a.GetType()
 
 To create a strongly typed array, that is, an array that can contain only
 values of a particular type, cast the variable as an array type, such as
-string[], long[], or int32[]. To cast an array, precede the variable name with
-an array type enclosed in brackets. For example, to create a 32-bit integer
-array named $ia containing four integers (1500, 2230, 3350, and 4000), type:
+**string[]**, **long[]**, or **int32[]**. To cast an array, precede the
+variable name with an array type enclosed in brackets. For example, to create a
+32-bit integer array named `$ia` containing four integers (1500, 2230, 3350,
+and 4000), type:
 
 ```powershell
 [int32[]]$ia = 1500,2230,3350,4000
 ```
 
-As a result, the $ia array can contain only integers.
+As a result, the `$ia` array can contain only integers.
 
 You can create arrays that are cast to any supported type in the Microsoft
-.NET Framework. For example, the objects that Get-Process retrieves to
-represent processes are of the System.Diagnostics.Process type. To create a
+.NET Framework. For example, the objects that `Get-Process` retrieves to
+represent processes are of the **System.Diagnostics.Process** type. To create a
 strongly typed array of process objects, enter the following command:
 
 ```powershell
@@ -88,26 +88,32 @@ You can use the array operator to create an array of zero or one object. For
 example:
 
 ```powershell
-PS> $a = @("Hello World")
-PS> $a.Count
+$a = @("Hello World")
+$a.Count
+```
+
+```Output
 1
 ```
 
 ```powershell
-PS> $b = @()
-PS> $b.Count
+$b = @()
+$b.Count
+```
+
+```Output
 0
 ```
 
-The array operator is particularly useful in scripts when you are getting
-objects, but do not know how many objects you will get. For example:
+The array operator is useful in scripts when you are getting objects, but do
+not know how many objects you get. For example:
 
 ```powershell
 $p = @(Get-Process Notepad)
 ```
 
 For more information about the array sub-expression operator, see
-about_Operators.
+[about_Operators](about_Operators.md).
 
 ## Accessing and using array elements
 
@@ -121,7 +127,7 @@ array containing integers 0, 1, 2, until 9; typing:
 $a
 ```
 
-```output
+```Output
 0
 1
 2
@@ -142,7 +148,7 @@ first element in the `$a` array, type:
 $a[0]
 ```
 
-```output
+```Output
 0
 ```
 
@@ -152,7 +158,7 @@ To display the third element in the `$a` array, type:
 $a[2]
 ```
 
-```output
+```Output
 2
 ```
 
@@ -164,7 +170,7 @@ type:
 $a[1..4]
 ```
 
-```output
+```Output
 1
 2
 3
@@ -180,7 +186,7 @@ $a = 0 .. 9
 $a[-3..-1]
 ```
 
-```output
+```Output
 7
 8
 9
@@ -193,7 +199,7 @@ $a = 0 .. 9
 $a[-1..-3]
 ```
 
-```output
+```Output
 9
 8
 7
@@ -207,7 +213,7 @@ $a = 0 .. 9
 $a[2..-2]
 ```
 
-```output
+```Output
 2
 1
 0
@@ -228,7 +234,7 @@ $a = 0 .. 9
 $a[0,2+4..6]
 ```
 
-```output
+```Output
 0
 2
 4
@@ -245,7 +251,7 @@ $a = 0..9
 $a[+0..2+4..6+8]
 ```
 
-```output
+```Output
 0
 1
 2
@@ -268,7 +274,7 @@ foreach ($element in $a) {
 }
 ```
 
-```output
+```Output
 0
 1
 2
@@ -295,7 +301,7 @@ for ($i = 0; $i -le ($a.length - 1); $i += 2) {
 }
 ```
 
-```output
+```Output
 0
 2
 4
@@ -316,7 +322,7 @@ while($i -lt 4) {
 }
 ```
 
-```output
+```Output
 0
 1
 2
@@ -337,7 +343,7 @@ $a.Count
 $a.Length
 ```
 
-```output
+```Output
 10
 10
 ```
@@ -359,19 +365,19 @@ $a = @(
 "`$a rank: $r"
 ```
 
-```output
+```Output
 $a rank: 1
 ```
 
 Building a truly multidimensional array, in PowerShell, requires the
-assistance of the *.Net Framework*. Like in the following example:
+assistance of the .Net Framework. Like in the following example:
 
 ```powershell
 [int[,]]$rank2 = [int[,]]::new(5,5)
 $rank2.rank
 ```
 
-```output
+```Output
 2
 ```
 
@@ -390,7 +396,7 @@ $a.Clear()
 $a | % { $null -eq $_ }
 ```
 
-```output
+```Output
 True
 True
 True
@@ -404,7 +410,7 @@ $intA.Clear()
 $intA
 ```
 
-```output
+```Output
 0
 0
 0
@@ -419,33 +425,34 @@ The ForEach method has several overloads that perform different operations.
 
 ```
 ForEach(scriptblock expression)
+ForEach(scriptblock expression, object[] arguments)
 ForEach(type convertToType)
 ForEach(string propertyName)
 ForEach(string propertyName, object[] newValue)
 ForEach(string methodName)
 ForEach(string methodName, object[] arguments)
-ForEach(scriptblock expression, object[] arguments)
 ```
 
 #### ForEach(scriptblock expression)
 
 #### ForEach(scriptblock expression, object[] arguments)
 
+This method was added in PowerShell v4.
+
 > [!NOTE]
-> The syntax requires the usage of a script block. Parentheses are optional.
+> The syntax requires the usage of a script block. Parentheses are optional if
+> the scriptblock is the only parameter. Also, there must not be a space
+> between the method and the opening parentheses or brace.
 
 The following example shows how use the foreach method. In this case the
 intent is to generate the square value of the elements in the array.
-
-Please note this method was added in PowerShell v4 and is not available in versions below this.
-For prior versions please use the Pipelining method to the ForEach-Object Cmdlet
 
 ```powershell
 $a = @(0 .. 3)
 $a.ForEach({ $_ * $_})
 ```
 
-```output
+```Output
 0
 1
 4
@@ -466,7 +473,7 @@ type; the following example shows how to convert a list of string dates to
 @("1/1/2017", "2/1/2017", "3/1/2017").ForEach([datetime])
 ```
 
-```output
+```Output
 
 Sunday, January 1, 2017 12:00:00 AM
 Wednesday, February 1, 2017 12:00:00 AM
@@ -487,7 +494,7 @@ values for every item in the collection.
 (dir 'C:\Temp').ForEach('LastAccessTime') | Get-Unique
 ```
 
-```output
+```Output
 Wednesday, June 20, 2018 9:21:57 AM
 ```
 
@@ -502,7 +509,7 @@ the collection.
 ("one", "two", "three").ForEach("ToUpper")
 ```
 
-```output
+```Output
 ONE
 TWO
 THREE
@@ -531,13 +538,15 @@ Where(scriptblock expression[, WhereOperatorSelectionMode mode
                             [, int numberToReturn]])
 ```
 
+> [!NOTE]
+> The syntax requires the usage of a script block. Parentheses are optional if
+> the scriptblock is the only parameter. Also, there must not be a space
+> between the method and the opening parentheses or brace.
+
 The `Expression` is scriptblock that is required for filtering, the `mode`
 optional argument allows additional selection capabilities, and the
 `numberToReturn` optional argument allows the ability to limit how many items
 are returned from the filter.
-
-> [!NOTE]
-> The syntax requires the usage of a script block. Parentheses are optional.
 
 The following example shows how to select all odd numbers from the array.
 
@@ -545,7 +554,7 @@ The following example shows how to select all odd numbers from the array.
 (0..9).Where{ $_ % 2 }
 ```
 
-```output
+```Output
 1
 3
 5
@@ -553,7 +562,17 @@ The following example shows how to select all odd numbers from the array.
 9
 ```
 
-The following selection modes are available.
+The acceptable values for `mode` are:
+
+- Default (0) - Return all items
+- First (1) - Return the first item
+- Last (2) - Return the last item
+- SkipUntil (3) - Skip items until condition is true, the return the remaining
+  items
+- Until (4) - Return all items until condition is true
+- Split (5) - Return an array of two elements
+  - The first element contains matching items
+  - The second element contains the remaining items
 
 #### Default
 
@@ -586,10 +605,10 @@ $logs.Where({$_.CreationTime -gt $h}, 'Last', 5)
 
 The `SkipUntil` mode skips all objects in a collection until an object passes
 the script block expression filter. It then returns **ALL** remaining collection
-items without testing them. *Only one passing item is tested*
+items without testing them. _Only one passing item is tested_.
 
-This means the returned collection will contain both *passing* and
-*non-passing* items that have NOT been tested.
+This means the returned collection contains both _passing_ and
+_non-passing_ items that have NOT been tested.
 
 The number of items returned can be limited by passing a value to the
 `numberToReturn` argument.
@@ -600,7 +619,7 @@ $computers = "Server01", "Server02", "Server03", "localhost", "Server04"
 $computers.Where({ Test-Connection $_ }, 'SkipUntil', 1)
 ```
 
-```output
+```Output
 localhost
 ```
 
@@ -608,11 +627,10 @@ localhost
 
 The `Until` mode inverts the `SkipUntil` mode.  It returns **ALL** items in a
 collection until an item passes the script block expression. Once an item
-*passes* the scriptblock expression, the `Where` method stops processing items.
+_passes_ the scriptblock expression, the `Where` method stops processing items.
 
-This means that you will receive the first set of *non-passing* items from the
-`Where` method. *After* one item passes, the rest will NOT be tested nor
-returned.
+This means that you receive the first set of _non-passing_ items from the
+`Where` method. _After_ one item passes, the rest are NOT tested or returned.
 
 The number of items returned can be limited by passing a value to the
 `numberToReturn` argument.
@@ -624,7 +642,7 @@ The number of items returned can be limited by passing a value to the
 (1..50).Where({$_ -le 10})
 ```
 
-```output
+```Output
 1
 2
 3
@@ -641,9 +659,9 @@ The number of items returned can be limited by passing a value to the
 > Both `Until` and `SkipUntil` operate under the premise of NOT testing a batch
 > of items.
 >
-> `Until` returns the items **BEFORE** the first *pass*.
+> `Until` returns the items **BEFORE** the first _pass_.
 >
-> `SkipUntil` returns all the items **AFTER** the first *pass*, including the
+> `SkipUntil` returns all the items **AFTER** the first _pass_, including the
 > first passing item.
 
 #### Split
@@ -651,10 +669,10 @@ The number of items returned can be limited by passing a value to the
 The `Split` mode splits, or groups collection items into two separate
 collections. Those that pass the scriptblock expression, and those that do not.
 
-If a `numberToReturn` is specified, the first collection, will contain the
-*passing* items, not to exceed the value specified.
+If a `numberToReturn` is specified, the first collection, contains the
+_passing_ items, not to exceed the value specified.
 
-The remaining objects, even those that **PASS** the expression filter, will be
+The remaining objects, even those that **PASS** the expression filter, are
 returned in the second collection.
 
 ```powershell
@@ -662,7 +680,7 @@ $running, $stopped = (Get-Service).Where({$_.Status -eq 'Running'}, 'Split')
 $running
 ```
 
-```output
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Running  Appinfo            Application Information
@@ -675,7 +693,7 @@ Running  Audiosrv           Windows Audio
 $stopped
 ```
 
-```output
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Stopped  AJRouter           AllJoyn Router Service
@@ -687,13 +705,14 @@ Stopped  AppIDSvc           Application Identity
 ## Get the members of an array
 
 To get the properties and methods of an array, such as the Length property and
-the SetValue method, use the InputObject parameter of the Get-Member cmdlet.
+the **SetValue** method, use the **InputObject** parameter of the `Get-Member`
+cmdlet.
 
 When you pipe an array to `Get-Member`, PowerShell sends the items one
 at a time and `Get-Member` returns the type of each item in the array (ignoring
 duplicates).
 
-When you use the *-InputObject* parameter, `Get-Member` returns the members of
+When you use the **InputObject** parameter, `Get-Member` returns the members of
 the array.
 
 For example, the following command gets the members of the `$a` array
@@ -704,9 +723,9 @@ Get-Member -InputObject $a
 ```
 
 You can also get the members of an array by typing a comma (,) before the
-value that is piped to the Get-Member cmdlet. The comma makes the array the
-second item in an array of arrays. Windows PowerShell pipes the arrays one at
-a time and Get-Member returns the members of the array. Like the next two
+value that is piped to the `Get-Member` cmdlet. The comma makes the array the
+second item in an array of arrays. PowerShell pipes the arrays one at
+a time and `Get-Member` returns the members of the array. Like the next two
 examples.
 
 ```powershell
@@ -773,7 +792,7 @@ $z = $x + $y
 
 As a result, the `$z` array contains 1, 3, 5, and 9.
 
-To delete an array, assign a value of $null to the array. The following
+To delete an array, assign a value of `$null` to the array. The following
 command deletes the array in the `$a` variable.
 
 `$a = $null`
@@ -798,7 +817,7 @@ $a.Count
 $a.Length
 ```
 
-```output
+```Output
 0
 0
 ```
@@ -813,7 +832,7 @@ $a[0]
 $a[-1]
 ```
 
-```output
+```Output
 1
 1
 4

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -34,7 +34,7 @@ $A = 22,5,10,8,12,9,80
 ```
 
 You can also create and initialize an array by using the range operator (`..`).
-The following example creates an array named containing the values 5 through 8.
+The following example creates an array containing the values 5 through 8.
 
 ```powershell
 $B = 5..8
@@ -44,8 +44,8 @@ As a result, `$B` contains four values: 5, 6, 7, and 8.
 
 When no data type is specified, PowerShell creates each array as an object
 array (**System.Object[]**). To determine the data type of an array, use the
-GetType() method. For example, to determine the data type of the `$a` array,
-type:
+**GetType()** method. For example, to determine the data type of the `$A`
+array, type:
 
 ```powershell
 $a.GetType()
@@ -369,8 +369,8 @@ $a = @(
 $a rank: 1
 ```
 
-Building a truly multidimensional array, in PowerShell, requires the
-assistance of the .Net Framework. Like in the following example:
+The following example shows how to create a truly multidimensional array using
+the .Net Framework.
 
 ```powershell
 [int[,]]$rank2 = [int[,]]::new(5,5)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -34,7 +34,7 @@ $A = 22,5,10,8,12,9,80
 ```
 
 You can also create and initialize an array by using the range operator (`..`).
-The following example creates an array named containing the values 5 through 8.
+The following example creates an array containing the values 5 through 8.
 
 ```powershell
 $B = 5..8
@@ -44,8 +44,8 @@ As a result, `$B` contains four values: 5, 6, 7, and 8.
 
 When no data type is specified, PowerShell creates each array as an object
 array (**System.Object[]**). To determine the data type of an array, use the
-GetType() method. For example, to determine the data type of the `$a` array,
-type:
+**GetType()** method. For example, to determine the data type of the `$A`
+array, type:
 
 ```powershell
 $a.GetType()
@@ -369,8 +369,8 @@ $a = @(
 $a rank: 1
 ```
 
-Building a truly multidimensional array, in PowerShell, requires the
-assistance of the .Net Framework. Like in the following example:
+The following example shows how to create a truly multidimensional array using
+the .Net Framework.
 
 ```powershell
 [int[,]]$rank2 = [int[,]]::new(5,5)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 06/09/2017
+ms.date: 12/04/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_arrays?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Arrays
@@ -26,27 +26,26 @@ To create and initialize an array, assign multiple values to a variable. The
 values stored in the array are delimited with a comma and separated from the
 variable name by the assignment operator (=).
 
-For example, to create an array named $A that contains the seven numeric (int)
+For example, to create an array named `$A` that contains the seven numeric (int)
 values of 22, 5, 10, 8, 12, 9, and 80, type:
 
 ```powershell
 $A = 22,5,10,8,12,9,80
 ```
 
-You can also create and initialize an array by using the range operator (..).
-For example, to create and initialize an array named "$B" that contains the
-values 5 through 8, type:
+You can also create and initialize an array by using the range operator (`..`).
+The following example creates an array named containing the values 5 through 8.
 
 ```powershell
 $B = 5..8
 ```
 
-As a result, $B contains four values: 5, 6, 7, and 8.
+As a result, `$B` contains four values: 5, 6, 7, and 8.
 
-When no data type is specified, PowerShell creates each array as an
-object array (type: System.Object[]). To determine the data type of an array,
-use the GetType() method. For example, to determine the data type of the $a
-array, type:
+When no data type is specified, PowerShell creates each array as an object
+array (**System.Object[]**). To determine the data type of an array, use the
+GetType() method. For example, to determine the data type of the `$a` array,
+type:
 
 ```powershell
 $a.GetType()
@@ -54,19 +53,20 @@ $a.GetType()
 
 To create a strongly typed array, that is, an array that can contain only
 values of a particular type, cast the variable as an array type, such as
-string[], long[], or int32[]. To cast an array, precede the variable name with
-an array type enclosed in brackets. For example, to create a 32-bit integer
-array named $ia containing four integers (1500, 2230, 3350, and 4000), type:
+**string[]**, **long[]**, or **int32[]**. To cast an array, precede the
+variable name with an array type enclosed in brackets. For example, to create a
+32-bit integer array named `$ia` containing four integers (1500, 2230, 3350,
+and 4000), type:
 
 ```powershell
 [int32[]]$ia = 1500,2230,3350,4000
 ```
 
-As a result, the $ia array can contain only integers.
+As a result, the `$ia` array can contain only integers.
 
 You can create arrays that are cast to any supported type in the Microsoft
-.NET Framework. For example, the objects that Get-Process retrieves to
-represent processes are of the System.Diagnostics.Process type. To create a
+.NET Framework. For example, the objects that `Get-Process` retrieves to
+represent processes are of the **System.Diagnostics.Process** type. To create a
 strongly typed array of process objects, enter the following command:
 
 ```powershell
@@ -105,15 +105,15 @@ $b.Count
 0
 ```
 
-The array operator is particularly useful in scripts when you are getting
-objects, but do not know how many objects you will get. For example:
+The array operator is useful in scripts when you are getting objects, but do
+not know how many objects you get. For example:
 
 ```powershell
 $p = @(Get-Process Notepad)
 ```
 
 For more information about the array sub-expression operator, see
-about_Operators.
+[about_Operators](about_Operators.md).
 
 ## Accessing and using array elements
 
@@ -127,7 +127,7 @@ array containing integers 0, 1, 2, until 9; typing:
 $a
 ```
 
-```output
+```Output
 0
 1
 2
@@ -148,7 +148,7 @@ first element in the `$a` array, type:
 $a[0]
 ```
 
-```output
+```Output
 0
 ```
 
@@ -158,7 +158,7 @@ To display the third element in the `$a` array, type:
 $a[2]
 ```
 
-```output
+```Output
 2
 ```
 
@@ -170,7 +170,7 @@ type:
 $a[1..4]
 ```
 
-```output
+```Output
 1
 2
 3
@@ -186,7 +186,7 @@ $a = 0 .. 9
 $a[-3..-1]
 ```
 
-```output
+```Output
 7
 8
 9
@@ -199,7 +199,7 @@ $a = 0 .. 9
 $a[-1..-3]
 ```
 
-```output
+```Output
 9
 8
 7
@@ -213,7 +213,7 @@ $a = 0 .. 9
 $a[2..-2]
 ```
 
-```output
+```Output
 2
 1
 0
@@ -234,7 +234,7 @@ $a = 0 .. 9
 $a[0,2+4..6]
 ```
 
-```output
+```Output
 0
 2
 4
@@ -251,7 +251,7 @@ $a = 0..9
 $a[+0..2+4..6+8]
 ```
 
-```output
+```Output
 0
 1
 2
@@ -274,7 +274,7 @@ foreach ($element in $a) {
 }
 ```
 
-```output
+```Output
 0
 1
 2
@@ -301,7 +301,7 @@ for ($i = 0; $i -le ($a.length - 1); $i += 2) {
 }
 ```
 
-```output
+```Output
 0
 2
 4
@@ -322,7 +322,7 @@ while($i -lt 4) {
 }
 ```
 
-```output
+```Output
 0
 1
 2
@@ -343,7 +343,7 @@ $a.Count
 $a.Length
 ```
 
-```output
+```Output
 10
 10
 ```
@@ -365,19 +365,19 @@ $a = @(
 "`$a rank: $r"
 ```
 
-```output
+```Output
 $a rank: 1
 ```
 
 Building a truly multidimensional array, in PowerShell, requires the
-assistance of the *.Net Framework*. Like in the following example:
+assistance of the .Net Framework. Like in the following example:
 
 ```powershell
 [int[,]]$rank2 = [int[,]]::new(5,5)
 $rank2.rank
 ```
 
-```output
+```Output
 2
 ```
 
@@ -396,7 +396,7 @@ $a.Clear()
 $a | % { $null -eq $_ }
 ```
 
-```output
+```Output
 True
 True
 True
@@ -410,7 +410,7 @@ $intA.Clear()
 $intA
 ```
 
-```output
+```Output
 0
 0
 0
@@ -425,33 +425,34 @@ The ForEach method has several overloads that perform different operations.
 
 ```
 ForEach(scriptblock expression)
+ForEach(scriptblock expression, object[] arguments)
 ForEach(type convertToType)
 ForEach(string propertyName)
 ForEach(string propertyName, object[] newValue)
 ForEach(string methodName)
 ForEach(string methodName, object[] arguments)
-ForEach(scriptblock expression, object[] arguments)
 ```
 
 #### ForEach(scriptblock expression)
 
 #### ForEach(scriptblock expression, object[] arguments)
 
+This method was added in PowerShell v4.
+
 > [!NOTE]
-> The syntax requires the usage of a script block. Parentheses are optional.
+> The syntax requires the usage of a script block. Parentheses are optional if
+> the scriptblock is the only parameter. Also, there must not be a space
+> between the method and the opening parentheses or brace.
 
 The following example shows how use the foreach method. In this case the
 intent is to generate the square value of the elements in the array.
-
-Please note this method was added in PowerShell v4 and is not available in versions below this.
-For prior versions please use the Pipelining method to the ForEach-Object Cmdlet
 
 ```powershell
 $a = @(0 .. 3)
 $a.ForEach({ $_ * $_})
 ```
 
-```output
+```Output
 0
 1
 4
@@ -472,7 +473,7 @@ type; the following example shows how to convert a list of string dates to
 @("1/1/2017", "2/1/2017", "3/1/2017").ForEach([datetime])
 ```
 
-```output
+```Output
 
 Sunday, January 1, 2017 12:00:00 AM
 Wednesday, February 1, 2017 12:00:00 AM
@@ -493,7 +494,7 @@ values for every item in the collection.
 (dir 'C:\Temp').ForEach('LastAccessTime') | Get-Unique
 ```
 
-```output
+```Output
 Wednesday, June 20, 2018 9:21:57 AM
 ```
 
@@ -508,7 +509,7 @@ the collection.
 ("one", "two", "three").ForEach("ToUpper")
 ```
 
-```output
+```Output
 ONE
 TWO
 THREE
@@ -537,13 +538,15 @@ Where(scriptblock expression[, WhereOperatorSelectionMode mode
                             [, int numberToReturn]])
 ```
 
+> [!NOTE]
+> The syntax requires the usage of a script block. Parentheses are optional if
+> the scriptblock is the only parameter. Also, there must not be a space
+> between the method and the opening parentheses or brace.
+
 The `Expression` is scriptblock that is required for filtering, the `mode`
 optional argument allows additional selection capabilities, and the
 `numberToReturn` optional argument allows the ability to limit how many items
 are returned from the filter.
-
-> [!NOTE]
-> The syntax requires the usage of a script block. Parentheses are optional.
 
 The following example shows how to select all odd numbers from the array.
 
@@ -551,7 +554,7 @@ The following example shows how to select all odd numbers from the array.
 (0..9).Where{ $_ % 2 }
 ```
 
-```output
+```Output
 1
 3
 5
@@ -559,7 +562,17 @@ The following example shows how to select all odd numbers from the array.
 9
 ```
 
-The following selection modes are available.
+The acceptable values for `mode` are:
+
+- Default (0) - Return all items
+- First (1) - Return the first item
+- Last (2) - Return the last item
+- SkipUntil (3) - Skip items until condition is true, the return the remaining
+  items
+- Until (4) - Return all items until condition is true
+- Split (5) - Return an array of two elements
+  - The first element contains matching items
+  - The second element contains the remaining items
 
 #### Default
 
@@ -592,10 +605,10 @@ $logs.Where({$_.CreationTime -gt $h}, 'Last', 5)
 
 The `SkipUntil` mode skips all objects in a collection until an object passes
 the script block expression filter. It then returns **ALL** remaining collection
-items without testing them. *Only one passing item is tested*
+items without testing them. _Only one passing item is tested_.
 
-This means the returned collection will contain both *passing* and
-*non-passing* items that have NOT been tested.
+This means the returned collection contains both _passing_ and
+_non-passing_ items that have NOT been tested.
 
 The number of items returned can be limited by passing a value to the
 `numberToReturn` argument.
@@ -606,7 +619,7 @@ $computers = "Server01", "Server02", "Server03", "localhost", "Server04"
 $computers.Where({ Test-Connection $_ }, 'SkipUntil', 1)
 ```
 
-```output
+```Output
 localhost
 ```
 
@@ -614,11 +627,10 @@ localhost
 
 The `Until` mode inverts the `SkipUntil` mode.  It returns **ALL** items in a
 collection until an item passes the script block expression. Once an item
-*passes* the scriptblock expression, the `Where` method stops processing items.
+_passes_ the scriptblock expression, the `Where` method stops processing items.
 
-This means that you will receive the first set of *non-passing* items from the
-`Where` method. *After* one item passes, the rest will NOT be tested nor
-returned.
+This means that you receive the first set of _non-passing_ items from the
+`Where` method. _After_ one item passes, the rest are NOT tested or returned.
 
 The number of items returned can be limited by passing a value to the
 `numberToReturn` argument.
@@ -630,7 +642,7 @@ The number of items returned can be limited by passing a value to the
 (1..50).Where({$_ -le 10})
 ```
 
-```output
+```Output
 1
 2
 3
@@ -647,9 +659,9 @@ The number of items returned can be limited by passing a value to the
 > Both `Until` and `SkipUntil` operate under the premise of NOT testing a batch
 > of items.
 >
-> `Until` returns the items **BEFORE** the first *pass*.
+> `Until` returns the items **BEFORE** the first _pass_.
 >
-> `SkipUntil` returns all the items **AFTER** the first *pass*, including the
+> `SkipUntil` returns all the items **AFTER** the first _pass_, including the
 > first passing item.
 
 #### Split
@@ -657,10 +669,10 @@ The number of items returned can be limited by passing a value to the
 The `Split` mode splits, or groups collection items into two separate
 collections. Those that pass the scriptblock expression, and those that do not.
 
-If a `numberToReturn` is specified, the first collection, will contain the
-*passing* items, not to exceed the value specified.
+If a `numberToReturn` is specified, the first collection, contains the
+_passing_ items, not to exceed the value specified.
 
-The remaining objects, even those that **PASS** the expression filter, will be
+The remaining objects, even those that **PASS** the expression filter, are
 returned in the second collection.
 
 ```powershell
@@ -668,7 +680,7 @@ $running, $stopped = (Get-Service).Where({$_.Status -eq 'Running'}, 'Split')
 $running
 ```
 
-```output
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Running  Appinfo            Application Information
@@ -681,7 +693,7 @@ Running  Audiosrv           Windows Audio
 $stopped
 ```
 
-```output
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Stopped  AJRouter           AllJoyn Router Service
@@ -693,13 +705,14 @@ Stopped  AppIDSvc           Application Identity
 ## Get the members of an array
 
 To get the properties and methods of an array, such as the Length property and
-the SetValue method, use the InputObject parameter of the Get-Member cmdlet.
+the **SetValue** method, use the **InputObject** parameter of the `Get-Member`
+cmdlet.
 
 When you pipe an array to `Get-Member`, PowerShell sends the items one
 at a time and `Get-Member` returns the type of each item in the array (ignoring
 duplicates).
 
-When you use the *-InputObject* parameter, `Get-Member` returns the members of
+When you use the **InputObject** parameter, `Get-Member` returns the members of
 the array.
 
 For example, the following command gets the members of the `$a` array
@@ -710,9 +723,9 @@ Get-Member -InputObject $a
 ```
 
 You can also get the members of an array by typing a comma (,) before the
-value that is piped to the Get-Member cmdlet. The comma makes the array the
+value that is piped to the `Get-Member` cmdlet. The comma makes the array the
 second item in an array of arrays. PowerShell pipes the arrays one at
-a time and Get-Member returns the members of the array. Like the next two
+a time and `Get-Member` returns the members of the array. Like the next two
 examples.
 
 ```powershell
@@ -779,7 +792,7 @@ $z = $x + $y
 
 As a result, the `$z` array contains 1, 3, 5, and 9.
 
-To delete an array, assign a value of $null to the array. The following
+To delete an array, assign a value of `$null` to the array. The following
 command deletes the array in the `$a` variable.
 
 `$a = $null`
@@ -804,7 +817,7 @@ $a.Count
 $a.Length
 ```
 
-```output
+```Output
 0
 0
 ```
@@ -819,7 +832,7 @@ $a[0]
 $a[-1]
 ```
 
-```output
+```Output
 1
 1
 4

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 06/09/2017
+ms.date: 12/04/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_arrays?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Arrays
@@ -26,27 +26,26 @@ To create and initialize an array, assign multiple values to a variable. The
 values stored in the array are delimited with a comma and separated from the
 variable name by the assignment operator (=).
 
-For example, to create an array named $A that contains the seven numeric (int)
+For example, to create an array named `$A` that contains the seven numeric (int)
 values of 22, 5, 10, 8, 12, 9, and 80, type:
 
 ```powershell
 $A = 22,5,10,8,12,9,80
 ```
 
-You can also create and initialize an array by using the range operator (..).
-For example, to create and initialize an array named "$B" that contains the
-values 5 through 8, type:
+You can also create and initialize an array by using the range operator (`..`).
+The following example creates an array named containing the values 5 through 8.
 
 ```powershell
 $B = 5..8
 ```
 
-As a result, $B contains four values: 5, 6, 7, and 8.
+As a result, `$B` contains four values: 5, 6, 7, and 8.
 
-When no data type is specified, PowerShell creates each array as an
-object array (type: System.Object[]). To determine the data type of an array,
-use the GetType() method. For example, to determine the data type of the $a
-array, type:
+When no data type is specified, PowerShell creates each array as an object
+array (**System.Object[]**). To determine the data type of an array, use the
+GetType() method. For example, to determine the data type of the `$a` array,
+type:
 
 ```powershell
 $a.GetType()
@@ -54,19 +53,20 @@ $a.GetType()
 
 To create a strongly typed array, that is, an array that can contain only
 values of a particular type, cast the variable as an array type, such as
-string[], long[], or int32[]. To cast an array, precede the variable name with
-an array type enclosed in brackets. For example, to create a 32-bit integer
-array named $ia containing four integers (1500, 2230, 3350, and 4000), type:
+**string[]**, **long[]**, or **int32[]**. To cast an array, precede the
+variable name with an array type enclosed in brackets. For example, to create a
+32-bit integer array named `$ia` containing four integers (1500, 2230, 3350,
+and 4000), type:
 
 ```powershell
 [int32[]]$ia = 1500,2230,3350,4000
 ```
 
-As a result, the $ia array can contain only integers.
+As a result, the `$ia` array can contain only integers.
 
 You can create arrays that are cast to any supported type in the Microsoft
-.NET Framework. For example, the objects that Get-Process retrieves to
-represent processes are of the System.Diagnostics.Process type. To create a
+.NET Framework. For example, the objects that `Get-Process` retrieves to
+represent processes are of the **System.Diagnostics.Process** type. To create a
 strongly typed array of process objects, enter the following command:
 
 ```powershell
@@ -105,15 +105,15 @@ $b.Count
 0
 ```
 
-The array operator is particularly useful in scripts when you are getting
-objects, but do not know how many objects you will get. For example:
+The array operator is useful in scripts when you are getting objects, but do
+not know how many objects you get. For example:
 
 ```powershell
 $p = @(Get-Process Notepad)
 ```
 
 For more information about the array sub-expression operator, see
-about_Operators.
+[about_Operators](about_Operators.md).
 
 ## Accessing and using array elements
 
@@ -127,7 +127,7 @@ array containing integers 0, 1, 2, until 9; typing:
 $a
 ```
 
-```output
+```Output
 0
 1
 2
@@ -148,7 +148,7 @@ first element in the `$a` array, type:
 $a[0]
 ```
 
-```output
+```Output
 0
 ```
 
@@ -158,7 +158,7 @@ To display the third element in the `$a` array, type:
 $a[2]
 ```
 
-```output
+```Output
 2
 ```
 
@@ -170,7 +170,7 @@ type:
 $a[1..4]
 ```
 
-```output
+```Output
 1
 2
 3
@@ -186,7 +186,7 @@ $a = 0 .. 9
 $a[-3..-1]
 ```
 
-```output
+```Output
 7
 8
 9
@@ -199,7 +199,7 @@ $a = 0 .. 9
 $a[-1..-3]
 ```
 
-```output
+```Output
 9
 8
 7
@@ -213,7 +213,7 @@ $a = 0 .. 9
 $a[2..-2]
 ```
 
-```output
+```Output
 2
 1
 0
@@ -234,7 +234,7 @@ $a = 0 .. 9
 $a[0,2+4..6]
 ```
 
-```output
+```Output
 0
 2
 4
@@ -251,7 +251,7 @@ $a = 0..9
 $a[+0..2+4..6+8]
 ```
 
-```output
+```Output
 0
 1
 2
@@ -274,7 +274,7 @@ foreach ($element in $a) {
 }
 ```
 
-```output
+```Output
 0
 1
 2
@@ -301,7 +301,7 @@ for ($i = 0; $i -le ($a.length - 1); $i += 2) {
 }
 ```
 
-```output
+```Output
 0
 2
 4
@@ -322,7 +322,7 @@ while($i -lt 4) {
 }
 ```
 
-```output
+```Output
 0
 1
 2
@@ -343,7 +343,7 @@ $a.Count
 $a.Length
 ```
 
-```output
+```Output
 10
 10
 ```
@@ -365,19 +365,19 @@ $a = @(
 "`$a rank: $r"
 ```
 
-```output
+```Output
 $a rank: 1
 ```
 
 Building a truly multidimensional array, in PowerShell, requires the
-assistance of the *.Net Framework*. Like in the following example:
+assistance of the .Net Framework. Like in the following example:
 
 ```powershell
 [int[,]]$rank2 = [int[,]]::new(5,5)
 $rank2.rank
 ```
 
-```output
+```Output
 2
 ```
 
@@ -396,7 +396,7 @@ $a.Clear()
 $a | % { $null -eq $_ }
 ```
 
-```output
+```Output
 True
 True
 True
@@ -410,7 +410,7 @@ $intA.Clear()
 $intA
 ```
 
-```output
+```Output
 0
 0
 0
@@ -425,33 +425,34 @@ The ForEach method has several overloads that perform different operations.
 
 ```
 ForEach(scriptblock expression)
+ForEach(scriptblock expression, object[] arguments)
 ForEach(type convertToType)
 ForEach(string propertyName)
 ForEach(string propertyName, object[] newValue)
 ForEach(string methodName)
 ForEach(string methodName, object[] arguments)
-ForEach(scriptblock expression, object[] arguments)
 ```
 
 #### ForEach(scriptblock expression)
 
 #### ForEach(scriptblock expression, object[] arguments)
 
+This method was added in PowerShell v4.
+
 > [!NOTE]
-> The syntax requires the usage of a script block. Parentheses are optional.
+> The syntax requires the usage of a script block. Parentheses are optional if
+> the scriptblock is the only parameter. Also, there must not be a space
+> between the method and the opening parentheses or brace.
 
 The following example shows how use the foreach method. In this case the
 intent is to generate the square value of the elements in the array.
-
-Please note this method was added in PowerShell v4 and is not available in versions below this.
-For prior versions please use the Pipelining method to the ForEach-Object Cmdlet
 
 ```powershell
 $a = @(0 .. 3)
 $a.ForEach({ $_ * $_})
 ```
 
-```output
+```Output
 0
 1
 4
@@ -472,7 +473,7 @@ type; the following example shows how to convert a list of string dates to
 @("1/1/2017", "2/1/2017", "3/1/2017").ForEach([datetime])
 ```
 
-```output
+```Output
 
 Sunday, January 1, 2017 12:00:00 AM
 Wednesday, February 1, 2017 12:00:00 AM
@@ -493,7 +494,7 @@ values for every item in the collection.
 (dir 'C:\Temp').ForEach('LastAccessTime') | Get-Unique
 ```
 
-```output
+```Output
 Wednesday, June 20, 2018 9:21:57 AM
 ```
 
@@ -508,7 +509,7 @@ the collection.
 ("one", "two", "three").ForEach("ToUpper")
 ```
 
-```output
+```Output
 ONE
 TWO
 THREE
@@ -537,13 +538,15 @@ Where(scriptblock expression[, WhereOperatorSelectionMode mode
                             [, int numberToReturn]])
 ```
 
+> [!NOTE]
+> The syntax requires the usage of a script block. Parentheses are optional if
+> the scriptblock is the only parameter. Also, there must not be a space
+> between the method and the opening parentheses or brace.
+
 The `Expression` is scriptblock that is required for filtering, the `mode`
 optional argument allows additional selection capabilities, and the
 `numberToReturn` optional argument allows the ability to limit how many items
 are returned from the filter.
-
-> [!NOTE]
-> The syntax requires the usage of a script block. Parentheses are optional.
 
 The following example shows how to select all odd numbers from the array.
 
@@ -551,7 +554,7 @@ The following example shows how to select all odd numbers from the array.
 (0..9).Where{ $_ % 2 }
 ```
 
-```output
+```Output
 1
 3
 5
@@ -559,7 +562,17 @@ The following example shows how to select all odd numbers from the array.
 9
 ```
 
-The following selection modes are available.
+The acceptable values for `mode` are:
+
+- Default (0) - Return all items
+- First (1) - Return the first item
+- Last (2) - Return the last item
+- SkipUntil (3) - Skip items until condition is true, the return the remaining
+  items
+- Until (4) - Return all items until condition is true
+- Split (5) - Return an array of two elements
+  - The first element contains matching items
+  - The second element contains the remaining items
 
 #### Default
 
@@ -592,10 +605,10 @@ $logs.Where({$_.CreationTime -gt $h}, 'Last', 5)
 
 The `SkipUntil` mode skips all objects in a collection until an object passes
 the script block expression filter. It then returns **ALL** remaining collection
-items without testing them. *Only one passing item is tested*
+items without testing them. _Only one passing item is tested_.
 
-This means the returned collection will contain both *passing* and
-*non-passing* items that have NOT been tested.
+This means the returned collection contains both _passing_ and
+_non-passing_ items that have NOT been tested.
 
 The number of items returned can be limited by passing a value to the
 `numberToReturn` argument.
@@ -606,7 +619,7 @@ $computers = "Server01", "Server02", "Server03", "localhost", "Server04"
 $computers.Where({ Test-Connection $_ }, 'SkipUntil', 1)
 ```
 
-```output
+```Output
 localhost
 ```
 
@@ -614,11 +627,10 @@ localhost
 
 The `Until` mode inverts the `SkipUntil` mode.  It returns **ALL** items in a
 collection until an item passes the script block expression. Once an item
-*passes* the scriptblock expression, the `Where` method stops processing items.
+_passes_ the scriptblock expression, the `Where` method stops processing items.
 
-This means that you will receive the first set of *non-passing* items from the
-`Where` method. *After* one item passes, the rest will NOT be tested nor
-returned.
+This means that you receive the first set of _non-passing_ items from the
+`Where` method. _After_ one item passes, the rest are NOT tested or returned.
 
 The number of items returned can be limited by passing a value to the
 `numberToReturn` argument.
@@ -630,7 +642,7 @@ The number of items returned can be limited by passing a value to the
 (1..50).Where({$_ -le 10})
 ```
 
-```output
+```Output
 1
 2
 3
@@ -647,9 +659,9 @@ The number of items returned can be limited by passing a value to the
 > Both `Until` and `SkipUntil` operate under the premise of NOT testing a batch
 > of items.
 >
-> `Until` returns the items **BEFORE** the first *pass*.
+> `Until` returns the items **BEFORE** the first _pass_.
 >
-> `SkipUntil` returns all the items **AFTER** the first *pass*, including the
+> `SkipUntil` returns all the items **AFTER** the first _pass_, including the
 > first passing item.
 
 #### Split
@@ -657,10 +669,10 @@ The number of items returned can be limited by passing a value to the
 The `Split` mode splits, or groups collection items into two separate
 collections. Those that pass the scriptblock expression, and those that do not.
 
-If a `numberToReturn` is specified, the first collection, will contain the
-*passing* items, not to exceed the value specified.
+If a `numberToReturn` is specified, the first collection, contains the
+_passing_ items, not to exceed the value specified.
 
-The remaining objects, even those that **PASS** the expression filter, will be
+The remaining objects, even those that **PASS** the expression filter, are
 returned in the second collection.
 
 ```powershell
@@ -668,7 +680,7 @@ $running, $stopped = (Get-Service).Where({$_.Status -eq 'Running'}, 'Split')
 $running
 ```
 
-```output
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Running  Appinfo            Application Information
@@ -681,7 +693,7 @@ Running  Audiosrv           Windows Audio
 $stopped
 ```
 
-```output
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Stopped  AJRouter           AllJoyn Router Service
@@ -693,13 +705,14 @@ Stopped  AppIDSvc           Application Identity
 ## Get the members of an array
 
 To get the properties and methods of an array, such as the Length property and
-the SetValue method, use the InputObject parameter of the Get-Member cmdlet.
+the **SetValue** method, use the **InputObject** parameter of the `Get-Member`
+cmdlet.
 
 When you pipe an array to `Get-Member`, PowerShell sends the items one
 at a time and `Get-Member` returns the type of each item in the array (ignoring
 duplicates).
 
-When you use the *-InputObject* parameter, `Get-Member` returns the members of
+When you use the **InputObject** parameter, `Get-Member` returns the members of
 the array.
 
 For example, the following command gets the members of the `$a` array
@@ -710,9 +723,9 @@ Get-Member -InputObject $a
 ```
 
 You can also get the members of an array by typing a comma (,) before the
-value that is piped to the Get-Member cmdlet. The comma makes the array the
+value that is piped to the `Get-Member` cmdlet. The comma makes the array the
 second item in an array of arrays. PowerShell pipes the arrays one at
-a time and Get-Member returns the members of the array. Like the next two
+a time and `Get-Member` returns the members of the array. Like the next two
 examples.
 
 ```powershell
@@ -779,7 +792,7 @@ $z = $x + $y
 
 As a result, the `$z` array contains 1, 3, 5, and 9.
 
-To delete an array, assign a value of $null to the array. The following
+To delete an array, assign a value of `$null` to the array. The following
 command deletes the array in the `$a` variable.
 
 `$a = $null`
@@ -804,7 +817,7 @@ $a.Count
 $a.Length
 ```
 
-```output
+```Output
 0
 0
 ```
@@ -819,7 +832,7 @@ $a[0]
 $a[-1]
 ```
 
-```output
+```Output
 1
 1
 4

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -34,7 +34,7 @@ $A = 22,5,10,8,12,9,80
 ```
 
 You can also create and initialize an array by using the range operator (`..`).
-The following example creates an array named containing the values 5 through 8.
+The following example creates an array containing the values 5 through 8.
 
 ```powershell
 $B = 5..8
@@ -44,8 +44,8 @@ As a result, `$B` contains four values: 5, 6, 7, and 8.
 
 When no data type is specified, PowerShell creates each array as an object
 array (**System.Object[]**). To determine the data type of an array, use the
-GetType() method. For example, to determine the data type of the `$a` array,
-type:
+**GetType()** method. For example, to determine the data type of the `$A`
+array, type:
 
 ```powershell
 $a.GetType()
@@ -369,8 +369,8 @@ $a = @(
 $a rank: 1
 ```
 
-Building a truly multidimensional array, in PowerShell, requires the
-assistance of the .Net Framework. Like in the following example:
+The following example shows how to create a truly multidimensional array using
+the .Net Framework.
 
 ```powershell
 [int[,]]$rank2 = [int[,]]::new(5,5)


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #5186  - qualify ForEach() and Where() syntax
Fixes [AB#1653248](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1653248)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
