### PR TITLE
[Fixes 5376] Updates Write-Output

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Output.md
@@ -8,7 +8,6 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: Write-Output
 ---
-
 # Write-Output
 
 ## SYNOPSIS
@@ -22,22 +21,25 @@ Write-Output [-InputObject] <PSObject[]> [-NoEnumerate] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Write-Output** cmdlet sends the specified object down the pipeline to the next command.
-If the command is the last command in the pipeline, the object is displayed in the console.
 
-**Write-Output** sends objects down the primary pipeline, also known as the "output stream" or the "success pipeline." To send error objects down the error pipeline, use Write-Error.
+The `Write-Output` cmdlet sends the specified object down the pipeline to the next command. If the
+command is the last command in the pipeline, the object is displayed in the console.
+
+`Write-Output` sends objects down the primary pipeline, also known as the "output stream" or the
+"success pipeline." To send error objects down the error pipeline, use `Write-Error`.
 
 This cmdlet is typically used in scripts to display strings and other objects on the console.
-However, because the default behavior is to display the objects at the end of a pipeline, it is generally not necessary to use the cmdlet.
-For instance, `Get-Process | Write-Output` is equivalent to `Get-Process`.
+However, because the default behavior is to display the objects at the end of a pipeline, it is
+generally not necessary to use the cmdlet. For instance, `Get-Process | Write-Output` is equivalent
+to `Get-Process`.
 
 ## EXAMPLES
 
 ### Example 1: Get objects and write them to the console
-```
-PS C:\> $P = Get-Process
-PS C:\> Write-Output $P
-PS C:\> $P
+
+```powershell
+$P = Get-Process
+Write-Output $P
 ```
 
 The first command gets processes running on the computer and stores them in the $P variable.
@@ -45,29 +47,41 @@ The first command gets processes running on the computer and stores them in the 
 The second and third commands display the process objects in $P on the console.
 
 ### Example 2: Pass output to another cmdlet
-```
-PS C:\> Write-Output "test output" | Get-Member
+
+```PowerShell
+Write-Output "test output" | Get-Member
 ```
 
-This command pipes the "test output" string to the Get-Member cmdlet, which displays the members of the **System.String** class, demonstrating that the string was passed along the pipeline.
+This command pipes the "test output" string to the `Get-Member` cmdlet, which displays the members of
+the **System.String** class, demonstrating that the string was passed along the pipeline.
 
 ### Example 3: Suppress enumeration in output
-```
-PS C:\> Write-Output @(1,2,3) | measure
 
+```powershell
+Write-Output @(1,2,3) | Measure-Object
+```
+
+```Output
 Count    : 3
 ...
-
-PS C:\> Write-Output @(1,2,3) -NoEnumerate | measure
-
-Count    : 1
 ```
 
-This command adds the *NoEnumerate* parameter to treat a collection or array as a single object through the pipeline.
+```powershell
+Write-Output @(1,2,3) -NoEnumerate | Measure-Object
+```
+
+```Output
+Count    : 1
+...
+```
+
+This command adds the **NoEnumerate** parameter to treat a collection or array as a single object
+through the pipeline.
 
 ## PARAMETERS
 
 ### -InputObject
+
 Specifies the objects to send down the pipeline.
 Enter a variable that contains the objects, or type a command or expression that gets the objects.
 
@@ -84,9 +98,17 @@ Accept wildcard characters: False
 ```
 
 ### -NoEnumerate
-By default, the **Write-Output** cmdlet always enumerates its output.
-The *NoEnumerate* parameter suppresses the default behavior, and prevents **Write-Output** from enumerating output.
-The *NoEnumerate* parameter has no effect on collections that were created by wrapping commands in parentheses, because the parentheses force enumeration.
+
+By default, the `Write-Output` cmdlet always enumerates its output. The **NoEnumerate** parameter
+suppresses the default behavior, and prevents `Write-Output` from enumerating output. The
+**NoEnumerate** parameter has no effect on collections that were created by wrapping commands in
+parentheses, because the parentheses force enumeration.
+
+> [!IMPORTANT]
+> There is an issue with this switch in Windows PowerShell that is fixed in PowerShell 6.2 and above.
+> When using **NoEnumerate** and explicitly using the **InputObject** parameter, the command will
+> still enumerate. The workaround is to positionally define the **InputObject** parameter and the
+> enumeration will be suppressed.
 
 ```yaml
 Type: SwitchParameter
@@ -101,17 +123,20 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe objects to **Write-Output**.
+
+You can pipe objects to `Write-Output`.
 
 ## OUTPUTS
 
 ### System.Management.Automation.PSObject
-**Write-Output** returns the objects that are submitted as input.
+
+`Write-Output` returns the objects that are submitted as input.
 
 ## NOTES
 

--- a/reference/6/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Write-Output.md
@@ -16,7 +16,7 @@ If the command is the last command in the pipeline, the objects are displayed in
 
 ## SYNTAX
 
-```powershell
+```
 Write-Output [-InputObject] <PSObject[]> [-NoEnumerate] [<CommonParameters>]
 ```
 

