### PR TITLE
Update Remove-Service.md - Typo in param desc

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Remove-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/Remove-Service.md
@@ -57,7 +57,7 @@ Get-Service -DisplayName "Test Service" | Remove-Service
 
 ### -InputObject
 
-Specifies **ServiceController** objects that represent the services to stop. Enter a variable that
+Specifies **ServiceController** objects that represent the services to remove. Enter a variable that
 contains the objects, or type a command or expression that gets the objects.
 
 ```yaml

--- a/reference/7.0/Microsoft.PowerShell.Management/Remove-Service.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Remove-Service.md
@@ -57,7 +57,7 @@ Get-Service -DisplayName "Test Service" | Remove-Service
 
 ### -InputObject
 
-Specifies **ServiceController** objects that represent the services to stop. Enter a variable that
+Specifies **ServiceController** objects that represent the services to remove. Enter a variable that
 contains the objects, or type a command or expression that gets the objects.
 
 ```yaml

--- a/reference/7.1/Microsoft.PowerShell.Management/Remove-Service.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Remove-Service.md
@@ -57,7 +57,7 @@ Get-Service -DisplayName "Test Service" | Remove-Service
 
 ### -InputObject
 
-Specifies **ServiceController** objects that represent the services to stop. Enter a variable that
+Specifies **ServiceController** objects that represent the services to remove. Enter a variable that
 contains the objects, or type a command or expression that gets the objects.
 
 ```yaml


### PR DESCRIPTION
Typo for -InputObject description. Should say "remove" not "stop".

# PR Summary
Simple typo in the description of the -InputObject parameter. It should say "remove" instead of "stop"

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
