### PR TITLE
[Fixes #5245] Clarity for function blocks

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -376,7 +376,7 @@ function.
 > [!IMPORTANT]
 > If your function defines a `Begin`, `Process` or `End` block, all of your code
 > must reside inside those blocks. No code will be recognized outside the blocks
-> if **any** of the blocks are defined.
+> if *any* of the blocks are defined.
 
 The `Process` statement list runs one time for each object in the pipeline.
 While the `Process` block is running, each pipeline object is assigned to the

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -6,9 +6,11 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: about_Functions
 ---
+
 # About Functions
 
 ## Short description
+
 Describes how to create and use functions in PowerShell.
 
 ## Long description
@@ -138,7 +140,7 @@ about dynamic parameters in functions, see
 You can define any number of named parameters. You can include a default value
 for named parameters, as described later in this topic.
 
-You can define parameters inside the braces using the **Param** keyword, as
+You can define parameters inside the braces using the `Param` keyword, as
 shown in the following sample syntax:
 
 ```
@@ -173,8 +175,8 @@ a variable that contains the parameter name. The value of that variable can be
 used in the function.
 
 The following example is a function called `Get-SmallFiles`. This function
-has a `$size` parameter. The function displays all the files that are smaller
-than the value of the `$size` parameter, and it excludes directories:
+has a `$Size` parameter. The function displays all the files that are smaller
+than the value of the `$Size` parameter, and it excludes directories:
 
 ```powershell
 function Get-SmallFiles {
@@ -185,7 +187,7 @@ function Get-SmallFiles {
 }
 ```
 
-In the function, you can use the `$size` variable, which is the name defined for
+In the function, you can use the `$Size` variable, which is the name defined for
 the parameter.
 
 To use this function, type the following command:
@@ -228,7 +230,7 @@ description of your parameter, and specifying the **Help** property of
 function Get-SmallFiles {
   param (
       [PSDefaultValue(Help = '100')]
-      $size = 100
+      $Size = 100
   )
 }
 ```
@@ -373,7 +375,8 @@ function.
 
 > [!IMPORTANT]
 > If your function defines a `Begin`, `Process` or `End` block, all of your code
-> must reside inside one of the blocks.
+> must reside inside those blocks. No code will be recognized outside the blocks
+> if **any** of the blocks are defined.
 
 The `Process` statement list runs one time for each object in the pipeline.
 While the `Process` block is running, each pipeline object is assigned to the

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -6,9 +6,11 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: about_Functions
 ---
+
 # About Functions
 
 ## Short description
+
 Describes how to create and use functions in PowerShell.
 
 ## Long description
@@ -138,7 +140,7 @@ about dynamic parameters in functions, see
 You can define any number of named parameters. You can include a default value
 for named parameters, as described later in this topic.
 
-You can define parameters inside the braces using the **Param** keyword, as
+You can define parameters inside the braces using the `Param` keyword, as
 shown in the following sample syntax:
 
 ```
@@ -373,7 +375,8 @@ function.
 
 > [!IMPORTANT]
 > If your function defines a `Begin`, `Process` or `End` block, all of your code
-> must reside inside one of the blocks.
+> must reside inside those blocks. No code will be recognized outside the blocks
+> if **any** of the blocks are defined.
 
 The `Process` statement list runs one time for each object in the pipeline.
 While the `Process` block is running, each pipeline object is assigned to the

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -376,7 +376,7 @@ function.
 > [!IMPORTANT]
 > If your function defines a `Begin`, `Process` or `End` block, all of your code
 > must reside inside those blocks. No code will be recognized outside the blocks
-> if **any** of the blocks are defined.
+> if *any* of the blocks are defined.
 
 The `Process` statement list runs one time for each object in the pipeline.
 While the `Process` block is running, each pipeline object is assigned to the

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -376,7 +376,7 @@ function.
 > [!IMPORTANT]
 > If your function defines a `Begin`, `Process` or `End` block, all of your code
 > must reside inside those blocks. No code will be recognized outside the blocks
-> if **any** of the blocks are defined.
+> if *any* of the blocks are defined.
 
 The `Process` statement list runs one time for each object in the pipeline.
 While the `Process` block is running, each pipeline object is assigned to the

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -6,9 +6,11 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: about_Functions
 ---
+
 # About Functions
 
 ## Short description
+
 Describes how to create and use functions in PowerShell.
 
 ## Long description
@@ -138,7 +140,7 @@ about dynamic parameters in functions, see
 You can define any number of named parameters. You can include a default value
 for named parameters, as described later in this topic.
 
-You can define parameters inside the braces using the **Param** keyword, as
+You can define parameters inside the braces using the `Param` keyword, as
 shown in the following sample syntax:
 
 ```
@@ -373,7 +375,8 @@ function.
 
 > [!IMPORTANT]
 > If your function defines a `Begin`, `Process` or `End` block, all of your code
-> must reside inside one of the blocks.
+> must reside inside the blocks. No code will be recognized if **any** of the
+> blocks are defined.
 
 The `Process` statement list runs one time for each object in the pipeline.
 While the `Process` block is running, each pipeline object is assigned to the

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -375,8 +375,8 @@ function.
 
 > [!IMPORTANT]
 > If your function defines a `Begin`, `Process` or `End` block, all of your code
-> must reside inside the blocks. No code will be recognized if **any** of the
-> blocks are defined.
+> must reside inside those blocks. No code will be recognized outside the blocks
+> if **any** of the blocks are defined.
 
 The `Process` statement list runs one time for each object in the pipeline.
 While the `Process` block is running, each pipeline object is assigned to the

--- a/reference/7/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/7/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -175,8 +175,8 @@ a variable that contains the parameter name. The value of that variable can be
 used in the function.
 
 The following example is a function called `Get-SmallFiles`. This function
-has a `$size` parameter. The function displays all the files that are smaller
-than the value of the `$size` parameter, and it excludes directories:
+has a `$Size` parameter. The function displays all the files that are smaller
+than the value of the `$Size` parameter, and it excludes directories:
 
 ```powershell
 function Get-SmallFiles {
@@ -187,7 +187,7 @@ function Get-SmallFiles {
 }
 ```
 
-In the function, you can use the `$size` variable, which is the name defined for
+In the function, you can use the `$Size` variable, which is the name defined for
 the parameter.
 
 To use this function, type the following command:
@@ -230,7 +230,7 @@ description of your parameter, and specifying the **Help** property of
 function Get-SmallFiles {
   param (
       [PSDefaultValue(Help = '100')]
-      $size = 100
+      $Size = 100
   )
 }
 ```


### PR DESCRIPTION
# PR Summary
Adds clarity to `Important` note about `Begin`, `Process`, and `End` blocks

## PR Context
Fixes #5245 
Fixes [AB#1660248](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1660248)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