--- a/reference/6/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Write-Output.md
@@ -8,7 +8,6 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: Write-Output
 ---
-
 # Write-Output
 
 ## SYNOPSIS
@@ -17,27 +16,30 @@ If the command is the last command in the pipeline, the objects are displayed in
 
 ## SYNTAX
 
-```
+```powershell
 Write-Output [-InputObject] <PSObject[]> [-NoEnumerate] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Write-Output** cmdlet sends the specified object down the pipeline to the next command.
+
+The `Write-Output` cmdlet sends the specified object down the pipeline to the next command.
 If the command is the last command in the pipeline, the object is displayed in the console.
 
-**Write-Output** sends objects down the primary pipeline, also known as the "output stream" or the "success pipeline." To send error objects down the error pipeline, use Write-Error.
+`Write-Output` sends objects down the primary pipeline, also known as the "output stream" or the
+"success pipeline." To send error objects down the error pipeline, use Write-Error.
 
 This cmdlet is typically used in scripts to display strings and other objects on the console.
-However, because the default behavior is to display the objects at the end of a pipeline, it is generally not necessary to use the cmdlet.
-For instance, `Get-Process | Write-Output` is equivalent to `Get-Process`.
+However, because the default behavior is to display the objects at the end of a pipeline, it is
+generally not necessary to use the cmdlet. For instance, `Get-Process | Write-Output` is equivalent
+to `Get-Process`.
 
 ## EXAMPLES
 
 ### Example 1: Get objects and write them to the console
-```
-PS C:\> $P = Get-Process
-PS C:\> Write-Output $P
-PS C:\> $P
+
+```powershell
+$P = Get-Process
+Write-Output $P
 ```
 
 The first command gets processes running on the computer and stores them in the $P variable.
@@ -45,31 +47,43 @@ The first command gets processes running on the computer and stores them in the 
 The second and third commands display the process objects in $P on the console.
 
 ### Example 2: Pass output to another cmdlet
-```
-PS C:\> Write-Output "test output" | Get-Member
+
+```powershell
+Write-Output "test output" | Get-Member
 ```
 
-This command pipes the "test output" string to the Get-Member cmdlet, which displays the members of the **System.String** class, demonstrating that the string was passed along the pipeline.
+This command pipes the "test output" string to the Get-Member cmdlet, which displays the members of
+the **System.String** class, demonstrating that the string was passed along the pipeline.
 
 ### Example 3: Suppress enumeration in output
-```
-PS C:\> Write-Output @(1,2,3) | measure
 
+```powershell
+Write-Output @(1,2,3) | Measure-Object
+```
+
+```Output
 Count    : 3
 ...
-
-PS C:\> Write-Output @(1,2,3) -NoEnumerate | measure
-
-Count    : 1
 ```
 
-This command adds the *NoEnumerate* parameter to treat a collection or array as a single object through the pipeline.
+```powershell
+Write-Output @(1,2,3) -NoEnumerate | Measure-Object
+```
+
+```Output
+Count    : 1
+...
+```
+
+This command adds the **NoEnumerate** parameter to treat a collection or array as a single object
+through the pipeline.
 
 ## PARAMETERS
 
 ### -InputObject
-Specifies the objects to send down the pipeline.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
+
+Specifies the objects to send down the pipeline. Enter a variable that contains the objects, or type
+a command or expression that gets the objects.
 
 ```yaml
 Type: PSObject[]
