### PR TITLE
Fixes #5079 - PowerShell 7 Group-Object case-sensitive hash tables

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Group-Object.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 4/26/2019
+ms.date: 12/04/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/group-object?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Group-Object
 ---
+
 # Group-Object
 
 ## SYNOPSIS
@@ -15,9 +16,11 @@ Groups objects that contain the same value for specified properties.
 
 ## SYNTAX
 
+### HashTable
+
 ```
-Group-Object [-NoElement] [-AsHashTable] [-AsString] [-InputObject <PSObject>] [[-Property] <Object[]>]
- [-Culture <String>] [-CaseSensitive] [<CommonParameters>]
+Group-Object [-NoElement] [-AsHashTable] [-AsString] [-InputObject <PSObject>]
+ [[-Property] <Object[]>] [-Culture <String>] [-CaseSensitive] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,7 +37,7 @@ property, and then, within each property group, it groups by the value of the ne
 ### Example 1: Group files by extension
 
 This example recursively gets the files under `$PSHOME` and groups them by file name extension. The
-output is sent to the `Sort-Object` cmdlet which sorts them by the count files found for the given
+output is sent to the `Sort-Object` cmdlet, which sorts them by the count files found for the given
 extension. The empty **Name** represents directories.
 
 This example uses the **NoElement** parameter to omit the members of the group.
@@ -63,9 +66,8 @@ Count Name
 
 ### Example 2: Group integers by odds and evens
 
-This example shows how to use script blocks as the value of the **Property** parameter.
-
-This command displays the integers from 1 to 20, grouped by odds and even.
+This example shows how to use script blocks as the value of the **Property** parameter. This command
+displays the integers from 1 to 20, grouped by odds and even.
 
 ```powershell
 1..20 | Group-Object -Property {$_ % 2}
@@ -74,17 +76,18 @@ This command displays the integers from 1 to 20, grouped by odds and even.
 ```Output
 Count Name                      Group
 ----- ----                      -----
-   10 1                         {1, 3, 5, 7, 9, 11, 13, 15, 17, 19}
-   10 0                         {2, 4, 6, 8, 10, 12, 14, 16, 18, 20}
+   10 1                         {1, 3, 5, 7...}
+   10 0                         {2, 4, 6, 8...}
 ```
 
 ### Example 3: Group event log events by EntryType
 
-These commands display the 1,000 most recent entries in the System event log, grouped by **EntryType**.
+This example displays the 1,000 most recent entries in the System event log, grouped by
+**EntryType**.
 
-In the output, the **Count** column represents the number of entries in each group, the **Name**
-column represents the **EventType** values that define a group, and the **Group** column represents
-the objects in each group.
+In the output, the **Count** column represents the number of entries in each group. The **Name**
+column represents the **EventType** values that define a group. The **Group** column represents the
+objects in each group.
 
 ```powershell
 Get-WinEvent -LogName System -MaxEvents 1000 | Group-Object -Property LevelDisplayName
@@ -93,23 +96,22 @@ Get-WinEvent -LogName System -MaxEvents 1000 | Group-Object -Property LevelDispl
 ```Output
 Count Name          Group
 ----- ----          -----
