### PR TITLE
Pipeline input is not accepted to Name and Computername

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
@@ -289,7 +289,7 @@ Aliases: Cn
 Required: False
 Position: Named
 Default value: Local computer
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -421,7 +421,7 @@ Aliases: ProcessName
 Required: False
 Position: 0
 Default value: None
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: False
 Accept wildcard characters: True
 ```
 


### PR DESCRIPTION
The following command does not work:
"smss" | Get-Process
So this cmdlet does not accept string input by property name.

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.x preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [ ] I have read the [contributors guide](https://docs.microsoft.com/powershell/scripting/community/contributing/overview) and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