@@ -84,15 +98,15 @@ Accept wildcard characters: False
 ```
 
 ### -NoEnumerate
-By default, the **Write-Output** cmdlet always enumerates its output.
-The *NoEnumerate* parameter suppresses the default behavior, and prevents **Write-Output** from enumerating output.
-The *NoEnumerate* parameter has no effect on collections that were created by wrapping commands in parentheses, because the parentheses force enumeration.
+
+By default, the `Write-Output` cmdlet always enumerates its output. The **NoEnumerate** parameter
+suppresses the default behavior, and prevents `Write-Output` from enumerating output. The
+**NoEnumerate** parameter has no effect on collections that were created by wrapping commands in
+parentheses, because the parentheses force enumeration.
 
 > [!NOTE]
-> This switch only works correctly with PowerShell Core 6.2 and newer. On older
-> versions of PowerShell Core, the collection is still enumerated even with
-> use of this switch.  The behavior in PowerShell Core 6.2 is consistent with
-> Windows PowerShell.
+> This switch only works correctly with PowerShell Core 6.2 and newer. On older versions of
+> PowerShell Core, the collection is still enumerated even with use of this switch.
 
 ```yaml
 Type: SwitchParameter
@@ -107,17 +121,20 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe objects to **Write-Output**.
+
+You can pipe objects to `Write-Output`.
 
 ## OUTPUTS
 
 ### System.Management.Automation.PSObject
-**Write-Output** returns the objects that are submitted as input.
+
+`Write-Output` returns the objects that are submitted as input.
 
 ## NOTES
 
@@ -138,5 +155,3 @@ You can pipe objects to **Write-Output**.
 [Write-Verbose](Write-Verbose.md)
 
 [Write-Warning](Write-Warning.md)
-
-

--- a/reference/7.0/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Write-Output.md
@@ -16,7 +16,7 @@ If the command is the last command in the pipeline, the objects are displayed in
 
 ## SYNTAX
 
-```powershell
+```
 Write-Output [-InputObject] <PSObject[]> [-NoEnumerate] [<CommonParameters>]
 ```
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Write-Output.md
@@ -8,7 +8,6 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: Write-Output
 ---
-
 # Write-Output
 
 ## SYNOPSIS
@@ -17,27 +16,30 @@ If the command is the last command in the pipeline, the objects are displayed in
 
 ## SYNTAX
 
-```
+```powershell
 Write-Output [-InputObject] <PSObject[]> [-NoEnumerate] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Write-Output** cmdlet sends the specified object down the pipeline to the next command.
+
+The `Write-Output` cmdlet sends the specified object down the pipeline to the next command.
 If the command is the last command in the pipeline, the object is displayed in the console.
 
-**Write-Output** sends objects down the primary pipeline, also known as the "output stream" or the "success pipeline." To send error objects down the error pipeline, use Write-Error.
+`Write-Output` sends objects down the primary pipeline, also known as the "output stream" or the
+"success pipeline." To send error objects down the error pipeline, use Write-Error.
 
 This cmdlet is typically used in scripts to display strings and other objects on the console.
-However, because the default behavior is to display the objects at the end of a pipeline, it is generally not necessary to use the cmdlet.
-For instance, `Get-Process | Write-Output` is equivalent to `Get-Process`.
+However, because the default behavior is to display the objects at the end of a pipeline, it is
+generally not necessary to use the cmdlet. For instance, `Get-Process | Write-Output` is equivalent
+to `Get-Process`.
 
 ## EXAMPLES
 
 ### Example 1: Get objects and write them to the console
-```
-PS C:\> $P = Get-Process
-PS C:\> Write-Output $P
-PS C:\> $P
+
+```powershell
+$P = Get-Process
+Write-Output $P
 ```
 
 The first command gets processes running on the computer and stores them in the $P variable.
@@ -45,31 +47,43 @@ The first command gets processes running on the computer and stores them in the 
 The second and third commands display the process objects in $P on the console.
 
 ### Example 2: Pass output to another cmdlet
-```
-PS C:\> Write-Output "test output" | Get-Member
+
+```powershell
+Write-Output "test output" | Get-Member
 ```
 
-This command pipes the "test output" string to the Get-Member cmdlet, which displays the members of the **System.String** class, demonstrating that the string was passed along the pipeline.
+This command pipes the "test output" string to the Get-Member cmdlet, which displays the members of
+the **System.String** class, demonstrating that the string was passed along the pipeline.
 
 ### Example 3: Suppress enumeration in output
-```
-PS C:\> Write-Output @(1,2,3) | measure
 