-  153 Error         {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics.�
-  722 Information   {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics.�
-  125 Warning       {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics.�
+  153 Error         {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics...}
+  722 Information   {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics...}
+  125 Warning       {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics...}
 ```
 
 ### Example 4: Group processes by priority class
 
-This example demonstrates the effect of the **NoElement** parameter.
-These commands group the processes on the computer by priority class.
+This example demonstrates the effect of the **NoElement** parameter. These commands group the
+processes on the computer by priority class.
 
-The first command uses the `Get-Process` cmdlet to get the processes on the computer.
-It uses a pipeline operator `|` to send the results to `Group-Object`, which groups the objects by
-the value of the **PriorityClass** property of the process.
+The first command uses the `Get-Process` cmdlet to get the processes on the computer and sends the
+objects down the pipeline. `Group-Object`groups the objects by the value of the **PriorityClass**
+property of the process.
 
-The second command is identical to the first, except that it uses the **NoElement** parameter to
-eliminate the members of the group from the output.
-The result is a table with only the count and property value name.
+The second example uses the **NoElement** parameter to eliminate the members of the group from the
+output. The result is a table with only the **Count** and **Name** property value.
 
 The results are shown in the following sample output.
 
@@ -141,11 +143,11 @@ Count Name
 
 ### Example 5: Group processes by name
 
-The following example uses `Group-Object` to multiple instances of processes running on the local
-computer.
+The following example uses `Group-Object` to group multiple instances of processes running on the
+local computer. `Where-Object` displays processes with more than one instance.
 
 ```powershell
-Get-Process | Group-Object -Property Name -NoElement | Where {$_.count -gt 1}
+Get-Process | Group-Object -Property Name -NoElement | Where-Object {$_.Count -gt 1}
 ```
 
 ```Output
@@ -157,10 +159,10 @@ Count Name
 2     wmiprvse
 ```
 
-### Example 8: Group objects in a hash table
+### Example 6: Group objects in a hash table
 
 This example uses the **AsHashTable** and **AsString** parameters to return the groups in a hash
-table, that is, as a collection of key-value pairs.
+table, as a collection of key-value pairs.
 
 In the resulting hash table, each property value is a key, and the group elements are the values.
 Because each key is a property of the hash table object, you can use dot notation to display the
@@ -169,35 +171,36 @@ values.
 The first command gets the `Get` and `Set` cmdlets in the session, groups them by verb, returns the
 groups as a hash table, and saves the hash table in the `$A` variable.
 
-The second command displays the hash table in `$A`.
-There are two key-value pairs, one for the `Get` cmdlets and one for the `Set` cmdlets.
+The second command displays the hash table in `$A`. There are two key-value pairs, one for the `Get`
+cmdlets and one for the `Set` cmdlets.
 
-The third command uses dot notation to display the values of the **Get** key in `$A`.
-The values are **CmdletInfo** object.
-The **AsString** parameter does not convert the objects in the groups to strings.
+The third command uses dot notation, `$A.Get` to display the values of the **Get** key in `$A`. The
+values are **CmdletInfo** object. The **AsString** parameter doesn't convert the objects in the
+groups to strings.
 
 ```powershell
-$A = Get-Command get-*, set-* -CommandType cmdlet | Group-Object -Property verb -AsHashTable -AsString
+$A = Get-Command Get-*, Set-* -CommandType cmdlet | Group-Object -Property Verb -AsHashTable -AsString
 $A
 ```
 
 ```Output
-Name    Value
-----    -----
-Get     {Get-PSCallStack, Get-PSBreakpoint, Get-PSDrive, Get-PSSession...}
-Set     {Set-Service, Set-StrictMode, Set-PSDebug, Set-PSSessionConfiguration...}
+Name     Value
+----     -----
+Get      {Get-Acl, Get-Alias, Get-AppLockerFileInformation, Get-AppLockerPolicy...}
+Set      {Set-Acl, Set-Alias, Set-AppBackgroundTaskResourcePolicy, Set-AppLockerPolicy...}
 ```
 
 ```powershell
-$A.get
+$A.Get
 ```
 
 ```Output
-CommandType     Name                 Definition
------------     ----                 ----------
-Cmdlet          Get-PSCallStack      Get-PSCallStack [-Verbose] [-Debug] [-ErrorAction <ActionPrefer...
-Cmdlet          Get-PSBreakpoint     Get-PSBreakpoint [[-Id] <Int32[]>] [-Verbose] [-Debug] [-ErrorA...
-Cmdlet          Get-PSDrive          Get-PSDrive [[-Name] <String[]>] [-Scope <String>] [-PSProvider...
+CommandType     Name                               Version    Source
+-----------     ----                               -------    ------
+Cmdlet          Get-Acl                            3.0.0.0    Microsoft.PowerShell.Security
+Cmdlet          Get-Alias                          3.1.0.0    Microsoft.PowerShell.Utility
+Cmdlet          Get-AppLockerFileInformation       2.0.0.0    AppLocker
+Cmdlet          Get-AppLockerPolicy                2.0.0.0    AppLocker
 ...
 ```
 
@@ -205,13 +208,13 @@ Cmdlet          Get-PSDrive          Get-PSDrive [[-Name] <String[]>] [-Scope <S
 
 ### -AsHashTable
 
-Indicates that this cmdlet returns the group as a hash table.
-The keys of the hash table are the property values by which the objects are grouped.
-The values of the hash table are the objects that have that property value.
+Indicates that this cmdlet returns the group as a hash table. The keys of the hash table are the
+property values by which the objects are grouped. The values of the hash table are the objects that
+have that property value.
 
 By itself, the **AsHashTable** parameter returns each hash table in which each key is an instance of
-the grouped object.
-When used with the **AsString** parameter, the keys in the hash table are strings.
+the grouped object. When used with the **AsString** parameter, the keys in the hash table are
+strings.
 
 ```yaml
 Type: SwitchParameter
@@ -220,16 +223,16 @@ Aliases: AHT
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -AsString
 
-Indicates that this cmdlet converts the hash table keys to strings.
-By default, the hash table keys are instances of the grouped object.
-This parameter is valid only when used with the **AsHashTable** parameter.
+Indicates that this cmdlet converts the hash table keys to strings. By default, the hash table keys
+are instances of the grouped object. This parameter is valid only when used with the **AsHashTable**
+parameter.
 
 ```yaml
 Type: SwitchParameter
@@ -238,15 +241,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -CaseSensitive
 
-Indicates that this cmdlet makes the grouping case-sensitive.
-Without this parameter, the property values of objects in a group might have different cases.
+Indicates that this cmdlet makes the grouping case-sensitive. Without this parameter, the property
+values of objects in a group might have different cases.
 
 ```yaml
 Type: SwitchParameter
@@ -255,7 +258,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -278,12 +281,12 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the objects to group.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
+Specifies the objects to group. Enter a variable that contains the objects, or type a command or
+expression that gets the objects.
 
 When you use the **InputObject** parameter to submit a collection of objects to `Group-Object`,
-`Group-Object` receives one object that represents the collection.
-As a result, it creates a single group with that object as its member.
+`Group-Object` receives one object that represents the collection. As a result, it creates a single
+group with that object as its member.
 
 To group the objects in a collection, pipe the objects to `Group-Object`.
 
@@ -310,19 +313,19 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Property
 
-Specifies the properties for grouping.
-The objects are arranged into groups based on the value of the specified property.
+Specifies the properties for grouping. The objects are arranged into groups based on the value of
+the specified property.
 
-The value of the **Property** parameter can be a new calculated property.
-To create a calculated, property, create a hash table with an **Expression** key that specifies a string
-or script block value.
+The value of the **Property** parameter can be a new calculated property. To create a calculated,
+property, create a hash table with an **Expression** key that specifies a string or script block
+value.
 
 ```yaml
 Type: Object[]
@@ -340,7 +343,8 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](../Microsoft.PowerShell.Core/About/about_CommonParameters.md).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -352,44 +356,46 @@ You can pipe any object to `Group-Object`.
 
 ### Microsoft.PowerShell.Commands.GroupInfo or System.Collections.Hashtable
 
-When you use the **AsHashTable** parameter, `Group-Object` returns a hash table.
+When you use the **AsHashTable** parameter, `Group-Object` returns a **Hashtable** object.
 Otherwise, it returns a **GroupInfo** object.
 
 ## NOTES
 
-- You can also use the **GroupBy** parameter of the formatting cmdlets (such as `Format-Table`
-  and `Format-List`) to group objects. Unlike `Group-Object`, which creates a single
-  table with a row for each property value, the **GroupBy** parameters create a table for each
-  property value with a row for each item that has the property value.
+You can use the **GroupBy** parameter of the formatting cmdlets, such as `Format-Table` and
+`Format-List`, to group objects. Unlike `Group-Object`, which creates a single table with a row for
+each property value, the **GroupBy** parameters create a table for each property value with a row
+for each item that has the property value.
 
-  `Group-Object` does not require that the objects being grouped be of the same Microsoft .NET
-  Framework type. When grouping objects of different .NET Framework types, `Group-Object` uses the
-  following rules:
+`Group-Object` doesn't require that the objects being grouped are of the same Microsoft .NET
+Framework type. When grouping objects of different .NET Framework types, `Group-Object` uses the
+following rules:
 
-  - Same Property Names and Types.
-    If the objects have a property with the specified name, and the property values have the same .NET
-    Framework type, the property values are grouped by using the same rules that would be used for
-    objects of the same type.
+- Same Property Names and Types.
 
-  - Same Property Names, Different Types.
-    If the objects have a property with the specified name, but the property values have a different
-    .NET Framework type in different objects, `Group-Object` uses the .NET Framework type of the first
-    occurrence of the property as the .NET Framework type for that property group.
-    When an object has a property with a different type, the property value is converted to the type for
-    that group. If the type conversion fails, the object is not included in the group.
+  If the objects have a property with the specified name, and the property values have the same .NET
+  Framework type, the property values are grouped by using the same rules that would be used for
+  objects of the same type.
 
-  - Missing Properties.
-    Objects that do not have a specified property are considered ungroupable.
-    Ungroupable objects appear in the final **GroupInfo** object output in a group named
-    `AutomationNull.Value`.
+- Same Property Names, Different Types.
+
+  If the objects have a property with the specified name, but the property values have a different
+  .NET Framework type in different objects, `Group-Object` uses the .NET Framework type of the first
+  occurrence of the property as the .NET Framework type for that property group. When an object has
+  a property with a different type, the property value is converted to the type for that group. If
+  the type conversion fails, the object is not included in the group.
+
+- Missing Properties.
+
+  Objects that don't have a specified property can't be grouped. Objects that aren't grouped appear
+  in the final **GroupInfo** object output in a group named `AutomationNull.Value`.
 
 ## RELATED LINKS
+
+[about_Hash_Tables](../Microsoft.PowerShell.Core/About/about_Hash_Tables.md)
 
 [Compare-Object](Compare-Object.md)
 
 [ForEach-Object](../Microsoft.PowerShell.Core/ForEach-Object.md)
-
-[Where-Object](../Microsoft.PowerShell.Core/Where-Object.md)
 
 [Measure-Object](Measure-Object.md)
 
@@ -400,3 +406,5 @@ Otherwise, it returns a **GroupInfo** object.
 [Sort-Object](Sort-Object.md)
 
 [Tee-Object](Tee-Object.md)
+
+[Where-Object](../Microsoft.PowerShell.Core/Where-Object.md)

--- a/reference/6/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Group-Object.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 4/26/2019
+ms.date: 12/04/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/group-object?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Group-Object
 ---
+
 # Group-Object
 
 ## SYNOPSIS
@@ -15,9 +16,11 @@ Groups objects that contain the same value for specified properties.
 
 ## SYNTAX
 
+### HashTable
+
 ```
-Group-Object [-NoElement] [-AsHashTable] [-AsString] [-InputObject <PSObject>] [[-Property] <Object[]>]
- [-Culture <String>] [-CaseSensitive] [<CommonParameters>]
+Group-Object [-NoElement] [-AsHashTable] [-AsString] [-InputObject <PSObject>]
+ [[-Property] <Object[]>] [-Culture <String>] [-CaseSensitive] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,7 +37,7 @@ property, and then, within each property group, it groups by the value of the ne
 ### Example 1: Group files by extension
 
 This example recursively gets the files under `$PSHOME` and groups them by file name extension. The
-output is sent to the `Sort-Object` cmdlet which sorts them by the count files found for the given
+output is sent to the `Sort-Object` cmdlet, which sorts them by the count files found for the given
 extension. The empty **Name** represents directories.
 
 This example uses the **NoElement** parameter to omit the members of the group.
@@ -63,9 +66,8 @@ Count Name
 
 ### Example 2: Group integers by odds and evens
 
-This example shows how to use script blocks as the value of the **Property** parameter.
-
-This command displays the integers from 1 to 20, grouped by odds and even.
+This example shows how to use script blocks as the value of the **Property** parameter. This command
+displays the integers from 1 to 20, grouped by odds and even.
 
 ```powershell
 1..20 | Group-Object -Property {$_ % 2}
@@ -74,17 +76,18 @@ This command displays the integers from 1 to 20, grouped by odds and even.
 ```Output
 Count Name                      Group
 ----- ----                      -----
-   10 1                         {1, 3, 5, 7, 9, 11, 13, 15, 17, 19}
-   10 0                         {2, 4, 6, 8, 10, 12, 14, 16, 18, 20}
+   10 0                         {2, 4, 6, 8...}
+   10 1                         {1, 3, 5, 7...}
 ```
 
 ### Example 3: Group event log events by EntryType
 
-These commands display the 1,000 most recent entries in the System event log, grouped by **EntryType**.
+This example displays the 1,000 most recent entries in the System event log, grouped by
+**EntryType**.
 
-In the output, the **Count** column represents the number of entries in each group, the **Name**
-column represents the **EventType** values that define a group, and the **Group** column represents
-the objects in each group.
+In the output, the **Count** column represents the number of entries in each group. The **Name**
+column represents the **EventType** values that define a group. The **Group** column represents the
+objects in each group.
 
 ```powershell
 Get-WinEvent -LogName System -MaxEvents 1000 | Group-Object -Property LevelDisplayName
@@ -93,23 +96,22 @@ Get-WinEvent -LogName System -MaxEvents 1000 | Group-Object -Property LevelDispl
 ```Output
 Count Name          Group
 ----- ----          -----
-  153 Error         {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics.…
-  722 Information   {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics.…
-  125 Warning       {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics.…
+  153 Error         {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics...}
+  722 Information   {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics...}
+  125 Warning       {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics...}
 ```
 
 ### Example 4: Group processes by priority class
 
-This example demonstrates the effect of the **NoElement** parameter.
-These commands group the processes on the computer by priority class.
+This example demonstrates the effect of the **NoElement** parameter. These commands group the
+processes on the computer by priority class.
 
-The first command uses the `Get-Process` cmdlet to get the processes on the computer.
-It uses a pipeline operator `|` to send the results to `Group-Object`, which groups the objects by
-the value of the **PriorityClass** property of the process.
+The first command uses the `Get-Process` cmdlet to get the processes on the computer and sends the
+objects down the pipeline. `Group-Object`groups the objects by the value of the **PriorityClass**
+property of the process.
 
-The second command is identical to the first, except that it uses the **NoElement** parameter to
-eliminate the members of the group from the output.
-The result is a table with only the count and property value name.
+The second example uses the **NoElement** parameter to eliminate the members of the group from the
+output. The result is a table with only the **Count** and **Name** property value.
 
 The results are shown in the following sample output.
 
@@ -141,11 +143,11 @@ Count Name
 
 ### Example 5: Group processes by name
 
-The following example uses `Group-Object` to multiple instances of processes running on the local
-computer.
+The following example uses `Group-Object` to group multiple instances of processes running on the
+local computer. `Where-Object` displays processes with more than one instance.
 
 ```powershell
-Get-Process | Group-Object -Property Name -NoElement | Where {$_.count -gt 1}
+Get-Process | Group-Object -Property Name -NoElement | Where-Object {$_.Count -gt 1}
 ```
 
 ```Output
@@ -157,10 +159,10 @@ Count Name
 2     wmiprvse
 ```
 
-### Example 8: Group objects in a hash table
+### Example 6: Group objects in a hash table
 
 This example uses the **AsHashTable** and **AsString** parameters to return the groups in a hash
-table, that is, as a collection of key-value pairs.
+table, as a collection of key-value pairs.
 
 In the resulting hash table, each property value is a key, and the group elements are the values.
 Because each key is a property of the hash table object, you can use dot notation to display the
@@ -169,35 +171,36 @@ values.
 The first command gets the `Get` and `Set` cmdlets in the session, groups them by verb, returns the
 groups as a hash table, and saves the hash table in the `$A` variable.
 
-The second command displays the hash table in `$A`.
-There are two key-value pairs, one for the `Get` cmdlets and one for the `Set` cmdlets.
+The second command displays the hash table in `$A`. There are two key-value pairs, one for the `Get`
+cmdlets and one for the `Set` cmdlets.
 
-The third command uses dot notation to display the values of the **Get** key in `$A`.
-The values are **CmdletInfo** object.
-The **AsString** parameter does not convert the objects in the groups to strings.
+The third command uses dot notation, `$A.Get` to display the values of the **Get** key in `$A`. The
+values are **CmdletInfo** object. The **AsString** parameter doesn't convert the objects in the
+groups to strings.
 
 ```powershell
-$A = Get-Command get-*, set-* -CommandType cmdlet | Group-Object -Property verb -AsHashTable -AsString
+$A = Get-Command Get-*, Set-* -CommandType cmdlet | Group-Object -Property Verb -AsHashTable -AsString
 $A
 ```
 
 ```Output
-Name    Value
-----    -----
-Get     {Get-PSCallStack, Get-PSBreakpoint, Get-PSDrive, Get-PSSession...}
-Set     {Set-Service, Set-StrictMode, Set-PSDebug, Set-PSSessionConfiguration...}
+Name     Value
+----     -----
+Get      {Get-Acl, Get-Alias, Get-AppLockerFileInformation, Get-AppLockerPolicy...}
+Set      {Set-Acl, Set-Alias, Set-AppBackgroundTaskResourcePolicy, Set-AppLockerPolicy...}
 ```
 
 ```powershell
-$A.get
+$A.Get
 ```
 
 ```Output
-CommandType     Name                 Definition
------------     ----                 ----------
-Cmdlet          Get-PSCallStack      Get-PSCallStack [-Verbose] [-Debug] [-ErrorAction <ActionPrefer...
-Cmdlet          Get-PSBreakpoint     Get-PSBreakpoint [[-Id] <Int32[]>] [-Verbose] [-Debug] [-ErrorA...
-Cmdlet          Get-PSDrive          Get-PSDrive [[-Name] <String[]>] [-Scope <String>] [-PSProvider...
+CommandType     Name                               Version    Source
+-----------     ----                               -------    ------
+Cmdlet          Get-Acl                            6.1.0.0    Microsoft.PowerShell.Security
+Cmdlet          Get-Alias                          6.1.0.0    Microsoft.PowerShell.Utility
+Cmdlet          Get-AuthenticodeSignature          6.1.0.0    Microsoft.PowerShell.Security
+Cmdlet          Get-ChildItem                      6.1.0.0    Microsoft.PowerShell.Management
 ...
 ```
 
@@ -205,13 +208,13 @@ Cmdlet          Get-PSDrive          Get-PSDrive [[-Name] <String[]>] [-Scope <S
 
 ### -AsHashTable
 
-Indicates that this cmdlet returns the group as a hash table.
-The keys of the hash table are the property values by which the objects are grouped.
-The values of the hash table are the objects that have that property value.
+Indicates that this cmdlet returns the group as a hash table. The keys of the hash table are the
+property values by which the objects are grouped. The values of the hash table are the objects that
+have that property value.
 
 By itself, the **AsHashTable** parameter returns each hash table in which each key is an instance of
-the grouped object.
-When used with the **AsString** parameter, the keys in the hash table are strings.
+the grouped object. When used with the **AsString** parameter, the keys in the hash table are
+strings.
 
 ```yaml
 Type: SwitchParameter
@@ -220,16 +223,16 @@ Aliases: AHT
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -AsString
 
-Indicates that this cmdlet converts the hash table keys to strings.
-By default, the hash table keys are instances of the grouped object.
-This parameter is valid only when used with the **AsHashTable** parameter.
+Indicates that this cmdlet converts the hash table keys to strings. By default, the hash table keys
+are instances of the grouped object. This parameter is valid only when used with the **AsHashTable**
+parameter.
 
 ```yaml
 Type: SwitchParameter
@@ -238,15 +241,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -CaseSensitive
 
-Indicates that this cmdlet makes the grouping case-sensitive.
-Without this parameter, the property values of objects in a group might have different cases.
+Indicates that this cmdlet makes the grouping case-sensitive. Without this parameter, the property
+values of objects in a group might have different cases.
 
 ```yaml
 Type: SwitchParameter
@@ -255,7 +258,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -278,12 +281,12 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the objects to group.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
+Specifies the objects to group. Enter a variable that contains the objects, or type a command or
+expression that gets the objects.
 
 When you use the **InputObject** parameter to submit a collection of objects to `Group-Object`,
-`Group-Object` receives one object that represents the collection.
-As a result, it creates a single group with that object as its member.
+`Group-Object` receives one object that represents the collection. As a result, it creates a single
+group with that object as its member.
 
 To group the objects in a collection, pipe the objects to `Group-Object`.
 
@@ -310,19 +313,19 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Property
 
-Specifies the properties for grouping.
-The objects are arranged into groups based on the value of the specified property.
+Specifies the properties for grouping. The objects are arranged into groups based on the value of
+the specified property.
 
-The value of the **Property** parameter can be a new calculated property.
-To create a calculated, property, create a hash table with an **Expression** key that specifies a string
-or script block value.
+The value of the **Property** parameter can be a new calculated property. To create a calculated,
+property, create a hash table with an **Expression** key that specifies a string or script block
+value.
 
 ```yaml
 Type: Object[]
@@ -340,7 +343,8 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](../Microsoft.PowerShell.Core/About/about_CommonParameters.md).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -352,44 +356,45 @@ You can pipe any object to `Group-Object`.
 
 ### Microsoft.PowerShell.Commands.GroupInfo or System.Collections.Hashtable
 
-When you use the **AsHashTable** parameter, `Group-Object` returns a hash table.
+When you use the **AsHashTable** parameter, `Group-Object` returns a **Hashtable** object.
 Otherwise, it returns a **GroupInfo** object.
 
 ## NOTES
 
-- You can also use the **GroupBy** parameter of the formatting cmdlets (such as `Format-Table`
-  and `Format-List`) to group objects. Unlike `Group-Object`, which creates a single
-  table with a row for each property value, the **GroupBy** parameters create a table for each
-  property value with a row for each item that has the property value.
+You can use the **GroupBy** parameter of the formatting cmdlets, such as `Format-Table` and
+`Format-List`, to group objects. Unlike `Group-Object`, which creates a single table with a row for
+each property value, the **GroupBy** parameters create a table for each property value with a row
+for each item that has the property value.
 
-  `Group-Object` does not require that the objects being grouped be of the same Microsoft .NET
-  Framework type. When grouping objects of different .NET Framework types, `Group-Object` uses the
-  following rules:
+`Group-Object` doesn't require that the objects being grouped are of the same Microsoft .NET Core
+type. When grouping objects of different .NET Core types, `Group-Object` uses the following rules:
 
-  - Same Property Names and Types.
-    If the objects have a property with the specified name, and the property values have the same .NET
-    Framework type, the property values are grouped by using the same rules that would be used for
-    objects of the same type.
+- Same Property Names and Types.
 
-  - Same Property Names, Different Types.
-    If the objects have a property with the specified name, but the property values have a different
-    .NET Framework type in different objects, `Group-Object` uses the .NET Framework type of the first
-    occurrence of the property as the .NET Framework type for that property group.
-    When an object has a property with a different type, the property value is converted to the type for
-    that group. If the type conversion fails, the object is not included in the group.
+  If the objects have a property with the specified name, and the property values have the same .NET
+  Core type, the property values are grouped by using the same rules that would be used for objects
+  of the same type.
 
-  - Missing Properties.
-    Objects that do not have a specified property are considered ungroupable.
-    Ungroupable objects appear in the final **GroupInfo** object output in a group named
-    `AutomationNull.Value`.
+- Same Property Names, Different Types.
+
+  If the objects have a property with the specified name, but the property values have a different
+  .NET Core type in different objects, `Group-Object` uses the .NET Core type of the first
+  occurrence of the property as the .NET Core type for that property group. When an object has a
+  property with a different type, the property value is converted to the type for that group. If the
+  type conversion fails, the object isn't included in the group.
+
+- Missing Properties.
+
+  Objects that don't have a specified property can't be grouped. Objects that aren't grouped appear
+  in the final **GroupInfo** object output in a group named `AutomationNull.Value`.
 
 ## RELATED LINKS
+
+[about_Hash_Tables](../Microsoft.PowerShell.Core/About/about_Hash_Tables.md)
 
 [Compare-Object](Compare-Object.md)
 
 [ForEach-Object](../Microsoft.PowerShell.Core/ForEach-Object.md)
-
-[Where-Object](../Microsoft.PowerShell.Core/Where-Object.md)
 
 [Measure-Object](Measure-Object.md)
 
@@ -400,3 +405,5 @@ Otherwise, it returns a **GroupInfo** object.
 [Sort-Object](Sort-Object.md)
 
 [Tee-Object](Tee-Object.md)
+
+[Where-Object](../Microsoft.PowerShell.Core/Where-Object.md)

--- a/reference/7/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Group-Object.md
@@ -3,11 +3,12 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 4/26/2019
+ms.date: 12/04/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/group-object?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Group-Object
 ---
+
 # Group-Object
 
 ## SYNOPSIS
@@ -15,9 +16,11 @@ Groups objects that contain the same value for specified properties.
 
 ## SYNTAX
 
+### HashTable
+
 ```
-Group-Object [-NoElement] [-AsHashTable] [-AsString] [-InputObject <PSObject>] [[-Property] <Object[]>]
- [-Culture <String>] [-CaseSensitive] [<CommonParameters>]
+Group-Object [-NoElement] [-AsHashTable] [-AsString] [-InputObject <PSObject>]
+ [[-Property] <Object[]>] [-Culture <String>] [-CaseSensitive] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,12 +32,16 @@ number of items with that value.
 If you specify more than one property, `Group-Object` first groups them by the values of the first
 property, and then, within each property group, it groups by the value of the next property.
 
+Beginning in PowerShell 7, `Group-Object` can combine the **CaseSensitive** and **AsHashtable**
+parameters to create a case-sensitive hash table. The hash table keys use case-sensitive comparisons
+and output a **System.Collections.Hashtable** object.
+
 ## EXAMPLES
 
 ### Example 1: Group files by extension
 
 This example recursively gets the files under `$PSHOME` and groups them by file name extension. The
-output is sent to the `Sort-Object` cmdlet which sorts them by the count files found for the given
+output is sent to the `Sort-Object` cmdlet, which sorts them by the count files found for the given
 extension. The empty **Name** represents directories.
 
 This example uses the **NoElement** parameter to omit the members of the group.
@@ -63,9 +70,8 @@ Count Name
 
 ### Example 2: Group integers by odds and evens
 
-This example shows how to use script blocks as the value of the **Property** parameter.
-
-This command displays the integers from 1 to 20, grouped by odds and even.
+This example shows how to use script blocks as the value of the **Property** parameter. This command
+displays the integers from 1 to 20, grouped by odds and even.
 
 ```powershell
 1..20 | Group-Object -Property {$_ % 2}
@@ -74,17 +80,18 @@ This command displays the integers from 1 to 20, grouped by odds and even.
 ```Output
 Count Name                      Group
 ----- ----                      -----
-   10 1                         {1, 3, 5, 7, 9, 11, 13, 15, 17, 19}
-   10 0                         {2, 4, 6, 8, 10, 12, 14, 16, 18, 20}
+   10 0                         {2, 4, 6, 8...}
+   10 1                         {1, 3, 5, 7...}
 ```
 
 ### Example 3: Group event log events by EntryType
 
-These commands display the 1,000 most recent entries in the System event log, grouped by **EntryType**.
+This example displays the 1,000 most recent entries in the System event log, grouped by
+**EntryType**.
 
-In the output, the **Count** column represents the number of entries in each group, the **Name**
-column represents the **EventType** values that define a group, and the **Group** column represents
-the objects in each group.
+In the output, the **Count** column represents the number of entries in each group. The **Name**
+column represents the **EventType** values that define a group. The **Group** column represents the
+objects in each group.
 
 ```powershell
 Get-WinEvent -LogName System -MaxEvents 1000 | Group-Object -Property LevelDisplayName
@@ -93,23 +100,22 @@ Get-WinEvent -LogName System -MaxEvents 1000 | Group-Object -Property LevelDispl
 ```Output
 Count Name          Group
 ----- ----          -----
-  153 Error         {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics.…
-  722 Information   {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics.…
-  125 Warning       {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics.…
+  153 Error         {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics...}
+  722 Information   {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics...}
+  125 Warning       {System.Diagnostics.Eventing.Reader.EventLogRecord, System.Diagnostics...}
 ```
 
 ### Example 4: Group processes by priority class
 
-This example demonstrates the effect of the **NoElement** parameter.
-These commands group the processes on the computer by priority class.
+This example demonstrates the effect of the **NoElement** parameter. These commands group the
+processes on the computer by priority class.
 
-The first command uses the `Get-Process` cmdlet to get the processes on the computer.
-It uses a pipeline operator `|` to send the results to `Group-Object`, which groups the objects by
-the value of the **PriorityClass** property of the process.
+The first command uses the `Get-Process` cmdlet to get the processes on the computer and sends the
+objects down the pipeline. `Group-Object`groups the objects by the value of the **PriorityClass**
+property of the process.
 
-The second command is identical to the first, except that it uses the **NoElement** parameter to
-eliminate the members of the group from the output.
-The result is a table with only the count and property value name.
+The second example uses the **NoElement** parameter to eliminate the members of the group from the
+output. The result is a table with only the **Count** and **Name** property value.
 
 The results are shown in the following sample output.
 
@@ -141,11 +147,11 @@ Count Name
 
 ### Example 5: Group processes by name
 
-The following example uses `Group-Object` to multiple instances of processes running on the local
-computer.
+The following example uses `Group-Object` to group multiple instances of processes running on the
+local computer. `Where-Object` displays processes with more than one instance.
 
 ```powershell
-Get-Process | Group-Object -Property Name -NoElement | Where {$_.count -gt 1}
+Get-Process | Group-Object -Property Name -NoElement | Where-Object {$_.Count -gt 1}
 ```
 
 ```Output
@@ -157,10 +163,10 @@ Count Name
 2     wmiprvse
 ```
 
-### Example 8: Group objects in a hash table
+### Example 6: Group objects in a hash table
 
 This example uses the **AsHashTable** and **AsString** parameters to return the groups in a hash
-table, that is, as a collection of key-value pairs.
+table, as a collection of key-value pairs.
 
 In the resulting hash table, each property value is a key, and the group elements are the values.
 Because each key is a property of the hash table object, you can use dot notation to display the
@@ -169,49 +175,76 @@ values.
 The first command gets the `Get` and `Set` cmdlets in the session, groups them by verb, returns the
 groups as a hash table, and saves the hash table in the `$A` variable.
 
-The second command displays the hash table in `$A`.
-There are two key-value pairs, one for the `Get` cmdlets and one for the `Set` cmdlets.
+The second command displays the hash table in `$A`. There are two key-value pairs, one for the `Get`
+cmdlets and one for the `Set` cmdlets.
 
-The third command uses dot notation to display the values of the **Get** key in `$A`.
-The values are **CmdletInfo** object.
-The **AsString** parameter does not convert the objects in the groups to strings.
+The third command uses dot notation, `$A.Get` to display the values of the **Get** key in `$A`. The
+values are **CmdletInfo** object. The **AsString** parameter doesn't convert the objects in the
+groups to strings.
 
 ```powershell
-$A = Get-Command get-*, set-* -CommandType cmdlet | Group-Object -Property verb -AsHashTable -AsString
+$A = Get-Command Get-*, Set-* -CommandType cmdlet | Group-Object -Property Verb -AsHashTable -AsString
 $A
 ```
 
 ```Output
-Name    Value
-----    -----
-Get     {Get-PSCallStack, Get-PSBreakpoint, Get-PSDrive, Get-PSSession...}
-Set     {Set-Service, Set-StrictMode, Set-PSDebug, Set-PSSessionConfiguration...}
+Name     Value
+----     -----
+Get      {Get-Acl, Get-Alias, Get-AppLockerFileInformation, Get-AppLockerPolicy...}
+Set      {Set-Acl, Set-Alias, Set-AppBackgroundTaskResourcePolicy, Set-AppLockerPolicy...}
 ```
 
 ```powershell
-$A.get
+$A.Get
 ```
 
 ```Output
-CommandType     Name                 Definition
------------     ----                 ----------
-Cmdlet          Get-PSCallStack      Get-PSCallStack [-Verbose] [-Debug] [-ErrorAction <ActionPrefer...
-Cmdlet          Get-PSBreakpoint     Get-PSBreakpoint [[-Id] <Int32[]>] [-Verbose] [-Debug] [-ErrorA...
-Cmdlet          Get-PSDrive          Get-PSDrive [[-Name] <String[]>] [-Scope <String>] [-PSProvider...
+CommandType     Name                                Version    Source
+-----------     ----                                -------    ------
+Cmdlet          Get-Acl                             7.0.0.0    Microsoft.PowerShell.Security
+Cmdlet          Get-Alias                           7.0.0.0    Microsoft.PowerShell.Utility
+Cmdlet          Get-AppLockerFileInformation        2.0.0.0    AppLocker
+Cmdlet          Get-AppLockerPolicy                 2.0.0.0    AppLocker
 ...
 ```
+
+### Example 7: Create a case-sensitive hash table
+
+This example combines the **CaseSensitive** and **AsHashTable** parameters to create a
+case-sensitive hash table. The files in the example have extensions of `.txt` and `.TXT`.
+
+```powershell
+$hash = Get-ChildItem -Path C:\Files | Group-Object -Property Extension -CaseSensitive -AsHashTable
+$hash
+```
+
+```Output
+Name           Value
+----           -----
+.TXT           {C:\Files\File7.TXT, C:\Files\File8.TXT, C:\Files\File9.TXT}
+.txt           {C:\Files\file1.txt, C:\Files\file2.txt, C:\Files\file3.txt}
+```
+
+The `$hash` variable stores the **System.Collections.Hashtable** object. `Get-ChildItem` gets the
+file names from the `C:\Files` directory and sends the **System.IO.FileInfo** objects down the
+pipeline. `Group-Object` groups the objects using the **Property** value **Extension**. The
+**CaseSensitive** and **AsHashTable** parameters create the hash table and the keys are grouped
+using the case-sensitive keys `.txt` and `.TXT`.
 
 ## PARAMETERS
 
 ### -AsHashTable
 
-Indicates that this cmdlet returns the group as a hash table.
-The keys of the hash table are the property values by which the objects are grouped.
-The values of the hash table are the objects that have that property value.
+Indicates that this cmdlet returns the group as a hash table. The keys of the hash table are the
+property values by which the objects are grouped. The values of the hash table are the objects that
+have that property value.
 
 By itself, the **AsHashTable** parameter returns each hash table in which each key is an instance of
-the grouped object.
-When used with the **AsString** parameter, the keys in the hash table are strings.
+the grouped object. When used with the **AsString** parameter, the keys in the hash table are
+strings.
+
+Beginning in PowerShell 7, to create case-sensitive hash tables, include **CaseSensitive** and
+**AsHashtable** in your command.
 
 ```yaml
 Type: SwitchParameter
@@ -220,16 +253,16 @@ Aliases: AHT
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -AsString
 
-Indicates that this cmdlet converts the hash table keys to strings.
-By default, the hash table keys are instances of the grouped object.
-This parameter is valid only when used with the **AsHashTable** parameter.
+Indicates that this cmdlet converts the hash table keys to strings. By default, the hash table keys
+are instances of the grouped object. This parameter is valid only when used with the **AsHashTable**
+parameter.
 
 ```yaml
 Type: SwitchParameter
@@ -238,15 +271,18 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -CaseSensitive
 
-Indicates that this cmdlet makes the grouping case-sensitive.
-Without this parameter, the property values of objects in a group might have different cases.
+Indicates that this cmdlet makes the grouping case-sensitive. Without this parameter, the property
+values of objects in a group might have different cases.
+
+Beginning in PowerShell 7, to create case-sensitive hash tables, include **CaseSensitive** and
+**AsHashtable** in your command.
 
 ```yaml
 Type: SwitchParameter
@@ -255,7 +291,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -278,12 +314,12 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the objects to group.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
+Specifies the objects to group. Enter a variable that contains the objects, or type a command or
+expression that gets the objects.
 
 When you use the **InputObject** parameter to submit a collection of objects to `Group-Object`,
-`Group-Object` receives one object that represents the collection.
-As a result, it creates a single group with that object as its member.
+`Group-Object` receives one object that represents the collection. As a result, it creates a single
+group with that object as its member.
 
 To group the objects in a collection, pipe the objects to `Group-Object`.
 
@@ -310,19 +346,19 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Property
 
-Specifies the properties for grouping.
-The objects are arranged into groups based on the value of the specified property.
+Specifies the properties for grouping. The objects are arranged into groups based on the value of
+the specified property.
 
-The value of the **Property** parameter can be a new calculated property.
-To create a calculated, property, create a hash table with an **Expression** key that specifies a string
-or script block value.
+The value of the **Property** parameter can be a new calculated property. To create a calculated,
+property, create a hash table with an **Expression** key that specifies a string or script block
+value.
 
 ```yaml
 Type: Object[]
@@ -340,7 +376,8 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](../Microsoft.PowerShell.Core/About/about_CommonParameters.md).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -352,44 +389,45 @@ You can pipe any object to `Group-Object`.
 
 ### Microsoft.PowerShell.Commands.GroupInfo or System.Collections.Hashtable
 
-When you use the **AsHashTable** parameter, `Group-Object` returns a hash table.
+When you use the **AsHashTable** parameter, `Group-Object` returns a **Hashtable** object.
 Otherwise, it returns a **GroupInfo** object.
 
 ## NOTES
 
-- You can also use the **GroupBy** parameter of the formatting cmdlets (such as `Format-Table`
-  and `Format-List`) to group objects. Unlike `Group-Object`, which creates a single
-  table with a row for each property value, the **GroupBy** parameters create a table for each
-  property value with a row for each item that has the property value.
+You can use the **GroupBy** parameter of the formatting cmdlets, such as `Format-Table` and
+`Format-List`, to group objects. Unlike `Group-Object`, which creates a single table with a row for
+each property value, the **GroupBy** parameters create a table for each property value with a row
+for each item that has the property value.
 
-  `Group-Object` does not require that the objects being grouped be of the same Microsoft .NET
-  Framework type. When grouping objects of different .NET Framework types, `Group-Object` uses the
-  following rules:
+`Group-Object` doesn't require that the objects being grouped are of the same Microsoft .NET Core
+type. When grouping objects of different .NET Core types, `Group-Object` uses the following rules:
 
-  - Same Property Names and Types.
-    If the objects have a property with the specified name, and the property values have the same .NET
-    Framework type, the property values are grouped by using the same rules that would be used for
-    objects of the same type.
+- Same Property Names and Types.
 
-  - Same Property Names, Different Types.
-    If the objects have a property with the specified name, but the property values have a different
-    .NET Framework type in different objects, `Group-Object` uses the .NET Framework type of the first
-    occurrence of the property as the .NET Framework type for that property group.
-    When an object has a property with a different type, the property value is converted to the type for
-    that group. If the type conversion fails, the object is not included in the group.
+  If the objects have a property with the specified name, and the property values have the same .NET
+  Core type, the property values are grouped by using the same rules that would be used for objects
+  of the same type.
 
-  - Missing Properties.
-    Objects that do not have a specified property are considered ungroupable.
-    Ungroupable objects appear in the final **GroupInfo** object output in a group named
-    `AutomationNull.Value`.
+- Same Property Names, Different Types.
+
+  If the objects have a property with the specified name, but the property values have a different
+  .NET Core type in different objects, `Group-Object` uses the .NET Core type of the first
+  occurrence of the property as the .NET Core type for that property group. When an object has a
+  property with a different type, the property value is converted to the type for that group. If the
+  type conversion fails, the object isn't included in the group.
+
+- Missing Properties.
+
+  Objects that don't have a specified property can't be grouped. Objects that aren't grouped appear
+  in the final **GroupInfo** object output in a group named `AutomationNull.Value`.
 
 ## RELATED LINKS
+
+[about_Hash_Tables](../Microsoft.PowerShell.Core/About/about_Hash_Tables.md)
 
 [Compare-Object](Compare-Object.md)
 
 [ForEach-Object](../Microsoft.PowerShell.Core/ForEach-Object.md)
-
-[Where-Object](../Microsoft.PowerShell.Core/Where-Object.md)
 
 [Measure-Object](Measure-Object.md)
 
@@ -400,3 +438,5 @@ Otherwise, it returns a **GroupInfo** object.
 [Sort-Object](Sort-Object.md)
 
 [Tee-Object](Tee-Object.md)
+
+[Where-Object](../Microsoft.PowerShell.Core/Where-Object.md)


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

- Fixes [AB#1650163](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1650163)
- Fixes #5079
- PowerShell 7:
  - Create case-sensitive hash tables using the parameters **CaseSensitive** and **AsHashtable**.
  - Adds Example 7 for case-sensitive hash table.
- Copyedits, style, paragraph reflows for PS 5.1, 6, and 7.

Acrolinx scores:
Original version: 95
Updated version: 98

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
