### PR TITLE
adds link to about_scopes

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -6,7 +6,6 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: about_Remote_Variables
 ---
-
 # About Remote Variables
 
 ## Short description
@@ -78,7 +77,7 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-A variable reference such as `$using:var` expands to the value of variable `$var` 
+A variable reference such as `$using:var` expands to the value of variable `$var`
 from the caller's context. You do not get access to the caller's variable object.
 The `Using` scope modifier cannot be used to modify a local variable within the
 **PSSession**. For example, the following code does not work:
@@ -88,6 +87,8 @@ $s = New-PSSession -ComputerName S1
 $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {$Using:ps = 'Cannot assign new value'}
 ```
+
+For more information about `Using`, see [about_Scopes](./about_Scopes.md)
 
 ### Using splatting
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -6,7 +6,6 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: about_Remote_Variables
 ---
-
 # About Remote Variables
 
 ## Short description
@@ -78,7 +77,7 @@ Invoke-Command -ComputerName S1 -ScriptBlock {
 }
 ```
 
-A variable reference such as `$using:var` expands to the value of variable `$var` 
+A variable reference such as `$using:var` expands to the value of variable `$var`
 from the caller's context. You do not get access to the caller's variable object.
 The `Using` scope modifier cannot be used to modify a local variable within the
 **PSSession**. For example, the following code does not work:
@@ -88,6 +87,8 @@ $s = New-PSSession -ComputerName S1
 $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
+
+For more information about `Using`, see [about_Scopes](./about_Scopes.md)
 
 ### Using splatting
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -6,7 +6,6 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: about_Remote_Variables
 ---
-
 # About Remote Variables
 
 ## Short description
@@ -78,7 +77,7 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-A variable reference such as `$using:var` expands to the value of variable `$var` 
+A variable reference such as `$using:var` expands to the value of variable `$var`
 from the caller's context. You do not get access to the caller's variable object.
 The `Using` scope modifier cannot be used to modify a local variable within the
 **PSSession**. For example, the following code does not work:
@@ -88,6 +87,8 @@ $s = New-PSSession -ComputerName S1
 $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {$Using:ps = 'Cannot assign new value'}
 ```
+
+For more information about `Using`, see [about_Scopes](./about_Scopes.md)
 
 ### Using splatting
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -6,7 +6,6 @@ online version: https://docs.microsoft.com/powershell/module/microsoft.powershel
 schema: 2.0.0
 title: about_Remote_Variables
 ---
-
 # About Remote Variables
 
 ## Short description
@@ -78,7 +77,7 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-A variable reference such as `$using:var` expands to the value of variable `$var` 
+A variable reference such as `$using:var` expands to the value of variable `$var`
 from the caller's context. You do not get access to the caller's variable object.
 The `Using` scope modifier cannot be used to modify a local variable within the
 **PSSession**. For example, the following code does not work:
@@ -88,6 +87,8 @@ $s = New-PSSession -ComputerName S1
 $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {$Using:ps = 'Cannot assign new value'}
 ```
+
+For more information about `Using`, see [about_Scopes](./about_Scopes.md)
 
 ### Using splatting
 


### PR DESCRIPTION
# PR Summary

Adds link to about_Scopes to expand on the `Using` scope modifier

## PR Context

Fixes #5068 
Fixes [AB#1696312](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1696312)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://docs.microsoft.com/powershell/scripting/community/contributing/overview) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