+```powershell
+Write-Output @(1,2,3) | Measure-Object
+```
+
+```Output
 Count    : 3
 ...
-
-PS C:\> Write-Output @(1,2,3) -NoEnumerate | measure
-
-Count    : 1
 ```
 
-This command adds the *NoEnumerate* parameter to treat a collection or array as a single object through the pipeline.
+```powershell
+Write-Output @(1,2,3) -NoEnumerate | Measure-Object
+```
+
+```Output
+Count    : 1
+...
+```
+
+This command adds the **NoEnumerate** parameter to treat a collection or array as a single object
+through the pipeline.
 
 ## PARAMETERS
 
 ### -InputObject
-Specifies the objects to send down the pipeline.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
+
+Specifies the objects to send down the pipeline. Enter a variable that contains the objects, or type
+a command or expression that gets the objects.
 
 ```yaml
 Type: PSObject[]
@@ -84,15 +98,15 @@ Accept wildcard characters: False
 ```
 
 ### -NoEnumerate
-By default, the **Write-Output** cmdlet always enumerates its output.
-The *NoEnumerate* parameter suppresses the default behavior, and prevents **Write-Output** from enumerating output.
-The *NoEnumerate* parameter has no effect on collections that were created by wrapping commands in parentheses, because the parentheses force enumeration.
+
+By default, the `Write-Output` cmdlet always enumerates its output. The **NoEnumerate** parameter
+suppresses the default behavior, and prevents `Write-Output` from enumerating output. The
+**NoEnumerate** parameter has no effect on collections that were created by wrapping commands in
+parentheses, because the parentheses force enumeration.
 
 > [!NOTE]
-> This switch only works correctly with PowerShell Core 6.2 and newer. On older
-> versions of PowerShell Core, the collection is still enumerated even with
-> use of this switch.  The behavior in PowerShell Core 6.2 is consistent with
-> Windows PowerShell.
+> This switch only works correctly with PowerShell Core 6.2 and newer. On older versions of
+> PowerShell Core, the collection is still enumerated even with use of this switch.
 
 ```yaml
 Type: SwitchParameter
@@ -107,17 +121,20 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe objects to **Write-Output**.
+
+You can pipe objects to `Write-Output`.
 
 ## OUTPUTS
 
 ### System.Management.Automation.PSObject
-**Write-Output** returns the objects that are submitted as input.
+
+`Write-Output` returns the objects that are submitted as input.
 
 ## NOTES
 
@@ -138,5 +155,3 @@ You can pipe objects to **Write-Output**.
 [Write-Verbose](Write-Verbose.md)
 
 [Write-Warning](Write-Warning.md)
-
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Write-Output.md
@@ -16,7 +16,7 @@ If the command is the last command in the pipeline, the objects are displayed in
 
 ## SYNTAX
 
-```powershell
+```
 Write-Output [-InputObject] <PSObject[]> [-NoEnumerate] [<CommonParameters>]
 ```
 

--- a/reference/7.1/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Write-Output.md
@@ -8,7 +8,6 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: Write-Output
 ---
-
 # Write-Output
 
 ## SYNOPSIS
@@ -17,27 +16,30 @@ If the command is the last command in the pipeline, the objects are displayed in
 
 ## SYNTAX
 
-```
+```powershell
 Write-Output [-InputObject] <PSObject[]> [-NoEnumerate] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Write-Output** cmdlet sends the specified object down the pipeline to the next command.
+
+The `Write-Output` cmdlet sends the specified object down the pipeline to the next command.
 If the command is the last command in the pipeline, the object is displayed in the console.
 
-**Write-Output** sends objects down the primary pipeline, also known as the "output stream" or the "success pipeline." To send error objects down the error pipeline, use Write-Error.
+`Write-Output` sends objects down the primary pipeline, also known as the "output stream" or the
+"success pipeline." To send error objects down the error pipeline, use Write-Error.
 
 This cmdlet is typically used in scripts to display strings and other objects on the console.
