### PR TITLE
Fixes #5120 - clarify language of escape sequences

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 08/05/2019
+ms.date: 12/19/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_special_characters?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Special_Characters
@@ -11,31 +11,44 @@ title: about_Special_Characters
 
 ## Short description
 
-Describes the special characters that you can use to control how PowerShell
-interprets the next character in a command or parameter.
+Describes the special character sequences that control how PowerShell
+interprets the next characters in the sequence.
 
 ## Long description
 
 PowerShell supports a set of special character sequences that are used to
-represent characters that aren't part of the standard character set.
+represent characters that aren't part of the standard character set. The
+sequences are commonly known as _escape sequences_.
 
-PowerShell's special characters are only interpreted when they're enclosed in
-double-quoted (`"`) strings. Special characters begin with the backtick
-character, known as the grave accent (ASCII 96), and are case-sensitive.
+Escape sequences begin with the backtick character, known as the grave accent
+(ASCII 96), and are case-sensitive. The backtick character can also be referred
+to as the _escape character_.
 
-PowerShell recognizes these special characters:
+Escape sequences are only interpreted when contained in double-quoted (`"`)
+strings.
 
-| Character | Description             |
-| --------- | ----------------------- |
-| `` `0 ``  | Null                    |
-| `` `a ``  | Alert                   |
-| `` `b ``  | Backspace               |
-| `` `f ``  | Form feed               |
-| `` `n ``  | New line                |
-| `` `r ``  | Carriage return         |
-| `` `t ``  | Horizontal tab          |
-| `` `v ``  | Vertical tab            |
-| `--%`     | Stop parsing            |
+PowerShell recognizes these escape sequences:
+
+|  Sequence   |       Description       |
+| ----------- | ----------------------- |
+| `` `0 ``    | Null                    |
+| `` `a ``    | Alert                   |
+| `` `b ``    | Backspace               |
+| `` `f ``    | Form feed               |
+| `` `n ``    | New line                |
+| `` `r ``    | Carriage return         |
+| `` `t ``    | Horizontal tab          |
+| `` `v ``    | Vertical tab            |
+
+PowerShell also has a special token to mark where you want parsing to stop. All
+characters that follow this token are used as literal values that aren't
+interpreted.
+
+Special parsing token:
+
+| Sequence |            Description             |
+| -------- | ---------------------------------- |
+| `--%`    | Stop parsing anything that follows |
 
 ## Null (`0)
 
@@ -134,27 +147,49 @@ The horizontal tab (`` `v ``) character advances to the next vertical tab stop
 and writes all subsequent output beginning at that point. The vertical tab
 character only affects printed documents. It doesn't affect screen output.
 
-## Stop parsing  (--%)
+## Stop-parsing token (--%)
 
-The stop-parsing (`--%`) symbol prevents PowerShell from interpreting arguments
-in program calls as PowerShell commands and expressions.
+The stop-parsing (`--%`) token prevents PowerShell from interpreting strings as
+PowerShell commands and expressions. This allows those strings to be passed to
+other programs for interpretation.
 
-Place the stop-parsing symbol after the program name and before program
+Place the stop-parsing token after the program name and before program
 arguments that might cause errors.
 
-In this example, the `Icacls` command uses the stop-parsing symbol.
+In this example, the `Icacls` command uses the stop-parsing token.
 
 ```powershell
 icacls X:\VMS --% /grant Dom\HVAdmin:(CI)(OI)F
 ```
 
-PowerShell sends the following command to `Icacls`.
+PowerShell sends the following string to `Icacls`.
 
-```Output
+```
 X:\VMS /grant Dom\HVAdmin:(CI)(OI)F
 ```
 
-For more information about the stop-parsing symbol, see [about_Parsing](about_Parsing.md).
+Here is another example. The **showArgs** function outputs the values passed to
+it. In this example, we pass the variable named `$HOME` to the function twice.
+
+```powershell
+function showArgs {
+  "`$args = " + ($args -join '|')
+}
+
+showArgs $HOME --% $HOME
+```
+
+You can see in the output that, for the first parameter, the variable `$HOME`
+is interpreted by PowerShell so that the value of the variable is passed to the
+function. The second use of `$HOME` comes after the stop-parsing token, so the
+string "$HOME" is passed to the function without interpretation.
+
+```Output
+$args = C:\Users\username|--%|$HOME
+```
+
+For more information about the stop-parsing token, see
+[about_Parsing](about_Parsing.md).
 
 ## See also
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 08/05/2019
+ms.date: 12/19/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_special_characters?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Special_Characters
@@ -11,33 +11,46 @@ title: about_Special_Characters
 
 ## Short description
 
-Describes the special characters that you can use to control how PowerShell
-interprets the next character in a command or parameter.
+Describes the special character sequences that control how PowerShell
+interprets the next characters in the sequence.
 
 ## Long description
 
 PowerShell supports a set of special character sequences that are used to
-represent characters that aren't part of the standard character set.
+represent characters that aren't part of the standard character set. The
+sequences are commonly known as _escape sequences_.
 
-PowerShell's special characters are only interpreted when they're enclosed in
-double-quoted (`"`) strings. Special characters begin with the backtick
-character, known as the grave accent (ASCII 96), and are case-sensitive.
+Escape sequences begin with the backtick character, known as the grave accent
+(ASCII 96), and are case-sensitive. The backtick character can also be referred
+to as the _escape character_.
 
