### PR TITLE
Copyedits for Join-String and Out-String

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 12/13/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/out-string?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Out-String
@@ -12,10 +12,11 @@ title: Out-String
 # Out-String
 
 ## SYNOPSIS
-
 Sends objects to the host as a series of strings.
 
 ## SYNTAX
+
+### All
 
 ```
 Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParameters>]
@@ -23,62 +24,88 @@ Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParamete
 
 ## DESCRIPTION
 
-The `Out-String` cmdlet converts the objects that Windows PowerShell manages into an array of strings.
-By default, `Out-String` accumulates the strings and returns them as a single string, but you can use the **Stream** parameter to direct `Out-String` to return one string at a time.
-This cmdlet lets you search and manipulate string output as you would in traditional shells when object manipulation is less convenient.
+The `Out-String` cmdlet converts the objects that PowerShell manages into an array of strings. By
+default, `Out-String` accumulates the strings and returns them as a single string, but you can use
+the **Stream** parameter to direct `Out-String` to return one string at a time. This cmdlet lets you
+search and manipulate string output as you would in traditional shells when object manipulation is
+less convenient.
 
 ## EXAMPLES
 
 ### Example 1: Output text to the console as a string
 
-```
-PS C:\> Get-Content C:\test1\testfile2.txt | Out-String
+This example sends a file's contents to the `Out-String` cmdlet and displays it in the PowerShell
+console.
+
+```powershell
+Get-Content -Path C:\Test\Testfile.txt | Out-String
 ```
 
-This command sends the content of the Testfile2.txt file to the console as a single string.
-It uses the `Get-Content` cmdlet to get the content of the file.
-The pipeline operator (|) sends the content to `Out-String`, which sends the content to the console as a string.
+`Get-Culture` sends the contents of the `Testfile.txt` file down the pipeline. Each line of the file
+has its own properties. `Out-String` converts the objects into an array of strings and then displays
+the contents as one string in the PowerShell console.
+
+> [!NOTE]
+> To compare the differences about how `Get-Content` and `Out-String` display the properties:
+>
+> `Get-Content -Path C:\Test\Testfile.txt | Select-Object -Property *`
+>
+> `Get-Content -Path C:\Test\Testfile.txt | Out-String | Select-Object -Property *`
 
 ### Example 2: Get the current culture and convert the data to strings
 
-The first command uses the `Get-Culture` cmdlet to get the regional settings.
-The pipeline operator (|) sends the result to the `Select-Object` cmdlet,
-which selects all properties (*) of the culture object that `Get-Culture` returned.
-The command then stores the results in the `$C` variable.
-
-The second command uses the `Out-String` cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property).
-It uses the **InputObject** parameter to pass the `$C` variable to `Out-String`.
-The *Width* parameter is set to 100 characters per line to prevent truncation.
+This example gets the regional settings for the current user and converts the object data to
+strings.
 
 ```powershell
-PS C:\> $C = Get-Culture | Select-Object *
-PS C:\> Out-String -InputObject $C -Width 100
+$C = Get-Culture | Select-Object -Property *
+Out-String -InputObject $C -Width 100
 ```
 
-These commands get the regional settings for the current user and convert the data to strings.
+The `$C` variable stores a **Selected.System.Globalization.CultureInfo** object. The object is the
+result of `Get-Culture` sending output down the pipeline to `Select-Object`. The **Property**
+parameter uses an asterisk (`*`) wildcard to specify all properties are contained in the object.
+
+`Out-String` uses the **InputObject** parameter to specify the **CultureInfo** object stored in the
+`$C` variable. The objects in `$C` are converted to a string. The **Width** parameter is set to 100
+characters per line to prevent truncation.
+
+> [!NOTE]
+> To view the `Out-String` array, store the output to a variable and use an array index to view the
+> elements. For more information about the array index, see
+> [about_Arrays](../microsoft.powershell.core/about/about_arrays.md).
+>
+> `$str = Out-String -InputObject $C -Width 100`
 
 ### Example 3: Working with objects
 
+This example demonstrates the difference between working with objects and working with strings. The
+command displays an alias that includes the text **gcm**, the alias for `Get-Command`.
+
 ```powershell
-PS C:\> Get-Alias | Out-String -Stream | Select-String "Get-Command"
+Get-Alias | Out-String -Stream | Select-String -Pattern "gcm"
 ```
 
-This example demonstrates the difference between working with objects and working with strings.
-The command displays aliases that include the phrase "Get-Command".
-It uses the `Get-Alias` cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
+```Output
+Alias           gcm -> Get-Command
+```
 
-The pipeline operator (|) sends the output of the `Get-Alias` cmdlet to the `Out-String` cmdlet, which converts the objects to a series of strings.
-It uses the **Stream** parameter of `Out-String` to send each string individually, instead of concatenating them into a single string.
-Another pipeline operator sends the strings to the `Select-String` cmdlet, which selects the strings that include"*Get-Command" anywhere in the string.
+`Get-Alias` gets the **System.Management.Automation.AliasInfo** objects, one for each alias, and
+sends the objects down the pipeline. `Out-String` uses the **Stream** parameter to convert each
+object to a string rather concatenating all the objects into a single string. The **System.String**
+objects are sent down the pipeline and `Select-String` uses the **Pattern** parameter to find
+matches for the text **gcm**.
 
-If you omit the **Stream** parameter, the command displays all of the aliases, because `Select-String` finds "Get-Command" in the single string that `Out-String` returns, and the formatter displays the string as a table.
+> [!NOTE]
+> If you omit the **Stream** parameter, the command displays all the aliases because `Select-String`
+> finds the text **gcm** in the single string that `Out-String` returns.
 
 ## PARAMETERS
 
 ### -InputObject
 
-Specifies the objects to be written to a string.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
+Specifies the objects to be written to a string. Enter a variable that contains the objects, or type
+a command or expression that gets the objects.
 
 ```yaml
 Type: PSObject
@@ -94,10 +121,8 @@ Accept wildcard characters: False
 
 ### -Stream
 
-Indicates that the cmdlet sends the strings for each object separately.
-By default, the strings for each object are accumulated and sent as a single string.
-
-To use the **Stream** parameter, type `-Stream` or its alias, `ost`.
+Indicates that the cmdlet sends a separate string for each object. By default, the strings for each
+object are accumulated and sent as a single string.
 
 ```yaml
 Type: SwitchParameter
@@ -106,18 +131,17 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Width
 
