### PR TITLE
Fixes #5406 - add about_parameter_sets

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 05/20/2019
+ms.date: 02/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_Advanced_Parameters
@@ -227,7 +227,7 @@ Param(
 )
 ```
 
-For more information about parameter sets, see [Cmdlet Parameter Sets](/powershell/scripting/developer/cmdlet/cmdlet-parameter-sets).
+For more information about parameter sets, see [About Parameter Sets](about_parameter_sets.md).
 
 ### ValueFromPipeline argument
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -1,0 +1,198 @@
+---
+title: about_Parameter_Sets
+ms.date: 02/11/2020
+---
+# About parameter sets
+
+## SHORT DESCRIPTION
+Describes how to define and use parameter sets in advanced functions.
+
+## LONG DESCRIPTION
+
+PowerShell uses parameter sets to enable you to write a single function that
+can do different actions for different scenarios. Parameter sets enable you to
+expose different parameters to the user. And, to return different information
+based on the parameters specified by the user.
+
+## Parameter set requirements
+
+The following requirements apply to all parameter sets.
+
+- Each parameter set must have at least one unique parameter. If possible, make
+  this parameter a mandatory parameter.
+
+- A parameter set that contains multiple positional parameters must define
+  unique positions for each parameter. No two positional parameters can specify
+  the same position.
+
+- Only one parameter in a set can declare the `ValueFromPipeline` keyword with
+  a value of `true`. Multiple parameters can define the
+  `ValueFromPipelineByPropertyName` keyword with a value of `true`.
+
+- If no parameter set is specified for a parameter, the parameter belongs to
+  all parameter sets.
+
+> [!NOTE]
+> There is a limit of 32 parameter sets.
+
+## Default parameter sets
+
+When multiple parameter sets are defined, the `DefaultParameterSetName` keyword
+of the **CmdletBinding** attribute specifies the default parameter set.
+PowerShell uses the default parameter set when it can't determine the parameter
+set to use based on the information provided to the command. For more
+information about the **CmdletBinding** attribute, see
+[about_functions_cmdletbindingattribute](about_functions_cmdletbindingattribute.md).
+
+## Declaring parameter sets
+
+To create a parameter set, you must specify the `ParameterSetName` keyword of
+the **Parameter** attribute for every parameter in the parameter set. For
+parameters that belong to multiple parameter sets, add a **Parameter**
+attribute for each parameter set.
+
+The **Parameter** attribute enables you to define the parameter differently for
+each parameter set. For example, you can define a parameter as mandatory in one
+set and optional in another. However, each parameter set must contain at least
+one unique parameter.
+
+Parameters that don't have an assigned parameter set name belong to all
+parameter sets.
+
+### Example
+
+The following example function counts the number lines, characters, and words
+in a text file. Using parameters, you can specify which values you want
+returned and which files you want to measure. There are four parameter sets
+defined:
+
+- Path
+- PathAll
+- LiteralPath
+- LiteralPathAll
+
+```powershell
+function Measure-Lines {
+    [CmdletBinding(DefaultParameterSetName = 'Path')]
+    param (
+        [Parameter(Mandatory = $true,
+            ParameterSetName = 'Path',
+            HelpMessage = 'Enter one or more filenames',
+            Position = 0)]
+        [Parameter(Mandatory = $true,
+            ParameterSetName = 'PathAll',
+            Position = 0)]
+        [string[]]$Path,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'LiteralPathAll')]
+        [Parameter(Mandatory = $true,
+            ParameterSetName = 'LiteralPath',
+            HelpMessage = 'Enter a single filename',
+            ValueFromPipeline = $true)]
+        [string]$LiteralPath,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'LiteralPath')]
+        [switch]$Lines,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'LiteralPath')]
+        [switch]$Words,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'LiteralPath')]
+        [switch]$Characters,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'PathAll')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'LiteralPathAll')]
+        [switch]$All,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'PathAll')]
+        [switch]$Recurse
+    )
+
+    begin {
+        if ($All) {
+            $Lines = $Words = $Characters = $true
+        }
+        elseif (($Words -eq $false) -and ($Characters -eq $false)) {
+            $Lines = $true
+        }
+
+        if ($Path) {
+            $Files = Get-ChildItem -Path $Path -Recurse:$Recurse
+        }
+        else {
+            $Files = Get-ChildItem -LiteralPath $LiteralPath
+        }
+    }
+    process {
+        foreach ($file in $Files) {
+            $result = [ordered]@{ }
+            $result.Add('File', $file.fullname)
+
+            $content = Get-Content -LiteralPath $file.fullname
+
+            if ($Lines) { $result.Add('Lines', $content.Length) }
+
+            if ($Words) {
+                $wc = 0
+                foreach ($line in $content) { $wc += $line.split(' ').Length }
+                $result.Add('Words', $wc)
+            }
+
+            if ($Characters) {
+                $cc = 0
+                foreach ($line in $content) { $cc += $line.Length }
+                $result.Add('Characters', $cc)
+            }
+
+            New-Object -TypeName psobject -Property $result
+        }
+    }
+}
+```
+
+Each parameter set must have a unique parameter or a unique combination of
+parameters. The `Path` and `PathAll` parameter sets are very similar but the
+**All** parameter is unique to the `PathAll` parameter set. The same is true
+with the `LiteralPath` and `LiteralPathAll` parameter sets. Even though the
+`PathAll` and `LiteralPathAll` parameter sets both have the **All** parameter,
+the **Path** and **LiteralPath** parameters differentiate them.
+
+Use `Get-Command -Syntax` shows you the syntax of each parameter set. However
+it does not show the name of the parameter set. The following example shows
+which parameters can be used in each parameter set.
+
+```powershell
+(Get-Command Measure-Lines).ParameterSets |
+  Select-Object -Property @{n='ParameterSetName';e={$_.name}},
+    @{n='Parameters';e={$_.ToString()}}
+```
+
+```Output
+ParameterSetName Parameters
+---------------- ----------
+Path             [-Path] <string[]> [-Lines] [-Words] [-Characters] [-Recurse] [<CommonParameters>]
+PathAll          [-Path] <string[]> -All [-Recurse] [<CommonParameters>]
+LiteralPath      -LiteralPath <string> [-Lines] [-Words] [-Characters] [<CommonParameters>]
+LiteralPathAll   -LiteralPath <string> -All [<CommonParameters>]
+```
+
+### Parameter sets in action
+
+In this example, we are using the `PathAll` parameter set.
+
+```powershell
+Measure-Lines test* -All
+```
+
+```Output
+File                       Lines Words Characters
+----                       ----- ----- ----------
+C:\temp\test\test.help.txt    31   562       2059
+C:\temp\test\test.md          30  1527       3224
+C:\temp\test\test.ps1          3     3         79
+C:\temp\test\test[1].txt      31   562       2059
+```

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 11/21/2019
+ms.date: 02/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_Advanced_Parameters
@@ -227,7 +227,7 @@ Param(
 )
 ```
 
