### PR TITLE
Proposing adding unblock file step to the list of steps

### DIFF
--- a/reference/docs-conceptual/gallery/how-to/working-with-packages/manual-download.md
+++ b/reference/docs-conceptual/gallery/how-to/working-with-packages/manual-download.md
@@ -51,7 +51,8 @@ For the list of NuGet-specific elements, see [Using manual download to acquire a
 
 The steps are as follows:
 
-1. Extract the contents of the NuGet package to a local folder.
+1. Unblock the Internet-downloaded NuGet package (`.nupkg`) file, for example using `Unblock-File -Path C:\Downloads\module.nupkg` cmdlet.
+2. Extract the contents of the NuGet package to a local folder.
 2. Delete the NuGet-specific elements from the folder.
 3. Rename the folder. The default folder name is usually `<name>.<version>`. The version can
    include `-prerelease` if the module is tagged as a prerelease version. Rename the folder to just
@@ -74,7 +75,8 @@ The easiest approach is to extract the NuGet package, then use the script direct
 
 The steps are as follows:
 
-1. Extract the contents of the NuGet package.
+1. Unblock the Internet-downloaded NuGet package (`.nupkg`) file, for example using `Unblock-File -Path C:\Downloads\package.nupkg` cmdlet.
+2. Extract the contents of the NuGet package.
 2. The `.PS1` file in the folder can be used directly from this location.
 3. You may delete the NuGet-specific elements in the folder.
 


### PR DESCRIPTION
# PR Summary
Please see https://github.com/MicrosoftDocs/office-docs-powershell/issues/5000
I am a _collaborator_ for the _office-docs-powershell_ repo, I stumbled upon this article and I am kindly proposing adding some steps to avoid receiving a _Could not load file or assembly_ error when trying to use a module directly downloading the nupkg package file as this article describes.

## PR Context
N/A as this is for docs-conceptual

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.x preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [x] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