-Specifies the number of characters in each line of output.
-Any additional characters are truncated, not wrapped.
-The **Width** parameter applies only to objects that are being formatted.
-If you omit this parameter, the width is determined by the characteristics of the host program.
-The default value for the Windows PowerShell console is 80 (characters).
+Specifies the number of characters in each line of output. Any additional characters are truncated,
+not wrapped. The **Width** parameter applies only to objects that are being formatted. If you omit
+this parameter, the width is determined by the characteristics of the host program. The default
+value for the PowerShell console is 80 characters.
 
 ```yaml
 Type: Int32
@@ -133,13 +157,16 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
 
-You can pipe objects to `Out-String`.
+You can send objects down the pipeline to `Out-String`.
 
 ## OUTPUTS
 
@@ -149,12 +176,13 @@ You can pipe objects to `Out-String`.
 
 ## NOTES
 
-* The cmdlets that contain the **Out** verb that do not format objects;
-they just render them and send them to the specified display destination.
-If you send an unformatted object to an **Out** cmdlet, the cmdlet sends it to a formatting cmdlet before rendering it.
-* The **Out** cmdlets do not have parameters that take names or file paths.
-To send data to an **Out** cmdlet, use a pipeline operator (|) to send the output of a Windows PowerShell command to the cmdlet.
-You can also store data in a variable and use the **InputObject** parameter to pass the data to the cmdlet.
+The cmdlets that contain the `Out` verb that don't format objects; they just render objects and send
+them to the specified display destination. If you send an unformatted object to an `Out` cmdlet, the
+cmdlet sends it to a formatting cmdlet before rendering it.
+
+The `Out` cmdlets don't have parameters that accept names or file paths. To send the output of a
+PowerShell command to an `Out` cmdlet, use the pipeline. Or, you can store data in a variable and
+use the **InputObject** parameter to pass the data to the cmdlet.
 
 ## RELATED LINKS
 
@@ -169,5 +197,3 @@ You can also store data in a variable and use the **InputObject** parameter to p
 [Out-GridView](Out-GridView.md)
 
 [Out-Printer](Out-Printer.md)
-
-

--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
@@ -176,9 +176,8 @@ You can send objects down the pipeline to `Out-String`.
 
 ## NOTES
 
-The cmdlets that contain the `Out` verb that don't format objects; they just render objects and send
-them to the specified display destination. If you send an unformatted object to an `Out` cmdlet, the
-cmdlet sends it to a formatting cmdlet before rendering it.
+The cmdlets that contain the `Out` verb don't format objects. The `Out` cmdlets send objects to the
+formatter for the specified display destination.
 
 The `Out` cmdlets don't have parameters that accept names or file paths. To send the output of a
 PowerShell command to an `Out` cmdlet, use the pipeline. Or, you can store data in a variable and

--- a/reference/6/Microsoft.PowerShell.Utility/Join-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Join-String.md
@@ -116,11 +116,11 @@ For more information about automatic variables and substrings, see
 This example joins service names with each service on a separate line and indented by a tab.
 
 ```powershell
-Get-Service -Name se* | Join-String -Property Name -Separator "`r`n`t" -OutputPrefix "`t"
+Get-Service -Name se* | Join-String -Property Name -Separator "`r`n`t" -OutputPrefix "Services:`n`t"
 ```
 
 ```Output
-
+Services:
     seclogon
     SecurityHealthService
     SEMgrSvc
@@ -138,7 +138,7 @@ asterisk (`*`) is a wildcard for any character.
 The objects are sent down the pipeline to `Join-String` that uses the **Property** parameter to
 specify the service names. The **Separator** parameter specifies three special characters that
 represent a carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``). The **OutputPrefix**
-inserts a tab before the first line of output.
+inserts a label **Services:** with a new line and tab before the first line of output.
 
 For more information about special characters, see
 [about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md).

--- a/reference/6/Microsoft.PowerShell.Utility/Join-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Join-String.md
@@ -1,7 +1,7 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 02/01/2019
+ms.date: 12/12/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/join-string?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Join-String
@@ -14,81 +14,109 @@ Combines objects from the pipeline into a single string.
 
 ## SYNTAX
 
-### default (Default)
+### Default (Default)
 
 ```
 Join-String [[-Property] <PSPropertyExpression>] [[-Separator] <String>] [-OutputPrefix <String>]
- [-OutputSuffix <String>] [-InputObject <PSObject>] [<CommonParameters>]
+ [-OutputSuffix <String>] [-UseCulture] [-InputObject <PSObject[]>] [<CommonParameters>]
 ```
 
 ### SingleQuote
 
 ```
 Join-String [[-Property] <PSPropertyExpression>] [[-Separator] <String>] [-OutputPrefix <String>]
- [-OutputSuffix <String>] [-SingleQuote] [-InputObject <PSObject>] [<CommonParameters>]
+ [-OutputSuffix <String>] [-SingleQuote] [-UseCulture] [-InputObject <PSObject[]>]
+ [<CommonParameters>]
 ```
 
 ### DoubleQuote
 
 ```
 Join-String [[-Property] <PSPropertyExpression>] [[-Separator] <String>] [-OutputPrefix <String>]
- [-OutputSuffix <String>] [-DoubleQuote] [-InputObject <PSObject>] [<CommonParameters>]
+ [-OutputSuffix <String>] [-DoubleQuote] [-UseCulture] [-InputObject <PSObject[]>]
+ [<CommonParameters>]
 ```
 
 ### Format
 
 ```
 Join-String [[-Property] <PSPropertyExpression>] [[-Separator] <String>] [-OutputPrefix <String>]
- [-OutputSuffix <String>] [-FormatString <String>] [-InputObject <PSObject>] [<CommonParameters>]
+ [-OutputSuffix <String>] [-FormatString <String>] [-UseCulture] [-InputObject <PSObject[]>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Join-String` cmdlet joins (combines) text from pipeline objects into a single string.
+The `Join-String` cmdlet joins, or combines, text from pipeline objects into a single string.
 
 If no parameters are specified, the pipeline objects are converted to a string and joined with the
-default separatator $OFS.
+default separator `$OFS`.
 
-By specifying a property name, the value of the property is converted to a string and joined into a
+By specifying a property name, the property's value is converted to a string and joined into a
 string.
 
-Instead of a property name, a script block can be used. In that case the result of the scriptblock
-will be converted to a string before joining it to form the result. It can either combine the text
-of a property of an object or the result of converting the object to a string.
+Instead of a property name, a script block can be used. The script block's result is converted to a
+string before it's joined to form the result. It can either combine the text of an object's property
+or the result of the object that was converted to a string.
 
 This cmdlet was introduced in PowerShell 6.2.
 
 ## EXAMPLES
 
-### Example 1
+### Example 1: Join directory names
+
+This example joins directory names, wraps the output in double-quotes, and separates the directory
+names with a command and space (`, `). The output is a string object.
 
 ```powershell
-PS> gci -Directory c:\ | join-string -Property Name -DoubleQuote -Separator ', '
+Get-ChildItem -Directory C:\ | Join-String -Property Name -DoubleQuote -Separator ', '
 ```
 
 ```Output
 "PerfLogs", "Program Files", "Program Files (x86)", "Users", "Windows"
 ```
 
