### PR TITLE
Fixes 5227. Adds context for $args in splatting in advanced functions

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -6,16 +6,14 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: about_Splatting
 ---
+
 # About Splatting
 
 ## SHORT DESCRIPTION
+
 Describes how to use splatting to pass parameters to commands in PowerShell.
 
 ## LONG DESCRIPTION
-
-[This topic was contributed by Rohn Edwards of Gulfport, Mississippi, a system
-administrator and the winner of the Advanced Division of the 2012 Scripting
-Games. Revised for Windows PowerShell 3.0.]
 
 Splatting is a method of passing a collection of parameter values to a command
 as unit. PowerShell associates each value in the collection with a command
@@ -24,7 +22,7 @@ which look like standard variables, but begin with an At symbol (`@`) instead
 of a dollar sign (`$`). The At symbol tells PowerShell that you are passing a
 collection of values, instead of a single value.
 
-Splatting makes your commands shorter and easier to read. You can re-use the
+Splatting makes your commands shorter and easier to read. You can reuse the
 splatting values in different command calls and use splatting to pass parameter
 values from the `$PSBoundParameters` automatic variable to other scripts and
 functions.
@@ -34,7 +32,7 @@ all parameters of a command.
 
 ## SYNTAX
 
-```
+```powershell
 <CommandName> <optional parameters> @<HashTable> <optional parameters>
 <CommandName> <optional parameters> @<Array> <optional parameters>
 ```
@@ -47,7 +45,7 @@ parameter list.
 When splatting, you do not need to use a hash table or an array to pass all
 parameters. You may pass some parameters by using splatting and pass others by
 position or by parameter name. Also, you can splat multiple objects in a single
-command just so you pass no more than one value for each parameter.
+command so you don't pass more than one value for each parameter.
 
 ## SPLATTING WITH HASH TABLES
 
@@ -71,7 +69,7 @@ table of parameter-name and parameter-value pairs and stores it in the
 variable in a command with splatting. The At symbol (`@HashArguments`) replaces
 the dollar sign (`$HashArguments`) in the command.
 
-To provide a value for the WhatIf switch parameter, use `$True` or `$False`.
+To provide a value for the **WhatIf** switch parameter, use `$True` or `$False`.
 
 ```powershell
 $HashArguments = @{
@@ -115,7 +113,7 @@ Copy-Item @ArrayArguments -WhatIf
 
 ## EXAMPLES
 
-This example shows how to re-use splatted values in different commands. The
+This example shows how to reuse splatted values in different commands. The
 commands in this example use the `Write-Host` cmdlet to write messages to the
 host program console. It uses splatting to specify the foreground and
 background colors.
@@ -281,6 +279,11 @@ FileVersionInfo    : File:             C:\Windows\System32\WindowsPowerShell
 ```
 
 ## NOTES
+
+If you make a function into an advanced function by using either the
+**CmdletBinding** or **Parameter** attributes, the `$args` automatic variable
+is no longer available in the function. Advanced functions require explicit
+parameter definition.
 
 PowerShell Desired State Configuration (DSC) was not designed to use splatting.
 You cannot use splatting to pass values into a DSC resource. For more

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -32,7 +32,7 @@ all parameters of a command.
 
 ## SYNTAX
 
-```powershell
+```
 <CommandName> <optional parameters> @<HashTable> <optional parameters>
 <CommandName> <optional parameters> @<Array> <optional parameters>
 ```

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -6,16 +6,14 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: about_Splatting
 ---
+
 # About Splatting
 
 ## SHORT DESCRIPTION
+
 Describes how to use splatting to pass parameters to commands in PowerShell.
 
 ## LONG DESCRIPTION
-
-[This topic was contributed by Rohn Edwards of Gulfport, Mississippi, a system
-administrator and the winner of the Advanced Division of the 2012 Scripting
-Games. Revised for Windows PowerShell 3.0.]
 
 Splatting is a method of passing a collection of parameter values to a command
 as unit. PowerShell associates each value in the collection with a command
@@ -24,7 +22,7 @@ which look like standard variables, but begin with an At symbol (`@`) instead
 of a dollar sign (`$`). The At symbol tells PowerShell that you are passing a
 collection of values, instead of a single value.
 
-Splatting makes your commands shorter and easier to read. You can re-use the
+Splatting makes your commands shorter and easier to read. You can reuse the
 splatting values in different command calls and use splatting to pass parameter
 values from the `$PSBoundParameters` automatic variable to other scripts and
 functions.
@@ -34,7 +32,7 @@ all parameters of a command.
 
 ## SYNTAX
 
-```
+```powershell
 <CommandName> <optional parameters> @<HashTable> <optional parameters>
 <CommandName> <optional parameters> @<Array> <optional parameters>
 ```
@@ -47,7 +45,7 @@ parameter list.
 When splatting, you do not need to use a hash table or an array to pass all
 parameters. You may pass some parameters by using splatting and pass others by
 position or by parameter name. Also, you can splat multiple objects in a single
-command just so you pass no more than one value for each parameter.
+command so you don't pass more than one value for each parameter.
 
 ## SPLATTING WITH HASH TABLES
 
@@ -71,7 +69,7 @@ table of parameter-name and parameter-value pairs and stores it in the
 variable in a command with splatting. The At symbol (`@HashArguments`) replaces
 the dollar sign (`$HashArguments`) in the command.
 
-To provide a value for the WhatIf switch parameter, use `$True` or `$False`.
+To provide a value for the **WhatIf** switch parameter, use `$True` or `$False`.
 
 ```powershell
 $HashArguments = @{
@@ -115,7 +113,7 @@ Copy-Item @ArrayArguments -WhatIf
 
 ## EXAMPLES
 
-This example shows how to re-use splatted values in different commands. The
+This example shows how to reuse splatted values in different commands. The
 commands in this example use the `Write-Host` cmdlet to write messages to the
 host program console. It uses splatting to specify the foreground and
 background colors.
@@ -281,6 +279,11 @@ FileVersionInfo    : File:             C:\Windows\System32\WindowsPowerShell
 ```
 
 ## NOTES
+
+If you make a function into an advanced function by using either the
+**CmdletBinding** or **Parameter** attributes, the `$args` automatic variable
+is no longer available in the function. Advanced functions require explicit
+parameter definition.
 
 PowerShell Desired State Configuration (DSC) was not designed to use splatting.
 You cannot use splatting to pass values into a DSC resource. For more

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -32,7 +32,7 @@ all parameters of a command.
 
 ## SYNTAX
 
-```powershell
+```
 <CommandName> <optional parameters> @<HashTable> <optional parameters>
 <CommandName> <optional parameters> @<Array> <optional parameters>
 ```

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -6,16 +6,14 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: about_Splatting
 ---
+
 # About Splatting
 
 ## SHORT DESCRIPTION
+
 Describes how to use splatting to pass parameters to commands in PowerShell.
 
 ## LONG DESCRIPTION
-
-[This topic was contributed by Rohn Edwards of Gulfport, Mississippi, a system
-administrator and the winner of the Advanced Division of the 2012 Scripting
-Games. Revised for Windows PowerShell 3.0.]
 
 Splatting is a method of passing a collection of parameter values to a command
 as unit. PowerShell associates each value in the collection with a command
@@ -24,7 +22,7 @@ which look like standard variables, but begin with an At symbol (`@`) instead
 of a dollar sign (`$`). The At symbol tells PowerShell that you are passing a
 collection of values, instead of a single value.
 
-Splatting makes your commands shorter and easier to read. You can re-use the
+Splatting makes your commands shorter and easier to read. You can reuse the
 splatting values in different command calls and use splatting to pass parameter
 values from the `$PSBoundParameters` automatic variable to other scripts and
 functions.
@@ -34,7 +32,7 @@ all parameters of a command.
 
 ## SYNTAX
 
-```
+```powershell
 <CommandName> <optional parameters> @<HashTable> <optional parameters>
 <CommandName> <optional parameters> @<Array> <optional parameters>
 ```
@@ -47,7 +45,7 @@ parameter list.
 When splatting, you do not need to use a hash table or an array to pass all
 parameters. You may pass some parameters by using splatting and pass others by
 position or by parameter name. Also, you can splat multiple objects in a single
-command just so you pass no more than one value for each parameter.
+command so you don't pass more than one value for each parameter.
 
 ## SPLATTING WITH HASH TABLES
 
@@ -71,7 +69,7 @@ table of parameter-name and parameter-value pairs and stores it in the
 variable in a command with splatting. The At symbol (`@HashArguments`) replaces
 the dollar sign (`$HashArguments`) in the command.
 
-To provide a value for the WhatIf switch parameter, use `$True` or `$False`.
+To provide a value for the **WhatIf** switch parameter, use `$True` or `$False`.
 
 ```powershell
 $HashArguments = @{
@@ -115,7 +113,7 @@ Copy-Item @ArrayArguments -WhatIf
 
 ## EXAMPLES
 
-This example shows how to re-use splatted values in different commands. The
+This example shows how to reuse splatted values in different commands. The
 commands in this example use the `Write-Host` cmdlet to write messages to the
 host program console. It uses splatting to specify the foreground and
 background colors.
@@ -281,6 +279,11 @@ FileVersionInfo    : File:             C:\Windows\System32\WindowsPowerShell
 ```
 
 ## NOTES
+
+If you make a function into an advanced function by using either the
+**CmdletBinding** or **Parameter** attributes, the `$args` automatic variable
+is no longer available in the function. Advanced functions require explicit
+parameter definition.
 
 PowerShell Desired State Configuration (DSC) was not designed to use splatting.
 You cannot use splatting to pass values into a DSC resource. For more

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -32,7 +32,7 @@ all parameters of a command.
 
 ## SYNTAX
 
-```powershell
+```
 <CommandName> <optional parameters> @<HashTable> <optional parameters>
 <CommandName> <optional parameters> @<Array> <optional parameters>
 ```


### PR DESCRIPTION
# PR Summary
$args automatic variable doesn't exist inside advanced function and that wasn't clear in about_Splatting article. 

## PR Context
Fixes #5227 
Fixes [AB#1658294](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1658294)
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
