### PR TITLE
Update alpine package name in installation guide

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
@@ -313,7 +313,7 @@ pwsh
 
 ### Installation via Direct Download - Alpine 3.9 and 3.10
 
-Download the tar.gz package `powershell_7.0.0-linux-x64.tar.gz` from the [releases][] page onto
+Download the tar.gz package `powershell-7.0.0-linux-alpine-x64.tar.gz` from the [releases][] page onto
 the Alpine machine.
 
 Then, in the terminal, execute the following commands:


### PR DESCRIPTION
# PR Summary
The "Installing PowerShell on Linux" has a wrong name of the alpine package. The PR corrects it.

The change is minor, but the current state of documentation led me to incorrect docker-container, that I had to debug for a while.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.x preview content
- [x] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [x] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
