### PR TITLE
Fixes #2626 - cmdlet only work on existing paths

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Convert-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Convert-Path.md
@@ -3,64 +3,73 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/09/2017
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/convert-path?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Convert-Path
 ---
-
 # Convert-Path
 
 ## SYNOPSIS
-Converts a path from a Windows PowerShell path to a Windows PowerShell provider path.
+Converts a path from a PowerShell path to a PowerShell provider path.
 
 ## SYNTAX
 
 ### Path (Default)
+
 ```
 Convert-Path [-Path] <String[]> [-UseTransaction] [<CommonParameters>]
 ```
 
 ### LiteralPath
+
 ```
 Convert-Path -LiteralPath <String[]> [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Convert-Path** cmdlet converts a path from a Windows PowerShell path to a Windows PowerShell provider path.
+
+The `Convert-Path` cmdlet converts a path from a PowerShell path to a PowerShell provider path.
 
 ## EXAMPLES
 
 ### Example 1: Convert the working directory to a standard file system path
+
+This example converts the current working directory, which is represented by a dot (`.`), to a
+standard FileSystem path.
+
 ```
 PS C:\> Convert-Path .
+C:\
 ```
-
-This command converts the current working directory, which is represented by a dot (.), to a standard file system path.
 
 ### Example 2: Convert a provider path to a standard registry path
-```
-PS C:\> Convert-Path HKLM:\Software\Microsoft
-```
 
-This command converts the Windows PowerShell provider path to a standard registry path.
+This example converts the PowerShell provider path to a standard registry path.
+
+```powershell
+PS C:\> Convert-Path HKLM:\Software\Microsoft
+HKEY_LOCAL_MACHINE\Software\Microsoft
+```
 
 ### Example 3: Convert a path to a string
-```
+
+This example converts the path to the home directory of the current provider, which is the
+FileSystem provider, to a string.
+
+```powershell
 PS C:\> Convert-Path ~
 C:\Users\User01
 ```
 
-This command converts the path to the home directory of the current provider, which is the FileSystem provider, to a string.
-
 ## PARAMETERS
 
 ### -LiteralPath
