### PR TITLE
Fixes #5106 - clarify use of scriptblock and input

### DIFF
--- a/reference/6/ThreadJob/Start-ThreadJob.md
+++ b/reference/6/ThreadJob/Start-ThreadJob.md
@@ -58,12 +58,14 @@ Id   Name   PSJobTypeName   State        HasMoreData   Location     Command
 
 ### Example 2 - Compare the performance of Start-Job and Start-ThreadJob
 
-This example shows the difference between `Start-Job` and `Start-ThreadJob`.
+This example shows the difference between `Start-Job` and `Start-ThreadJob`. The jobs run the
+`Start-Sleep` cmdlet for 1 second. Since the jobs run in parallel, the total execution time
+is about 1 second, plus any time required to create the jobs.
 
 ```powershell
 # start five background jobs each running 1 second
-Measure-Command {1..5 | % {Start-Job {Sleep 1}} | Wait-Job} | Select TotalSeconds
-Measure-Command {1..5 | % {Start-ThreadJob {Sleep 1}} | Wait-Job} | Select TotalSeconds
+Measure-Command {1..5 | % {Start-Job {Start-Sleep 1}} | Wait-Job} | Select-Object TotalSeconds
+Measure-Command {1..5 | % {Start-ThreadJob {Start-Sleep 1}} | Wait-Job} | Select-Object TotalSeconds
 ```
 
 ```Output
@@ -73,11 +75,11 @@ TotalSeconds
    1.5735008
 ```
 
-As shown above, `Start-Job` takes about 4.8 seconds to create five jobs. `Start-ThreadJob` is 8
-times faster, taking about 0.6 seconds to create five jobs. The results may vary in your environment
-but the relative improvement should be the same.
+After subtracting 1 second for execution time, you can see that `Start-Job` takes about 4.8 seconds
+to create five jobs. `Start-ThreadJob` is 8 times faster, taking about 0.6 seconds to create five
+jobs. The results may vary in your environment but the relative improvement should be the same.
 
-### Example 3 - Create jobs using **InputObject**
+### Example 3 - Create jobs using InputObject
 
 In this example, the script block uses the `$input` variable to receive input from the
 **InputObject** parameter. This can also be done by piping objects to `Start-ThreadJob`.

--- a/reference/6/ThreadJob/Start-ThreadJob.md
+++ b/reference/6/ThreadJob/Start-ThreadJob.md
@@ -1,7 +1,7 @@
 ---
 external help file: ThreadJob.dll-Help.xml
 Module Name: threadjob
-ms.date: 07/09/2019
+ms.date: 12/19/2019
 online version: https://docs.microsoft.com/powershell/module/threadjob/start-threadjob?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-ThreadJob
@@ -49,11 +49,11 @@ Get-Job
 ```
 
 ```Output
