### PR TITLE
Update Get-Date -UFormat %s Example

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Get-Date.md
@@ -508,7 +508,7 @@ The valid **UFormat specifiers** are displayed in the following table:
 | `%R` | Time in 24-hour format -no seconds | 17:45 |
 | `%r` | Time in 12-hour format | 09:15:36 AM |
 | `%S` | Seconds | 05 |
-| `%s` | Seconds elapsed since January 1, 1970 00:00:00 | 1150451174.95705 |
+| `%s` | Seconds elapsed since January 1, 1970 00:00:00 | 1150451174 |
 | `%t` | Horizontal tab character | |
 | `%T` | Time in 24-hour format | 17:45:52 |
 | `%U` | Same as 'W' | |


### PR DESCRIPTION
# PR Summary
Get-Date -Uformat %s returns an string formatted with 0 decimals (string formatted as "{0:0}"). In Windows PowerShell the stated example of 1150451174.95705 was correct. A correct example for PowerShell 7 would be 1150451174.

Fixes issue #5680 

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.x preview content
- [x] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [x] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist
- [x] I have read the [contributors guide](https://docs.microsoft.com/powershell/scripting/community/contributing/overview) and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