-PowerShell recognizes these special characters:
+Escape sequences are only interpreted when contained in double-quoted (`"`)
+strings.
 
-| Character | Description             |
-| --------- | ----------------------- |
-| `` `0 ``  | Null                    |
-| `` `a ``  | Alert                   |
-| `` `b ``  | Backspace               |
-| `` `e ``  | Escape                  |
-| `` `f ``  | Form feed               |
-| `` `n ``  | New line                |
-| `` `r ``  | Carriage return         |
-| `` `t ``  | Horizontal tab          |
-| `` `u{x} ``  | Unicode escape sequence |
-| `` `v ``  | Vertical tab            |
-| `--%`     | Stop parsing            |
+PowerShell recognizes these escape sequences:
+
+|  Sequence   |       Description       |
+| ----------- | ----------------------- |
+| `` `0 ``    | Null                    |
+| `` `a ``    | Alert                   |
+| `` `b ``    | Backspace               |
+| `` `e ``    | Escape                  |
+| `` `f ``    | Form feed               |
+| `` `n ``    | New line                |
+| `` `r ``    | Carriage return         |
+| `` `t ``    | Horizontal tab          |
+| `` `u{x} `` | Unicode escape sequence |
+| `` `v ``    | Vertical tab            |
+
+PowerShell also has a special token to mark where you want parsing to stop. All
+characters that follow this token are used as literal values that aren't
+interpreted.
+
+Special parsing token:
+
+| Sequence |            Description             |
+| -------- | ---------------------------------- |
+| `--%`    | Stop parsing anything that follows |
 
 ## Null (`0)
 
@@ -79,10 +92,12 @@ The escape (`` `e ``) character is most commonly used to specify a virtual
 terminal sequence (ANSI escape sequence) that modifies the color of text and
 other text attributes such as bolding and underlining. These sequences can also
 be used for cursor positioning and scrolling. The PowerShell host must support
-virtual terminal sequences. This can be checked on PowerShell v5 and higher
-with the boolean property `$Host.UI.SupportsVirtualTerminal`.
+virtual terminal sequences. You can check the boolean value of
+`$Host.UI.SupportsVirtualTerminal` to determine if these ANSI sequences are
+supported.
 
-For more information about ANSI escape sequences, see [ANSI_escape_code](https://en.wikipedia.org/wiki/ANSI_escape_code).
+For more information about ANSI escape sequences, see
+[ANSI_escape_code](https://en.wikipedia.org/wiki/ANSI_escape_code).
 
 The following example outputs text with a green foreground color.
 
@@ -158,8 +173,8 @@ The Unicode escape sequence (`` `u{x} ``) allows you to specify any Unicode
 character by the hexadecimal representation of its code point. This includes
 Unicode characters above the Basic Multilingual Plane (> `0xFFFF`) which
 includes emoji characters such as the **thumbs up** (`` `u{1F44D} ``)
-character. The Unicode escape sequence requires at least one hexidecimal digit
-and supports up to six hexidecimal digits. The maximum hexidecimal value for
+character. The Unicode escape sequence requires at least one hexadecimal digit
+and supports up to six hexadecimal digits. The maximum hexadecimal value for
 the sequence is `10FFFF`.
 
 This example outputs the **up down arrow** (&#x2195;) symbol.
@@ -174,27 +189,49 @@ The horizontal tab (`` `v ``) character advances to the next vertical tab stop
 and writes all subsequent output beginning at that point. The vertical tab
 character only affects printed documents. It doesn't affect screen output.
 
