### PR TITLE
Add more information about 'using' scope modifier

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -131,9 +131,11 @@ serialization process converts objects to a **PSObject** that contains the
 original objects properties but not its methods.
 
 For a limited set of types, deserialization rehydrates objects back to the
-original type. The rehydrated object contains the properties but not the
-methods of the original instance. Also, rehydrated certificate types do not
-include the private key.
+original type. The rehydrated object is a copy of the original object instance.
+It has the type properties and methods. For simple types, such as
+**System.Version**, the copy is exact. For complex types, the copy is
+imperfect. For example, rehydrated certificate objects do not include the
+private key.
 
 Instances of all other types are **PSObject** instances. The **PSTypeNames**
 property contains the original type name prefixed with **Deserialized**, for

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -127,13 +127,17 @@ sessions, they are passed by reference.
 Remotely executed commands and background jobs run out-of-process.
 Out-of-process sessions use XML-based serialization and deserialization to make
 the values of variables available across the process boundaries. The
-serialization process converts objects to a general type that contains the
+serialization process converts objects to a **PSObject** that contains the
 original objects properties but not its methods.
 
-Deserialization maintains type fidelity only for a limited set of known types.
-Instances of all other types are emulated. The **PSTypeNames** property
-contains the original type name prefixed with **Deserialized**, for example,
-**Deserialized.System.Data.DataTable**
+For a limited set of types, deserialization rehydrates objects back to the
+original type. The rehydrated object contains the properties but not the
+methods of the original instance. Also, rehydrated certificate types do not
+include the private key.
+
+Instances of all other types are **PSObject** instances. The **PSTypeNames**
+property contains the original type name prefixed with **Deserialized**, for
+example, **Deserialized.System.Data.DataTable**
 
 ## Using local variables with **ArgumentList** parameter
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -115,20 +115,25 @@ the following contexts:
 - Remotely executed commands, started with `Invoke-Command` using the
   **ComputerName** or **Session** parameter (remote session)
 - Background jobs, started with `Start-Job` (out-of-process session)
-- Thread jobs, started via `Start-ThreadJob` (separate thread session)
+- Thread jobs started via `Start-ThreadJob` (separate thread session)
 
-Depending on the context, embedded variables are copied values of the variables
-in the caller's scope. Out-of-process sessions, such as remote sessions,
-background jobs, and workflows, receive values of variables through the
-PowerShell serialization system.
+Depending on the context, embedded variable values are either independent
+copies of the data in the caller's scope or references to it. In remote and
+out-of-process sessions, they are always independent copies. In thread
+sessions, they are passed by reference.
 
 ## Serialization of variable values
 
-Remotely executed commands and background jobs run out-of-process. PowerShell
-uses XML-based serialization and deserialization to make the values of
-variables available across the process boundaries. The serialization process
-converts objects to a **PSObject** type. The **PSObject** is general type that
-contains the original objects properties but not its methods.
+Remotely executed commands and background jobs run out-of-process.
+Out-of-process sessions use XML-based serialization and deserialization to make
+the values of variables available across the process boundaries. The
+serialization process converts objects to a general type that contains the
+original objects properties but not its methods.
+
+Deserialization maintains type fidelity only for a limited set of known types.
+Instances of all other types are emulated. The **PSTypeNames** property
+contains the original type name prefixed with **Deserialized**, for example,
+**Deserialized.System.Data.DataTable**
 
 ## Using local variables with **ArgumentList** parameter
 