-For more information about parameter sets, see [Cmdlet Parameter Sets](/powershell/scripting/developer/cmdlet/cmdlet-parameter-sets).
+For more information about parameter sets, see [About Parameter Sets](about_parameter_sets.md).
 
 ### ValueFromPipeline argument
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -1,0 +1,198 @@
+---
+title: about_Parameter_Sets
+ms.date: 02/11/2020
+---
+# About parameter sets
+
+## SHORT DESCRIPTION
+Describes how to define and use parameter sets in advanced functions.
+
+## LONG DESCRIPTION
+
+PowerShell uses parameter sets to enable you to write a single function that
+can do different actions for different scenarios. Parameter sets enable you to
+expose different parameters to the user. And, to return different information
+based on the parameters specified by the user.
+
+## Parameter set requirements
+
+The following requirements apply to all parameter sets.
+
+- Each parameter set must have at least one unique parameter. If possible, make
+  this parameter a mandatory parameter.
+
+- A parameter set that contains multiple positional parameters must define
+  unique positions for each parameter. No two positional parameters can specify
+  the same position.
+
+- Only one parameter in a set can declare the `ValueFromPipeline` keyword with
+  a value of `true`. Multiple parameters can define the
+  `ValueFromPipelineByPropertyName` keyword with a value of `true`.
+
+- If no parameter set is specified for a parameter, the parameter belongs to
+  all parameter sets.
+
+> [!NOTE]
+> There is a limit of 32 parameter sets.
+
+## Default parameter sets
+
+When multiple parameter sets are defined, the `DefaultParameterSetName` keyword
+of the **CmdletBinding** attribute specifies the default parameter set.
+PowerShell uses the default parameter set when it can't determine the parameter
+set to use based on the information provided to the command. For more
+information about the **CmdletBinding** attribute, see
+[about_functions_cmdletbindingattribute](about_functions_cmdletbindingattribute.md).
+
+## Declaring parameter sets
+
+To create a parameter set, you must specify the `ParameterSetName` keyword of
+the **Parameter** attribute for every parameter in the parameter set. For
+parameters that belong to multiple parameter sets, add a **Parameter**
+attribute for each parameter set.
+
+The **Parameter** attribute enables you to define the parameter differently for
+each parameter set. For example, you can define a parameter as mandatory in one
+set and optional in another. However, each parameter set must contain at least
+one unique parameter.
+
+Parameters that don't have an assigned parameter set name belong to all
+parameter sets.
+
+### Example
+
+The following example function counts the number lines, characters, and words
+in a text file. Using parameters, you can specify which values you want
+returned and which files you want to measure. There are four parameter sets
+defined:
+
+- Path
+- PathAll
+- LiteralPath
+- LiteralPathAll
+
+```powershell
+function Measure-Lines {
+    [CmdletBinding(DefaultParameterSetName = 'Path')]
+    param (
+        [Parameter(Mandatory = $true,
+            ParameterSetName = 'Path',
+            HelpMessage = 'Enter one or more filenames',
+            Position = 0)]
+        [Parameter(Mandatory = $true,
+            ParameterSetName = 'PathAll',
+            Position = 0)]
+        [string[]]$Path,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'LiteralPathAll')]
+        [Parameter(Mandatory = $true,
+            ParameterSetName = 'LiteralPath',
+            HelpMessage = 'Enter a single filename',
+            ValueFromPipeline = $true)]
+        [string]$LiteralPath,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'LiteralPath')]
+        [switch]$Lines,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'LiteralPath')]
+        [switch]$Words,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'LiteralPath')]
+        [switch]$Characters,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'PathAll')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'LiteralPathAll')]
+        [switch]$All,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'PathAll')]
+        [switch]$Recurse
+    )
+
+    begin {
+        if ($All) {
+            $Lines = $Words = $Characters = $true
+        }
+        elseif (($Words -eq $false) -and ($Characters -eq $false)) {
+            $Lines = $true
+        }
+
+        if ($Path) {
+            $Files = Get-ChildItem -Path $Path -Recurse:$Recurse
+        }
+        else {
+            $Files = Get-ChildItem -LiteralPath $LiteralPath
+        }
+    }
+    process {
+        foreach ($file in $Files) {
+            $result = [ordered]@{ }
+            $result.Add('File', $file.fullname)
+
+            $content = Get-Content -LiteralPath $file.fullname
+
+            if ($Lines) { $result.Add('Lines', $content.Length) }
+
+            if ($Words) {
+                $wc = 0
+                foreach ($line in $content) { $wc += $line.split(' ').Length }
+                $result.Add('Words', $wc)
+            }
+
+            if ($Characters) {
+                $cc = 0
+                foreach ($line in $content) { $cc += $line.Length }
+                $result.Add('Characters', $cc)
+            }
+
+            New-Object -TypeName psobject -Property $result
+        }
+    }
+}
+```
+
+Each parameter set must have a unique parameter or a unique combination of
+parameters. The `Path` and `PathAll` parameter sets are very similar but the
+**All** parameter is unique to the `PathAll` parameter set. The same is true
+with the `LiteralPath` and `LiteralPathAll` parameter sets. Even though the
+`PathAll` and `LiteralPathAll` parameter sets both have the **All** parameter,
+the **Path** and **LiteralPath** parameters differentiate them.
+
+Use `Get-Command -Syntax` shows you the syntax of each parameter set. However
+it does not show the name of the parameter set. The following example shows
+which parameters can be used in each parameter set.
+
+```powershell
+(Get-Command Measure-Lines).ParameterSets |
+  Select-Object -Property @{n='ParameterSetName';e={$_.name}},
+    @{n='Parameters';e={$_.ToString()}}
+```
+
+```Output
+ParameterSetName Parameters
+---------------- ----------
+Path             [-Path] <string[]> [-Lines] [-Words] [-Characters] [-Recurse] [<CommonParameters>]
+PathAll          [-Path] <string[]> -All [-Recurse] [<CommonParameters>]
+LiteralPath      -LiteralPath <string> [-Lines] [-Words] [-Characters] [<CommonParameters>]
+LiteralPathAll   -LiteralPath <string> -All [<CommonParameters>]
+```
+
+### Parameter sets in action
+
+In this example, we are using the `PathAll` parameter set.
+
+```powershell
+Measure-Lines test* -All
+```
+
+```Output
+File                       Lines Words Characters
+----                       ----- ----- ----------
+C:\temp\test\test.help.txt    31   562       2059
+C:\temp\test\test.md          30  1527       3224
+C:\temp\test\test.ps1          3     3         79
+C:\temp\test\test[1].txt      31   562       2059
+```

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 11/21/2019
+ms.date: 02/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_Advanced_Parameters
@@ -227,7 +227,7 @@ Param(
 )
 ```
 
-For more information about parameter sets, see [Cmdlet Parameter Sets](/powershell/scripting/developer/cmdlet/cmdlet-parameter-sets).
+For more information about parameter sets, see [About Parameter Sets](about_parameter_sets.md).
 
 ### ValueFromPipeline argument
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -1,0 +1,198 @@
+---
+title: about_Parameter_Sets
+ms.date: 02/11/2020
+---
+# About parameter sets
+
+## SHORT DESCRIPTION
+Describes how to define and use parameter sets in advanced functions.
+
+## LONG DESCRIPTION
+
+PowerShell uses parameter sets to enable you to write a single function that
+can do different actions for different scenarios. Parameter sets enable you to
+expose different parameters to the user. And, to return different information
+based on the parameters specified by the user.
+
+## Parameter set requirements
+
+The following requirements apply to all parameter sets.
+
+- Each parameter set must have at least one unique parameter. If possible, make
+  this parameter a mandatory parameter.
+
+- A parameter set that contains multiple positional parameters must define
+  unique positions for each parameter. No two positional parameters can specify
+  the same position.
+
+- Only one parameter in a set can declare the `ValueFromPipeline` keyword with
+  a value of `true`. Multiple parameters can define the
+  `ValueFromPipelineByPropertyName` keyword with a value of `true`.
+
+- If no parameter set is specified for a parameter, the parameter belongs to
+  all parameter sets.
+
+> [!NOTE]
+> There is a limit of 32 parameter sets.
+
+## Default parameter sets
+
+When multiple parameter sets are defined, the `DefaultParameterSetName` keyword
+of the **CmdletBinding** attribute specifies the default parameter set.
+PowerShell uses the default parameter set when it can't determine the parameter
+set to use based on the information provided to the command. For more
+information about the **CmdletBinding** attribute, see
+[about_functions_cmdletbindingattribute](about_functions_cmdletbindingattribute.md).
+
+## Declaring parameter sets
+
+To create a parameter set, you must specify the `ParameterSetName` keyword of
+the **Parameter** attribute for every parameter in the parameter set. For
+parameters that belong to multiple parameter sets, add a **Parameter**
+attribute for each parameter set.
+
+The **Parameter** attribute enables you to define the parameter differently for
+each parameter set. For example, you can define a parameter as mandatory in one
+set and optional in another. However, each parameter set must contain at least
+one unique parameter.
+
+Parameters that don't have an assigned parameter set name belong to all
+parameter sets.
+
+### Example
+
+The following example function counts the number lines, characters, and words
+in a text file. Using parameters, you can specify which values you want
+returned and which files you want to measure. There are four parameter sets
+defined:
+
+- Path
+- PathAll
+- LiteralPath
+- LiteralPathAll
+
+```powershell
+function Measure-Lines {
+    [CmdletBinding(DefaultParameterSetName = 'Path')]
+    param (
+        [Parameter(Mandatory = $true,
+            ParameterSetName = 'Path',
+            HelpMessage = 'Enter one or more filenames',
+            Position = 0)]
+        [Parameter(Mandatory = $true,
+            ParameterSetName = 'PathAll',
+            Position = 0)]
+        [string[]]$Path,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'LiteralPathAll')]
+        [Parameter(Mandatory = $true,
+            ParameterSetName = 'LiteralPath',
+            HelpMessage = 'Enter a single filename',
+            ValueFromPipeline = $true)]
+        [string]$LiteralPath,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'LiteralPath')]
+        [switch]$Lines,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'LiteralPath')]
+        [switch]$Words,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'LiteralPath')]
+        [switch]$Characters,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'PathAll')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'LiteralPathAll')]
+        [switch]$All,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'PathAll')]
+        [switch]$Recurse
+    )
+
+    begin {
+        if ($All) {
+            $Lines = $Words = $Characters = $true
+        }
+        elseif (($Words -eq $false) -and ($Characters -eq $false)) {
+            $Lines = $true
+        }
+
+        if ($Path) {
+            $Files = Get-ChildItem -Path $Path -Recurse:$Recurse
+        }
+        else {
+            $Files = Get-ChildItem -LiteralPath $LiteralPath
+        }
+    }
+    process {
+        foreach ($file in $Files) {
+            $result = [ordered]@{ }
+            $result.Add('File', $file.fullname)
+
+            $content = Get-Content -LiteralPath $file.fullname
+
+            if ($Lines) { $result.Add('Lines', $content.Length) }
+
+            if ($Words) {
+                $wc = 0
+                foreach ($line in $content) { $wc += $line.split(' ').Length }
+                $result.Add('Words', $wc)
+            }
+
+            if ($Characters) {
+                $cc = 0
+                foreach ($line in $content) { $cc += $line.Length }
+                $result.Add('Characters', $cc)
+            }
+
+            New-Object -TypeName psobject -Property $result
+        }
+    }
+}
+```
+
+Each parameter set must have a unique parameter or a unique combination of
+parameters. The `Path` and `PathAll` parameter sets are very similar but the
+**All** parameter is unique to the `PathAll` parameter set. The same is true
+with the `LiteralPath` and `LiteralPathAll` parameter sets. Even though the
+`PathAll` and `LiteralPathAll` parameter sets both have the **All** parameter,
+the **Path** and **LiteralPath** parameters differentiate them.
+
+Use `Get-Command -Syntax` shows you the syntax of each parameter set. However
+it does not show the name of the parameter set. The following example shows
+which parameters can be used in each parameter set.
+
+```powershell
+(Get-Command Measure-Lines).ParameterSets |
+  Select-Object -Property @{n='ParameterSetName';e={$_.name}},
+    @{n='Parameters';e={$_.ToString()}}
+```
+
+```Output
+ParameterSetName Parameters
+---------------- ----------
+Path             [-Path] <string[]> [-Lines] [-Words] [-Characters] [-Recurse] [<CommonParameters>]
+PathAll          [-Path] <string[]> -All [-Recurse] [<CommonParameters>]
+LiteralPath      -LiteralPath <string> [-Lines] [-Words] [-Characters] [<CommonParameters>]
+LiteralPathAll   -LiteralPath <string> -All [<CommonParameters>]
+```
+
+### Parameter sets in action
+
+In this example, we are using the `PathAll` parameter set.
+
+```powershell
+Measure-Lines test* -All
+```
+
+```Output
+File                       Lines Words Characters
+----                       ----- ----- ----------
+C:\temp\test\test.help.txt    31   562       2059
+C:\temp\test\test.md          30  1527       3224
+C:\temp\test\test.ps1          3     3         79
+C:\temp\test\test[1].txt      31   562       2059
+```

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 11/21/2019
+ms.date: 02/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_Advanced_Parameters
@@ -227,7 +227,7 @@ Param(
 )
 ```
 