-This example joins the directory names of c:\, double qouted and separated by ', ' to a string.
+`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\` drive.
+The objects are sent down the pipeline to `Join-String`. The **Property** parameter specifies the
+directory names. The **DoubleQuote** parameter wraps the directory names with double-quote marks.
+The **Separator** parameter specifies to use a comma and space (`, `) to separate the directory
+names.
 
-### Example 2
+The `Get-ChildItem` objects are **System.IO.DirectoryInfo** and `Join-String` converts the objects
+to **System.String**.
+
+### Example 2: Use a property substring to join directory names
+
+This example uses a substring method to get the first four letters of directory names, wraps the
+output in single-quotes, and separates the directory names with a semicolon (`;`).
 
 ```powershell
-PS> gci -Directory c:\ | join-string -Property {$_.Name.SubString(0,4)} -SingleQuote -Separator ';'
+Get-ChildItem -Directory C:\ | Join-String -Property {$_.Name.SubString(0,4)} -SingleQuote -Separator ';'
 ```
 
 ```Output
 'Perf';'Prog';'Prog';'User';'Wind'
 ```
 
-This example joins the first four letters of the directory names of c:\, single qouted and separated by ';' to a string.
+`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\` drive.
+The objects are sent down the pipeline to `Join-String`.
 
+The **Property** parameter script block uses automatic variable (`$_`) to specify each object's
+**Name** property substring. The substring gets the first four letters of each directory name. The
+substring specifies the character start and end positions. The **SingleQuote** parameter wraps the
+directory names with single-quote marks. The **Separator** parameter specifies to use a semicolon
+(`;`) to separate the directory names.
 
-### Example 3
+For more information about automatic variables and substrings, see
+[about_Automatic_Variables](../microsoft.powershell.core/about/about_automatic_variables.md) and
+[Substring](/dotnet/api/system.string.substring).
+
+### Example 3: Display join output on a separate line
+
+This example joins service names with each service on a separate line and indented by a tab.
 
 ```powershell
-PS> gsv se* | Join-String Name -Separator "`r`n`t" -OutputPrefix "`t"
+Get-Service -Name se* | Join-String -Property Name -Separator "`r`n`t" -OutputPrefix "`t"
 ```
 
 ```Output
@@ -103,14 +131,35 @@ PS> gsv se* | Join-String Name -Separator "`r`n`t" -OutputPrefix "`t"
     SessionEnv
 ```
 
-This example joins the the names of services with names starting on 'se' with each service on a
-separate line and indented by a tab.
+`Get-Service` uses the **Name** parameter with to specify services that begin with `se*`. The
+asterisk (`*`) is a wildcard for any character.
 
+The objects are sent down the pipeline to `Join-String` that uses the **Property** parameter to
+specify the service names. The **Separator** parameter specifies three special characters that
+represent a carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``). The **OutputPrefix**
+inserts a tab before the first line of output.
+
+For more information about special characters, see
+[about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md).
 
 ### Example 4
 
+This example generates a PowerShell class definition from a custom **PSOBject** by joining the names
+of the properties.
+
+This code sample uses splatting to reduce the line length and improve readability. For more
+information, see [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).
+
 ```powershell
-PS> ([pscustomobject] @{Name = "Joe"; Age = 42}).PSObject.Properties | join-string -Property Name -FormatString '  ${0}' -OutputPrefix "class {`n" -OutputSuffix "`n}`n" -Separator "`n"
+$obj = ([pscustomobject] @{Name = "Joe"; Age = 42}).PSObject.Properties
+$parms = @{
+  Property = "Name"
+  FormatString = '  ${0}'
+  OutputPrefix = "class {`n"
+  OutputSuffix = "`n}`n"
+  Separator = "`n"
+}
+$obj | Join-String @parms
 ```
 
 ```Output
@@ -120,14 +169,11 @@ class {
 }
 ```
 
-This example generates a PowerShell class definition from a custom PSOBject by joining the names of
-the properties.
-
 ## PARAMETERS
 
 ### -DoubleQuote
 
-Wrap the string value of each pipeline object in double-quotes.
+Wraps the string value of each pipeline object in double-quotes.
 
 ```yaml
 Type: SwitchParameter
@@ -136,7 +182,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -176,7 +222,8 @@ Accept wildcard characters: False
 
 ### -OutputPrefix
 
-Text that will be prepended to that output string.
+Text that's inserted before the output string. The string can contain special characters such as
+carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``).
 
 ```yaml
 Type: String
@@ -192,7 +239,8 @@ Accept wildcard characters: False
 
 ### -OutputSuffix
 
-Text that will be appened to that output string.
+Text that's appended to the output string. The string can contain special characters such as
+carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``).
 
 ```yaml
 Type: String
@@ -208,7 +256,7 @@ Accept wildcard characters: False
 
 ### -Property
 
-The name of a property (or a property expression) that will project the pipeline object to text.
+The name of a property, or a property expression, that will project the pipeline object to text.
 
 ```yaml
 Type: PSPropertyExpression
@@ -224,7 +272,8 @@ Accept wildcard characters: False
 
 ### -Separator
 
-A text that will be inserted between the text for each pipeline object.
+Text or characters such as a comma or semicolon that's inserted between the text for each pipeline
+object.
 
 ```yaml
 Type: String
@@ -240,7 +289,7 @@ Accept wildcard characters: False
 
 ### -SingleQuote
 
-Wrap the string value of each pipeline object in single-quotes.
+Wraps the string value of each pipeline object in single quotes.
 
 ```yaml
 Type: SwitchParameter
@@ -249,7 +298,24 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseCulture
+
+Uses the list separator for the current culture as the item delimiter. To find the list separator
+for a culture, use the following command: `(Get-Culture).TextInfo.ListSeparator`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -258,7 +324,8 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -272,3 +339,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
+[about_Automatic_Variables](../microsoft.powershell.core/about/about_automatic_variables.md)
+
+[about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md)
+
+[Substring](/dotnet/api/system.string.substring)

--- a/reference/6/Microsoft.PowerShell.Utility/Join-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Join-String.md
@@ -143,16 +143,15 @@ inserts a label **Services:** with a new line and tab before the first line of o
 For more information about special characters, see
 [about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md).
 
-### Example 4
+### Example 4: Create a class definition from an object
 
-This example generates a PowerShell class definition from a custom **PSOBject** by joining the names
-of the properties.
+This example generates a PowerShell class definition using an existing object as a template.
 
 This code sample uses splatting to reduce the line length and improve readability. For more
 information, see [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).
 
 ```powershell
