### PR TITLE
Fixes #5631 - support for negative number added in PS7

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Split.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 12/20/2017
+ms.date: 03/24/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_split?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Split
@@ -114,7 +114,7 @@ substring become part of the substring.
 'Chocolate-Vanilla-Strawberry-Blueberry' -split '(-)', 3
 ```
 
-```output
+```Output
 Chocolate
 -
 Vanilla
@@ -131,10 +131,13 @@ the substrings are returned. A value of 0 returns all the substrings. Negative
 values return the amount of substrings requested starting from the end of the
 input string.
 
-Max-substrings does not specify the maximum number of objects that are
-returned; its value equals the maximum number of times that a string is split.
-If you submit more than one string (an array of strings) to the Split operator
-, the Max-substrings limit is applied to each string separately.
+> [!NOTE]
+> Support for negative values was added in PowerShell 7.
+
+**Max-substrings** does not specify the maximum number of objects that are
+returned. its value equals the maximum number of times that a string is split.
+If you submit more than one string (an array of strings) to the `-split`
+operator, the **Max-substrings** limit is applied to each string separately.
 
 Example:
 
@@ -143,7 +146,7 @@ $c = "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune"
 $c -split ",", 5
 ```
 
-```output
+```Output
 Mercury
 Venus
 Earth
@@ -156,7 +159,7 @@ $c = "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune"
 $c -split ",", -5
 ```
 
-```output
+```Output
 Mercury,Venus,Earth,Mars
 Jupiter
 Saturn
@@ -176,7 +179,7 @@ $c = "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune"
 $c -split {$_ -eq "e" -or $_ -eq "p"}
 ```
 
-```output
+```Output
 M
 rcury,V
 nus,
@@ -285,7 +288,7 @@ The following statement splits the string at whitespace.
 -split "Windows PowerShell 2.0`nWindows PowerShell with remoting"
 ```
 
-```output
+```Output
 
 Windows
 PowerShell
@@ -302,7 +305,7 @@ The following statement splits the string at any comma.
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -split ','
 ```
 
-```output
+```Output
 Mercury
 Venus
 Earth
@@ -319,7 +322,7 @@ The following statement splits the string at the pattern "er".
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -split 'er'
 ```
 
-```output
+```Output
 M
 cury,Venus,Earth,Mars,Jupit
 ,Saturn,Uranus,Neptune
@@ -331,7 +334,7 @@ The following statement performs a case-sensitive split at the letter "N".
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -cSplit 'N'
 ```
 
-```output
+```Output
 Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,
 eptune
 ```
@@ -342,7 +345,7 @@ The following statement splits the string at "e" and "t".
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -split '[et]'
 ```
 
-```output
+```Output
 M
 rcury,V
 nus,
@@ -362,7 +365,7 @@ resulting substrings to six substrings.
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -split '[er]', 6
 ```
 
-```output
+```Output
 M
 
 cu
@@ -377,7 +380,7 @@ The following statement splits a string into three substrings.
 "a,b,c,d,e,f,g,h" -split ",", 3
 ```
 
-```output
+```Output
 a
 b
 c,d,e,f,g,h
@@ -390,7 +393,7 @@ starting from the end of the string.
 "a,b,c,d,e,f,g,h" -split ",", -3
 ```
 
-```output
+```Output
 a,b,c,d,e,f
 g
 h
@@ -403,7 +406,7 @@ The following statement splits two strings into three substrings.
 "a,b,c,d", "e,f,g,h" -split ",", 3
 ```
 
-```output
+```Output
 a
 b
 c,d
@@ -429,7 +432,7 @@ $a = @'
 $a -split "^\d", 0, "multiline"
 ```
 
-```output
+```Output
 
 The first line.
 
@@ -450,7 +453,7 @@ newline.
 "This.is.a.test" -split "\."
 ```
 
-```output
+```Output
 This
 is
 a
@@ -468,7 +471,7 @@ specified.
 "This.is.a.test" -split ".", 0, "simplematch"
 ```
 
-```output
+```Output
 This
 is
 a
@@ -484,7 +487,7 @@ $c = "LastName, FirstName; Address, City, State, Zip"
 $c -split $(if ($i -lt 1) {","} else {";"})
 ```
 
-```output
+```Output
 LastName, FirstName
  Address, City, State, Zip
 ```

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Split.md
@@ -135,7 +135,7 @@ input string.
 > Support for negative values was added in PowerShell 7.
 
 **Max-substrings** does not specify the maximum number of objects that are
-returned. its value equals the maximum number of times that a string is split.
+returned. Its value equals the maximum number of times that a string is split.
 If you submit more than one string (an array of strings) to the `-split`
 operator, the **Max-substrings** limit is applied to each string separately.
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Split.md
@@ -135,7 +135,7 @@ input string.
 > Support for negative values was added in PowerShell 7.
 
 **Max-substrings** does not specify the maximum number of objects that are
-returned. its value equals the maximum number of times that a string is split.
+returned. Its value equals the maximum number of times that a string is split.
 If you submit more than one string (an array of strings) to the `-split`
 operator, the **Max-substrings** limit is applied to each string separately.
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Split.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 12/20/2017
+ms.date: 03/24/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_split?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Split
@@ -114,7 +114,7 @@ substring become part of the substring.
 'Chocolate-Vanilla-Strawberry-Blueberry' -split '(-)', 3
 ```
 
