### PR TITLE
Issue 5498: about_regular_Expressions: fix "the the", "When"

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -193,9 +193,9 @@ characters.
 ```
 
 > [!NOTE]
-> WHen defining a regex containing an `$` anchor, be sure to enclose the regex
+> When defining a regex containing an `$` anchor, be sure to enclose the regex
 > using single quotes (`'`) instead of double quotes (`"`) or PowerShell will
-> expand the the expression as a variable.
+> expand the expression as a variable.
 
 When using anchors in PowerShell, you should understand the difference between
 **Singleline** and **Multiline** regular expression options.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -193,9 +193,9 @@ characters.
 ```
 
 > [!NOTE]
-> WHen defining a regex containing an `$` anchor, be sure to enclose the regex
+> When defining a regex containing an `$` anchor, be sure to enclose the regex
 > using single quotes (`'`) instead of double quotes (`"`) or PowerShell will
-> expand the the expression as a variable.
+> expand the expression as a variable.
 
 When using anchors in PowerShell, you should understand the difference between
 **Singleline** and **Multiline** regular expression options.

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -193,9 +193,9 @@ characters.
 ```
 
 > [!NOTE]
-> WHen defining a regex containing an `$` anchor, be sure to enclose the regex
+> When defining a regex containing an `$` anchor, be sure to enclose the regex
 > using single quotes (`'`) instead of double quotes (`"`) or PowerShell will
-> expand the the expression as a variable.
+> expand the expression as a variable.
 
 When using anchors in PowerShell, you should understand the difference between
 **Singleline** and **Multiline** regular expression options.

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -193,9 +193,9 @@ characters.
 ```
 
 > [!NOTE]
-> WHen defining a regex containing an `$` anchor, be sure to enclose the regex
+> When defining a regex containing an `$` anchor, be sure to enclose the regex
 > using single quotes (`'`) instead of double quotes (`"`) or PowerShell will
-> expand the the expression as a variable.
+> expand the expression as a variable.
 
 When using anchors in PowerShell, you should understand the difference between
 **Singleline** and **Multiline** regular expression options.


### PR DESCRIPTION
# PR Summary
Fix Issue #5498: about_regular_Expressions: fix "the the", "When"

In about_regular_Expressions the "note" on the anchor tag section " WHen defining a regex containing an $ anchor, be sure to enclose the regex using single quotes (') instead of double quotes (") or PowerShell will expand the the expression as a variable." has the word when with a capital 'h' and the word 'the' twice.

## PR Context
Fixed all versions of about_regular_Expressions

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
