### PR TITLE
Fix relative link from Get-Error to about_Try_Catch_Finally

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Utility/Get-Error.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Get-Error.md
@@ -161,4 +161,4 @@ Output in a **PSExtendedError** object.
 
 ## RELATED LINKS
 
-[about_Try_Catch_Finally](about_Try_Catch_Finally.md)
+[about_Try_Catch_Finally](../microsoft.powershell.Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md)

--- a/reference/7.0/Microsoft.PowerShell.Utility/Get-Error.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Get-Error.md
@@ -161,4 +161,4 @@ Output in a **PSExtendedError** object.
 
 ## RELATED LINKS
 
-[about_Try_Catch_Finally](../microsoft.powershell.Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md)
+[about_Try_Catch_Finally](../Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md)

--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-Error.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-Error.md
@@ -161,4 +161,4 @@ Output in a **PSExtendedError** object.
 
 ## RELATED LINKS
 
-[about_Try_Catch_Finally](about_Try_Catch_Finally.md)
+[about_Try_Catch_Finally](../microsoft.powershell.Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md)

--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-Error.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-Error.md
@@ -161,4 +161,4 @@ Output in a **PSExtendedError** object.
 
 ## RELATED LINKS
 
-[about_Try_Catch_Finally](../microsoft.powershell.Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md)
+[about_Try_Catch_Finally](../Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md)


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fix relative link from Get-Error to about_Try_Catch_Finally (link assumed target is in same module folder as Microsoft.PowerShell.Utility/Get-Error, but it's in Microsoft.PowerShell.Core/About/

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [X] Version 7.x preview content
- [X] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [X] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