-$obj = ([pscustomobject] @{Name = "Joe"; Age = 42}).PSObject.Properties
+$obj = [pscustomobject] @{Name = "Joe"; Age = 42}
 $parms = @{
   Property = "Name"
   FormatString = '  ${0}'
@@ -160,7 +159,7 @@ $parms = @{
   OutputSuffix = "`n}`n"
   Separator = "`n"
 }
-$obj | Join-String @parms
+$obj.PSObject.Properties | Join-String @parms
 ```
 
 ```Output

--- a/reference/6/Microsoft.PowerShell.Utility/Join-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Join-String.md
@@ -120,6 +120,7 @@ Get-Service -Name se* | Join-String -Property Name -Separator "`r`n`t" -OutputPr
 ```
 
 ```Output
+
     seclogon
     SecurityHealthService
     SEMgrSvc

--- a/reference/6/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Out-String.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 12/13/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/out-string?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Out-String
@@ -12,7 +12,6 @@ title: Out-String
 # Out-String
 
 ## SYNOPSIS
-
 Sends objects to the host as a series of strings.
 
 ## SYNTAX
@@ -31,80 +30,128 @@ Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParamete
 
 ## DESCRIPTION
 
-The `Out-String` cmdlet converts the objects that PowerShell manages into an array of strings.
-By default, `Out-String` accumulates the strings and returns them as a single string, but you can use the stream parameter to direct `Out-String` to return one string at a time.
-This cmdlet lets you search and manipulate string output as you would in traditional shells when object manipulation is less convenient.
+The `Out-String` cmdlet converts the objects that PowerShell manages into an array of strings. By
+default, `Out-String` accumulates the strings and returns them as a single string, but you can use
+the **Stream** parameter to direct `Out-String` to return one string at a time. This cmdlet lets you
+search and manipulate string output as you would in traditional shells when object manipulation is
+less convenient.
 
 ## EXAMPLES
 
 ### Example 1: Output text to the console as a string
 
+This example sends a file's contents to the `Out-String` cmdlet and displays it in the PowerShell
+console.
+
 ```powershell
-PS> Get-Content C:\test1\testfile2.txt | Out-String
+Get-Content -Path C:\Test\Testfile.txt | Out-String
 ```
 
-This command sends the content of the Testfile2.txt file to the console as a single string.
-It uses the `Get-Content` cmdlet to get the content of the file.
-The pipeline operator (|) sends the content to `Out-String`, which sends the content to the console as a string.
+`Get-Culture` sends the contents of the `Testfile.txt` file down the pipeline. Each line of the file
+has its own properties. `Out-String` converts the objects into an array of strings and then displays
+the contents as one string in the PowerShell console.
+
+> [!NOTE]
+> To compare the differences about how `Get-Content` and `Out-String` display the properties:
+>
+> `Get-Content -Path C:\Test\Testfile.txt | Select-Object -Property *`
+>
+> `Get-Content -Path C:\Test\Testfile.txt | Out-String | Select-Object -Property *`
 
 ### Example 2: Get the current culture and convert the data to strings
 
-The first command uses the `Get-Culture` cmdlet to get the regional settings.
-The pipeline operator (|) sends the result to the `Select-Object` cmdlet,
-which selects all properties (*) of the culture object that `Get-Culture` returned.
-The command then stores the results in the `$C` variable.
-
-The second command uses the `Out-String` cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property).
-It uses the **InputObject** parameter to pass the `$C` variable to `Out-String`.
-The *Width* parameter is set to 100 characters per line to prevent truncation.
+This example gets the regional settings for the current user and converts the object data to
+strings.
 
 ```powershell
-PS> $C = Get-Culture | Select-Object *
-PS> Out-String -InputObject $C -Width 100
+$C = Get-Culture | Select-Object -Property *
+Out-String -InputObject $C -Width 100
 ```
 
-These commands get the regional settings for the current user and convert the data to strings.
+The `$C` variable stores a **Selected.System.Globalization.CultureInfo** object. The object is the
+result of `Get-Culture` sending output down the pipeline to `Select-Object`. The **Property**
+parameter uses an asterisk (`*`) wildcard to specify all properties are contained in the object.
+
+`Out-String` uses the **InputObject** parameter to specify the **CultureInfo** object stored in the
+`$C` variable. The objects in `$C` are converted to a string. The **Width** parameter is set to 100
+characters per line to prevent truncation.
+
+> [!NOTE]
+> To view the `Out-String` array, store the output to a variable and use an array index to view the
+> elements. For more information about the array index, see
+> [about_Arrays](../microsoft.powershell.core/about/about_arrays.md).
+>
+> `$str = Out-String -InputObject $C -Width 100`
 
 ### Example 3: Working with objects
 
+This example demonstrates the difference between working with objects and working with strings. The
+command displays an alias that includes the text **gcm**, the alias for `Get-Command`.
+
 ```powershell
-PS> Get-Alias | Out-String -Stream | Select-String "Get-Command"
+Get-Alias | Out-String -Stream | Select-String -Pattern "gcm"
 ```
 
-This example demonstrates the difference between working with objects and working with strings.
-The command displays aliases that include the phrase "Get-Command".
-It uses the `Get-Alias` cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
+```Output
+Alias           gcm -> Get-Command
+```
 
-The pipeline operator (|) sends the output of the `Get-Alias` cmdlet to the `Out-String` cmdlet, which converts the objects to a series of strings.
-It uses the **Stream** parameter of `Out-String` to send each string individually, instead of concatenating them into a single string.
-Another pipeline operator sends the strings to the `Select-String` cmdlet, which selects the strings that include "Get-Command" anywhere in the string.
+`Get-Alias` gets the **System.Management.Automation.AliasInfo** objects, one for each alias, and
+sends the objects down the pipeline. `Out-String` uses the **Stream** parameter to convert each
+object to a string rather concatenating all the objects into a single string. The **System.String**
+objects are sent down the pipeline and `Select-String` uses the **Pattern** parameter to find
+matches for the text **gcm**.
 
-If you omit the **Stream** parameter, the command displays all of the aliases, because `Select-String` finds "Get-Command" in the single string that `Out-String` returns, and the formatter displays the string as a table.
+> [!NOTE]
+> If you omit the **Stream** parameter, the command displays all the aliases because `Select-String`
+> finds the text **gcm** in the single string that `Out-String` returns.
 
