### PR TITLE
Remove note about Experimental features that are no longer experimental

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_If.md
@@ -97,10 +97,6 @@ else {
 
 ### Using the ternary operator syntax
 
-> [!NOTE]
-> This is an experimental feature. For more information see
-> [about_Experimental_Features](about_Experimental_Features.md).
-
 PowerShell 7.0 introduced a new syntax using the ternary operator. It follows the C# ternary
 operator syntax:
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -415,10 +415,6 @@ Get-PSSnapin | Where-Object {$_.vendor -ne "Microsoft"}
 
 #### Pipeline chain operators `&&` and `||`
 
-> [!NOTE]
-> This is an experimental feature. For more information see
-> [about_Experimental_Features](about_Experimental_Features.md).
-
 Conditionally execute the right-hand side pipeline based on the success of the
 left-hand side pipeline.
 
@@ -495,13 +491,8 @@ of the `Get-Member` cmdlet.
 
 #### Ternary operator `? <if-true> : <if-false>`
 
-> [!NOTE]
-> This is an experimental feature. For more information see
-> [about_Experimental_Features](about_Experimental_Features.md).
-
 You can use the ternary operator as a replacement for the `if-else` statement
-in simple conditional cases. The ternary operator was introduced in PowerShell
-7.0 as an experimental feature.
+in simple conditional cases.
 
 For more information, see [about_If](about_If.md).
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Pipeline_Chain_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Pipeline_Chain_Operators.md
@@ -14,10 +14,6 @@ Describes chaining pipelines with the `&&` and `||` operators in PowerShell.
 
 ## Long description
 
-> [!NOTE]
-> This is an experimental feature. For more information see
-> [about_Experimental_Features](about_Experimental_Features.md).
-
 Beginning in PowerShell 7, PowerShell implements the `&&` and `||` operators to
 conditionally chain pipelines. These operators are known in PowerShell as
 *pipeline chain operators*, and are similar to

--- a/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -76,10 +76,6 @@ Starting in Windows PowerShell 3.0, there are two different ways to construct a 
   By default, the parallel scriptblocks use the current working directory of the caller that started
   the parallel tasks.
 
-> [!NOTE]
-> This is an experimental feature. For more information see
-> [about_Experimental_Features](about/about_Experimental_Features.md).
-
 ## EXAMPLES
 
 ### Example 1: Divide integers in an array


### PR DESCRIPTION
# PR Summary
Removed notes about ternary and chain operators, and foreach-object -parallel being experimental.

## PR Context
Fix https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5287

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
