### PR TITLE
[Fixes 5517] Adds information about $PSModulePath

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -241,36 +241,41 @@ The environment variables that store preferences include:
   module, such as the commands it exports.
 
   By default on Windows, this cache is normally stored in the file
-  `Microsoft\Windows\PowerShell\ModuleAnalysisCache` within `$env:LOCALAPPDATA`. The cache is typically read
-  at startup while searching for a command and is written on a background thread sometime after a
-  module is imported.
+  `Microsoft\Windows\PowerShell\ModuleAnalysisCache` within
+  `$env:LOCALAPPDATA`. The cache is typically read at startup while searching
+  for a command and is written on a background thread sometime after a module
+  is imported.
 
-  To change the default location of the cache, set the `$env:PSModuleAnalysisCachePath` environment
-  variable before starting PowerShell. Changes to this environment variable only affects children
-  processes. The value should name a full path (including filename) that PowerShell has permission to
-  create and write files. To disable the file cache, set this value to an invalid location, for
-  example:
+  To change the default location of the cache, set the
+  `$env:PSModuleAnalysisCachePath` environment variable before starting
+  PowerShell. Changes to this environment variable only affects children
+  processes. The value should name a full path (including filename) that
+  PowerShell has permission to create and write files. To disable the file
+  cache, set this value to an invalid location, for example:
 
-```powershell
-# `NUL` here is a special device on Windows that cannot be written to, on non-Windows you would
-# use `/dev/null`
-$env:PSModuleAnalysisCachePath = 'NUL'
-```
+  ```powershell
+  # `NUL` here is a special device on Windows that cannot be written to, on non-Windows you would
+  # use `/dev/null`
+  $env:PSModuleAnalysisCachePath = 'NUL'
+  ```
 
-  This sets the path to an invalid device. If PowerShell can't write to the path, no error is
-  returned, but you can see error reporting by using a tracer:
+  This sets the path to an invalid device. If PowerShell can't write to the
+  path, no error is returned, but you can see error reporting by using a
+  tracer:
 
-```powershell
-Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerShell.Management -Force }
-```
+  ```powershell
+  Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerShell.Management -Force }
+  ```
 
 - PSDisableModuleAnalysisCacheCleanup
 
-  When writing out the module analysis cache, PowerShell checks for modules that no longer exist
-  to avoid an unnecessarily large cache. Sometimes these checks are not desirable, in which case you
-  can turn them off by setting this environment variable value to `1`.
+  When writing out the module analysis cache, PowerShell checks for modules
+  that no longer exist to avoid an unnecessarily large cache. Sometimes these
+  checks are not desirable, in which case you can turn them off by setting this
+  environment variable value to `1`.
 
-  Setting this environment variable takes effect immediately in the current process.
+  Setting this environment variable takes effect immediately in the current
+  process.
 
 - PSModulePath
 
@@ -278,67 +283,76 @@ Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerS
   for modules in the specified directories when you do not specify a full path
   to a module.
 
-  The default value of $Env:PSModulePath is:
+  The default value of `$Env:PSModulePath` is:
 
-  ```
+  ```powershell
   $HOME\Documents\WindowsPowerShell\Modules; $PSHOME\Modules
   ```
 
-PowerShell sets the value of "\$PSHOME\\Modules" in the registry. It
-sets the value of "\$HOME\\Documents\\WindowsPowerShell\\Modules" each time you
-start PowerShell.
+  - All Users scope
 
-In addition, setup programs that install modules in other directories, such as
-the Program Files directory, can append their locations to the value of
-PSModulePath.
+    The `$PSHOME\Modules` folder contains modules that ship with Windows and
+    PowerShell.
 
-To change the default module directories for the current session, use the
-following command format to change the value of the PSModulePath environment
-variable.
+  - Current User scope
 
-For example, to add the "C:\\Program Files\\Fabrikam\\Modules" directory to
-the value of the PSModulePath environment variable, type:
+    The user-specific **CurrentUser** location is the
+    `WindowsPowerShell\Modules` folder located in the **Documents** location in
+    your user profile. The specific path of that location varies by version of
+    Windows and whether or not you are using folder redirection. By default, on
+    Windows 10, that location is `$HOME\Documents\WindowsPowerShell\Modules`.
 
-```powershell
-$Env:PSModulePath = $Env:PSModulePath+";C:\Program Files\Fabrikam\Modules"
-```
+  In addition, setup programs that install modules in other directories, such as
+  the Program Files directory, can append their locations to the value of
+  `PSModulePath`.
 
-The semi-colon (;) in the command separates the new path from the path that
-precedes it in the list.
+  To change the default module directories for the current session, use the
+  following command format to change the value of the `PSModulePath` environment
+  variable.
 
-To change the value of PSModulePath in every session, add the previous command
-to your PowerShell profile or use the SetEnvironmentVariable method of
-the Environment class.
+  For example, to add the `C:\\Program Files\\Fabrikam\\Modules` directory to
+  the value of the PSModulePath environment variable, type:
 
-The following command uses the GetEnvironmentVariable method to get the
-machine setting of PSModulePath and the SetEnvironmentVariable method to add
-the C:\\Program Files\\Fabrikam\\Modules path to the value.
+  ```powershell
+  $Env:PSModulePath = $Env:PSModulePath+";C:\Program Files\Fabrikam\Modules"
+  ```
 
-```powershell
-$path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
- "Machine")
-[System.Environment]::SetEnvironmentVariable("PSModulePath", $path +
-";C:\Program Files\Fabrikam\Modules", "Machine")
-```
+  The semi-colon (;) in the command separates the new path from the path that
+  precedes it in the list.
 
-To add a path to the user setting, change the target value to User.
+  To change the value of `PSModulePath` in every session, add the previous
+  command to your PowerShell profile or use the **SetEnvironmentVariable**
+  method of the **Environment** class.
 
-```powershell
-$path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
- "User")
-[System.Environment]::SetEnvironmentVariable("PSModulePath", $path +
-";$home\Documents\Fabrikam\Modules", "User")
-```
+  The following command uses the **GetEnvironmentVariable** method to get the
+  machine setting of `PSModulePath` and the **SetEnvironmentVariable** method
+  to add the `C:\\Program Files\\Fabrikam\\Modules` path to the value.
 
-For more information about the methods of the System.Environment class, see
-[Environment Methods](/dotnet/api/system.environment) in
-MSDN.
+  ```powershell
+  $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
+   "Machine")
+  [System.Environment]::SetEnvironmentVariable("PSModulePath", $path +
+  ";C:\Program Files\Fabrikam\Modules", "Machine")
+  ```
 
-You can add also add a command that changes the value to your profile or use
-System in Control Panel to change the value of the PSModulePath environment
-variable in the registry.
+  To add a path to the user setting, change the target value to User.
 
-For more information, see [about_Modules](about_Modules.md).
+  ```powershell
+  $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
+   "User")
+  [System.Environment]::SetEnvironmentVariable("PSModulePath", $path +
+  ";$home\Documents\Fabrikam\Modules", "User")
+  ```
+
+  For more information about the methods of the System.Environment class, see
+  [Environment Methods](/dotnet/api/system.environment) in
+  MSDN.
+
+  You can add also add a command that changes the value to your profile or use
+  System in Control Panel to change the value of the `PSModulePath` environment
+  variable in the registry.
+
+  For more information, see [about_Modules](about_Modules.md).
 
 ## SEE ALSO
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -310,7 +310,7 @@ The environment variables that store preferences include:
   following command format to change the value of the `PSModulePath` environment
   variable.
 
-  For example, to add the `C:\\Program Files\\Fabrikam\\Modules` directory to
+  For example, to add the `C:\Program Files\Fabrikam\Modules` directory to
   the value of the PSModulePath environment variable, type:
 
   ```powershell
@@ -326,7 +326,7 @@ The environment variables that store preferences include:
 
   The following command uses the **GetEnvironmentVariable** method to get the
   machine setting of `PSModulePath` and the **SetEnvironmentVariable** method