-```output
+```Output
 Chocolate
 -
 Vanilla
@@ -131,10 +131,13 @@ the substrings are returned. A value of 0 returns all the substrings. Negative
 values return the amount of substrings requested starting from the end of the
 input string.
 
-Max-substrings does not specify the maximum number of objects that are
-returned; its value equals the maximum number of times that a string is split.
-If you submit more than one string (an array of strings) to the Split operator
-, the Max-substrings limit is applied to each string separately.
+> [!NOTE]
+> Support for negative values was added in PowerShell 7.
+
+**Max-substrings** does not specify the maximum number of objects that are
+returned. its value equals the maximum number of times that a string is split.
+If you submit more than one string (an array of strings) to the `-split`
+operator, the **Max-substrings** limit is applied to each string separately.
 
 Example:
 
@@ -143,7 +146,7 @@ $c = "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune"
 $c -split ",", 5
 ```
 
-```output
+```Output
 Mercury
 Venus
 Earth
@@ -156,7 +159,7 @@ $c = "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune"
 $c -split ",", -5
 ```
 
-```output
+```Output
 Mercury,Venus,Earth,Mars
 Jupiter
 Saturn
@@ -176,7 +179,7 @@ $c = "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune"
 $c -split {$_ -eq "e" -or $_ -eq "p"}
 ```
 
-```output
+```Output
 M
 rcury,V
 nus,
@@ -285,7 +288,7 @@ The following statement splits the string at whitespace.
 -split "Windows PowerShell 2.0`nWindows PowerShell with remoting"
 ```
 
-```output
+```Output
 
 Windows
 PowerShell
@@ -302,7 +305,7 @@ The following statement splits the string at any comma.
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -split ','
 ```
 
-```output
+```Output
 Mercury
 Venus
 Earth
@@ -319,7 +322,7 @@ The following statement splits the string at the pattern "er".
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -split 'er'
 ```
 
-```output
+```Output
 M
 cury,Venus,Earth,Mars,Jupit
 ,Saturn,Uranus,Neptune
@@ -331,7 +334,7 @@ The following statement performs a case-sensitive split at the letter "N".
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -cSplit 'N'
 ```
 
-```output
+```Output
 Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,
 eptune
 ```
@@ -342,7 +345,7 @@ The following statement splits the string at "e" and "t".
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -split '[et]'
 ```
 
-```output
+```Output
 M
 rcury,V
 nus,
@@ -362,7 +365,7 @@ resulting substrings to six substrings.
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -split '[er]', 6
 ```
 
-```output
+```Output
 M
 
 cu
@@ -377,7 +380,7 @@ The following statement splits a string into three substrings.
 "a,b,c,d,e,f,g,h" -split ",", 3
 ```
 
-```output
+```Output
 a
 b
 c,d,e,f,g,h
@@ -390,7 +393,7 @@ starting from the end of the string.
 "a,b,c,d,e,f,g,h" -split ",", -3
 ```
 
-```output
+```Output
 a,b,c,d,e,f
 g
 h
@@ -403,7 +406,7 @@ The following statement splits two strings into three substrings.
 "a,b,c,d", "e,f,g,h" -split ",", 3
 ```
 
-```output
+```Output
 a
 b
 c,d
@@ -429,7 +432,7 @@ $a = @'
 $a -split "^\d", 0, "multiline"
 ```
 
-```output
+```Output
 
 The first line.
 
@@ -450,7 +453,7 @@ newline.
 "This.is.a.test" -split "\."
 ```
 
-```output
+```Output
 This
 is
 a
@@ -468,7 +471,7 @@ specified.
 "This.is.a.test" -split ".", 0, "simplematch"
 ```
 
-```output
+```Output
 This
 is
 a
@@ -484,7 +487,7 @@ $c = "LastName, FirstName; Address, City, State, Zip"
 $c -split $(if ($i -lt 1) {","} else {";"})
 ```
 
-```output
+```Output
 LastName, FirstName
  Address, City, State, Zip
 ```

--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-70.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-70.md
@@ -458,6 +458,7 @@ For more information about
 - Fix a resource leak by unregistering the event handler from AppDomain.CurrentDomain.ProcessExit (#10626)
 - Add support to ActionPreference.Break to break into debugger when Debug, Error, Information, Progress, Verbose or Warning messages are generated (#8205) (Thanks @KirkMunro!)
 - Enable starting control panel add-ins within PowerShell Core without specifying .CPL extension. (#9828)
+- Support negative numbers in -split operator (#8960) (Thanks @ece-jacob-scott!)
 
 ### General Cmdlet Updates and Fixes
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes #5631 - support for negative number added in PS7
Fixes [AB#1700648](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1700648)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://docs.microsoft.com/powershell/scripting/community/contributing/overview) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
