### PR TITLE
[Fixes 5354] Fixes Typo in Out-String

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
@@ -41,7 +41,7 @@ console.
 Get-Content -Path C:\Test\Testfile.txt | Out-String
 ```
 
-`Get-Culture` sends the contents of the `Testfile.txt` file down the pipeline. Each line of the file
+`Get-Content` sends the contents of the `Testfile.txt` file down the pipeline. Each line of the file
 has its own properties. `Out-String` converts the objects into an array of strings and then displays
 the contents as one string in the PowerShell console.
 

--- a/reference/6/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Out-String.md
@@ -47,7 +47,7 @@ console.
 Get-Content -Path C:\Test\Testfile.txt | Out-String
 ```
 
-`Get-Culture` sends the contents of the `Testfile.txt` file down the pipeline. Each line of the file
+`Get-Content` sends the contents of the `Testfile.txt` file down the pipeline. Each line of the file
 has its own properties. `Out-String` converts the objects into an array of strings and then displays
 the contents as one string in the PowerShell console.
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Out-String.md
@@ -47,7 +47,7 @@ console.
 Get-Content -Path C:\Test\Testfile.txt | Out-String
 ```
 
-`Get-Culture` sends the contents of the `Testfile.txt` file down the pipeline. Each line of the file
+`Get-Content` sends the contents of the `Testfile.txt` file down the pipeline. Each line of the file
 has its own properties. `Out-String` converts the objects into an array of strings and then displays
 the contents as one string in the PowerShell console.
 

--- a/reference/7.1/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Out-String.md
@@ -47,7 +47,7 @@ console.
 Get-Content -Path C:\Test\Testfile.txt | Out-String
 ```
 
-`Get-Culture` sends the contents of the `Testfile.txt` file down the pipeline. Each line of the file
+`Get-Content` sends the contents of the `Testfile.txt` file down the pipeline. Each line of the file
 has its own properties. `Out-String` converts the objects into an array of strings and then displays
 the contents as one string in the PowerShell console.
 


### PR DESCRIPTION
# PR Summary
Fixes type in Out-String

## PR Context
Fixes #5354 
Fixes [AB#1668657](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1668657)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