-Id     Name            PSJobTypeName   State         HasMoreData     Location             Command
---     ----            -------------   -----         -----------     --------             -------
-1      Job1            ThreadJob       Running       True            PowerShell            1..100 | % { sleep 1;...
-2      Job2            ThreadJob       Running       True            PowerShell            1..100 | % { sleep 1;...
-3      Job3            ThreadJob       NotStarted    False           PowerShell            1..100 | % { sleep 1;...
+Id   Name   PSJobTypeName   State        HasMoreData   Location     Command
+--   ----   -------------   -----        -----------   --------     -------
+1    Job1   ThreadJob       Running      True          PowerShell   1..100 | % { sleep 1;...
+2    Job2   ThreadJob       Running      True          PowerShell   1..100 | % { sleep 1;...
+3    Job3   ThreadJob       NotStarted   False         PowerShell   1..100 | % { sleep 1;...
 ```
 
 ### Example 2 - Compare the performance of Start-Job and Start-ThreadJob
@@ -69,16 +69,50 @@ Measure-Command {1..5 | % {Start-ThreadJob {Sleep 1}} | Wait-Job} | Select Total
 ```Output
 TotalSeconds
 ------------
-   5.7665849 # jobs creation time > 4.7 sec; results may vary
-   1.5735008 # jobs creation time < 0.6 sec (8 times less!)
+   5.7665849
+   1.5735008
 ```
+
+As shown above, `Start-Job` takes about 4.8 seconds to create five jobs. `Start-ThreadJob` is 8
+times faster, taking about 0.6 seconds to create five jobs. The results may vary in your environment
+but the relative improvement should be the same.
+
+### Example 3 - Create jobs using **InputObject**
+
+In this example, the script block uses the `$input` variable to receive input from the
+**InputObject** parameter. This can also be done by piping objects to `Start-ThreadJob`.
+
+```powershell
+$j = Start-ThreadJob -InputObject (Get-Process pwsh) -ScriptBlock { $input | Out-String }
+$j | Wait-Job | Receive-Job
+```
+
+```Output
+ NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
+ ------    -----      -----     ------      --  -- -----------
+     94   145.80     159.02      18.31   18276   1 pwsh
+    101   163.30     222.05      29.00   35928   1 pwsh
+```
+
+```powershell
+$j = Get-Process pwsh | Start-ThreadJob -ScriptBlock { $input | Out-String }
+$j | Wait-Job | Receive-Job
+```
+
+```Output
+ NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
+ ------    -----      -----     ------      --  -- -----------
+     94   145.80     159.02      18.31   18276   1 pwsh
+    101   163.30     222.05      29.00   35928   1 pwsh
+```
+
 
 ## PARAMETERS
 
 ### -ArgumentList
 
 Specifies an array of arguments, or parameter values, for the script that is specified by the
-**FilePath** parameter.
+**FilePath** or **ScriptBlock** parameters.
 
 **ArgumentList** must be the last parameter on the command line. All the values that follow the
 parameter name are interpreted values in the argument list.
@@ -137,11 +171,8 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies input to the command. Enter a variable that contains the objects, or type a command or
-expression that generates the objects.
-
-In the value of the **ScriptBlock** parameter, use the `$Input` automatic variable to represent the
-input objects.
+Specifies the objects used as input to the script block. It also allows for pipeline input. Use the
+`$input` automatic variable in the script block to access the input objects.
 
 ```yaml
 Type: System.Management.Automation.PSObject

--- a/reference/7/ThreadJob/Start-ThreadJob.md
+++ b/reference/7/ThreadJob/Start-ThreadJob.md
@@ -58,12 +58,14 @@ Id   Name   PSJobTypeName   State        HasMoreData   Location     Command
 
 ### Example 2 - Compare the performance of Start-Job and Start-ThreadJob
 
-This example shows the difference between `Start-Job` and `Start-ThreadJob`.
+This example shows the difference between `Start-Job` and `Start-ThreadJob`. The jobs run the
+`Start-Sleep` cmdlet for 1 second. Since the jobs run in parallel, the total execution time
+is about 1 second, plus any time required to create the jobs.
 
 ```powershell
 # start five background jobs each running 1 second
-Measure-Command {1..5 | % {Start-Job {Sleep 1}} | Wait-Job} | Select TotalSeconds
-Measure-Command {1..5 | % {Start-ThreadJob {Sleep 1}} | Wait-Job} | Select TotalSeconds
+Measure-Command {1..5 | % {Start-Job {Start-Sleep 1}} | Wait-Job} | Select-Object TotalSeconds
+Measure-Command {1..5 | % {Start-ThreadJob {Start-Sleep 1}} | Wait-Job} | Select-Object TotalSeconds
 ```
 
 ```Output
@@ -73,11 +75,11 @@ TotalSeconds
    1.5735008
 ```
 
-As shown above, `Start-Job` takes about 4.8 seconds to create five jobs. `Start-ThreadJob` is 8
-times faster, taking about 0.6 seconds to create five jobs. The results may vary in your environment
-but the relative improvement should be the same.
+After subtracting 1 second for execution time, you can see that `Start-Job` takes about 4.8 seconds
+to create five jobs. `Start-ThreadJob` is 8 times faster, taking about 0.6 seconds to create five
+jobs. The results may vary in your environment but the relative improvement should be the same.
 
-### Example 3 - Create jobs using **InputObject**
+### Example 3 - Create jobs using InputObject
 
 In this example, the script block uses the `$input` variable to receive input from the
 **InputObject** parameter. This can also be done by piping objects to `Start-ThreadJob`.

--- a/reference/7/ThreadJob/Start-ThreadJob.md
+++ b/reference/7/ThreadJob/Start-ThreadJob.md
@@ -1,7 +1,7 @@
 ---
 external help file: ThreadJob.dll-Help.xml
 Module Name: threadjob
-ms.date: 11/04/2019
+ms.date: 12/19/2019
 online version: https://docs.microsoft.com/powershell/module/threadjob/start-threadjob?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-ThreadJob
@@ -49,11 +49,11 @@ Get-Job
 ```
 
 ```Output
-Id     Name            PSJobTypeName   State         HasMoreData     Location             Command
---     ----            -------------   -----         -----------     --------             -------
-1      Job1            ThreadJob       Running       True            PowerShell            1..100 | % { sleep 1;...
-2      Job2            ThreadJob       Running       True            PowerShell            1..100 | % { sleep 1;...
-3      Job3            ThreadJob       NotStarted    False           PowerShell            1..100 | % { sleep 1;...
+Id   Name   PSJobTypeName   State        HasMoreData   Location     Command
+--   ----   -------------   -----        -----------   --------     -------
+1    Job1   ThreadJob       Running      True          PowerShell   1..100 | % { sleep 1;...
+2    Job2   ThreadJob       Running      True          PowerShell   1..100 | % { sleep 1;...
+3    Job3   ThreadJob       NotStarted   False         PowerShell   1..100 | % { sleep 1;...
 ```
 
 ### Example 2 - Compare the performance of Start-Job and Start-ThreadJob
@@ -69,16 +69,50 @@ Measure-Command {1..5 | % {Start-ThreadJob {Sleep 1}} | Wait-Job} | Select Total
 ```Output
 TotalSeconds
 ------------
-   5.7665849 # jobs creation time > 4.7 sec; results may vary
-   1.5735008 # jobs creation time < 0.6 sec (8 times less!)
+   5.7665849
+   1.5735008
 ```
+
+As shown above, `Start-Job` takes about 4.8 seconds to create five jobs. `Start-ThreadJob` is 8
+times faster, taking about 0.6 seconds to create five jobs. The results may vary in your environment
+but the relative improvement should be the same.
+
+### Example 3 - Create jobs using **InputObject**
+
+In this example, the script block uses the `$input` variable to receive input from the
+**InputObject** parameter. This can also be done by piping objects to `Start-ThreadJob`.
+
+```powershell
+$j = Start-ThreadJob -InputObject (Get-Process pwsh) -ScriptBlock { $input | Out-String }
+$j | Wait-Job | Receive-Job
+```
+
+```Output
+ NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
+ ------    -----      -----     ------      --  -- -----------
+     94   145.80     159.02      18.31   18276   1 pwsh
+    101   163.30     222.05      29.00   35928   1 pwsh
+```
+
+```powershell
+$j = Get-Process pwsh | Start-ThreadJob -ScriptBlock { $input | Out-String }
+$j | Wait-Job | Receive-Job
+```
+
+```Output
+ NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
+ ------    -----      -----     ------      --  -- -----------
+     94   145.80     159.02      18.31   18276   1 pwsh
+    101   163.30     222.05      29.00   35928   1 pwsh
+```
+
 
 ## PARAMETERS
 
 ### -ArgumentList
 
 Specifies an array of arguments, or parameter values, for the script that is specified by the
-**FilePath** parameter.
+**FilePath** or **ScriptBlock** parameters.
 
 **ArgumentList** must be the last parameter on the command line. All the values that follow the
 parameter name are interpreted values in the argument list.
@@ -137,11 +171,8 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies input to the command. Enter a variable that contains the objects, or type a command or
-expression that generates the objects.
-
-In the value of the **ScriptBlock** parameter, use the `$Input` automatic variable to represent the
-input objects.
+Specifies the objects used as input to the script block. It also allows for pipeline input. Use the
+`$input` automatic variable in the script block to access the input objects.
 
 ```yaml
 Type: System.Management.Automation.PSObject


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #5106 - clarify use of scriptblock and input
Fixes [AB#1658371](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1658371)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
