### PR TITLE
[Fixes 5481] Updates Get-WinEvent

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
@@ -760,6 +760,12 @@ Specifies the event logs that this cmdlet get events from. Enter the event log n
 comma-separated list. Wildcards are permitted. You can also pipe log names to the `Get-WinEvent`
 cmdlet.
 
+> [!NOTE]
+> PowerShell does not limit the amount of logs you can request. However, the `Get-WinEvent` cmdlet
+> queries the Windows API which has a limit of 256. This can make it difficult to filter through all
+> of your logs at one time. You can work around this by using a `foreach` loop to iterate through each
+> log like this: `Get-WinEvent -ListLog * | ForEach-Object{ Get-WinEvent -LogName $_.Logname }`
+
 ```yaml
 Type: String[]
 Parameter Sets: GetLogSet

--- a/reference/6/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
+++ b/reference/6/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
@@ -783,6 +783,12 @@ Specifies the event logs that this cmdlet get events from. Enter the event log n
 comma-separated list. Wildcards are permitted. You can also pipe log names to the `Get-WinEvent`
 cmdlet.
 
+> [!NOTE]
+> PowerShell does not limit the amount of logs you can request. However, the `Get-WinEvent` cmdlet
+> queries the Windows API which has a limit of 256. This can make it difficult to filter through all
+> of your logs at one time. You can work around this by using a `foreach` loop to iterate through each
+> log like this: `Get-WinEvent -ListLog * | ForEach-Object{ Get-WinEvent -LogName $_.Logname }`
+
 ```yaml
 Type: String[]
 Parameter Sets: GetLogSet

--- a/reference/7.0/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
+++ b/reference/7.0/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
@@ -783,6 +783,12 @@ Specifies the event logs that this cmdlet get events from. Enter the event log n
 comma-separated list. Wildcards are permitted. You can also pipe log names to the `Get-WinEvent`
 cmdlet.
 
+> [!NOTE]
+> PowerShell does not limit the amount of logs you can request. However, the `Get-WinEvent` cmdlet
+> queries the Windows API which has a limit of 256. This can make it difficult to filter through all
+> of your logs at one time. You can work around this by using a `foreach` loop to iterate through each
+> log like this: `Get-WinEvent -ListLog * | ForEach-Object{ Get-WinEvent -LogName $_.Logname }`
+
 ```yaml
 Type: String[]
 Parameter Sets: GetLogSet

--- a/reference/7.1/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
+++ b/reference/7.1/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
@@ -783,6 +783,12 @@ Specifies the event logs that this cmdlet get events from. Enter the event log n
 comma-separated list. Wildcards are permitted. You can also pipe log names to the `Get-WinEvent`
 cmdlet.
 
+> [!NOTE]
+> PowerShell does not limit the amount of logs you can request. However, the `Get-WinEvent` cmdlet
+> queries the Windows API which has a limit of 256. This can make it difficult to filter through all
+> of your logs at one time. You can work around this by using a `foreach` loop to iterate through each
+> log like this: `Get-WinEvent -ListLog * | ForEach-Object{ Get-WinEvent -LogName $_.Logname }`
+
 ```yaml
 Type: String[]
 Parameter Sets: GetLogSet


### PR DESCRIPTION
# PR Summary
Adds Note about `Get-WinEvent` Windows API Limit and workaround

## PR Context
Fixes #5481 
Fixes [AB#1681492](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1681492)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
