### PR TITLE
Fixes #3310 - Updates ConvertTo-XML

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -142,7 +142,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/convertto-xml?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertTo-Xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -8,7 +8,6 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: ConvertTo-Xml
 ---
-
 # ConvertTo-Xml
 
 ## SYNOPSIS
@@ -22,17 +21,25 @@ ConvertTo-Xml [-Depth <Int32>] [-InputObject] <PSObject> [-NoTypeInformation] [-
 ```
 
 ## DESCRIPTION
-The `ConvertTo-Xml` cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
-To use this cmdlet, pipe one or more objects to the cmdlet, or use the **InputObject** parameter to specify the object.
 
-When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit multiple objects, `ConvertTo-Xml` returns a single XML document that includes representations of all of the objects.
+The `ConvertTo-Xml` cmdlet creates an [XML-based](/dotnet/api/system.xml.xmldocument) representation
+of one or more Microsoft .NET Framework objects. To use this cmdlet, pipe one or more objects to the
+cmdlet, or use the **InputObject** parameter to specify the object.
 
-This cmdlet is similar to `Export-Clixml` except that `Export-Clixml` stores the resulting XML in a file.
-`ConvertTo-Xml` returns the XML, so you can continue to process it in PowerShell.
+When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit
+multiple objects, `ConvertTo-Xml` returns a single, in-memory XML document that includes
+representations of all of the objects.
+
+This cmdlet is similar to [Export-Clixml](./Export-Clixml.md) except that `Export-Clixml` stores the
+resulting XML in a [Common Language Infrastructure(CLI) XML](https://www.ecma-international.org/publications/standards/Ecma-335.htm)
+file that can be reimported as objects with [Import-Clixml](./Import-Clixml.md). `ConvertTo-Xml`
+returns an in-memory representation of an XML document, so you can continue to process it in
+PowerShell. `ConvertTo-Xml` does not have an option to convert objects to CLI XML.
 
 ## EXAMPLES
 
 ### Example 1: Convert a date to XML
+
 ```
 PS C:\> Get-Date | ConvertTo-Xml
 ```
@@ -40,16 +47,18 @@ PS C:\> Get-Date | ConvertTo-Xml
 This command converts the current date (a **DateTime** object) to XML.
 
 ### Example 2: Convert processes to XML
+
 ```
 PS C:\> ConvertTo-Xml -As "Document" -InputObject (Get-Process) -Depth 3
 ```
 
-This command converts the process objects that represent all of the processes on the computer into an XML document.
-The objects are expanded to a depth of three levels.
+This command converts the process objects that represent all of the processes on the computer into
+an XML document. The objects are expanded to a depth of three levels.
 
 ## PARAMETERS
 
 ### -As
+
 Determines the output format.
 The acceptable values for this parameter are:
 
@@ -76,13 +85,15 @@ Accept wildcard characters: False
 ```
 
 ### -Depth
-Specifies how many levels of contained objects are included in the XML representation.
-The default value is 1.
 
-For example, if the object's properties also contain objects, to save an XML representation of the properties of the contained objects, you must specify a depth of 2.
+Specifies how many levels of contained objects are included in the XML representation. The default
+value is 1.
 
-The default value can be overridden for the object type in the Types.ps1xml files.
-For more information, see about_Types.ps1xml.
+For example, if the object's properties also contain objects, to save an XML representation of the
+properties of the contained objects, you must specify a depth of 2.
+
+The default value can be overridden for the object type in the Types.ps1xml files. For more
+information, see about_Types.ps1xml.
 
 ```yaml
 Type: Int32
@@ -97,9 +108,9 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies the object to be converted.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
-You can also pipe objects to **ConvertTo-XML**.
+
+Specifies the object to be converted. Enter a variable that contains the objects, or type a command
+or expression that gets the objects. You can also pipe objects to **ConvertTo-XML**.
 
 ```yaml
 Type: PSObject
@@ -114,6 +125,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoTypeInformation
+
 Omits the Type attribute from the object nodes.
 
 ```yaml
@@ -129,16 +141,19 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
+
 You can pipe any object to **ConvertTo-XML**.
 
 ## OUTPUTS
 
 ### System.String or System.Xml.XmlDocument
+
 The value of the *As* parameter determines the type of object that **ConvertTo-XML** returns.
 
 ## NOTES
@@ -154,5 +169,3 @@ The value of the *As* parameter determines the type of object that **ConvertTo-X
 [Get-Date](Get-Date.md)
 
 [Import-Clixml](Import-Clixml.md)
-
-

--- a/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -142,7 +142,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/convertto-xml?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertTo-Xml

--- a/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -22,13 +22,19 @@ ConvertTo-Xml [-Depth <Int32>] [-InputObject] <PSObject> [-NoTypeInformation] [-
 
 ## DESCRIPTION
 
-The `ConvertTo-Xml` cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
-To use this cmdlet, pipe one or more objects to the cmdlet, or use the **InputObject** parameter to specify the object.
+The `ConvertTo-Xml` cmdlet creates an [XML-based](/dotnet/api/system.xml.xmldocument) representation
+of one or more Microsoft .NET Framework objects. To use this cmdlet, pipe one or more objects to the
+cmdlet, or use the **InputObject** parameter to specify the object.
 
-When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit multiple objects, `ConvertTo-Xml` returns a single XML document that includes representations of all of the objects.
+When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit
+multiple objects, `ConvertTo-Xml` returns a single, in-memory XML document that includes
+representations of all of the objects.
 
-This cmdlet is similar to `Export-Clixml` except that `Export-Clixml` stores the resulting XML in a file.
-`ConvertTo-Xml` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to [Export-Clixml](./Export-Clixml.md) except that `Export-Clixml` stores the
+resulting XML in a [Common Language Infrastructure(CLI) XML](https://www.ecma-international.org/publications/standards/Ecma-335.htm)
+file that can be reimported as objects with [Import-Clixml](./Import-Clixml.md). `ConvertTo-Xml`
+returns an in-memory representation of an XML document, so you can continue to process it in
+PowerShell. `ConvertTo-Xml` does not have an option to convert objects to CLI XML.
 
 ## EXAMPLES
 
@@ -46,8 +52,8 @@ This command converts the current date (a **DateTime** object) to XML.
 PS C:\> ConvertTo-Xml -As "Document" -InputObject (Get-Process) -Depth 3
 ```
 
-This command converts the process objects that represent all of the processes on the computer into an XML document.
-The objects are expanded to a depth of three levels.
+This command converts the process objects that represent all of the processes on the computer into
+an XML document. The objects are expanded to a depth of three levels.
 
 ## PARAMETERS
 
@@ -80,13 +86,14 @@ Accept wildcard characters: False
 
 ### -Depth
 
-Specifies how many levels of contained objects are included in the XML representation.
-The default value is 1.
+Specifies how many levels of contained objects are included in the XML representation. The default
+value is 1.
 
-For example, if the object's properties also contain objects, to save an XML representation of the properties of the contained objects, you must specify a depth of 2.
+For example, if the object's properties also contain objects, to save an XML representation of the
+properties of the contained objects, you must specify a depth of 2.
 
-The default value can be overridden for the object type in the Types.ps1xml files.
-For more information, see about_Types.ps1xml.
+The default value can be overridden for the object type in the Types.ps1xml files. For more
+information, see about_Types.ps1xml.
 
 ```yaml
 Type: Int32
@@ -102,9 +109,8 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the object to be converted.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
-You can also pipe objects to **ConvertTo-XML**.
+Specifies the object to be converted. Enter a variable that contains the objects, or type a command
+or expression that gets the objects. You can also pipe objects to **ConvertTo-XML**.
 
 ```yaml
 Type: PSObject
@@ -163,5 +169,3 @@ The value of the *As* parameter determines the type of object that **ConvertTo-X
 [Get-Date](Get-Date.md)
 
 [Import-Clixml](Import-Clixml.md)
-
-

--- a/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -142,7 +142,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/convertto-xml?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertTo-Xml

--- a/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -22,13 +22,19 @@ ConvertTo-Xml [-Depth <Int32>] [-InputObject] <PSObject> [-NoTypeInformation] [-
 
 ## DESCRIPTION
 
-The `ConvertTo-Xml` cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
-To use this cmdlet, pipe one or more objects to the cmdlet, or use the **InputObject** parameter to specify the object.
+The `ConvertTo-Xml` cmdlet creates an [XML-based](/dotnet/api/system.xml.xmldocument) representation
+of one or more Microsoft .NET Framework objects. To use this cmdlet, pipe one or more objects to the
+cmdlet, or use the **InputObject** parameter to specify the object.
 
-When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit multiple objects, `ConvertTo-Xml` returns a single XML document that includes representations of all of the objects.
+When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit
+multiple objects, `ConvertTo-Xml` returns a single, in-memory XML document that includes
+representations of all of the objects.
 
-This cmdlet is similar to `Export-Clixml` except that `Export-Clixml` stores the resulting XML in a file.
-`ConvertTo-Xml` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to [Export-Clixml](./Export-Clixml.md) except that `Export-Clixml` stores the
+resulting XML in a [Common Language Infrastructure(CLI) XML](https://www.ecma-international.org/publications/standards/Ecma-335.htm)
+file that can be reimported as objects with [Import-Clixml](./Import-Clixml.md). `ConvertTo-Xml`
+returns an in-memory representation of an XML document, so you can continue to process it in
+PowerShell. `ConvertTo-Xml` does not have an option to convert objects to CLI XML.
 
 ## EXAMPLES
 
@@ -46,8 +52,8 @@ This command converts the current date (a **DateTime** object) to XML.
 PS C:\> ConvertTo-Xml -As "Document" -InputObject (Get-Process) -Depth 3
 ```
 
-This command converts the process objects that represent all of the processes on the computer into an XML document.
-The objects are expanded to a depth of three levels.
+This command converts the process objects that represent all of the processes on the computer into
+an XML document. The objects are expanded to a depth of three levels.
 
 ## PARAMETERS
 
@@ -80,13 +86,14 @@ Accept wildcard characters: False
 
 ### -Depth
 
-Specifies how many levels of contained objects are included in the XML representation.
-The default value is 1.
+Specifies how many levels of contained objects are included in the XML representation. The default
+value is 1.
 
-For example, if the object's properties also contain objects, to save an XML representation of the properties of the contained objects, you must specify a depth of 2.
+For example, if the object's properties also contain objects, to save an XML representation of the
+properties of the contained objects, you must specify a depth of 2.
 
-The default value can be overridden for the object type in the Types.ps1xml files.
-For more information, see about_Types.ps1xml.
+The default value can be overridden for the object type in the Types.ps1xml files. For more
+information, see about_Types.ps1xml.
 
 ```yaml
 Type: Int32
@@ -102,9 +109,8 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the object to be converted.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
-You can also pipe objects to **ConvertTo-XML**.
+Specifies the object to be converted. Enter a variable that contains the objects, or type a command
+or expression that gets the objects. You can also pipe objects to **ConvertTo-XML**.
 
 ```yaml
 Type: PSObject
@@ -163,5 +169,3 @@ The value of the *As* parameter determines the type of object that **ConvertTo-X
 [Get-Date](Get-Date.md)
 
 [Import-Clixml](Import-Clixml.md)
-
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -142,7 +142,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -22,13 +22,19 @@ ConvertTo-Xml [-Depth <Int32>] [-InputObject] <PSObject> [-NoTypeInformation] [-
 
 ## DESCRIPTION
 
-The `ConvertTo-Xml` cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
-To use this cmdlet, pipe one or more objects to the cmdlet, or use the **InputObject** parameter to specify the object.
+The `ConvertTo-Xml` cmdlet creates an [XML-based](/dotnet/api/system.xml.xmldocument) representation
+of one or more Microsoft .NET Framework objects. To use this cmdlet, pipe one or more objects to the
+cmdlet, or use the **InputObject** parameter to specify the object.
 
-When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit multiple objects, `ConvertTo-Xml` returns a single XML document that includes representations of all of the objects.
+When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit
+multiple objects, `ConvertTo-Xml` returns a single, in-memory XML document that includes
+representations of all of the objects.
 
-This cmdlet is similar to `Export-Clixml` except that `Export-Clixml` stores the resulting XML in a file.
-`ConvertTo-Xml` returns the XML, so you can continue to process it in PowerShell.
+This cmdlet is similar to [Export-Clixml](./Export-Clixml.md) except that `Export-Clixml` stores the
+resulting XML in a [Common Language Infrastructure(CLI) XML](https://www.ecma-international.org/publications/standards/Ecma-335.htm)
+file that can be reimported as objects with [Import-Clixml](./Import-Clixml.md). `ConvertTo-Xml`
+returns an in-memory representation of an XML document, so you can continue to process it in
+PowerShell. `ConvertTo-Xml` does not have an option to convert objects to CLI XML.
 
 ## EXAMPLES
 
@@ -46,8 +52,8 @@ This command converts the current date (a **DateTime** object) to XML.
 PS C:\> ConvertTo-Xml -As "Document" -InputObject (Get-Process) -Depth 3
 ```
 
-This command converts the process objects that represent all of the processes on the computer into an XML document.
-The objects are expanded to a depth of three levels.
+This command converts the process objects that represent all of the processes on the computer into
+an XML document. The objects are expanded to a depth of three levels.
 
 ## PARAMETERS
 
@@ -80,13 +86,14 @@ Accept wildcard characters: False
 
 ### -Depth
 
-Specifies how many levels of contained objects are included in the XML representation.
-The default value is 1.
+Specifies how many levels of contained objects are included in the XML representation. The default
+value is 1.
 
-For example, if the object's properties also contain objects, to save an XML representation of the properties of the contained objects, you must specify a depth of 2.
+For example, if the object's properties also contain objects, to save an XML representation of the
+properties of the contained objects, you must specify a depth of 2.
 
-The default value can be overridden for the object type in the Types.ps1xml files.
-For more information, see about_Types.ps1xml.
+The default value can be overridden for the object type in the Types.ps1xml files. For more
+information, see about_Types.ps1xml.
 
 ```yaml
 Type: Int32
@@ -102,9 +109,8 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the object to be converted.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
-You can also pipe objects to **ConvertTo-XML**.
+Specifies the object to be converted. Enter a variable that contains the objects, or type a command
+or expression that gets the objects. You can also pipe objects to **ConvertTo-XML**.
 
 ```yaml
 Type: PSObject
@@ -163,5 +169,3 @@ The value of the *As* parameter determines the type of object that **ConvertTo-X
 [Get-Date](Get-Date.md)
 
 [Import-Clixml](Import-Clixml.md)
-
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 03/12/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/convertto-xml?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertTo-Xml


### PR DESCRIPTION
# PR Summary

Customer noticed that the current documentation suggested that `ConvertTo-XML` and `Export-Clixml` were essentially the same with the difference being in-memory vs to a file. 

This is not the case as `Export-Clixml` outputs a CLI XML schema XML document and is reimported as `System.Object`'s whereas, `ConvertTo-Xml` creates an in-memory XML document representation of all the objects passed to it. 

## PR Context

Fixes #3310 
Fixes [AB#1694055](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1694055)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://docs.microsoft.com/powershell/scripting/community/contributing/overview) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
