### PR TITLE
Chasewilson ghi4964

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PowerShell_exe.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PowerShell_exe.md
@@ -150,12 +150,9 @@ For example, the following command uses the **All** parameter of the
 `Get-Script.ps1` script file: `-File .\Get-Script.ps1 -All`
 
 In rare cases, you might need to provide a **Boolean** value for a switch
-parameter. To provide a **Boolean** value for a switch parameter in the value
-of the File parameter, if you are in **cmd.exe**, enclose the parameter name
-and value in curly braces, such as the following:
-`-File .\Get-Script.ps1 {-All:$False}`. If you are in a PowerShell host, use
-the **Command** parameter without using curly braces, such as the following:
-`powershell -Command {.\Get-Script.ps1 -All:$False}`.
+parameter. It is not possible to pass an explicit boolean value for a switch
+parameter when running a script in the way. This limitation was removed in
+PowerShell 6 (`pwsh.exe`).
 
 #### -ExecutionPolicy \<ExecutionPolicy\>
 


### PR DESCRIPTION
# PR Summary

Passing an explicit boolean value is not possible in the PowerShell.exe command line tools. 

## PR Context

Fixes #4964

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.x preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://docs.microsoft.com/powershell/scripting/community/contributing/overview) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
