### PR TITLE
Added clarifying statement and example in about_Remote_Variables

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -78,7 +78,10 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-The `Using` scope modifier cannot be used to modify a local variable from **PSSession**.
+A variable reference such as `$using:var` expands to the value of variable `$var` 
+from the caller's context. You do not get access to the caller's variable object.
+The `Using` scope modifier cannot be used to modify a local variable within the
+**PSSession**. For example, the following code does not work:
 
 ```powershell
 $s = New-PSSession -ComputerName S1

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -78,6 +78,14 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
+The `Using` scope modifier cannot be used to modify a local variable from **PSSession**.
+
+```powershell
+$s = New-PSSession -ComputerName S1
+$ps = "*PowerShell*"
+Invoke-Command -Session $s -ScriptBlock {$Using:ps = 'Cannot assign new value'}
+```
+
 ### Using splatting
 
 PowerShell splatting passes a collection of parameter names and values to a

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -45,6 +45,14 @@ Invoke-Command -Session $s -ScriptBlock {$ps = "*PowerShell*"}
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $ps}
 ```
 
+The `Using` scope modifier cannot be used to modify a local variable from **PSSession**.
+
+```powershell
+$s = New-PSSession -ComputerName S1
+$ps = "*PowerShell*"
+Invoke-Command -Session $s -ScriptBlock {$Using:ps = 'Cannot assign new value'}
+```
+
 ## Using local variables
 
 You can use local variables in remote commands, but the variable must be

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -78,7 +78,10 @@ Invoke-Command -ComputerName S1 -ScriptBlock {
 }
 ```
 
-The `Using` scope modifier can be used in a **PSSession**.
+A variable reference such as `$using:var` expands to the value of variable `$var` 
+from the caller's context. You do not get access to the caller's variable object.
+The `Using` scope modifier cannot be used to modify a local variable within the
+**PSSession**. For example, the following code does not work:
 
 ```powershell
 $s = New-PSSession -ComputerName S1

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -78,7 +78,10 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-The `Using` scope modifier cannot be used to modify a local variable from **PSSession**.
+A variable reference such as `$using:var` expands to the value of variable `$var` 
+from the caller's context. You do not get access to the caller's variable object.
+The `Using` scope modifier cannot be used to modify a local variable within the
+**PSSession**. For example, the following code does not work:
 
 ```powershell
 $s = New-PSSession -ComputerName S1

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -78,6 +78,14 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
+The `Using` scope modifier cannot be used to modify a local variable from **PSSession**.
+
+```powershell
+$s = New-PSSession -ComputerName S1
+$ps = "*PowerShell*"
+Invoke-Command -Session $s -ScriptBlock {$Using:ps = 'Cannot assign new value'}
+```
+
 ### Using splatting
 
 PowerShell splatting passes a collection of parameter names and values to a

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -78,7 +78,10 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-The `Using` scope modifier cannot be used to modify a local variable from **PSSession**.
+A variable reference such as `$using:var` expands to the value of variable `$var` 
+from the caller's context. You do not get access to the caller's variable object.
+The `Using` scope modifier cannot be used to modify a local variable within the
+**PSSession**. For example, the following code does not work:
 
 ```powershell
 $s = New-PSSession -ComputerName S1

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -78,6 +78,14 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
+The `Using` scope modifier cannot be used to modify a local variable from **PSSession**.
+
+```powershell
+$s = New-PSSession -ComputerName S1
+$ps = "*PowerShell*"
+Invoke-Command -Session $s -ScriptBlock {$Using:ps = 'Cannot assign new value'}
+```
+
 ### Using splatting
 
 PowerShell splatting passes a collection of parameter names and values to a


### PR DESCRIPTION
# PR Summary
Current about_Remote_Variables content does not specifically state that use of $Using:var is not assignable from the remote session. I added the clarifying statement (that a local variable cannot be re-assigned, modified from the remote session) and example code just after introduction of the concept of using a local variable in a remote session.

Fixes #5070

## PR Context

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [X] Version 7.x preview content
- [X] Version 7.0 content
- [X] Version 6 content
- [X] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [X] I have read the [contributors guide](https://docs.microsoft.com/powershell/scripting/community/contributing/overview) and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
