### PR TITLE
removed command prompt "PS> " from examples

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -199,7 +199,7 @@ the session configuration has a LanguageMode property. You can find the
 language mode by getting the value of the LanguageMode property.
 
 ```powershell
-PS> (Get-PSSessionConfiguration -Name Test).LanguageMode
+(Get-PSSessionConfiguration -Name Test).LanguageMode
 FullLanguage
 ```
 
@@ -216,7 +216,7 @@ state.
 For example:
 
 ```powershell
-PS> $ExecutionContext.SessionState.LanguageMode
+$ExecutionContext.SessionState.LanguageMode
 ConstrainedLanguage
 ```
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -206,7 +206,7 @@ the session configuration has a LanguageMode property. You can find the
 language mode by getting the value of the LanguageMode property.
 
 ```powershell
-PS> (Get-PSSessionConfiguration -Name Test).LanguageMode
+(Get-PSSessionConfiguration -Name Test).LanguageMode
 FullLanguage
 ```
 
@@ -223,7 +223,7 @@ state.
 For example:
 
 ```powershell
-PS> $ExecutionContext.SessionState.LanguageMode
+$ExecutionContext.SessionState.LanguageMode
 ConstrainedLanguage
 ```
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -206,7 +206,7 @@ the session configuration has a LanguageMode property. You can find the
 language mode by getting the value of the LanguageMode property.
 
 ```powershell
-PS> (Get-PSSessionConfiguration -Name Test).LanguageMode
+(Get-PSSessionConfiguration -Name Test).LanguageMode
 FullLanguage
 ```
 
@@ -223,7 +223,7 @@ state.
 For example:
 
 ```powershell
-PS> $ExecutionContext.SessionState.LanguageMode
+$ExecutionContext.SessionState.LanguageMode
 ConstrainedLanguage
 ```
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -206,7 +206,7 @@ the session configuration has a LanguageMode property. You can find the
 language mode by getting the value of the LanguageMode property.
 
 ```powershell
-PS> (Get-PSSessionConfiguration -Name Test).LanguageMode
+(Get-PSSessionConfiguration -Name Test).LanguageMode
 FullLanguage
 ```
 
@@ -223,7 +223,7 @@ state.
 For example:
 
 ```powershell
-PS> $ExecutionContext.SessionState.LanguageMode
+$ExecutionContext.SessionState.LanguageMode
 ConstrainedLanguage
 ```
 


### PR DESCRIPTION
# PR Summary
edited About_Language_Mode.md for all versions and removed "PS> " from code examples. 
Fixes #5705

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