-  to add the `C:\\Program Files\\Fabrikam\\Modules` path to the value.
+  to add the `C:\Program Files\Fabrikam\Modules` path to the value.
 
   ```powershell
   $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
@@ -345,8 +345,7 @@ The environment variables that store preferences include:
   ```
 
   For more information about the methods of the System.Environment class, see
-  [Environment Methods](/dotnet/api/system.environment) in
-  MSDN.
+  [Environment Methods](/dotnet/api/system.environment).
 
   You can add also add a command that changes the value to your profile or use
   System in Control Panel to change the value of the `PSModulePath` environment

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -299,7 +299,7 @@ The default locations assigned to `$env:PSModulePath` are:
 - User-specific modules: These are modules installed by the user in the user's
   scope. `Install-Module` has a **Scope** parameter that allows you to specify
   whether the module is installed for the current user or for all users. For
-  more information, see [Install-Module](../Install-Module.md).
+  more information, see [Install-Module](../../PowerShellGet/Install-Module.md).
 
   The user-specific **CurrentUser** location is the `PowerShell\Modules` folder located in the
   **Documents** location in your user profile. The specific path of that

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -289,7 +289,7 @@ locations that are searched to find modules and resources.
 
 The default locations assigned to `$env:PSModulePath` are:
 
-- System-wide locations: `$PSHOME\Modules` or (`$env:windir\System32\PowerShell\<version>\Modules`)
+- System-wide locations: `$PSHOME\Modules` or (`$env:windir\System32\WindowsPowerShell\<version>\Modules`)
 
   These folders contain modules that ship with Windows and PowerShell.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -284,44 +284,35 @@ a module does not uninstall the module. For more information, see
 
 ## Module and DSC Resource Locations, and PSModulePath
 
-The following are default locations for PowerShell modules. Starting in
-PowerShell 4.0, with the introduction of DSC, a new default module and DSC
-resource folder was introduced. For more information about DSC, see
-[about_DesiredStateConfiguration](/powershell/module/Microsoft.PowerShell.Core/About/about_DesiredStateConfiguration).
+The `$env:PSModulePath` environment variable contains a list of folder
+locations that are searched to find modules and resources.
 
-- System: `$PSHOME\Modules` or
-  (`$env:windir\System32\WindowsPowerShell\v1.0\Modules`)
-  System modules are those that ship with Windows and PowerShell.
+The default locations assigned to `$env:PSModulePath` are:
 
-  Starting in PowerShell 4.0, when PowerShell Desired State Configuration
-  (DSC) was introduced, DSC resources that are included with PowerShell are
-  also stored in `$PSHOME\Modules`, in the
+- System-wide locations: `$PSHOME\Modules` or (`$env:windir\System32\PowerShell\<version>\Modules`)
+
+  These folders contain modules that ship with Windows and PowerShell.
+
+  DSC resources that are included with PowerShell are stored in the
   `$PSHOME\Modules\PSDesiredStateConfiguration\DSCResources` folder.
 
-- Current user: `$HOME\Documents\WindowsPowerShell\Modules`
-  (`$env:UserProfile\Documents\WindowsPowerShell\Modules`)
+- User-specific modules: These are modules installed by the user in the user's
+  scope. `Install-Module` has a **Scope** parameter that allows you to specify
+  whether the module is installed for the current user or for all users. For
+  more information, see [Install-Module](../Install-Module.md).
 
-  or
+  The user-specific **CurrentUser** location is the `PowerShell\Modules` folder located in the
+  **Documents** location in your user profile. The specific path of that
+  location varies by version of Windows and whether or not you are using folder
+  redirection. By default, on Windows 10, that location is
+  `$HOME\Documents\PowerShell\Modules`.
 
-  `$HOME\My Documents\WindowsPowerShell\Modules`
-  (`$env:UserProfile\My Documents\WindowsPowerShell\Modules`)
+  The user-specific **AllUsers** location is
+  `$env:PROGRAMFILES\WindowsPowerShell\Modules`.
 