-## Stop parsing  (--%)
+## Stop-parsing token (--%)
 
-The stop-parsing (`--%`) symbol prevents PowerShell from interpreting arguments
-in program calls as PowerShell commands and expressions.
+The stop-parsing (`--%`) token prevents PowerShell from interpreting strings as
+PowerShell commands and expressions. This allows those strings to be passed to
+other programs for interpretation.
 
-Place the stop-parsing symbol after the program name and before program
+Place the stop-parsing token after the program name and before program
 arguments that might cause errors.
 
-In this example, the `Icacls` command uses the stop-parsing symbol.
+In this example, the `Icacls` command uses the stop-parsing token.
 
 ```powershell
 icacls X:\VMS --% /grant Dom\HVAdmin:(CI)(OI)F
 ```
 
-PowerShell sends the following command to `Icacls`.
+PowerShell sends the following string to `Icacls`.
 
-```Output
+```
 X:\VMS /grant Dom\HVAdmin:(CI)(OI)F
 ```
 
-For more information about the stop-parsing symbol, see [about_Parsing](about_Parsing.md).
+Here is another example. The **showArgs** function outputs the values passed to
+it. In this example, we pass the variable named `$HOME` to the function twice.
+
+```powershell
+function showArgs {
+  "`$args = " + ($args -join '|')
+}
+
+showArgs $HOME --% $HOME
+```
+
+You can see in the output that, for the first parameter, the variable `$HOME`
+is interpreted by PowerShell so that the value of the variable is passed to the
+function. The second use of `$HOME` comes after the stop-parsing token, so the
+string "$HOME" is passed to the function without interpretation.
+
+```Output
+$args = C:\Users\username|--%|$HOME
+```
+
+For more information about the stop-parsing token, see
+[about_Parsing](about_Parsing.md).
 
 ## See also
 

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 08/05/2019
+ms.date: 12/19/2019
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_special_characters?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Special_Characters
@@ -11,33 +11,46 @@ title: about_Special_Characters
 
 ## Short description
 
-Describes the special characters that you can use to control how PowerShell
-interprets the next character in a command or parameter.
+Describes the special character sequences that control how PowerShell
+interprets the next characters in the sequence.
 
 ## Long description
 
 PowerShell supports a set of special character sequences that are used to
-represent characters that aren't part of the standard character set.
+represent characters that aren't part of the standard character set. The
+sequences are commonly known as _escape sequences_.
 
-PowerShell's special characters are only interpreted when they're enclosed in
-double-quoted (`"`) strings. Special characters begin with the backtick
-character, known as the grave accent (ASCII 96), and are case-sensitive.
+Escape sequences begin with the backtick character, known as the grave accent
+(ASCII 96), and are case-sensitive. The backtick character can also be referred
+to as the _escape character_.
 
-PowerShell recognizes these special characters:
+Escape sequences are only interpreted when contained in double-quoted (`"`)
+strings.
 
-| Character | Description             |
-| --------- | ----------------------- |
-| `` `0 ``  | Null                    |
-| `` `a ``  | Alert                   |
-| `` `b ``  | Backspace               |
-| `` `e ``  | Escape                  |
-| `` `f ``  | Form feed               |
-| `` `n ``  | New line                |
-| `` `r ``  | Carriage return         |
-| `` `t ``  | Horizontal tab          |
-| `` `u{x} ``  | Unicode escape sequence |
-| `` `v ``  | Vertical tab            |
-| `--%`     | Stop parsing            |
+PowerShell recognizes these escape sequences:
+
+|  Sequence   |       Description       |
+| ----------- | ----------------------- |
+| `` `0 ``    | Null                    |
+| `` `a ``    | Alert                   |
+| `` `b ``    | Backspace               |
+| `` `e ``    | Escape                  |
+| `` `f ``    | Form feed               |
+| `` `n ``    | New line                |
+| `` `r ``    | Carriage return         |
+| `` `t ``    | Horizontal tab          |
+| `` `u{x} `` | Unicode escape sequence |
+| `` `v ``    | Vertical tab            |
+
+PowerShell also has a special token to mark where you want parsing to stop. All
+characters that follow this token are used as literal values that aren't
+interpreted.
+
+Special parsing token:
+
+| Sequence |            Description             |
+| -------- | ---------------------------------- |
+| `--%`    | Stop parsing anything that follows |
 
 ## Null (`0)
 
