### PR TITLE
Clarify Command precedence for not-loaded commands

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -106,7 +106,7 @@ For more information about how PowerShell uses wildcards, see [about_Wildcards](
 > few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
-when it runs commands:
+when it runs commands for all items loaded in the current session:
 
   1. Alias
   2. Function
@@ -119,6 +119,14 @@ runs the first `help` item that it finds.
 
 For example, if your session contains a cmdlet and a function, both named
 `Get-Map`, when you type `Get-Map`, PowerShell runs the function.
+
+> [!NOTE]
+> This only applies to loaded commands. If there is a `build` executable and an
+> Alias `build` for a function with the name of `Invoke-Build` inside a module that
+> is not loaded into the current session, PowerShell will execute the `build` executable
+> instead. It will not auto-load modules if it finds the external executable in this case.
+> It is only if no external executable is found that an alias / function / cmdlet with
+> the given name is invoked, thereby triggering auto-loading of its module.
 
 When the session contains items of the same type that have the same name,
 PowerShell runs the newer item.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -106,12 +106,12 @@ For more information about how PowerShell uses wildcards, see [about_Wildcards](
 > few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
-when it runs commands:
+when it runs commands for all items loaded in the current session:
 
   1. Alias
   2. Function
   3. Cmdlet
-  4. Native Windows commands
+  4. External executable files (programs and scripts)
 
 Therefore, if you type "help", PowerShell first looks for an alias named
 `help`, then a function named `Help`, and finally a cmdlet named `Help`. It
@@ -119,6 +119,14 @@ runs the first `help` item that it finds.
 
 For example, if your session contains a cmdlet and a function, both named
 `Get-Map`, when you type `Get-Map`, PowerShell runs the function.
+
+> [!NOTE]
+> This only applies to loaded commands. If there is a `build` executable and an
+> Alias `build` for a function with the name of `Invoke-Build` inside a module that
+> is not loaded into the current session, PowerShell will execute the `build` executable
+> instead. It will not auto-load modules if it finds the external executable in this case.
+> It is only if no external executable is found that an alias / function / cmdlet with
+> the given name is invoked, thereby triggering auto-loading of its module.
 
 When the session contains items of the same type that have the same name,
 PowerShell runs the newer item.

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -106,12 +106,12 @@ For more information about how PowerShell uses wildcards, see [about_Wildcards](
 > few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
-when it runs commands:
+when it runs commands for all items loaded in the current session:
 
   1. Alias
   2. Function
   3. Cmdlet
-  4. Native Windows commands
+  4. External executable files (programs and scripts)
 
 Therefore, if you type "help", PowerShell first looks for an alias named
 `help`, then a function named `Help`, and finally a cmdlet named `Help`. It
@@ -119,6 +119,14 @@ runs the first `help` item that it finds.
 
 For example, if your session contains a cmdlet and a function, both named
 `Get-Map`, when you type `Get-Map`, PowerShell runs the function.
+
+> [!NOTE]
+> This only applies to loaded commands. If there is a `build` executable and an
+> Alias `build` for a function with the name of `Invoke-Build` inside a module that
+> is not loaded into the current session, PowerShell will execute the `build` executable
+> instead. It will not auto-load modules if it finds the external executable in this case.
+> It is only if no external executable is found that an alias / function / cmdlet with
+> the given name is invoked, thereby triggering auto-loading of its module.
 
 When the session contains items of the same type that have the same name,
 PowerShell runs the newer item.

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -106,12 +106,12 @@ For more information about how PowerShell uses wildcards, see [about_Wildcards](
 > few guarantees that the file will be found.
 
 If you do not specify a path, PowerShell uses the following precedence order
-when it runs commands:
+when it runs commands for all items loaded in the current session:
 
   1. Alias
   2. Function
   3. Cmdlet
-  4. Native Windows commands
+  4. External executable files (programs and scripts)
 
 Therefore, if you type "help", PowerShell first looks for an alias named
 `help`, then a function named `Help`, and finally a cmdlet named `Help`. It
@@ -119,6 +119,14 @@ runs the first `help` item that it finds.
 
 For example, if your session contains a cmdlet and a function, both named
 `Get-Map`, when you type `Get-Map`, PowerShell runs the function.
+
+> [!NOTE]
+> This only applies to loaded commands. If there is a `build` executable and an
+> Alias `build` for a function with the name of `Invoke-Build` inside a module that
+> is not loaded into the current session, PowerShell will execute the `build` executable
+> instead. It will not auto-load modules if it finds the external executable in this case.
+> It is only if no external executable is found that an alias / function / cmdlet with
+> the given name is invoked, thereby triggering auto-loading of its module.
 
 When the session contains items of the same type that have the same name,
 PowerShell runs the newer item.


### PR DESCRIPTION
# PR Summary
Clarify Command precedence for not-loaded commands

fixes #4976 

Clarify that PowerShell-native commands
only take precedence over external executables
when their associated modules have been loaded.
If no external executable is found, it will
try to auto-load modules.

Clarify for PS 6 and above that it can be any native executable,
not only native Windows commands

## PR Context
Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [x] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
