### PR TITLE
Fix parameter names for Register-ArgumentCompleter -Native

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -79,15 +79,15 @@ cmdlet and only returns running services.
 ```powershell
 $s = {
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
-    $services = Get-Service | Where-Object {$_.Status -eq "Running" }
-    $services | Where-Object { $_.Name -like "$wordToComplete*" } | ForEach-Object {
-        New-Object -Type System.Management.Automation.CompletionResult -ArgumentList $_,
-            $_,
+    $services = Get-Service | Where-Object {$_.Status -eq "Running" -and $_.Name -like "$wordToComplete*"}
+    $services | ForEach-Object {
+        New-Object -Type System.Management.Automation.CompletionResult -ArgumentList $_.Name,
+            $_.Name,
             "ParameterValue",
-            $_
+            $_.Name
     }
 }
-Register-ArgumentCompleter -CommandName dotnet -Native -ScriptBlock $s
+Register-ArgumentCompleter -CommandName Stop-Service -ParameterName Name -ScriptBlock $s
 ```
 
 The first command creates a script block which takes the required parameters which are passed in

--- a/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -12,6 +12,7 @@ title: Register-ArgumentCompleter
 # Register-ArgumentCompleter
 
 ## SYNOPSIS
+
 Registers a custom argument completer.
 
 ## SYNTAX
@@ -123,11 +124,11 @@ example adds tab-completion for the `dotnet` Command Line Interface (CLI).
 
 ```powershell
 $scriptblock = {
-     param($commandName, $wordToComplete, $cursorPosition)
-         dotnet complete --position $cursorPosition "$wordToComplete" | ForEach-Object {
+    param($wordToComplete, $commandAst, $cursorPosition)
+        dotnet complete --position $cursorPosition $commandAst.ToString() | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
-         }
- }
+        }
+}
 Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock $scriptblock
 ```
 
@@ -221,11 +222,12 @@ When you specify the **Native** parameter, the script block must take the follow
 the specified order. The names of the parameters aren't important because PowerShell passes in the
 values by position.
 
-- `$commandName` (Position 0) - This parameter is set to the name of the
-  command for which the script block is providing tab completion.
-- `$wordToComplete` (Position 1) - This parameter is set to value the user has
-  provided before they pressed <kbd>Tab</kbd>. Your script block should use this value
-  to determine tab completion values.
+- `$wordToComplete` (Position 0) - This parameter is set to value the user has provided before they
+  pressed <kbd>Tab</kbd>. Your script block should use this value to determine tab completion
+  values.
+- `$commandAst` (Position 1) - This parameter is set to the Abstract Syntax
+  Tree (AST) for the current input line. For more information, see
+  [Ast Class](/dotnet/api/system.management.automation.language.ast).
 - `$cursorPosition` (Position 2) - This parameter is set to the position of the cursor when the user
   pressed <kbd>Tab</kbd>.
 

--- a/reference/6/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/6/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -12,6 +12,7 @@ title: Register-ArgumentCompleter
 # Register-ArgumentCompleter
 
 ## SYNOPSIS
+
 Registers a custom argument completer.
 
 ## SYNTAX
@@ -123,11 +124,11 @@ example adds tab-completion for the `dotnet` Command Line Interface (CLI).
 
 ```powershell
 $scriptblock = {
-     param($commandName, $wordToComplete, $cursorPosition)
-         dotnet complete --position $cursorPosition "$wordToComplete" | ForEach-Object {
+    param($wordToComplete, $commandAst, $cursorPosition)
+        dotnet complete --position $cursorPosition $commandAst.ToString() | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
-         }
- }
+        }
+}
 Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock $scriptblock
 ```
 
@@ -221,11 +222,12 @@ When you specify the **Native** parameter, the script block must take the follow
 the specified order. The names of the parameters aren't important because PowerShell passes in the
 values by position.
 
-- `$commandName` (Position 0) - This parameter is set to the name of the
-  command for which the script block is providing tab completion.
-- `$wordToComplete` (Position 1) - This parameter is set to value the user has
-  provided before they pressed <kbd>Tab</kbd>. Your script block should use this value
-  to determine tab completion values.
+- `$wordToComplete` (Position 0) - This parameter is set to value the user has provided before they
+  pressed <kbd>Tab</kbd>. Your script block should use this value to determine tab completion
+  values.
+- `$commandAst` (Position 1) - This parameter is set to the Abstract Syntax
+  Tree (AST) for the current input line. For more information, see
+  [Ast Class](/dotnet/api/system.management.automation.language.ast).
 - `$cursorPosition` (Position 2) - This parameter is set to the position of the cursor when the user
   pressed <kbd>Tab</kbd>.
 

