### PR TITLE
docs: Fix syntax under Authentication

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -246,9 +246,9 @@ Available Authentication Options:
   authentication will be used.
 - **Basic**: Requires **Credential**. The credentials will be used to send an RFC 7617 Basic
   Authentication `Authorization: Basic` header in the format of `base64(user:password)`.
-- **Bearer**: Requires **Token**. Will send and RFC 6750 `Authorization: Bearer` header with the
+- **Bearer**: Requires **Token**. Will send an RFC 6750 `Authorization: Bearer` header with the
   supplied token. This is an alias for **OAuth**
-- **OAuth**: Requires **Token**. Will send and RFC 6750 `Authorization: Bearer` header with the
+- **OAuth**: Requires **Token**. Will send an RFC 6750 `Authorization: Bearer` header with the
   supplied token. This is an alias for **Bearer**
 
 Supplying **Authentication** will override any `Authorization` headers supplied to **Headers** or


### PR DESCRIPTION
Under Available Authentication Options, Bearer and OAuth both stated 'Will send and RFC 6750'.
This has been updated to read as: 'Will send an RFC 6750'

# PR Summary
docs: Fix syntax under **Authentication**

Under Available Authentication Options, **Bearer** and **OAuth** both stated 'Will send and RFC 6750'.

This has been updated to read as: 'Will send an RFC 6750'

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.x preview content
- [ ] Version 7.0 content
- [X] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [X] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [X] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
