### PR TITLE
Swap references to Get-WmiObject to CIM cmdlets

### DIFF
--- a/reference/docs-conceptual/samples/Getting-WMI-Objects--Get-CimInstance-.md
+++ b/reference/docs-conceptual/samples/Getting-WMI-Objects--Get-CimInstance-.md
@@ -1,11 +1,11 @@
 ---
 ms.date:  12/23/2019
 keywords:  powershell,cmdlet
-title:  Getting WMI Objects Get WmiObject
+title:  Getting WMI Objects Get CimInstance
 ---
-# Getting WMI Objects (Get-WmiObject)
+# Getting WMI Objects (Get-CimInstance)
 
-## Getting WMI Objects (Get-WmiObject)
+## Getting WMI Objects (Get-CimInstance)
 
 Windows Management Instrumentation (WMI) is a core technology for Windows system administration
 because it exposes a wide range of information in a uniform manner. Because of how much WMI makes
@@ -84,7 +84,7 @@ parameters. With `Get-CimInstance`, if no name is specified for the first parame
 treats it as the **Class** parameter. This means the last command could have been issued by typing:
 
 ```powershell
-Get-WmiObject Win32_OperatingSystem
+Get-CimInstance Win32_OperatingSystem
 ```
 
 The **Win32_OperatingSystem** class has many more properties than those displayed here. You can use


### PR DESCRIPTION
# PR Summary
`Get-WmiObject` isn't in PS7, so doesn't belong in the docs. Most references had already been changed to use cim cmdlets, but a couple had been missed, notably the title.

There have been a couple of related issues for this, but there don't appear to be any open or referencing this page, so none to link.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.x preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [x] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