-### Example 4: Using NoNewLine
+### Example 4: Using the NoNewLine parameter
+
+This example shows how the **NoNewLine** parameter removes new lines that are created by the
+PowerShell formatter. New lines that are part of the string objects created with `Out-String` aren't
+removed.
+
+The example uses a special character (`` `n ``) to create a new line. For more information, see
+[about_Special_Characters](/microsoft.powershell.core/about/about_special_characters).
 
 ```
-PS> "a", "b" | Out-String -NoNewLine
+PS> "a", "b`n", "c", "d" | Out-String
+a
+b
+
+c
+d
+
+PS> "a", "b`n", "c", "d" | Out-String -NoNewline
 ab
+cd
 
 PS> @{key='value'} | Out-String
+
 Name   Value
 ----   -----
 key    value
 
 PS> @{key='value'} | Out-String -NoNewLine
-Name Value  -----  key value
+
+Name    Value----     -----key     value
 ```
 
-Not using `-NoNewLine` would have resulted in an output like `a<newline>b<newline>`.
-It should be noted that `-NoNewLine` does not strip newlines embedded within a string but strips out embedded newlines from formatter-generated output. Compare the second and third commands in this examples for clarity.
+A string of characters is sent down the pipeline to `Out-String`. The default formatter displays the
+output that includes new lines. The `` "b`n" `` includes the new line special character. When the
+**NoNewline** parameter is used, the new lines created by the formatter are removed. But, the new
+line created with the special character is preserved.
+
+The key/value pair is an example of how `Out-String` uses the default formatter to add new lines.
+When the **NoNewline** parameter is used, the new lines created by the formatter are removed.
 
 ## PARAMETERS
 
 ### -InputObject
 
-Specifies the objects to be written to a string.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
+Specifies the objects to be written to a string. Enter a variable that contains the objects, or type
+a command or expression that gets the objects.
 
 ```yaml
 Type: PSObject
@@ -120,8 +167,8 @@ Accept wildcard characters: False
 
 ### -NoNewline
 
-Removes all newlines from formatter generated output. Note that newlines present as part of string
-objects are preserved.
+Removes all newlines from output generated by the PowerShell formatter. Newlines that are part of
+the string objects are preserved.
 
 This parameter was introduced in PowerShell 6.0.
 
@@ -132,17 +179,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Stream
 
-Indicates that the cmdlet sends the strings for each object separately.
-By default, the strings for each object are accumulated and sent as a single string.
-
-To use the **Stream** parameter, type `-Stream` or its alias, `ost`.
+Indicates that the cmdlet sends a separate string for each object. By default, the strings for each
+object are accumulated and sent as a single string.
 
 ```yaml
 Type: SwitchParameter
@@ -151,18 +196,17 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Width
 
-Specifies the number of characters in each line of output.
-Any additional characters are truncated, not wrapped.
-The **Width** parameter applies only to objects that are being formatted.
-If you omit this parameter, the width is determined by the characteristics of the host program.
-The default value for the PowerShell console is 80 (characters).
+Specifies the number of characters in each line of output. Any additional characters are truncated,
+not wrapped. The **Width** parameter applies only to objects that are being formatted. If you omit
+this parameter, the width is determined by the characteristics of the host program. The default
+value for the PowerShell console is 80 characters.
 
 ```yaml
 Type: Int32
@@ -178,13 +222,16 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
 
-You can pipe objects to `Out-String`.
+You can send objects down the pipeline to `Out-String`.
 
 ## OUTPUTS
 
@@ -194,12 +241,13 @@ You can pipe objects to `Out-String`.
 
 ## NOTES
 
-* The cmdlets that contain the **Out** verb that do not format objects;
-they just render them and send them to the specified display destination.
-If you send an unformatted object to an **Out** cmdlet, the cmdlet sends it to a formatting cmdlet before rendering it.
-* The **Out** cmdlets do not have parameters that take names or file paths.
-To send data to an **Out** cmdlet, use a pipeline operator (|) to send the output of a PowerShell command to the cmdlet.
-You can also store data in a variable and use the **InputObject** parameter to pass the data to the cmdlet.
+The cmdlets that contain the `Out` verb that don't format objects; they just render objects and send
+them to the specified display destination. If you send an unformatted object to an `Out` cmdlet, the
+cmdlet sends it to a formatting cmdlet before rendering it.
+
+The `Out` cmdlets don't have parameters that accept names or file paths. To send the output of a
+PowerShell command to an `Out` cmdlet, use the pipeline. Or, you can store data in a variable and
+use the **InputObject** parameter to pass the data to the cmdlet.
 
 ## RELATED LINKS
 
@@ -210,5 +258,3 @@ You can also store data in a variable and use the **InputObject** parameter to p
 [Out-Host](../Microsoft.PowerShell.Core/Out-Host.md)
 
 [Out-Null](../Microsoft.PowerShell.Core/Out-Null.md)
-
-

--- a/reference/6/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Out-String.md
@@ -241,9 +241,8 @@ You can send objects down the pipeline to `Out-String`.
 
 ## NOTES
 
-The cmdlets that contain the `Out` verb that don't format objects; they just render objects and send
-them to the specified display destination. If you send an unformatted object to an `Out` cmdlet, the
-cmdlet sends it to a formatting cmdlet before rendering it.
+The cmdlets that contain the `Out` verb don't format objects. The `Out` cmdlets send objects to the
+formatter for the specified display destination.
 
 The `Out` cmdlets don't have parameters that accept names or file paths. To send the output of a
 PowerShell command to an `Out` cmdlet, use the pipeline. Or, you can store data in a variable and

--- a/reference/7/Microsoft.PowerShell.Utility/Join-String.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Join-String.md
@@ -116,11 +116,11 @@ For more information about automatic variables and substrings, see
 This example joins service names with each service on a separate line and indented by a tab.
 
 ```powershell
-Get-Service -Name se* | Join-String -Property Name -Separator "`r`n`t" -OutputPrefix "`t"
+Get-Service -Name se* | Join-String -Property Name -Separator "`r`n`t" -OutputPrefix "Services:`n`t"
 ```
 
 ```Output
-
+Services:
     seclogon
     SecurityHealthService
     SEMgrSvc
@@ -138,7 +138,7 @@ asterisk (`*`) is a wildcard for any character.
 The objects are sent down the pipeline to `Join-String` that uses the **Property** parameter to
 specify the service names. The **Separator** parameter specifies three special characters that
 represent a carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``). The **OutputPrefix**
-inserts a tab before the first line of output.
+inserts a label **Services:** with a new line and tab before the first line of output.
 
 For more information about special characters, see
 [about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md).

--- a/reference/7/Microsoft.PowerShell.Utility/Join-String.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Join-String.md
@@ -1,7 +1,7 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 02/01/2019
+ms.date: 12/12/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/join-string?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Join-String
@@ -14,81 +14,109 @@ Combines objects from the pipeline into a single string.
 
 ## SYNTAX
 
