### PR TITLE
[Fixes 5132] Updates Out-Default

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Out-Default.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Out-Default.md
@@ -114,7 +114,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [about_Format.ps1xml](About/about_Format.ps1xml.md)
 
-[Out-Default: Secrets Revealed](https://get-powershellblog.blogspot.com/2017/04/out-default-secrets-revealed.html)
-
 [How PowerShell Formatting and Outputting REALLY works](https://devblogs.microsoft.com/powershell/how-powershell-formatting-and-outputting-really-works/)
-

--- a/reference/6/Microsoft.PowerShell.Core/Out-Default.md
+++ b/reference/6/Microsoft.PowerShell.Core/Out-Default.md
@@ -114,7 +114,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [about_Format.ps1xml](About/about_Format.ps1xml.md)
 
-[Out-Default: Secrets Revealed](https://get-powershellblog.blogspot.com/2017/04/out-default-secrets-revealed.html)
-
 [How PowerShell Formatting and Outputting REALLY works](https://devblogs.microsoft.com/powershell/how-powershell-formatting-and-outputting-really-works/)
-

--- a/reference/7.0/Microsoft.PowerShell.Core/Out-Default.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Out-Default.md
@@ -114,7 +114,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [about_Format.ps1xml](About/about_Format.ps1xml.md)
 
-[Out-Default: Secrets Revealed](https://get-powershellblog.blogspot.com/2017/04/out-default-secrets-revealed.html)
-
 [How PowerShell Formatting and Outputting REALLY works](https://devblogs.microsoft.com/powershell/how-powershell-formatting-and-outputting-really-works/)
-

--- a/reference/7.1/Microsoft.PowerShell.Core/Out-Default.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Out-Default.md
@@ -114,7 +114,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [about_Format.ps1xml](About/about_Format.ps1xml.md)
 
-[Out-Default: Secrets Revealed](https://get-powershellblog.blogspot.com/2017/04/out-default-secrets-revealed.html)
-
 [How PowerShell Formatting and Outputting REALLY works](https://devblogs.microsoft.com/powershell/how-powershell-formatting-and-outputting-really-works/)
-


### PR DESCRIPTION
# PR Summary

Removing link to external article about Out-Default behavior

## PR Context

Fixes #5132 
Fixes [AB#1693869](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1693869)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://docs.microsoft.com/powershell/scripting/community/contributing/overview) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
