### PR TITLE
ThreadJob module works in Windows PowerShell too

### DIFF
--- a/reference/docs-conceptual/whats-new/cmdlet-versions.md
+++ b/reference/docs-conceptual/whats-new/cmdlet-versions.md
@@ -43,7 +43,7 @@ This is a work in progress. Please help us keep this information fresh.
 | PSScheduledJob                            | &check; |         |         |         | Windows only |
 | PSWorkflow                                | &check; |         |         |         | Windows only |
 | PSWorkflowUtility                         | &check; |         |         |         | Windows only |
-| ThreadJob                                 |         | &check; | &check; | &check; |              |
+| ThreadJob                                 | &check; | &check; | &check; | &check; |              |
 
 ## Cmdlet release history
 
@@ -630,6 +630,6 @@ This is a work in progress. Please help us keep this information fresh.
 
 ### ThreadJob
 
-|   Cmdlet name   |  5.1  |   6.x   |   7.0   |   7.1   | Note |
-| --------------- | :---: | :-----: | :-----: | :-----: | ---- |
-| Start-ThreadJob |       | &check; | &check; | &check; |      |
+|   Cmdlet name   |   5.1   |   6.x   |   7.0   |   7.1   | Note |
+| --------------- | :-----: | :-----: | :-----: | :-----: | ---- |
+| Start-ThreadJob | &check; | &check; | &check; | &check; |      |


### PR DESCRIPTION
# PR Summary
Add "check" for ThreadJob module and Start-ThreadJob cmdlet.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [x] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