-  This is the location for user-added modules prior to PowerShell 4.0.
-
-In PowerShell 4.0 and later releases of PowerShell, user-added modules and DSC
-resources are stored in `C:\Program Files\WindowsPowerShell\Modules`. Modules
-and DSC resources in this location are accessible by all users of the
-computer. This change was required because the DSC engine runs as local
-system, and could not access user-specific paths, such as
-`$home\Documents\WindowsPowerShell\Modules`.
-
-Starting in PowerShell 5.0, with the addition of the PowerShellGet module, and
-the [PowerShell Gallery](https://www.powershellgallery.com) of community and
-Microsoft-created resources, the `Install-Module` command installs modules and
-DSC resources to `C:\Program Files\WindowsPowerShell\Modules` by default.
-
-Note: To add or change files in the `$env:Windir\System32` directory, start
-PowerShell with the "Run as administrator" option.
+> [!NOTE]
+> To add or change files in the `$env:Windir\System32` directory, start
+> PowerShell with the "Run as administrator" option.
 
 You can change the default module locations on your system by changing the
 value of the **PSModulePath** environment variable, `$Env:PSModulePath`. The

--- a/reference/5.1/PowershellGet/Install-Module.md
+++ b/reference/5.1/PowershellGet/Install-Module.md
@@ -225,7 +225,7 @@ Accept wildcard characters: False
 Specifies the maximum version of a single module to install. The version installed must be less than
 or equal to **MaximumVersion**. If you want to install multiple modules, you cannot use
 **MaximumVersion**. **MaximumVersion** and **RequiredVersion** cannot be used in the same
-`Install-Module` command. 
+`Install-Module` command.
 
 ```yaml
 Type: String
@@ -502,3 +502,5 @@ the **RequiredVersion** value.
 [Uninstall-Module](Uninstall-Module.md)
 
 [Update-Module](Update-Module.md)
+
+[about_Module](../Microsoft.PowerShell.Core/About/about_Modules)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -319,7 +319,7 @@ Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerS
   following command format to change the value of the `PSModulePath` environment
   variable.
 
-  For example, to add the `C:\\Program Files\\Fabrikam\\Modules` directory to
+  For example, to add the `C:\Program Files\Fabrikam\Modules` directory to
   the value of the PSModulePath environment variable, type:
 
   ```powershell
@@ -335,7 +335,7 @@ Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerS
 
   The following command uses the **GetEnvironmentVariable** method to get the
   machine setting of `PSModulePath` and the **SetEnvironmentVariable** method
-  to add the `C:\\Program Files\\Fabrikam\\Modules` path to the value.
+  to add the `C:\Program Files\Fabrikam\Modules` path to the value.
 
   ```powershell
   $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -189,8 +189,8 @@ $Env:path += ":/usr/local/temp"
 
 You can also use the Item cmdlets, such as `Set-Item`, `Remove-Item`, and
 `Copy-Item` to change the values of environment variables. For example, to use
-the `Set-Item` cmdlet to append `;c:\temp` to the value of the `Path` environment
-variable, use the following syntax:
+the `Set-Item` cmdlet to append `;c:\temp` to the value of the `Path`
+environment variable, use the following syntax:
 
 ```powershell
 Set-Item -Path Env:Path -Value ($Env:Path + ";C:\Temp")
@@ -249,15 +249,17 @@ The environment variables that store preferences include:
   module, such as the commands it exports.
 
   By default on Windows, this cache is normally stored in the file
-  `Microsoft\Windows\PowerShell\ModuleAnalysisCache` within `$env:LOCALAPPDATA`. The cache is typically read
-  at startup while searching for a command and is written on a background thread sometime after a
-  module is imported.
+  `Microsoft\Windows\PowerShell\ModuleAnalysisCache` within
+  `$env:LOCALAPPDATA`. The cache is typically read at startup while searching
+  for a command and is written on a background thread sometime after a module
+  is imported.
 
-  To change the default location of the cache, set the `$env:PSModuleAnalysisCachePath` environment
-  variable before starting PowerShell. Changes to this environment variable only affects children
-  processes. The value should name a full path (including filename) that PowerShell has permission to
-  create and write files. To disable the file cache, set this value to an invalid location, for
-  example:
+  To change the default location of the cache, set the
+  `$env:PSModuleAnalysisCachePath` environment variable before starting
+  PowerShell. Changes to this environment variable only affects children
+  processes. The value should name a full path (including filename) that
+  PowerShell has permission to create and write files. To disable the file
+  cache, set this value to an invalid location, for example:
 
 ```powershell
 # `NUL` here is a special device on Windows that cannot be written to, on non-Windows you would
@@ -265,8 +267,9 @@ The environment variables that store preferences include:
 $env:PSModuleAnalysisCachePath = 'NUL'
 ```
 
-  This sets the path to an invalid device. If PowerShell can't write to the path, no error is
-  returned, but you can see error reporting by using a tracer:
+  This sets the path to an invalid device. If PowerShell can't write to the
+  path, no error is returned, but you can see error reporting by using a
+  tracer:
 
 ```powershell
 Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerShell.Management -Force }
@@ -274,93 +277,91 @@ Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerS
 
 - PSDisableModuleAnalysisCacheCleanup
 
-  When writing out the module analysis cache, PowerShell checks for modules that no longer exist
-  to avoid an unnecessarily large cache. Sometimes these checks are not desirable, in which case you
-  can turn them off by setting this environment variable value to `1`.
+  When writing out the module analysis cache, PowerShell checks for modules
+  that no longer exist to avoid an unnecessarily large cache. Sometimes these
+  checks are not desirable, in which case you can turn them off by setting this
+  environment variable value to `1`.
 
-  Setting this environment variable takes effect immediately in the current process.
+  Setting this environment variable takes effect immediately in the current
+  process.
 
 - PSModulePath
 
-  Stores the paths to the default module directories. PowerShell looks for
-  modules in the specified directories when you do not specify a full path to a
-  module.
+  Stores the paths to the default module directories. PowerShell looks
+  for modules in the specified directories when you do not specify a full path
+  to a module.
 
-  The default value of `$Env:PSModulePath` on Windows is:
-
-  ```powershell
-  $HOME\Documents\WindowsPowerShell\Modules;$PSHOME\Modules
-  ```
-
-  The default value of `$Env:PSModulePath` on Linux or macOS is:
+  The default value of `$Env:PSModulePath` is:
 
   ```powershell
-  $HOME/.local/share/powershell/Modules:/usr/local/share/powershell/Modules:$PSHOME/Modules
+  $HOME\Documents\WindowsPowerShell\Modules; $PSHOME\Modules
   ```
 
-PowerShell sets the value of `$PSHOME\Modules` in the registry. It sets the
-value of `$HOME\Documents\PowerShell\Modules` each time you start PowerShell.
+  - All Users scope
 
-In addition, setup programs that install modules in other directories, such as
-the `Program Files` directory, can append their locations to the value of
-PSModulePath.
+    The `$PSHOME\Modules` folder contains modules that ship with Windows and
+    PowerShell.
 
-To change the default module directories for the current session, use the
-following command format to change the value of the `PSModulePath` environment
-variable.
+  - Current User scope
 
-For example, to add the `C:\Program Files\Fabrikam\Modules` directory to the
-value of the `PSModulePath` environment variable, type:
+    The user-specific **CurrentUser** location is the `PowerShell\Modules`
+    folder located in the **Documents** location in your user profile. The
+    specific path of that location varies by version of Windows and whether or
+    not you are using folder redirection. By default, on Windows 10, that
+    location is `$HOME\Documents\PowerShell\Modules`. On Linux or Mac, the
+    **CurrentUser** location is `$HOME/.local/share/powershell/Modules`.
 
-```powershell
-$Env:PSModulePath += ";C:\Program Files\Fabrikam\Modules"
-```
+  In addition, setup programs that install modules in other directories, such
+  as the Program Files directory, can append their locations to the value of
+  `PSModulePath`.
 
-On Windows, the semicolon (`;`) in the command separates the new path from the
-path that precedes it in the list.
+  To change the default module directories for the current session, use the
+  following command format to change the value of the `PSModulePath` environment
+  variable.
 
-On Linux or MacOS, to add the `/usr/local/Fabrikam/Modules` directory to
-the value of the `PSModulePath` environment variable, type:
+  For example, to add the `C:\\Program Files\\Fabrikam\\Modules` directory to
+  the value of the PSModulePath environment variable, type:
 
-```powershell
-$Env:PSModulePath += ":/usr/local/Fabrikam/Modules"
-```
+  ```powershell
+  $Env:PSModulePath = $Env:PSModulePath+";C:\Program Files\Fabrikam\Modules"
+  ```
 
-On Linux or MacOS, the colon (`:`) in the command separates the new path from
-the path that precedes it in the list.
+  The semi-colon (;) in the command separates the new path from the path that
+  precedes it in the list.
 
-To change the value of `PSModulePath` in every session, add the previous
-command to your PowerShell profile
+  To change the value of `PSModulePath` in every session, add the previous
+  command to your PowerShell profile or use the **SetEnvironmentVariable**
+  method of the **Environment** class.
 
-On Windows systems, you can also use the **SetEnvironmentVariable** method of
-the **Environment** class. The following command uses the
-**GetEnvironmentVariable** method to get the machine setting of
-`PSModulePath` and the **SetEnvironmentVariable** method to add the
-`C:\Program Files\Fabrikam\Modules` path to the value.
+  The following command uses the **GetEnvironmentVariable** method to get the
+  machine setting of `PSModulePath` and the **SetEnvironmentVariable** method
+  to add the `C:\\Program Files\\Fabrikam\\Modules` path to the value.
 
-```powershell
-$path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
- "Machine")
-[System.Environment]::SetEnvironmentVariable("PSModulePath", $path +
-";C:\Program Files\Fabrikam\Modules", "Machine")
-```
+  ```powershell
+  $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
+   "Machine")
+  [System.Environment]::SetEnvironmentVariable("PSModulePath", $path +
+  ";C:\Program Files\Fabrikam\Modules", "Machine")
+  ```
 
-To add a path to the user setting, change the target value to User.
+  To add a path to the user setting, change the target value to User.
 
-```powershell
-$path = [System.Environment]::GetEnvironmentVariable('PSModulePath','User')
-[System.Environment]::SetEnvironmentVariable('PSModulePath', $path +
-";$home\Documents\Fabrikam\Modules", 'User')
-```
+  ```powershell
+  $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
+   "User")
+  [System.Environment]::SetEnvironmentVariable("PSModulePath", $path +
+  ";$home\Documents\Fabrikam\Modules", "User")
+  ```
 
-For more information about the methods of the System.Environment class, see
-[Environment Methods](/dotnet/api/system.environment).
+  For more information about the methods of the System.Environment class, see
+  [Environment Methods](/dotnet/api/system.environment) in
+  MSDN.
 
-You can add also add a command that changes the value to your profile or use
-System in Control Panel to change the value of the `PSModulePath` environment
-variable in the registry.
+  You can add also add a command that changes the value to your profile or use
+  System in Control Panel to change the value of the `PSModulePath` environment
+  variable in the registry.
 
-For more information, see [about_Modules](about_Modules.md).
+  For more information, see [about_Modules](about_Modules.md).
 
 ## SEE ALSO
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -284,44 +284,37 @@ a module does not uninstall the module. For more information, see
 
 ## Module and DSC Resource Locations, and PSModulePath
 
-The following are default locations for PowerShell modules. Starting in
-PowerShell 4.0, with the introduction of DSC, a new default module and DSC
-resource folder was introduced. For more information about DSC, see
-[about_DesiredStateConfiguration](/powershell/module/Microsoft.PowerShell.Core/About/about_DesiredStateConfiguration).
+The `$env:PSModulePath` environment variable contains a list of folder
+locations that are searched to find modules and resources.
 
-- System: `$PSHOME\Modules` or
-  (`$env:windir\System32\WindowsPowerShell\v1.0\Modules`)
-  System modules are those that ship with Windows and PowerShell.
+The default locations assigned to `$env:PSModulePath` are:
 
-  Starting in PowerShell 4.0, when PowerShell Desired State Configuration
-  (DSC) was introduced, DSC resources that are included with PowerShell are
-  also stored in `$PSHOME\Modules`, in the
+- System-wide locations: `$PSHOME\Modules`
+
+  These folders contain modules that ship with Windows and PowerShell.
+
+  DSC resources that are included with PowerShell are stored in the
   `$PSHOME\Modules\PSDesiredStateConfiguration\DSCResources` folder.
 
-- Current user: `$HOME\Documents\WindowsPowerShell\Modules`
-  (`$env:UserProfile\Documents\WindowsPowerShell\Modules`)
+- User-specific modules: These are modules installed by the user in the user's
+  scope. `Install-Module` has a **Scope** parameter that allows you to specify
+  whether the module is installed for the current user or for all users. For
+  more information, see [Install-Module](../Install-Module.md).
 
-  or
+  The user-specific **CurrentUser** location on Windows is the
+  `PowerShell\Modules` folder located in the **Documents** location in your
+  user profile. The specific path of that location varies by version of Windows
+  and whether or not you are using folder redirection. By default, on Windows
+  10, that location is `$HOME\Documents\PowerShell\Modules`. On Linux or Mac,
+  the **CurrentUser** location is `$HOME/.local/share/powershell/Modules`.
 
-  `$HOME\My Documents\WindowsPowerShell\Modules`
-  (`$env:UserProfile\My Documents\WindowsPowerShell\Modules`)
+  The user-specific **AllUsers** location is
+  `$env:PROGRAMFILES\WindowsPowerShell\Modules`. on Windows. On Linux or Mac
+  the modules are stores at `/usr/local/share/powershell/Modules`.
 
-  This is the location for user-added modules prior to PowerShell 4.0.
-
-In PowerShell 4.0 and later releases of PowerShell, user-added modules and DSC
-resources are stored in `C:\Program Files\WindowsPowerShell\Modules`. Modules
-and DSC resources in this location are accessible by all users of the
-computer. This change was required because the DSC engine runs as local
-system, and could not access user-specific paths, such as
-`$home\Documents\WindowsPowerShell\Modules`.
-
-Starting in PowerShell 5.0, with the addition of the PowerShellGet module, and
-the [PowerShell Gallery](https://www.powershellgallery.com) of community and
-Microsoft-created resources, the `Install-Module` command installs modules and
-DSC resources to `C:\Program Files\WindowsPowerShell\Modules` by default.
-
-Note: To add or change files in the `$env:Windir\System32` directory, start
-PowerShell with the "Run as administrator" option.
+> [!NOTE]
+> To add or change files in the `$env:Windir\System32` directory, start
+> PowerShell with the "Run as administrator" option.
 
 You can change the default module locations on your system by changing the
 value of the **PSModulePath** environment variable, `$Env:PSModulePath`. The

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -299,7 +299,7 @@ The default locations assigned to `$env:PSModulePath` are:
 - User-specific modules: These are modules installed by the user in the user's
   scope. `Install-Module` has a **Scope** parameter that allows you to specify
   whether the module is installed for the current user or for all users. For
-  more information, see [Install-Module](../Install-Module.md).
+  more information, see [Install-Module](../../PowerShellGet/Install-Module.md).
 
   The user-specific **CurrentUser** location on Windows is the
   `PowerShell\Modules` folder located in the **Documents** location in your

--- a/reference/6/PowerShellGet/Install-Module.md
+++ b/reference/6/PowerShellGet/Install-Module.md
@@ -240,7 +240,7 @@ Accept wildcard characters: False
 Specifies the maximum version of a single module to install. The version installed must be less than
 or equal to **MaximumVersion**. If you want to install multiple modules, you cannot use
 **MaximumVersion**. **MaximumVersion** and **RequiredVersion** cannot be used in the same
-`Install-Module` command. 
+`Install-Module` command.
 
 ```yaml
 Type: String
