### PR TITLE
Fixes #5561 - clarify naming convention

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 12/14/2018
+ms.date: 03/13/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_experimental_features?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: About experimental features
@@ -33,7 +33,7 @@ specific user.
 
 Use the `Experimental` attribute to declare some code as experimental.
 
-Use the following synxtax to declare the `Experimental` attribute providing the
+Use the following syntax to declare the `Experimental` attribute providing the
 name of the experimental feature and the action to take if the experimental
 feature is enabled:
 
@@ -41,18 +41,20 @@ feature is enabled:
 [Experimental(NameOfExperimentalFeature, ExperimentAction)]
 ```
 
-The `ExperimentAction` parameter must be specified and the only valid values are:
+For modules, the `NameOfExperimentalFeature` must follow the form of
+`<modulename>.<experimentname>`. The `ExperimentAction` parameter must be
+specified and the only valid values are:
 
 - `Show` means to show this experimental feature if the feature is enabled
 - `Hide` means to hide this experimental feature if the feature is enabled
 
-### Declaring Experimental Features in Modules Written in C#
+### Declaring Experimental Features in Modules Written in C\#
 
-Module authors who want to use the Experimental Feature flags can declare
-a cmdlet as experimental by using the `Experimental` attribute:
+Module authors who want to use the Experimental Feature flags can declare a
+cmdlet as experimental by using the `Experimental` attribute.
 
 ```csharp
