### PR TITLE
Fixes #5552 - explain Path as LiteralPath

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
@@ -182,10 +182,10 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies the name of the new item.
-
-You can specify the name of the new item in the **Name** or **Path** parameter value, and you can
-specify the path of the new item in **Name** or **Path** value.
+Specifies the name of the new item. You can specify the name of the new item in the **Name** or
+**Path** parameter value, and you can specify the path of the new item in **Name** or **Path**
+value. Items names passed using the **Name** parameter are created relative to the value of the
+**Path** parameter.
 
 ```yaml
 Type: String
@@ -201,10 +201,15 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path of the location of the new item.
-Wildcard characters are permitted.
+Specifies the path of the location of the new item. The default is the current location when
+**Path** is omitted. You can specify the name of the new item in **Name**, or include it in
+**Path**. Items names passed using the **Name** parameter are created relative to the value of the
+**Path** parameter.
 
-You can specify the name of the new item in **Name**, or include it in **Path**.
+For this cmdlet, the **Path** parameter works like the **LiteralPath** parameter of other cmdlets.
+Wildcard characters are not interpreted. All characters are passed to the location's provider. The
+provider may not support all characters. For example, you cannot create a filename that contains an
+asterisk (`*`) character.
 
 ```yaml
 Type: String[]
@@ -213,9 +218,9 @@ Aliases:
 
 Required: True (pathSet), False (nameSet)
 Position: 0
-Default value: None
+Default value: Current location
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: True
+Accept wildcard characters: False
 ```
 
 ### -UseTransaction

--- a/reference/6/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/6/Microsoft.PowerShell.Management/New-Item.md
@@ -234,10 +234,10 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies the name of the new item.
-
-You can specify the name of the new item in the **Name** or **Path** parameter value, and you can
-specify the path of the new item in **Name** or **Path** value.
+Specifies the name of the new item. You can specify the name of the new item in the **Name** or
+**Path** parameter value, and you can specify the path of the new item in **Name** or **Path**
+value. Items names passed using the **Name** parameter are created relative to the value of the
+**Path** parameter.
 
 ```yaml
 Type: String
@@ -253,9 +253,15 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path of the location of the new item.
-Wildcard characters are permitted.
-You can specify the name of the new item in **Name**, or include it in **Path**.
+Specifies the path of the location of the new item. The default is the current location when
+**Path** is omitted. You can specify the name of the new item in **Name**, or include it in
+**Path**. Items names passed using the **Name** parameter are created relative to the value of the
+**Path** parameter.
+
+For this cmdlet, the **Path** parameter works like the **LiteralPath** parameter of other cmdlets.
+Wildcard characters are not interpreted. All characters are passed to the location's provider. The
+provider may not support all characters. For example, you cannot create a filename that contains an
+asterisk (`*`) character.
 
 ```yaml
 Type: String[]
@@ -264,9 +270,9 @@ Aliases:
 
 Required: True (pathSet), False (nameSet)
 Position: 0
-Default value: None
+Default value: Current location
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: True
+Accept wildcard characters: False
 ```
 
 ### -Value

--- a/reference/7.0/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/New-Item.md
@@ -234,10 +234,10 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies the name of the new item.
-
-You can specify the name of the new item in the **Name** or **Path** parameter value, and you can
-specify the path of the new item in **Name** or **Path** value.
+Specifies the name of the new item. You can specify the name of the new item in the **Name** or
+**Path** parameter value, and you can specify the path of the new item in **Name** or **Path**
+value. Items names passed using the **Name** parameter are created relative to the value of the
+**Path** parameter.
 
 ```yaml
 Type: String
@@ -253,20 +253,26 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path of the location of the new item.
-Wildcard characters are permitted.
-You can specify the name of the new item in **Name**, or include it in **Path**.
+Specifies the path of the location of the new item. The default is the current location when
+**Path** is omitted. You can specify the name of the new item in **Name**, or include it in
+**Path**. Items names passed using the **Name** parameter are created relative to the value of the
+**Path** parameter.
+
+For this cmdlet, the **Path** parameter works like the **LiteralPath** parameter of other cmdlets.
+Wildcard characters are not interpreted. All characters are passed to the location's provider. The
+provider may not support all characters. For example, you cannot create a filename that contains an
+asterisk (`*`) character.
 
 ```yaml
 Type: String[]
-Parameter Sets: pathSet
+Parameter Sets: pathSet, nameSet
 Aliases:
 
 Required: True (pathSet), False (nameSet)
 Position: 0
-Default value: None
+Default value: Current location
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: True
+Accept wildcard characters: False
 ```
 
 ### -Value

--- a/reference/7.1/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/New-Item.md
@@ -234,10 +234,10 @@ Accept wildcard characters: False
 
 ### -Name
 
-Specifies the name of the new item.
-
-You can specify the name of the new item in the **Name** or **Path** parameter value, and you can
-specify the path of the new item in **Name** or **Path** value.
+Specifies the name of the new item. You can specify the name of the new item in the **Name** or
+**Path** parameter value, and you can specify the path of the new item in **Name** or **Path**
+value. Items names passed using the **Name** parameter are created relative to the value of the
+**Path** parameter.
 
 ```yaml
 Type: String
@@ -253,9 +253,15 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path of the location of the new item.
-Wildcard characters are permitted.
-You can specify the name of the new item in **Name**, or include it in **Path**.
+Specifies the path of the location of the new item. The default is the current location when
+**Path** is omitted. You can specify the name of the new item in **Name**, or include it in
+**Path**. Items names passed using the **Name** parameter are created relative to the value of the
+**Path** parameter.
+
+For this cmdlet, the **Path** parameter works like the **LiteralPath** parameter of other cmdlets.
+Wildcard characters are not interpreted. All characters are passed to the location's provider. The
+provider may not support all characters. For example, you cannot create a filename that contains an
+asterisk (`*`) character.
 
 ```yaml
 Type: String[]
@@ -264,9 +270,9 @@ Aliases:
 
 Required: True (pathSet), False (nameSet)
 Position: 0
-Default value: None
+Default value: Current location
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: True
+Accept wildcard characters: False
 ```
 
 ### -Value


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #5552 - explain Path as LiteralPath
Fixes [AB#1688434](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1688434)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/CONTRIBUTING.md) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