@@ -527,3 +527,5 @@ The publisher will specify the required modules and their versions in the module
 [Uninstall-Module](Uninstall-Module.md)
 
 [Update-Module](Update-Module.md)
+
+[about_Module](../Microsoft.PowerShell.Core/About/about_Modules)

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -189,8 +189,8 @@ $Env:path += ":/usr/local/temp"
 
 You can also use the Item cmdlets, such as `Set-Item`, `Remove-Item`, and
 `Copy-Item` to change the values of environment variables. For example, to use
-the `Set-Item` cmdlet to append `;c:\temp` to the value of the `Path` environment
-variable, use the following syntax:
+the `Set-Item` cmdlet to append `;c:\temp` to the value of the `Path`
+environment variable, use the following syntax:
 
 ```powershell
 Set-Item -Path Env:Path -Value ($Env:Path + ";C:\Temp")
@@ -249,15 +249,17 @@ The environment variables that store preferences include:
   module, such as the commands it exports.
 
   By default on Windows, this cache is normally stored in the file
-  `Microsoft\Windows\PowerShell\ModuleAnalysisCache` within `$env:LOCALAPPDATA`. The cache is typically read
-  at startup while searching for a command and is written on a background thread sometime after a
-  module is imported.
+  `Microsoft\Windows\PowerShell\ModuleAnalysisCache` within
+  `$env:LOCALAPPDATA`. The cache is typically read at startup while searching
+  for a command and is written on a background thread sometime after a module
+  is imported.
 
-  To change the default location of the cache, set the `$env:PSModuleAnalysisCachePath` environment
-  variable before starting PowerShell. Changes to this environment variable only affects children
-  processes. The value should name a full path (including filename) that PowerShell has permission to
-  create and write files. To disable the file cache, set this value to an invalid location, for
-  example:
+  To change the default location of the cache, set the
+  `$env:PSModuleAnalysisCachePath` environment variable before starting
+  PowerShell. Changes to this environment variable only affects children
+  processes. The value should name a full path (including filename) that
+  PowerShell has permission to create and write files. To disable the file
+  cache, set this value to an invalid location, for example:
 
 ```powershell
 # `NUL` here is a special device on Windows that cannot be written to, on non-Windows you would
@@ -265,8 +267,9 @@ The environment variables that store preferences include:
 $env:PSModuleAnalysisCachePath = 'NUL'
 ```
 
-  This sets the path to an invalid device. If PowerShell can't write to the path, no error is
-  returned, but you can see error reporting by using a tracer:
+  This sets the path to an invalid device. If PowerShell can't write to the
+  path, no error is returned, but you can see error reporting by using a
+  tracer:
 
 ```powershell
 Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerShell.Management -Force }
@@ -274,101 +277,90 @@ Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerS
 
 - PSDisableModuleAnalysisCacheCleanup
 
-  When writing out the module analysis cache, PowerShell checks for modules that no longer exist
-  to avoid an unnecessarily large cache. Sometimes these checks are not desirable, in which case you
-  can turn them off by setting this environment variable value to `1`.
+  When writing out the module analysis cache, PowerShell checks for modules
+  that no longer exist to avoid an unnecessarily large cache. Sometimes these
+  checks are not desirable, in which case you can turn them off by setting this
+  environment variable value to `1`.
 
-  Setting this environment variable takes effect immediately in the current process.
+  Setting this environment variable takes effect immediately in the current
+  process.
 
 - PSModulePath
 
-  Stores the paths to the default module directories. PowerShell looks for
-  modules in the specified directories when you do not specify a full path to a
-  module.
+  Stores the paths to the default module directories. PowerShell looks
+  for modules in the specified directories when you do not specify a full path
+  to a module.
 