-Specifies, as a string array, the path to be converted.
-The value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+
+Specifies, as a string array, the path to be converted. The value of the **LiteralPath** parameter
+is used exactly as it is typed. No characters are interpreted as wildcards. If the path includes
+escape characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not
+to interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -75,7 +84,8 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies the Windows PowerShell path to be converted.
+
+Specifies the PowerShell path to be converted.
 
 ```yaml
 Type: String[]
@@ -107,28 +117,40 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
+
 You can pipe a path, but not a literal path, to this cmdlet.
 
 ## OUTPUTS
 
 ### System.String
+
 This cmdlet returns a string that contains the converted path.
 
 ## NOTES
-* The cmdlets that contain the Path noun manipulate path names and return the names in a concise format that all Windows PowerShell providers can interpret. They are designed for use in programs and scripts where you want to display all or part of a path name in a particular format. Use them like you would use Dirname, Normpath, Realpath, Join, or other path manipulators.
 
-  You can use the path cmdlets with several providers, including the FileSystem, Registry, and Certificate providers.
+The cmdlets that contain the Path noun manipulate path names and return the names in a concise
+format that all PowerShell providers can interpret. They are designed for use in programs and
+scripts where you want to display all or part of a path name in a particular format. Use them like
+you would use **Dirname**, **Normpath**, **Realpath**, **Join**, or other path manipulators.
 
-  This cmdlet is designed to work with the data exposed by any provider.
-To list the providers available in your session, type `Get-PSProvider`.
-For more information, see about_Providers.
+You can use the path cmdlets with several providers, including the FileSystem, Registry, and
+Certificate providers.
 
-*
+This cmdlet is designed to work with the data exposed by any provider. To list the providers
+available in your session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
+
+`Convert-Path` only converts existing paths. It cannot be used to convert a location that does not
+exist yet.
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Location.md
@@ -3,12 +3,11 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/09/2017
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/get-location?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Location
 ---
-
 # Get-Location
 
 ## SYNOPSIS
@@ -17,152 +16,139 @@ Gets information about the current working location or a location stack.
 ## SYNTAX
 
 ### Location (Default)
+
 ```
 Get-Location [-PSProvider <String[]>] [-PSDrive <String[]>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### Stack
+
 ```
 Get-Location [-Stack] [-StackName <String[]>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-Location** cmdlet gets an object that represents the current directory, much like the print working directory (pwd) command.
 
-When you move between Windows PowerShell drives, Windows PowerShell retains your location in each drive.
-You can use this cmdlet to find your location in each drive.
+The `Get-Location` cmdlet gets an object that represents the current directory, much like the print
+working directory (pwd) command.
 
-You can use this cmdlet to get the current directory at run time and use it in functions and scripts, such as in a function that displays the current directory in the Windows PowerShell prompt.
+When you move between PowerShell drives, PowerShell retains your location in each drive. You can use
+this cmdlet to find your location in each drive.
 
-You can also use this cmdlet to display the locations in a location stack.
-For more information, see the Notes and the descriptions of the *Stack* and *StackName* parameters.
+You can use this cmdlet to get the current directory at run time and use it in functions and
+scripts, such as in a function that displays the current directory in the PowerShell prompt.
+
+You can also use this cmdlet to display the locations in a location stack. For more information, see
+the Notes and the descriptions of the **Stack** and **StackName** parameters.
 
 ## EXAMPLES
 
 ### Example 1: Display your current drive location
-```
+
+This command displays your location in the current PowerShell drive.
+
+```powershell
 PS C:\Windows> Get-Location
+```
+
+```Output
 Path
 ----
 C:\Windows
 ```
 
-This command displays your location in the current Windows PowerShell drive.
-
-For instance, if you are in the Windows directory of the C: drive, it displays the path to that directory.
+For instance, if you are in the `Windows` directory of the `C:` drive, it displays the path to that
+directory.
 
 ### Example 2: Display your current location for different drives
-```
-The first command uses the **Set-Location** cmdlet to set the current location to the Windows subdirectory of the C: drive.
+
+This example demonstrates the use of `Get-Location` to display your current location in different
+PowerShell drives. `Set-Location` is used to change the location to several different paths on
+different **PSDrives**.
+
+```powershell
 PS C:\> Set-Location C:\Windows
-
-The second command uses the **Set-Location** cmdlet to change the location to the HKLM:\Software\Microsoft registry key. When you change to a location in the HKLM: drive, Windows PowerShell retains your location in the C: drive.
 PS C:\Windows> Set-Location HKLM:\Software\Microsoft
-PS HKLM:\Software\Microsoft>
-
-The third command uses the **Set-Location** cmdlet to change the location to the HKCU:\Control Panel\Input Method registry key.
 PS HKLM:\Software\Microsoft> Set-Location "HKCU:\Control Panel\Input Method"
-PS HKCU:\Control Panel\Input Method>
-
-The fourth command uses the **Get-Location** cmdlet to find the current location on the C: drive. It uses the *PSDrive* parameter to specify the drive.
 PS HKCU:\Control Panel\Input Method> Get-Location -PSDrive C
-
-
 
 Path
 ----
 C:\Windows
 
+PS C:\Windows> Get-Location -PSDrive HKLM
 
-The fifth command uses the **Set-Location** cmdlet to return to the C: drive. Even though the command does not specify a subdirectory, Windows PowerShell returns you to the saved location.
+Path
+----
+HKLM:\Software\Microsoft
+
 PS HKCU:\Control Panel\Input Method> Set-Location C:
-PS C:\Windows>
-
-The sixth command uses the **Get-Location** cmdlet to find the current location in the drives supported by the Windows PowerShell registry provider. **Get-Location** returns the location of the most recently accessed registry drive, HKCU.
 PS C:\Windows> Get-Location -PSProvider registry
-
-
-
 
 Path
 ----
 HKCU:\Control Panel\Input Method
-
-
-To see the current location in the HKLM: drive, you need to use the *PSDrive* parameter to specify the drive. The seventh command does just this:
-PS C:\Windows> Get-Location -PSDrive HKLM
-
-
 
 Path
 ----
 HKLM:\Software\Microsoft
 ```
 
-This example demonstrates the use of **Get-Location** to display your current location in different Windows PowerShell drives.
+### Example 3: Get locations using stacks
 
-### Example 3:
-```
-The first command sets the current location to the Windows directory on the C: drive.
-PS C:\> Set-Location C:\Windows
+This example shows how to use the **Stack** and **StackName** parameters of `Get-Location` to list
+the locations in the current location stack and alternate location stacks.
 
-The second command uses the **Push-Location** cmdlet to push the current location (C:\Windows) onto the current location stack and change to the System32 subdirectory. Because no stack is specified, the current location is pushed onto the current location stack. By default, the current location stack is the unnamed default location stack.
+The `Push-Location` cmdlet is used to change into three different locations. The third push uses a
+different stack name. The **Stack** parameter of `Get-Location` displays the contents of the default
+stack. The **StackName** parameter of `Get-Location` displays the contents of the stack named
+`Stack2`.
+
+```powershell
+PS C:\> Push-Location C:\Windows
 PS C:\Windows>Push-Location System32
-
-The third command uses the *StackName* parameter of the **Push-Location** cmdlet to push the current location (C:\Windows\System32) onto the Stack2 stack and to change the current location to the WindowsPowerShell subdirectory. If the Stack2 stack does not exist, **Push-Location** creates it.
 PS C:\Windows\System32>Push-Location WindowsPowerShell -StackName Stack2
-
-The fourth command uses the *Stack* parameter of the **Get-Location** cmdlet to get the locations in the current location stack. By default, the current stack is the unnamed default location stack.
 C:\Windows\System32\WindowsPowerShell>Get-Location -Stack
-
-
 
 Path
 ----
 C:\Windows
+C:\
 
-
-The fifth command uses the *StackName* parameter of the **Get-Location** cmdlet to get the locations in the Stack2 stack.
 C:\Windows\System32\WindowsPowerShell>Get-Location -StackName Stack2
-
-
 
 Path
 ----
 C:\Windows\System32
 ```
 
-This example shows how to use the *Stack* and *StackName* parameters of **Get-Location** to list the locations in the current location stack and alternate location stacks.
-For more information about location stacks, see the Notes.
+### Example 4: Customize the PowerShell prompt
 
-### Example 4: Customize the Windows PowerShell prompt
-```
+This example shows how to customize the PowerShell prompt.
+
+```powershell
 PS C:\>
 function prompt { 'PowerShell: ' + (get-location) + '> '}
 PowerShell: C:\WINDOWS>
 ```
 
-This example shows how to customize the Windows PowerShell prompt.
-The function that defines the prompt includes a **Get-Location** command, which is run whenever the prompt appears in the console.
+The function that defines the prompt includes a `Get-Location` command, which is run whenever the
+prompt appears in the console.
 
-The format of the default Windows PowerShell prompt is defined by a special function named prompt.
-You can change the prompt in your console by creating a new function named prompt.
+The format of the default PowerShell prompt is defined by a special function named `prompt`. You can
+change the prompt in your console by creating a new function named `prompt`.
 
 To see the current prompt function, type the following command: `Get-Content Function:prompt`
-
-The command begins with the function keyword followed by the function name, prompt.
-The function body appears within braces ( {} ).
-
-This command defines a new prompt that begins with the string "PowerShell: ".
-To append the current location, it uses a **Get-Location** command, which runs when the prompt function is called.
-The prompt ends with the string "\> ".
 
 ## PARAMETERS
 
 ### -PSDrive
-Specifies the current location in the specified Windows PowerShell drive that this cmdlet gets in the operation.
 
-For instance, if you are in the Certificate: drive, you can use this parameter to find your current location in the C: drive.
+Specifies the current location in the specified PowerShell drive that this cmdlet gets in the
+operation.
+
+For instance, if you are in the `Certificate:` drive, you can use this parameter to find your
+current location in the `C:` drive.
 
 ```yaml
 Type: String[]
@@ -177,11 +163,13 @@ Accept wildcard characters: False
 ```
 
 ### -PSProvider
-Specifies the current location in the drive supported by the Windows PowerShell provider that this cmdlet gets in the operation.
 
-If the specified provider supports more than one drive, this cmdlet returns the location on the most recently accessed drive.
+Specifies the current location in the drive supported by the PowerShell provider that this cmdlet
+gets in the operation. If the specified provider supports more than one drive, this cmdlet returns
+the location on the most recently accessed drive.
 
-For example, if you are in the C: drive, you can use this parameter to find your current location in the drives of the Windows PowerShellRegistry provider.
+For example, if you are in the `C:` drive, you can use this parameter to find your current location
+in the drives of the PowerShell **Registry** provider.
 
 ```yaml
 Type: String[]
@@ -196,10 +184,11 @@ Accept wildcard characters: False
 ```
 
 ### -Stack
+
 Indicates that this cmdlet displays the locations in the current location stack.
 
-To display the locations in a different location stack, use the *StackName* parameter.
-For information about location stacks, see the Notes.
+To display the locations in a different location stack, use the **StackName** parameter. For
+information about location stacks, see the Notes.
 
 ```yaml
 Type: SwitchParameter
@@ -214,14 +203,14 @@ Accept wildcard characters: False
 ```
 
 ### -StackName
-Specifies, as a string array, the named location stacks.
-Enter one or more location stack names.
 
-To display the locations in the current location stack, use the *Stack* parameter.
-To make a location stack the current location stack, use the Set-Location parameter.
-For information about location stacks, see the Notes.
+Specifies, as a string array, the named location stacks. Enter one or more location stack names.
 
-This cmdlet cannot display the locations in the unnamed default stack unless it is the current stack.
+To display the locations in the current location stack, use the **Stack** parameter. To make a
+location stack the current location stack, use the `Set-Location` parameter.
+
+This cmdlet cannot display the locations in the unnamed default stack unless it is the current
+stack.
 
 ```yaml
 Type: String[]
@@ -252,52 +241,66 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
 
 ## OUTPUTS
 
 ### System.Management.Automation.PathInfo or System.Management.Automation.PathInfoStack
-If you use the *Stack* or *StackName* parameters, this cmdlet returns a **StackInfo** object.
+
+If you use the **Stack** or **StackName** parameters, this cmdlet returns a **StackInfo** object.
 Otherwise, it returns a **PathInfo** object.
 
 ## NOTES
-* This cmdlet is designed to work with the data exposed by any provider. To list the providers in your session, type `Get-PSProvider`. For more information, see about_Providers.
 
-  The ways that the *PSProvider*, *PSDrive*, *Stack*, and *StackName* parameters interact depends on the provider.
-Some combinations will result in errors, such as specifying both a drive and a provider that does not expose that drive.
-If no parameters are specified, this cmdlet returns the **PathInfo** object for the provider that contains the current working location.
+PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
+This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+when calling .NET APIs or running native applications without providing explicit directory paths.
+The `Get-Location` cmdlet returns the current directory of the current PowerShell runspace.
 
-  A stack is a last-in, first-out list in which only the most recently added item is accessible.
-You add items to a stack in the order that you use them, and then retrieve them for use in the reverse order.
-Windows PowerShell lets you store provider locations in location stacks.
-Windows PowerShell creates an unnamed default location stack and you can create multiple named location stacks.
-If you do not specify a stack name, Windows PowerShell uses the current location stack.
-By default, the unnamed default location is the current location stack, but you can use the **Set-Location** cmdlet to change the current location stack.
+This cmdlet is designed to work with the data exposed by any provider. To list the providers in your
+session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-  To manage location stacks, use the Windows PowerShellLocation cmdlets, as follows.
+The ways that the **PSProvider**, **PSDrive**, **Stack**, and **StackName** parameters interact
+depends on the provider. Some combinations will result in errors, such as specifying both a drive
+and a provider that does not expose that drive. If no parameters are specified, this cmdlet returns
+the **PathInfo** object for the provider that contains the current working location.
 
-  - To add a location to a location stack, use the Push-Location cmdlet.
+A stack is a last-in, first-out list in which only the most recently added item is accessible. You
+add items to a stack in the order that you use them, and then retrieve them for use in the reverse
+order. PowerShell lets you store provider locations in location stacks. PowerShell creates an
+unnamed default location stack and you can create multiple named location stacks. If you do not
+specify a stack name, PowerShell uses the current location stack. By default, the unnamed default
+location is the current location stack, but you can use the `Set-Location` cmdlet to change the
+current location stack.
 
-  - To get a location from a location stack, use the Pop-Location cmdlet.
+To manage location stacks, use the PowerShellLocation cmdlets, as follows.
 
-  - To display the locations in the current location stack, use the *Stack* parameter of the **Get-Location** cmdlet.
-To display the locations in a named location stack, use the *StackName* parameter of the **Get-Location** cmdlet.
+- To add a location to a location stack, use the `Push-Location` cmdlet.
+- To get a location from a location stack, use the `Pop-Location` cmdlet.
+- To display the locations in the current location stack, use the **Stack** parameter of the
+  `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
+  parameter of the `Get-Location` cmdlet.
+- To create a new location stack, use the **StackName** parameter of the `Push-Location` cmdlet.
+  If you specify a stack that does not exist, `Push-Location` creates the stack.
+- To make a location stack the current location stack, use the **StackName** parameter of the
+  `Set-Location` cmdlet.
 
-  - To create a new location stack, use the *StackName* parameter of the **Push-Location** cmdlet.
-If you specify a stack that does not exist, **Push-Location** creates the stack.
-
-  - To make a location stack the current location stack, use the *StackName* parameter of the **Set-Location** cmdlet.
-
-  The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use the **Push-Location** or **Pop-Location** add or get items from the default stack or use this cmdlet command to display the locations in the unnamed stack.
-To make the unnamed stack the current stack, use the *StackName* parameter of the **Set-Location** cmdlet with a value of $null or an empty string ("").
-
-*
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you cannot no longer use the
+`Push-Location` or `Pop-Location` add or get items from the default stack or use this cmdlet command
+to display the locations in the unnamed stack. To make the unnamed stack the current stack, use the
+**StackName** parameter of the `Set-Location` cmdlet with a value of $null or an empty string ("").
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Resolve-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Resolve-Path.md
@@ -2,16 +2,14 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 08/23/2018
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/resolve-path?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Resolve-Path
 ---
-
 # Resolve-Path
 
 ## SYNOPSIS
-
 Resolves the wildcard characters in a path, and displays the path contents.
 
 ## SYNTAX
@@ -112,8 +110,8 @@ PS C:\> Resolve-Path -LiteralPath 'test[xml]'
 
 ### -Credential
 
-Specifies a user account that has permission to perform this action.
-The default is the current user.
+Specifies a user account that has permission to perform this action. The default is the current
+user.
 
 Type a user name, such as User01 or Domain01\User01, or pass a **PSCredential** object. You can
 create a **PSCredential** object using the `Get-Credential` cmdlet. If you type a user name, this
@@ -135,11 +133,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the path to be resolved.
-The value of the **LiteralPath** parameter is used exactly as typed.
-No characters are interpreted as wildcard characters.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies the path to be resolved. The value of the **LiteralPath** parameter is used exactly as
+typed. No characters are interpreted as wildcard characters. If the path includes escape characters,
+enclose it in single quotation marks. Single quotation marks tell PowerShell not to interpret any
+characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -155,9 +152,8 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the PowerShell path to resolve.
-This parameter is required.
-You can also pipe a path string to `Resolve-Path`.
+Specifies the PowerShell path to resolve. This parameter is required. You can also pipe a path
+string to `Resolve-Path`. Wildcard characters are permitted.
 
 ```yaml
 Type: String[]
@@ -165,10 +161,10 @@ Parameter Sets: Path
 Aliases:
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Relative
@@ -208,7 +204,8 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](../Microsoft.PowerShell.Core/About/about_CommonParameters.md).
 
 ## INPUTS
 
