### PR TITLE
Microsoft.PowerShell.Core/*/About/about_Scopes: Minor spelling correction

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -105,7 +105,7 @@ optional scope modifiers:
 
 - `global:` - Specifies that the name exists in the **Global** scope.
 - `local:` - Specifies that the name exists in the **Local** scope. The current
-  scope is alway the **Local** scope.
+  scope is always the **Local** scope.
 - `private:` - Specifies that the name is **Private** and only visible to the
   current scope.
 - `script:` - Specifies that the name exists in the **Script** scope.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -105,7 +105,7 @@ optional scope modifiers:
 
 - `global:` - Specifies that the name exists in the **Global** scope.
 - `local:` - Specifies that the name exists in the **Local** scope. The current
-  scope is alway the **Local** scope.
+  scope is always the **Local** scope.
 - `private:` - Specifies that the name is **Private** and only visible to the
   current scope.
 - `script:` - Specifies that the name exists in the **Script** scope.

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -105,7 +105,7 @@ optional scope modifiers:
 
 - `global:` - Specifies that the name exists in the **Global** scope.
 - `local:` - Specifies that the name exists in the **Local** scope. The current
-  scope is alway the **Local** scope.
+  scope is always the **Local** scope.
 - `private:` - Specifies that the name is **Private** and only visible to the
   current scope.
 - `script:` - Specifies that the name exists in the **Script** scope.

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -105,7 +105,7 @@ optional scope modifiers:
 
 - `global:` - Specifies that the name exists in the **Global** scope.
 - `local:` - Specifies that the name exists in the **Local** scope. The current
-  scope is alway the **Local** scope.
+  scope is always the **Local** scope.
 - `private:` - Specifies that the name is **Private** and only visible to the
   current scope.
 - `script:` - Specifies that the name exists in the **Script** scope.


### PR DESCRIPTION
# PR Summary
Change "is alway the local scope" → "is always the local scope".

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [X] Version 7.x preview content
- [X] Version 7.0 content
- [X] Version 6 content
- [X] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [X] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoftdocs/powershell-docs/5448)
<!-- Reviewable:end -->