-For more information about parameter sets, see [Cmdlet Parameter Sets](/powershell/scripting/developer/cmdlet/cmdlet-parameter-sets).
+For more information about parameter sets, see [About Parameter Sets](about_parameter_sets.md).
 
 ### ValueFromPipeline argument
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -1,0 +1,198 @@
+---
+title: about_Parameter_Sets
+ms.date: 02/11/2020
+---
+# About parameter sets
+
+## SHORT DESCRIPTION
+Describes how to define and use parameter sets in advanced functions.
+
+## LONG DESCRIPTION
+
+PowerShell uses parameter sets to enable you to write a single function that
+can do different actions for different scenarios. Parameter sets enable you to
+expose different parameters to the user. And, to return different information
+based on the parameters specified by the user.
+
+## Parameter set requirements
+
+The following requirements apply to all parameter sets.
+
+- Each parameter set must have at least one unique parameter. If possible, make
+  this parameter a mandatory parameter.
+
+- A parameter set that contains multiple positional parameters must define
+  unique positions for each parameter. No two positional parameters can specify
+  the same position.
+
+- Only one parameter in a set can declare the `ValueFromPipeline` keyword with
+  a value of `true`. Multiple parameters can define the
+  `ValueFromPipelineByPropertyName` keyword with a value of `true`.
+
+- If no parameter set is specified for a parameter, the parameter belongs to
+  all parameter sets.
+
+> [!NOTE]
+> There is a limit of 32 parameter sets.
+
+## Default parameter sets
+
+When multiple parameter sets are defined, the `DefaultParameterSetName` keyword
+of the **CmdletBinding** attribute specifies the default parameter set.
+PowerShell uses the default parameter set when it can't determine the parameter
+set to use based on the information provided to the command. For more
+information about the **CmdletBinding** attribute, see
+[about_functions_cmdletbindingattribute](about_functions_cmdletbindingattribute.md).
+
+## Declaring parameter sets
+
+To create a parameter set, you must specify the `ParameterSetName` keyword of
+the **Parameter** attribute for every parameter in the parameter set. For
+parameters that belong to multiple parameter sets, add a **Parameter**
+attribute for each parameter set.
+
+The **Parameter** attribute enables you to define the parameter differently for
+each parameter set. For example, you can define a parameter as mandatory in one
+set and optional in another. However, each parameter set must contain at least
+one unique parameter.
+
+Parameters that don't have an assigned parameter set name belong to all
+parameter sets.
+
+### Example
+
+The following example function counts the number lines, characters, and words
+in a text file. Using parameters, you can specify which values you want
+returned and which files you want to measure. There are four parameter sets
+defined:
+
+- Path
+- PathAll
+- LiteralPath
+- LiteralPathAll
+
+```powershell
+function Measure-Lines {
+    [CmdletBinding(DefaultParameterSetName = 'Path')]
+    param (
+        [Parameter(Mandatory = $true,
+            ParameterSetName = 'Path',
+            HelpMessage = 'Enter one or more filenames',
+            Position = 0)]
+        [Parameter(Mandatory = $true,
+            ParameterSetName = 'PathAll',
+            Position = 0)]
+        [string[]]$Path,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'LiteralPathAll')]
+        [Parameter(Mandatory = $true,
+            ParameterSetName = 'LiteralPath',
+            HelpMessage = 'Enter a single filename',
+            ValueFromPipeline = $true)]
+        [string]$LiteralPath,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'LiteralPath')]
+        [switch]$Lines,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'LiteralPath')]
+        [switch]$Words,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'LiteralPath')]
+        [switch]$Characters,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'PathAll')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'LiteralPathAll')]
+        [switch]$All,
+
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetName = 'PathAll')]
+        [switch]$Recurse
+    )
+
+    begin {
+        if ($All) {
+            $Lines = $Words = $Characters = $true
+        }
+        elseif (($Words -eq $false) -and ($Characters -eq $false)) {
+            $Lines = $true
+        }
+
+        if ($Path) {
+            $Files = Get-ChildItem -Path $Path -Recurse:$Recurse
+        }
+        else {
+            $Files = Get-ChildItem -LiteralPath $LiteralPath
+        }
+    }
+    process {
+        foreach ($file in $Files) {
+            $result = [ordered]@{ }
+            $result.Add('File', $file.fullname)
+
+            $content = Get-Content -LiteralPath $file.fullname
+
+            if ($Lines) { $result.Add('Lines', $content.Length) }
+
+            if ($Words) {
+                $wc = 0
+                foreach ($line in $content) { $wc += $line.split(' ').Length }
+                $result.Add('Words', $wc)
+            }
+
+            if ($Characters) {
+                $cc = 0
+                foreach ($line in $content) { $cc += $line.Length }
+                $result.Add('Characters', $cc)
+            }
+
+            New-Object -TypeName psobject -Property $result
+        }
+    }
+}
+```
+
+Each parameter set must have a unique parameter or a unique combination of
+parameters. The `Path` and `PathAll` parameter sets are very similar but the
+**All** parameter is unique to the `PathAll` parameter set. The same is true
+with the `LiteralPath` and `LiteralPathAll` parameter sets. Even though the
+`PathAll` and `LiteralPathAll` parameter sets both have the **All** parameter,
+the **Path** and **LiteralPath** parameters differentiate them.
+
+Use `Get-Command -Syntax` shows you the syntax of each parameter set. However
+it does not show the name of the parameter set. The following example shows
+which parameters can be used in each parameter set.
+
+```powershell
+(Get-Command Measure-Lines).ParameterSets |
+  Select-Object -Property @{n='ParameterSetName';e={$_.name}},
+    @{n='Parameters';e={$_.ToString()}}
+```
+
+```Output
+ParameterSetName Parameters
+---------------- ----------
+Path             [-Path] <string[]> [-Lines] [-Words] [-Characters] [-Recurse] [<CommonParameters>]
+PathAll          [-Path] <string[]> -All [-Recurse] [<CommonParameters>]
+LiteralPath      -LiteralPath <string> [-Lines] [-Words] [-Characters] [<CommonParameters>]
+LiteralPathAll   -LiteralPath <string> -All [<CommonParameters>]
+```
+
+### Parameter sets in action
+
+In this example, we are using the `PathAll` parameter set.
+
+```powershell
+Measure-Lines test* -All
+```
+
+```Output
+File                       Lines Words Characters
+----                       ----- ----- ----------
+C:\temp\test\test.help.txt    31   562       2059
+C:\temp\test\test.md          30  1527       3224
+C:\temp\test\test.ps1          3     3         79
+C:\temp\test\test[1].txt      31   562       2059
+```


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #5406 - add about_parameter_sets
Fixes [AB#1675509](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1675509)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
