### PR TITLE
Update TOC to point to renamed WMI/CIM file

### DIFF
--- a/reference/docs-conceptual/samples/Sample-Scripts-for-Administration.yml
+++ b/reference/docs-conceptual/samples/Sample-Scripts-for-Administration.yml
@@ -35,8 +35,8 @@ landingContent:
             url: ./creating-.net-and-com-objects--new-object-.md
           - text: Using static classes and methods
             url: ./using-static-classes-and-methods.md
-          - text: Getting WMI objects - Get-WmiObject
-            url: ./getting-wmi-objects--get-wmiobject-.md
+          - text: Getting WMI objects - Get-CimInstance
+            url: ./getting-wmi-objects--get-ciminstance-.md
   - title: Managing computers
     linkLists:
       - linkListType: how-to-guide

--- a/reference/docs-conceptual/toc.yml
+++ b/reference/docs-conceptual/toc.yml
@@ -654,8 +654,8 @@
           href: samples/creating-.net-and-com-objects--new-object-.md
         - name: Using static classes and methods
           href: samples/using-static-classes-and-methods.md
-        - name: Getting WMI objects - Get-WmiObject
-          href: samples/getting-wmi-objects--get-wmiobject-.md
+        - name: Getting WMI objects - Get-CimInstance
+          href: samples/getting-wmi-objects--get-ciminstance-.md
     - name: Managing computers
       items:
         - name: Changing computer state


### PR DESCRIPTION
# PR Summary
Sorry, realised I missed these off the previous PR - update two references pointing to the now-renamed file.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.x preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [x] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