-However, because the default behavior is to display the objects at the end of a pipeline, it is generally not necessary to use the cmdlet.
-For instance, `Get-Process | Write-Output` is equivalent to `Get-Process`.
+However, because the default behavior is to display the objects at the end of a pipeline, it is
+generally not necessary to use the cmdlet. For instance, `Get-Process | Write-Output` is equivalent
+to `Get-Process`.
 
 ## EXAMPLES
 
 ### Example 1: Get objects and write them to the console
-```
-PS C:\> $P = Get-Process
-PS C:\> Write-Output $P
-PS C:\> $P
+
+```powershell
+$P = Get-Process
+Write-Output $P
 ```
 
 The first command gets processes running on the computer and stores them in the $P variable.
@@ -45,31 +47,43 @@ The first command gets processes running on the computer and stores them in the 
 The second and third commands display the process objects in $P on the console.
 
 ### Example 2: Pass output to another cmdlet
-```
-PS C:\> Write-Output "test output" | Get-Member
+
+```powershell
+Write-Output "test output" | Get-Member
 ```
 
-This command pipes the "test output" string to the Get-Member cmdlet, which displays the members of the **System.String** class, demonstrating that the string was passed along the pipeline.
+This command pipes the "test output" string to the Get-Member cmdlet, which displays the members of
+the **System.String** class, demonstrating that the string was passed along the pipeline.
 
 ### Example 3: Suppress enumeration in output
-```
-PS C:\> Write-Output @(1,2,3) | measure
 
+```powershell
+Write-Output @(1,2,3) | Measure-Object
+```
+
+```Output
 Count    : 3
 ...
-
-PS C:\> Write-Output @(1,2,3) -NoEnumerate | measure
-
-Count    : 1
 ```
 
-This command adds the *NoEnumerate* parameter to treat a collection or array as a single object through the pipeline.
+```powershell
+Write-Output @(1,2,3) -NoEnumerate | Measure-Object
+```
+
+```Output
+Count    : 1
+...
+```
+
+This command adds the **NoEnumerate** parameter to treat a collection or array as a single object
+through the pipeline.
 
 ## PARAMETERS
 
 ### -InputObject
-Specifies the objects to send down the pipeline.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
+
+Specifies the objects to send down the pipeline. Enter a variable that contains the objects, or type
+a command or expression that gets the objects.
 
 ```yaml
 Type: PSObject[]
@@ -84,15 +98,15 @@ Accept wildcard characters: False
 ```
 
 ### -NoEnumerate
-By default, the **Write-Output** cmdlet always enumerates its output.
-The *NoEnumerate* parameter suppresses the default behavior, and prevents **Write-Output** from enumerating output.
-The *NoEnumerate* parameter has no effect on collections that were created by wrapping commands in parentheses, because the parentheses force enumeration.
+
+By default, the `Write-Output` cmdlet always enumerates its output. The **NoEnumerate** parameter
+suppresses the default behavior, and prevents `Write-Output` from enumerating output. The
+**NoEnumerate** parameter has no effect on collections that were created by wrapping commands in
+parentheses, because the parentheses force enumeration.
 
 > [!NOTE]
-> This switch only works correctly with PowerShell Core 6.2 and newer. On older
-> versions of PowerShell Core, the collection is still enumerated even with
-> use of this switch.  The behavior in PowerShell Core 6.2 is consistent with
-> Windows PowerShell.
+> This switch only works correctly with PowerShell Core 6.2 and newer. On older versions of
+> PowerShell Core, the collection is still enumerated even with use of this switch.
 
 ```yaml
 Type: SwitchParameter
@@ -107,17 +121,20 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe objects to **Write-Output**.
+
+You can pipe objects to `Write-Output`.
 
 ## OUTPUTS
 
 ### System.Management.Automation.PSObject
-**Write-Output** returns the objects that are submitted as input.
+
+`Write-Output` returns the objects that are submitted as input.
 
 ## NOTES
 
@@ -138,5 +155,3 @@ You can pipe objects to **Write-Output**.
 [Write-Verbose](Write-Verbose.md)
 
 [Write-Warning](Write-Warning.md)
-
-


### PR DESCRIPTION
# PR Summary
Adds information about  known bug with **NoEnumerate** parameter in Write-Output.

## PR Context
Fixes #5376 
Fixes [AB#1682665](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1682665)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