-### default (Default)
+### Default (Default)
 
 ```
 Join-String [[-Property] <PSPropertyExpression>] [[-Separator] <String>] [-OutputPrefix <String>]
- [-OutputSuffix <String>] [-InputObject <PSObject>] [<CommonParameters>]
+ [-OutputSuffix <String>] [-UseCulture] [-InputObject <PSObject[]>] [<CommonParameters>]
 ```
 
 ### SingleQuote
 
 ```
 Join-String [[-Property] <PSPropertyExpression>] [[-Separator] <String>] [-OutputPrefix <String>]
- [-OutputSuffix <String>] [-SingleQuote] [-InputObject <PSObject>] [<CommonParameters>]
+ [-OutputSuffix <String>] [-SingleQuote] [-UseCulture] [-InputObject <PSObject[]>]
+ [<CommonParameters>]
 ```
 
 ### DoubleQuote
 
 ```
 Join-String [[-Property] <PSPropertyExpression>] [[-Separator] <String>] [-OutputPrefix <String>]
- [-OutputSuffix <String>] [-DoubleQuote] [-InputObject <PSObject>] [<CommonParameters>]
+ [-OutputSuffix <String>] [-DoubleQuote] [-UseCulture] [-InputObject <PSObject[]>]
+ [<CommonParameters>]
 ```
 
 ### Format
 
 ```
 Join-String [[-Property] <PSPropertyExpression>] [[-Separator] <String>] [-OutputPrefix <String>]
- [-OutputSuffix <String>] [-FormatString <String>] [-InputObject <PSObject>] [<CommonParameters>]
+ [-OutputSuffix <String>] [-FormatString <String>] [-UseCulture] [-InputObject <PSObject[]>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `Join-String` cmdlet joins (combines) text from pipeline objects into a single string.
+The `Join-String` cmdlet joins, or combines, text from pipeline objects into a single string.
 
 If no parameters are specified, the pipeline objects are converted to a string and joined with the
-default separatator $OFS.
+default separator `$OFS`.
 
-By specifying a property name, the value of the property is converted to a string and joined into a
+By specifying a property name, the property's value is converted to a string and joined into a
 string.
 
-Instead of a property name, a script block can be used. In that case the result of the scriptblock
-will be converted to a string before joining it to form the result. It can either combine the text
-of a property of an object or the result of converting the object to a string.
+Instead of a property name, a script block can be used. The script block's result is converted to a
+string before it's joined to form the result. It can either combine the text of an object's property
+or the result of the object that was converted to a string.
 
 This cmdlet was introduced in PowerShell 6.2.
 
 ## EXAMPLES
 
-### Example 1
+### Example 1: Join directory names
+
+This example joins directory names, wraps the output in double-quotes, and separates the directory
+names with a command and space (`, `). The output is a string object.
 
 ```powershell
-PS> gci -Directory c:\ | join-string -Property Name -DoubleQuote -Separator ', '
+Get-ChildItem -Directory C:\ | Join-String -Property Name -DoubleQuote -Separator ', '
 ```
 
 ```Output
 "PerfLogs", "Program Files", "Program Files (x86)", "Users", "Windows"
 ```
 
-This example joins the directory names of c:\, double qouted and separated by ', ' to a string.
+`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\` drive.
+The objects are sent down the pipeline to `Join-String`. The **Property** parameter specifies the
+directory names. The **DoubleQuote** parameter wraps the directory names with double-quote marks.
+The **Separator** parameter specifies to use a comma and space (`, `) to separate the directory
+names.
 
-### Example 2
+The `Get-ChildItem` objects are **System.IO.DirectoryInfo** and `Join-String` converts the objects
+to **System.String**.
+
+### Example 2: Use a property substring to join directory names
+
+This example uses a substring method to get the first four letters of directory names, wraps the
+output in single-quotes, and separates the directory names with a semicolon (`;`).
 
 ```powershell
-PS> gci -Directory c:\ | join-string -Property {$_.Name.SubString(0,4)} -SingleQuote -Separator ';'
+Get-ChildItem -Directory C:\ | Join-String -Property {$_.Name.SubString(0,4)} -SingleQuote -Separator ';'
 ```
 
 ```Output
 'Perf';'Prog';'Prog';'User';'Wind'
 ```
 
-This example joins the first four letters of the directory names of c:\, single qouted and separated by ';' to a string.
+`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\` drive.
+The objects are sent down the pipeline to `Join-String`.
 
+The **Property** parameter script block uses automatic variable (`$_`) to specify each object's
+**Name** property substring. The substring gets the first four letters of each directory name. The
+substring specifies the character start and end positions. The **SingleQuote** parameter wraps the
+directory names with single-quote marks. The **Separator** parameter specifies to use a semicolon
+(`;`) to separate the directory names.
 
-### Example 3
+For more information about automatic variables and substrings, see
+[about_Automatic_Variables](../microsoft.powershell.core/about/about_automatic_variables.md) and
+[Substring](/dotnet/api/system.string.substring).
+
+### Example 3: Display join output on a separate line
+
+This example joins service names with each service on a separate line and indented by a tab.
 
 ```powershell
-PS> gsv se* | Join-String Name -Separator "`r`n`t" -OutputPrefix "`t"
+Get-Service -Name se* | Join-String -Property Name -Separator "`r`n`t" -OutputPrefix "`t"
 ```
 
 ```Output
@@ -103,14 +131,35 @@ PS> gsv se* | Join-String Name -Separator "`r`n`t" -OutputPrefix "`t"
     SessionEnv
 ```
 
-This example joins the the names of services with names starting on 'se' with each service on a
-separate line and indented by a tab.
+`Get-Service` uses the **Name** parameter with to specify services that begin with `se*`. The
+asterisk (`*`) is a wildcard for any character.
 
+The objects are sent down the pipeline to `Join-String` that uses the **Property** parameter to
+specify the service names. The **Separator** parameter specifies three special characters that
+represent a carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``). The **OutputPrefix**
+inserts a tab before the first line of output.
+
+For more information about special characters, see
+[about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md).
 
 ### Example 4
 
+This example generates a PowerShell class definition from a custom **PSOBject** by joining the names
+of the properties.
+
+This code sample uses splatting to reduce the line length and improve readability. For more
+information, see [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).
+
 ```powershell
-PS> ([pscustomobject] @{Name = "Joe"; Age = 42}).PSObject.Properties | join-string -Property Name -FormatString '  ${0}' -OutputPrefix "class {`n" -OutputSuffix "`n}`n" -Separator "`n"
+$obj = ([pscustomobject] @{Name = "Joe"; Age = 42}).PSObject.Properties
+$parms = @{
+  Property = "Name"
+  FormatString = '  ${0}'
+  OutputPrefix = "class {`n"
+  OutputSuffix = "`n}`n"
+  Separator = "`n"
+}
+$obj | Join-String @parms
 ```
 
 ```Output
@@ -120,14 +169,11 @@ class {
 }
 ```
 
-This example generates a PowerShell class definition from a custom PSOBject by joining the names of
-the properties.
-
 ## PARAMETERS
 
 ### -DoubleQuote
 
-Wrap the string value of each pipeline object in double-quotes.
+Wraps the string value of each pipeline object in double-quotes.
 
 ```yaml
 Type: SwitchParameter
@@ -136,7 +182,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -176,7 +222,8 @@ Accept wildcard characters: False
 
 ### -OutputPrefix
 
-Text that will be prepended to that output string.
+Text that's inserted before the output string. The string can contain special characters such as
+carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``).
 
 ```yaml
 Type: String
@@ -192,7 +239,8 @@ Accept wildcard characters: False
 
 ### -OutputSuffix
 
-Text that will be appened to that output string.
+Text that's appended to the output string. The string can contain special characters such as
+carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``).
 
 ```yaml
 Type: String
@@ -208,7 +256,7 @@ Accept wildcard characters: False
 
 ### -Property
 