-  The default value of `$Env:PSModulePath` on Windows is:
-
-  ```powershell
-  $HOME\Documents\PowerShell\Modules;$env:PROGRAMFILES\PowerShell\Modules;$PSHOME\Modules
-  ```
-
-  The default value of `$Env:PSModulePath` on Linux or macOS is:
+  The default value of `$Env:PSModulePath` is:
 
   ```powershell
-  $HOME/.local/share/powershell/Modules:/usr/local/share/powershell/Modules:$PSHOME/Modules
+  $HOME\Documents\WindowsPowerShell\Modules; $PSHOME\Modules
   ```
 
-PowerShell will prefix the user module path, the shared module path, and the $PSHOME
-module path to `PSModulePath` if it is not already in `PSModulePath`.
+  - All Users scope
 
-In addition, on Windows, if the inherited `PSModulePath` is the same as the one stored
-as the user environment variable, then the machine `PSModulePath` environment variable
-is appended to the end.
+    The `$PSHOME\Modules` folder contains modules that ship with Windows and
+    PowerShell.
 
-Also, setup programs that install modules in other directories, such as
-the `Program Files` directory, can append their locations to the value of
-PSModulePath.
+  - Current User scope
 
-To change the default module directories for the current session, use the
-following command format to change the value of the `PSModulePath` environment
-variable.
+    The user-specific **CurrentUser** location is the
+    `WindowsPowerShell\Modules` folder located in the **Documents** location in
+    your user profile. The specific path of that location varies by version of
+    Windows and whether or not you are using folder redirection. By default, on
+    Windows 10, that location is `$HOME\Documents\WindowsPowerShell\Modules`.
 
-For example, to add the `C:\Program Files\Fabrikam\Modules` directory to the
-value of the `PSModulePath` environment variable, type:
+  In addition, setup programs that install modules in other directories, such as
+  the Program Files directory, can append their locations to the value of
+  `PSModulePath`.
 
-```powershell
-$Env:PSModulePath += ";C:\Program Files\Fabrikam\Modules"
-```
+  To change the default module directories for the current session, use the
+  following command format to change the value of the `PSModulePath` environment
+  variable.
 
-On Windows, the semicolon (`;`) in the command separates the new path from the
-path that precedes it in the list.
+  For example, to add the `C:\\Program Files\\Fabrikam\\Modules` directory to
+  the value of the PSModulePath environment variable, type:
 
-On Linux or MacOS, to add the `/usr/local/Fabrikam/Modules` directory to
-the value of the `PSModulePath` environment variable, type:
+  ```powershell
+  $Env:PSModulePath = $Env:PSModulePath+";C:\Program Files\Fabrikam\Modules"
+  ```
 
-```powershell
-$Env:PSModulePath += ":/usr/local/Fabrikam/Modules"
-```
+  The semi-colon (;) in the command separates the new path from the path that
+  precedes it in the list.
 
-On Linux or MacOS, the colon (`:`) in the command separates the new path from
-the path that precedes it in the list.
+  To change the value of `PSModulePath` in every session, add the previous
+  command to your PowerShell profile or use the **SetEnvironmentVariable**
+  method of the **Environment** class.
 
-To change the value of `PSModulePath` in every session, add the previous
-command to your PowerShell profile
+  The following command uses the **GetEnvironmentVariable** method to get the
+  machine setting of `PSModulePath` and the **SetEnvironmentVariable** method
+  to add the `C:\\Program Files\\Fabrikam\\Modules` path to the value.
 
-On Windows systems, you can also use the **SetEnvironmentVariable** method of
-the **Environment** class. The following command uses the
-**GetEnvironmentVariable** method to get the machine setting of
-`PSModulePath` and the **SetEnvironmentVariable** method to add the
-`C:\Program Files\Fabrikam\Modules` path to the value.
+  ```powershell
+  $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
+   "Machine")
+  [System.Environment]::SetEnvironmentVariable("PSModulePath", $path +
+  ";C:\Program Files\Fabrikam\Modules", "Machine")
+  ```
 
-```powershell
-$path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
- "Machine")
-[System.Environment]::SetEnvironmentVariable("PSModulePath", $path +
-";C:\Program Files\Fabrikam\Modules", "Machine")
-```
+  To add a path to the user setting, change the target value to User.
 
-To add a path to the user setting, change the target value to User.
+  ```powershell
+  $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
+   "User")
+  [System.Environment]::SetEnvironmentVariable("PSModulePath", $path +
+  ";$home\Documents\Fabrikam\Modules", "User")
+  ```
 
-```powershell
-$path = [System.Environment]::GetEnvironmentVariable('PSModulePath','User')
-[System.Environment]::SetEnvironmentVariable('PSModulePath', $path +
-";$home\Documents\Fabrikam\Modules", 'User')
-```
+  For more information about the methods of the System.Environment class, see
+  [Environment Methods](/dotnet/api/system.environment) in
+  MSDN.
 
-For more information about the methods of the System.Environment class, see
-[Environment Methods](/dotnet/api/system.environment).
+  You can add also add a command that changes the value to your profile or use
+  System in Control Panel to change the value of the `PSModulePath` environment
+  variable in the registry.
 
-You can add also add a command that changes the value to your profile or use
-System in Control Panel to change the value of the `PSModulePath` environment
-variable in the registry.
-
-When starting Windows PowerShell or PowerShell ISE, PowerShell will remove the
-version specific user module path, shared module path, and $PSHOME module path
-from `PSModulePath` given to the child process.
-
-For more information, see [about_Modules](about_Modules.md).
+  For more information, see [about_Modules](about_Modules.md).
 
 ## SEE ALSO
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -318,7 +318,7 @@ Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerS
   following command format to change the value of the `PSModulePath` environment
   variable.
 
-  For example, to add the `C:\\Program Files\\Fabrikam\\Modules` directory to
+  For example, to add the `C:\Program Files\Fabrikam\Modules` directory to
   the value of the PSModulePath environment variable, type:
 
   ```powershell
@@ -334,7 +334,7 @@ Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerS
 
   The following command uses the **GetEnvironmentVariable** method to get the
   machine setting of `PSModulePath` and the **SetEnvironmentVariable** method
-  to add the `C:\\Program Files\\Fabrikam\\Modules` path to the value.
+  to add the `C:\Program Files\Fabrikam\Modules` path to the value.
 
   ```powershell
   $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -284,44 +284,37 @@ a module does not uninstall the module. For more information, see
 
 ## Module and DSC Resource Locations, and PSModulePath
 
-The following are default locations for PowerShell modules. Starting in
-PowerShell 4.0, with the introduction of DSC, a new default module and DSC
-resource folder was introduced. For more information about DSC, see
-[about_DesiredStateConfiguration](/powershell/module/Microsoft.PowerShell.Core/About/about_DesiredStateConfiguration).
+The `$env:PSModulePath` environment variable contains a list of folder
+locations that are searched to find modules and resources.
 
-- System: `$PSHOME\Modules` or
-  (`$env:windir\System32\WindowsPowerShell\v1.0\Modules`)
-  System modules are those that ship with Windows and PowerShell.
+The default locations assigned to `$env:PSModulePath` are:
 
-  Starting in PowerShell 4.0, when PowerShell Desired State Configuration
-  (DSC) was introduced, DSC resources that are included with PowerShell are
-  also stored in `$PSHOME\Modules`, in the
+- System-wide locations: `$PSHOME\Modules`
+
+  These folders contain modules that ship with Windows and PowerShell.
+
+  DSC resources that are included with PowerShell are stored in the
   `$PSHOME\Modules\PSDesiredStateConfiguration\DSCResources` folder.
 
-- Current user: `$HOME\Documents\WindowsPowerShell\Modules`
-  (`$env:UserProfile\Documents\WindowsPowerShell\Modules`)
+- User-specific modules: These are modules installed by the user in the user's
+  scope. `Install-Module` has a **Scope** parameter that allows you to specify
+  whether the module is installed for the current user or for all users. For
+  more information, see [Install-Module](../Install-Module.md).
 