@@ -221,14 +218,18 @@ You can pipe a string that contains a path to this cmdlet.
 ### System.Management.Automation.PathInfo, System.String
 
 Returns a **PathInfo** object. Returns a string value for the resolved path if you specify the
-*Relative* parameter.
+**Relative** parameter.
 
 ## NOTES
 
-- The `*-Path` cmdlets work with the FileSystem, Registry, and Certificate providers.
-- `Resolve-Path` is designed to work with any provider. To list the providers available in your
-  session, type `Get-PSProvider`. For more information, see
-  [about_providers](../microsoft.powershell.core/about/about_providers.md).
+The `*-Path` cmdlets work with the FileSystem, Registry, and Certificate providers.
+
+`Resolve-Path` is designed to work with any provider. To list the providers available in your
+session, type `Get-PSProvider`. For more information, see
+[about_providers](../microsoft.powershell.core/about/about_providers.md).
+
+`Resolve-Path` only resolves existing paths. It cannot be used to resolve a location that does not
+exist yet.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Management/Convert-Path.md
+++ b/reference/6/Microsoft.PowerShell.Management/Convert-Path.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/09/2017
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/convert-path?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Convert-Path
@@ -29,46 +29,47 @@ Convert-Path -LiteralPath <String[]> [<CommonParameters>]
 
 ## DESCRIPTION
 
-The **Convert-Path** cmdlet converts a path from a PowerShell path to a PowerShell provider path.
+The `Convert-Path` cmdlet converts a path from a PowerShell path to a PowerShell provider path.
 
 ## EXAMPLES
 
 ### Example 1: Convert the working directory to a standard file system path
+
+This example converts the current working directory, which is represented by a dot (`.`), to a
+standard FileSystem path.
 
 ```
 PS C:\> Convert-Path .
 C:\
 ```
 
-This command converts the current working directory, which is represented by a dot (.), to a standard file system path.
-
 ### Example 2: Convert a provider path to a standard registry path
 
-```
+This example converts the PowerShell provider path to a standard registry path.
+
+```powershell
 PS C:\> Convert-Path HKLM:\Software\Microsoft
 HKEY_LOCAL_MACHINE\Software\Microsoft
 ```
 
-This command converts the PowerShell provider path to a standard registry path.
-
 ### Example 3: Convert a path to a string
 
-```
+This example converts the path to the home directory of the current provider, which is the
+FileSystem provider, to a string.
+
+```powershell
 PS C:\> Convert-Path ~
 C:\Users\User01
 ```
-
-This command converts the path to the home directory of the current provider, which is the FileSystem provider, to a string.
 
 ## PARAMETERS
 
 ### -LiteralPath
 
-Specifies, as a string array, the path to be converted.
-The value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies, as a string array, the path to be converted. The value of the **LiteralPath** parameter
+is used exactly as it is typed. No characters are interpreted as wildcards. If the path includes
+escape characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not
+to interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -100,7 +101,10 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -116,15 +120,20 @@ This cmdlet returns a string that contains the converted path.
 
 ## NOTES
 
-* The cmdlets that contain the Path noun manipulate path names and return the names in a concise format that all PowerShell providers can interpret. They are designed for use in programs and scripts where you want to display all or part of a path name in a particular format. Use them like you would use Dirname, Normpath, Realpath, Join, or other path manipulators.
+The cmdlets that contain the Path noun manipulate path names and return the names in a concise
+format that all PowerShell providers can interpret. They are designed for use in programs and
+scripts where you want to display all or part of a path name in a particular format. Use them like
+you would use **Dirname**, **Normpath**, **Realpath**, **Join**, or other path manipulators.
 
-  You can use the path cmdlets with several providers, including the FileSystem, Registry, and Certificate providers.
+You can use the path cmdlets with several providers, including the FileSystem, Registry, and
+Certificate providers.
 
-  This cmdlet is designed to work with the data exposed by any provider.
-To list the providers available in your session, type `Get-PSProvider`.
-For more information, see about_Providers.
+This cmdlet is designed to work with the data exposed by any provider. To list the providers
+available in your session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-*
+`Convert-Path` only converts existing paths. It cannot be used to convert a location that does not
+exist yet.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-Location.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/09/2017
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/get-location?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Location
@@ -29,147 +29,126 @@ Get-Location [-Stack] [-StackName <String[]>] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The **Get-Location** cmdlet gets an object that represents the current directory, much like the print working directory (pwd) command.
+The `Get-Location` cmdlet gets an object that represents the current directory, much like the print
+working directory (pwd) command.
 
-When you move between PowerShell drives, PowerShell retains your location in each drive.
-You can use this cmdlet to find your location in each drive.
+When you move between PowerShell drives, PowerShell retains your location in each drive. You can use
+this cmdlet to find your location in each drive.
 
-You can use this cmdlet to get the current directory at run time and use it in functions and scripts, such as in a function that displays the current directory in the PowerShell prompt.
+You can use this cmdlet to get the current directory at run time and use it in functions and
+scripts, such as in a function that displays the current directory in the PowerShell prompt.
 
-You can also use this cmdlet to display the locations in a location stack.
-For more information, see the Notes and the descriptions of the *Stack* and *StackName* parameters.
+You can also use this cmdlet to display the locations in a location stack. For more information, see
+the Notes and the descriptions of the **Stack** and **StackName** parameters.
 
 ## EXAMPLES
 
 ### Example 1: Display your current drive location
 
-```
+This command displays your location in the current PowerShell drive.
+
+```powershell
 PS C:\Windows> Get-Location
+```
+
+```Output
 Path
 ----
 C:\Windows
 ```
 
-This command displays your location in the current PowerShell drive.
-
-For instance, if you are in the Windows directory of the C: drive, it displays the path to that directory.
+For instance, if you are in the `Windows` directory of the `C:` drive, it displays the path to that
+directory.
 
 ### Example 2: Display your current location for different drives
 
-```
-The first command uses the **Set-Location** cmdlet to set the current location to the Windows subdirectory of the C: drive.
+This example demonstrates the use of `Get-Location` to display your current location in different
+PowerShell drives. `Set-Location` is used to change the location to several different paths on
+different **PSDrives**.
+
+```powershell
 PS C:\> Set-Location C:\Windows
-
-The second command uses the **Set-Location** cmdlet to change the location to the HKLM:\Software\Microsoft registry key. When you change to a location in the HKLM: drive, PowerShell retains your location in the C: drive.
 PS C:\Windows> Set-Location HKLM:\Software\Microsoft
-PS HKLM:\Software\Microsoft>
-
-The third command uses the **Set-Location** cmdlet to change the location to the HKCU:\Control Panel\Input Method registry key.
 PS HKLM:\Software\Microsoft> Set-Location "HKCU:\Control Panel\Input Method"
-PS HKCU:\Control Panel\Input Method>
-
-The fourth command uses the **Get-Location** cmdlet to find the current location on the C: drive. It uses the *PSDrive* parameter to specify the drive.
 PS HKCU:\Control Panel\Input Method> Get-Location -PSDrive C
-
-
 
 Path
 ----
 C:\Windows
 
+PS C:\Windows> Get-Location -PSDrive HKLM
 
-The fifth command uses the **Set-Location** cmdlet to return to the C: drive. Even though the command does not specify a subdirectory, PowerShell returns you to the saved location.
+Path
+----
+HKLM:\Software\Microsoft
+
 PS HKCU:\Control Panel\Input Method> Set-Location C:
-PS C:\Windows>
-
-The sixth command uses the **Get-Location** cmdlet to find the current location in the drives supported by the PowerShell registry provider. **Get-Location** returns the location of the most recently accessed registry drive, HKCU.
 PS C:\Windows> Get-Location -PSProvider registry
-
-
-
 
 Path
 ----
 HKCU:\Control Panel\Input Method
-
-
-To see the current location in the HKLM: drive, you need to use the *PSDrive* parameter to specify the drive. The seventh command does just this:
-PS C:\Windows> Get-Location -PSDrive HKLM
-
-
 
 Path
 ----
 HKLM:\Software\Microsoft
 ```
 
-This example demonstrates the use of **Get-Location** to display your current location in different PowerShell drives.
+### Example 3: Get locations using stacks
 
-### Example 3:
+This example shows how to use the **Stack** and **StackName** parameters of `Get-Location` to list
+the locations in the current location stack and alternate location stacks.
 
-```
-The first command sets the current location to the Windows directory on the C: drive.
-PS C:\> Set-Location C:\Windows
+The `Push-Location` cmdlet is used to change into three different locations. The third push uses a
+different stack name. The **Stack** parameter of `Get-Location` displays the contents of the default
+stack. The **StackName** parameter of `Get-Location` displays the contents of the stack named
+`Stack2`.
 
-The second command uses the **Push-Location** cmdlet to push the current location (C:\Windows) onto the current location stack and change to the System32 subdirectory. Because no stack is specified, the current location is pushed onto the current location stack. By default, the current location stack is the unnamed default location stack.
+```powershell
+PS C:\> Push-Location C:\Windows
 PS C:\Windows>Push-Location System32
-
-The third command uses the *StackName* parameter of the **Push-Location** cmdlet to push the current location (C:\Windows\System32) onto the Stack2 stack and to change the current location to the WindowsPowerShell subirectory. If the Stack2 stack does not exist, **Push-Location** creates it.
 PS C:\Windows\System32>Push-Location WindowsPowerShell -StackName Stack2
-
-The fourth command uses the *Stack* parameter of the **Get-Location** cmdlet to get the locations in the current location stack. By default, the current stack is the unnamed default location stack.
 C:\Windows\System32\WindowsPowerShell>Get-Location -Stack
-
-
 
 Path
 ----
 C:\Windows
