### PR TITLE
[Fixes #5262] Typo in example

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -8,9 +8,11 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: Export-PSSession
 ---
+
 # Export-PSSession
 
 ## SYNOPSIS
+
 Exports commands from another session and saves them in a PowerShell module.
 
 ## SYNTAX
@@ -67,12 +69,12 @@ This example exports all of the `Get` and `Set` commands from a server.
 
 ```powershell
 $S = New-PSSession -ConnectionUri http://exchange.microsoft.com/mailbox -Credential exchangeadmin01@hotmail.com -Authentication Negotiate
-Export-PSSession -Session $R -Module exch* -CommandName Get-*, Set-* -FormatTypeName * -OutputModule $pshome\Modules\Exchange -Encoding ASCII
+Export-PSSession -Session $S -Module exch* -CommandName Get-*, Set-* -FormatTypeName * -OutputModule $PSHOME\Modules\Exchange -Encoding ASCII
 ```
 
 These commands export the `Get` and `Set` commands from a Microsoft Exchange Server snap-in on a
-remote computer to an Exchange module in the `$pshome`\Modules directory on the local computer.
-Placing the module in the `$pshome`\Modules directory makes it accessible to all users of the
+remote computer to an Exchange module in the `$PSHOME`\Modules directory on the local computer.
+Placing the module in the `$PSHOME`\Modules directory makes it accessible to all users of the
 computer.
 
 ### Example 3: Export commands from a remote computer
@@ -182,7 +184,7 @@ Exports the variant of the command that results from using the specified argumen
 values).
 
 For example, to export the variant of the `Get-Item` command in the certificate (Cert:) drive in
-the PSSession in `$S`, type `export-pssession -session $S -command get-item -argumentlist cert:`.
+the PSSession in `$S`, type `Export-PSSession -Session $S -Command Get-Item -ArgumentList cert:`.
 
 ```yaml
 Type: Object[]

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -73,8 +73,8 @@ Export-PSSession -Session $S -Module exch* -CommandName Get-*, Set-* -FormatType
 ```
 
 These commands export the `Get` and `Set` commands from a Microsoft Exchange Server snap-in on a
-remote computer to an Exchange module in the `$PSHOME`\Modules directory on the local computer.
-Placing the module in the `$PSHOME`\Modules directory makes it accessible to all users of the
+remote computer to an Exchange module in the `$PSHOME\Modules` directory on the local computer.
+Placing the module in the `$PSHOME\Modules` directory makes it accessible to all users of the
 computer.
 
 ### Example 3: Export commands from a remote computer

--- a/reference/6/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -8,9 +8,11 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: Export-PSSession
 ---
+
 # Export-PSSession
 
 ## SYNOPSIS
+
 Exports commands from another session and saves them in a PowerShell module.
 
 ## SYNTAX
@@ -67,12 +69,12 @@ This example exports all of the `Get` and `Set` commands from a server.
 
 ```powershell
 $S = New-PSSession -ConnectionUri http://exchange.microsoft.com/mailbox -Credential exchangeadmin01@hotmail.com -Authentication Negotiate
-Export-PSSession -Session $R -Module exch* -CommandName Get-*, Set-* -FormatTypeName * -OutputModule $pshome\Modules\Exchange -Encoding ASCII
+Export-PSSession -Session $S -Module exch* -CommandName Get-*, Set-* -FormatTypeName * -OutputModule $PSHOME\Modules\Exchange -Encoding ASCII
 ```
 
 These commands export the `Get` and `Set` commands from a Microsoft Exchange Server snap-in on a
-remote computer to an Exchange module in the `$pshome`\Modules directory on the local computer.
-Placing the module in the `$pshome`\Modules directory makes it accessible to all users of the
+remote computer to an Exchange module in the `$PSHOME`\Modules directory on the local computer.
+Placing the module in the `$PSHOME`\Modules directory makes it accessible to all users of the
 computer.
 
 ### Example 3: Export commands from a remote computer
