### PR TITLE
[Fixes 5487] Get-InstalledModule

### DIFF
--- a/reference/5.1/PowershellGet/Get-InstalledModule.md
+++ b/reference/5.1/PowershellGet/Get-InstalledModule.md
@@ -96,9 +96,9 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies the maximum, or newest, version of a module to get.
-The **MaximumVersion** and **RequiredVersion** parameters are mutually exclusive; you cannot use both
-parameters in the same command.
+Specifies the maximum, or newest, version of a module to get. The **MaximumVersion** and
+**RequiredVersion** parameters are mutually exclusive; you cannot use both parameters in the same
+command.
 
 ```yaml
 Type: String
@@ -114,9 +114,9 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of a single module to get.
-The **MinimumVersion** and **RequiredVersion** parameters are mutually exclusive; you cannot use both
-parameters in the same command.
+Specifies the minimum version of a single module to get. The **MinimumVersion** and
+**RequiredVersion** parameters are mutually exclusive; you cannot use both parameters in the same
+command.
 
 ```yaml
 Type: String
@@ -172,7 +172,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### Microsoft.PowerShell.Commands.PSRepositoryItemInfo
+### System.Management.Automation.PSCustomObject
 
 ## NOTES
 

--- a/reference/5.1/PowershellGet/Get-InstalledModule.md
+++ b/reference/5.1/PowershellGet/Get-InstalledModule.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 05/23/2019
+ms.date: 02/27/2020
 online version: https://docs.microsoft.com/powershell/module/powershellget/get-installedmodule?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-InstalledModule

--- a/reference/6/PowerShellGet/Get-InstalledModule.md
+++ b/reference/6/PowerShellGet/Get-InstalledModule.md
@@ -96,9 +96,9 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies the maximum, or newest, version of a module to get.
-The **MaximumVersion** and **RequiredVersion** parameters are mutually exclusive; you cannot use both
-parameters in the same command.
+Specifies the maximum, or newest, version of a module to get. The **MaximumVersion** and
+**RequiredVersion** parameters are mutually exclusive; you cannot use both parameters in the same
+command.
 
 ```yaml
 Type: String
@@ -114,9 +114,9 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of a single module to get.
-The **MinimumVersion** and **RequiredVersion** parameters are mutually exclusive; you cannot use both
-parameters in the same command.
+Specifies the minimum version of a single module to get. The **MinimumVersion** and
+**RequiredVersion** parameters are mutually exclusive; you cannot use both parameters in the same
+command.
 
 ```yaml
 Type: String
@@ -172,7 +172,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### Microsoft.PowerShell.Commands.PSRepositoryItemInfo
+### System.Management.Automation.PSCustomObject
 
 ## NOTES
 

--- a/reference/6/PowerShellGet/Get-InstalledModule.md
+++ b/reference/6/PowerShellGet/Get-InstalledModule.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 05/23/2019
+ms.date: 02/27/2020
 online version: https://docs.microsoft.com/powershell/module/powershellget/get-installedmodule?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-InstalledModule

--- a/reference/7.0/PowerShellGet/Get-InstalledModule.md
+++ b/reference/7.0/PowerShellGet/Get-InstalledModule.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 05/23/2019
+ms.date: 02/27/2020
 online version: https://docs.microsoft.com/powershell/module/powershellget/get-installedmodule?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-InstalledModule

--- a/reference/7.0/PowerShellGet/Get-InstalledModule.md
+++ b/reference/7.0/PowerShellGet/Get-InstalledModule.md
@@ -96,9 +96,9 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies the maximum, or newest, version of a module to get.
-The **MaximumVersion** and **RequiredVersion** parameters are mutually exclusive; you cannot use both
-parameters in the same command.
+Specifies the maximum, or newest, version of a module to get. The **MaximumVersion** and
+**RequiredVersion** parameters are mutually exclusive; you cannot use both parameters in the same
+command.
 
 ```yaml
 Type: String
@@ -114,9 +114,9 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of a single module to get.
-The **MinimumVersion** and **RequiredVersion** parameters are mutually exclusive; you cannot use both
-parameters in the same command.
+Specifies the minimum version of a single module to get. The **MinimumVersion** and
+**RequiredVersion** parameters are mutually exclusive; you cannot use both parameters in the same
+command.
 
 ```yaml
 Type: String
@@ -172,7 +172,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### Microsoft.PowerShell.Commands.PSRepositoryItemInfo
+### System.Management.Automation.PSCustomObject
 
 ## NOTES
 

--- a/reference/7.1/PowerShellGet/Get-InstalledModule.md
+++ b/reference/7.1/PowerShellGet/Get-InstalledModule.md
@@ -3,7 +3,7 @@ external help file: PSModule-help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: PowerShellGet
-ms.date: 05/23/2019
+ms.date: 02/27/2020
 online version: https://docs.microsoft.com/powershell/module/powershellget/get-installedmodule?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-InstalledModule

--- a/reference/7.1/PowerShellGet/Get-InstalledModule.md
+++ b/reference/7.1/PowerShellGet/Get-InstalledModule.md
@@ -96,9 +96,9 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies the maximum, or newest, version of a module to get.
-The **MaximumVersion** and **RequiredVersion** parameters are mutually exclusive; you cannot use both
-parameters in the same command.
+Specifies the maximum, or newest, version of a module to get. The **MaximumVersion** and
+**RequiredVersion** parameters are mutually exclusive; you cannot use both parameters in the same
+command.
 
 ```yaml
 Type: String
@@ -114,9 +114,9 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies the minimum version of a single module to get.
-The **MinimumVersion** and **RequiredVersion** parameters are mutually exclusive; you cannot use both
-parameters in the same command.
+Specifies the minimum version of a single module to get. The **MinimumVersion** and
+**RequiredVersion** parameters are mutually exclusive; you cannot use both parameters in the same
+command.
 
 ```yaml
 Type: String
@@ -172,7 +172,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### Microsoft.PowerShell.Commands.PSRepositoryItemInfo
+### System.Management.Automation.PSCustomObject
 
 ## NOTES
 


### PR DESCRIPTION
# PR Summary
Documented Output Type is incorrect.

## PR Context

Fixes #5487 
Fixes [AB#1682010](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1682010)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
