### PR TITLE
Adds new example, minor updates, and formatting.

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Location.md
@@ -44,11 +44,8 @@ stack. For more information about location stacks, see the Notes.
 
 ### Example 1: Set the current location
 
-```powershell
-Set-Location -Path "HKLM:"
 ```
-
-```output
+PS C:\> Set-Location -Path "HKLM:"
 PS HKLM:\>
 ```
 
@@ -56,11 +53,11 @@ This command sets the current location to the root of the HKLM: drive.
 
 ### Example 2: Set the current location and display that location
 
-```powershell
-Set-Location -Path "Env:" -PassThru
+```
+PS C:\> Set-Location -Path "Env:" -PassThru
 ```
 
-```output
+```Output
 Path
 ----
 Env:\
@@ -73,11 +70,8 @@ parameter to direct PowerShell to return a **PathInfo** object that represents t
 
 ### Example 3: Set location to the C: drive
 
-```powershell
-Set-Location C:
 ```
-
-```output
+PS Env:\> Set-Location C:
 PS C:\>
 ```
 
@@ -85,8 +79,8 @@ This command sets the current location C: drive in the FileSystem provider.
 
 ### Example 4: Set the current location to a named stack
 
-```powershell
-Set-Location -StackName "WSManPaths"
+```
+PS C:\> Set-Location 'C:\Program Files\PowerShell\' -StackName "WSManPaths"
 ```
 
 This command makes the WSManPaths location stack the current location stack.

--- a/reference/6/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Location.md
@@ -45,7 +45,7 @@ stack. For more information about location stacks, see the Notes.
 ### Example 1: Set the current location
 
 ```powershell
-PS C:\> Set-Location -Path "HKLM:"
+Set-Location -Path "HKLM:"
 ```
 
 ```output
@@ -57,7 +57,7 @@ This command sets the current location to the root of the HKLM: drive.
 ### Example 2: Set the current location and display that location
 
 ```powershell
-PS C:\> Set-Location -Path "Env:" -PassThru
+Set-Location -Path "Env:" -PassThru
 ```
 
 ```output
@@ -74,7 +74,11 @@ parameter to direct PowerShell to return a **PathInfo** object that represents t
 ### Example 3: Set location to the C: drive
 
 ```powershell
-PS C:\> Set-Location C:
+Set-Location C:
+```
+
+```output
+PS C:\>
 ```
 
 This command sets the current location C: drive in the FileSystem provider.
@@ -82,13 +86,37 @@ This command sets the current location C: drive in the FileSystem provider.
 ### Example 4: Set the current location to a named stack
 
 ```powershell
-PS C:\> Set-Location -StackName "WSManPaths"
+Set-Location -StackName "WSManPaths"
 ```
 
 This command makes the WSManPaths location stack the current location stack.
 
 The `*-Location` cmdlets use the current location stack unless a different location stack is
