### PR TITLE
[Fixes 3067] Adds more info on trap scoping

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Trap.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Trap.md
@@ -6,9 +6,11 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: about_Trap
 ---
+
 # About Trap
 
 ## Short description
+
 Describes a keyword that handles a terminating error.
 
 ## Long description
@@ -280,6 +282,11 @@ Remove-Item -ErrorAction Stop ThisFileDoesNotExist
 trap { "whoops 1"; continue }
 trap { "whoops 2"; continue }
 ```
+
+> [!IMPORTANT]
+> A Trap statement is scoped to where it compiles. If you have a Trap statement
+> inside a dot sourced script or function, when the dot sourced script or
+> function exits, all Trap statements inside are removed.
 
 ### Using the `break` and `continue` keywords
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Trap.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Trap.md
@@ -285,8 +285,8 @@ trap { "whoops 2"; continue }
 
 > [!IMPORTANT]
 > A Trap statement is scoped to where it compiles. If you have a Trap statement
-> inside a dot sourced script or function, when the dot sourced script or
-> function exits, all Trap statements inside are removed.
+> inside a function or dot sourced script, when the function or dot sourced
+> script exits, all Trap statements inside are removed.
 
 ### Using the `break` and `continue` keywords
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Trap.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Trap.md
@@ -6,9 +6,11 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: about_Trap
 ---
+
 # About Trap
 
 ## Short description
+
 Describes a keyword that handles a terminating error.
 
 ## Long description
@@ -280,6 +282,11 @@ Remove-Item -ErrorAction Stop ThisFileDoesNotExist
 trap { "whoops 1"; continue }
 trap { "whoops 2"; continue }
 ```
+
+> [!IMPORTANT]
+> A Trap statement is scoped to where it compiles. If you have a Trap statement
+> inside a function or dot sourced script, when the function or dot sourced
+> script exits, all Trap statements inside are removed.
 
 ### Using the `break` and `continue` keywords
 

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Trap.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Trap.md
@@ -6,9 +6,11 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: about_Trap
 ---
+
 # About Trap
 
 ## Short description
+
 Describes a keyword that handles a terminating error.
 
 ## Long description
@@ -280,6 +282,11 @@ Remove-Item -ErrorAction Stop ThisFileDoesNotExist
 trap { "whoops 1"; continue }
 trap { "whoops 2"; continue }
 ```
+
+> [!IMPORTANT]
+> A Trap statement is scoped to where it compiles. If you have a Trap statement
+> inside a function or dot sourced script, when the function or dot sourced
+> script exits, all Trap statements inside are removed.
 
 ### Using the `break` and `continue` keywords
 


### PR DESCRIPTION
# PR Summary
Trap statements work within specific scopes and needs more information for dot sourced scripts

## PR Context
Fixes #3067
Fixes [AB#1658896](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1658896)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
