### PR TITLE
Fix a typo

### DIFF
--- a/reference/docs-conceptual/install/PowerShell-in-Docker.md
+++ b/reference/docs-conceptual/install/PowerShell-in-Docker.md
@@ -36,7 +36,7 @@ docker run -it mcr.microsoft.com/powershell
 
 ### Remove the image when no longer needed
 
-The following command is used to delete the Docker container when you no longer need it.
+The following command is used to delete the Docker image when you no longer need it.
 
 ```console
 docker rmi mcr.microsoft.com/powershell


### PR DESCRIPTION
# PR Summary
`docker rmi` command removes an image not a container.

**Conceptual articles**
- [x] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide](https://docs.microsoft.com/powershell/scripting/community/contributing/overview) and followed the style and process guidelines
- [x] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the
    title and remove the prefix when the PR is ready.