+C:\
 
-
-The fifth command uses the *StackName* parameter of the **Get-Location** cmdlet to get the locations in the Stack2 stack.
 C:\Windows\System32\WindowsPowerShell>Get-Location -StackName Stack2
-
-
 
 Path
 ----
 C:\Windows\System32
 ```
 
-This example shows how to use the *Stack* and *StackName* parameters of **Get-Location** to list the locations in the current location stack and alternate location stacks.
-For more information about location stacks, see the Notes.
-
 ### Example 4: Customize the PowerShell prompt
 
-```
+This example shows how to customize the PowerShell prompt.
+
+```powershell
 PS C:\>
 function prompt { 'PowerShell: ' + (get-location) + '> '}
 PowerShell: C:\WINDOWS>
 ```
 
-This example shows how to customize the PowerShell prompt.
-The function that defines the prompt includes a **Get-Location** command, which is run whenever the prompt appears in the console.
+The function that defines the prompt includes a `Get-Location` command, which is run whenever the
+prompt appears in the console.
 
-The format of the default PowerShell prompt is defined by a special function named prompt.
-You can change the prompt in your console by creating a new function named prompt.
+The format of the default PowerShell prompt is defined by a special function named `prompt`. You can
+change the prompt in your console by creating a new function named `prompt`.
 
 To see the current prompt function, type the following command: `Get-Content Function:prompt`
-
-The command begins with the function keyword followed by the function name, prompt.
-The function body appears within braces ( {} ).
-
-This command defines a new prompt that begins with the string "PowerShell: ".
-To append the current location, it uses a **Get-Location** command, which runs when the prompt function is called.
-The prompt ends with the string "\> ".
 
 ## PARAMETERS
 
 ### -PSDrive
 
-Specifies the current location in the specified PowerShell drive that this cmdlet gets in the operation.
+Specifies the current location in the specified PowerShell drive that this cmdlet gets in the
+operation.
 
-For instance, if you are in the Certificate: drive, you can use this parameter to find your current location in the C: drive.
+For instance, if you are in the `Certificate:` drive, you can use this parameter to find your
+current location in the `C:` drive.
 
 ```yaml
 Type: String[]
@@ -185,11 +164,12 @@ Accept wildcard characters: False
 
 ### -PSProvider
 
-Specifies the current location in the drive supported by the PowerShell provider that this cmdlet gets in the operation.
+Specifies the current location in the drive supported by the PowerShell provider that this cmdlet
+gets in the operation. If the specified provider supports more than one drive, this cmdlet returns
+the location on the most recently accessed drive.
 
-If the specified provider supports more than one drive, this cmdlet returns the location on the most recently accessed drive.
-
-For example, if you are in the C: drive, you can use this parameter to find your current location in the drives of the PowerShellRegistry provider.
+For example, if you are in the `C:` drive, you can use this parameter to find your current location
+in the drives of the PowerShell **Registry** provider.
 
 ```yaml
 Type: String[]
@@ -207,8 +187,8 @@ Accept wildcard characters: False
 
 Indicates that this cmdlet displays the locations in the current location stack.
 
-To display the locations in a different location stack, use the *StackName* parameter.
-For information about location stacks, see the Notes.
+To display the locations in a different location stack, use the **StackName** parameter. For
+information about location stacks, see the Notes.
 
 ```yaml
 Type: SwitchParameter
@@ -224,14 +204,13 @@ Accept wildcard characters: False
 
 ### -StackName
 
-Specifies, as a string array, the named location stacks.
-Enter one or more location stack names.
+Specifies, as a string array, the named location stacks. Enter one or more location stack names.
 
-To display the locations in the current location stack, use the *Stack* parameter.
-To make a location stack the current location stack, use the Set-Location parameter.
-For information about location stacks, see the Notes.
+To display the locations in the current location stack, use the **Stack** parameter. To make a
+location stack the current location stack, use the `Set-Location` parameter.
 
-This cmdlet cannot display the locations in the unnamed default stack unless it is the current stack.
+This cmdlet cannot display the locations in the unnamed default stack unless it is the current
+stack.
 
 ```yaml
 Type: String[]
@@ -247,7 +226,10 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -259,43 +241,50 @@ You cannot pipe input to this cmdlet.
 
 ### System.Management.Automation.PathInfo or System.Management.Automation.PathInfoStack
 
-If you use the *Stack* or *StackName* parameters, this cmdlet returns a **StackInfo** object.
+If you use the **Stack** or **StackName** parameters, this cmdlet returns a **StackInfo** object.
 Otherwise, it returns a **PathInfo** object.
 
 ## NOTES
 
-* This cmdlet is designed to work with the data exposed by any provider. To list the providers in your session, type `Get-PSProvider`. For more information, see about_Providers.
+PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
+This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+when calling .NET APIs or running native applications without providing explicit directory paths.
+The `Get-Location` cmdlet returns the current directory of the current PowerShell runspace.
 
-  The ways that the *PSProvider*, *PSDrive*, *Stack*, and *StackName* parameters interact depends on the provider.
-Some combinations will result in errors, such as specifying both a drive and a provider that does not expose that drive.
-If no parameters are specified, this cmdlet returns the **PathInfo** object for the provider that contains the current working location.
+This cmdlet is designed to work with the data exposed by any provider. To list the providers in your
+session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-  A stack is a last-in, first-out list in which only the most recently added item is accessible.
-You add items to a stack in the order that you use them, and then retrieve them for use in the reverse order.
-PowerShell lets you store provider locations in location stacks.
-PowerShell creates an unnamed default location stack and you can create multiple named location stacks.
-If you do not specify a stack name, PowerShell uses the current location stack.
-By default, the unnamed default location is the current location stack, but you can use the **Set-Location** cmdlet to change the current location stack.
+The ways that the **PSProvider**, **PSDrive**, **Stack**, and **StackName** parameters interact
+depends on the provider. Some combinations will result in errors, such as specifying both a drive
+and a provider that does not expose that drive. If no parameters are specified, this cmdlet returns
+the **PathInfo** object for the provider that contains the current working location.
 
-  To manage location stacks, use the PowerShellLocation cmdlets, as follows.
+A stack is a last-in, first-out list in which only the most recently added item is accessible. You
+add items to a stack in the order that you use them, and then retrieve them for use in the reverse
+order. PowerShell lets you store provider locations in location stacks. PowerShell creates an
+unnamed default location stack and you can create multiple named location stacks. If you do not
+specify a stack name, PowerShell uses the current location stack. By default, the unnamed default
+location is the current location stack, but you can use the `Set-Location` cmdlet to change the
+current location stack.
 
-  - To add a location to a location stack, use the Push-Location cmdlet.
+To manage location stacks, use the PowerShellLocation cmdlets, as follows.
 
-  - To get a location from a location stack, use the Pop-Location cmdlet.
+- To add a location to a location stack, use the `Push-Location` cmdlet.
+- To get a location from a location stack, use the `Pop-Location` cmdlet.
+- To display the locations in the current location stack, use the **Stack** parameter of the
+  `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
+  parameter of the `Get-Location` cmdlet.
+- To create a new location stack, use the **StackName** parameter of the `Push-Location` cmdlet.
+  If you specify a stack that does not exist, `Push-Location` creates the stack.
+- To make a location stack the current location stack, use the **StackName** parameter of the
+  `Set-Location` cmdlet.
 
-  - To display the locations in the current location stack, use the *Stack* parameter of the **Get-Location** cmdlet.
-To display the locations in a named location stack, use the *StackName* parameter of the **Get-Location** cmdlet.
-
-  - To create a new location stack, use the *StackName* parameter of the **Push-Location** cmdlet.
-If you specify a stack that does not exist, **Push-Location** creates the stack.
-
-  - To make a location stack the current location stack, use the *StackName* parameter of the **Set-Location** cmdlet.
-
-  The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use the **Push-Location** or **Pop-Location** add or get items from the default stack or use this cmdlet command to display the locations in the unnamed stack.
-To make the unnamed stack the current stack, use the *StackName* parameter of the **Set-Location** cmdlet with a value of $null or an empty string ("").
-
-*
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you cannot no longer use the
+`Push-Location` or `Pop-Location` add or get items from the default stack or use this cmdlet command
+to display the locations in the unnamed stack. To make the unnamed stack the current stack, use the
+**StackName** parameter of the `Set-Location` cmdlet with a value of $null or an empty string ("").
 
 ## RELATED LINKS
 
@@ -304,5 +293,3 @@ To make the unnamed stack the current stack, use the *StackName* parameter of th
 [Push-Location](Push-Location.md)
 
 [Set-Location](Set-Location.md)
-
-

--- a/reference/6/Microsoft.PowerShell.Management/Resolve-Path.md
+++ b/reference/6/Microsoft.PowerShell.Management/Resolve-Path.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 5/14/2019
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/resolve-path?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Resolve-Path
@@ -109,8 +109,8 @@ PS C:\> Resolve-Path -LiteralPath 'test[xml]'
 
 ### -Credential
 
-Specifies a user account that has permission to perform this action.
-The default is the current user.
+Specifies a user account that has permission to perform this action. The default is the current
+user.
 
 Type a user name, such as User01 or Domain01\User01, or pass a **PSCredential** object. You can
 create a **PSCredential** object using the `Get-Credential` cmdlet. If you type a user name, this
@@ -132,11 +132,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the path to be resolved.
-The value of the **LiteralPath** parameter is used exactly as typed.
-No characters are interpreted as wildcard characters.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies the path to be resolved. The value of the **LiteralPath** parameter is used exactly as
+typed. No characters are interpreted as wildcard characters. If the path includes escape characters,
+enclose it in single quotation marks. Single quotation marks tell PowerShell not to interpret any
+characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -152,10 +151,8 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the PowerShell path to resolve.
-This parameter is required.
-You can also pipe a path string to `Resolve-Path`.
-Wildcard characters are permitted.
+Specifies the PowerShell path to resolve. This parameter is required. You can also pipe a path
+string to `Resolve-Path`. Wildcard characters are permitted.
 
 ```yaml
 Type: String[]
