### PR TITLE
[Fixes 5548] Adds information about $this automatic variable

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -533,6 +533,9 @@ and change the current loop iteration. For more information, see
 In a script block that defines a script property or script method, the
 `$this` variable refers to the object that is being extended.
 
+In a custom class, the `$this` variable refers to the class object itself
+allowing access to properties and methods defined in the class.
+
 ### $true
 
 Contains **True**. You can use this variable to represent **True** in commands

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -156,6 +156,10 @@ Methods define the actions that a class can perform. Methods may take
 parameters that provide input data. Methods can return output. Data returned by
 a method can be any defined data type.
 
+When defining a method for a class, you reference the current class object by
+using the `$this` automatic variable. This allows you to access properties and
+other methods defined in the current class.
+
 ### Example simple class with properties and methods
 
 Extending the **Rack** class to add and remove devices

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -556,6 +556,9 @@ and change the current loop iteration. For more information, see
 In a script block that defines a script property or script method, the
 `$this` variable refers to the object that is being extended.
 
+In a custom class, the `$this` variable refers to the class object itself
+allowing access to properties and methods defined in the class.
+
 ### $true
 
 Contains **True**. You can use this variable to represent **True** in commands

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -156,6 +156,10 @@ Methods define the actions that a class can perform. Methods may take
 parameters that provide input data. Methods can return output. Data returned by
 a method can be any defined data type.
 
+When defining a method for a class, you reference the current class object by
+using the `$this` automatic variable. This allows you to access properties and
+other methods defined in the current class.
+
 ### Example simple class with properties and methods
 
 Extending the **Rack** class to add and remove devices

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -527,6 +527,9 @@ and change the current loop iteration. For more information, see
 In a script block that defines a script property or script method, the
 `$this` variable refers to the object that is being extended.
 
+In a custom class, the `$this` variable refers to the class object itself
+allowing access to properties and methods defined in the class.
+
 ### $true
 
 Contains **True**. You can use this variable to represent **True** in commands

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -156,6 +156,10 @@ Methods define the actions that a class can perform. Methods may take
 parameters that provide input data. Methods can return output. Data returned by
 a method can be any defined data type.
 
+When defining a method for a class, you reference the current class object by
+using the `$this` automatic variable. This allows you to access properties and
+other methods defined in the current class.
+
 ### Example simple class with properties and methods
 
 Extending the **Rack** class to add and remove devices

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -156,6 +156,10 @@ Methods define the actions that a class can perform. Methods may take
 parameters that provide input data. Methods can return output. Data returned by
 a method can be any defined data type.
 
+When defining a method for a class, you reference the current class object by
+using the `$this` automatic variable. This allows you to access properties and
+other methods defined in the current class.
+
 ### Example simple class with properties and methods
 
 Extending the **Rack** class to add and remove devices


### PR DESCRIPTION
# PR Summary
about_Classes and about_Automatic were missing information about $this and it's use in PowerShell Classes

## PR Context

Fixes #5548
Fixes [AB#1688124](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1688124)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