@@ -175,3 +180,4 @@ Invoke-Command -ComputerName S1 -ScriptBlock {
 
 [New-PSSession](../New-PSSession.md)
 
+[Start-ThreadJob](/powershell/module/ThreadJob/Start-ThreadJob)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -105,13 +105,52 @@ $Splat = @{ Name = "Win*"; Include = "WinRM" }
 Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
 ```
 
-## Using local variables in PowerShell 2.0
+### Other situations where the 'Using' scope modifier is needed
+
+For anything that executes out-of-runspace, doesn't execute directly in the
+caller's runspace, you need the `Using` scope modifier in order to embed
+variable values from the caller's scope, so that the out-of-runspace code
+can access it. (Conversely, all other contexts neither require nor support the
+'Using' scope modifier.) Specifically, this includes the following contexts:
+
+- Remotely executed commands, started with Invoke-Command's `-ComputerName` or
+  `-Session` parameter (remote runspace)
+- Background jobs, started with Start-Job (out-of-process runspace)
+- Thread jobs, started via Start-ThreadJob (separate runspace)
+- InlineScript in Workflows (out-of-process)
+
+> [!NOTE]
+> Note that out-of-runspace code can never modify variables in the caller's
+> scope. However, in the case of thread jobs (but not during remoting and not in
+> background jobs), if the variable value happens to be an instance of a reference
+> type (like a collection type), it is possible to modify that instance in
+> another thread, which requires synchronizing the modifications across threads,
+> should multiple threads perform modifications.
+
+## Serialization of variable values
+
+Remotely executed commands and background jobs run out-of-process. For values
+in variables to cross these process boundaries they undergo XML-based
+serialization and deserialization. This typically involves loss of type fidelity
+\- both on input and output. --> todo: example needed
+
+Thread jobs, by contrast, because they run in a different runspace (thread) in
+the same process receive $using: variable values as their original, live objects
+and, similarly, return such objects.
+
+The caveat is that explicit synchronization across runspaces (threads) may be
+needed, if they all access a given, mutable object - which is most likely to
+happen with ForEach-Object -Parallel.
+
+Generally, though, thread jobs are the better alternative to background jobs in
+most cases, due to their significantly better performance, lower resource use,
+and type fidelity.
+
+## Using local variables with `-ArgumentList` parameter
 
 You can use local variables in a remote command by defining parameters for the
 remote command and using the **ArgumentList** parameter of the `Invoke-Command`
 cmdlet to specify the local variable as the parameter value.
-
-The following command format is valid on PowerShell 2.0 and later versions:
 
 - Use the `param` keyword to define parameters for the remote command. The
   parameter names are placeholders that don't need to match the local
@@ -143,6 +182,8 @@ Invoke-Command -ComputerName S1 -ScriptBlock {
 [about_Scopes](about_Scopes.md)
 
 [about_Splatting](about_Splatting.md)
+
+[about_Variables](about_Variables.md)
 
 [Enter-PSSession](../Enter-PSSession.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 07/23/2019
+ms.date: 03/13/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_remote_variables?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Remote_Variables
@@ -107,46 +107,30 @@ Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
 
 ### Other situations where the 'Using' scope modifier is needed
 
-For anything that executes out-of-runspace, doesn't execute directly in the
-caller's runspace, you need the `Using` scope modifier in order to embed
-variable values from the caller's scope, so that the out-of-runspace code
-can access it. (Conversely, all other contexts neither require nor support the
-'Using' scope modifier.) Specifically, this includes the following contexts:
+For any script or command that executes out of session, you need the `Using`
+scope modifier to embed variable values from the calling session scope, so that
+out of session code can access them. The `Using` scope modifier is supported in
+the following contexts:
 
-- Remotely executed commands, started with Invoke-Command's `-ComputerName` or
-  `-Session` parameter (remote runspace)
-- Background jobs, started with Start-Job (out-of-process runspace)
-- Thread jobs, started via Start-ThreadJob (separate runspace)
-- InlineScript in Workflows (out-of-process)
+- Remotely executed commands, started with `Invoke-Command` using the
+  **ComputerName** or **Session** parameter (remote session)
+- Background jobs, started with `Start-Job` (out-of-process session)
+- Thread jobs, started via `Start-ThreadJob` (separate thread session)
 
-> [!NOTE]
-> Note that out-of-runspace code can never modify variables in the caller's
-> scope. However, in the case of thread jobs (but not during remoting and not in
-> background jobs), if the variable value happens to be an instance of a reference
-> type (like a collection type), it is possible to modify that instance in
-> another thread, which requires synchronizing the modifications across threads,
-> should multiple threads perform modifications.
+Depending on the context, embedded variables are copied values of the variables
+in the caller's scope. Out-of-process sessions, such as remote sessions,
+background jobs, and workflows, receive values of variables through the
+PowerShell serialization system.
 
 ## Serialization of variable values
 
-Remotely executed commands and background jobs run out-of-process. For values
-in variables to cross these process boundaries they undergo XML-based
-serialization and deserialization. This typically involves loss of type fidelity
-\- both on input and output. --> todo: example needed
+Remotely executed commands and background jobs run out-of-process. PowerShell
+uses XML-based serialization and deserialization to make the values of
+variables available across the process boundaries. The serialization process
+converts objects to a **PSObject** type. The **PSObject** is general type that
+contains the original objects properties but not its methods.
 
-Thread jobs, by contrast, because they run in a different runspace (thread) in
-the same process receive $using: variable values as their original, live objects
-and, similarly, return such objects.
-
-The caveat is that explicit synchronization across runspaces (threads) may be
-needed, if they all access a given, mutable object - which is most likely to
-happen with ForEach-Object -Parallel.
-
-Generally, though, thread jobs are the better alternative to background jobs in
-most cases, due to their significantly better performance, lower resource use,
-and type fidelity.
-
-## Using local variables with `-ArgumentList` parameter
+## Using local variables with **ArgumentList** parameter
 
 You can use local variables in a remote command by defining parameters for the
 remote command and using the **ArgumentList** parameter of the `Invoke-Command`
@@ -190,3 +174,4 @@ Invoke-Command -ComputerName S1 -ScriptBlock {
 [Invoke-Command](../Invoke-Command.md)
 
 [New-PSSession](../New-PSSession.md)
+

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 01/23/2020
+ms.date: 03/13/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scopes?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_scopes
@@ -191,9 +191,40 @@ Using is a special scope modifier that identifies a local variable in a remote
 command. Without a modifier, PowerShell expects variables in remote commands
 to be defined in the remote session.
 
-The Using scope modifier is introduced in PowerShell 3.0.
+The `Using` scope modifier is introduced in PowerShell 3.0.
+
+r any script or command that executes out of session, you need the `Using`
+scope modifier to embed variable values from the calling session scope, so that
+out of session code can access them. The `Using` scope modifier is supported in
+the following contexts:
+
+- Remotely executed commands, started with `Invoke-Command` using the
+  **ComputerName** or **Session** parameter (remote session)
+- Background jobs, started with `Start-Job` (out-of-process session)
+- Thread jobs, started via `Start-ThreadJob` (separate runspace)
+
+Depending on the context, embedded variables are copies values or references to
+the caller's scope variables. Out-of-process sessions, such as remote sessions,
+background jobs, and workflows, receive values of variables through the
+PowerShell serialization system.
 
 For more information, see [about_Remote_Variables](about_Remote_Variables.md).
+
+But for thread jobs receive references to variables. This means it is possible
+to modify call scope variables in a different thread. To safely modify
+variables requires thread synchronization.
+
+For more information see:
+
+- [Start-ThreadJob](../../ThreadJob/Start-ThreadJob.md)
+
+#### Serialization of variable values
+
+Remotely executed commands and background jobs run out-of-process. PowerShell
+uses XML-based serialization and deserialization to make the values of
+variables available across the process boundaries. The serialization process
+converts objects to a **PSObject** type. The **PSObject** is general type that
+contains the original objects properties but not its methods.
 
 ### The AllScope Option
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -227,9 +227,11 @@ serialization process converts objects to a **PSObject** that contains the
 original objects properties but not its methods.
 
 For a limited set of types, deserialization rehydrates objects back to the
-original type. The rehydrated object contains the properties but not the
-methods of the original instance. Also, rehydrated certificate types do not
-include the private key.
+original type. The rehydrated object is a copy of the original object instance.
+It has the type properties and methods. For simple types, such as
+**System.Version**, the copy is exact. For complex types, the copy is
+imperfect. For example, rehydrated certificate objects do not include the
+private key.
 
 Instances of all other types are **PSObject** instances. The **PSTypeNames**
 property contains the original type name prefixed with **Deserialized**, for

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -193,7 +193,7 @@ to be defined in the remote session.
 
 The `Using` scope modifier is introduced in PowerShell 3.0.
 
-r any script or command that executes out of session, you need the `Using`
+For any script or command that executes out of session, you need the `Using`
 scope modifier to embed variable values from the calling session scope, so that
 out of session code can access them. The `Using` scope modifier is supported in
 the following contexts:
@@ -201,18 +201,18 @@ the following contexts:
 - Remotely executed commands, started with `Invoke-Command` using the
   **ComputerName** or **Session** parameter (remote session)
 - Background jobs, started with `Start-Job` (out-of-process session)
-- Thread jobs, started via `Start-ThreadJob` (separate runspace)
+- Thread jobs, started via `Start-ThreadJob` or `ForEach-Object -Parallel`
+  (separate thread session)
 
-Depending on the context, embedded variables are copies values or references to
-the caller's scope variables. Out-of-process sessions, such as remote sessions,
-background jobs, and workflows, receive values of variables through the
-PowerShell serialization system.
+Depending on the context, embedded variable values are either independent
+copies of the data in the caller's scope or references to it. In remote and
+out-of-process sessions, they are always independent copies.
 
 For more information, see [about_Remote_Variables](about_Remote_Variables.md).
 
-But for thread jobs receive references to variables. This means it is possible
-to modify call scope variables in a different thread. To safely modify
-variables requires thread synchronization.
+In thread sessions, they are passed by reference. This means it is possible to
+modify call scope variables in a different thread. To safely modify variables
+requires thread synchronization.
 
 For more information see:
 
@@ -637,3 +637,5 @@ Invoke-Command $s {
 [about_Functions](about_Functions.md)
 
 [about_Script_Blocks](about_Script_Blocks.md)
+
+[Start-ThreadJob](/powershell/module/ThreadJob/Start-ThreadJob)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -220,11 +220,20 @@ For more information see:
 
 #### Serialization of variable values
 
-Remotely executed commands and background jobs run out-of-process. PowerShell
-uses XML-based serialization and deserialization to make the values of
-variables available across the process boundaries. The serialization process
-converts objects to a **PSObject** type. The **PSObject** is general type that
-contains the original objects properties but not its methods.
+Remotely executed commands and background jobs run out-of-process.
+Out-of-process sessions use XML-based serialization and deserialization to make
+the values of variables available across the process boundaries. The
+serialization process converts objects to a **PSObject** that contains the
+original objects properties but not its methods.
+
+For a limited set of types, deserialization rehydrates objects back to the
+original type. The rehydrated object contains the properties but not the
+methods of the original instance. Also, rehydrated certificate types do not
+include the private key.
+
+Instances of all other types are **PSObject** instances. The **PSTypeNames**
+property contains the original type name prefixed with **Deserialized**, for
+example, **Deserialized.System.Data.DataTable**
 
 ### The AllScope Option
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -132,9 +132,11 @@ serialization process converts objects to a **PSObject** that contains the
 original objects properties but not its methods.
 
 For a limited set of types, deserialization rehydrates objects back to the
-original type. The rehydrated object contains the properties but not the
-methods of the original instance. Also, rehydrated certificate types do not
-include the private key.
+original type. The rehydrated object is a copy of the original object instance.
+It has the type properties and methods. For simple types, such as
+**System.Version**, the copy is exact. For complex types, the copy is
+imperfect. For example, rehydrated certificate objects do not include the
+private key.
 
 Instances of all other types are **PSObject** instances. The **PSTypeNames**
 property contains the original type name prefixed with **Deserialized**, for

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -113,22 +113,28 @@ out of session code can access them. The `Using` scope modifier is supported in
 the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
-  **ComputerName** or **Session** parameter (remote session)
+  **ComputerName**, **HostName**, **SSHConnection** or **Session** parameters
+  (remote session)
 - Background jobs, started with `Start-Job` (out-of-process session)
-- Thread jobs, started via `Start-ThreadJob` (separate thread session)
+- Thread jobs started via `Start-ThreadJob` (separate thread session)
 
-Depending on the context, embedded variables are copied values of the variables
-in the caller's scope. Out-of-process sessions, such as remote sessions,
-background jobs, and workflows, receive values of variables through the
-PowerShell serialization system.
+Depending on the context, embedded variable values are either independent
+copies of the data in the caller's scope or references to it. In remote and
+out-of-process sessions, they are always independent copies. In thread
+sessions, they are passed by reference.
 
 ## Serialization of variable values
 
-Remotely executed commands and background jobs run out-of-process. PowerShell
-uses XML-based serialization and deserialization to make the values of
-variables available across the process boundaries. The serialization process
-converts objects to a **PSObject** type. The **PSObject** is general type that
-contains the original objects properties but not its methods.
+Remotely executed commands and background jobs run out-of-process.
+Out-of-process sessions use XML-based serialization and deserialization to make
+the values of variables available across the process boundaries. The
+serialization process converts objects to a general type that contains the
+original objects properties but not its methods.
+
+Deserialization maintains type fidelity only for a limited set of known types.
+Instances of all other types are emulated. The **PSTypeNames** property
+contains the original type name prefixed with **Deserialized**, for example,
+**Deserialized.System.Data.DataTable**
 
 ## Using local variables with **ArgumentList** parameter
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -128,13 +128,17 @@ sessions, they are passed by reference.
 Remotely executed commands and background jobs run out-of-process.
 Out-of-process sessions use XML-based serialization and deserialization to make
 the values of variables available across the process boundaries. The
-serialization process converts objects to a general type that contains the
+serialization process converts objects to a **PSObject** that contains the
 original objects properties but not its methods.
 
-Deserialization maintains type fidelity only for a limited set of known types.
-Instances of all other types are emulated. The **PSTypeNames** property
-contains the original type name prefixed with **Deserialized**, for example,
-**Deserialized.System.Data.DataTable**
+For a limited set of types, deserialization rehydrates objects back to the
+original type. The rehydrated object contains the properties but not the
+methods of the original instance. Also, rehydrated certificate types do not
+include the private key.
+
+Instances of all other types are **PSObject** instances. The **PSTypeNames**
+property contains the original type name prefixed with **Deserialized**, for
+example, **Deserialized.System.Data.DataTable**
 
 ## Using local variables with **ArgumentList** parameter
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -193,26 +193,26 @@ to be defined in the remote session.
 
 The `Using` scope modifier is introduced in PowerShell 3.0.
 
-r any script or command that executes out of session, you need the `Using`
+For any script or command that executes out of session, you need the `Using`
 scope modifier to embed variable values from the calling session scope, so that
 out of session code can access them. The `Using` scope modifier is supported in
 the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
-  **ComputerName** or **Session** parameter (remote session)
+  **ComputerName**, **HostName**, **SSHConnection** or **Session** parameters
+  (remote session)
 - Background jobs, started with `Start-Job` (out-of-process session)
-- Thread jobs, started via `Start-ThreadJob` (separate runspace)
+- Thread jobs started via `Start-ThreadJob` (separate thread session)
 
-Depending on the context, embedded variables are copies values or references to
-the caller's scope variables. Out-of-process sessions, such as remote sessions,
-background jobs, and workflows, receive values of variables through the
-PowerShell serialization system.
+Depending on the context, embedded variable values are either independent
+copies of the data in the caller's scope or references to it. In remote and
+out-of-process sessions, they are always independent copies.
 
 For more information, see [about_Remote_Variables](about_Remote_Variables.md).
 
-But for thread jobs receive references to variables. This means it is possible
-to modify call scope variables in a different thread. To safely modify
-variables requires thread synchronization.
+In thread sessions, they are passed by reference. This means it is possible to
+modify call scope variables in a different thread. To safely modify variables
+requires thread synchronization.
 
 For more information see:
 
@@ -637,3 +637,5 @@ Invoke-Command $s {
 [about_Functions](about_Functions.md)
 
 [about_Script_Blocks](about_Script_Blocks.md)
+
+[Start-ThreadJob](/powershell/module/ThreadJob/Start-ThreadJob)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -227,9 +227,11 @@ serialization process converts objects to a **PSObject** that contains the
 original objects properties but not its methods.
 
 For a limited set of types, deserialization rehydrates objects back to the
-original type. The rehydrated object contains the properties but not the
-methods of the original instance. Also, rehydrated certificate types do not
-include the private key.
+original type. The rehydrated object is a copy of the original object instance.
+It has the type properties and methods. For simple types, such as
+**System.Version**, the copy is exact. For complex types, the copy is
+imperfect. For example, rehydrated certificate objects do not include the
+private key.
 
 Instances of all other types are **PSObject** instances. The **PSTypeNames**
 property contains the original type name prefixed with **Deserialized**, for

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -220,11 +220,20 @@ For more information see:
 
 #### Serialization of variable values
 
-Remotely executed commands and background jobs run out-of-process. PowerShell
-uses XML-based serialization and deserialization to make the values of
-variables available across the process boundaries. The serialization process
-converts objects to a **PSObject** type. The **PSObject** is general type that
-contains the original objects properties but not its methods.
+Remotely executed commands and background jobs run out-of-process.
+Out-of-process sessions use XML-based serialization and deserialization to make
+the values of variables available across the process boundaries. The
+serialization process converts objects to a **PSObject** that contains the
+original objects properties but not its methods.
+
+For a limited set of types, deserialization rehydrates objects back to the
+original type. The rehydrated object contains the properties but not the
+methods of the original instance. Also, rehydrated certificate types do not
+include the private key.
+
+Instances of all other types are **PSObject** instances. The **PSTypeNames**
+property contains the original type name prefixed with **Deserialized**, for
+example, **Deserialized.System.Data.DataTable**
 
 ### The AllScope Option
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 01/23/2020
+ms.date: 03/13/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scopes?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_scopes
@@ -191,9 +191,40 @@ Using is a special scope modifier that identifies a local variable in a remote
 command. Without a modifier, PowerShell expects variables in remote commands
 to be defined in the remote session.
 
-The Using scope modifier is introduced in PowerShell 3.0.
+The `Using` scope modifier is introduced in PowerShell 3.0.
+
+r any script or command that executes out of session, you need the `Using`
+scope modifier to embed variable values from the calling session scope, so that
+out of session code can access them. The `Using` scope modifier is supported in
+the following contexts:
+
+- Remotely executed commands, started with `Invoke-Command` using the
+  **ComputerName** or **Session** parameter (remote session)
+- Background jobs, started with `Start-Job` (out-of-process session)
+- Thread jobs, started via `Start-ThreadJob` (separate runspace)
+
+Depending on the context, embedded variables are copies values or references to
+the caller's scope variables. Out-of-process sessions, such as remote sessions,
+background jobs, and workflows, receive values of variables through the
+PowerShell serialization system.
 
 For more information, see [about_Remote_Variables](about_Remote_Variables.md).
+
+But for thread jobs receive references to variables. This means it is possible
+to modify call scope variables in a different thread. To safely modify
+variables requires thread synchronization.
+
+For more information see:
+
+- [Start-ThreadJob](../../ThreadJob/Start-ThreadJob.md)
+
+#### Serialization of variable values
+
+Remotely executed commands and background jobs run out-of-process. PowerShell
+uses XML-based serialization and deserialization to make the values of
+variables available across the process boundaries. The serialization process
+converts objects to a **PSObject** type. The **PSObject** is general type that
+contains the original objects properties but not its methods.
 
 ### The AllScope Option
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -129,13 +129,17 @@ sessions, they are passed by reference.
 Remotely executed commands and background jobs run out-of-process.
 Out-of-process sessions use XML-based serialization and deserialization to make
 the values of variables available across the process boundaries. The
-serialization process converts objects to a general type that contains the
+serialization process converts objects to a **PSObject** that contains the
 original objects properties but not its methods.
 
-Deserialization maintains type fidelity only for a limited set of known types.
-Instances of all other types are emulated. The **PSTypeNames** property
-contains the original type name prefixed with **Deserialized**, for example,
-**Deserialized.System.Data.DataTable**
+For a limited set of types, deserialization rehydrates objects back to the
+original type. The rehydrated object contains the properties but not the
+methods of the original instance. Also, rehydrated certificate types do not
+include the private key.
+
+Instances of all other types are **PSObject** instances. The **PSTypeNames**
+property contains the original type name prefixed with **Deserialized**, for
+example, **Deserialized.System.Data.DataTable**
 
 ## Using local variables with **ArgumentList** parameter
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -113,23 +113,29 @@ out of session code can access them. The `Using` scope modifier is supported in
 the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
-  **ComputerName** or **Session** parameter (remote session)
+  **ComputerName**, **HostName**, **SSHConnection** or **Session** parameters
+  (remote session)
 - Background jobs, started with `Start-Job` (out-of-process session)
 - Thread jobs, started via `Start-ThreadJob` or `ForEach-Object -Parallel`
   (separate thread session)
 
-Depending on the context, embedded variables are copied values of the variables
-in the caller's scope. Out-of-process sessions, such as remote sessions,
-background jobs, and workflows, receive values of variables through the
-PowerShell serialization system.
+Depending on the context, embedded variable values are either independent
+copies of the data in the caller's scope or references to it. In remote and
+out-of-process sessions, they are always independent copies. In thread
+sessions, they are passed by reference.
 
 ## Serialization of variable values
 
-Remotely executed commands and background jobs run out-of-process. PowerShell
-uses XML-based serialization and deserialization to make the values of
-variables available across the process boundaries. The serialization process
-converts objects to a **PSObject** type. The **PSObject** is general type that
-contains the original objects properties but not its methods.
+Remotely executed commands and background jobs run out-of-process.
+Out-of-process sessions use XML-based serialization and deserialization to make
+the values of variables available across the process boundaries. The
+serialization process converts objects to a general type that contains the
+original objects properties but not its methods.
+
+Deserialization maintains type fidelity only for a limited set of known types.
+Instances of all other types are emulated. The **PSTypeNames** property
+contains the original type name prefixed with **Deserialized**, for example,
+**Deserialized.System.Data.DataTable**
 
 ## Using local variables with **ArgumentList** parameter
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -105,13 +105,52 @@ $Splat = @{ Name = "Win*"; Include = "WinRM" }
 Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
 ```
 
-## Using local variables in PowerShell 2.0
+### Other situations where the 'Using' scope modifier is needed
+
+For anything that executes out-of-runspace, doesn't execute directly in the
+caller's runspace, you need the `Using` scope modifier in order to embed
+variable values from the caller's scope, so that the out-of-runspace code
+can access it. (Conversely, all other contexts neither require nor support the
+'Using' scope modifier.) Specifically, this includes the following contexts:
+
+- Remotely executed commands, started with Invoke-Command's `-ComputerName` or
+  `-Session` parameter (remote runspace)
+- Background jobs, started with Start-Job (out-of-process runspace)
+- Thread jobs, started via Start-ThreadJob or ForEach-Object -Parallel
+  (separate runspace)
+
+> [!NOTE]
+> Note that out-of-runspace code can never modify variables in the caller's
+> scope. However, in the case of thread jobs (but not during remoting and not in
+> background jobs), if the variable value happens to be an instance of a reference
+> type (like a collection type), it is possible to modify that instance in
+> another thread, which requires synchronizing the modifications across threads,
+> should multiple threads perform modifications.
+
+## Serialization of variable values
+
+Remotely executed commands and background jobs run out-of-process. For values
+in variables to cross these process boundaries they undergo XML-based
+serialization and deserialization. This typically involves loss of type fidelity
+\- both on input and output. --> todo: example needed
+
+Thread jobs, by contrast, because they run in a different runspace (thread) in
+the same process receive $using: variable values as their original, live objects
+and, similarly, return such objects.
+
+The caveat is that explicit synchronization across runspaces (threads) may be
+needed, if they all access a given, mutable object - which is most likely to
+happen with ForEach-Object -Parallel.
+
+Generally, though, thread jobs are the better alternative to background jobs in
+most cases, due to their significantly better performance, lower resource use,
+and type fidelity.
+
+## Using local variables with `-ArgumentList` parameter
 
 You can use local variables in a remote command by defining parameters for the
 remote command and using the **ArgumentList** parameter of the `Invoke-Command`
 cmdlet to specify the local variable as the parameter value.
-
-The following command format is valid on PowerShell 2.0 and later versions:
 
 - Use the `param` keyword to define parameters for the remote command. The
   parameter names are placeholders that don't need to match the local

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -133,9 +133,11 @@ serialization process converts objects to a **PSObject** that contains the
 original objects properties but not its methods.
 
 For a limited set of types, deserialization rehydrates objects back to the
-original type. The rehydrated object contains the properties but not the
-methods of the original instance. Also, rehydrated certificate types do not
-include the private key.
+original type. The rehydrated object is a copy of the original object instance.
+It has the type properties and methods. For simple types, such as
+**System.Version**, the copy is exact. For complex types, the copy is
+imperfect. For example, rehydrated certificate objects do not include the
+private key.
 
 Instances of all other types are **PSObject** instances. The **PSTypeNames**
 property contains the original type name prefixed with **Deserialized**, for

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 07/23/2019
+ms.date: 03/13/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_remote_variables?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Remote_Variables
@@ -107,46 +107,31 @@ Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
 
 ### Other situations where the 'Using' scope modifier is needed
 
-For anything that executes out-of-runspace, doesn't execute directly in the
-caller's runspace, you need the `Using` scope modifier in order to embed
-variable values from the caller's scope, so that the out-of-runspace code
-can access it. (Conversely, all other contexts neither require nor support the
-'Using' scope modifier.) Specifically, this includes the following contexts:
+For any script or command that executes out of session, you need the `Using`
+scope modifier to embed variable values from the calling session scope, so that
+out of session code can access them. The `Using` scope modifier is supported in
+the following contexts:
 
-- Remotely executed commands, started with Invoke-Command's `-ComputerName` or
-  `-Session` parameter (remote runspace)
-- Background jobs, started with Start-Job (out-of-process runspace)
-- Thread jobs, started via Start-ThreadJob or ForEach-Object -Parallel
-  (separate runspace)
+- Remotely executed commands, started with `Invoke-Command` using the
+  **ComputerName** or **Session** parameter (remote session)
+- Background jobs, started with `Start-Job` (out-of-process session)
+- Thread jobs, started via `Start-ThreadJob` or `ForEach-Object -Parallel`
+  (separate thread session)
 
-> [!NOTE]
-> Note that out-of-runspace code can never modify variables in the caller's
-> scope. However, in the case of thread jobs (but not during remoting and not in
-> background jobs), if the variable value happens to be an instance of a reference
-> type (like a collection type), it is possible to modify that instance in
-> another thread, which requires synchronizing the modifications across threads,
-> should multiple threads perform modifications.
+Depending on the context, embedded variables are copied values of the variables
+in the caller's scope. Out-of-process sessions, such as remote sessions,
+background jobs, and workflows, receive values of variables through the
+PowerShell serialization system.
 
 ## Serialization of variable values
 
-Remotely executed commands and background jobs run out-of-process. For values
-in variables to cross these process boundaries they undergo XML-based
-serialization and deserialization. This typically involves loss of type fidelity
-\- both on input and output. --> todo: example needed
+Remotely executed commands and background jobs run out-of-process. PowerShell
+uses XML-based serialization and deserialization to make the values of
+variables available across the process boundaries. The serialization process
+converts objects to a **PSObject** type. The **PSObject** is general type that
+contains the original objects properties but not its methods.
 
-Thread jobs, by contrast, because they run in a different runspace (thread) in
-the same process receive $using: variable values as their original, live objects
-and, similarly, return such objects.
-
-The caveat is that explicit synchronization across runspaces (threads) may be
-needed, if they all access a given, mutable object - which is most likely to
-happen with ForEach-Object -Parallel.
-
-Generally, though, thread jobs are the better alternative to background jobs in
-most cases, due to their significantly better performance, lower resource use,
-and type fidelity.
-
-## Using local variables with `-ArgumentList` parameter
+## Using local variables with **ArgumentList** parameter
 
 You can use local variables in a remote command by defining parameters for the
 remote command and using the **ArgumentList** parameter of the `Invoke-Command`
@@ -183,8 +168,14 @@ Invoke-Command -ComputerName S1 -ScriptBlock {
 
 [about_Splatting](about_Splatting.md)
 
+[about_Variables](about_Variables.md)
+
 [Enter-PSSession](../Enter-PSSession.md)
 
 [Invoke-Command](../Invoke-Command.md)
 
 [New-PSSession](../New-PSSession.md)
+
+[Start-ThreadJob](../../ThreadJob/Start-ThreadJob.md)
+
+[ForEach-Object](../ForEach-Object.md#notes)

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -222,11 +222,20 @@ For more information see:
 
 #### Serialization of variable values
 
-Remotely executed commands and background jobs run out-of-process. PowerShell
-uses XML-based serialization and deserialization to make the values of
-variables available across the process boundaries. The serialization process
-converts objects to a **PSObject** type. The **PSObject** is general type that
-contains the original objects properties but not its methods.
+Remotely executed commands and background jobs run out-of-process.
+Out-of-process sessions use XML-based serialization and deserialization to make
+the values of variables available across the process boundaries. The
+serialization process converts objects to a **PSObject** that contains the
+original objects properties but not its methods.
+
+For a limited set of types, deserialization rehydrates objects back to the
+original type. The rehydrated object contains the properties but not the
+methods of the original instance. Also, rehydrated certificate types do not
+include the private key.
+
+Instances of all other types are **PSObject** instances. The **PSTypeNames**
+property contains the original type name prefixed with **Deserialized**, for
+example, **Deserialized.System.Data.DataTable**
 
 ### The AllScope Option
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -229,9 +229,11 @@ serialization process converts objects to a **PSObject** that contains the
 original objects properties but not its methods.
 
 For a limited set of types, deserialization rehydrates objects back to the
-original type. The rehydrated object contains the properties but not the
-methods of the original instance. Also, rehydrated certificate types do not
-include the private key.
+original type. The rehydrated object is a copy of the original object instance.
+It has the type properties and methods. For simple types, such as
+**System.Version**, the copy is exact. For complex types, the copy is
+imperfect. For example, rehydrated certificate objects do not include the
+private key.
 
 Instances of all other types are **PSObject** instances. The **PSTypeNames**
 property contains the original type name prefixed with **Deserialized**, for

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 01/23/2020
+ms.date: 03/13/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scopes?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_scopes
@@ -191,9 +191,42 @@ Using is a special scope modifier that identifies a local variable in a remote
 command. Without a modifier, PowerShell expects variables in remote commands
 to be defined in the remote session.
 
-The Using scope modifier is introduced in PowerShell 3.0.
+The `Using` scope modifier is introduced in PowerShell 3.0.
+
+r any script or command that executes out of session, you need the `Using`
+scope modifier to embed variable values from the calling session scope, so that
+out of session code can access them. The `Using` scope modifier is supported in
+the following contexts:
+
+- Remotely executed commands, started with `Invoke-Command` using the
+  **ComputerName** or **Session** parameter (remote session)
+- Background jobs, started with `Start-Job` (out-of-process session)
+- Thread jobs, started via `Start-ThreadJob` or `ForEach-Object -Parallel`
+  (separate runspace)
+
+Depending on the context, embedded variables are copies values or references to
+the caller's scope variables. Out-of-process sessions, such as remote sessions,
+background jobs, and workflows, receive values of variables through the
+PowerShell serialization system.
 
 For more information, see [about_Remote_Variables](about_Remote_Variables.md).
+
+But for thread jobs receive references to variables. This means it is possible
+to modify call scope variables in a different thread. To safely modify
+variables requires thread synchronization.
+
+For more information see:
+
+- [Start-ThreadJob](../../ThreadJob/Start-ThreadJob.md)
+- [ForEach-Object](../ForEach-Object.md#notes)
+
+#### Serialization of variable values
+
+Remotely executed commands and background jobs run out-of-process. PowerShell
+uses XML-based serialization and deserialization to make the values of
+variables available across the process boundaries. The serialization process
+converts objects to a **PSObject** type. The **PSObject** is general type that
+contains the original objects properties but not its methods.
 
 ### The AllScope Option
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -193,27 +193,27 @@ to be defined in the remote session.
 
 The `Using` scope modifier is introduced in PowerShell 3.0.
 
-r any script or command that executes out of session, you need the `Using`
+For any script or command that executes out of session, you need the `Using`
 scope modifier to embed variable values from the calling session scope, so that
 out of session code can access them. The `Using` scope modifier is supported in
 the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
-  **ComputerName** or **Session** parameter (remote session)
+  **ComputerName**, **HostName**, **SSHConnection** or **Session** parameters
+  (remote session)
 - Background jobs, started with `Start-Job` (out-of-process session)
 - Thread jobs, started via `Start-ThreadJob` or `ForEach-Object -Parallel`
-  (separate runspace)
+  (separate thread session)
 
-Depending on the context, embedded variables are copies values or references to
-the caller's scope variables. Out-of-process sessions, such as remote sessions,
-background jobs, and workflows, receive values of variables through the
-PowerShell serialization system.
+Depending on the context, embedded variable values are either independent
+copies of the data in the caller's scope or references to it. In remote and
+out-of-process sessions, they are always independent copies.
 
 For more information, see [about_Remote_Variables](about_Remote_Variables.md).
 
-But for thread jobs receive references to variables. This means it is possible
-to modify call scope variables in a different thread. To safely modify
-variables requires thread synchronization.
+In thread sessions, they are passed by reference. This means it is possible to
+modify call scope variables in a different thread. To safely modify variables
+requires thread synchronization.
 
 For more information see:
 
@@ -639,3 +639,5 @@ Invoke-Command $s {
 [about_Functions](about_Functions.md)
 
 [about_Script_Blocks](about_Script_Blocks.md)
+
+[Start-ThreadJob](/powershell/module/ThreadJob/Start-ThreadJob)

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -129,13 +129,17 @@ sessions, they are passed by reference.
 Remotely executed commands and background jobs run out-of-process.
 Out-of-process sessions use XML-based serialization and deserialization to make
 the values of variables available across the process boundaries. The
-serialization process converts objects to a general type that contains the
+serialization process converts objects to a **PSObject** that contains the
 original objects properties but not its methods.
 
-Deserialization maintains type fidelity only for a limited set of known types.
-Instances of all other types are emulated. The **PSTypeNames** property
-contains the original type name prefixed with **Deserialized**, for example,
-**Deserialized.System.Data.DataTable**
+For a limited set of types, deserialization rehydrates objects back to the
+original type. The rehydrated object contains the properties but not the
+methods of the original instance. Also, rehydrated certificate types do not
+include the private key.
+
+Instances of all other types are **PSObject** instances. The **PSTypeNames**
+property contains the original type name prefixed with **Deserialized**, for
+example, **Deserialized.System.Data.DataTable**
 
 ## Using local variables with **ArgumentList** parameter
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -113,23 +113,29 @@ out of session code can access them. The `Using` scope modifier is supported in
 the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
-  **ComputerName** or **Session** parameter (remote session)
+  **ComputerName**, **HostName**, **SSHConnection** or **Session** parameters
+  (remote session)
 - Background jobs, started with `Start-Job` (out-of-process session)
 - Thread jobs, started via `Start-ThreadJob` or `ForEach-Object -Parallel`
   (separate thread session)
 
-Depending on the context, embedded variables are copied values of the variables
-in the caller's scope. Out-of-process sessions, such as remote sessions,
-background jobs, and workflows, receive values of variables through the
-PowerShell serialization system.
+Depending on the context, embedded variable values are either independent
+copies of the data in the caller's scope or references to it. In remote and
+out-of-process sessions, they are always independent copies. In thread
+sessions, they are passed by reference.
 
 ## Serialization of variable values
 
-Remotely executed commands and background jobs run out-of-process. PowerShell
-uses XML-based serialization and deserialization to make the values of
-variables available across the process boundaries. The serialization process
-converts objects to a **PSObject** type. The **PSObject** is general type that
-contains the original objects properties but not its methods.
+Remotely executed commands and background jobs run out-of-process.
+Out-of-process sessions use XML-based serialization and deserialization to make
+the values of variables available across the process boundaries. The
+serialization process converts objects to a general type that contains the
+original objects properties but not its methods.
+
+Deserialization maintains type fidelity only for a limited set of known types.
+Instances of all other types are emulated. The **PSTypeNames** property
+contains the original type name prefixed with **Deserialized**, for example,
+**Deserialized.System.Data.DataTable**
 
 ## Using local variables with **ArgumentList** parameter
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -105,13 +105,52 @@ $Splat = @{ Name = "Win*"; Include = "WinRM" }
 Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
 ```
 
-## Using local variables in PowerShell 2.0
+### Other situations where the 'Using' scope modifier is needed
+
+For anything that executes out-of-runspace, doesn't execute directly in the
+caller's runspace, you need the `Using` scope modifier in order to embed
+variable values from the caller's scope, so that the out-of-runspace code
+can access it. (Conversely, all other contexts neither require nor support the
+'Using' scope modifier.) Specifically, this includes the following contexts:
+
+- Remotely executed commands, started with Invoke-Command's `-ComputerName` or
+  `-Session` parameter (remote runspace)
+- Background jobs, started with Start-Job (out-of-process runspace)
+- Thread jobs, started via Start-ThreadJob or ForEach-Object -Parallel
+  (separate runspace)
+
+> [!NOTE]
+> Note that out-of-runspace code can never modify variables in the caller's
+> scope. However, in the case of thread jobs (but not during remoting and not in
+> background jobs), if the variable value happens to be an instance of a reference
+> type (like a collection type), it is possible to modify that instance in
+> another thread, which requires synchronizing the modifications across threads,
+> should multiple threads perform modifications.
+
+## Serialization of variable values
+
+Remotely executed commands and background jobs run out-of-process. For values
+in variables to cross these process boundaries they undergo XML-based
+serialization and deserialization. This typically involves loss of type fidelity
+\- both on input and output. --> todo: example needed
+
+Thread jobs, by contrast, because they run in a different runspace (thread) in
+the same process receive $using: variable values as their original, live objects
+and, similarly, return such objects.
+
+The caveat is that explicit synchronization across runspaces (threads) may be
+needed, if they all access a given, mutable object - which is most likely to
+happen with ForEach-Object -Parallel.
+
+Generally, though, thread jobs are the better alternative to background jobs in
+most cases, due to their significantly better performance, lower resource use,
+and type fidelity.
+
+## Using local variables with `-ArgumentList` parameter
 
 You can use local variables in a remote command by defining parameters for the
 remote command and using the **ArgumentList** parameter of the `Invoke-Command`
 cmdlet to specify the local variable as the parameter value.
-
-The following command format is valid on PowerShell 2.0 and later versions:
 
 - Use the `param` keyword to define parameters for the remote command. The
   parameter names are placeholders that don't need to match the local

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -133,9 +133,11 @@ serialization process converts objects to a **PSObject** that contains the
 original objects properties but not its methods.
 
 For a limited set of types, deserialization rehydrates objects back to the
-original type. The rehydrated object contains the properties but not the
-methods of the original instance. Also, rehydrated certificate types do not
-include the private key.
+original type. The rehydrated object is a copy of the original object instance.
+It has the type properties and methods. For simple types, such as
+**System.Version**, the copy is exact. For complex types, the copy is
+imperfect. For example, rehydrated certificate objects do not include the
+private key.
 
 Instances of all other types are **PSObject** instances. The **PSTypeNames**
 property contains the original type name prefixed with **Deserialized**, for

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 07/23/2019
+ms.date: 03/13/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_remote_variables?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Remote_Variables
@@ -107,46 +107,31 @@ Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
 
 ### Other situations where the 'Using' scope modifier is needed
 
-For anything that executes out-of-runspace, doesn't execute directly in the
-caller's runspace, you need the `Using` scope modifier in order to embed
-variable values from the caller's scope, so that the out-of-runspace code
-can access it. (Conversely, all other contexts neither require nor support the
-'Using' scope modifier.) Specifically, this includes the following contexts:
+For any script or command that executes out of session, you need the `Using`
+scope modifier to embed variable values from the calling session scope, so that
+out of session code can access them. The `Using` scope modifier is supported in
+the following contexts:
 
-- Remotely executed commands, started with Invoke-Command's `-ComputerName` or
-  `-Session` parameter (remote runspace)
-- Background jobs, started with Start-Job (out-of-process runspace)
-- Thread jobs, started via Start-ThreadJob or ForEach-Object -Parallel
-  (separate runspace)
+- Remotely executed commands, started with `Invoke-Command` using the
+  **ComputerName** or **Session** parameter (remote session)
+- Background jobs, started with `Start-Job` (out-of-process session)
+- Thread jobs, started via `Start-ThreadJob` or `ForEach-Object -Parallel`
+  (separate thread session)
 
-> [!NOTE]
-> Note that out-of-runspace code can never modify variables in the caller's
-> scope. However, in the case of thread jobs (but not during remoting and not in
-> background jobs), if the variable value happens to be an instance of a reference
-> type (like a collection type), it is possible to modify that instance in
-> another thread, which requires synchronizing the modifications across threads,
-> should multiple threads perform modifications.
+Depending on the context, embedded variables are copied values of the variables
+in the caller's scope. Out-of-process sessions, such as remote sessions,
+background jobs, and workflows, receive values of variables through the
+PowerShell serialization system.
 
 ## Serialization of variable values
 
-Remotely executed commands and background jobs run out-of-process. For values
-in variables to cross these process boundaries they undergo XML-based
-serialization and deserialization. This typically involves loss of type fidelity
-\- both on input and output. --> todo: example needed
+Remotely executed commands and background jobs run out-of-process. PowerShell
+uses XML-based serialization and deserialization to make the values of
+variables available across the process boundaries. The serialization process
+converts objects to a **PSObject** type. The **PSObject** is general type that
+contains the original objects properties but not its methods.
 
-Thread jobs, by contrast, because they run in a different runspace (thread) in
-the same process receive $using: variable values as their original, live objects
-and, similarly, return such objects.
-
-The caveat is that explicit synchronization across runspaces (threads) may be
-needed, if they all access a given, mutable object - which is most likely to
-happen with ForEach-Object -Parallel.
-
-Generally, though, thread jobs are the better alternative to background jobs in
-most cases, due to their significantly better performance, lower resource use,
-and type fidelity.
-
-## Using local variables with `-ArgumentList` parameter
+## Using local variables with **ArgumentList** parameter
 
 You can use local variables in a remote command by defining parameters for the
 remote command and using the **ArgumentList** parameter of the `Invoke-Command`
@@ -183,8 +168,14 @@ Invoke-Command -ComputerName S1 -ScriptBlock {
 
 [about_Splatting](about_Splatting.md)
 
+[about_Variables](about_Variables.md)
+
 [Enter-PSSession](../Enter-PSSession.md)
 
 [Invoke-Command](../Invoke-Command.md)
 
 [New-PSSession](../New-PSSession.md)
+
+[Start-ThreadJob](../../ThreadJob/Start-ThreadJob.md)
+
+[ForEach-Object](../ForEach-Object.md#notes)

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 01/23/2020
+ms.date: 03/13/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scopes?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_scopes
@@ -191,9 +191,42 @@ Using is a special scope modifier that identifies a local variable in a remote
 command. Without a modifier, PowerShell expects variables in remote commands
 to be defined in the remote session.
 
-The Using scope modifier is introduced in PowerShell 3.0.
+The `Using` scope modifier is introduced in PowerShell 3.0.
+
+r any script or command that executes out of session, you need the `Using`
+scope modifier to embed variable values from the calling session scope, so that
+out of session code can access them. The `Using` scope modifier is supported in
+the following contexts:
+
+- Remotely executed commands, started with `Invoke-Command` using the
+  **ComputerName** or **Session** parameter (remote session)
+- Background jobs, started with `Start-Job` (out-of-process session)
+- Thread jobs, started via `Start-ThreadJob` or `ForEach-Object -Parallel`
+  (separate runspace)
+
+Depending on the context, embedded variables are copies values or references to
+the caller's scope variables. Out-of-process sessions, such as remote sessions,
+background jobs, and workflows, receive values of variables through the
+PowerShell serialization system.
 
 For more information, see [about_Remote_Variables](about_Remote_Variables.md).
+
+But for thread jobs receive references to variables. This means it is possible
+to modify call scope variables in a different thread. To safely modify
+variables requires thread synchronization.
+
+For more information see:
+
+- [Start-ThreadJob](../../ThreadJob/Start-ThreadJob.md)
+- [ForEach-Object](../ForEach-Object.md#notes)
+
+#### Serialization of variable values
+
+Remotely executed commands and background jobs run out-of-process. PowerShell
+uses XML-based serialization and deserialization to make the values of
+variables available across the process boundaries. The serialization process
+converts objects to a **PSObject** type. The **PSObject** is general type that
+contains the original objects properties but not its methods.
 
 ### The AllScope Option
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -222,11 +222,20 @@ For more information see:
 
 #### Serialization of variable values
 
-Remotely executed commands and background jobs run out-of-process. PowerShell
-uses XML-based serialization and deserialization to make the values of
-variables available across the process boundaries. The serialization process
-converts objects to a **PSObject** type. The **PSObject** is general type that
-contains the original objects properties but not its methods.
+Remotely executed commands and background jobs run out-of-process.
+Out-of-process sessions use XML-based serialization and deserialization to make
+the values of variables available across the process boundaries. The
+serialization process converts objects to a **PSObject** that contains the
+original objects properties but not its methods.
+
+For a limited set of types, deserialization rehydrates objects back to the
+original type. The rehydrated object contains the properties but not the
+methods of the original instance. Also, rehydrated certificate types do not
+include the private key.
+
+Instances of all other types are **PSObject** instances. The **PSTypeNames**
+property contains the original type name prefixed with **Deserialized**, for
+example, **Deserialized.System.Data.DataTable**
 
 ### The AllScope Option
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -229,9 +229,11 @@ serialization process converts objects to a **PSObject** that contains the
 original objects properties but not its methods.
 
 For a limited set of types, deserialization rehydrates objects back to the
-original type. The rehydrated object contains the properties but not the
-methods of the original instance. Also, rehydrated certificate types do not
-include the private key.
+original type. The rehydrated object is a copy of the original object instance.
+It has the type properties and methods. For simple types, such as
+**System.Version**, the copy is exact. For complex types, the copy is
+imperfect. For example, rehydrated certificate objects do not include the
+private key.
 
 Instances of all other types are **PSObject** instances. The **PSTypeNames**
 property contains the original type name prefixed with **Deserialized**, for

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -193,27 +193,27 @@ to be defined in the remote session.
 
 The `Using` scope modifier is introduced in PowerShell 3.0.
 
-r any script or command that executes out of session, you need the `Using`
+For any script or command that executes out of session, you need the `Using`
 scope modifier to embed variable values from the calling session scope, so that
 out of session code can access them. The `Using` scope modifier is supported in
 the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
-  **ComputerName** or **Session** parameter (remote session)
+  **ComputerName**, **HostName**, **SSHConnection** or **Session** parameters
+  (remote session)
 - Background jobs, started with `Start-Job` (out-of-process session)
 - Thread jobs, started via `Start-ThreadJob` or `ForEach-Object -Parallel`
-  (separate runspace)
+  (separate thread session)
 
-Depending on the context, embedded variables are copies values or references to
-the caller's scope variables. Out-of-process sessions, such as remote sessions,
-background jobs, and workflows, receive values of variables through the
-PowerShell serialization system.
+Depending on the context, embedded variable values are either independent
+copies of the data in the caller's scope or references to it. In remote and
+out-of-process sessions, they are always independent copies.
 
 For more information, see [about_Remote_Variables](about_Remote_Variables.md).
 
-But for thread jobs receive references to variables. This means it is possible
-to modify call scope variables in a different thread. To safely modify
-variables requires thread synchronization.
+In thread sessions, they are passed by reference. This means it is possible to
+modify call scope variables in a different thread. To safely modify variables
+requires thread synchronization.
 
 For more information see:
 
@@ -639,3 +639,5 @@ Invoke-Command $s {
 [about_Functions](about_Functions.md)
 
 [about_Script_Blocks](about_Script_Blocks.md)
+
+[Start-ThreadJob](/powershell/module/ThreadJob/Start-ThreadJob)


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Replaces PR #5497 - I had to close this PR because the branch was too stale.
Fixes #5068

@PaulHigin @Jawz84 @mklement0 I made some changes based on the feedback. Let me know how this looks.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://docs.microsoft.com/powershell/scripting/community/contributing/overview) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