@@ -182,7 +184,7 @@ Exports the variant of the command that results from using the specified argumen
 values).
 
 For example, to export the variant of the `Get-Item` command in the certificate (Cert:) drive in
-the PSSession in `$S`, type `export-pssession -session $S -command get-item -argumentlist cert:`.
+the PSSession in `$S`, type `Export-PSSession -Session $S -Command Get-Item -ArgumentList cert:`.
 
 ```yaml
 Type: Object[]

--- a/reference/6/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -73,8 +73,8 @@ Export-PSSession -Session $S -Module exch* -CommandName Get-*, Set-* -FormatType
 ```
 
 These commands export the `Get` and `Set` commands from a Microsoft Exchange Server snap-in on a
-remote computer to an Exchange module in the `$PSHOME`\Modules directory on the local computer.
-Placing the module in the `$PSHOME`\Modules directory makes it accessible to all users of the
+remote computer to an Exchange module in the `$PSHOME\Modules` directory on the local computer.
+Placing the module in the `$PSHOME\Modules` directory makes it accessible to all users of the
 computer.
 
 ### Example 3: Export commands from a remote computer

--- a/reference/7/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -8,9 +8,11 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: Export-PSSession
 ---
+
 # Export-PSSession
 
 ## SYNOPSIS
+
 Exports commands from another session and saves them in a PowerShell module.
 
 ## SYNTAX
@@ -67,12 +69,12 @@ This example exports all of the `Get` and `Set` commands from a server.
 
 ```powershell
 $S = New-PSSession -ConnectionUri http://exchange.microsoft.com/mailbox -Credential exchangeadmin01@hotmail.com -Authentication Negotiate
-Export-PSSession -Session $R -Module exch* -CommandName Get-*, Set-* -FormatTypeName * -OutputModule $pshome\Modules\Exchange -Encoding ASCII
+Export-PSSession -Session $S -Module exch* -CommandName Get-*, Set-* -FormatTypeName * -OutputModule $PSHOME\Modules\Exchange -Encoding ASCII
 ```
 
 These commands export the `Get` and `Set` commands from a Microsoft Exchange Server snap-in on a
-remote computer to an Exchange module in the `$pshome`\Modules directory on the local computer.
-Placing the module in the `$pshome`\Modules directory makes it accessible to all users of the
+remote computer to an Exchange module in the `$PSHOME`\Modules directory on the local computer.
+Placing the module in the `$PSHOME`\Modules directory makes it accessible to all users of the
 computer.
 
 ### Example 3: Export commands from a remote computer
@@ -182,7 +184,7 @@ Exports the variant of the command that results from using the specified argumen
 values).
 
 For example, to export the variant of the `Get-Item` command in the certificate (Cert:) drive in
-the PSSession in `$S`, type `export-pssession -session $S -command get-item -argumentlist cert:`.
+the PSSession in `$S`, type `Export-PSSession -Session $S -Command Get-Item -ArgumentList cert:`.
 
 ```yaml
 Type: Object[]

--- a/reference/7/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/7/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -73,8 +73,8 @@ Export-PSSession -Session $S -Module exch* -CommandName Get-*, Set-* -FormatType
 ```
 
 These commands export the `Get` and `Set` commands from a Microsoft Exchange Server snap-in on a
-remote computer to an Exchange module in the `$PSHOME`\Modules directory on the local computer.
-Placing the module in the `$PSHOME`\Modules directory makes it accessible to all users of the
+remote computer to an Exchange module in the `$PSHOME\Modules` directory on the local computer.
+Placing the module in the `$PSHOME\Modules` directory makes it accessible to all users of the
 computer.
 
 ### Example 3: Export commands from a remote computer


### PR DESCRIPTION
# PR Summary
Typo in a PowerShell example. Misnamed variable that would cause the example code not to work.

## PR Context
Fixes #5262 
Fixes [AB#1660588](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1660588)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
