### PR TITLE
Remove confused entry from redirection file

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -20241,11 +20241,6 @@
       "redirect_document_id": false
     },
     {
-      "source_path": "reference/virtual-directory-module/Microsoft.PowerShell.Core/Clear-Host.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/module/microsoft.powershell.core/clear-host",
-      "redirect_document_id": false
-    },
-    {
       "source_path": "reference/virtual-directory-module/Microsoft.PowerShell.Core/Environment-Provider.md",
       "redirect_url": "https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_environment_provider",
       "redirect_document_id": false
@@ -20273,11 +20268,6 @@
     {
       "source_path": "reference/virtual-directory-module/Microsoft.PowerShell.Core/Get-Item-for-FileSystem.md",
       "redirect_url": "https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_filesystem_provider/get-item-for-filesystem",
-      "redirect_document_id": false
-    },
-    {
-      "source_path": "reference/virtual-directory-module/Microsoft.PowerShell.Core/Get-Verb.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/module/microsoft.powershell.core/get-verb",
       "redirect_document_id": false
     },
     {


### PR DESCRIPTION
After this change:

+ https://review.docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/clear-host?branch=qinezh%2Fredirect will be redirected to https://review.docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/clear-host?branch=qinezh%2Fredirect&view=powershell-7
+ https://review.docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/get-verb?branch=qinezh%2Fredirect will be redirected to https://review.docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/get-verb?branch=qinezh%2Fredirect&view=powershell-5.1

while these two links are not working in live site:

+ https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/clear-host
+ https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/get-verb