### PR TITLE
Add ConvertFrom-SecureString -AsPlainText documentation

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
+++ b/reference/7.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
@@ -8,6 +8,7 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: ConvertFrom-SecureString
 ---
+
 # ConvertFrom-SecureString
 
 ## SYNOPSIS
@@ -16,13 +17,16 @@ Converts a secure string to an encrypted standard string.
 ## SYNTAX
 
 ### Secure (Default)
-
 ```
 ConvertFrom-SecureString [-SecureString] <SecureString> [[-SecureKey] <SecureString>] [<CommonParameters>]
 ```
 
-### Open
+### AsPlainText
+```
+ConvertFrom-SecureString [-SecureString] <SecureString> [-AsPlainText] [<CommonParameters>]
+```
 
+### Open
 ```
 ConvertFrom-SecureString [-SecureString] <SecureString> [-Key <Byte[]>] [<CommonParameters>]
 ```
@@ -85,7 +89,31 @@ Because each decimal numeral represents a single byte (8 bits), the key has 24 d
 The second command uses the key in the `$Key` variable to convert the secure string to an encrypted
 standard string.
 
+### Example 4: Convert a secure string directly to a plaintext string
+
+```
+$secureString = ConvertTo-SecureString -String 'Example' -AsPlainText
+$secureString # 'System.Security.SecureString'
+ConvertFrom-SecureString -SecureString $secureString -AsPlainText # 'Example'
+```
+
 ## PARAMETERS
+
+### -AsPlainText
+When set, **ConvertFrom-SecureString** will convert secure strings to the decrypted plaintext string
+as output.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: AsPlainText
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Key
 
@@ -137,10 +165,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
--InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](../Microsoft.PowerShell.Core/About/about_CommonParameters.md).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/7.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
+++ b/reference/7.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
@@ -91,7 +91,7 @@ standard string.
 
 ### Example 4: Convert a secure string directly to a plaintext string
 
-```
+```powershell
 $secureString = ConvertTo-SecureString -String 'Example' -AsPlainText
 $secureString # 'System.Security.SecureString'
 ConvertFrom-SecureString -SecureString $secureString -AsPlainText # 'Example'
@@ -100,7 +100,7 @@ ConvertFrom-SecureString -SecureString $secureString -AsPlainText # 'Example'
 ## PARAMETERS
 
 ### -AsPlainText
-When set, **ConvertFrom-SecureString** will convert secure strings to the decrypted plaintext string
+When set, `ConvertFrom-SecureString** will convert secure strings to the decrypted plaintext string
 as output.
 
 ```yaml
@@ -165,7 +165,10 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters:
+`-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`,`-InformationVariable`,
+`-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`.
+For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/7.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
+++ b/reference/7.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
@@ -105,7 +105,7 @@ ConvertFrom-SecureString -SecureString $secureString -AsPlainText # 'Example'
 
 ### -AsPlainText
 
-When set, `ConvertFrom-SecureString** will convert secure strings to the decrypted plaintext string
+When set, `ConvertFrom-SecureString` will convert secure strings to the decrypted plaintext string
 as output.
 
 ```yaml

--- a/reference/7.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
+++ b/reference/7.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
@@ -12,21 +12,25 @@ title: ConvertFrom-SecureString
 # ConvertFrom-SecureString
 
 ## SYNOPSIS
+
 Converts a secure string to an encrypted standard string.
 
 ## SYNTAX
 
 ### Secure (Default)
+
 ```
 ConvertFrom-SecureString [-SecureString] <SecureString> [[-SecureKey] <SecureString>] [<CommonParameters>]
 ```
 
 ### AsPlainText
+
 ```
 ConvertFrom-SecureString [-SecureString] <SecureString> [-AsPlainText] [<CommonParameters>]
 ```
 
 ### Open
+
 ```
 ConvertFrom-SecureString [-SecureString] <SecureString> [-Key <Byte[]>] [<CommonParameters>]
 ```
@@ -100,6 +104,7 @@ ConvertFrom-SecureString -SecureString $secureString -AsPlainText # 'Example'
 ## PARAMETERS
 
 ### -AsPlainText
+
 When set, `ConvertFrom-SecureString** will convert secure strings to the decrypted plaintext string
 as output.
 
@@ -165,6 +170,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters:
 `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`,`-InformationVariable`,
 `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`.


### PR DESCRIPTION
# PR Summary
Documents the new `-AsPlainText` parameter on `ConvertFrom-SecureString`.

## PR Context

`-AsPlainText` was added to `ConvertFrom-SecureString` in https://github.com/PowerShell/PowerShell/pull/11142.

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