@@ -79,10 +92,12 @@ The escape (`` `e ``) character is most commonly used to specify a virtual
 terminal sequence (ANSI escape sequence) that modifies the color of text and
 other text attributes such as bolding and underlining. These sequences can also
 be used for cursor positioning and scrolling. The PowerShell host must support
-virtual terminal sequences. This can be checked on PowerShell v5 and higher
-with the boolean property `$Host.UI.SupportsVirtualTerminal`.
+virtual terminal sequences. You can check the boolean value of
+`$Host.UI.SupportsVirtualTerminal` to determine if these ANSI sequences are
+supported.
 
-For more information about ANSI escape sequences, see [ANSI_escape_code](https://en.wikipedia.org/wiki/ANSI_escape_code).
+For more information about ANSI escape sequences, see
+[ANSI_escape_code](https://en.wikipedia.org/wiki/ANSI_escape_code).
 
 The following example outputs text with a green foreground color.
 
@@ -158,8 +173,8 @@ The Unicode escape sequence (`` `u{x} ``) allows you to specify any Unicode
 character by the hexadecimal representation of its code point. This includes
 Unicode characters above the Basic Multilingual Plane (> `0xFFFF`) which
 includes emoji characters such as the **thumbs up** (`` `u{1F44D} ``)
-character. The Unicode escape sequence requires at least one hexidecimal digit
-and supports up to six hexidecimal digits. The maximum hexidecimal value for
+character. The Unicode escape sequence requires at least one hexadecimal digit
+and supports up to six hexadecimal digits. The maximum hexadecimal value for
 the sequence is `10FFFF`.
 
 This example outputs the **up down arrow** (&#x2195;) symbol.
@@ -174,27 +189,49 @@ The horizontal tab (`` `v ``) character advances to the next vertical tab stop
 and writes all subsequent output beginning at that point. The vertical tab
 character only affects printed documents. It doesn't affect screen output.
 
-## Stop parsing  (--%)
+## Stop-parsing token (--%)
 
-The stop-parsing (`--%`) symbol prevents PowerShell from interpreting arguments
-in program calls as PowerShell commands and expressions.
+The stop-parsing (`--%`) token prevents PowerShell from interpreting strings as
+PowerShell commands and expressions. This allows those strings to be passed to
+other programs for interpretation.
 
-Place the stop-parsing symbol after the program name and before program
+Place the stop-parsing token after the program name and before program
 arguments that might cause errors.
 
-In this example, the `Icacls` command uses the stop-parsing symbol.
+In this example, the `Icacls` command uses the stop-parsing token.
 
 ```powershell
 icacls X:\VMS --% /grant Dom\HVAdmin:(CI)(OI)F
 ```
 
-PowerShell sends the following command to `Icacls`.
+PowerShell sends the following string to `Icacls`.
 
-```Output
+```
 X:\VMS /grant Dom\HVAdmin:(CI)(OI)F
 ```
 
-For more information about the stop-parsing symbol, see [about_Parsing](about_Parsing.md).
+Here is another example. The **showArgs** function outputs the values passed to
+it. In this example, we pass the variable named `$HOME` to the function twice.
+
+```powershell
+function showArgs {
+  "`$args = " + ($args -join '|')
+}
+
+showArgs $HOME --% $HOME
+```
+
+You can see in the output that, for the first parameter, the variable `$HOME`
+is interpreted by PowerShell so that the value of the variable is passed to the
+function. The second use of `$HOME` comes after the stop-parsing token, so the
+string "$HOME" is passed to the function without interpretation.
+
+```Output
+$args = C:\Users\username|--%|$HOME
+```
+
+For more information about the stop-parsing token, see
+[about_Parsing](about_Parsing.md).
 
 ## See also
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #5120 - clarify language of escape sequences
Fixes [AB#1658645](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1658645)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
