### PR TITLE
Enable builds for PowerShell v7

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,7 @@ $ReferenceDocset = Join-Path $PSScriptRoot 'reference'
 
 # Go through all the directories in the reference folder
 $jobs = [System.Collections.Generic.List[object]]::new()
-$excludeList = 'module', 'media', 'docs-conceptual', 'mapping', 'bread', '7'
+$excludeList = 'module', 'media', 'docs-conceptual', 'mapping', 'bread'
 Get-ChildItem $ReferenceDocset -Directory -Exclude $excludeList | ForEach-Object -Process {
     $job = Start-ThreadJob -Name $_.Name -ArgumentList @($SkipCabs,$pandocExePath,$PSScriptRoot,$_) -ScriptBlock {
         param($SkipCabs, $pandocExePath, $WorkingDirectory, $DocSet)


### PR DESCRIPTION
# PR Summary
Enable build for powershell 7 docs

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
