### PR TITLE
Updated Comments

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
@@ -44,7 +44,7 @@ Name    Enabled  Description
 User02  True     Description of this account.
 ```
 
-This command creates a local user account without an initial password.  This is not a recommended "best practice".
+This command creates a local user account and does not specify the *AccountExpires* or *Password* parameters. Therefore, the account doesn't expire or have a password by default.
 
 ### Example 2: Create a user account that has a password
 ```
@@ -274,19 +274,26 @@ This cmdlet returns a **LocalUser** object.
 This object provides information about the user account.
 
 ## NOTES
-* A user name cannot be identical to any other user name or group name on the computer. A user name cannot consist only of periods (.) or spaces. A user name can contain up to 20 uppercase characters or lowercase characters. A user name cannot contain the following characters:
 
-" / \ \[ \] : ; | = , + * ? \< \> @
-* A password can contain up to 127 characters.
-* The **PrincipalSource** property is a property on **LocalUser**, **LocalGroup**, and **LocalPrincipal** objects that describes the source of the object. The possible sources are as follows:
+- A user name cannot be identical to any other user name or group name on the computer. A user name
+  cannot consist only of periods (.) or spaces. A user name can contain up to 20 uppercase
+  characters or lowercase characters. A user name cannot contain the following characters:
 
-- Local
-- Active Directory
-- Azure Active Directory group
-- Microsoft Account
+`" / \ \[ \] : ; | = , + * ? \< \> @`
 
-**PrincipalSource** is supported only by Windows 10, Windows Server 2016, and later versions of the Windows operating system. For earlier versions, the property is blank. As of Windows 10 1909 with PowerShell 5.1 the **PrincipalSource** property is no longer available.
+- A password can contain up to 127 characters.
+- The **PrincipalSource** property is a property on **LocalUser**, **LocalGroup**, and
+  **LocalPrincipal** objects that describes the source of the object. The possible sources are as
+  follows:
 
+  - Local
+  - Active Directory
+  - Azure Active Directory group
+  - Microsoft Account
+
+> [!NOTE]
+> **PrincipalSource** is supported only by Windows 10, Windows Server 2016, and later versions of the
+> Windows operating system. For earlier versions, the property is blank.
 ## RELATED LINKS
 
 [Disable-LocalUser](Disable-LocalUser.md)

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
@@ -44,9 +44,7 @@ Name    Enabled  Description
 User02  True     Description of this account.
 ```
 
-This command creates a local user account.
-The command does not specify the *AccountExpires* parameter.
-Therefore, the account does not expire.
+This command creates a local user account without an initial password.  This is not a recommended "best practice".
 
 ### Example 2: Create a user account that has a password
 ```
@@ -287,7 +285,7 @@ This object provides information about the user account.
 - Azure Active Directory group
 - Microsoft Account
 
-**PrincipalSource** is supported only by Windows 10, Windows Server 2016, and later versions of the Windows operating system. For earlier versions, the property is blank.
+**PrincipalSource** is supported only by Windows 10, Windows Server 2016, and later versions of the Windows operating system. For earlier versions, the property is blank. As of Windows 10 1909 with PowerShell 5.1 the **PrincipalSource** property is no longer available.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
Example 1 doesn't even address -NoPassword and Windows 10 1909 with PowerShell 5.1 doesn't support the -PrincipalSource property at all.

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7 content
- [ ] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [x] Fundamental conceptual articles
- [x] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
