### PR TITLE
[Fixes #1818] Restructures Information for Clarity on Debugging cmdlets

### DIFF
--- a/reference/docs-conceptual/components/ise/Accessibility-in-Windows-PowerShell-ISE.md
+++ b/reference/docs-conceptual/components/ise/Accessibility-in-Windows-PowerShell-ISE.md
@@ -172,8 +172,8 @@ You can use the following keyboard shortcuts to start the Windows PowerShell con
 ## Breakpoint Management
 
 For the visually impaired, breakpoint information is available through the cmdlets for managing
-breakpoints, such as [Get-PSBreakpoint](../../../6/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md)
-and [Set-PSBreakpoint](../../../6/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md).
+breakpoints, such as [Get-PSBreakpoint](/reference/6/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md)
+and [Set-PSBreakpoint](/reference/6/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md).
 For more information please see 'How to manage breakpoints' in
 [How to Debug Scripts in the Windows PowerShell ISE](How-to-Debug-Scripts-in-Windows-PowerShell-ISE.md).
 

--- a/reference/docs-conceptual/components/ise/Accessibility-in-Windows-PowerShell-ISE.md
+++ b/reference/docs-conceptual/components/ise/Accessibility-in-Windows-PowerShell-ISE.md
@@ -1,7 +1,7 @@
 ---
-ms.date:  06/05/2017
-keywords:  powershell,cmdlet
-title:  Accessibility in Windows PowerShell ISE
+ms.date: 06/05/2017
+keywords: powershell,cmdlet
+title: Accessibility in Windows PowerShell ISE
 ---
 
 # Accessibility in Windows PowerShell ISE
@@ -27,7 +27,7 @@ make Windows PowerShell ISE more accessible for people with disabilities:
 
 - Keyboard Shortcuts
 
-- Syntax Coloring Table and the ability to modify several other color settings using the [$psISE.Options](https://technet.microsoft.com/library/75e2a76f-f3d1-490b-ad5d-e3829946aabb)
+- Syntax Coloring Table and the ability to modify several other color settings using the [$psISE.Options](object-model/The-ISEOptions-Object.md)
   scripting object.
 
 - Text Size Change
@@ -70,19 +70,19 @@ Do one of the following:
 
 You can use the following keyboard shortcuts when you edit text.
 
-|          Action           |Keyboard Shortcuts|          Use in         |
-|---------------------------|------------------|-------------------------|
-|**Copy**                   |CTRL+C            |Script Pane, Console Pane|
-|**Cut**                    |CTRL+X            |Script Pane, Console Pane|
-|**Find in Script**         |CTRL+F            |Script Pane              |
-|**Find Next in Script**    |F3                |Script Pane              |
-|**Find Previous in Script**|SHIFT+F3          |Script Pane              |
-|**Paste**                  |CTRL+V            |Script Pane, Console Pane|
-|**Redo**                   |CTRL+Y            |Script Pane, Console Pane|
-|**Replace in Script**      |CTRL+H            |Script Pane              |
-|**Save**                   |CTRL+S            |Script Pane              |
-|**Select All**             |CTRL+A            |Script Pane, Console Pane|
-|**Undo**                   |CTRL+Z            |Script Pane, Console Pane|
+|           Action            |       Keyboard Shortcuts       |          Use in           |
+| --------------------------- | ------------------------------ | ------------------------- |
+| **Copy**                    | <kbd>CTRL</kbd>+<kbd>C</kbd>   | Script Pane, Console Pane |
+| **Cut**                     | <kbd>CTRL</kbd>+<kbd>X</kbd>   | Script Pane, Console Pane |
+| **Find in Script**          | <kbd>CTRL</kbd>+<kbd>F</kbd>   | Script Pane               |
+| **Find Next in Script**     | <kbd>F3</kbd>                  | Script Pane               |
+| **Find Previous in Script** | <kbd>SHIFT</kbd>+<kbd>F3</kbd> | Script Pane               |
+| **Paste**                   | <kbd>CTRL</kbd>+<kbd>V</kbd>   | Script Pane, Console Pane |
+| **Redo**                    | <kbd>CTRL</kbd>+<kbd>Y</kbd>   | Script Pane, Console Pane |
+| **Replace in Script**       | <kbd>CTRL</kbd>+<kbd>H</kbd>   | Script Pane               |
+| **Save**                    | <kbd>CTRL</kbd>+<kbd>S</kbd>   | Script Pane               |
+| **Select All**              | <kbd>CTRL</kbd>+<kbd>A</kbd>   | Script Pane, Console Pane |
+| **Undo**                    | <kbd>CTRL</kbd>+<kbd>Z</kbd>   | Script Pane, Console Pane |
 
 ## Keyboard shortcuts for running scripts
 
@@ -90,90 +90,90 @@ You can use the following keyboard shortcuts when you run scripts in the Script 
 
 |Action|Keyboard Shortcut|
 |----------|---------------------|
-|**New**|CTRL+N|
-|**Open**|CTRL+O|
-|**Run**|F5|
-|**Run Selection**|F8|
-|**Stop Execution**|CTRL+BREAK. CTRL+C can be used when the context is unambiguous (when there is no text selected).|
-|**Tab** (to next script)|CTRL+TAB **Note:** Tab to next script works only when you have a single PowerShell tab open, or when you have more than one PowerShell tab open, but the focus is in the Script Pane.|
-|**Tab** (to previous script)|CTRL+SHIFT+TAB **Note:** Tab to previous script works when you have only one PowerShell tab open, or if you have more  than one PowerShell tab open, and the focus is in the Script Pane.|
+|**New**|<kbd>CTRL</kbd>+<kbd>N</kbd>|
+|**Open**|<kbd>CTRL</kbd>+<kbd>O</kbd>|
+|**Run**|<kbd>F5</kbd>|
+|**Run Selection**|<kbd>F8</kbd>|
+|**Stop Execution**|<kbd>CTRL</kbd>+<kbd>BREAK</kbd>. <kbd>CTRL</kbd>+<kbd>C</kbd> can be used when the context is unambiguous (when there is no text selected).|
+|**Tab** (to next script)|<kbd>CTRL</kbd>+<kbd>TAB</kbd> **Note:** Tab to next script works only when you have a single PowerShell tab open, or when you have more than one PowerShell tab open, but the focus is in the Script Pane.|
+|**Tab** (to previous script)|<kbd>CTRL</kbd>+<kbd>SHIFT</kbd+<kbd>TAB</kbd> **Note:** Tab to previous script works when you have only one PowerShell tab open, or if you have more  than one PowerShell tab open, and the focus is in the Script Pane.|
 
 ## Keyboard shortcuts for customizing the view
 
 You can use the following keyboard shortcuts to customize the view in Windows PowerShell ISE. They
 are accessible from all the panes in the application.
 
-|          Action          |Keyboard Shortcut|
-|--------------------------|-----------------|
-|**Go to Console Pane**    |CTRL+D           |
-|**Go to Script Pane**     |CTRL+I           |
-|**Show Script Pane**      |CTRL+R           |
-|**Hide Script Pane**      |CTRL+R           |
-|**Move Script Pane Up**   |CTRL+1           |
-|**Move Script Pane Right**|CTRL+2           |
-|**Maximize Script Pane**  |CTRL+3           |
-|**Zoom In**               |CTRL+PLUS SIGN   |
-|**Zoom Out**              |CTRL+MINUS SIGN  |
+|           Action           |           Keyboard Shortcut           |
+| -------------------------- | ------------------------------------- |
+| **Go to Console Pane**     | <kbd>CTRL</kbd>+<kbd>D</kbd>          |
+| **Go to Script Pane**      | <kbd>CTRL</kbd>+<kbd>I</kbd>          |
+| **Show Script Pane**       | <kbd>CTRL</kbd>+<kbd>R</kbd>          |
+| **Hide Script Pane**       | <kbd>CTRL</kbd>+<kbd>R</kbd>          |
+| **Move Script Pane Up**    | <kbd>CTRL</kbd>+<kbd>1</kbd>          |
+| **Move Script Pane Right** | <kbd>CTRL</kbd>+<kbd>2</kbd>          |
+| **Maximize Script Pane**   | <kbd>CTRL</kbd>+<kbd>3</kbd>          |
+| **Zoom In**                | <kbd>CTRL</kbd>+<kbd>PLUS</kbd> SIGN  |
+| **Zoom Out**               | <kbd>CTRL</kbd>+<kbd>MINUS</kbd> SIGN |
 
 ## Keyboard shortcuts for debugging scripts
 
 You can use the following keyboard shortcuts when you debug scripts.
 
-|          Action          |Keyboard Shortcut|              Use in                |
-|--------------------------|-----------------|------------------------------------|
-|**Run/Continue**          |F5               |Script Pane, when debugging a script|
-|**Step Into**             |F11              |Script Pane, when debugging a script|
-|**Step Over**             |F10              |Script Pane, when debugging a script|
-|**Step Out**              |SHIFT+F11        |Script Pane, when debugging a script|
-|**Display Call Stack**    |CTRL+SHIFT+D     |Script Pane, when debugging a script|
-|**List Breakpoints**      |CTRL+SHIFT+L     |Script Pane, when debugging a script|
-|**Toggle Breakpoint**     |F9               |Script Pane, when debugging a script|
-|**Remove All Breakpoints**|CTRL+SHIFT+F9    |Script Pane, when debugging a script|
-|**Stop Debugger**         |SHIFT+F5         |Script Pane, when debugging a script|
+|           Action           |               Keyboard Shortcut               |                Use in                |
+| -------------------------- | --------------------------------------------- | ------------------------------------ |
+| **Run/Continue**           | <kbd>F5</kbd>                                 | Script Pane, when debugging a script |
+| **Step Into**              | <kbd>F11</kbd>                                | Script Pane, when debugging a script |
+| **Step Over**              | <kbd>F10</kbd>                                | Script Pane, when debugging a script |
+| **Step Out**               | <kbd>SHIFT</kbd>+<kbd>F11</kbd>               | Script Pane, when debugging a script |
+| **Display Call Stack**     | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd+<kbd>D</kbd>  | Script Pane, when debugging a script |
+| **List Breakpoints**       | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd+<kbd>L</kbd>  | Script Pane, when debugging a script |
+| **Toggle Breakpoint**      | <kbd>F9</kbd>                                 | Script Pane, when debugging a script |
+| **Remove All Breakpoints** | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd+<kbd>F9</kbd> | Script Pane, when debugging a script |
+| **Stop Debugger**          | <kbd>SHIFT</kbd>+<kbd>F5</kbd>                | Script Pane, when debugging a script |
 
 > [!NOTE]
 > You can also use the keyboard shortcuts designed for the Windows PowerShell console when you debug
 > scripts in Windows PowerShell ISE. To use these shortcuts, you must type the shortcut in the
 > Console Pane and press ENTER.
 
-|                Action                 |Keyboard Shortcut|              Use in                 |
-|---------------------------------------|-----------------|-------------------------------------|
-|**Continue**                           |C                |Console Pane, when debugging a script|
-|**Step Into**                          |S                |Console Pane, when debugging a script|
-|**Step Over**                          |V                |Console Pane, when debugging a script|
-|**Step Out**                           |O                |Console Pane, when debugging a script|
-|**Repeat Last Command**(Step Into/Over)|ENTER            |Console Pane, when debugging a script|
-|**Display Call Stack**                 |K                |Console Pane, when debugging a script|
-|**Stop Debugging**                     |Q                |Console Pane, when debugging a script|
-|**List the Script**                    |L                |Console Pane, when debugging a script|
-|**Display Console Debugging Commands** |H or ?           |Console Pane, when debugging a script|
+|                 Action                  | Keyboard Shortcut |                Use in                 |
+| --------------------------------------- | ----------------- | ------------------------------------- |
+| **Continue**                            | C                 | Console Pane, when debugging a script |
+| **Step Into**                           | S                 | Console Pane, when debugging a script |
+| **Step Over**                           | V                 | Console Pane, when debugging a script |
+| **Step Out**                            | O                 | Console Pane, when debugging a script |
+| **Repeat Last Command**(Step Into/Over) | ENTER             | Console Pane, when debugging a script |
+| **Display Call Stack**                  | K                 | Console Pane, when debugging a script |
+| **Stop Debugging**                      | Q                 | Console Pane, when debugging a script |
+| **List the Script**                     | L                 | Console Pane, when debugging a script |
+| **Display Console Debugging Commands**  | H or ?            | Console Pane, when debugging a script |
 
 ## Keyboard shortcuts for Windows PowerShell tabs
 
 You can use the following keyboard shortcuts when you use Windows PowerShell tabs.
 
-|            Action             |                     Keyboard Shortcut                            |
-|-------------------------------|------------------------------------------------------------------|
-|**Close PowerShell Tab**       |CTRL+W                                                            |
-|**New PowerShell Tab**         |CTRL+T                                                            |
-|**Previous PowerShell tab**    |CTRL+SHIFT+TAB (Only when no files are open on any PowerShell tab)|
-|**Next Windows PowerShell tab**|CTRL+TAB (Only when no files are open on any PowerShell tab)      |
+|             Action              |                                 Keyboard Shortcut                                  |
+| ------------------------------- | ---------------------------------------------------------------------------------- |
+| **Close PowerShell Tab**        | <kbd>CTRL</kbd>+<kbd>W</kbd>                                                       |
+| **New PowerShell Tab**          | <kbd>CTRL</kbd>+<kbd>T</kbd>                                                       |
+| **Previous PowerShell tab**     | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd+<kbd>TAB</kbd> (Only when no files are open on any PowerShell tab)                 |
+| **Next Windows PowerShell tab** | <kbd>CTRL</kbd>+<kbd>TAB</kbd> (Only when no files are open on any PowerShell tab) |
 
 ## Keyboard shortcuts for starting and exiting
 
 You can use the following keyboard shortcuts to start the Windows PowerShell console
 (**PowerShell.exe**) or to exit Windows PowerShell ISE.
 
-|                        Action                       |Keyboard Shortcut|
-|-----------------------------------------------------|-----------------|
-|**Exit**                                             |ALT+F4           |
-|**Start PowerShell.exe** (Windows PowerShell console)|CTRL+SHIFT+P     |
+|                        Action                         |              Keyboard Shortcut               |
+| ----------------------------------------------------- | -------------------------------------------- |
+| **Exit**                                              | <kbd>ALT</kbd>+<kbd>F4</kbd>                 |
+| **Start PowerShell.exe** (Windows PowerShell console) | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd+<kbd>P</kbd> |
 
 ## Breakpoint Management
 
 For the visually impaired, breakpoint information is available through the cmdlets for managing
-breakpoints, such as [Get-PSBreakpoint](https://technet.microsoft.com/library/0bf48936-00ab-411c-b5e0-9b10a812a3c6)
-and [Set-PSBreakpoint](https://technet.microsoft.com/library/6afd5d2c-a285-4796-8607-3cbf49471420).
+breakpoints, such as [Get-PSBreakpoint](../../../5.1/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md)
+and [Set-PSBreakpoint](../../../5.1/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md).
 For more information please see 'How to manage breakpoints' in
 [How to Debug Scripts in the Windows PowerShell ISE](How-to-Debug-Scripts-in-Windows-PowerShell-ISE.md).
 

--- a/reference/docs-conceptual/components/ise/Accessibility-in-Windows-PowerShell-ISE.md
+++ b/reference/docs-conceptual/components/ise/Accessibility-in-Windows-PowerShell-ISE.md
@@ -103,17 +103,17 @@ You can use the following keyboard shortcuts when you run scripts in the Script 
 You can use the following keyboard shortcuts to customize the view in Windows PowerShell ISE. They
 are accessible from all the panes in the application.
 
-|           Action           |           Keyboard Shortcut           |
-| -------------------------- | ------------------------------------- |
-| **Go to Console Pane**     | <kbd>CTRL</kbd>+<kbd>D</kbd>          |
-| **Go to Script Pane**      | <kbd>CTRL</kbd>+<kbd>I</kbd>          |
-| **Show Script Pane**       | <kbd>CTRL</kbd>+<kbd>R</kbd>          |
-| **Hide Script Pane**       | <kbd>CTRL</kbd>+<kbd>R</kbd>          |
-| **Move Script Pane Up**    | <kbd>CTRL</kbd>+<kbd>1</kbd>          |
-| **Move Script Pane Right** | <kbd>CTRL</kbd>+<kbd>2</kbd>          |
-| **Maximize Script Pane**   | <kbd>CTRL</kbd>+<kbd>3</kbd>          |
-| **Zoom In**                | <kbd>CTRL</kbd>+<kbd>PLUS</kbd> SIGN  |
-| **Zoom Out**               | <kbd>CTRL</kbd>+<kbd>MINUS</kbd> SIGN |
+|           Action           |         Keyboard Shortcut        |
+| -------------------------- | -------------------------------- |
+| **Go to Console Pane**     | <kbd>CTRL</kbd>+<kbd>D</kbd>     |
+| **Go to Script Pane**      | <kbd>CTRL</kbd>+<kbd>I</kbd>     |
+| **Show Script Pane**       | <kbd>CTRL</kbd>+<kbd>R</kbd>     |
+| **Hide Script Pane**       | <kbd>CTRL</kbd>+<kbd>R</kbd>     |
+| **Move Script Pane Up**    | <kbd>CTRL</kbd>+<kbd>1</kbd>     |
+| **Move Script Pane Right** | <kbd>CTRL</kbd>+<kbd>2</kbd>     |
+| **Maximize Script Pane**   | <kbd>CTRL</kbd>+<kbd>3</kbd>     |
+| **Zoom In**                | <kbd>CTRL</kbd>+<kbd>PLUS</kbd>  |
+| **Zoom Out**               | <kbd>CTRL</kbd>+<kbd>MINUS</kbd> |
 
 ## Keyboard shortcuts for debugging scripts
 

--- a/reference/docs-conceptual/components/ise/Accessibility-in-Windows-PowerShell-ISE.md
+++ b/reference/docs-conceptual/components/ise/Accessibility-in-Windows-PowerShell-ISE.md
@@ -3,31 +3,40 @@ ms.date:  06/05/2017
 keywords:  powershell,cmdlet
 title:  Accessibility in Windows PowerShell ISE
 ---
+
 # Accessibility in Windows PowerShell ISE
 
-This topic describes the accessibility features of Windows PowerShell Integrated Scripting Environment (ISE) that you might find helpful.
+This topic describes the accessibility features of Windows PowerShell Integrated Scripting
+Environment (ISE) that you might find helpful.
 
-* [How to change the size and location of the Console and Script Panes](#how-to-change-the-size-and-location-of-the-console-and-script-panes)
-* [Keyboard shortcuts for editing text](#keyboard-shortcuts-for-editing-text)
-* [Keyboard shortcuts for running scripts](#keyboard-shortcuts-for-running-scripts)
-* [Keyboard shortcuts for customizing the view](#keyboard-shortcuts-for-customizing-the-view)
-* [Keyboard shortcuts for debugging scripts](#keyboard-shortcuts-for-debugging-scripts)
-* [Keyboard shortcuts for Windows PowerShell tabs](#keyboard-shortcuts-for-windows-powershell-tabs)
-* [Keyboard shortcuts for starting and exiting](#keyboard-shortcuts-for-starting-and-exiting)
+- [How to change the size and location of the Console and Script Panes](#how-to-change-the-size-and-location-of-the-console-and-script-panes)
+- [Keyboard shortcuts for editing text](#keyboard-shortcuts-for-editing-text)
+- [Keyboard shortcuts for running scripts](#keyboard-shortcuts-for-running-scripts)
+- [Keyboard shortcuts for customizing the view](#keyboard-shortcuts-for-customizing-the-view)
+- [Keyboard shortcuts for debugging scripts](#keyboard-shortcuts-for-debugging-scripts)
+- [Keyboard shortcuts for Windows PowerShell tabs](#keyboard-shortcuts-for-windows-powershell-tabs)
+- [Keyboard shortcuts for starting and exiting](#keyboard-shortcuts-for-starting-and-exiting)
+- [Breakpoint management with cmdlets](#breakpoint-management)
 
-Microsoft is committed to making its products and services easier for everyone to use. The following topics provide information about the features, products, and services that make Windows PowerShell ISE more accessible for people with disabilities.
+Microsoft is committed to making its products and services easier for everyone to use. The following
+topics provide information about the features, products, and services that make Windows PowerShell
+ISE more accessible for people with disabilities.
 
-Windows PowerShell ISE supports high contrast mode. For the visually impaired, breakpoint information is available through the cmdlets for managing breakpoints, such as [Get-PSBreakpoint](https://technet.microsoft.com/library/0bf48936-00ab-411c-b5e0-9b10a812a3c6) and [Set-PSBreakpoint](https://technet.microsoft.com/library/6afd5d2c-a285-4796-8607-3cbf49471420). For more information please see 'How to manage breakpoints' in [How to Debug Scripts in the Windows PowerShell ISE](How-to-Debug-Scripts-in-Windows-PowerShell-ISE.md). In addition to accessibility features and utilities in Microsoft Windows, the following features make Windows PowerShell ISE more accessible for people with disabilities:
+In addition to accessibility features and utilities in Microsoft Windows, the following features
+make Windows PowerShell ISE more accessible for people with disabilities:
 
 - Keyboard Shortcuts
 
-- Syntax Coloring Table and the ability to modify several other color settings using the [$psISE.Options](https://technet.microsoft.com/library/75e2a76f-f3d1-490b-ad5d-e3829946aabb) scripting object.
+- Syntax Coloring Table and the ability to modify several other color settings using the [$psISE.Options](https://technet.microsoft.com/library/75e2a76f-f3d1-490b-ad5d-e3829946aabb)
+  scripting object.
 
 - Text Size Change
 
 ## How to change the size and location of the Console and Script Panes
 
-You can use the following steps to change the size and location of the Console Pane and the Script Pane. When you open the Windows PowerShell ISE again, the size and location changes you made will be retained.
+You can use the following steps to change the size and location of the Console Pane and the Script
+Pane. When you open the Windows PowerShell ISE again, the size and location changes you made will be
+retained.
 
 ### To resize the Script Pane and Console Pane
 
@@ -39,33 +48,41 @@ You can use the following steps to change the size and location of the Console P
 
 Do one of the following:
 
-- To move the Script Pane above the Console Pane, press **CTRL+1** or, on the toolbar, click the **Show Script Pane Top** icon, or in the **View** menu, click **Show Script Pane Top**.
+- To move the Script Pane above the Console Pane, press <kbd>CTRL</kbd>+<kbd>1</kbd> or, on the toolbar, click the
+  **Show Script Pane Top** icon, or in the **View** menu, click **Show Script Pane Top**.
 
-- To move the Script Pane to the right of the Console Pane, press **CTRL+2** or, on the toolbar, click the **Show Script Pane Right** icon, or in the **View** menu, click **Show Script Pane Right**.
+- To move the Script Pane to the right of the Console Pane, press <kbd>CTRL</kbd>+<kbd>2</kbd> or, on the toolbar,
+  click the **Show Script Pane Right** icon, or in the **View** menu, click **Show Script Pane
+  Right**.
 
-- To maximize the Script Pane, press **CTRL+3** or, on the toolbar, click the **Show Script Pane Maximized** icon, or in the **View** menu, click **Show Script Pane Maximized**.
+- To maximize the Script Pane, press <kbd>CTRL</kbd>+<kbd>3</kbd> or, on the toolbar, click the **Show Script Pane
+  Maximized** icon, or in the **View** menu, click **Show Script Pane Maximized**.
 
-- To maximize the Console Pane and hide the Script Pane, on the far right edge of the row of tabs, click the **Hide Script Pane** icon, in the **View** menu, click to deselect the **Show Script Pane** menu option.
+- To maximize the Console Pane and hide the Script Pane, on the far right edge of the row of tabs,
+  click the **Hide Script Pane** icon, in the **View** menu, click to deselect the **Show Script
+  Pane** menu option.
 
-- To display the Script Pane when the Console Pane is maximized, on the far right edge of the row of tabs, click the **Show Script Pane** icon, or in the **View** menu, click to select the **Show Script Pane** menu option.
+- To display the Script Pane when the Console Pane is maximized, on the far right edge of the row of
+  tabs, click the **Show Script Pane** icon, or in the **View** menu, click to select the **Show
+  Script Pane** menu option.
 
 ## Keyboard shortcuts for editing text
 
 You can use the following keyboard shortcuts when you edit text.
 
-|Action|Keyboard Shortcuts|Use in|
-|----------|----------------------|----------|
-|**Copy**|CTRL+C|Script Pane, Console Pane|
-|**Cut**|CTRL+X|Script Pane, Console Pane|
-|**Find in Script**|CTRL+F|Script Pane|
-|**Find Next in Script**|F3|Script Pane|
-|**Find Previous in Script**|SHIFT+F3|Script Pane|
-|**Paste**|CTRL+V|Script Pane, Console Pane|
-|**Redo**|CTRL+Y|Script Pane, Console Pane|
-|**Replace in Script**|CTRL+H|Script Pane|
-|**Save**|CTRL+S|Script Pane|
-|**Select All**|CTRL+A|Script Pane, Console Pane|
-|**Undo**|CTRL+Z|Script Pane, Console Pane|
+|          Action           |Keyboard Shortcuts|          Use in         |
+|---------------------------|------------------|-------------------------|
+|**Copy**                   |CTRL+C            |Script Pane, Console Pane|
+|**Cut**                    |CTRL+X            |Script Pane, Console Pane|
+|**Find in Script**         |CTRL+F            |Script Pane              |
+|**Find Next in Script**    |F3                |Script Pane              |
+|**Find Previous in Script**|SHIFT+F3          |Script Pane              |
+|**Paste**                  |CTRL+V            |Script Pane, Console Pane|
+|**Redo**                   |CTRL+Y            |Script Pane, Console Pane|
+|**Replace in Script**      |CTRL+H            |Script Pane              |
+|**Save**                   |CTRL+S            |Script Pane              |
+|**Select All**             |CTRL+A            |Script Pane, Console Pane|
+|**Undo**                   |CTRL+Z            |Script Pane, Console Pane|
 
 ## Keyboard shortcuts for running scripts
 
@@ -83,74 +100,82 @@ You can use the following keyboard shortcuts when you run scripts in the Script 
 
 ## Keyboard shortcuts for customizing the view
 
-You can use the following keyboard shortcuts to customize the view in Windows PowerShell ISE. They are accessible from all the panes in the application.
+You can use the following keyboard shortcuts to customize the view in Windows PowerShell ISE. They
+are accessible from all the panes in the application.
 
-|Action|Keyboard Shortcut|
-|----------|---------------------|
-|**Go to Console Pane**|CTRL+D|
-|**Go to Script Pane**|CTRL+I|
-|**Show Script Pane**|CTRL+R|
-|**Hide Script Pane**|CTRL+R|
-||
-|**Move Script Pane Up**|CTRL+1|
-|**Move Script Pane Right**|CTRL+2|
-|**Maximize Script Pane**|CTRL+3|
-|**Zoom In**|CTRL+PLUS SIGN|
-|**Zoom Out**|CTRL+MINUS SIGN|
+|          Action          |Keyboard Shortcut|
+|--------------------------|-----------------|
+|**Go to Console Pane**    |CTRL+D           |
+|**Go to Script Pane**     |CTRL+I           |
+|**Show Script Pane**      |CTRL+R           |
+|**Hide Script Pane**      |CTRL+R           |
+|**Move Script Pane Up**   |CTRL+1           |
+|**Move Script Pane Right**|CTRL+2           |
+|**Maximize Script Pane**  |CTRL+3           |
+|**Zoom In**               |CTRL+PLUS SIGN   |
+|**Zoom Out**              |CTRL+MINUS SIGN  |
 
 ## Keyboard shortcuts for debugging scripts
 
 You can use the following keyboard shortcuts when you debug scripts.
 
-|Action|Keyboard Shortcut|Use in|
-|----------|---------------------|----------|
-|**Run/Continue**|F5|Script Pane, when debugging a script|
-|**Step Into**|F11|Script Pane, when debugging a script|
-|**Step Over**|F10|Script Pane, when debugging a script|
-|**Step Out**|SHIFT+F11|Script Pane, when debugging a script|
-|**Display Call Stack**|CTRL+SHIFT+D|Script Pane, when debugging a script|
-|**List Breakpoints**|CTRL+SHIFT+L|Script Pane, when debugging a script|
-|**Toggle Breakpoint**|F9|Script Pane, when debugging a script|
-|**Remove All Breakpoints**|CTRL+SHIFT+F9|Script Pane, when debugging a script|
-|**Stop Debugger**|SHIFT+F5|Script Pane, when debugging a script|
+|          Action          |Keyboard Shortcut|              Use in                |
+|--------------------------|-----------------|------------------------------------|
+|**Run/Continue**          |F5               |Script Pane, when debugging a script|
+|**Step Into**             |F11              |Script Pane, when debugging a script|
+|**Step Over**             |F10              |Script Pane, when debugging a script|
+|**Step Out**              |SHIFT+F11        |Script Pane, when debugging a script|
+|**Display Call Stack**    |CTRL+SHIFT+D     |Script Pane, when debugging a script|
+|**List Breakpoints**      |CTRL+SHIFT+L     |Script Pane, when debugging a script|
+|**Toggle Breakpoint**     |F9               |Script Pane, when debugging a script|
+|**Remove All Breakpoints**|CTRL+SHIFT+F9    |Script Pane, when debugging a script|
+|**Stop Debugger**         |SHIFT+F5         |Script Pane, when debugging a script|
 
 > [!NOTE]
->
-> You can also use the keyboard shortcuts designed for the Windows PowerShell
-> console when you debug scripts in Windows PowerShell ISE. To use these
-> shortcuts, you must type the shortcut in the Console Pane and press ENTER.
+> You can also use the keyboard shortcuts designed for the Windows PowerShell console when you debug
+> scripts in Windows PowerShell ISE. To use these shortcuts, you must type the shortcut in the
+> Console Pane and press ENTER.
 
-|Action|Keyboard Shortcut|Use in|
-|----------|---------------------|----------|
-|**Continue**|C|Console Pane, when debugging a script|
-|**Step Into**|S|Console Pane, when debugging a script|
-|**Step Over**|V|Console Pane, when debugging a script|
-|**Step Out**|O|Console Pane, when debugging a script|
-|**Repeat Last Command** (for Step Into or Step Over)|ENTER|Console Pane, when debugging a script|
-|**Display Call Stack**|K|Console Pane, when debugging a script|
-|**Stop Debugging**|Q|Console Pane, when debugging a script|
-|**List the Script**|L|Console Pane, when debugging a script|
-|**Display Console Debugging Commands**|H or ?|Console Pane, when debugging a script|
+|                Action                 |Keyboard Shortcut|              Use in                 |
+|---------------------------------------|-----------------|-------------------------------------|
+|**Continue**                           |C                |Console Pane, when debugging a script|
+|**Step Into**                          |S                |Console Pane, when debugging a script|
+|**Step Over**                          |V                |Console Pane, when debugging a script|
+|**Step Out**                           |O                |Console Pane, when debugging a script|
+|**Repeat Last Command**(Step Into/Over)|ENTER            |Console Pane, when debugging a script|
+|**Display Call Stack**                 |K                |Console Pane, when debugging a script|
+|**Stop Debugging**                     |Q                |Console Pane, when debugging a script|
+|**List the Script**                    |L                |Console Pane, when debugging a script|
+|**Display Console Debugging Commands** |H or ?           |Console Pane, when debugging a script|
 
 ## Keyboard shortcuts for Windows PowerShell tabs
 
 You can use the following keyboard shortcuts when you use Windows PowerShell tabs.
 
-|Action|Keyboard Shortcut|
-|----------|---------------------|
-|**Close PowerShell Tab**|CTRL+W|
-|**New PowerShell Tab**|CTRL+T|
-|**Previous PowerShell tab**|CTRL+SHIFT+TAB. This shortcut works only when no files are open on any PowerShell tab.|
-|**Next Windows PowerShell tab**|CTRL+TAB. This shortcut works only when no files are open on any PowerShell tab.|
+|            Action             |                     Keyboard Shortcut                            |
+|-------------------------------|------------------------------------------------------------------|
+|**Close PowerShell Tab**       |CTRL+W                                                            |
+|**New PowerShell Tab**         |CTRL+T                                                            |
+|**Previous PowerShell tab**    |CTRL+SHIFT+TAB (Only when no files are open on any PowerShell tab)|
+|**Next Windows PowerShell tab**|CTRL+TAB (Only when no files are open on any PowerShell tab)      |
 
 ## Keyboard shortcuts for starting and exiting
 
-You can use the following keyboard shortcuts to start the Windows PowerShell console (PowerShell.exe) or to exit Windows PowerShell ISE.
+You can use the following keyboard shortcuts to start the Windows PowerShell console
+(**PowerShell.exe**) or to exit Windows PowerShell ISE.
 
-|Action|Keyboard Shortcut|
-|----------|---------------------|
-|**Exit**|ALT+F4|
-|**Start PowerShell.exe** (Windows PowerShell console)|CTRL+SHIFT+P|
+|                        Action                       |Keyboard Shortcut|
+|-----------------------------------------------------|-----------------|
+|**Exit**                                             |ALT+F4           |
+|**Start PowerShell.exe** (Windows PowerShell console)|CTRL+SHIFT+P     |
+
+## Breakpoint Management
+
+For the visually impaired, breakpoint information is available through the cmdlets for managing
+breakpoints, such as [Get-PSBreakpoint](https://technet.microsoft.com/library/0bf48936-00ab-411c-b5e0-9b10a812a3c6)
+and [Set-PSBreakpoint](https://technet.microsoft.com/library/6afd5d2c-a285-4796-8607-3cbf49471420).
+For more information please see 'How to manage breakpoints' in
+[How to Debug Scripts in the Windows PowerShell ISE](How-to-Debug-Scripts-in-Windows-PowerShell-ISE.md).
 
 ## See Also
 

--- a/reference/docs-conceptual/components/ise/Accessibility-in-Windows-PowerShell-ISE.md
+++ b/reference/docs-conceptual/components/ise/Accessibility-in-Windows-PowerShell-ISE.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 06/05/2017
+ms.date: 12/19/2019
 keywords: powershell,cmdlet
 title: Accessibility in Windows PowerShell ISE
 ---
@@ -27,8 +27,8 @@ make Windows PowerShell ISE more accessible for people with disabilities:
 
 - Keyboard Shortcuts
 
-- Syntax Coloring Table and the ability to modify several other color settings using the [$psISE.Options](object-model/The-ISEOptions-Object.md)
-  scripting object.
+- Syntax Coloring Table and the ability to modify several other color settings using the
+  [$psISE.Options](object-model/The-ISEOptions-Object.md) scripting object.
 
 - Text Size Change
 
@@ -88,15 +88,15 @@ You can use the following keyboard shortcuts when you edit text.
 
 You can use the following keyboard shortcuts when you run scripts in the Script Pane.
 
-|Action|Keyboard Shortcut|
-|----------|---------------------|
-|**New**|<kbd>CTRL</kbd>+<kbd>N</kbd>|
-|**Open**|<kbd>CTRL</kbd>+<kbd>O</kbd>|
-|**Run**|<kbd>F5</kbd>|
-|**Run Selection**|<kbd>F8</kbd>|
-|**Stop Execution**|<kbd>CTRL</kbd>+<kbd>BREAK</kbd>. <kbd>CTRL</kbd>+<kbd>C</kbd> can be used when the context is unambiguous (when there is no text selected).|
-|**Tab** (to next script)|<kbd>CTRL</kbd>+<kbd>TAB</kbd> **Note:** Tab to next script works only when you have a single PowerShell tab open, or when you have more than one PowerShell tab open, but the focus is in the Script Pane.|
-|**Tab** (to previous script)|<kbd>CTRL</kbd>+<kbd>SHIFT</kbd+<kbd>TAB</kbd> **Note:** Tab to previous script works when you have only one PowerShell tab open, or if you have more  than one PowerShell tab open, and the focus is in the Script Pane.|
+|            Action            |                                                                                                     Keyboard Shortcut                                                                                                      |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **New**                      | <kbd>CTRL</kbd>+<kbd>N</kbd>                                                                                                                                                                                               |
+| **Open**                     | <kbd>CTRL</kbd>+<kbd>O</kbd>                                                                                                                                                                                               |
+| **Run**                      | <kbd>F5</kbd>                                                                                                                                                                                                              |
+| **Run Selection**            | <kbd>F8</kbd>                                                                                                                                                                                                              |
+| **Stop Execution**           | <kbd>CTRL</kbd>+<kbd>BREAK</kbd>. <kbd>CTRL</kbd>+<kbd>C</kbd> can be used when the context is unambiguous (when there is no text selected).                                                                               |
+| **Tab** (to next script)     | <kbd>CTRL</kbd>+<kbd>TAB</kbd> **Note:** Tab to next script works only when you have a single PowerShell tab open, or when you have more than one PowerShell tab open, but the focus is in the Script Pane.                |
+| **Tab** (to previous script) | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</kbd> **Note:** Tab to previous script works when you have only one PowerShell tab open, or if you have more  than one PowerShell tab open, and the focus is in the Script Pane. |
 
 ## Keyboard shortcuts for customizing the view
 
@@ -119,34 +119,34 @@ are accessible from all the panes in the application.
 
 You can use the following keyboard shortcuts when you debug scripts.
 
-|           Action           |               Keyboard Shortcut               |                Use in                |
-| -------------------------- | --------------------------------------------- | ------------------------------------ |
-| **Run/Continue**           | <kbd>F5</kbd>                                 | Script Pane, when debugging a script |
-| **Step Into**              | <kbd>F11</kbd>                                | Script Pane, when debugging a script |
-| **Step Over**              | <kbd>F10</kbd>                                | Script Pane, when debugging a script |
-| **Step Out**               | <kbd>SHIFT</kbd>+<kbd>F11</kbd>               | Script Pane, when debugging a script |
-| **Display Call Stack**     | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd+<kbd>D</kbd>  | Script Pane, when debugging a script |
-| **List Breakpoints**       | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd+<kbd>L</kbd>  | Script Pane, when debugging a script |
-| **Toggle Breakpoint**      | <kbd>F9</kbd>                                 | Script Pane, when debugging a script |
-| **Remove All Breakpoints** | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd+<kbd>F9</kbd> | Script Pane, when debugging a script |
-| **Stop Debugger**          | <kbd>SHIFT</kbd>+<kbd>F5</kbd>                | Script Pane, when debugging a script |
+|           Action           |               Keyboard Shortcut                |                Use in                |
+| -------------------------- | ---------------------------------------------- | ------------------------------------ |
+| **Run/Continue**           | <kbd>F5</kbd>                                  | Script Pane, when debugging a script |
+| **Step Into**              | <kbd>F11</kbd>                                 | Script Pane, when debugging a script |
+| **Step Over**              | <kbd>F10</kbd>                                 | Script Pane, when debugging a script |
+| **Step Out**               | <kbd>SHIFT</kbd>+<kbd>F11</kbd>                | Script Pane, when debugging a script |
+| **Display Call Stack**     | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>D</kbd>  | Script Pane, when debugging a script |
+| **List Breakpoints**       | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>L</kbd>  | Script Pane, when debugging a script |
+| **Toggle Breakpoint**      | <kbd>F9</kbd>                                  | Script Pane, when debugging a script |
+| **Remove All Breakpoints** | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>F9</kbd> | Script Pane, when debugging a script |
+| **Stop Debugger**          | <kbd>SHIFT</kbd>+<kbd>F5</kbd>                 | Script Pane, when debugging a script |
 
 > [!NOTE]
 > You can also use the keyboard shortcuts designed for the Windows PowerShell console when you debug
 > scripts in Windows PowerShell ISE. To use these shortcuts, you must type the shortcut in the
 > Console Pane and press ENTER.
 
-|                 Action                  | Keyboard Shortcut |                Use in                 |
-| --------------------------------------- | ----------------- | ------------------------------------- |
-| **Continue**                            | C                 | Console Pane, when debugging a script |
-| **Step Into**                           | S                 | Console Pane, when debugging a script |
-| **Step Over**                           | V                 | Console Pane, when debugging a script |
-| **Step Out**                            | O                 | Console Pane, when debugging a script |
-| **Repeat Last Command**(Step Into/Over) | ENTER             | Console Pane, when debugging a script |
-| **Display Call Stack**                  | K                 | Console Pane, when debugging a script |
-| **Stop Debugging**                      | Q                 | Console Pane, when debugging a script |
-| **List the Script**                     | L                 | Console Pane, when debugging a script |
-| **Display Console Debugging Commands**  | H or ?            | Console Pane, when debugging a script |
+|                 Action                  |      Keyboard Shortcut       |                Use in                 |
+| --------------------------------------- | ---------------------------- | ------------------------------------- |
+| **Continue**                            | <kbd>C</kbd>                 | Console Pane, when debugging a script |
+| **Step Into**                           | <kbd>S</kbd>                 | Console Pane, when debugging a script |
+| **Step Over**                           | <kbd>V</kbd>                 | Console Pane, when debugging a script |
+| **Step Out**                            | <kbd>O</kbd>                 | Console Pane, when debugging a script |
+| **Repeat Last Command**(Step Into/Over) | <kbd>ENTER</kbd>             | Console Pane, when debugging a script |
+| **Display Call Stack**                  | <kbd>K</kbd>                 | Console Pane, when debugging a script |
+| **Stop Debugging**                      | <kbd>Q</kbd>                 | Console Pane, when debugging a script |
+| **List the Script**                     | <kbd>L</kbd>                 | Console Pane, when debugging a script |
+| **Display Console Debugging Commands**  | <kbd>H</kbd> or <kbd>?</kbd> | Console Pane, when debugging a script |
 
 ## Keyboard shortcuts for Windows PowerShell tabs
 
@@ -156,7 +156,7 @@ You can use the following keyboard shortcuts when you use Windows PowerShell tab
 | ------------------------------- | ---------------------------------------------------------------------------------- |
 | **Close PowerShell Tab**        | <kbd>CTRL</kbd>+<kbd>W</kbd>                                                       |
 | **New PowerShell Tab**          | <kbd>CTRL</kbd>+<kbd>T</kbd>                                                       |
-| **Previous PowerShell tab**     | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd+<kbd>TAB</kbd> (Only when no files are open on any PowerShell tab)                 |
+| **Previous PowerShell tab**     | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</kbd> (Only when no files are open on any PowerShell tab)                 |
 | **Next Windows PowerShell tab** | <kbd>CTRL</kbd>+<kbd>TAB</kbd> (Only when no files are open on any PowerShell tab) |
 
 ## Keyboard shortcuts for starting and exiting
@@ -164,10 +164,10 @@ You can use the following keyboard shortcuts when you use Windows PowerShell tab
 You can use the following keyboard shortcuts to start the Windows PowerShell console
 (**PowerShell.exe**) or to exit Windows PowerShell ISE.
 
-|                        Action                         |              Keyboard Shortcut               |
-| ----------------------------------------------------- | -------------------------------------------- |
-| **Exit**                                              | <kbd>ALT</kbd>+<kbd>F4</kbd>                 |
-| **Start PowerShell.exe** (Windows PowerShell console) | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd+<kbd>P</kbd> |
+|                        Action                         |               Keyboard Shortcut               |
+| ----------------------------------------------------- | --------------------------------------------- |
+| **Exit**                                              | <kbd>ALT</kbd>+<kbd>F4</kbd>                  |
+| **Start PowerShell.exe** (Windows PowerShell console) | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>P</kbd> |
 
 ## Breakpoint Management
 

--- a/reference/docs-conceptual/components/ise/Accessibility-in-Windows-PowerShell-ISE.md
+++ b/reference/docs-conceptual/components/ise/Accessibility-in-Windows-PowerShell-ISE.md
@@ -172,8 +172,8 @@ You can use the following keyboard shortcuts to start the Windows PowerShell con
 ## Breakpoint Management
 
 For the visually impaired, breakpoint information is available through the cmdlets for managing
-breakpoints, such as [Get-PSBreakpoint](../../../5.1/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md)
-and [Set-PSBreakpoint](../../../5.1/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md).
+breakpoints, such as [Get-PSBreakpoint](../../../6/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md)
+and [Set-PSBreakpoint](../../../6/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md).
 For more information please see 'How to manage breakpoints' in
 [How to Debug Scripts in the Windows PowerShell ISE](How-to-Debug-Scripts-in-Windows-PowerShell-ISE.md).
 


### PR DESCRIPTION
# PR Summary
Customer pointed out that the structure of information didn't flow well for accessibility with debugging help.

## PR Context
Fixes #1818 
Fixes [AB#1658580](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1658580)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [x] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