--- a/reference/7.0/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -12,6 +12,7 @@ title: Register-ArgumentCompleter
 # Register-ArgumentCompleter
 
 ## SYNOPSIS
+
 Registers a custom argument completer.
 
 ## SYNTAX
@@ -123,11 +124,11 @@ example adds tab-completion for the `dotnet` Command Line Interface (CLI).
 
 ```powershell
 $scriptblock = {
-     param($commandName, $wordToComplete, $cursorPosition)
-         dotnet complete --position $cursorPosition "$wordToComplete" | ForEach-Object {
+    param($wordToComplete, $commandAst, $cursorPosition)
+        dotnet complete --position $cursorPosition $commandAst.ToString() | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
-         }
- }
+        }
+}
 Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock $scriptblock
 ```
 
@@ -221,11 +222,12 @@ When you specify the **Native** parameter, the script block must take the follow
 the specified order. The names of the parameters aren't important because PowerShell passes in the
 values by position.
 
-- `$commandName` (Position 0) - This parameter is set to the name of the
-  command for which the script block is providing tab completion.
-- `$wordToComplete` (Position 1) - This parameter is set to value the user has
-  provided before they pressed <kbd>Tab</kbd>. Your script block should use this value
-  to determine tab completion values.
+- `$wordToComplete` (Position 0) - This parameter is set to value the user has provided before they
+  pressed <kbd>Tab</kbd>. Your script block should use this value to determine tab completion
+  values.
+- `$commandAst` (Position 1) - This parameter is set to the Abstract Syntax
+  Tree (AST) for the current input line. For more information, see
+  [Ast Class](/dotnet/api/system.management.automation.language.ast).
 - `$cursorPosition` (Position 2) - This parameter is set to the position of the cursor when the user
   pressed <kbd>Tab</kbd>.
 

--- a/reference/7.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -12,6 +12,7 @@ title: Register-ArgumentCompleter
 # Register-ArgumentCompleter
 
 ## SYNOPSIS
+
 Registers a custom argument completer.
 
 ## SYNTAX
@@ -123,11 +124,11 @@ example adds tab-completion for the `dotnet` Command Line Interface (CLI).
 
 ```powershell
 $scriptblock = {
-     param($commandName, $wordToComplete, $cursorPosition)
-         dotnet complete --position $cursorPosition "$wordToComplete" | ForEach-Object {
+    param($wordToComplete, $commandAst, $cursorPosition)
+        dotnet complete --position $cursorPosition $commandAst.ToString() | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
-         }
- }
+        }
+}
 Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock $scriptblock
 ```
 
@@ -221,11 +222,12 @@ When you specify the **Native** parameter, the script block must take the follow
 the specified order. The names of the parameters aren't important because PowerShell passes in the
 values by position.
 
-- `$commandName` (Position 0) - This parameter is set to the name of the
-  command for which the script block is providing tab completion.
-- `$wordToComplete` (Position 1) - This parameter is set to value the user has
-  provided before they pressed <kbd>Tab</kbd>. Your script block should use this value
-  to determine tab completion values.
+- `$wordToComplete` (Position 0) - This parameter is set to value the user has provided before they
+  pressed <kbd>Tab</kbd>. Your script block should use this value to determine tab completion
+  values.
+- `$commandAst` (Position 1) - This parameter is set to the Abstract Syntax
+  Tree (AST) for the current input line. For more information, see
+  [Ast Class](/dotnet/api/system.management.automation.language.ast).
 - `$cursorPosition` (Position 2) - This parameter is set to the position of the cursor when the user
   pressed <kbd>Tab</kbd>.
 


### PR DESCRIPTION
# PR Summary

Fixes #5393  
I replaced the existing examples with my proposed improvements as described in the issue.
I also updated the parameter details for the -Native parameter set.
In the 5.1 version of the document, I fixed the example for -CommandName too, as I discovered it was clearly flawed. I tested this example on Windows PowerShell 5.1 and can confirm it works.

I tested the new pwsh 6+ examples too, and can confirm they work as intended.

## PR Context

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
