### PR TITLE
Fixes #4301 - Block type update in Add-Type cmdlet

### DIFF
--- a/reference/7/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Add-Type.md
@@ -64,7 +64,7 @@ class is available in all PowerShell sessions.
 
 You can specify the type by specifying an existing assembly or source code files, or you can specify
 the source code inline or saved in a variable. You can even specify only a method and `Add-Type`
-will define and generate the class. On Windows, you can use this feature to make Platform Invoke
+defines and generates the class. On Windows, you can use this feature to make Platform Invoke
 (P/Invoke) calls to unmanaged functions in PowerShell. If you specify source code, `Add-Type`
 compiles the specified source code and generates an in-memory assembly that contains the new .NET
 Core types.
@@ -72,6 +72,10 @@ Core types.
 You can use the parameters of `Add-Type` to specify an alternate language and compiler, C# is the
 default, compiler options, assembly dependencies, the class namespace, the names of the type, and
 the resulting assembly.
+
+Beginning in PowerShell 7, `Add-Type` does not compile a type if a type with the same name already
+exists. Also, `Add-Type` looks for assemblies in a `ref` folder under the folder that contains
+`pwsh.dll`.
 
 ## EXAMPLES
 
@@ -222,8 +226,9 @@ $ShowWindowAsync::ShowWindowAsync((Get-Process -Id $Pid).MainWindowHandle, 4)
 ```
 
 The `$Signature` variable stores the C# signature of the `ShowWindowAsync` function. To ensure that
-the resulting method will be visible in a PowerShell session, the `public` keyword was added to the
-standard signature. For more information, see [ShowWindowAsync function](/windows/win32/api/winuser/nf-winuser-showwindowasync).
+the resulting method is visible in a PowerShell session, the `public` keyword was added to the
+standard signature. For more information, see
+[ShowWindowAsync function](/windows/win32/api/winuser/nf-winuser-showwindowasync).
 
 The `$ShowWindowAsync` variable stores the object created by the `Add-Type` **PassThru** parameter.
 The `Add-Type` cmdlet adds the `ShowWindowAsync` function to the PowerShell session as a static
@@ -257,7 +262,7 @@ Enter the full or simple name, also known as the partial name, of an assembly. W
 are permitted in the assembly name. If you enter a simple or partial name, `Add-Type` resolves it to
 the full name, and then uses the full name to load the assembly.
 
-This parameter doesn't accept a path or a file name. To enter the path to the assembly dynamic-link
+This parameter doesn't accept a path or a filename. To enter the path to the assembly dynamic-link
 library (DLL) file, use the **Path** parameter.
 
 ```yaml
@@ -413,7 +418,7 @@ Accept wildcard characters: False
 ### -OutputAssembly
 
 Generates a DLL file for the assembly with the specified name in the location. Enter an optional
-path and file name. Wildcard characters are permitted. By default, `Add-Type` generates the assembly
+path and filename. Wildcard characters are permitted. By default, `Add-Type` generates the assembly
 only in memory.
 
 ```yaml
@@ -475,8 +480,8 @@ Accept wildcard characters: False
 Specifies the path to source code files or assembly DLL files that contain the types.
 
 If you submit source code files, `Add-Type` compiles the code in the files and creates an in-memory
-assembly of the types. The file name extension specified in the value of **Path** determines the
-compiler that `Add-Type` uses.
+assembly of the types. The file extension specified in the value of **Path** determines the compiler
+that `Add-Type` uses.
 
 If you submit an assembly file, `Add-Type` takes the types from the assembly. To specify an
 in-memory assembly or the global assembly cache, use the **AssemblyName** parameter.


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #4301 - Block type update in Add-Type cmdlet
Fixes [AB#1658247](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1658247)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