-The name of a property (or a property expression) that will project the pipeline object to text.
+The name of a property, or a property expression, that will project the pipeline object to text.
 
 ```yaml
 Type: PSPropertyExpression
@@ -224,7 +272,8 @@ Accept wildcard characters: False
 
 ### -Separator
 
-A text that will be inserted between the text for each pipeline object.
+Text or characters such as a comma or semicolon that's inserted between the text for each pipeline
+object.
 
 ```yaml
 Type: String
@@ -240,7 +289,7 @@ Accept wildcard characters: False
 
 ### -SingleQuote
 
-Wrap the string value of each pipeline object in single-quotes.
+Wraps the string value of each pipeline object in single quotes.
 
 ```yaml
 Type: SwitchParameter
@@ -249,7 +298,24 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseCulture
+
+Uses the list separator for the current culture as the item delimiter. To find the list separator
+for a culture, use the following command: `(Get-Culture).TextInfo.ListSeparator`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -258,7 +324,8 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -272,3 +339,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
+[about_Automatic_Variables](../microsoft.powershell.core/about/about_automatic_variables.md)
+
+[about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md)
+
+[Substring](/dotnet/api/system.string.substring)

--- a/reference/7/Microsoft.PowerShell.Utility/Join-String.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Join-String.md
@@ -143,16 +143,15 @@ inserts a label **Services:** with a new line and tab before the first line of o
 For more information about special characters, see
 [about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md).
 
-### Example 4
+### Example 4: Create a class definition from an object
 
-This example generates a PowerShell class definition from a custom **PSOBject** by joining the names
-of the properties.
+This example generates a PowerShell class definition using an existing object as a template.
 
 This code sample uses splatting to reduce the line length and improve readability. For more
 information, see [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).
 
 ```powershell
-$obj = ([pscustomobject] @{Name = "Joe"; Age = 42}).PSObject.Properties
+$obj = [pscustomobject] @{Name = "Joe"; Age = 42}
 $parms = @{
   Property = "Name"
   FormatString = '  ${0}'
@@ -160,7 +159,7 @@ $parms = @{
   OutputSuffix = "`n}`n"
   Separator = "`n"
 }
-$obj | Join-String @parms
+$obj.PSObject.Properties | Join-String @parms
 ```
 
 ```Output

--- a/reference/7/Microsoft.PowerShell.Utility/Join-String.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Join-String.md
@@ -120,6 +120,7 @@ Get-Service -Name se* | Join-String -Property Name -Separator "`r`n`t" -OutputPr
 ```
 
 ```Output
+
     seclogon
     SecurityHealthService
     SEMgrSvc

--- a/reference/7/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Out-String.md
@@ -241,9 +241,8 @@ You can send objects down the pipeline to `Out-String`.
 
 ## NOTES
 
-The cmdlets that contain the `Out` verb that don't format objects; they just render objects and send
-them to the specified display destination. If you send an unformatted object to an `Out` cmdlet, the
-cmdlet sends it to a formatting cmdlet before rendering it.
+The cmdlets that contain the `Out` verb don't format objects. The `Out` cmdlets send objects to the
+formatter for the specified display destination.
 
 The `Out` cmdlets don't have parameters that accept names or file paths. To send the output of a
 PowerShell command to an `Out` cmdlet, use the pipeline. Or, you can store data in a variable and

--- a/reference/7/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Out-String.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 12/13/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/out-string?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Out-String
@@ -12,7 +12,6 @@ title: Out-String
 # Out-String
 
 ## SYNOPSIS
-
 Sends objects to the host as a series of strings.
 
 ## SYNTAX
@@ -31,80 +30,128 @@ Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParamete
 
 ## DESCRIPTION
 
-The `Out-String` cmdlet converts the objects that PowerShell manages into an array of strings.
-By default, `Out-String` accumulates the strings and returns them as a single string, but you can use the stream parameter to direct `Out-String` to return one string at a time.
-This cmdlet lets you search and manipulate string output as you would in traditional shells when object manipulation is less convenient.
+The `Out-String` cmdlet converts the objects that PowerShell manages into an array of strings. By
+default, `Out-String` accumulates the strings and returns them as a single string, but you can use
+the **Stream** parameter to direct `Out-String` to return one string at a time. This cmdlet lets you
+search and manipulate string output as you would in traditional shells when object manipulation is
+less convenient.
 
 ## EXAMPLES
 
 ### Example 1: Output text to the console as a string
 
+This example sends a file's contents to the `Out-String` cmdlet and displays it in the PowerShell
+console.
+
 ```powershell
-PS> Get-Content C:\test1\testfile2.txt | Out-String
+Get-Content -Path C:\Test\Testfile.txt | Out-String
 ```
 
-This command sends the content of the Testfile2.txt file to the console as a single string.
-It uses the `Get-Content` cmdlet to get the content of the file.
-The pipeline operator (|) sends the content to `Out-String`, which sends the content to the console as a string.
+`Get-Culture` sends the contents of the `Testfile.txt` file down the pipeline. Each line of the file
+has its own properties. `Out-String` converts the objects into an array of strings and then displays
+the contents as one string in the PowerShell console.
+
+> [!NOTE]
+> To compare the differences about how `Get-Content` and `Out-String` display the properties:
+>
+> `Get-Content -Path C:\Test\Testfile.txt | Select-Object -Property *`
+>
+> `Get-Content -Path C:\Test\Testfile.txt | Out-String | Select-Object -Property *`
 
 ### Example 2: Get the current culture and convert the data to strings
 
-The first command uses the `Get-Culture` cmdlet to get the regional settings.
-The pipeline operator (|) sends the result to the `Select-Object` cmdlet,
-which selects all properties (*) of the culture object that `Get-Culture` returned.
-The command then stores the results in the `$C` variable.
-
-The second command uses the `Out-String` cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property).
-It uses the **InputObject** parameter to pass the `$C` variable to `Out-String`.
-The *Width* parameter is set to 100 characters per line to prevent truncation.
+This example gets the regional settings for the current user and converts the object data to
+strings.
 
 ```powershell
-PS> $C = Get-Culture | Select-Object *
-PS> Out-String -InputObject $C -Width 100
+$C = Get-Culture | Select-Object -Property *
+Out-String -InputObject $C -Width 100
 ```
 
-These commands get the regional settings for the current user and convert the data to strings.
+The `$C` variable stores a **Selected.System.Globalization.CultureInfo** object. The object is the
+result of `Get-Culture` sending output down the pipeline to `Select-Object`. The **Property**
+parameter uses an asterisk (`*`) wildcard to specify all properties are contained in the object.
+
+`Out-String` uses the **InputObject** parameter to specify the **CultureInfo** object stored in the
+`$C` variable. The objects in `$C` are converted to a string. The **Width** parameter is set to 100
+characters per line to prevent truncation.
+
+> [!NOTE]
+> To view the `Out-String` array, store the output to a variable and use an array index to view the
+> elements. For more information about the array index, see
+> [about_Arrays](../microsoft.powershell.core/about/about_arrays.md).
+>
+> `$str = Out-String -InputObject $C -Width 100`
 
 ### Example 3: Working with objects
 