-  or
+  The user-specific **CurrentUser** location on Windows is the
+  `PowerShell\Modules` folder located in the **Documents** location in your
+  user profile. The specific path of that location varies by version of Windows
+  and whether or not you are using folder redirection. By default, on Windows
+  10, that location is `$HOME\Documents\PowerShell\Modules`. On Linux or Mac,
+  the **CurrentUser** location is `$HOME/.local/share/powershell/Modules`.
 
-  `$HOME\My Documents\WindowsPowerShell\Modules`
-  (`$env:UserProfile\My Documents\WindowsPowerShell\Modules`)
+  The user-specific **AllUsers** location is
+  `$env:PROGRAMFILES\WindowsPowerShell\Modules`. on Windows. On Linux or Mac
+  the modules are stores at `/usr/local/share/powershell/Modules`.
 
-  This is the location for user-added modules prior to PowerShell 4.0.
-
-In PowerShell 4.0 and later releases of PowerShell, user-added modules and DSC
-resources are stored in `C:\Program Files\WindowsPowerShell\Modules`. Modules
-and DSC resources in this location are accessible by all users of the
-computer. This change was required because the DSC engine runs as local
-system, and could not access user-specific paths, such as
-`$home\Documents\WindowsPowerShell\Modules`.
-
-Starting in PowerShell 5.0, with the addition of the PowerShellGet module, and
-the [PowerShell Gallery](https://www.powershellgallery.com) of community and
-Microsoft-created resources, the `Install-Module` command installs modules and
-DSC resources to `C:\Program Files\WindowsPowerShell\Modules` by default.
-
-Note: To add or change files in the `$env:Windir\System32` directory, start
-PowerShell with the "Run as administrator" option.
+> [!NOTE]
+> To add or change files in the `$env:Windir\System32` directory, start
+> PowerShell with the "Run as administrator" option.
 
 You can change the default module locations on your system by changing the
 value of the **PSModulePath** environment variable, `$Env:PSModulePath`. The

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -299,7 +299,7 @@ The default locations assigned to `$env:PSModulePath` are:
 - User-specific modules: These are modules installed by the user in the user's
   scope. `Install-Module` has a **Scope** parameter that allows you to specify
   whether the module is installed for the current user or for all users. For
-  more information, see [Install-Module](../Install-Module.md).
+  more information, see [Install-Module](../../PowerShellGet/Install-Module.md).
 
   The user-specific **CurrentUser** location on Windows is the
   `PowerShell\Modules` folder located in the **Documents** location in your

--- a/reference/7.0/PowerShellGet/Install-Module.md
+++ b/reference/7.0/PowerShellGet/Install-Module.md
@@ -240,7 +240,7 @@ Accept wildcard characters: False
 Specifies the maximum version of a single module to install. The version installed must be less than
 or equal to **MaximumVersion**. If you want to install multiple modules, you cannot use
 **MaximumVersion**. **MaximumVersion** and **RequiredVersion** cannot be used in the same
-`Install-Module` command. 
+`Install-Module` command.
 
 ```yaml
 Type: String
@@ -527,3 +527,5 @@ The publisher will specify the required modules and their versions in the module
 [Uninstall-Module](Uninstall-Module.md)
 
 [Update-Module](Update-Module.md)
+
+[about_Module](../Microsoft.PowerShell.Core/About/about_Modules)

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -189,8 +189,8 @@ $Env:path += ":/usr/local/temp"
 
 You can also use the Item cmdlets, such as `Set-Item`, `Remove-Item`, and
 `Copy-Item` to change the values of environment variables. For example, to use
-the `Set-Item` cmdlet to append `;c:\temp` to the value of the `Path` environment
-variable, use the following syntax:
+the `Set-Item` cmdlet to append `;c:\temp` to the value of the `Path`
+environment variable, use the following syntax:
 
 ```powershell
 Set-Item -Path Env:Path -Value ($Env:Path + ";C:\Temp")
@@ -249,15 +249,17 @@ The environment variables that store preferences include:
   module, such as the commands it exports.
 
   By default on Windows, this cache is normally stored in the file
-  `Microsoft\Windows\PowerShell\ModuleAnalysisCache` within `$env:LOCALAPPDATA`. The cache is typically read
-  at startup while searching for a command and is written on a background thread sometime after a
-  module is imported.
+  `Microsoft\Windows\PowerShell\ModuleAnalysisCache` within
+  `$env:LOCALAPPDATA`. The cache is typically read at startup while searching
+  for a command and is written on a background thread sometime after a module
+  is imported.
 
-  To change the default location of the cache, set the `$env:PSModuleAnalysisCachePath` environment
-  variable before starting PowerShell. Changes to this environment variable only affects children
-  processes. The value should name a full path (including filename) that PowerShell has permission to
-  create and write files. To disable the file cache, set this value to an invalid location, for
-  example:
+  To change the default location of the cache, set the
+  `$env:PSModuleAnalysisCachePath` environment variable before starting
+  PowerShell. Changes to this environment variable only affects children
+  processes. The value should name a full path (including filename) that
+  PowerShell has permission to create and write files. To disable the file
+  cache, set this value to an invalid location, for example:
 
 ```powershell
 # `NUL` here is a special device on Windows that cannot be written to, on non-Windows you would
@@ -265,8 +267,9 @@ The environment variables that store preferences include:
 $env:PSModuleAnalysisCachePath = 'NUL'
 ```
 
-  This sets the path to an invalid device. If PowerShell can't write to the path, no error is
-  returned, but you can see error reporting by using a tracer:
+  This sets the path to an invalid device. If PowerShell can't write to the
+  path, no error is returned, but you can see error reporting by using a
+  tracer:
 
 ```powershell
 Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerShell.Management -Force }
@@ -274,101 +277,90 @@ Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerS
 
 - PSDisableModuleAnalysisCacheCleanup
 
-  When writing out the module analysis cache, PowerShell checks for modules that no longer exist
-  to avoid an unnecessarily large cache. Sometimes these checks are not desirable, in which case you
-  can turn them off by setting this environment variable value to `1`.
+  When writing out the module analysis cache, PowerShell checks for modules
+  that no longer exist to avoid an unnecessarily large cache. Sometimes these
+  checks are not desirable, in which case you can turn them off by setting this
+  environment variable value to `1`.
 
-  Setting this environment variable takes effect immediately in the current process.
+  Setting this environment variable takes effect immediately in the current
+  process.
 
 - PSModulePath
 
-  Stores the paths to the default module directories. PowerShell looks for
-  modules in the specified directories when you do not specify a full path to a
-  module.
+  Stores the paths to the default module directories. PowerShell looks
+  for modules in the specified directories when you do not specify a full path
+  to a module.
 
-  The default value of `$Env:PSModulePath` on Windows is:
-
-  ```powershell
-  $HOME\Documents\PowerShell\Modules;$env:PROGRAMFILES\PowerShell\Modules;$PSHOME\Modules
-  ```
-
-  The default value of `$Env:PSModulePath` on Linux or macOS is:
+  The default value of `$Env:PSModulePath` is:
 
   ```powershell
-  $HOME/.local/share/powershell/Modules:/usr/local/share/powershell/Modules:$PSHOME/Modules
+  $HOME\Documents\WindowsPowerShell\Modules; $PSHOME\Modules
   ```
 
-PowerShell will prefix the user module path, the shared module path, and the $PSHOME
-module path to `PSModulePath` if it is not already in `PSModulePath`.
+  - All Users scope
 
-In addition, on Windows, if the inherited `PSModulePath` is the same as the one stored
-as the user environment variable, then the machine `PSModulePath` environment variable
-is appended to the end.
+    The `$PSHOME\Modules` folder contains modules that ship with Windows and
+    PowerShell.
 
-Also, setup programs that install modules in other directories, such as
-the `Program Files` directory, can append their locations to the value of
-PSModulePath.
+  - Current User scope
 
-To change the default module directories for the current session, use the
-following command format to change the value of the `PSModulePath` environment
-variable.
+    The user-specific **CurrentUser** location is the
+    `WindowsPowerShell\Modules` folder located in the **Documents** location in
+    your user profile. The specific path of that location varies by version of
+    Windows and whether or not you are using folder redirection. By default, on
+    Windows 10, that location is `$HOME\Documents\WindowsPowerShell\Modules`.
 
-For example, to add the `C:\Program Files\Fabrikam\Modules` directory to the
-value of the `PSModulePath` environment variable, type:
+  In addition, setup programs that install modules in other directories, such as
+  the Program Files directory, can append their locations to the value of
+  `PSModulePath`.
 
-```powershell
-$Env:PSModulePath += ";C:\Program Files\Fabrikam\Modules"
-```
+  To change the default module directories for the current session, use the
+  following command format to change the value of the `PSModulePath` environment
+  variable.
 
-On Windows, the semicolon (`;`) in the command separates the new path from the
-path that precedes it in the list.
+  For example, to add the `C:\\Program Files\\Fabrikam\\Modules` directory to
+  the value of the PSModulePath environment variable, type:
 
-On Linux or MacOS, to add the `/usr/local/Fabrikam/Modules` directory to
-the value of the `PSModulePath` environment variable, type:
+  ```powershell
+  $Env:PSModulePath = $Env:PSModulePath+";C:\Program Files\Fabrikam\Modules"
+  ```
 
-```powershell
-$Env:PSModulePath += ":/usr/local/Fabrikam/Modules"
-```
+  The semi-colon (;) in the command separates the new path from the path that
+  precedes it in the list.
 
-On Linux or MacOS, the colon (`:`) in the command separates the new path from
-the path that precedes it in the list.
+  To change the value of `PSModulePath` in every session, add the previous
+  command to your PowerShell profile or use the **SetEnvironmentVariable**
+  method of the **Environment** class.
 
-To change the value of `PSModulePath` in every session, add the previous
-command to your PowerShell profile
+  The following command uses the **GetEnvironmentVariable** method to get the
+  machine setting of `PSModulePath` and the **SetEnvironmentVariable** method
+  to add the `C:\\Program Files\\Fabrikam\\Modules` path to the value.
 
-On Windows systems, you can also use the **SetEnvironmentVariable** method of
-the **Environment** class. The following command uses the
-**GetEnvironmentVariable** method to get the machine setting of
-`PSModulePath` and the **SetEnvironmentVariable** method to add the
-`C:\Program Files\Fabrikam\Modules` path to the value.
+  ```powershell
+  $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
+   "Machine")
+  [System.Environment]::SetEnvironmentVariable("PSModulePath", $path +
+  ";C:\Program Files\Fabrikam\Modules", "Machine")
+  ```
 
-```powershell
-$path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
- "Machine")
-[System.Environment]::SetEnvironmentVariable("PSModulePath", $path +
-";C:\Program Files\Fabrikam\Modules", "Machine")
-```
+  To add a path to the user setting, change the target value to User.
 
-To add a path to the user setting, change the target value to User.
+  ```powershell
+  $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
+   "User")
+  [System.Environment]::SetEnvironmentVariable("PSModulePath", $path +
+  ";$home\Documents\Fabrikam\Modules", "User")
+  ```
 
-```powershell
-$path = [System.Environment]::GetEnvironmentVariable('PSModulePath','User')
-[System.Environment]::SetEnvironmentVariable('PSModulePath', $path +
-";$home\Documents\Fabrikam\Modules", 'User')
-```
+  For more information about the methods of the System.Environment class, see
+  [Environment Methods](/dotnet/api/system.environment) in
+  MSDN.
 
-For more information about the methods of the System.Environment class, see
-[Environment Methods](/dotnet/api/system.environment).
+  You can add also add a command that changes the value to your profile or use
+  System in Control Panel to change the value of the `PSModulePath` environment
+  variable in the registry.
 
-You can add also add a command that changes the value to your profile or use
-System in Control Panel to change the value of the `PSModulePath` environment
-variable in the registry.
-
-When starting Windows PowerShell or PowerShell ISE, PowerShell will remove the
-version specific user module path, shared module path, and $PSHOME module path
-from `PSModulePath` given to the child process.
-
-For more information, see [about_Modules](about_Modules.md).
+  For more information, see [about_Modules](about_Modules.md).
 
 ## SEE ALSO
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -318,7 +318,7 @@ Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerS
   following command format to change the value of the `PSModulePath` environment
   variable.
 
-  For example, to add the `C:\\Program Files\\Fabrikam\\Modules` directory to
+  For example, to add the `C:\Program Files\Fabrikam\Modules` directory to
   the value of the PSModulePath environment variable, type:
 
   ```powershell
