### PR TITLE
Updated Start-Process Example 6 to Include 'runasuser' for Verb Availability

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Start-Process.md
@@ -102,6 +102,7 @@ $startExe.verbs
 ```Output
 open
 runas
+runasuser
 ```
 
 The example uses `New-Object` to create a **System.Diagnostics.ProcessStartInfo** object for

--- a/reference/6/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/6/Microsoft.PowerShell.Management/Start-Process.md
@@ -102,6 +102,7 @@ $startExe.verbs
 ```Output
 open
 runas
+runasuser
 ```
 
 The example uses `New-Object` to create a **System.Diagnostics.ProcessStartInfo** object for

--- a/reference/7/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/7/Microsoft.PowerShell.Management/Start-Process.md
@@ -102,6 +102,7 @@ $startExe.verbs
 ```Output
 open
 runas
+runasuser
 ```
 
 The example uses `New-Object` to create a **System.Diagnostics.ProcessStartInfo** object for


### PR DESCRIPTION
# PR Summary
Updated **Example 6: Using different verbs to start a process** for `Start-Process` so that the `$startExe.verbs` output properly matches the behavior documented in the **Parameters -Verb** section and observed within the shell.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [X] Version 7 content
- [X] Version 6 content
- [X] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [X] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
