### PR TITLE
Fixes #5200 - New-WebServiceProxy removed in v6

### DIFF
--- a/reference/docs-conceptual/whats-new/breaking-changes-ps6.md
+++ b/reference/docs-conceptual/whats-new/breaking-changes-ps6.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  11/15/2019
+ms.date:  12/18/2019
 keywords:  powershell,core
 title:  Breaking Changes for PowerShell 6.0
 ---
@@ -10,10 +10,12 @@ title:  Breaking Changes for PowerShell 6.0
 
 ### PowerShell Workflow
 
-[PowerShell Workflow][workflow] is a feature in Windows PowerShell that builds on top of [Windows Workflow Foundation (WF)][workflow-foundation] that enables the creation of robust runbooks for long-running or parallelized tasks.
+[PowerShell Workflow][workflow] is a feature in Windows PowerShell that builds on top of
+[Windows Workflow Foundation (WF)][workflow-foundation] that enables the creation of robust runbooks
+for long-running or parallelized tasks.
 
-Due to the lack of support for Windows Workflow Foundation in .NET Core, we will not continue to
-support PowerShell Workflow in PowerShell Core.
+Due to the lack of support for Windows Workflow Foundation in .NET Core, we are not supporting
+PowerShell Workflow in PowerShell Core.
 
 In the future, we would like to enable native parallelism/concurrency in the PowerShell language
 without the need for PowerShell Workflow.
@@ -67,6 +69,11 @@ functionality with new functionality and a redesigned syntax:
 
 Due to the use of unsupported APIs, `Microsoft.PowerShell.LocalAccounts` has been removed from
 PowerShell Core until a better solution is found.
+
+### `New-WebServiceProxy` cmdlet removed
+
+.NET Core does not support the Windows Communication Framework, which provide services for using the
+SOAP protocol. This cmdlet was removed because it requires SOAP.
 
 ### `*-Computer` cmdlets
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #5200 - New-WebServiceProxy removed in v6
Fixes [AB#1658293](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1658293)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7 content
- [x] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [x] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