@@ -189,27 +186,32 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](../Microsoft.PowerShell.Core/About/about_CommonParameters.md).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](../Microsoft.PowerShell.Core/About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to this cmdlet
+You can pipe a string that contains a path to this cmdlet.
 
 ## OUTPUTS
 
 ### System.Management.Automation.PathInfo, System.String
 
 Returns a **PathInfo** object. Returns a string value for the resolved path if you specify the
-*Relative* parameter.
+**Relative** parameter.
 
 ## NOTES
 
-- The `*-Path` cmdlets work with the FileSystem, Registry, and Certificate providers.
-- `Resolve-Path` is designed to work with any provider. To list the providers available in your
-  session, type `Get-PSProvider`. For more information, see
-  [about_providers](../microsoft.powershell.core/about/about_providers.md).
+The `*-Path` cmdlets work with the FileSystem, Registry, and Certificate providers.
+
+`Resolve-Path` is designed to work with any provider. To list the providers available in your
+session, type `Get-PSProvider`. For more information, see
+[about_providers](../microsoft.powershell.core/about/about_providers.md).
+
+`Resolve-Path` only resolves existing paths. It cannot be used to resolve a location that does not
+exist yet.
 
 ## RELATED LINKS
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Convert-Path.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Convert-Path.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/09/2017
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/convert-path?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Convert-Path
@@ -29,46 +29,47 @@ Convert-Path -LiteralPath <String[]> [<CommonParameters>]
 
 ## DESCRIPTION
 
-The **Convert-Path** cmdlet converts a path from a PowerShell path to a PowerShell provider path.
+The `Convert-Path` cmdlet converts a path from a PowerShell path to a PowerShell provider path.
 
 ## EXAMPLES
 
 ### Example 1: Convert the working directory to a standard file system path
+
+This example converts the current working directory, which is represented by a dot (`.`), to a
+standard FileSystem path.
 
 ```
 PS C:\> Convert-Path .
 C:\
 ```
 
-This command converts the current working directory, which is represented by a dot (.), to a standard file system path.
-
 ### Example 2: Convert a provider path to a standard registry path
 
-```
+This example converts the PowerShell provider path to a standard registry path.
+
+```powershell
 PS C:\> Convert-Path HKLM:\Software\Microsoft
 HKEY_LOCAL_MACHINE\Software\Microsoft
 ```
 
-This command converts the PowerShell provider path to a standard registry path.
-
 ### Example 3: Convert a path to a string
 
-```
+This example converts the path to the home directory of the current provider, which is the
+FileSystem provider, to a string.
+
+```powershell
 PS C:\> Convert-Path ~
 C:\Users\User01
 ```
-
-This command converts the path to the home directory of the current provider, which is the FileSystem provider, to a string.
 
 ## PARAMETERS
 
 ### -LiteralPath
 
-Specifies, as a string array, the path to be converted.
-The value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies, as a string array, the path to be converted. The value of the **LiteralPath** parameter
+is used exactly as it is typed. No characters are interpreted as wildcards. If the path includes
+escape characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not
+to interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -100,7 +101,10 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -116,15 +120,20 @@ This cmdlet returns a string that contains the converted path.
 
 ## NOTES
 
-* The cmdlets that contain the Path noun manipulate path names and return the names in a concise format that all PowerShell providers can interpret. They are designed for use in programs and scripts where you want to display all or part of a path name in a particular format. Use them like you would use Dirname, Normpath, Realpath, Join, or other path manipulators.
+The cmdlets that contain the Path noun manipulate path names and return the names in a concise
+format that all PowerShell providers can interpret. They are designed for use in programs and
+scripts where you want to display all or part of a path name in a particular format. Use them like
+you would use **Dirname**, **Normpath**, **Realpath**, **Join**, or other path manipulators.
 
-  You can use the path cmdlets with several providers, including the FileSystem, Registry, and Certificate providers.
+You can use the path cmdlets with several providers, including the FileSystem, Registry, and
+Certificate providers.
 
-  This cmdlet is designed to work with the data exposed by any provider.
-To list the providers available in your session, type `Get-PSProvider`.
-For more information, see about_Providers.
+This cmdlet is designed to work with the data exposed by any provider. To list the providers
+available in your session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-*
+`Convert-Path` only converts existing paths. It cannot be used to convert a location that does not
+exist yet.
 
 ## RELATED LINKS
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Get-Location.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/09/2017
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/get-location?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Location
@@ -29,147 +29,126 @@ Get-Location [-Stack] [-StackName <String[]>] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The **Get-Location** cmdlet gets an object that represents the current directory, much like the print working directory (pwd) command.
+The `Get-Location` cmdlet gets an object that represents the current directory, much like the print
+working directory (pwd) command.
 
-When you move between PowerShell drives, PowerShell retains your location in each drive.
-You can use this cmdlet to find your location in each drive.
+When you move between PowerShell drives, PowerShell retains your location in each drive. You can use
+this cmdlet to find your location in each drive.
 
-You can use this cmdlet to get the current directory at run time and use it in functions and scripts, such as in a function that displays the current directory in the PowerShell prompt.
+You can use this cmdlet to get the current directory at run time and use it in functions and
+scripts, such as in a function that displays the current directory in the PowerShell prompt.
 
-You can also use this cmdlet to display the locations in a location stack.
-For more information, see the Notes and the descriptions of the *Stack* and *StackName* parameters.
+You can also use this cmdlet to display the locations in a location stack. For more information, see
+the Notes and the descriptions of the **Stack** and **StackName** parameters.
 
 ## EXAMPLES
 
 ### Example 1: Display your current drive location
 
-```
+This command displays your location in the current PowerShell drive.
+
+```powershell
 PS C:\Windows> Get-Location
+```
+
+```Output
 Path
 ----
 C:\Windows
 ```
 
-This command displays your location in the current PowerShell drive.
-
-For instance, if you are in the Windows directory of the C: drive, it displays the path to that directory.
+For instance, if you are in the `Windows` directory of the `C:` drive, it displays the path to that
+directory.
 
 ### Example 2: Display your current location for different drives
 
-```
-The first command uses the **Set-Location** cmdlet to set the current location to the Windows subdirectory of the C: drive.
+This example demonstrates the use of `Get-Location` to display your current location in different
+PowerShell drives. `Set-Location` is used to change the location to several different paths on
+different **PSDrives**.
+
+```powershell
 PS C:\> Set-Location C:\Windows
-
-The second command uses the **Set-Location** cmdlet to change the location to the HKLM:\Software\Microsoft registry key. When you change to a location in the HKLM: drive, PowerShell retains your location in the C: drive.
 PS C:\Windows> Set-Location HKLM:\Software\Microsoft
-PS HKLM:\Software\Microsoft>
-
-The third command uses the **Set-Location** cmdlet to change the location to the HKCU:\Control Panel\Input Method registry key.
 PS HKLM:\Software\Microsoft> Set-Location "HKCU:\Control Panel\Input Method"
-PS HKCU:\Control Panel\Input Method>
-
-The fourth command uses the **Get-Location** cmdlet to find the current location on the C: drive. It uses the *PSDrive* parameter to specify the drive.
 PS HKCU:\Control Panel\Input Method> Get-Location -PSDrive C
-
-
 
 Path
 ----
 C:\Windows
 
+PS C:\Windows> Get-Location -PSDrive HKLM
 
-The fifth command uses the **Set-Location** cmdlet to return to the C: drive. Even though the command does not specify a subdirectory, PowerShell returns you to the saved location.
+Path
+----
+HKLM:\Software\Microsoft
+
 PS HKCU:\Control Panel\Input Method> Set-Location C:
-PS C:\Windows>
-
-The sixth command uses the **Get-Location** cmdlet to find the current location in the drives supported by the PowerShell registry provider. **Get-Location** returns the location of the most recently accessed registry drive, HKCU.
 PS C:\Windows> Get-Location -PSProvider registry
-
-
-
 
 Path
 ----
 HKCU:\Control Panel\Input Method
-
-
-To see the current location in the HKLM: drive, you need to use the *PSDrive* parameter to specify the drive. The seventh command does just this:
-PS C:\Windows> Get-Location -PSDrive HKLM
-
-
 
 Path
 ----
 HKLM:\Software\Microsoft
 ```
 
-This example demonstrates the use of **Get-Location** to display your current location in different PowerShell drives.
+### Example 3: Get locations using stacks
 
-### Example 3:
+This example shows how to use the **Stack** and **StackName** parameters of `Get-Location` to list
+the locations in the current location stack and alternate location stacks.
 
-```
-The first command sets the current location to the Windows directory on the C: drive.
-PS C:\> Set-Location C:\Windows
+The `Push-Location` cmdlet is used to change into three different locations. The third push uses a
+different stack name. The **Stack** parameter of `Get-Location` displays the contents of the default
+stack. The **StackName** parameter of `Get-Location` displays the contents of the stack named
+`Stack2`.
 
-The second command uses the **Push-Location** cmdlet to push the current location (C:\Windows) onto the current location stack and change to the System32 subdirectory. Because no stack is specified, the current location is pushed onto the current location stack. By default, the current location stack is the unnamed default location stack.
+```powershell
+PS C:\> Push-Location C:\Windows
 PS C:\Windows>Push-Location System32
-
-The third command uses the *StackName* parameter of the **Push-Location** cmdlet to push the current location (C:\Windows\System32) onto the Stack2 stack and to change the current location to the WindowsPowerShell subirectory. If the Stack2 stack does not exist, **Push-Location** creates it.
 PS C:\Windows\System32>Push-Location WindowsPowerShell -StackName Stack2
-
-The fourth command uses the *Stack* parameter of the **Get-Location** cmdlet to get the locations in the current location stack. By default, the current stack is the unnamed default location stack.
 C:\Windows\System32\WindowsPowerShell>Get-Location -Stack
-
-
 
 Path
 ----
 C:\Windows
+C:\
 
-
-The fifth command uses the *StackName* parameter of the **Get-Location** cmdlet to get the locations in the Stack2 stack.
 C:\Windows\System32\WindowsPowerShell>Get-Location -StackName Stack2
-
-
 
 Path
 ----
 C:\Windows\System32
 ```
 
-This example shows how to use the *Stack* and *StackName* parameters of **Get-Location** to list the locations in the current location stack and alternate location stacks.
-For more information about location stacks, see the Notes.
-
 ### Example 4: Customize the PowerShell prompt
 
-```
+This example shows how to customize the PowerShell prompt.
+
+```powershell
 PS C:\>
 function prompt { 'PowerShell: ' + (get-location) + '> '}
 PowerShell: C:\WINDOWS>
 ```
 
-This example shows how to customize the PowerShell prompt.
-The function that defines the prompt includes a **Get-Location** command, which is run whenever the prompt appears in the console.
+The function that defines the prompt includes a `Get-Location` command, which is run whenever the
+prompt appears in the console.
 
-The format of the default PowerShell prompt is defined by a special function named prompt.
-You can change the prompt in your console by creating a new function named prompt.
+The format of the default PowerShell prompt is defined by a special function named `prompt`. You can
+change the prompt in your console by creating a new function named `prompt`.
 
 To see the current prompt function, type the following command: `Get-Content Function:prompt`
-
-The command begins with the function keyword followed by the function name, prompt.
-The function body appears within braces ( {} ).
-
-This command defines a new prompt that begins with the string "PowerShell: ".
-To append the current location, it uses a **Get-Location** command, which runs when the prompt function is called.
-The prompt ends with the string "\> ".
 
 ## PARAMETERS
 
 ### -PSDrive
 
-Specifies the current location in the specified PowerShell drive that this cmdlet gets in the operation.
+Specifies the current location in the specified PowerShell drive that this cmdlet gets in the
+operation.
 
-For instance, if you are in the Certificate: drive, you can use this parameter to find your current location in the C: drive.
+For instance, if you are in the `Certificate:` drive, you can use this parameter to find your
+current location in the `C:` drive.
 
 ```yaml
 Type: String[]
@@ -185,11 +164,12 @@ Accept wildcard characters: False
 
 ### -PSProvider
 
-Specifies the current location in the drive supported by the PowerShell provider that this cmdlet gets in the operation.
+Specifies the current location in the drive supported by the PowerShell provider that this cmdlet
+gets in the operation. If the specified provider supports more than one drive, this cmdlet returns
+the location on the most recently accessed drive.
 
-If the specified provider supports more than one drive, this cmdlet returns the location on the most recently accessed drive.
-
-For example, if you are in the C: drive, you can use this parameter to find your current location in the drives of the PowerShellRegistry provider.
+For example, if you are in the `C:` drive, you can use this parameter to find your current location
+in the drives of the PowerShell **Registry** provider.
 
 ```yaml
 Type: String[]
@@ -207,8 +187,8 @@ Accept wildcard characters: False
 
 Indicates that this cmdlet displays the locations in the current location stack.
 
-To display the locations in a different location stack, use the *StackName* parameter.
-For information about location stacks, see the Notes.
+To display the locations in a different location stack, use the **StackName** parameter. For
+information about location stacks, see the Notes.
 
 ```yaml
 Type: SwitchParameter
@@ -224,14 +204,13 @@ Accept wildcard characters: False
 
 ### -StackName
 
-Specifies, as a string array, the named location stacks.
-Enter one or more location stack names.
+Specifies, as a string array, the named location stacks. Enter one or more location stack names.
 
-To display the locations in the current location stack, use the *Stack* parameter.
-To make a location stack the current location stack, use the Set-Location parameter.
-For information about location stacks, see the Notes.
+To display the locations in the current location stack, use the **Stack** parameter. To make a
+location stack the current location stack, use the `Set-Location` parameter.
 
-This cmdlet cannot display the locations in the unnamed default stack unless it is the current stack.
+This cmdlet cannot display the locations in the unnamed default stack unless it is the current
+stack.
 
 ```yaml
 Type: String[]
@@ -247,7 +226,10 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -259,43 +241,50 @@ You cannot pipe input to this cmdlet.
 
 ### System.Management.Automation.PathInfo or System.Management.Automation.PathInfoStack
 
-If you use the *Stack* or *StackName* parameters, this cmdlet returns a **StackInfo** object.
+If you use the **Stack** or **StackName** parameters, this cmdlet returns a **StackInfo** object.
 Otherwise, it returns a **PathInfo** object.
 
 ## NOTES
 
-* This cmdlet is designed to work with the data exposed by any provider. To list the providers in your session, type `Get-PSProvider`. For more information, see about_Providers.
+PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
+This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+when calling .NET APIs or running native applications without providing explicit directory paths.
+The `Get-Location` cmdlet returns the current directory of the current PowerShell runspace.
 
-  The ways that the *PSProvider*, *PSDrive*, *Stack*, and *StackName* parameters interact depends on the provider.
-Some combinations will result in errors, such as specifying both a drive and a provider that does not expose that drive.
-If no parameters are specified, this cmdlet returns the **PathInfo** object for the provider that contains the current working location.
+This cmdlet is designed to work with the data exposed by any provider. To list the providers in your
+session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-  A stack is a last-in, first-out list in which only the most recently added item is accessible.
-You add items to a stack in the order that you use them, and then retrieve them for use in the reverse order.
-PowerShell lets you store provider locations in location stacks.
-PowerShell creates an unnamed default location stack and you can create multiple named location stacks.
-If you do not specify a stack name, PowerShell uses the current location stack.
-By default, the unnamed default location is the current location stack, but you can use the **Set-Location** cmdlet to change the current location stack.
+The ways that the **PSProvider**, **PSDrive**, **Stack**, and **StackName** parameters interact
+depends on the provider. Some combinations will result in errors, such as specifying both a drive
+and a provider that does not expose that drive. If no parameters are specified, this cmdlet returns
+the **PathInfo** object for the provider that contains the current working location.
 
-  To manage location stacks, use the PowerShellLocation cmdlets, as follows.
+A stack is a last-in, first-out list in which only the most recently added item is accessible. You
+add items to a stack in the order that you use them, and then retrieve them for use in the reverse
+order. PowerShell lets you store provider locations in location stacks. PowerShell creates an
+unnamed default location stack and you can create multiple named location stacks. If you do not
+specify a stack name, PowerShell uses the current location stack. By default, the unnamed default
+location is the current location stack, but you can use the `Set-Location` cmdlet to change the
+current location stack.
 
-  - To add a location to a location stack, use the Push-Location cmdlet.
+To manage location stacks, use the PowerShellLocation cmdlets, as follows.
 
-  - To get a location from a location stack, use the Pop-Location cmdlet.
+- To add a location to a location stack, use the `Push-Location` cmdlet.
+- To get a location from a location stack, use the `Pop-Location` cmdlet.
+- To display the locations in the current location stack, use the **Stack** parameter of the
+  `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
+  parameter of the `Get-Location` cmdlet.
+- To create a new location stack, use the **StackName** parameter of the `Push-Location` cmdlet.
+  If you specify a stack that does not exist, `Push-Location` creates the stack.
+- To make a location stack the current location stack, use the **StackName** parameter of the
+  `Set-Location` cmdlet.
 
-  - To display the locations in the current location stack, use the *Stack* parameter of the **Get-Location** cmdlet.
-To display the locations in a named location stack, use the *StackName* parameter of the **Get-Location** cmdlet.
-
-  - To create a new location stack, use the *StackName* parameter of the **Push-Location** cmdlet.
-If you specify a stack that does not exist, **Push-Location** creates the stack.
-
-  - To make a location stack the current location stack, use the *StackName* parameter of the **Set-Location** cmdlet.
-
-  The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use the **Push-Location** or **Pop-Location** add or get items from the default stack or use this cmdlet command to display the locations in the unnamed stack.
-To make the unnamed stack the current stack, use the *StackName* parameter of the **Set-Location** cmdlet with a value of $null or an empty string ("").
-
-*
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you cannot no longer use the
+`Push-Location` or `Pop-Location` add or get items from the default stack or use this cmdlet command
+to display the locations in the unnamed stack. To make the unnamed stack the current stack, use the
+**StackName** parameter of the `Set-Location` cmdlet with a value of $null or an empty string ("").
 
 ## RELATED LINKS
 
@@ -304,5 +293,3 @@ To make the unnamed stack the current stack, use the *StackName* parameter of th
 [Push-Location](Push-Location.md)
 
 [Set-Location](Set-Location.md)
-
-

--- a/reference/7.0/Microsoft.PowerShell.Management/Resolve-Path.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Resolve-Path.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 5/14/2019
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/resolve-path?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Resolve-Path
@@ -109,8 +109,8 @@ PS C:\> Resolve-Path -LiteralPath 'test[xml]'
 
 ### -Credential
 
-Specifies a user account that has permission to perform this action.
-The default is the current user.
+Specifies a user account that has permission to perform this action. The default is the current
+user.
 
 Type a user name, such as User01 or Domain01\User01, or pass a **PSCredential** object. You can
 create a **PSCredential** object using the `Get-Credential` cmdlet. If you type a user name, this
@@ -132,11 +132,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the path to be resolved.
-The value of the **LiteralPath** parameter is used exactly as typed.
-No characters are interpreted as wildcard characters.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies the path to be resolved. The value of the **LiteralPath** parameter is used exactly as
+typed. No characters are interpreted as wildcard characters. If the path includes escape characters,
+enclose it in single quotation marks. Single quotation marks tell PowerShell not to interpret any
+characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -152,10 +151,8 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the PowerShell path to resolve.
-This parameter is required.
-You can also pipe a path string to `Resolve-Path`.
-Wildcard characters are permitted.
+Specifies the PowerShell path to resolve. This parameter is required. You can also pipe a path
+string to `Resolve-Path`. Wildcard characters are permitted.
 
 ```yaml
 Type: String[]
@@ -189,27 +186,32 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](../Microsoft.PowerShell.Core/About/about_CommonParameters.md).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](../Microsoft.PowerShell.Core/About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### System.String
 
-You can pipe a string that contains a path to this cmdlet
+You can pipe a string that contains a path to this cmdlet.
 
 ## OUTPUTS
 
 ### System.Management.Automation.PathInfo, System.String
 
 Returns a **PathInfo** object. Returns a string value for the resolved path if you specify the
-*Relative* parameter.
+**Relative** parameter.
 
 ## NOTES
 
-- The `*-Path` cmdlets work with the FileSystem, Registry, and Certificate providers.
-- `Resolve-Path` is designed to work with any provider. To list the providers available in your
-  session, type `Get-PSProvider`. For more information, see
-  [about_providers](../microsoft.powershell.core/about/about_providers.md).
+The `*-Path` cmdlets work with the FileSystem, Registry, and Certificate providers.
+
+`Resolve-Path` is designed to work with any provider. To list the providers available in your
+session, type `Get-PSProvider`. For more information, see
+[about_providers](../microsoft.powershell.core/about/about_providers.md).
+
+`Resolve-Path` only resolves existing paths. It cannot be used to resolve a location that does not
+exist yet.
 
 ## RELATED LINKS
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Convert-Path.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Convert-Path.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/09/2017
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/convert-path?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Convert-Path
@@ -29,46 +29,47 @@ Convert-Path -LiteralPath <String[]> [<CommonParameters>]
 
 ## DESCRIPTION
 
-The **Convert-Path** cmdlet converts a path from a PowerShell path to a PowerShell provider path.
+The `Convert-Path` cmdlet converts a path from a PowerShell path to a PowerShell provider path.
 
 ## EXAMPLES
 
 ### Example 1: Convert the working directory to a standard file system path
+
+This example converts the current working directory, which is represented by a dot (`.`), to a
+standard FileSystem path.
 
 ```
 PS C:\> Convert-Path .
 C:\
 ```
 
-This command converts the current working directory, which is represented by a dot (.), to a standard file system path.
-
 ### Example 2: Convert a provider path to a standard registry path
 
-```
+This example converts the PowerShell provider path to a standard registry path.
+
+```powershell
 PS C:\> Convert-Path HKLM:\Software\Microsoft
 HKEY_LOCAL_MACHINE\Software\Microsoft
 ```
 
-This command converts the PowerShell provider path to a standard registry path.
-
 ### Example 3: Convert a path to a string
 
-```
+This example converts the path to the home directory of the current provider, which is the
+FileSystem provider, to a string.
+
+```powershell
 PS C:\> Convert-Path ~
 C:\Users\User01
 ```
-
-This command converts the path to the home directory of the current provider, which is the FileSystem provider, to a string.
 
 ## PARAMETERS
 
 ### -LiteralPath
 
-Specifies, as a string array, the path to be converted.
-The value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies, as a string array, the path to be converted. The value of the **LiteralPath** parameter
+is used exactly as it is typed. No characters are interpreted as wildcards. If the path includes
+escape characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not
+to interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -100,7 +101,10 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -116,15 +120,20 @@ This cmdlet returns a string that contains the converted path.
 
 ## NOTES
 
-* The cmdlets that contain the Path noun manipulate path names and return the names in a concise format that all PowerShell providers can interpret. They are designed for use in programs and scripts where you want to display all or part of a path name in a particular format. Use them like you would use Dirname, Normpath, Realpath, Join, or other path manipulators.
+The cmdlets that contain the Path noun manipulate path names and return the names in a concise
+format that all PowerShell providers can interpret. They are designed for use in programs and
+scripts where you want to display all or part of a path name in a particular format. Use them like
+you would use **Dirname**, **Normpath**, **Realpath**, **Join**, or other path manipulators.
 
-  You can use the path cmdlets with several providers, including the FileSystem, Registry, and Certificate providers.
+You can use the path cmdlets with several providers, including the FileSystem, Registry, and
+Certificate providers.
 
-  This cmdlet is designed to work with the data exposed by any provider.
-To list the providers available in your session, type `Get-PSProvider`.
-For more information, see about_Providers.
+This cmdlet is designed to work with the data exposed by any provider. To list the providers
+available in your session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-*
+`Convert-Path` only converts existing paths. It cannot be used to convert a location that does not
+exist yet.
 
 ## RELATED LINKS
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Get-Location.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/09/2017
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/get-location?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Location
@@ -29,147 +29,126 @@ Get-Location [-Stack] [-StackName <String[]>] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The **Get-Location** cmdlet gets an object that represents the current directory, much like the print working directory (pwd) command.
+The `Get-Location` cmdlet gets an object that represents the current directory, much like the print
+working directory (pwd) command.
 
-When you move between PowerShell drives, PowerShell retains your location in each drive.
-You can use this cmdlet to find your location in each drive.
+When you move between PowerShell drives, PowerShell retains your location in each drive. You can use
+this cmdlet to find your location in each drive.
 
-You can use this cmdlet to get the current directory at run time and use it in functions and scripts, such as in a function that displays the current directory in the PowerShell prompt.
+You can use this cmdlet to get the current directory at run time and use it in functions and
+scripts, such as in a function that displays the current directory in the PowerShell prompt.
 
-You can also use this cmdlet to display the locations in a location stack.
-For more information, see the Notes and the descriptions of the *Stack* and *StackName* parameters.
+You can also use this cmdlet to display the locations in a location stack. For more information, see
+the Notes and the descriptions of the **Stack** and **StackName** parameters.
 
 ## EXAMPLES
 
 ### Example 1: Display your current drive location
 
-```
+This command displays your location in the current PowerShell drive.
+
+```powershell
 PS C:\Windows> Get-Location
+```
+
+```Output
 Path
 ----
 C:\Windows
 ```
 
-This command displays your location in the current PowerShell drive.
-
-For instance, if you are in the Windows directory of the C: drive, it displays the path to that directory.
+For instance, if you are in the `Windows` directory of the `C:` drive, it displays the path to that
+directory.
 
 ### Example 2: Display your current location for different drives
 
-```
-The first command uses the **Set-Location** cmdlet to set the current location to the Windows subdirectory of the C: drive.
+This example demonstrates the use of `Get-Location` to display your current location in different
+PowerShell drives. `Set-Location` is used to change the location to several different paths on
+different **PSDrives**.
+
+```powershell
 PS C:\> Set-Location C:\Windows
-
-The second command uses the **Set-Location** cmdlet to change the location to the HKLM:\Software\Microsoft registry key. When you change to a location in the HKLM: drive, PowerShell retains your location in the C: drive.
 PS C:\Windows> Set-Location HKLM:\Software\Microsoft
-PS HKLM:\Software\Microsoft>
-
-The third command uses the **Set-Location** cmdlet to change the location to the HKCU:\Control Panel\Input Method registry key.
 PS HKLM:\Software\Microsoft> Set-Location "HKCU:\Control Panel\Input Method"
-PS HKCU:\Control Panel\Input Method>
-
-The fourth command uses the **Get-Location** cmdlet to find the current location on the C: drive. It uses the *PSDrive* parameter to specify the drive.
 PS HKCU:\Control Panel\Input Method> Get-Location -PSDrive C
-
-
 
 Path
 ----
 C:\Windows
 
+PS C:\Windows> Get-Location -PSDrive HKLM
 
-The fifth command uses the **Set-Location** cmdlet to return to the C: drive. Even though the command does not specify a subdirectory, PowerShell returns you to the saved location.
+Path
+----
+HKLM:\Software\Microsoft
+
 PS HKCU:\Control Panel\Input Method> Set-Location C:
-PS C:\Windows>
-
-The sixth command uses the **Get-Location** cmdlet to find the current location in the drives supported by the PowerShell registry provider. **Get-Location** returns the location of the most recently accessed registry drive, HKCU.
 PS C:\Windows> Get-Location -PSProvider registry
-
-
-
 
 Path
 ----
 HKCU:\Control Panel\Input Method
-
-
-To see the current location in the HKLM: drive, you need to use the *PSDrive* parameter to specify the drive. The seventh command does just this:
-PS C:\Windows> Get-Location -PSDrive HKLM
-
-
 
 Path
 ----
 HKLM:\Software\Microsoft
 ```
 
-This example demonstrates the use of **Get-Location** to display your current location in different PowerShell drives.
+### Example 3: Get locations using stacks
 
-### Example 3:
+This example shows how to use the **Stack** and **StackName** parameters of `Get-Location` to list
+the locations in the current location stack and alternate location stacks.
 
-```
-The first command sets the current location to the Windows directory on the C: drive.
-PS C:\> Set-Location C:\Windows
+The `Push-Location` cmdlet is used to change into three different locations. The third push uses a
+different stack name. The **Stack** parameter of `Get-Location` displays the contents of the default
+stack. The **StackName** parameter of `Get-Location` displays the contents of the stack named
+`Stack2`.
 
-The second command uses the **Push-Location** cmdlet to push the current location (C:\Windows) onto the current location stack and change to the System32 subdirectory. Because no stack is specified, the current location is pushed onto the current location stack. By default, the current location stack is the unnamed default location stack.
+```powershell
+PS C:\> Push-Location C:\Windows
 PS C:\Windows>Push-Location System32
-
-The third command uses the *StackName* parameter of the **Push-Location** cmdlet to push the current location (C:\Windows\System32) onto the Stack2 stack and to change the current location to the WindowsPowerShell subirectory. If the Stack2 stack does not exist, **Push-Location** creates it.
 PS C:\Windows\System32>Push-Location WindowsPowerShell -StackName Stack2
-
-The fourth command uses the *Stack* parameter of the **Get-Location** cmdlet to get the locations in the current location stack. By default, the current stack is the unnamed default location stack.
 C:\Windows\System32\WindowsPowerShell>Get-Location -Stack
-
-
 
 Path
 ----
 C:\Windows
+C:\
 
-
-The fifth command uses the *StackName* parameter of the **Get-Location** cmdlet to get the locations in the Stack2 stack.
 C:\Windows\System32\WindowsPowerShell>Get-Location -StackName Stack2
-
-
 
 Path
 ----
 C:\Windows\System32
 ```
 
-This example shows how to use the *Stack* and *StackName* parameters of **Get-Location** to list the locations in the current location stack and alternate location stacks.
-For more information about location stacks, see the Notes.
-
 ### Example 4: Customize the PowerShell prompt
 
-```
+This example shows how to customize the PowerShell prompt.
+
+```powershell
 PS C:\>
 function prompt { 'PowerShell: ' + (get-location) + '> '}
 PowerShell: C:\WINDOWS>
 ```
 
-This example shows how to customize the PowerShell prompt.
-The function that defines the prompt includes a **Get-Location** command, which is run whenever the prompt appears in the console.
+The function that defines the prompt includes a `Get-Location` command, which is run whenever the
+prompt appears in the console.
 
-The format of the default PowerShell prompt is defined by a special function named prompt.
-You can change the prompt in your console by creating a new function named prompt.
+The format of the default PowerShell prompt is defined by a special function named `prompt`. You can
+change the prompt in your console by creating a new function named `prompt`.
 
 To see the current prompt function, type the following command: `Get-Content Function:prompt`
-
-The command begins with the function keyword followed by the function name, prompt.
-The function body appears within braces ( {} ).
-
-This command defines a new prompt that begins with the string "PowerShell: ".
-To append the current location, it uses a **Get-Location** command, which runs when the prompt function is called.
-The prompt ends with the string "\> ".
 
 ## PARAMETERS
 
 ### -PSDrive
 
-Specifies the current location in the specified PowerShell drive that this cmdlet gets in the operation.
+Specifies the current location in the specified PowerShell drive that this cmdlet gets in the
+operation.
 
-For instance, if you are in the Certificate: drive, you can use this parameter to find your current location in the C: drive.
+For instance, if you are in the `Certificate:` drive, you can use this parameter to find your
+current location in the `C:` drive.
 
 ```yaml
 Type: String[]
@@ -185,11 +164,12 @@ Accept wildcard characters: False
 
 ### -PSProvider
 
-Specifies the current location in the drive supported by the PowerShell provider that this cmdlet gets in the operation.
+Specifies the current location in the drive supported by the PowerShell provider that this cmdlet
+gets in the operation. If the specified provider supports more than one drive, this cmdlet returns
+the location on the most recently accessed drive.
 
-If the specified provider supports more than one drive, this cmdlet returns the location on the most recently accessed drive.
-
-For example, if you are in the C: drive, you can use this parameter to find your current location in the drives of the PowerShellRegistry provider.
+For example, if you are in the `C:` drive, you can use this parameter to find your current location
+in the drives of the PowerShell **Registry** provider.
 
 ```yaml
 Type: String[]
@@ -207,8 +187,8 @@ Accept wildcard characters: False
 
 Indicates that this cmdlet displays the locations in the current location stack.
 
-To display the locations in a different location stack, use the *StackName* parameter.
-For information about location stacks, see the Notes.
+To display the locations in a different location stack, use the **StackName** parameter. For
+information about location stacks, see the Notes.
 
 ```yaml
 Type: SwitchParameter
@@ -224,14 +204,13 @@ Accept wildcard characters: False
 
 ### -StackName
 
-Specifies, as a string array, the named location stacks.
-Enter one or more location stack names.
+Specifies, as a string array, the named location stacks. Enter one or more location stack names.
 
-To display the locations in the current location stack, use the *Stack* parameter.
-To make a location stack the current location stack, use the Set-Location parameter.
-For information about location stacks, see the Notes.
+To display the locations in the current location stack, use the **Stack** parameter. To make a
+location stack the current location stack, use the `Set-Location` parameter.
 
-This cmdlet cannot display the locations in the unnamed default stack unless it is the current stack.
+This cmdlet cannot display the locations in the unnamed default stack unless it is the current
+stack.
 
 ```yaml
 Type: String[]
@@ -247,7 +226,10 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -259,43 +241,50 @@ You cannot pipe input to this cmdlet.
 
 ### System.Management.Automation.PathInfo or System.Management.Automation.PathInfoStack
 
-If you use the *Stack* or *StackName* parameters, this cmdlet returns a **StackInfo** object.
+If you use the **Stack** or **StackName** parameters, this cmdlet returns a **StackInfo** object.
 Otherwise, it returns a **PathInfo** object.
 
 ## NOTES
 
-* This cmdlet is designed to work with the data exposed by any provider. To list the providers in your session, type `Get-PSProvider`. For more information, see about_Providers.
+PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
+This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+when calling .NET APIs or running native applications without providing explicit directory paths.
+The `Get-Location` cmdlet returns the current directory of the current PowerShell runspace.
 
-  The ways that the *PSProvider*, *PSDrive*, *Stack*, and *StackName* parameters interact depends on the provider.
-Some combinations will result in errors, such as specifying both a drive and a provider that does not expose that drive.
-If no parameters are specified, this cmdlet returns the **PathInfo** object for the provider that contains the current working location.
+This cmdlet is designed to work with the data exposed by any provider. To list the providers in your
+session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-  A stack is a last-in, first-out list in which only the most recently added item is accessible.
-You add items to a stack in the order that you use them, and then retrieve them for use in the reverse order.
-PowerShell lets you store provider locations in location stacks.
-PowerShell creates an unnamed default location stack and you can create multiple named location stacks.
-If you do not specify a stack name, PowerShell uses the current location stack.
-By default, the unnamed default location is the current location stack, but you can use the **Set-Location** cmdlet to change the current location stack.
+The ways that the **PSProvider**, **PSDrive**, **Stack**, and **StackName** parameters interact
+depends on the provider. Some combinations will result in errors, such as specifying both a drive
+and a provider that does not expose that drive. If no parameters are specified, this cmdlet returns
+the **PathInfo** object for the provider that contains the current working location.
 
-  To manage location stacks, use the PowerShellLocation cmdlets, as follows.
+A stack is a last-in, first-out list in which only the most recently added item is accessible. You
+add items to a stack in the order that you use them, and then retrieve them for use in the reverse
+order. PowerShell lets you store provider locations in location stacks. PowerShell creates an
+unnamed default location stack and you can create multiple named location stacks. If you do not
+specify a stack name, PowerShell uses the current location stack. By default, the unnamed default
+location is the current location stack, but you can use the `Set-Location` cmdlet to change the
+current location stack.
 
-  - To add a location to a location stack, use the Push-Location cmdlet.
+To manage location stacks, use the PowerShellLocation cmdlets, as follows.
 
-  - To get a location from a location stack, use the Pop-Location cmdlet.
+- To add a location to a location stack, use the `Push-Location` cmdlet.
+- To get a location from a location stack, use the `Pop-Location` cmdlet.
+- To display the locations in the current location stack, use the **Stack** parameter of the
+  `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
+  parameter of the `Get-Location` cmdlet.
+- To create a new location stack, use the **StackName** parameter of the `Push-Location` cmdlet.
+  If you specify a stack that does not exist, `Push-Location` creates the stack.
+- To make a location stack the current location stack, use the **StackName** parameter of the
+  `Set-Location` cmdlet.
 
-  - To display the locations in the current location stack, use the *Stack* parameter of the **Get-Location** cmdlet.
-To display the locations in a named location stack, use the *StackName* parameter of the **Get-Location** cmdlet.
-
-  - To create a new location stack, use the *StackName* parameter of the **Push-Location** cmdlet.
-If you specify a stack that does not exist, **Push-Location** creates the stack.
-
-  - To make a location stack the current location stack, use the *StackName* parameter of the **Set-Location** cmdlet.
-
-  The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use the **Push-Location** or **Pop-Location** add or get items from the default stack or use this cmdlet command to display the locations in the unnamed stack.
-To make the unnamed stack the current stack, use the *StackName* parameter of the **Set-Location** cmdlet with a value of $null or an empty string ("").
-
-*
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you cannot no longer use the
+`Push-Location` or `Pop-Location` add or get items from the default stack or use this cmdlet command
+to display the locations in the unnamed stack. To make the unnamed stack the current stack, use the
+**StackName** parameter of the `Set-Location` cmdlet with a value of $null or an empty string ("").
 
 ## RELATED LINKS
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Resolve-Path.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Resolve-Path.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 5/14/2019
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/resolve-path?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Resolve-Path
@@ -202,14 +202,18 @@ You can pipe a string that contains a path to this cmdlet
 ### System.Management.Automation.PathInfo, System.String
 
 Returns a **PathInfo** object. Returns a string value for the resolved path if you specify the
-*Relative* parameter.
+**Relative** parameter.
 
 ## NOTES
 
-- The `*-Path` cmdlets work with the FileSystem, Registry, and Certificate providers.
-- `Resolve-Path` is designed to work with any provider. To list the providers available in your
-  session, type `Get-PSProvider`. For more information, see
-  [about_providers](../microsoft.powershell.core/about/about_providers.md).
+The `*-Path` cmdlets work with the FileSystem, Registry, and Certificate providers.
+
+`Resolve-Path` is designed to work with any provider. To list the providers available in your
+session, type `Get-PSProvider`. For more information, see
+[about_providers](../microsoft.powershell.core/about/about_providers.md).
+
+`Resolve-Path` only resolves existing paths. It cannot be used to resolve a location that does not
+exist yet.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #2626 - cmdlet only work on existing paths
Fixes [AB#1696272](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1696272)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://docs.microsoft.com/powershell/scripting/community/contributing/overview) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