@@ -334,7 +334,7 @@ Trace-Command -PSHost -Name Modules -Expression { Import-Module Microsoft.PowerS
 
   The following command uses the **GetEnvironmentVariable** method to get the
   machine setting of `PSModulePath` and the **SetEnvironmentVariable** method
-  to add the `C:\\Program Files\\Fabrikam\\Modules` path to the value.
+  to add the `C:\Program Files\Fabrikam\Modules` path to the value.
 
   ```powershell
   $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -284,44 +284,37 @@ a module does not uninstall the module. For more information, see
 
 ## Module and DSC Resource Locations, and PSModulePath
 
-The following are default locations for PowerShell modules. Starting in
-PowerShell 4.0, with the introduction of DSC, a new default module and DSC
-resource folder was introduced. For more information about DSC, see
-[about_DesiredStateConfiguration](/powershell/module/Microsoft.PowerShell.Core/About/about_DesiredStateConfiguration).
+The `$env:PSModulePath` environment variable contains a list of folder
+locations that are searched to find modules and resources.
 
-- System: `$PSHOME\Modules` or
-  (`$env:windir\System32\WindowsPowerShell\v1.0\Modules`)
-  System modules are those that ship with Windows and PowerShell.
+The default locations assigned to `$env:PSModulePath` are:
 
-  Starting in PowerShell 4.0, when PowerShell Desired State Configuration
-  (DSC) was introduced, DSC resources that are included with PowerShell are
-  also stored in `$PSHOME\Modules`, in the
+- System-wide locations: `$PSHOME\Modules`
+
+  These folders contain modules that ship with Windows and PowerShell.
+
+  DSC resources that are included with PowerShell are stored in the
   `$PSHOME\Modules\PSDesiredStateConfiguration\DSCResources` folder.
 
-- Current user: `$HOME\Documents\WindowsPowerShell\Modules`
-  (`$env:UserProfile\Documents\WindowsPowerShell\Modules`)
+- User-specific modules: These are modules installed by the user in the user's
+  scope. `Install-Module` has a **Scope** parameter that allows you to specify
+  whether the module is installed for the current user or for all users. For
+  more information, see [Install-Module](../Install-Module.md).
 
-  or
+  The user-specific **CurrentUser** location on Windows is the
+  `PowerShell\Modules` folder located in the **Documents** location in your
+  user profile. The specific path of that location varies by version of Windows
+  and whether or not you are using folder redirection. By default, on Windows
+  10, that location is `$HOME\Documents\PowerShell\Modules`. On Linux or Mac,
+  the **CurrentUser** location is `$HOME/.local/share/powershell/Modules`.
 
-  `$HOME\My Documents\WindowsPowerShell\Modules`
-  (`$env:UserProfile\My Documents\WindowsPowerShell\Modules`)
+  The user-specific **AllUsers** location is
+  `$env:PROGRAMFILES\WindowsPowerShell\Modules`. on Windows. On Linux or Mac
+  the modules are stores at `/usr/local/share/powershell/Modules`.
 
-  This is the location for user-added modules prior to PowerShell 4.0.
-
-In PowerShell 4.0 and later releases of PowerShell, user-added modules and DSC
-resources are stored in `C:\Program Files\WindowsPowerShell\Modules`. Modules
-and DSC resources in this location are accessible by all users of the
-computer. This change was required because the DSC engine runs as local
-system, and could not access user-specific paths, such as
-`$home\Documents\WindowsPowerShell\Modules`.
-
-Starting in PowerShell 5.0, with the addition of the PowerShellGet module, and
-the [PowerShell Gallery](https://www.powershellgallery.com) of community and
-Microsoft-created resources, the `Install-Module` command installs modules and
-DSC resources to `C:\Program Files\WindowsPowerShell\Modules` by default.
-
-Note: To add or change files in the `$env:Windir\System32` directory, start
-PowerShell with the "Run as administrator" option.
+> [!NOTE]
+> To add or change files in the `$env:Windir\System32` directory, start
+> PowerShell with the "Run as administrator" option.
 
 You can change the default module locations on your system by changing the
 value of the **PSModulePath** environment variable, `$Env:PSModulePath`. The

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -299,7 +299,7 @@ The default locations assigned to `$env:PSModulePath` are:
 - User-specific modules: These are modules installed by the user in the user's
   scope. `Install-Module` has a **Scope** parameter that allows you to specify
   whether the module is installed for the current user or for all users. For
-  more information, see [Install-Module](../Install-Module.md).
+  more information, see [Install-Module](../../PowerShellGet/Install-Module.md).
 
   The user-specific **CurrentUser** location on Windows is the
   `PowerShell\Modules` folder located in the **Documents** location in your

--- a/reference/7.1/PowerShellGet/Install-Module.md
+++ b/reference/7.1/PowerShellGet/Install-Module.md
@@ -240,7 +240,7 @@ Accept wildcard characters: False
 Specifies the maximum version of a single module to install. The version installed must be less than
 or equal to **MaximumVersion**. If you want to install multiple modules, you cannot use
 **MaximumVersion**. **MaximumVersion** and **RequiredVersion** cannot be used in the same
-`Install-Module` command. 
+`Install-Module` command.
 
 ```yaml
 Type: String
@@ -527,3 +527,5 @@ The publisher will specify the required modules and their versions in the module
 [Uninstall-Module](Uninstall-Module.md)
 
 [Update-Module](Update-Module.md)
+
+[about_Module](../Microsoft.PowerShell.Core/About/about_Modules)

--- a/reference/docs-conceptual/developer/module/modifying-the-psmodulepath-installation-path.md
+++ b/reference/docs-conceptual/developer/module/modifying-the-psmodulepath-installation-path.md
@@ -70,3 +70,5 @@ will remove the **c:\ModulePath** path from the current session.
 ## See Also
 
 [Writing a Windows PowerShell Module](./writing-a-windows-powershell-module.md)
+
+[about_Modules](../../../7.0/Microsoft.PowerShell.Core/About/about_modules.md)

--- a/reference/docs-conceptual/developer/module/modifying-the-psmodulepath-installation-path.md
+++ b/reference/docs-conceptual/developer/module/modifying-the-psmodulepath-installation-path.md
@@ -11,9 +11,21 @@ caps.latest.revision: 15
 ---
 # Modifying the PSModulePath Installation Path
 
-The `PSModulePath` environment variable stores the paths to the locations of the modules that are installed on disk. PowerShell uses this variable to locate modules when the user does not specify the full path to a module. The paths in this variable are searched in the order in which they appear.
+The `PSModulePath` environment variable stores the paths to the locations of the modules that are
+installed on disk. PowerShell uses this variable to locate modules when the user does not specify
+the full path to a module. The paths in this variable are searched in the order in which they
+appear.
 
-When PowerShell starts, `PSModulePath` is created as a system environment variable with the following default value: `$HOME\Documents\PowerShell\Modules; $PSHOME\Modules` or `$HOME\Documents\WindowsPowerShell\Modules; $PSHOME\Modules` for Windows PowerShell.
+When PowerShell starts, `PSModulePath` is created as a system environment variable with the
+following default value: `$HOME\Documents\PowerShell\Modules; $PSHOME\Modules` on Windows and
+`$HOME/.local/share/powershell/Modules: usr/local/share/powershell/Modules` on Linux or Mac, and
+`$HOME\Documents\WindowsPowerShell\Modules; $PSHOME\Modules` for Windows PowerShell.
+
+> [!NOTE]
+> The user-specific **CurrentUser** location is the `WindowsPowerShell\Modules` folder located in
+> the **Documents** location in your user profile. The specific path of that location varies by
+> version of Windows and whether or not you are using folder redirection. By default, on Windows 10,
+> that location is `$HOME\Documents\WindowsPowerShell\Modules`.
 
 ## To view the PSModulePath variable
 
@@ -25,17 +37,24 @@ To view the paths that are specified in the `PSModulePath` variable, type the fo
 
 To add paths to this variable, use one of the following methods:
 
-- To add a temporary value that is available only for the current session, run the following command at the command line:
+- To add a temporary value that is available only for the current session, run the following command
+  at the command line:
 
   `$env:PSModulePath = $env:PSModulePath + "$([System.IO.Path]::PathSeparator)$MyModulePath"`
 
-- To add a persistent value that is available whenever a session is opened, add the above command to a PowerShell profile file (`$PROFILE`)>
+- To add a persistent value that is available whenever a session is opened, add the above command to
+  a PowerShell profile file (`$PROFILE`)>
 
   For more information about profiles, see [about_Profiles](/powershell/module/microsoft.powershell.core/about/about_profiles).
 
-- To add a persistent variable to the registry, create a new user environment variable called `PSModulePath` using the Environment Variables Editor in the **System Properties** dialog box.
+- To add a persistent variable to the registry, create a new user environment variable called
+  `PSModulePath` using the Environment Variables Editor in the **System Properties** dialog box.
 
-- To add a persistent variable by using a script, use the .Net method [SetEnvironmentVariable](https://docs.microsoft.com/dotnet/api/system.environment.setenvironmentvariable) on the [System.Environment](https://docs.microsoft.com/dotnet/api/system.environment) class. For example, the following script adds the `C:\Program Files\Fabrikam\Module` path to the value of the `PSModulePath` environment variable for the computer. To add the path to the user `PSModulePath` environment variable, set the target to "User".
+- To add a persistent variable by using a script, use the .Net method [SetEnvironmentVariable](https://docs.microsoft.com/dotnet/api/system.environment.setenvironmentvariable)
+  on the [System.Environment](https://docs.microsoft.com/dotnet/api/system.environment) class. For
+  example, the following script adds the `C:\Program Files\Fabrikam\Module` path to the value of the
+  `PSModulePath` environment variable for the computer. To add the path to the user `PSModulePath`
+  environment variable, set the target to "User".
 
   ```powershell
   $CurrentValue = [Environment]::GetEnvironmentVariable("PSModulePath", "Machine")
@@ -45,7 +64,8 @@ To add paths to this variable, use one of the following methods:
 
 ## To remove locations from the PSModulePath
 
-You can remove paths from the variable using similar methods: for example, `$env:PSModulePath = $env:PSModulePath -replace "$([System.IO.Path]::PathSeparator)c:\\ModulePath"` will remove the **c:\ModulePath** path from the current session.
+You can remove paths from the variable using similar methods: for example, `$env:PSModulePath = $env:PSModulePath -replace "$([System.IO.Path]::PathSeparator)c:\\ModulePath"`
+will remove the **c:\ModulePath** path from the current session.
 
 ## See Also
 

--- a/reference/docs-conceptual/developer/module/modifying-the-psmodulepath-installation-path.md
+++ b/reference/docs-conceptual/developer/module/modifying-the-psmodulepath-installation-path.md
@@ -71,4 +71,4 @@ will remove the **c:\ModulePath** path from the current session.
 
 [Writing a Windows PowerShell Module](./writing-a-windows-powershell-module.md)
 
-[about_Modules](../../../7.0/Microsoft.PowerShell.Core/About/about_modules.md)
+[about_Modules](/powershell/module/microsoft.powershell.core/about/about_modules)


### PR DESCRIPTION
# PR Summary

Customer noticed that the information about creation of $PSModule path. 

## PR Context

Fixes #5517 
Fixes [AB#1687126](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1687126)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [x] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