+This example demonstrates the difference between working with objects and working with strings. The
+command displays an alias that includes the text **gcm**, the alias for `Get-Command`.
+
 ```powershell
-PS> Get-Alias | Out-String -Stream | Select-String "Get-Command"
+Get-Alias | Out-String -Stream | Select-String -Pattern "gcm"
 ```
 
-This example demonstrates the difference between working with objects and working with strings.
-The command displays aliases that include the phrase "Get-Command".
-It uses the `Get-Alias` cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
+```Output
+Alias           gcm -> Get-Command
+```
 
-The pipeline operator (|) sends the output of the `Get-Alias` cmdlet to the `Out-String` cmdlet, which converts the objects to a series of strings.
-It uses the **Stream** parameter of `Out-String` to send each string individually, instead of concatenating them into a single string.
-Another pipeline operator sends the strings to the `Select-String` cmdlet, which selects the strings that include "Get-Command" anywhere in the string.
+`Get-Alias` gets the **System.Management.Automation.AliasInfo** objects, one for each alias, and
+sends the objects down the pipeline. `Out-String` uses the **Stream** parameter to convert each
+object to a string rather concatenating all the objects into a single string. The **System.String**
+objects are sent down the pipeline and `Select-String` uses the **Pattern** parameter to find
+matches for the text **gcm**.
 
-If you omit the **Stream** parameter, the command displays all of the aliases, because `Select-String` finds "Get-Command" in the single string that `Out-String` returns, and the formatter displays the string as a table.
+> [!NOTE]
+> If you omit the **Stream** parameter, the command displays all the aliases because `Select-String`
+> finds the text **gcm** in the single string that `Out-String` returns.
 
-### Example 4: Using NoNewLine
+### Example 4: Using the NoNewLine parameter
+
+This example shows how the **NoNewLine** parameter removes new lines that are created by the
+PowerShell formatter. New lines that are part of the string objects created with `Out-String` aren't
+removed.
+
+The example uses a special character (`` `n ``) to create a new line. For more information, see
+[about_Special_Characters](/microsoft.powershell.core/about/about_special_characters).
 
 ```
-PS> "a", "b" | Out-String -NoNewLine
+PS> "a", "b`n", "c", "d" | Out-String
+a
+b
+
+c
+d
+
+PS> "a", "b`n", "c", "d" | Out-String -NoNewline
 ab
+cd
 
 PS> @{key='value'} | Out-String
+
 Name   Value
 ----   -----
 key    value
 
 PS> @{key='value'} | Out-String -NoNewLine
-Name Value  -----  key value
+
+Name    Value----     -----key     value
 ```
 
-Not using `-NoNewLine` would have resulted in an output like `a<newline>b<newline>`.
-It should be noted that `-NoNewLine` does not strip newlines embedded within a string but strips out embedded newlines from formatter-generated output. Compare the second and third commands in this examples for clarity.
+A string of characters is sent down the pipeline to `Out-String`. The default formatter displays the
+output that includes new lines. The `` "b`n" `` includes the new line special character. When the
+**NoNewline** parameter is used, the new lines created by the formatter are removed. But, the new
+line created with the special character is preserved.
+
+The key/value pair is an example of how `Out-String` uses the default formatter to add new lines.
+When the **NoNewline** parameter is used, the new lines created by the formatter are removed.
 
 ## PARAMETERS
 
 ### -InputObject
 
-Specifies the objects to be written to a string.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
+Specifies the objects to be written to a string. Enter a variable that contains the objects, or type
+a command or expression that gets the objects.
 
 ```yaml
 Type: PSObject
@@ -120,8 +167,8 @@ Accept wildcard characters: False
 
 ### -NoNewline
 
-Removes all newlines from formatter generated output. Note that newlines present as part of string
-objects are preserved.
+Removes all newlines from output generated by the PowerShell formatter. Newlines that are part of
+the string objects are preserved.
 
 This parameter was introduced in PowerShell 6.0.
 
@@ -132,17 +179,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Stream
 
-Indicates that the cmdlet sends the strings for each object separately.
-By default, the strings for each object are accumulated and sent as a single string.
-
-To use the **Stream** parameter, type `-Stream` or its alias, `ost`.
+Indicates that the cmdlet sends a separate string for each object. By default, the strings for each
+object are accumulated and sent as a single string.
 
 ```yaml
 Type: SwitchParameter
@@ -151,18 +196,17 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Width
 
-Specifies the number of characters in each line of output.
-Any additional characters are truncated, not wrapped.
-The **Width** parameter applies only to objects that are being formatted.
-If you omit this parameter, the width is determined by the characteristics of the host program.
-The default value for the PowerShell console is 80 (characters).
+Specifies the number of characters in each line of output. Any additional characters are truncated,
+not wrapped. The **Width** parameter applies only to objects that are being formatted. If you omit
+this parameter, the width is determined by the characteristics of the host program. The default
+value for the PowerShell console is 80 characters.
 
 ```yaml
 Type: Int32
@@ -178,13 +222,16 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
 
-You can pipe objects to `Out-String`.
+You can send objects down the pipeline to `Out-String`.
 
 ## OUTPUTS
 
@@ -194,12 +241,13 @@ You can pipe objects to `Out-String`.
 
 ## NOTES
 
-* The cmdlets that contain the **Out** verb that do not format objects;
-they just render them and send them to the specified display destination.
-If you send an unformatted object to an **Out** cmdlet, the cmdlet sends it to a formatting cmdlet before rendering it.
-* The **Out** cmdlets do not have parameters that take names or file paths.
-To send data to an **Out** cmdlet, use a pipeline operator (|) to send the output of a PowerShell command to the cmdlet.
-You can also store data in a variable and use the **InputObject** parameter to pass the data to the cmdlet.
+The cmdlets that contain the `Out` verb that don't format objects; they just render objects and send
+them to the specified display destination. If you send an unformatted object to an `Out` cmdlet, the
+cmdlet sends it to a formatting cmdlet before rendering it.
+
+The `Out` cmdlets don't have parameters that accept names or file paths. To send the output of a
+PowerShell command to an `Out` cmdlet, use the pipeline. Or, you can store data in a variable and
+use the **InputObject** parameter to pass the data to the cmdlet.
 
 ## RELATED LINKS
 
@@ -211,4 +259,6 @@ You can also store data in a variable and use the **InputObject** parameter to p
 
 [Out-Null](../Microsoft.PowerShell.Core/Out-Null.md)
 
+[Out-GridView](Out-GridView.md)
 
+[Out-Printer](Out-Printer.md)


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

- Fixes [AB#1655090](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1655090)
- Copyedits, style, paragraph reflows for all versions

`Join-String`
- Adds H2 descriptions and content to examples.
- Adds the **UseCulture** parameter description that was missing from the document.
Acrolinx scores:
Original version: 80
Updated version: 97


`Out-String`
- Adds content to update the examples
Acrolinx scores:
Original version: 91
Updated version: 99

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
