### PR TITLE
Fixes #5076 - doc version behavior

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -46,12 +46,12 @@ Get-FormatData
 
 ### Example 2: Get formatting data by type name
 
+This example gets the formatting data items whose names begin with
+`System.Management.Automation.Cmd`.
+
 ```powershell
 Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
 ```
-
-This command gets the formatting data items whose names begin with
-`System.Management.Automation.Cmd*`.
 
 ### Example 3: Examine a formatting data object
 
@@ -129,9 +129,10 @@ Get-Content c:\test\bits.format.ps1xml
 The first four commands use the `Get-FormatData`, `Import-Module`, and `Compare-Object` cmdlets to
 identify the format type that the **BitsTransfer** module adds to the session.
 
-The fifth command uses the `Get-FormatData` cmdlet to get the format type that the BitsTransfer
-module adds. It uses a pipeline operator (|) to send the format type object to the `Export-FormatData`
-cmdlet, which converts it back to XML and saves it in the specified format.ps1xml file.
+The fifth command uses the `Get-FormatData` cmdlet to get the format type that the **BitsTransfer**
+module adds. It uses a pipeline operator (`|`) to send the format type object to the
+`Export-FormatData` cmdlet, which converts it back to XML and saves it in the specified
+`format.ps1xml` file.
 
 The final command shows an excerpt of the `format.ps1xml` file content.
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 01/27/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-formatdata?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-FormatData
@@ -21,20 +21,24 @@ Get-FormatData [[-TypeName] <String[]>] [-PowerShellVersion <Version>] [<CommonP
 
 ## DESCRIPTION
 
-The **Get-FormatData** cmdlet gets the formatting data in the current session.
+The `Get-FormatData` cmdlet gets the formatting data in the current session.
 
-The formatting data in the session includes formatting data from Format.ps1xml formatting files, such as those in the $pshome directory, formatting data for modules that you import into the session, and formatting data for commands that you import into your session by using the Import-PSSession cmdlet.
+The formatting data in the session includes formatting data from `Format.ps1xml` formatting files,
+such as those in the `$PSHOME` directory, formatting data for modules that you import into the
+session, and formatting data for commands that you import into your session by using the
+`Import-PSSession` cmdlet.
 
-You can use this cmdlet to examine the formatting data.
-Then, you can use the Export-FormatData cmdlet to serialize the objects, convert them to XML, and save them in Format.ps1xml files.
+You can use this cmdlet to examine the formatting data. Then, you can use the `Export-FormatData`
+cmdlet to serialize the objects, convert them to XML, and save them in `Format.ps1xml` files.
 
-For more information about formatting files in PowerShell, see about_Format.ps1xml.
+For more information about formatting files in PowerShell, see
+[about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
 
 ## EXAMPLES
 
 ### Example 1: Get all formatting data
 
-This command gets all the formatting data in the session.
+This example gets all the formatting data in the session.
 
 ```powershell
 Get-FormatData
@@ -46,9 +50,12 @@ Get-FormatData
 Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
 ```
 
-This command gets the formatting data items whose names begin with System.Management.Automation.Cmd*.
+This command gets the formatting data items whose names begin with
+`System.Management.Automation.Cmd*`.
 
 ### Example 3: Examine a formatting data object
+
+This example shows how to get a formatting data object and examine its properties.
 
 ```powershell
 $F = Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
@@ -66,7 +73,9 @@ $F.FormatViewDefinition[0].control
 ```
 
 ```Output
-Headers          : {System.Management.Automation.TableControlColumnHeader, System.Management.Automation.TableControlColumnHeader, System.Management.Automation.TableControlColumnHeader,
+Headers          : {System.Management.Automation.TableControlColumnHeader,
+                   System.Management.Automation.TableControlColumnHeader,
+                   System.Management.Automation.TableControlColumnHeader,
                    System.Management.Automation.TableControlColumnHeader}
 Rows             : {System.Management.Automation.TableControlRow}
 AutoSize         : False
@@ -88,9 +97,10 @@ Version     Undefined    10
 Source      Undefined     0
 ```
 
-This example shows how to get a formatting data object and examine its properties.
-
 ### Example 4: Get formatting data and export it
+
+This example shows how to use `Get-FormatData` and `Export-FormatData` to export the formatting
+data that is added by a module.
 
 ```powershell
 $A = Get-FormatData
@@ -116,67 +126,42 @@ Get-Content c:\test\bits.format.ps1xml
 ...
 ```
 
-This example shows how to use **Get-FormatData** and **Export-FormatData** to export the formatting
-data that is added by a module.
+The first four commands use the `Get-FormatData`, `Import-Module`, and `Compare-Object` cmdlets to
+identify the format type that the **BitsTransfer** module adds to the session.
 
-The first four commands use the **Get-FormatData**, Import-Module, and Compare-Object cmdlets to
-identify the format type that the BitsTransfer module adds to the session.
-
-The fifth command uses the **Get-FormatData** cmdlet to get the format type that the BitsTransfer
-module adds. It uses a pipeline operator (|) to send the format type object to the Export-FormatData
+The fifth command uses the `Get-FormatData` cmdlet to get the format type that the BitsTransfer
+module adds. It uses a pipeline operator (|) to send the format type object to the `Export-FormatData`
 cmdlet, which converts it back to XML and saves it in the specified format.ps1xml file.
 
-The final command shows an excerpt of the format.ps1xml file content.
+The final command shows an excerpt of the `format.ps1xml` file content.
 
 ### Example 5: Get formatting data based on the specified version of PowerShell
 
+This example shows how to use `Get-FormatData` to get format data for a specified **TypeName** and
+PowerShell version.
+
 ```powershell
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 1.0
+Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion $PSVersionTable.PSVersion
 
 TypeNames                               FormatViewDefinition
 ---------                               --------------------
 {Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 2.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 3.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 4.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 5.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 5.1
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-This example shows how to use **Get-FormatData** to get format data for a specified TypeName and a
-specified PowerShell version.
 ```
+
+> [!IMPORTANT]
+> To ensure that the complete type formatting information is returned, you should always include the
+> **PowerShellVersion** parameter with the appropriate version. If the parameter and value are
+> omitted, you may not get all the correct type information.
 
 ## PARAMETERS
 
 ### -PowerShellVersion
 
-Specify the version of PowerShell this cmdlet gets for the formatting data.
-Enter a two digit number separated by a period.
+Specify the version of PowerShell this cmdlet gets for the formatting data. Enter a two digit number
+separated by a period.
+
+This parameter was added in PowerShell 5.1 to improve compatibility when remoting computers running
+older versions of PowerShell.
 
 ```yaml
 Type: Version
@@ -210,7 +195,10 @@ Accept wildcard characters: True
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -46,12 +46,12 @@ Get-FormatData
 
 ### Example 2: Get formatting data by type name
 
+This example gets the formatting data items whose names begin with
+`System.Management.Automation.Cmd`.
+
 ```powershell
 Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
 ```
-
-This command gets the formatting data items whose names begin with
-`System.Management.Automation.Cmd*`.
 
 ### Example 3: Examine a formatting data object
 
@@ -129,9 +129,10 @@ Get-Content c:\test\bits.format.ps1xml
 The first four commands use the `Get-FormatData`, `Import-Module`, and `Compare-Object` cmdlets to
 identify the format type that the **BitsTransfer** module adds to the session.
 
-The fifth command uses the `Get-FormatData` cmdlet to get the format type that the BitsTransfer
-module adds. It uses a pipeline operator (|) to send the format type object to the `Export-FormatData`
-cmdlet, which converts it back to XML and saves it in the specified format.ps1xml file.
+The fifth command uses the `Get-FormatData` cmdlet to get the format type that the **BitsTransfer**
+module adds. It uses a pipeline operator (`|`) to send the format type object to the
+`Export-FormatData` cmdlet, which converts it back to XML and saves it in the specified
+`format.ps1xml` file.
 
 The final command shows an excerpt of the `format.ps1xml` file content.
 

--- a/reference/6/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 01/27/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-formatdata?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-FormatData
@@ -21,20 +21,24 @@ Get-FormatData [[-TypeName] <String[]>] [-PowerShellVersion <Version>] [<CommonP
 
 ## DESCRIPTION
 
-The **Get-FormatData** cmdlet gets the formatting data in the current session.
+The `Get-FormatData` cmdlet gets the formatting data in the current session.
 
-The formatting data in the session includes formatting data from Format.ps1xml formatting files, such as those in the $pshome directory, formatting data for modules that you import into the session, and formatting data for commands that you import into your session by using the Import-PSSession cmdlet.
+The formatting data in the session includes formatting data from `Format.ps1xml` formatting files,
+such as those in the `$PSHOME` directory, formatting data for modules that you import into the
+session, and formatting data for commands that you import into your session by using the
+`Import-PSSession` cmdlet.
 
-You can use this cmdlet to examine the formatting data.
-Then, you can use the Export-FormatData cmdlet to serialize the objects, convert them to XML, and save them in Format.ps1xml files.
+You can use this cmdlet to examine the formatting data. Then, you can use the `Export-FormatData`
+cmdlet to serialize the objects, convert them to XML, and save them in `Format.ps1xml` files.
 
-For more information about formatting files in PowerShell, see about_Format.ps1xml.
+For more information about formatting files in PowerShell, see
+[about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
 
 ## EXAMPLES
 
 ### Example 1: Get all formatting data
 
-This command gets all the formatting data in the session.
+This example gets all the formatting data in the session.
 
 ```powershell
 Get-FormatData
@@ -46,9 +50,12 @@ Get-FormatData
 Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
 ```
 
-This command gets the formatting data items whose names begin with System.Management.Automation.Cmd*.
+This command gets the formatting data items whose names begin with
+`System.Management.Automation.Cmd*`.
 
 ### Example 3: Examine a formatting data object
+
+This example shows how to get a formatting data object and examine its properties.
 
 ```powershell
 $F = Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
@@ -66,7 +73,9 @@ $F.FormatViewDefinition[0].control
 ```
 
 ```Output
-Headers          : {System.Management.Automation.TableControlColumnHeader, System.Management.Automation.TableControlColumnHeader, System.Management.Automation.TableControlColumnHeader,
+Headers          : {System.Management.Automation.TableControlColumnHeader,
+                   System.Management.Automation.TableControlColumnHeader,
+                   System.Management.Automation.TableControlColumnHeader,
                    System.Management.Automation.TableControlColumnHeader}
 Rows             : {System.Management.Automation.TableControlRow}
 AutoSize         : False
@@ -88,9 +97,10 @@ Version     Undefined    10
 Source      Undefined     0
 ```
 
-This example shows how to get a formatting data object and examine its properties.
-
 ### Example 4: Get formatting data and export it
+
+This example shows how to use `Get-FormatData` and `Export-FormatData` to export the formatting
+data that is added by a module.
 
 ```powershell
 $A = Get-FormatData
@@ -116,67 +126,42 @@ Get-Content c:\test\bits.format.ps1xml
 ...
 ```
 
-This example shows how to use **Get-FormatData** and **Export-FormatData** to export the formatting
-data that is added by a module.
+The first four commands use the `Get-FormatData`, `Import-Module`, and `Compare-Object` cmdlets to
+identify the format type that the **BitsTransfer** module adds to the session.
 
-The first four commands use the **Get-FormatData**, Import-Module, and Compare-Object cmdlets to
-identify the format type that the BitsTransfer module adds to the session.
-
-The fifth command uses the **Get-FormatData** cmdlet to get the format type that the BitsTransfer
-module adds. It uses a pipeline operator (|) to send the format type object to the Export-FormatData
+The fifth command uses the `Get-FormatData` cmdlet to get the format type that the BitsTransfer
+module adds. It uses a pipeline operator (|) to send the format type object to the `Export-FormatData`
 cmdlet, which converts it back to XML and saves it in the specified format.ps1xml file.
 
-The final command shows an excerpt of the format.ps1xml file content.
+The final command shows an excerpt of the `format.ps1xml` file content.
 
 ### Example 5: Get formatting data based on the specified version of PowerShell
 
+This example shows how to use `Get-FormatData` to get format data for a specified **TypeName** and
+PowerShell version.
+
 ```powershell
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 1.0
+Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion $PSVersionTable.PSVersion
 
 TypeNames                               FormatViewDefinition
 ---------                               --------------------
 {Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 2.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 3.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 4.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 5.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 5.1
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-This example shows how to use **Get-FormatData** to get format data for a specified TypeName and a
-specified PowerShell version.
 ```
+
+> [!IMPORTANT]
+> To ensure that the complete type formatting information is returned, you should always include the
+> **PowerShellVersion** parameter with the appropriate version. If the parameter and value are
+> omitted, you may not get all the correct type information.
 
 ## PARAMETERS
 
 ### -PowerShellVersion
 
-Specify the version of PowerShell this cmdlet gets for the formatting data.
-Enter a two digit number separated by a period.
+Specify the version of PowerShell this cmdlet gets for the formatting data. Enter a two digit number
+separated by a period.
+
+This parameter was added in PowerShell 5.1 to improve compatibility when remoting computers running
+older versions of PowerShell.
 
 ```yaml
 Type: Version
@@ -210,7 +195,10 @@ Accept wildcard characters: True
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -46,12 +46,12 @@ Get-FormatData
 
 ### Example 2: Get formatting data by type name
 
+This example gets the formatting data items whose names begin with
+`System.Management.Automation.Cmd`.
+
 ```powershell
 Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
 ```
-
-This command gets the formatting data items whose names begin with
-`System.Management.Automation.Cmd*`.
 
 ### Example 3: Examine a formatting data object
 
@@ -129,9 +129,10 @@ Get-Content c:\test\bits.format.ps1xml
 The first four commands use the `Get-FormatData`, `Import-Module`, and `Compare-Object` cmdlets to
 identify the format type that the **BitsTransfer** module adds to the session.
 
-The fifth command uses the `Get-FormatData` cmdlet to get the format type that the BitsTransfer
-module adds. It uses a pipeline operator (|) to send the format type object to the `Export-FormatData`
-cmdlet, which converts it back to XML and saves it in the specified format.ps1xml file.
+The fifth command uses the `Get-FormatData` cmdlet to get the format type that the **BitsTransfer**
+module adds. It uses a pipeline operator (`|`) to send the format type object to the
+`Export-FormatData` cmdlet, which converts it back to XML and saves it in the specified
+`format.ps1xml` file.
 
 The final command shows an excerpt of the `format.ps1xml` file content.
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 01/27/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-formatdata?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-FormatData
@@ -21,20 +21,24 @@ Get-FormatData [[-TypeName] <String[]>] [-PowerShellVersion <Version>] [<CommonP
 
 ## DESCRIPTION
 
-The **Get-FormatData** cmdlet gets the formatting data in the current session.
+The `Get-FormatData` cmdlet gets the formatting data in the current session.
 
-The formatting data in the session includes formatting data from Format.ps1xml formatting files, such as those in the $pshome directory, formatting data for modules that you import into the session, and formatting data for commands that you import into your session by using the Import-PSSession cmdlet.
+The formatting data in the session includes formatting data from `Format.ps1xml` formatting files,
+such as those in the `$PSHOME` directory, formatting data for modules that you import into the
+session, and formatting data for commands that you import into your session by using the
+`Import-PSSession` cmdlet.
 
-You can use this cmdlet to examine the formatting data.
-Then, you can use the Export-FormatData cmdlet to serialize the objects, convert them to XML, and save them in Format.ps1xml files.
+You can use this cmdlet to examine the formatting data. Then, you can use the `Export-FormatData`
+cmdlet to serialize the objects, convert them to XML, and save them in `Format.ps1xml` files.
 
-For more information about formatting files in PowerShell, see about_Format.ps1xml.
+For more information about formatting files in PowerShell, see
+[about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
 
 ## EXAMPLES
 
 ### Example 1: Get all formatting data
 
-This command gets all the formatting data in the session.
+This example gets all the formatting data in the session.
 
 ```powershell
 Get-FormatData
@@ -46,9 +50,12 @@ Get-FormatData
 Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
 ```
 
-This command gets the formatting data items whose names begin with System.Management.Automation.Cmd*.
+This command gets the formatting data items whose names begin with
+`System.Management.Automation.Cmd*`.
 
 ### Example 3: Examine a formatting data object
+
+This example shows how to get a formatting data object and examine its properties.
 
 ```powershell
 $F = Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
@@ -66,7 +73,9 @@ $F.FormatViewDefinition[0].control
 ```
 
 ```Output
-Headers          : {System.Management.Automation.TableControlColumnHeader, System.Management.Automation.TableControlColumnHeader, System.Management.Automation.TableControlColumnHeader,
+Headers          : {System.Management.Automation.TableControlColumnHeader,
+                   System.Management.Automation.TableControlColumnHeader,
+                   System.Management.Automation.TableControlColumnHeader,
                    System.Management.Automation.TableControlColumnHeader}
 Rows             : {System.Management.Automation.TableControlRow}
 AutoSize         : False
@@ -88,9 +97,10 @@ Version     Undefined    10
 Source      Undefined     0
 ```
 
-This example shows how to get a formatting data object and examine its properties.
-
 ### Example 4: Get formatting data and export it
+
+This example shows how to use `Get-FormatData` and `Export-FormatData` to export the formatting
+data that is added by a module.
 
 ```powershell
 $A = Get-FormatData
@@ -116,67 +126,42 @@ Get-Content c:\test\bits.format.ps1xml
 ...
 ```
 
-This example shows how to use **Get-FormatData** and **Export-FormatData** to export the formatting
-data that is added by a module.
+The first four commands use the `Get-FormatData`, `Import-Module`, and `Compare-Object` cmdlets to
+identify the format type that the **BitsTransfer** module adds to the session.
 
-The first four commands use the **Get-FormatData**, Import-Module, and Compare-Object cmdlets to
-identify the format type that the BitsTransfer module adds to the session.
-
-The fifth command uses the **Get-FormatData** cmdlet to get the format type that the BitsTransfer
-module adds. It uses a pipeline operator (|) to send the format type object to the Export-FormatData
+The fifth command uses the `Get-FormatData` cmdlet to get the format type that the BitsTransfer
+module adds. It uses a pipeline operator (|) to send the format type object to the `Export-FormatData`
 cmdlet, which converts it back to XML and saves it in the specified format.ps1xml file.
 
-The final command shows an excerpt of the format.ps1xml file content.
+The final command shows an excerpt of the `format.ps1xml` file content.
 
 ### Example 5: Get formatting data based on the specified version of PowerShell
 
+This example shows how to use `Get-FormatData` to get format data for a specified **TypeName** and
+PowerShell version.
+
 ```powershell
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 1.0
+Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion $PSVersionTable.PSVersion
 
 TypeNames                               FormatViewDefinition
 ---------                               --------------------
 {Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 2.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 3.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 4.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 5.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 5.1
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-This example shows how to use **Get-FormatData** to get format data for a specified TypeName and a
-specified PowerShell version.
 ```
+
+> [!IMPORTANT]
+> To ensure that the complete type formatting information is returned, you should always include the
+> **PowerShellVersion** parameter with the appropriate version. If the parameter and value are
+> omitted, you may not get all the correct type information.
 
 ## PARAMETERS
 
 ### -PowerShellVersion
 
-Specify the version of PowerShell this cmdlet gets for the formatting data.
-Enter a two digit number separated by a period.
+Specify the version of PowerShell this cmdlet gets for the formatting data. Enter a two digit number
+separated by a period.
+
+This parameter was added in PowerShell 5.1 to improve compatibility when remoting computers running
+older versions of PowerShell.
 
 ```yaml
 Type: Version
@@ -210,7 +195,10 @@ Accept wildcard characters: True
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -229,4 +217,3 @@ You cannot pipe input to this cmdlet.
 [Export-FormatData](Export-FormatData.md)
 
 [Update-FormatData](Update-FormatData.md)
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -46,12 +46,12 @@ Get-FormatData
 
 ### Example 2: Get formatting data by type name
 
+This example gets the formatting data items whose names begin with
+`System.Management.Automation.Cmd`.
+
 ```powershell
 Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
 ```
-
-This command gets the formatting data items whose names begin with
-`System.Management.Automation.Cmd*`.
 
 ### Example 3: Examine a formatting data object
 
@@ -129,9 +129,10 @@ Get-Content c:\test\bits.format.ps1xml
 The first four commands use the `Get-FormatData`, `Import-Module`, and `Compare-Object` cmdlets to
 identify the format type that the **BitsTransfer** module adds to the session.
 
-The fifth command uses the `Get-FormatData` cmdlet to get the format type that the BitsTransfer
-module adds. It uses a pipeline operator (|) to send the format type object to the `Export-FormatData`
-cmdlet, which converts it back to XML and saves it in the specified format.ps1xml file.
+The fifth command uses the `Get-FormatData` cmdlet to get the format type that the **BitsTransfer**
+module adds. It uses a pipeline operator (`|`) to send the format type object to the
+`Export-FormatData` cmdlet, which converts it back to XML and saves it in the specified
+`format.ps1xml` file.
 
 The final command shows an excerpt of the `format.ps1xml` file content.
 

--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 01/27/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-formatdata?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-FormatData
@@ -21,20 +21,24 @@ Get-FormatData [[-TypeName] <String[]>] [-PowerShellVersion <Version>] [<CommonP
 
 ## DESCRIPTION
 
-The **Get-FormatData** cmdlet gets the formatting data in the current session.
+The `Get-FormatData` cmdlet gets the formatting data in the current session.
 
-The formatting data in the session includes formatting data from Format.ps1xml formatting files, such as those in the $pshome directory, formatting data for modules that you import into the session, and formatting data for commands that you import into your session by using the Import-PSSession cmdlet.
+The formatting data in the session includes formatting data from `Format.ps1xml` formatting files,
+such as those in the `$PSHOME` directory, formatting data for modules that you import into the
+session, and formatting data for commands that you import into your session by using the
+`Import-PSSession` cmdlet.
 
-You can use this cmdlet to examine the formatting data.
-Then, you can use the Export-FormatData cmdlet to serialize the objects, convert them to XML, and save them in Format.ps1xml files.
+You can use this cmdlet to examine the formatting data. Then, you can use the `Export-FormatData`
+cmdlet to serialize the objects, convert them to XML, and save them in `Format.ps1xml` files.
 
-For more information about formatting files in PowerShell, see about_Format.ps1xml.
+For more information about formatting files in PowerShell, see
+[about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
 
 ## EXAMPLES
 
 ### Example 1: Get all formatting data
 
-This command gets all the formatting data in the session.
+This example gets all the formatting data in the session.
 
 ```powershell
 Get-FormatData
@@ -46,9 +50,12 @@ Get-FormatData
 Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
 ```
 
-This command gets the formatting data items whose names begin with System.Management.Automation.Cmd*.
+This command gets the formatting data items whose names begin with
+`System.Management.Automation.Cmd*`.
 
 ### Example 3: Examine a formatting data object
+
+This example shows how to get a formatting data object and examine its properties.
 
 ```powershell
 $F = Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
@@ -66,7 +73,9 @@ $F.FormatViewDefinition[0].control
 ```
 
 ```Output
-Headers          : {System.Management.Automation.TableControlColumnHeader, System.Management.Automation.TableControlColumnHeader, System.Management.Automation.TableControlColumnHeader,
+Headers          : {System.Management.Automation.TableControlColumnHeader,
+                   System.Management.Automation.TableControlColumnHeader,
+                   System.Management.Automation.TableControlColumnHeader,
                    System.Management.Automation.TableControlColumnHeader}
 Rows             : {System.Management.Automation.TableControlRow}
 AutoSize         : False
@@ -88,9 +97,10 @@ Version     Undefined    10
 Source      Undefined     0
 ```
 
-This example shows how to get a formatting data object and examine its properties.
-
 ### Example 4: Get formatting data and export it
+
+This example shows how to use `Get-FormatData` and `Export-FormatData` to export the formatting
+data that is added by a module.
 
 ```powershell
 $A = Get-FormatData
@@ -116,67 +126,42 @@ Get-Content c:\test\bits.format.ps1xml
 ...
 ```
 
-This example shows how to use **Get-FormatData** and **Export-FormatData** to export the formatting
-data that is added by a module.
+The first four commands use the `Get-FormatData`, `Import-Module`, and `Compare-Object` cmdlets to
+identify the format type that the **BitsTransfer** module adds to the session.
 
-The first four commands use the **Get-FormatData**, Import-Module, and Compare-Object cmdlets to
-identify the format type that the BitsTransfer module adds to the session.
-
-The fifth command uses the **Get-FormatData** cmdlet to get the format type that the BitsTransfer
-module adds. It uses a pipeline operator (|) to send the format type object to the Export-FormatData
+The fifth command uses the `Get-FormatData` cmdlet to get the format type that the BitsTransfer
+module adds. It uses a pipeline operator (|) to send the format type object to the `Export-FormatData`
 cmdlet, which converts it back to XML and saves it in the specified format.ps1xml file.
 
-The final command shows an excerpt of the format.ps1xml file content.
+The final command shows an excerpt of the `format.ps1xml` file content.
 
 ### Example 5: Get formatting data based on the specified version of PowerShell
 
+This example shows how to use `Get-FormatData` to get format data for a specified **TypeName** and
+PowerShell version.
+
 ```powershell
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 1.0
+Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion $PSVersionTable.PSVersion
 
 TypeNames                               FormatViewDefinition
 ---------                               --------------------
 {Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 2.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 3.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 4.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 5.0
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-Get-FormatData -TypeName 'Microsoft.Powershell.Utility.FileHash' -PowerShellVersion 5.1
-
-TypeNames                               FormatViewDefinition
----------                               --------------------
-{Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
-
-This example shows how to use **Get-FormatData** to get format data for a specified TypeName and a
-specified PowerShell version.
 ```
+
+> [!IMPORTANT]
+> To ensure that the complete type formatting information is returned, you should always include the
+> **PowerShellVersion** parameter with the appropriate version. If the parameter and value are
+> omitted, you may not get all the correct type information.
 
 ## PARAMETERS
 
 ### -PowerShellVersion
 
-Specify the version of PowerShell this cmdlet gets for the formatting data.
-Enter a two digit number separated by a period.
+Specify the version of PowerShell this cmdlet gets for the formatting data. Enter a two digit number
+separated by a period.
+
+This parameter was added in PowerShell 5.1 to improve compatibility when remoting computers running
+older versions of PowerShell.
 
 ```yaml
 Type: Version
@@ -210,7 +195,10 @@ Accept wildcard characters: True
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -229,4 +217,3 @@ You cannot pipe input to this cmdlet.
 [Export-FormatData](Export-FormatData.md)
 
 [Update-FormatData](Update-FormatData.md)
-


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #5076 - doc version behavior
Fixes [AB#1669589](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1669589)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