-specified in the command. For information about location stacks, see the Notes.
+specified in the command. For information about location stacks, see the [Notes Section](#Notes).
+
+### Example 5: Navigate location history using +/-
+
+```
+PS C:\> Set-Location -Path $env:SystemRoot
+PS C:\Windows> Set-Location -Path Cert:
+PS Cert:\> Set-Location -Path HKLM:
+PS HKLM:\>
+
+# Navigate back through the history using "-"
+PS HKLM:\> Set-Location -Path -
+PS Cert:\> Set-Location -Path -
+PS C:\Windows>
+
+# Navigate using the Set-Location alias "cd" and the implicit positional Path parameter
+PS C:\Windows> cd -
+PS C:\> cd +
+PS C:\Windows> cd +
+PS Cert:\>
+```
+
+Using the alias, `cd -` or `cd +` is an easy way to navigate through your location history while
+in your terminal. For more information on navigating with `-`/`+`, see the [Path parameter](#-Path)
+section.
 
 ## PARAMETERS
 
@@ -103,8 +131,8 @@ PowerShell keeps a history of the last 20 locations you have set. If the path is
 then the new working location will be the previous working location in history (if it exists).
 Similarly, if the path is the `+` character, then the new working location will be the next working
 location in history (if it exists). This is similar to using `Pop-Location` and `Push-Location`
-except that the history is a list, not a stack, and there is no way to display this history list.
-
+except that the history is a list, not a stack, and is implicitly tracked, not manually controlled.
+Currently, there is no way to view the history list.
 
 ```yaml
 Type: String
@@ -145,7 +173,8 @@ PowerShell keeps a history of the last 20 locations you have set. If the path is
 then the new working location will be the previous working location in history (if it exists).
 Similarly, if the path is the `+` character, then the new working location will be the next working
 location in history (if it exists). This is similar to using `Pop-Location` and `Push-Location`
-except that the history is a list, not a stack, and there is no way to display this history list.
+except that the history is a list, not a stack, and is implicitly tracked, not manually controlled.
+Currently, there is no way to view the history list.
 
 ```yaml
 Type: String
@@ -203,7 +232,7 @@ representing the new stack context.
 
 ## NOTES
 
-* The `Set-Location` cmdlet is designed to work with the data exposed by any provider. To list the
+- The `Set-Location` cmdlet is designed to work with the data exposed by any provider. To list the
   providers available in your session, type `Get-PSProvider`. For more information, see
   [about_Providers](../Microsoft.PowerShell.Core/about/about_Providers.md).
 
@@ -215,20 +244,20 @@ representing the new stack context.
   location is the current location stack, but you can use the `Set-Location` cmdlet to change the
   current location stack.
 
-* To manage location stacks, use the `*-Location` cmdlets, as follows:
+- To manage location stacks, use the `*-Location` cmdlets, as follows:
 
-  * To add a location to a location stack, use the `Push-Location` cmdlet.
+  - To add a location to a location stack, use the `Push-Location` cmdlet.
 
-  * To get a location from a location stack, use the `Pop-Location` cmdlet.
+  - To get a location from a location stack, use the `Pop-Location` cmdlet.
 
-  * To display the locations in the current location stack, use the **Stack** parameter of the
+  - To display the locations in the current location stack, use the **Stack** parameter of the
     `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
     parameter of `Get-Location`.
 
-  * To create a new location stack, use the **StackName** parameter of `Push-Location`. If you
+  - To create a new location stack, use the **StackName** parameter of `Push-Location`. If you
     specify a stack that does not exist, `Push-Location` creates the stack.
 
-  * To make a location stack the current location stack, use the **StackName** parameter of
+  - To make a location stack the current location stack, use the **StackName** parameter of
     `Set-Location`.
 
     The unnamed default location stack is fully accessible only when it is the current location

--- a/reference/6/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Location.md
@@ -92,7 +92,7 @@ Set-Location -StackName "WSManPaths"
 This command makes the WSManPaths location stack the current location stack.
 
 The `*-Location` cmdlets use the current location stack unless a different location stack is
-specified in the command. For information about location stacks, see the [Notes Section](#Notes).
+specified in the command. For information about location stacks, see the Notes.
 
 ### Example 5: Navigate location history using +/-
 
@@ -115,8 +115,7 @@ PS Cert:\>
 ```
 
 Using the alias, `cd -` or `cd +` is an easy way to navigate through your location history while
-in your terminal. For more information on navigating with `-`/`+`, see the [Path parameter](#-Path)
-section.
+in your terminal. For more information on navigating with `-`/`+`, see the Path parameter.
 
 ## PARAMETERS
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Set-Location.md
@@ -92,7 +92,7 @@ Set-Location -StackName "WSManPaths"
 This command makes the WSManPaths location stack the current location stack.
 
 The `*-Location` cmdlets use the current location stack unless a different location stack is
-specified in the command. For information about location stacks, see the [Notes Section](#Notes).
+specified in the command. For information about location stacks, see the Notes.
 
 ### Example 5: Navigate location history using +/-
 
@@ -114,9 +114,8 @@ PS C:\Windows> cd +
 PS Cert:\>
 ```
 
-Using the alias, `cd -` or `cd +` is an easy way to navigate through your location history while
-in your terminal. For more information on navigating with `-`/`+`, see the [Path parameter](#-Path)
-section.
+Using the alias, `cd -` or `cd +` is an easy way to navigate through your location history while in
+your terminal. For more information on navigating with `-`/`+`, see the Path parameter.
 
 ## PARAMETERS
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Set-Location.md
@@ -44,11 +44,8 @@ stack. For more information about location stacks, see the Notes.
 
 ### Example 1: Set the current location
 
-```powershell
-Set-Location -Path "HKLM:"
 ```
-
-```output
+PS C:\> Set-Location -Path "HKLM:"
 PS HKLM:\>
 ```
 
@@ -56,11 +53,11 @@ This command sets the current location to the root of the HKLM: drive.
 
 ### Example 2: Set the current location and display that location
 
-```powershell
-Set-Location -Path "Env:" -PassThru
+```
+PS C:\> Set-Location -Path "Env:" -PassThru
 ```
 
-```output
+```Output
 Path
 ----
 Env:\
@@ -73,11 +70,8 @@ parameter to direct PowerShell to return a **PathInfo** object that represents t
 
 ### Example 3: Set location to the C: drive
 
-```powershell
-Set-Location C:
 ```
-
-```output
+PS Env:\> Set-Location C:
 PS C:\>
 ```
 
@@ -85,8 +79,8 @@ This command sets the current location C: drive in the FileSystem provider.
 
 ### Example 4: Set the current location to a named stack
 
-```powershell
-Set-Location -StackName "WSManPaths"
+```
+PS C:\> Set-Location 'C:\Program Files\PowerShell\' -StackName "WSManPaths"
 ```
 
 This command makes the WSManPaths location stack the current location stack.

--- a/reference/7.0/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Set-Location.md
@@ -45,7 +45,7 @@ stack. For more information about location stacks, see the Notes.
 ### Example 1: Set the current location
 
 ```powershell
-PS C:\> Set-Location -Path "HKLM:"
+Set-Location -Path "HKLM:"
 ```
 
 ```output
@@ -57,7 +57,7 @@ This command sets the current location to the root of the HKLM: drive.
 ### Example 2: Set the current location and display that location
 
 ```powershell
-PS C:\> Set-Location -Path "Env:" -PassThru
+Set-Location -Path "Env:" -PassThru
 ```
 
 ```output
@@ -74,7 +74,11 @@ parameter to direct PowerShell to return a **PathInfo** object that represents t
 ### Example 3: Set location to the C: drive
 
 ```powershell
-PS C:\> Set-Location C:
+Set-Location C:
+```
+
+```output
+PS C:\>
 ```
 
 This command sets the current location C: drive in the FileSystem provider.
@@ -82,13 +86,37 @@ This command sets the current location C: drive in the FileSystem provider.
 ### Example 4: Set the current location to a named stack
 
 ```powershell
-PS C:\> Set-Location -StackName "WSManPaths"
+Set-Location -StackName "WSManPaths"
 ```
 
 This command makes the WSManPaths location stack the current location stack.
 
 The `*-Location` cmdlets use the current location stack unless a different location stack is
-specified in the command. For information about location stacks, see the Notes.
+specified in the command. For information about location stacks, see the [Notes Section](#Notes).
+
+### Example 5: Navigate location history using +/-
+
+```
+PS C:\> Set-Location -Path $env:SystemRoot
+PS C:\Windows> Set-Location -Path Cert:
+PS Cert:\> Set-Location -Path HKLM:
+PS HKLM:\>
+
+# Navigate back through the history using "-"
+PS HKLM:\> Set-Location -Path -
+PS Cert:\> Set-Location -Path -
+PS C:\Windows>
+
+# Navigate using the Set-Location alias "cd" and the implicit positional Path parameter
+PS C:\Windows> cd -
+PS C:\> cd +
+PS C:\Windows> cd +
+PS Cert:\>
+```
+
+Using the alias, `cd -` or `cd +` is an easy way to navigate through your location history while
+in your terminal. For more information on navigating with `-`/`+`, see the [Path parameter](#-Path)
+section.
 
 ## PARAMETERS
 
@@ -103,8 +131,8 @@ PowerShell keeps a history of the last 20 locations you have set. If the path is
 then the new working location will be the previous working location in history (if it exists).
 Similarly, if the path is the `+` character, then the new working location will be the next working
 location in history (if it exists). This is similar to using `Pop-Location` and `Push-Location`
-except that the history is a list, not a stack, and there is no way to display this history list.
-
+except that the history is a list, not a stack, and is implicitly tracked, not manually controlled.
+Currently, there is no way to view the history list.
 
 ```yaml
 Type: String
@@ -145,7 +173,8 @@ PowerShell keeps a history of the last 20 locations you have set. If the path is
 then the new working location will be the previous working location in history (if it exists).
 Similarly, if the path is the `+` character, then the new working location will be the next working
 location in history (if it exists). This is similar to using `Pop-Location` and `Push-Location`
-except that the history is a list, not a stack, and there is no way to display this history list.
+except that the history is a list, not a stack, and is implicitly tracked, not manually controlled.
+Currently, there is no way to view the history list.
 
 ```yaml
 Type: String
@@ -203,7 +232,7 @@ representing the new stack context.
 
 ## NOTES
 
-* The `Set-Location` cmdlet is designed to work with the data exposed by any provider. To list the
+- The `Set-Location` cmdlet is designed to work with the data exposed by any provider. To list the
   providers available in your session, type `Get-PSProvider`. For more information, see
   [about_Providers](../Microsoft.PowerShell.Core/about/about_Providers.md).
 
@@ -215,20 +244,20 @@ representing the new stack context.
   location is the current location stack, but you can use the `Set-Location` cmdlet to change the
   current location stack.
 
-* To manage location stacks, use the `*-Location` cmdlets, as follows:
+- To manage location stacks, use the `*-Location` cmdlets, as follows:
 
-  * To add a location to a location stack, use the `Push-Location` cmdlet.
+  - To add a location to a location stack, use the `Push-Location` cmdlet.
 
-  * To get a location from a location stack, use the `Pop-Location` cmdlet.
+  - To get a location from a location stack, use the `Pop-Location` cmdlet.
 
-  * To display the locations in the current location stack, use the **Stack** parameter of the
+  - To display the locations in the current location stack, use the **Stack** parameter of the
     `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
     parameter of `Get-Location`.
 
-  * To create a new location stack, use the **StackName** parameter of `Push-Location`. If you
+  - To create a new location stack, use the **StackName** parameter of `Push-Location`. If you
     specify a stack that does not exist, `Push-Location` creates the stack.
 
-  * To make a location stack the current location stack, use the **StackName** parameter of
+  - To make a location stack the current location stack, use the **StackName** parameter of
     `Set-Location`.
 
     The unnamed default location stack is fully accessible only when it is the current location

--- a/reference/7.1/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Set-Location.md
@@ -92,7 +92,7 @@ PS C:\> Set-Location -StackName "WSManPaths"
 This command makes the WSManPaths location stack the current location stack.
 
 The `*-Location` cmdlets use the current location stack unless a different location stack is
-specified in the command. For information about location stacks, see the [Notes Section](#Notes).
+specified in the command. For information about location stacks, see the Notes.
 
 ### Example 5: Navigate location history using +/-
 
@@ -115,8 +115,7 @@ PS Cert:\>
 ```
 
 Using the alias, `cd -` or `cd +` is an easy way to navigate through your location history while
-in your terminal. For more information on navigating with `-`/`+`, see the [Path parameter](#-Path)
-section.
+in your terminal. For more information on navigating with `-`/`+`, see the Path parameter.
 
 ## PARAMETERS
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Set-Location.md
@@ -44,11 +44,8 @@ stack. For more information about location stacks, see the Notes.
 
 ### Example 1: Set the current location
 
-```powershell
-Set-Location -Path "HKLM:"
 ```
-
-```output
+PS C:\> Set-Location -Path "HKLM:"
 PS HKLM:\>
 ```
 
@@ -56,11 +53,11 @@ This command sets the current location to the root of the HKLM: drive.
 
 ### Example 2: Set the current location and display that location
 
-```powershell
-Set-Location -Path "Env:" -PassThru
+```
+PS C:\> Set-Location -Path "Env:" -PassThru
 ```
 
-```output
+```Output
 Path
 ----
 Env:\
@@ -73,11 +70,8 @@ parameter to direct PowerShell to return a **PathInfo** object that represents t
 
 ### Example 3: Set location to the C: drive
 
-```powershell
-Set-Location C:
 ```
-
-```output
+PS Env:\> Set-Location C:
 PS C:\>
 ```
 
@@ -85,8 +79,8 @@ This command sets the current location C: drive in the FileSystem provider.
 
 ### Example 4: Set the current location to a named stack
 
-```powershell
-PS C:\> Set-Location -StackName "WSManPaths"
+```
+PS C:\> Set-Location 'C:\Program Files\PowerShell\' -StackName "WSManPaths"
 ```
 
 This command makes the WSManPaths location stack the current location stack.

--- a/reference/7.1/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Set-Location.md
@@ -45,7 +45,7 @@ stack. For more information about location stacks, see the Notes.
 ### Example 1: Set the current location
 
 ```powershell
-PS C:\> Set-Location -Path "HKLM:"
+Set-Location -Path "HKLM:"
 ```
 
 ```output
@@ -57,7 +57,7 @@ This command sets the current location to the root of the HKLM: drive.
 ### Example 2: Set the current location and display that location
 
 ```powershell
-PS C:\> Set-Location -Path "Env:" -PassThru
+Set-Location -Path "Env:" -PassThru
 ```
 
 ```output
@@ -74,7 +74,11 @@ parameter to direct PowerShell to return a **PathInfo** object that represents t
 ### Example 3: Set location to the C: drive
 
 ```powershell
-PS C:\> Set-Location C:
+Set-Location C:
+```
+
+```output
+PS C:\>
 ```
 
 This command sets the current location C: drive in the FileSystem provider.
@@ -88,7 +92,31 @@ PS C:\> Set-Location -StackName "WSManPaths"
 This command makes the WSManPaths location stack the current location stack.
 
 The `*-Location` cmdlets use the current location stack unless a different location stack is
-specified in the command. For information about location stacks, see the Notes.
+specified in the command. For information about location stacks, see the [Notes Section](#Notes).
+
+### Example 5: Navigate location history using +/-
+
+```
+PS C:\> Set-Location -Path $env:SystemRoot
+PS C:\Windows> Set-Location -Path Cert:
+PS Cert:\> Set-Location -Path HKLM:
+PS HKLM:\>
+
+# Navigate back through the history using "-"
+PS HKLM:\> Set-Location -Path -
+PS Cert:\> Set-Location -Path -
+PS C:\Windows>
+
+# Navigate using the Set-Location alias "cd" and the implicit positional Path parameter
+PS C:\Windows> cd -
+PS C:\> cd +
+PS C:\Windows> cd +
+PS Cert:\>
+```
+
+Using the alias, `cd -` or `cd +` is an easy way to navigate through your location history while
+in your terminal. For more information on navigating with `-`/`+`, see the [Path parameter](#-Path)
+section.
 
 ## PARAMETERS
 
@@ -103,8 +131,8 @@ PowerShell keeps a history of the last 20 locations you have set. If the path is
 then the new working location will be the previous working location in history (if it exists).
 Similarly, if the path is the `+` character, then the new working location will be the next working
 location in history (if it exists). This is similar to using `Pop-Location` and `Push-Location`
-except that the history is a list, not a stack, and there is no way to display this history list.
-
+except that the history is a list, not a stack, and is implicitly tracked, not manually controlled.
+Currently, there is no way to view the history list.
 
 ```yaml
 Type: String
@@ -145,7 +173,8 @@ PowerShell keeps a history of the last 20 locations you have set. If the path is
 then the new working location will be the previous working location in history (if it exists).
 Similarly, if the path is the `+` character, then the new working location will be the next working
 location in history (if it exists). This is similar to using `Pop-Location` and `Push-Location`
-except that the history is a list, not a stack, and there is no way to display this history list.
+except that the history is a list, not a stack, and is implicitly tracked, not manually controlled.
+Currently, there is no way to view the history list.
 
 ```yaml
 Type: String
@@ -203,7 +232,7 @@ representing the new stack context.
 
 ## NOTES
 
-* The `Set-Location` cmdlet is designed to work with the data exposed by any provider. To list the
+- The `Set-Location` cmdlet is designed to work with the data exposed by any provider. To list the
   providers available in your session, type `Get-PSProvider`. For more information, see
   [about_Providers](../Microsoft.PowerShell.Core/about/about_Providers.md).
 
@@ -215,20 +244,20 @@ representing the new stack context.
   location is the current location stack, but you can use the `Set-Location` cmdlet to change the
   current location stack.
 
-* To manage location stacks, use the `*-Location` cmdlets, as follows:
+- To manage location stacks, use the `*-Location` cmdlets, as follows:
 
-  * To add a location to a location stack, use the `Push-Location` cmdlet.
+  - To add a location to a location stack, use the `Push-Location` cmdlet.
 
-  * To get a location from a location stack, use the `Pop-Location` cmdlet.
+  - To get a location from a location stack, use the `Pop-Location` cmdlet.
 
-  * To display the locations in the current location stack, use the **Stack** parameter of the
+  - To display the locations in the current location stack, use the **Stack** parameter of the
     `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
     parameter of `Get-Location`.
 
-  * To create a new location stack, use the **StackName** parameter of `Push-Location`. If you
+  - To create a new location stack, use the **StackName** parameter of `Push-Location`. If you
     specify a stack that does not exist, `Push-Location` creates the stack.
 
-  * To make a location stack the current location stack, use the **StackName** parameter of
+  - To make a location stack the current location stack, use the **StackName** parameter of
     `Set-Location`.
 
     The unnamed default location stack is fully accessible only when it is the current location


### PR DESCRIPTION
# PR Summary
Updates `Set-Location` documentation with an exaple for using `-`/`+` as the **Path** parameter Value as well as updates for formatting.

## PR Context
Fixes #5332 
Fixes [AB#1667146](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1667146)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