-[Experimental("PSWebCmdletV2", ExperimentAction.Show)]
+[Experimental("MyWebCmdlets.PSWebCmdletV2", ExperimentAction.Show)]
 [Cmdlet(Verbs.Invoke, "WebRequest")]
 public class InvokeWebRequestCommandV2 : WebCmdletBaseV2 { ... }
 ```
@@ -64,7 +66,7 @@ declare experimental cmdlets:
 
 ```powershell
 function Enable-SSHRemoting {
-    [Experimental("PSSSHRemoting", "Show")]
+    [Experimental("MyRemoting.PSSSHRemoting", "Show")]
     [CmdletBinding()]
     param()
     ...
@@ -76,28 +78,29 @@ function Enable-SSHRemoting {
 There are cases where an experimental feature cannot co-exist side-by-side with
 an existing feature or another experimental feature.
 
-For example, you can have an experimental cmdlet that overrides an existing cmdlet.
-The two versions can't coexist side by side. The `ExperimentAction.Hide` setting
-allows only one of the two cmdlets to be enabled at one time.
+For example, you can have an experimental cmdlet that overrides an existing
+cmdlet. The two versions can't coexist side by side. The
+`ExperimentAction.Hide` setting allows only one of the two cmdlets to be
+enabled at one time.
 
 In this example, we create a new experimental `Invoke-WebRequest` cmdlet.
 `InvokeWebRequestCommand` contains the non-experimental implementation.
 `InvokeWebRequestCommandV2` contains the experimental version of the cmdlet.
 
-The use of `ExperimentAction.Hide` will allow only one of the two features to be
-enabled at one time:
+The use of `ExperimentAction.Hide` will allow only one of the two features to
+be enabled at one time:
 
 ```csharp
-[Experimental("PSWebCmdletV2", ExperimentAction.Show)]
+[Experimental("MyWebCmdlets.PSWebCmdletV2", ExperimentAction.Show)]
 [Cmdlet(Verbs.Invoke, "WebRequest")]
 public class InvokeWebRequestCommandV2 : WebCmdletBaseV2 { ... }
 
-[Experimental("PSWebCmdletV2", ExperimentAction.Hide)]
+[Experimental("MyWebCmdlets.PSWebCmdletV2", ExperimentAction.Hide)]
 [Cmdlet(Verbs.Invoke, "WebRequest")]
 public class InvokeWebRequestCommand : WebCmdletBase { ... }
 ```
 
-When the `PSWebCmdletV2` experimental feature is enabled, the existing
+When the `MyWebCmdlets.PSWebCmdletV2` experimental feature is enabled, the existing
 `InvokeWebRequestCommand` implementation is hidden and the
 `InvokeWebRequestCommandV2` provides the implementation of
 `Invoke-WebRequest`.
@@ -107,18 +110,18 @@ to the non-experimental version when needed.
 
 ### Experimental Parameters in Cmdlets
 
-The `Experimental` attribute can also be applied to individual parameters.
-This allows you to create an experimental set of parameters for an existing
-cmdlet rather than an entirely new cmdlet.
+The `Experimental` attribute can also be applied to individual parameters. This
+allows you to create an experimental set of parameters for an existing cmdlet
+rather than an entirely new cmdlet.
 
 Here is an example in C#:
 
 ```csharp
-[Experimental("PSNewAddTypeCompilation", ExperimentAction.Show)]
+[Experimental("MyModule.PSNewAddTypeCompilation", ExperimentAction.Show)]
 [Parameter(ParameterSet = "NewCompilation")]
 public CompilationParameters CompileParameters { ... }
 
-[Experimental("PSNewAddTypeCompilation", ExperimentAction.Hide)]
+[Experimental("MyModule.PSNewAddTypeCompilation", ExperimentAction.Hide)]
 [Parameter()]
 public CodeDom CodeDom { ... }
 ```
@@ -127,10 +130,10 @@ Here is a different example in PowerShell script:
 
 ```powershell
 param(
-    [Experimental("PSNewFeature", "Show")]
+    [Experimental("MyModule.PSNewFeature", "Show")]
     [string] $NewName,
 
-    [Experimental("PSNewFeature", "Hide")]
+    [Experimental("MyModule.PSNewFeature", "Hide")]
     [string] $OldName
 )
 ```
@@ -138,15 +141,14 @@ param(
 ## Checking if an Experimental Feature is Enabled
 
 In your code, you will need to check if your experimental feature is enabled
-before taking appropriate action.
-You can determine if an experimental feature is enabled using the static
-`IsEnabled()` method on the `System.Management.Automation.ExperimentalFeature`
-class.
+before taking appropriate action. You can determine if an experimental feature
+is enabled using the static `IsEnabled()` method on the
+`System.Management.Automation.ExperimentalFeature` class.
 
 Here is an example in C#:
 
 ```csharp
-if (ExperimentalFeature.IsEnabled("MyExperimentalFeature"))
+if (ExperimentalFeature.IsEnabled("MyModule.MyExperimentalFeature"))
 {
    // code specific to the experimental feature
 }
@@ -155,7 +157,7 @@ if (ExperimentalFeature.IsEnabled("MyExperimentalFeature"))
 Here is an example in PowerShell script:
 
 ```powershell
-if ([ExperimentalFeature]::IsEnabled("MyExperimentalFeature"))
+if ([ExperimentalFeature]::IsEnabled("MyModule.MyExperimentalFeature"))
 {
   # code specific to the experimental feature
 }

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Experimental_Features.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Experimental_Features.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 12/14/2018
+ms.date: 03/13/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_experimental_features?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: About experimental features
@@ -33,7 +33,7 @@ specific user.
 
 Use the `Experimental` attribute to declare some code as experimental.
 
-Use the following synxtax to declare the `Experimental` attribute providing the
+Use the following syntax to declare the `Experimental` attribute providing the
 name of the experimental feature and the action to take if the experimental
 feature is enabled:
 
@@ -41,18 +41,20 @@ feature is enabled:
 [Experimental(NameOfExperimentalFeature, ExperimentAction)]
 ```
 
-The `ExperimentAction` parameter must be specified and the only valid values are:
+For modules, the `NameOfExperimentalFeature` must follow the form of
+`<modulename>.<experimentname>`. The `ExperimentAction` parameter must be
+specified and the only valid values are:
 
 - `Show` means to show this experimental feature if the feature is enabled
 - `Hide` means to hide this experimental feature if the feature is enabled
 
-### Declaring Experimental Features in Modules Written in C#
+### Declaring Experimental Features in Modules Written in C\#
 
-Module authors who want to use the Experimental Feature flags can declare
-a cmdlet as experimental by using the `Experimental` attribute:
+Module authors who want to use the Experimental Feature flags can declare a
+cmdlet as experimental by using the `Experimental` attribute.
 
 ```csharp
-[Experimental("PSWebCmdletV2", ExperimentAction.Show)]
+[Experimental("MyWebCmdlets.PSWebCmdletV2", ExperimentAction.Show)]
 [Cmdlet(Verbs.Invoke, "WebRequest")]
 public class InvokeWebRequestCommandV2 : WebCmdletBaseV2 { ... }
 ```
@@ -64,7 +66,7 @@ declare experimental cmdlets:
 
 ```powershell
 function Enable-SSHRemoting {
-    [Experimental("PSSSHRemoting", "Show")]
+    [Experimental("MyRemoting.PSSSHRemoting", "Show")]
     [CmdletBinding()]
     param()
     ...
@@ -76,28 +78,29 @@ function Enable-SSHRemoting {
 There are cases where an experimental feature cannot co-exist side-by-side with
 an existing feature or another experimental feature.
 
-For example, you can have an experimental cmdlet that overrides an existing cmdlet.
-The two versions can't coexist side by side. The `ExperimentAction.Hide` setting
-allows only one of the two cmdlets to be enabled at one time.
+For example, you can have an experimental cmdlet that overrides an existing
+cmdlet. The two versions can't coexist side by side. The
+`ExperimentAction.Hide` setting allows only one of the two cmdlets to be
+enabled at one time.
 
 In this example, we create a new experimental `Invoke-WebRequest` cmdlet.
 `InvokeWebRequestCommand` contains the non-experimental implementation.
 `InvokeWebRequestCommandV2` contains the experimental version of the cmdlet.
 
-The use of `ExperimentAction.Hide` will allow only one of the two features to be
-enabled at one time:
+The use of `ExperimentAction.Hide` will allow only one of the two features to
+be enabled at one time:
 
 ```csharp
-[Experimental("PSWebCmdletV2", ExperimentAction.Show)]
+[Experimental("MyWebCmdlets.PSWebCmdletV2", ExperimentAction.Show)]
 [Cmdlet(Verbs.Invoke, "WebRequest")]
 public class InvokeWebRequestCommandV2 : WebCmdletBaseV2 { ... }
 
-[Experimental("PSWebCmdletV2", ExperimentAction.Hide)]
+[Experimental("MyWebCmdlets.PSWebCmdletV2", ExperimentAction.Hide)]
 [Cmdlet(Verbs.Invoke, "WebRequest")]
 public class InvokeWebRequestCommand : WebCmdletBase { ... }
 ```
 
-When the `PSWebCmdletV2` experimental feature is enabled, the existing
+When the `MyWebCmdlets.PSWebCmdletV2` experimental feature is enabled, the existing
 `InvokeWebRequestCommand` implementation is hidden and the
 `InvokeWebRequestCommandV2` provides the implementation of
 `Invoke-WebRequest`.
@@ -107,18 +110,18 @@ to the non-experimental version when needed.
 
 ### Experimental Parameters in Cmdlets
 
-The `Experimental` attribute can also be applied to individual parameters.
-This allows you to create an experimental set of parameters for an existing
-cmdlet rather than an entirely new cmdlet.
+The `Experimental` attribute can also be applied to individual parameters. This
+allows you to create an experimental set of parameters for an existing cmdlet
+rather than an entirely new cmdlet.
 
 Here is an example in C#:
 
 ```csharp
-[Experimental("PSNewAddTypeCompilation", ExperimentAction.Show)]
+[Experimental("MyModule.PSNewAddTypeCompilation", ExperimentAction.Show)]
 [Parameter(ParameterSet = "NewCompilation")]
 public CompilationParameters CompileParameters { ... }
 
-[Experimental("PSNewAddTypeCompilation", ExperimentAction.Hide)]
+[Experimental("MyModule.PSNewAddTypeCompilation", ExperimentAction.Hide)]
 [Parameter()]
 public CodeDom CodeDom { ... }
 ```
@@ -127,10 +130,10 @@ Here is a different example in PowerShell script:
 
 ```powershell
 param(
-    [Experimental("PSNewFeature", "Show")]
+    [Experimental("MyModule.PSNewFeature", "Show")]
     [string] $NewName,
 
-    [Experimental("PSNewFeature", "Hide")]
+    [Experimental("MyModule.PSNewFeature", "Hide")]
     [string] $OldName
 )
 ```
@@ -138,15 +141,14 @@ param(
 ## Checking if an Experimental Feature is Enabled
 
 In your code, you will need to check if your experimental feature is enabled
-before taking appropriate action.
-You can determine if an experimental feature is enabled using the static
-`IsEnabled()` method on the `System.Management.Automation.ExperimentalFeature`
-class.
+before taking appropriate action. You can determine if an experimental feature
+is enabled using the static `IsEnabled()` method on the
+`System.Management.Automation.ExperimentalFeature` class.
 
 Here is an example in C#:
 
 ```csharp
-if (ExperimentalFeature.IsEnabled("MyExperimentalFeature"))
+if (ExperimentalFeature.IsEnabled("MyModule.MyExperimentalFeature"))
 {
    // code specific to the experimental feature
 }
@@ -155,7 +157,7 @@ if (ExperimentalFeature.IsEnabled("MyExperimentalFeature"))
 Here is an example in PowerShell script:
 
 ```powershell
-if ([ExperimentalFeature]::IsEnabled("MyExperimentalFeature"))
+if ([ExperimentalFeature]::IsEnabled("MyModule.MyExperimentalFeature"))
 {
   # code specific to the experimental feature
 }

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Experimental_Features.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Experimental_Features.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 12/14/2018
+ms.date: 03/13/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_experimental_features?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: About experimental features
@@ -33,7 +33,7 @@ specific user.
 
 Use the `Experimental` attribute to declare some code as experimental.
 
-Use the following synxtax to declare the `Experimental` attribute providing the
+Use the following syntax to declare the `Experimental` attribute providing the
 name of the experimental feature and the action to take if the experimental
 feature is enabled:
 
@@ -41,18 +41,20 @@ feature is enabled:
 [Experimental(NameOfExperimentalFeature, ExperimentAction)]
 ```
 
-The `ExperimentAction` parameter must be specified and the only valid values are:
+For modules, the `NameOfExperimentalFeature` must follow the form of
+`<modulename>.<experimentname>`. The `ExperimentAction` parameter must be
+specified and the only valid values are:
 
 - `Show` means to show this experimental feature if the feature is enabled
 - `Hide` means to hide this experimental feature if the feature is enabled
 
-### Declaring Experimental Features in Modules Written in C#
+### Declaring Experimental Features in Modules Written in C\#
 
-Module authors who want to use the Experimental Feature flags can declare
-a cmdlet as experimental by using the `Experimental` attribute:
+Module authors who want to use the Experimental Feature flags can declare a
+cmdlet as experimental by using the `Experimental` attribute.
 
 ```csharp
-[Experimental("PSWebCmdletV2", ExperimentAction.Show)]
+[Experimental("MyWebCmdlets.PSWebCmdletV2", ExperimentAction.Show)]
 [Cmdlet(Verbs.Invoke, "WebRequest")]
 public class InvokeWebRequestCommandV2 : WebCmdletBaseV2 { ... }
 ```
@@ -64,7 +66,7 @@ declare experimental cmdlets:
 
 ```powershell
 function Enable-SSHRemoting {
-    [Experimental("PSSSHRemoting", "Show")]
+    [Experimental("MyRemoting.PSSSHRemoting", "Show")]
     [CmdletBinding()]
     param()
     ...
@@ -76,28 +78,29 @@ function Enable-SSHRemoting {
 There are cases where an experimental feature cannot co-exist side-by-side with
 an existing feature or another experimental feature.
 
-For example, you can have an experimental cmdlet that overrides an existing cmdlet.
-The two versions can't coexist side by side. The `ExperimentAction.Hide` setting
-allows only one of the two cmdlets to be enabled at one time.
+For example, you can have an experimental cmdlet that overrides an existing
+cmdlet. The two versions can't coexist side by side. The
+`ExperimentAction.Hide` setting allows only one of the two cmdlets to be
+enabled at one time.
 
 In this example, we create a new experimental `Invoke-WebRequest` cmdlet.
 `InvokeWebRequestCommand` contains the non-experimental implementation.
 `InvokeWebRequestCommandV2` contains the experimental version of the cmdlet.
 
-The use of `ExperimentAction.Hide` will allow only one of the two features to be
-enabled at one time:
+The use of `ExperimentAction.Hide` will allow only one of the two features to
+be enabled at one time:
 
 ```csharp
-[Experimental("PSWebCmdletV2", ExperimentAction.Show)]
+[Experimental("MyWebCmdlets.PSWebCmdletV2", ExperimentAction.Show)]
 [Cmdlet(Verbs.Invoke, "WebRequest")]
 public class InvokeWebRequestCommandV2 : WebCmdletBaseV2 { ... }
 
-[Experimental("PSWebCmdletV2", ExperimentAction.Hide)]
+[Experimental("MyWebCmdlets.PSWebCmdletV2", ExperimentAction.Hide)]
 [Cmdlet(Verbs.Invoke, "WebRequest")]
 public class InvokeWebRequestCommand : WebCmdletBase { ... }
 ```
 
-When the `PSWebCmdletV2` experimental feature is enabled, the existing
+When the `MyWebCmdlets.PSWebCmdletV2` experimental feature is enabled, the existing
 `InvokeWebRequestCommand` implementation is hidden and the
 `InvokeWebRequestCommandV2` provides the implementation of
 `Invoke-WebRequest`.
@@ -107,18 +110,18 @@ to the non-experimental version when needed.
 
 ### Experimental Parameters in Cmdlets
 
-The `Experimental` attribute can also be applied to individual parameters.
-This allows you to create an experimental set of parameters for an existing
-cmdlet rather than an entirely new cmdlet.
+The `Experimental` attribute can also be applied to individual parameters. This
+allows you to create an experimental set of parameters for an existing cmdlet
+rather than an entirely new cmdlet.
 
 Here is an example in C#:
 
 ```csharp
-[Experimental("PSNewAddTypeCompilation", ExperimentAction.Show)]
+[Experimental("MyModule.PSNewAddTypeCompilation", ExperimentAction.Show)]
 [Parameter(ParameterSet = "NewCompilation")]
 public CompilationParameters CompileParameters { ... }
 
-[Experimental("PSNewAddTypeCompilation", ExperimentAction.Hide)]
+[Experimental("MyModule.PSNewAddTypeCompilation", ExperimentAction.Hide)]
 [Parameter()]
 public CodeDom CodeDom { ... }
 ```
@@ -127,10 +130,10 @@ Here is a different example in PowerShell script:
 
 ```powershell
 param(
-    [Experimental("PSNewFeature", "Show")]
+    [Experimental("MyModule.PSNewFeature", "Show")]
     [string] $NewName,
 
-    [Experimental("PSNewFeature", "Hide")]
+    [Experimental("MyModule.PSNewFeature", "Hide")]
     [string] $OldName
 )
 ```
@@ -138,15 +141,14 @@ param(
 ## Checking if an Experimental Feature is Enabled
 
 In your code, you will need to check if your experimental feature is enabled
-before taking appropriate action.
-You can determine if an experimental feature is enabled using the static
-`IsEnabled()` method on the `System.Management.Automation.ExperimentalFeature`
-class.
+before taking appropriate action. You can determine if an experimental feature
+is enabled using the static `IsEnabled()` method on the
+`System.Management.Automation.ExperimentalFeature` class.
 
 Here is an example in C#:
 
 ```csharp
-if (ExperimentalFeature.IsEnabled("MyExperimentalFeature"))
+if (ExperimentalFeature.IsEnabled("MyModule.MyExperimentalFeature"))
 {
    // code specific to the experimental feature
 }
@@ -155,7 +157,7 @@ if (ExperimentalFeature.IsEnabled("MyExperimentalFeature"))
 Here is an example in PowerShell script:
 
 ```powershell
-if ([ExperimentalFeature]::IsEnabled("MyExperimentalFeature"))
+if ([ExperimentalFeature]::IsEnabled("MyModule.MyExperimentalFeature"))
 {
   # code specific to the experimental feature
 }


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #5561 - clarify naming convention
Fixes [AB#1696562](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1696562)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://docs.microsoft.com/powershell/scripting/community/contributing/overview) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
