### PR TITLE
Fixes #4945 - argumentlist works like splatting

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 03/19/2020
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_arrays?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Arrays
@@ -462,6 +462,9 @@ $a.ForEach({ $_ * $_})
 Just like the `-ArgumentList` parameter of `ForEach-Object`, the `arguments`
 parameter allows the passing of an array of arguments to a script block
 configured to accept them.
+
+For more information about the behavior of **ArgumentList**, see
+[about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 #### ForEach(type convertToType)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -1,40 +1,40 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 11/28/2017
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_CmdletBindingAttribute
 ---
 # About Functions CmdletBindingAttribute
 
-## SHORT DESCRIPTION
+## Short description
 Describes the attribute that makes a function work like a compiled cmdlet.
 
-## LONG DESCRIPTION
+## Long description
 
-The CmdletBinding attribute is an attribute of functions that makes
-them operate like compiled cmdlets that are written in C#, and it
-provides access to features of cmdlets.
+The **CmdletBinding** attribute is an attribute of functions that makes them
+operate like compiled cmdlets that are written in C#, and it provides access to
+features of cmdlets.
 
-PowerShell binds the parameters of functions that have the
-CmdletBinding attribute in the same way that it binds the parameters of
-compiled cmdlets. The $PSCmdlet automatic variable is available to
-functions with the CmdletBinding attribute, but the $Args variable
-is not available.
+PowerShell binds the parameters of functions that have the **CmdletBinding**
+attribute in the same way that it binds the parameters of compiled cmdlets. The
+`$PSCmdlet` automatic variable is available to functions with the CmdletBinding
+attribute, but the `$Args` variable is not available.
 
-In functions that have the CmdletBinding attribute, unknown parameters
-and positional arguments that have no matching positional parameters
-cause parameter binding to fail.
+In functions that have the **CmdletBinding** attribute, unknown parameters and
+positional arguments that have no matching positional parameters cause
+parameter binding to fail.
 
-Note: Compiled cmdlets use the required Cmdlet attribute, which is similar
-to the CmdletBinding attribute that is described in this topic.
+> [!NOTE]
+> Compiled cmdlets use the required **Cmdlet** attribute, which is similar
+> to the **CmdletBinding** attribute that is described in this topic.
 
-## SYNTAX
+## Syntax
 
-The following example shows the format of a function that specifies all
-the optional arguments of the CmdletBinding attribute. A brief description
-of each argument follows this example.
+The following example shows the format of a function that specifies all the
+optional arguments of the **CmdletBinding** attribute. A brief description of
+each argument follows this example.
 
 ```powershell
 {
@@ -54,65 +54,65 @@ of each argument follows this example.
 
 ## ConfirmImpact
 
-The ConfirmImpact argument specifies when the action of the function
-should be confirmed by a call to the ShouldProcess method. The call to
-the ShouldProcess method displays a confirmation prompt only when the
-ConfirmImpact argument is equal to or greater than the value of the
-$ConfirmPreference preference variable. (The default value of the
-argument is Medium.) Specify this argument only when the
-SupportsShouldProcess argument is also specified.
+The **ConfirmImpact** argument specifies when the action of the function should
+be confirmed by a call to the **ShouldProcess** method. The call to the
+**ShouldProcess** method displays a confirmation prompt only when the
+**ConfirmImpact** argument is equal to or greater than the value of the
+`$ConfirmPreference` preference variable. (The default value of the argument is
+**Medium**.) Specify this argument only when the **SupportsShouldProcess**
+argument is also specified.
 
 For more information about confirmation requests, see [Requesting Confirmation](/powershell/scripting/developer/cmdlet/requesting-confirmation).
 
 ## DefaultParameterSetName
 
-The DefaultParameterSetName argument specifies the name of the parameter
-set that PowerShell will attempt to use when it cannot determine
-which parameter set to use. You can avoid this issue by making the
-unique parameter of each parameter set a mandatory parameter.
+The **DefaultParameterSetName** argument specifies the name of the parameter
+set that PowerShell will attempt to use when it cannot determine which
+parameter set to use. You can avoid this issue by making the unique parameter
+of each parameter set a mandatory parameter.
 
 ## HelpURI
 
-The HelpURI argument specifies the Internet address (Uniform Resource
-Identifier (URI)) of the online version of the help topic that describes
-the function. The value of the HelpURI argument must begin with "http"
-or "https".
+The **HelpURI** argument specifies the Internet address (Uniform Resource
+Identifier (URI)) of the online version of the help topic that describes the
+function. The value of the **HelpURI** argument must begin with "http" or
+"https".
 
-The HelpURI argument value is used for the value of the HelpURI property
-of the CommandInfo object that Get-Command returns for the function.
+The **HelpURI** argument value is used for the value of the **HelpURI**
+property of the **CommandInfo** object that `Get-Command` returns for the
+function.
 
-However, when help files are installed on the computer and the value of
-the first link in the RelatedLinks section of the help file is a URI,
-or the value of the first .Link directive in comment-based help is a URI,
-the URI in the help file is used as the value of the HelpUri property
-of the function.
+However, when help files are installed on the computer and the value of the
+first link in the **RelatedLinks** section of the help file is a URI, or the
+value of the first `.Link` directive in comment-based help is a URI, the URI in
+the help file is used as the value of the **HelpUri** property of the function.
 
-The `Get-Help` cmdlet uses the value of the HelpURI property to locate the
-online version of the function help topic when the Online parameter
-of `Get-Help` is specified in a command.
+The `Get-Help` cmdlet uses the value of the **HelpURI** property to locate the
+online version of the function help topic when the **Online** parameter of
+`Get-Help` is specified in a command.
 
 ## SupportsPaging
 
-The SupportsPaging argument adds the First, Skip, and IncludeTotalCount
-parameters to the function. These parameters allow users to select
-output from a very large result set. This argument is designed for cmdlets
-and functions that return data from large data stores that support data
+The **SupportsPaging** argument adds the **First**, **Skip**, and
+**IncludeTotalCount** parameters to the function. These parameters allow users
+to select output from a very large result set. This argument is designed for
+cmdlets and functions that return data from large data stores that support data
 selection, such as a SQL database.
 
 This argument was introduced in Windows PowerShell 3.0.
 
-* First: Gets only the first 'n' objects.
-* Skip:  Ignores the first 'n' objects and then gets the remaining objects.
-* IncludeTotalCount: Reports the number of objects in the data set (an integer)
-followed by the objects. If the cmdlet cannot determine the total count, it
-returns "Unknown total count".
+- **First**: Gets only the first 'n' objects.
+- **Skip**:  Ignores the first 'n' objects and then gets the remaining objects.
+- **IncludeTotalCount**: Reports the number of objects in the data set (an
+  integer) followed by the objects. If the cmdlet cannot determine the total
+  count, it returns "Unknown total count".
 
-PowerShell includes NewTotalCount, a helper method that gets the
-total count value to return and includes an estimate of the accuracy of the
-total count value.
+PowerShell includes **NewTotalCount**, a helper method that gets the total
+count value to return and includes an estimate of the accuracy of the total
+count value.
 
-The following sample function shows how to add support for the paging parameters
-to an advanced function.
+The following sample function shows how to add support for the paging
+parameters to an advanced function.
 
 ```powershell
 function Get-Numbers {
@@ -135,19 +135,19 @@ function Get-Numbers {
 
 ## SupportsShouldProcess
 
-The SupportsShouldProcess argument adds **Confirm** and **WhatIf** parameters
-to the function. The **Confirm** parameter prompts the user before it runs
-the command on each object in the pipeline. The **WhatIf** parameter lists the
-changes that the command would make, instead of running the command.
+The **SupportsShouldProcess** argument adds **Confirm** and **WhatIf**
+parameters to the function. The **Confirm** parameter prompts the user before
+it runs the command on each object in the pipeline. The **WhatIf** parameter
+lists the changes that the command would make, instead of running the command.
 
 ## PositionalBinding
 
-The PositionalBinding argument determines whether parameters in the function
-are positional by default. The default value is $True. You can use the
-PositionalBinding argument with a value of $False to disable positional
-binding.
+The **PositionalBinding** argument determines whether parameters in the
+function are positional by default. The default value is `$True`. You can use
+the **PositionalBinding** argument with a value of `$False` to disable
+positional binding.
 
-The PositionalBinding argument is introduced in Windows PowerShell 3.0.
+The **PositionalBinding** argument is introduced in Windows PowerShell 3.0.
 
 When parameters are positional, the parameter name is optional.
 PowerShell associates unnamed parameter values with the function parameters
@@ -157,29 +157,30 @@ function command.
 When parameters are not positional (they are "named"), the parameter
 name (or an abbreviation or alias of the name) is required in the command.
 
-When PositionalBinding is $True, function parameters are positional by
-default. PowerShell assigns position number to the parameters in
-the order in which they are declared in the function.
+When **PositionalBinding** is `$True`, function parameters are positional by
+default. PowerShell assigns position number to the parameters in the order in
+which they are declared in the function.
 
-When PositionalBinding is $False, function parameters are not positional
-by default. Unless the Position argument of the Parameter attribute is
+When **PositionalBinding** is `$False`, function parameters are not positional
+by default. Unless the **Position** argument of the **Parameter** attribute is
 declared on the parameter, the parameter name (or an alias or abbreviation)
 must be included when the parameter is used in a function.
 
-The Position argument of the Parameter attribute takes precedence over the
-PositionalBinding default value. You can use the Position argument to specify
-a position value for a parameter. For more information about the Position
-argument, see [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
+The **Position** argument of the **Parameter** attribute takes precedence over
+the **PositionalBinding** default value. You can use the **Position** argument
+to specify a position value for a parameter. For more information about the
+**Position** argument, see
+[about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
 
-## NOTES
+## Notes
 
-The SupportsTransactions argument is not supported in advanced functions.
+The **SupportsTransactions** argument is not supported in advanced functions.
 
-## KEYWORDS
+## Keywords
 
 about_Functions_CmdletBinding_Attribute
 
-## SEE ALSO
+## See also
 
 [about_Functions](about_Functions.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 08/28/2018
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_script_blocks?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Script_Blocks
@@ -64,7 +64,7 @@ example:
 Invoke-Command -ScriptBlock { Get-Process }
 ```
 
-```output
+```Output
 Handles  NPM(K)    PM(K)     WS(K) VM(M)   CPU(s)     Id ProcessName
 -------  ------    -----     ----- -----   ------     -- -----------
 999          28    39100     45020   262    15.88   1844 communicator
@@ -82,7 +82,7 @@ Invoke-Command -ScriptBlock { param($p1, $p2)
 } -ArgumentList "First", "Second"
 ```
 
-```output
+```Output
 p1: First
 p2: Second
 ```
@@ -90,6 +90,9 @@ p2: Second
 The script block in the preceding example uses the `param` keyword to
 create a parameters `$p1` and `$p2`. The string "First" is bound to the
 first parameter (`$p1`) and "Second" is bound to (`$p2`).
+
+For more information about the behavior of **ArgumentList**, see
+[about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 You can use variables to store and execute script blocks. The example below
 stores a script block in a variable and passes it to `Invoke-Command`.
@@ -99,7 +102,7 @@ $a = { Get-Service BITS }
 Invoke-Command -ScriptBlock $a
 ```
 
-```output
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Running  BITS               Background Intelligent Transfer Ser...
@@ -118,7 +121,7 @@ $a ={ param($p1, $p2)
 &$a -p2 "First" -p1 "Second"
 ```
 
-```output
+```Output
 p1: Second
 p2: First
 ```

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -1,19 +1,19 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 09/09/2019
-online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_splatting?view=powershell-5.1&WT.mc_id=ps-gethelp
+ms.date: 04/08/2020
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_splatting?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Splatting
 ---
 
 # About Splatting
 
-## SHORT DESCRIPTION
+## Short description
 
 Describes how to use splatting to pass parameters to commands in PowerShell.
 
-## LONG DESCRIPTION
+## Long description
 
 Splatting is a method of passing a collection of parameter values to a command
 as unit. PowerShell associates each value in the collection with a command
@@ -30,7 +30,7 @@ functions.
 Beginning in Windows PowerShell 3.0, you can also use splatting to represent
 all parameters of a command.
 
-## SYNTAX
+## Syntax
 
 ```
 <CommandName> <optional parameters> @<HashTable> <optional parameters>
@@ -47,7 +47,7 @@ parameters. You may pass some parameters by using splatting and pass others by
 position or by parameter name. Also, you can splat multiple objects in a single
 command so you don't pass more than one value for each parameter.
 
-## SPLATTING WITH HASH TABLES
+## Splatting with hash tables
 
 Use a hash table to splat parameter name and value pairs. You can use this
 format for all parameter types, including positional and switch parameters.
@@ -80,11 +80,11 @@ $HashArguments = @{
 Copy-Item @HashArguments
 ```
 
-Note: In the first command, the At symbol (@) indicates a hash table, not a
+Note: In the first command, the At symbol (`@`) indicates a hash table, not a
 splatted value. The syntax for hash tables in PowerShell is:
-`@{\<name\>=\<value\>; \<name\>=\<value\>; ...}*`
+`@{<name>=<value>; <name>=<value>; ...}`
 
-## SPLATTING WITH ARRAYS
+## Splatting with arrays
 
 Use an array to splat values for positional parameters, which do not require
 parameter names. The values must be in position-number order in the array.
@@ -111,7 +111,44 @@ $ArrayArguments = "test.txt", "test2.txt"
 Copy-Item @ArrayArguments -WhatIf
 ```
 
-## EXAMPLES
+### Using the ArgumentList parameter
+
+Several cmdlets have an **ArgumentList** parameter that is used to pass
+parameter values to a script block that is executed by the cmdlet. The
+**ArgumentList** parameter takes an array of values that is passed to the
+script block. PowerShell is effectively using array splatting to bind the
+values to the parameters of the script block. When using **ArgumentList**, if
+you need to pass an array as a single object bound to a single parameter, you
+must wrap the array in an array subexpression.
+
+The following example has a script block that takes a single parameter that is
+an array of strings.
+
+```powershell
+$array = 'Hello', 'World!'
+Invoke-Command -ScriptBlock { param([string[]]$words) $words -join ' '} -ArgumentList $array
+```
+
+In this example, only the first item in `$array` is passed to the script script
+block.
+
+```Output
+Hello
+```
+
+```powershell
+$array = 'Hello', 'World!'
+Invoke-Command -ScriptBlock { param([string[]]$words) $words -join ' '} -ArgumentList (,$array)
+```
+
+In this example, `$array` is wrapped in an array subexpress so that the entire
+array is passed to the script block as a single object.
+
+```Output
+Hello World!
+```
+
+## Examples
 
 This example shows how to reuse splatted values in different commands. The
 commands in this example use the `Write-Host` cmdlet to write messages to the
@@ -186,7 +223,7 @@ Test2 -a 1 -b 2 -c 3
 3
 ```
 
-## SPLATTING COMMAND PARAMETERS
+## Splatting command parameters
 
 You can use splatting to represent the parameters of a command. This technique
 is useful when you are creating a proxy function, that is, a function that
@@ -278,7 +315,7 @@ FileVersionInfo    : File:             C:\Windows\System32\WindowsPowerShell
                      Language:         English (United States)
 ```
 
-## NOTES
+## Notes
 
 If you make a function into an advanced function by using either the
 **CmdletBinding** or **Parameter** attributes, the `$args` automatic variable
@@ -289,7 +326,7 @@ PowerShell Desired State Configuration (DSC) was not designed to use splatting.
 You cannot use splatting to pass values into a DSC resource. For more
 information, see Gael Colas' article [Pseudo-Splatting DSC Resources](https://gaelcolas.com/2017/11/05/pseudo-splatting-dsc-resources/).
 
-## SEE ALSO
+## See also
 
 [about_Arrays](about_Arrays.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -31,129 +31,145 @@ ForEach-Object [-InputObject <PSObject>] [-MemberName] <String> [-ArgumentList <
 
 ## DESCRIPTION
 
-The **ForEach-Object** cmdlet performs an operation on each item in a collection of input objects.
-The input objects can be piped to the cmdlet or specified by using the *InputObject* parameter.
+The `ForEach-Object` cmdlet performs an operation on each item in a collection of input objects.
+The input objects can be piped to the cmdlet or specified by using the **InputObject** parameter.
 
-Starting in Windows PowerShell 3.0, there are two different ways to construct a **ForEach-Object** command.
+Starting in Windows PowerShell 3.0, there are two different ways to construct a `ForEach-Object` command.
 
-- **Script block**.
-  You can use a script block to specify the operation.
-  Within the script block, use the `$_` variable to represent the current object.
-  The script block is the value of the *Process* parameter.
-  The script block can contain any PowerShell script.
+- **Script block**. You can use a script block to specify the operation. Within the script block,
+  use the `$_` variable to represent the current object. The script block is the value of the
+  *Process* parameter. The script block can contain any PowerShell script.
 
-  For example, the following command gets the value of the **ProcessName** property of each process on the computer.
+  For example, the following command gets the value of the **ProcessName** property of each process
+  on the computer.
 
   `Get-Process | ForEach-Object {$_.ProcessName}`
 
-- **Operation statement**.
-  You can also write an operation statement, which is much more like natural language.
-  You can use the operation statement to specify a property value or call a method.
-  Operation statements were introduced in Windows PowerShell 3.0.
+- **Operation statement**. You can also write an operation statement, which is much more like
+  natural language. You can use the operation statement to specify a property value or call a
+  method. Operation statements were introduced in Windows PowerShell 3.0.
 
-  For example, the following command also gets the value of the **ProcessName** property of each process on the computer.
+  For example, the following command also gets the value of the **ProcessName** property of each
+  process on the computer.
 
   `Get-Process | ForEach-Object ProcessName`
 
-  When using the script block format, in addition to using the script block that describes the operations that are performed on each input object, you can provide two additional script blocks.
-  The Begin script block, which is the value of the *Begin* parameter, runs before this cmdlet processes the first input object.
-  The End script block, which is the value of the *End* parameter, runs after this cmdlet processes the last input object.
+  When using the script block format, in addition to using the script block that describes the
+  operations that are performed on each input object, you can provide two additional script blocks.
+  The Begin script block, which is the value of the **Begin** parameter, runs before this cmdlet
+  processes the first input object. The End script block, which is the value of the **End**
+  parameter, runs after this cmdlet processes the last input object.
 
 ## EXAMPLES
 
 ### Example 1: Divide integers in an array
 
+This example takes an array of three integers and divides each one of them by 1024.
+
 ```powershell
 30000, 56798, 12432 | ForEach-Object -Process {$_/1024}
 ```
 
-```output
+```Output
 29.296875
 55.466796875
 12.140625
 ```
 
-This command takes an array of three integers and divides each one of them by 1024.
-
 ### Example 2: Get the length of all the files in a directory
 
+This example processes the files and directories in the PowerShell installation directory `$PSHOME`.
+
 ```powershell
-Get-ChildItem $pshome | ForEach-Object -Process {if (!$_.PSIsContainer) {$_.Name; $_.Length / 1024; " " }}
+Get-ChildItem $PSHOME |
+  ForEach-Object -Process {if (!$_.PSIsContainer) {$_.Name; $_.Length / 1024; " " }}
 ```
 
-This command gets the files and directories in the PowerShell installation directory `$pshome` and passes them to the `ForEach-Object` cmdlet.
-If the object is not a directory, the script block gets the name of the file, divides the value of its **Length** property by 1024, and adds a space (" ") to separate it from the next entry.
-The cmdlet uses the **PSISContainer** property to determine whether an object is a directory.
+If the object is not a directory, the script block gets the name of the file, divides the value of
+its **Length** property by 1024, and adds a space (" ") to separate it from the next entry. The
+cmdlet uses the **PSISContainer** property to determine whether an object is a directory.
 
 ### Example 3: Operate on the most recent System events
+
+This example write the 1000 most recent events from the System event log to a text file. The current
+time is displayed before and after processing the events.
 
 ```powershell
 $Events = Get-EventLog -LogName System -Newest 1000
 $events | ForEach-Object -Begin {Get-Date} -Process {Out-File -FilePath Events.txt -Append -InputObject $_.Message} -End {Get-Date}
 ```
 
-This command gets the 1000 most recent events from the System event log and stores them in the `$Events` variable.
-It then pipes the events to the `ForEach-Object` cmdlet.
-
-The *Begin* parameter displays the current date and time.
-Next, the *Process* parameter uses the `Out-File` cmdlet to create a text file that is named events.txt and stores the message property of each of the events in that file.
-Last, the *End* parameter is used to display the date and time after all of the processing has completed.
+`Get-EventLog` gets the 1000 most recent events from the System event log and stores them in the
+`$Events` variable. `$Events` is then piped to the `ForEach-Object` cmdlet. The **Begin** parameter
+displays the current date and time. Next, the **Process** parameter uses the `Out-File` cmdlet to
+create a text file that is named events.txt and stores the message property of each of the events in
+that file. Last, the **End** parameter is used to display the date and time after all of the
+processing has completed.
 
 ### Example 4: Change the value of a Registry key
+
+This example changes the value of the **RemotePath** registry entry in all of the subkeys under the
+`HKCU:\Network` key to uppercase text.
 
 ```powershell
 Get-ItemProperty -Path HKCU:\Network\* | ForEach-Object {Set-ItemProperty -Path $_.PSPath -Name RemotePath -Value $_.RemotePath.ToUpper();}
 ```
 
-This command changes the value of the **RemotePath** registry entry in all of the subkeys under the HKCU:\Network key to uppercase text.
 You can use this format to change the form or content of a registry entry value.
 
 Each subkey in the **Network** key represents a mapped network drive that will reconnect at logon.
-The **RemotePath** entry contains the UNC path of the connected drive.
-For example, if you map the E: drive to \\\\Server\Share, there will be an E subkey of HKCU:\Network and the value of the **RemotePath** registry entry in the E subkey will be \\\\Server\Share.
+The **RemotePath** entry contains the UNC path of the connected drive. For example, if you map the
+E: drive to `\\Server\Share`, there will be an **E** subkey of `HKCU:\Network` and the value of the
+**RemotePath** registry entry in the **E** subkey is `\\Server\Share`.
 
-The command uses the `Get-ItemProperty` cmdlet to get all of the subkeys of the **Network** key and the `Set-ItemProperty` cmdlet to change the value of the **RemotePath** registry entry in each key.
-In the `Set-ItemProperty` command, the path is the value of the **PSPath** property of the registry key.
-This is a property of the Microsoft .NET Framework object that represents the registry key, not a registry entry.
-The command uses the **ToUpper()** method of the **RemotePath** value, which is a string (REG_SZ).
+The command uses the `Get-ItemProperty` cmdlet to get all of the subkeys of the **Network** key and
+the `Set-ItemProperty` cmdlet to change the value of the **RemotePath** registry entry in each key.
+In the `Set-ItemProperty` command, the path is the value of the **PSPath** property of the registry
+key. This is a property of the Microsoft .NET Framework object that represents the registry key, not
+a registry entry. The command uses the **ToUpper()** method of the **RemotePath** value, which is a
+string (REG_SZ).
 
-Because `Set-ItemProperty` is changing the property of each key, the `ForEach-Object` cmdlet is required to access the property.
+Because `Set-ItemProperty` is changing the property of each key, the `ForEach-Object` cmdlet is
+required to access the property.
 
 ### Example 5: Use the $Null automatic variable
+
+This example shows the effect of piping the `$Null` automatic variable to the `ForEach-Object` cmdlet.
 
 ```powershell
 1, 2, $null, 4 | ForEach-Object {"Hello"}
 ```
 
-```output
+```Output
 Hello
 Hello
 Hello
 Hello
 ```
 
-This example shows the effect of piping the `$Null` automatic variable to the `ForEach-Object` cmdlet.
-
 Because PowerShell treats null as an explicit placeholder, the `ForEach-Object` cmdlet generates a value for `$Null`, just as it does for other objects that you pipe to it.
 
-For more information about the `$Null` automatic variable, see about_Automatic_Variables.
 
 ### Example 6: Get property values
+
+This example gets the value of the **Path** property of all installed PowerShell modules by using
+the **MemberName** parameter of the `ForEach-Object` cmdlet.
 
 ```powershell
 Get-Module -ListAvailable | ForEach-Object -MemberName Path
 Get-Module -ListAvailable | Foreach Path
 ```
 
-These commands gets the value of the **Path** property of all installed PowerShell modules.
-They use the *MemberName* parameter to specify the **Path** property of modules.
+The second command is equivalent to the first. It uses the `Foreach` alias of the `ForEach-Object`
+cmdlet and omits the name of the **MemberName** parameter, which is optional.
 
-The second command is equivalent to the first.
-It uses the **Foreach** alias of the `ForEach-Object` cmdlet and omits the name of the *MemberName* parameter, which is optional.
-
-The `ForEach-Object` cmdlet is very useful for getting property values, because it gets the value without changing the type, unlike the **Format** cmdlets or the `Select-Object` cmdlet, which change the property value type.
+The `ForEach-Object` cmdlet is very useful for getting property values, because it gets the value
+without changing the type, unlike the **Format** cmdlets or the `Select-Object` cmdlet, which change
+the property value type.
 
 ### Example 7: Split module names into component names
+
+This examples shows three ways to split two dot-separated module names into their component names.
 
 ```powershell
 "Microsoft.PowerShell.Core", "Microsoft.PowerShell.Host" | ForEach-Object {$_.Split(".")}
@@ -161,7 +177,7 @@ The `ForEach-Object` cmdlet is very useful for getting property values, because 
 "Microsoft.PowerShell.Core", "Microsoft.PowerShell.Host" | Foreach Split "."
 ```
 
-```output
+```Output
 Microsoft
 PowerShell
 Core
@@ -170,27 +186,25 @@ PowerShell
 Host
 ```
 
-These commands split two dot-separated module names into their component names.
-The commands call the **Split** method of strings.
-The three commands use different syntax, but they are equivalent and interchangeable.
+The commands call the **Split** method of strings. The three commands use different syntax, but they
+are equivalent and interchangeable.
 
-The first command uses the traditional syntax, which includes a script block and the current object operator `$_`.
-It uses the dot syntax to specify the method and parentheses to enclose the delimiter argument.
+The first command uses the traditional syntax, which includes a script block and the current object
+operator `$_`. It uses the dot syntax to specify the method and parentheses to enclose the delimiter
+argument.
 
-The second command uses the *MemberName* parameter to specify the **Split** method and the *ArgumentName* parameter to identify the dot (".") as the split delimiter.
+The second command uses the **MemberName** parameter to specify the **Split** method and the
+**ArgumentName** parameter to identify the dot (".") as the split delimiter.
 
-The third command uses the **Foreach** alias of the **Foreach-Object** cmdlet and omits the names of the *MemberName* and *ArgumentList* parameters, which are optional.
-
-The output of these three commands, shown below, is identical.
-
-**Split** is just one of many useful methods of strings.
-To see all of the properties and methods of strings, pipe a string to the `Get-Member` cmdlet.
+The third command uses the **Foreach** alias of the `ForEach-Object` cmdlet and omits the names of
+the **MemberName** and **ArgumentList** parameters, which are optional.
 
 ## PARAMETERS
 
 ### -ArgumentList
 
-Specifies an array of arguments to a method call.
+Specifies an array of arguments to a method call. For more information about the behavior of
+**ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -240,13 +254,17 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the input objects.
-`ForEach-Object` runs the script block or operation statement on each input object.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
+Specifies the input objects. `ForEach-Object` runs the script block or operation statement on each
+input object. Enter a variable that contains the objects, or type a command or expression that gets
+the objects.
 
-When you use the *InputObject* parameter with `ForEach-Object`, instead of piping command results to `ForEach-Object`, the *InputObject* value is treated as a single object.
-This is true even if the value is a collection that is the result of a command, such as `-InputObject (Get-Process)`.
-Because *InputObject* cannot return individual properties from an array or collection of objects, we recommend that if you use `ForEach-Object` to perform operations on a collection of objects for those objects that have specific values in defined properties, you use `ForEach-Object` in the pipeline, as shown in the examples in this topic.
+When you use the **InputObject** parameter with `ForEach-Object`, instead of piping command results
+to `ForEach-Object`, the **InputObject** value is treated as a single object. This is true even if
+the value is a collection that is the result of a command, such as `-InputObject (Get-Process)`.
+Because **InputObject** cannot return individual properties from an array or collection of objects,
+we recommend that if you use `ForEach-Object` to perform operations on a collection of objects for
+those objects that have specific values in defined properties, you use `ForEach-Object` in the
+pipeline, as shown in the examples in this topic.
 
 ```yaml
 Type: PSObject
@@ -265,7 +283,9 @@ Accept wildcard characters: False
 Specifies the property to get or the method to call.
 
 Wildcard characters are permitted, but work only if the resulting string resolves to a unique value.
-If, for example, you run `Get-Process | ForEach -MemberName *Name`, and more than one member exists with a name that contains the string Name, such as the **ProcessName** and **Name** properties, the command fails.
+If, for example, you run `Get-Process | ForEach -MemberName *Name`, and more than one member exists
+with a name that contains the string Name, such as the **ProcessName** and **Name** properties, the
+command fails.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -283,8 +303,8 @@ Accept wildcard characters: True
 
 ### -Process
 
-Specifies the operation that is performed on each input object.
-Enter a script block that describes the operation.
+Specifies the operation that is performed on each input object. Enter a script block that describes
+the operation.
 
 ```yaml
 Type: ScriptBlock[]
@@ -300,7 +320,7 @@ Accept wildcard characters: False
 
 ### -RemainingScripts
 
-Specifies all script blocks that are not taken by the *Process* parameter.
+Specifies all script blocks that are not taken by the **Process** parameter.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -334,8 +354,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -351,7 +370,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -369,8 +390,9 @@ This cmdlet returns objects that are determined by the input.
 
 - The `ForEach-Object` cmdlet works much like the **Foreach** statement, except that you cannot pipe
   input to a **Foreach** statement. For more information about the **Foreach** statement, see [about_Foreach](./About/about_Foreach.md).
-- Starting in PowerShell 4.0, `Where` and `ForEach` methods were added for use with collections.
-- You can read more about these new methods here [about_arrays](./About/about_Arrays.md)
+
+- Starting in PowerShell 4.0, `Where` and `ForEach` methods were added for use with collections. You
+  can read more about these new methods here [about_arrays](./About/about_Arrays.md)
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -204,7 +204,7 @@ the **MemberName** and **ArgumentList** parameters, which are optional.
 ### -ArgumentList
 
 Specifies an array of arguments to a method call. For more information about the behavior of
-**ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+**ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
@@ -584,7 +584,7 @@ Specifies an array of arguments, or parameter values, that are passed to a scrip
 `Import-Module` command. This parameter is valid only when you're importing a script module.
 
 You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information
-about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+about the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 02/25/2020
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/import-module?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Import-Module
@@ -583,8 +583,8 @@ Accept wildcard characters: True
 Specifies an array of arguments, or parameter values, that are passed to a script module during the
 `Import-Module` command. This parameter is valid only when you're importing a script module.
 
-You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information,
-see [about_Aliases](About/about_Aliases.md).
+You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information
+about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/5.1/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -684,7 +684,7 @@ To use local variables in a command, use the following command format:
 
 The **param** keyword lists the local variables that are used in the command. **ArgumentList**
 supplies the values of the variables, in the order that they're listed. For more information about
-the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/5.1/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 10/17/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/invoke-command?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-Command
@@ -396,7 +396,7 @@ the name of the computer on which the command ran. The output of the second comm
 ### Example 11: Use the Param keyword in a script block
 
 The `Param` keyword and the **ArgumentList** parameter are used to pass variable values to named
-parameters in a script block. This example displays file names that begin with the letter `a` and
+parameters in a script block. This example displays filenames that begin with the letter `a` and
 have the `.pdf` extension.
 
 For more information about the `Param` keyword, see
@@ -470,7 +470,7 @@ When you submit the command, the content of the `Sample.ps1` file is copied into
 the script block is run on each of the remote computers. This procedure is equivalent to using the
 **ScriptBlock** parameter to submit the contents of the script.
 
-### Example 14: Run a command on a remote computer by using a URI
+### Example 14: Run a command on a remote computer using a URI
 
 This example shows how to run a command on a remote computer that's identified by a Uniform Resource
 Identifier (URI). This particular example runs a `Set-Mailbox` command on a remote Exchange server.
@@ -683,7 +683,8 @@ To use local variables in a command, use the following command format:
 -or- `<local-variable>`
 
 The **param** keyword lists the local variables that are used in the command. **ArgumentList**
-supplies the values of the variables, in the order that they're listed.
+supplies the values of the variables, in the order that they're listed. For more information about
+the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]
@@ -920,14 +921,15 @@ object and the password is stored as a [SecureString](/dotnet/api/system.securit
 > [How secure is SecureString?](/dotnet/api/system.security.securestring#how-secure-is-securestring).
 
 ```yaml
-Accept pipeline input: True (ByPropertyName)
-Position: Named
-Accept wildcard characters: False
-Parameter Sets: ComputerName, FilePathComputerName, Uri, FilePathUri, VMId, VMName, FilePathVMId, FilePathVMName
-Required: True (VMId, VMName, FilePathVMId, FilePathVMName), False (ComputerName, FilePathComputerName, Uri, FilePathUri)
-Default value: Current user
-Aliases:
 Type: PSCredential
+Parameter Sets: ComputerName, FilePathComputerName, Uri, FilePathUri, VMId, VMName, FilePathVMId, FilePathVMName
+Aliases:
+
+Required: True (VMId, VMName, FilePathVMId, FilePathVMName), False (ComputerName, FilePathComputerName, Uri, FilePathUri)
+Position: Named
+Default value: Current user
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
 ```
 
 ### -EnableNetworkAccess
@@ -941,18 +943,18 @@ A loopback session is a **PSSession** that originates and ends on the same compu
 loopback session, omit the **ComputerName** parameter or set its value to dot (`.`), localhost, or
 the name of the local computer.
 
-By default, loopback sessions are created by using a network token, which might not provide
-sufficient permission to authenticate to remote computers.
+By default, loopback sessions are created using a network token, which might not provide sufficient
+permission to authenticate to remote computers.
 
 The **EnableNetworkAccess** parameter is effective only in loopback sessions. If you use
 **EnableNetworkAccess** when you create a session on a remote computer, the command succeeds, but
 the parameter is ignored.
 
-You can allow remote access in a loopback session by using the **CredSSP** value of the
+You can allow remote access in a loopback session using the **CredSSP** value of the
 **Authentication** parameter, which delegates the session credentials to other computers.
 
 To protect the computer from malicious access, disconnected loopback sessions that have interactive
-tokens, which are those created by using **EnableNetworkAccess**, can be reconnected only from the
+tokens, which are those created using **EnableNetworkAccess**, can be reconnected only from the
 computer on which the session was created. Disconnected sessions that use CredSSP authentication can
 be reconnected from other computers. For more information, see `Disconnect-PSSession`.
 
@@ -973,7 +975,7 @@ Accept wildcard characters: False
 ### -FilePath
 
 Specifies a local script that this cmdlet runs on one or more remote computers. Enter the path and
-file name of the script, or pipe a script path to `Invoke-Command`. The script must reside on the
+filename of the script, or pipe a script path to `Invoke-Command`. The script must exist on the
 local computer or in a directory that the local computer can access. Use **ArgumentList** to specify
 the values of parameters in the script.
 
@@ -1121,8 +1123,7 @@ Accept wildcard characters: False
 
 Specifies the network port on the remote computer that is used for this command. To connect to a
 remote computer, the remote computer must be listening on the port that the connection uses. The
-default ports are 5985, which is the WinRM port for HTTP, and 5986, which is the WinRM port for
-HTTPS.
+default ports are 5985 (WinRM port for HTTP) and 5986 (WinRM port for HTTPS).
 
 Before using an alternate port, configure the WinRM listener on the remote computer to listen at
 that port. To configure the listener, type the following two commands at the PowerShell prompt:
@@ -1229,8 +1230,8 @@ Accept wildcard characters: False
 ### -SessionOption
 
 Specifies advanced options for the session. Enter a **SessionOption** object, such as one that you
-create by using the `New-PSSessionOption` cmdlet, or a hash table in which the keys are session
-option names and the values are session option values.
+create using the `New-PSSessionOption` cmdlet, or a hash table in which the keys are session option
+names and the values are session option values.
 
 The default values for the options are determined by the value of the `$PSSessionOption` preference
 variable, if it's set. Otherwise, the default values are established by options set in the session
@@ -1374,7 +1375,7 @@ is the name of the remote computer:
 
 `Set-Item -Path WSMan:\Localhost\Client\TrustedHosts -Value \<Remote-Computer-Name\>`
 
-When you disconnect a **PSSession**, by using the **InDisconnectedSession** parameter, the session
+When you disconnect a **PSSession** using the **InDisconnectedSession** parameter, the session
 state is **Disconnected** and the availability is **None**. The value of the **State** property is
 relative to the current session. A value of **Disconnected** means that the **PSSession** isn't
 connected to the current session. However, it doesn't mean that the **PSSession** is disconnected

--- a/reference/5.1/Microsoft.PowerShell.Core/New-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-module?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-Module
@@ -31,25 +31,32 @@ New-Module [-Name] <String> [-ScriptBlock] <ScriptBlock> [-Function <String[]>] 
 
 ## DESCRIPTION
 
-The **New-Module** cmdlet creates a dynamic module from a script block.
-The members of the dynamic module, such as functions and variables, are immediately available in the session and remain available until you close the session.
+The `New-Module` cmdlet creates a dynamic module from a script block. The members of the dynamic
+module, such as functions and variables, are immediately available in the session and remain
+available until you close the session.
 
-Like static modules, by default, the cmdlets and functions in a dynamic module are exported and the variables and aliases are not.
-However, you can use the Export-ModuleMember cmdlet and the parameters of **New-Module** to override the defaults.
+Like static modules, by default, the cmdlets and functions in a dynamic module are exported and the
+variables and aliases are not. However, you can use the Export-ModuleMember cmdlet and the
+parameters of `New-Module` to override the defaults.
 
-You can also use the *AsCustomObject* parameter of **New-Module** to return the dynamic module as a custom object.
-The members of the modules, such as functions, are implemented as script methods of the custom object instead of being imported into the session.
+You can also use the **AsCustomObject** parameter of `New-Module` to return the dynamic module as a
+custom object. The members of the modules, such as functions, are implemented as script methods of
+the custom object instead of being imported into the session.
 
-Dynamic modules exist only in memory, not on disk.
-Like all modules, the members of dynamic modules run in a private module scope that is a child of the global scope.
-Get-Module cannot get a dynamic module, but Get-Command can get the exported members.
+Dynamic modules exist only in memory, not on disk. Like all modules, the members of dynamic modules
+run in a private module scope that is a child of the global scope. Get-Module cannot get a dynamic
+module, but Get-Command can get the exported members.
 
-To make a dynamic module available to **Get-Module**, pipe a **New-Module** command to Import-Module, or pipe the module object that **New-Module** returns to **Import-Module**.
-This action adds the dynamic module to the **Get-Module** list, but it does not save the module to disk or make it persistent.
+To make a dynamic module available to `Get-Module`, pipe a `New-Module` command to Import-Module, or
+pipe the module object that `New-Module` returns to `Import-Module`. This action adds the dynamic
+module to the `Get-Module` list, but it does not save the module to disk or make it persistent.
 
 ## EXAMPLES
 
 ### Example 1: Create a dynamic module
+
+This example creates a new dynamic module with a function called `Hello`. The command returns a
+module object that represents the new dynamic module.
 
 ```powershell
 New-Module -ScriptBlock {function Hello {"Hello!"}}
@@ -72,10 +79,10 @@ ExportedVariables : {}
 NestedModules     : {}
 ```
 
-This command creates a new dynamic module with a function called Hello.
-The command returns a module object that represents the new dynamic module.
-
 ### Example 2: Working with dynamic modules and Get-Module and Get-Command
+
+This example demonstrates that dynamic modules are not returned by the `Get-Module` cmdlet. The
+members that they export are returned by the `Get-Command` cmdlet.
 
 ```powershell
 new-module -scriptblock {function Hello {"Hello!"}}
@@ -110,10 +117,10 @@ CommandType     Name   Definition
 Function        Hello  "Hello!"
 ```
 
-This example demonstrates that dynamic modules are not returned by the **Get-Module** cmdlet.
-The members that they export are returned by the **Get-Command** cmdlet.
-
 ### Example 3: Export a variable into the current session
+
+This example uses the `Export-ModuleMember` cmdlet to export a variable into the current session.
+Without the `Export-ModuleMember` command, only the function is exported.
 
 ```powershell
 New-Module -ScriptBlock {$SayHelloHelp="Type 'SayHello', a space, and a name."; function SayHello ($name) { "Hello, $name" }; Export-ModuleMember -function SayHello -Variable SayHelloHelp}
@@ -132,12 +139,17 @@ SayHello Jeffrey
 Hello, Jeffrey
 ```
 
-This command uses the **Export-ModuleMember** cmdlet to export a variable into the current session.
-Without the **Export-ModuleMember** command, only the function is exported.
-
 The output shows that both the variable and the function were exported into the session.
 
 ### Example 4: Make a dynamic module available to Get-Module
+
+This example demonstrates that you can make a dynamic module available to `Get-Module` by piping the
+dynamic module to `Import-Module`.
+
+`New-Module` creates a module object that is piped to the `Import-Module` cmdlet. The **Name**
+parameter of `New-Module` assigns a friendly name to the module. Because `Import-Module` does not
+return any objects by default, there is no output from this command. `Get-Module` that the
+**GreetingModule** has been imported into the current session.
 
 ```powershell
 New-Module -ScriptBlock {function Hello {"Hello!"}} -name GreetingModule | Import-Module
@@ -171,21 +183,23 @@ CommandType     Name                                                            
 Function        Hello                                                              "Hello!"
 ```
 
-This command demonstrates that you can make a dynamic module available to **Get-Module** by piping the dynamic module to **Import-Module**.
-
-The first command uses a pipeline operator (|) to send the module object that **New-Module** generates to the **Import-Module** cmdlet.
-The command uses the *Name* parameter of **New-Module** to assign a friendly name to the module.
-Because **Import-Module** does not return any objects by default, there is no output from this command.
-
-The second command uses **Get-Module** to get the modules in the session.
-The result shows that **Get-Module** can get the new dynamic module.
-
-The third command uses the **Get-Command** cmdlet to get the Hello function that the dynamic module exports.
+The `Get-Command` cmdlet shows the `Hello` function that the dynamic module exports.
 
 ### Example 5: Generate a custom object that has exported functions
 
+This example shows how to use the **AsCustomObject** parameter of `New-Module` to generate a custom
+object that has script methods that represent the exported functions.
+
+The `New-Module` cmdlet creates a dynamic module with two functions, `Hello` and `Goodbye`. The
+**AsCustomObject** parameter creates a custom object instead of the **PSModuleInfo** object that
+`New-Module` generates by default. This custom object is saved in the `$m` variable.
+The `$m` variable appears to have no assigned value.
+
 ```powershell
-$m = New-Module -ScriptBlock {function Hello ($name) {"Hello, $name"}; function Goodbye ($name) {"Goodbye, $name"}} -AsCustomObject
+$m = New-Module -ScriptBlock {
+  function Hello ($name) {"Hello, $name"}
+  function Goodbye ($name) {"Goodbye, $name"}
+} -AsCustomObject
 $m
 $m | Get-Member
 ```
@@ -218,22 +232,15 @@ $m.hello("Manoj")
 ```Output
 Hello, Manoj
 ```
-
-This example shows how to use the *AsCustomObject* parameter of **New-Module** to generate a custom object that has script methods that represent the exported functions.
-
-The first command uses the **New-Module** cmdlet to generate a dynamic module with two functions, Hello and Goodbye.
-The command uses the *AsCustomObject* parameter to generate a custom object instead of the PSModuleInfo object that **New-Module** generates by default.
-The command saves the custom object in the $m variable.
-
-The second command attempts to display the value of the $m variable.
-No content appears.
-
-The third command uses a pipeline operator to send the custom object to the **Get-Member** cmdlet, which displays the properties and methods of the custom object.
-The output shows that the object has script methods that represent the Hello and Goodbye functions.
-
-The fourth and fifth commands use the script method format to call the Hello and Goodbye functions.
+Piping `$m` to the `Get-Member` cmdlet displays the properties and methods of the custom object. The
+output shows that the object has script methods that represent the `Hello` and `Goodbye` functions.
+Finally, we call these script methods and display the results.
 
 ### Example 6: Get the results of the script block
+
+This example uses the **ReturnResult** parameter to request the results of running the script block
+instead of requesting a module object. The script block in the new module defines the `SayHello`
+function and then calls the function.
 
 ```powershell
 New-Module -ScriptBlock {function SayHello {"Hello, World!"}; SayHello} -ReturnResult
@@ -243,15 +250,12 @@ New-Module -ScriptBlock {function SayHello {"Hello, World!"}; SayHello} -ReturnR
 Hello, World!
 ```
 
-This command uses the *ReturnResult* parameter to request the results of running the script block instead of requesting a module object.
-
-The script block in the new module defines the SayHello function and then calls the function.
-
 ## PARAMETERS
 
 ### -ArgumentList
 
-Specifies an array of arguments which are parameter values that are passed to the script block.
+Specifies an array of arguments which are parameter values that are passed to the script block. For
+more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]
@@ -267,11 +271,12 @@ Accept wildcard characters: False
 
 ### -AsCustomObject
 
-Indicates that this cmdlet returns a custom object that represents the dynamic module.
-The module members are implemented as script methods of the custom object, but they are not imported into the session.
-You can save the custom object in a variable and use dot notation to invoke the members.
+Indicates that this cmdlet returns a custom object that represents the dynamic module. The module
+members are implemented as script methods of the custom object, but they are not imported into the
+session. You can save the custom object in a variable and use dot notation to invoke the members.
 
-If the module has multiple members with the same name, such as a function and a variable that are both named A, only one member with each name can be accessed from the custom object.
+If the module has multiple members with the same name, such as a function and a variable that are
+both named A, only one member with each name can be accessed from the custom object.
 
 ```yaml
 Type: SwitchParameter
@@ -288,11 +293,11 @@ Accept wildcard characters: False
 ### -Cmdlet
 
 Specifies an array of cmdlets that this cmdlet exports from the module into the current session.
-Enter a comma-separated list of cmdlets.
-Wildcard characters are permitted.
-By default, all cmdlets in the module are exported.
+Enter a comma-separated list of cmdlets. Wildcard characters are permitted. By default, all cmdlets
+in the module are exported.
 
-You cannot define cmdlets in a script block, but a dynamic module can include cmdlets if it imports the cmdlets from a binary module.
+You cannot define cmdlets in a script block, but a dynamic module can include cmdlets if it imports
+the cmdlets from a binary module.
 
 ```yaml
 Type: String[]
@@ -309,9 +314,8 @@ Accept wildcard characters: False
 ### -Function
 
 Specifies an array of functions that this cmdlet exports from the module into the current session.
-Enter a comma-separated list of functions.
-Wildcard characters are permitted.
-By default, all functions defined in a module are exported.
+Enter a comma-separated list of functions. Wildcard characters are permitted. By default, all
+functions defined in a module are exported.
 
 ```yaml
 Type: String[]
@@ -327,10 +331,10 @@ Accept wildcard characters: True
 
 ### -Name
 
-Specifies a name for the new module.
-You can also pipe a module name to New-Module.
+Specifies a name for the new module. You can also pipe a module name to New-Module.
 
-The default value is an autogenerated name that starts with `__DynamicModule_` and is followed by a GUID that specifies the path of the dynamic module.
+The default value is an autogenerated name that starts with `__DynamicModule_` and is followed by a
+GUID that specifies the path of the dynamic module.
 
 ```yaml
 Type: String
@@ -346,7 +350,8 @@ Accept wildcard characters: False
 
 ### -ReturnResult
 
-Indicates that this cmdlet runs the script block and returns the script block results instead of returning a module object.
+Indicates that this cmdlet runs the script block and returns the script block results instead of
+returning a module object.
 
 ```yaml
 Type: SwitchParameter
@@ -362,9 +367,8 @@ Accept wildcard characters: False
 
 ### -ScriptBlock
 
-Specifies the contents of the dynamic module.
-Enclose the contents in braces ( { } ) to create a script block.
-This parameter is required.
+Specifies the contents of the dynamic module. Enclose the contents in braces (`{}`) to create a
+script block. This parameter is required.
 
 ```yaml
 Type: ScriptBlock
@@ -380,7 +384,10 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -392,14 +399,14 @@ You can pipe a module name to this cmdlet.
 
 ### System.Management.Automation.PSModuleInfo, System.Management.Automation.PSCustomObject, or None
 
-This cmdlet generates a **PSModuleInfo** object, by default.
-If you use the *AsCustomObject* parameter, it generates a **PSCustomObject** object.
-If you use the *ReturnResult* parameter, it returns the result of evaluating the script block in the dynamic module.
+This cmdlet generates a **PSModuleInfo** object, by default. If you use the **AsCustomObject**
+parameter, it generates a **PSCustomObject** object. If you use the **ReturnResult** parameter, it
+returns the result of evaluating the script block in the dynamic module.
 
 ## NOTES
 
-* You can also refer to `New-Module` by its alias, `nmo`.
-  For more information, see [about_Aliases](About/about_Aliases.md).
+You can also refer to `New-Module` by its alias, `nmo`. For more information, see
+[about_Aliases](About/about_Aliases.md).
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Core/New-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-Module.md
@@ -255,7 +255,7 @@ Hello, World!
 ### -ArgumentList
 
 Specifies an array of arguments which are parameter values that are passed to the script block. For
-more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+more information about the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/5.1/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Start-Job.md
@@ -244,7 +244,7 @@ Specifies an array of arguments, or parameter values, for the script that is spe
 
 Arguments must be passed to **ArgumentList** as single-dimension array argument. For example, a
 comma-separated list. For more information about the behavior of **ArgumentList**, see
-[about_Splatting](about_Splatting.md#splatting-with-arrays).
+[about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Start-Job.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/09/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/start-job?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Job
@@ -243,8 +243,9 @@ Specifies an array of arguments, or parameter values, for the script that is spe
 **FilePath** parameter or a command specified with the **ScriptBlock** parameter.
 
 Arguments must be passed to **ArgumentList** as single-dimension array argument. For example, a
-comma-separated list. For more information about array dimensions, see
-[about_Arrays](./about/about_arrays.md#rank).
+comma-separated list. For more information about the behavior of **ArgumentList**, see
+[about_Splatting](about_Splatting.md#splatting-with-arrays).
+
 
 ```yaml
 Type: Object[]

--- a/reference/5.1/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Start-Process.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 04/18/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/start-process?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Process

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/export-pssession?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Export-PSSession

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Object.md
@@ -212,6 +212,8 @@ array. For example:
 
 `$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate -ArgumentList (,$bytes)`
 
+For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+
 The alias for **ArgumentList** is **Args**.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Object.md
@@ -212,7 +212,7 @@ array. For example:
 
 `$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate -ArgumentList (,$bytes)`
 
-For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+For more information about the behavior of **ArgumentList**, see [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md#splatting-with-arrays).
 
 The alias for **ArgumentList** is **Args**.
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -82,7 +82,8 @@ expression. In effect, the command being processed during the trace is
 Specifies the parameters and parameter values for the command being traced. The alias for
 **ArgumentList** is **Args**. This feature is especially useful for debugging dynamic parameters.
 
-For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+For more information about the behavior of **ArgumentList**, see
+[about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/5.1/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 04/09/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/trace-command?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Trace-Command
@@ -31,44 +31,58 @@ Trace-Command [-InputObject <PSObject>] [-Name] <String[]> [[-Option] <PSTraceSo
 ```
 
 ## DESCRIPTION
-The **Trace-Command** cmdlet configures and starts a trace of the specified expression or command.
+The `Trace-Command` cmdlet configures and starts a trace of the specified expression or command.
 It works like Set-TraceSource, except that it applies only to the specified command.
 
 ## EXAMPLES
 
 ### Example 1: Trace metadata processing, parameter binding, and an expression
-```
-PS C:\> Trace-Command -Name metadata,parameterbinding,cmdlet -Expression {Get-Process Notepad} -PSHost
+
+This example starts a trace of metadata processing, parameter binding, and cmdlet creation and
+destruction of the `Get-Process Notepad` expression.
+
+```powershell
+Trace-Command -Name metadata,parameterbinding,cmdlet -Expression {Get-Process Notepad} -PSHost
 ```
 
-This command starts a trace of metadata processing, parameter binding, and cmdlet creation and destruction of the `Get-Process Notepad` expression.
-It uses the *Name* parameter to specify the trace sources, the *Expression* parameter to specify the command, and the *PSHost* parameter to send the output to the console.
-Because it does not specify any tracing options or listener options, the command uses the defaults--All for the tracing options, and None for the listener options.
+It uses the **Name** parameter to specify the trace sources, the **Expression** parameter to specify
+the command, and the **PSHost** parameter to send the output to the console. Because it does not
+specify any tracing options or listener options, the command uses the defaults:
+
+- All for the tracing options
+- None for the listener options
 
 ### Example 2: Trace the actions of ParameterBinding operations
+
+This example traces the actions of the **ParameterBinding** operations of PowerShell while it processes
+a `Get-Alias` expression that takes input from the pipeline.
+
+
+```powershell
+$A = "i*"
+Trace-Command ParameterBinding {Get-Alias $Input} -PSHost -InputObject $A
 ```
-PS C:\> $A = "i*"
-PS C:\> Trace-Command ParameterBinding {Get-Alias $Input} -PSHost -InputObject $A
-```
 
-These commands trace the actions of the ParameterBinding operations of Windows PowerShell while it processes a Get-Alias expression that takes input from the pipeline.
+In `Trace-Command`, the **InputObject** parameter passes an object to the expression that is being
+processed during the trace.
 
-In **Trace-Command**, the *InputObject* parameter passes an object to the expression that is being processed during the trace.
+The first command stores the string `i*` in the `$A` variable. The second command uses the
+`Trace-Command` cmdlet with the ParameterBinding trace source. The **PSHost** parameter sends the
+output to the console.
 
-The first command stores the string "i*" in the $A variable.
-The second command uses the **Trace-Command** cmdlet with the ParameterBinding trace source.
-The *PSHost* parameter sends the output to the console.
-
-The expression being processed is `Get-Alias $Input`, where the $Input variable is associated with the *InputObject* parameter.
-The *InputObject* parameter passes the variable $A to the expression.
-In effect, the command being processed during the trace is `Get-Alias -InputObject $A" or "$A | Get-Alias`.
+The expression being processed is `Get-Alias $Input`, where the `$Input` variable is associated with
+the **InputObject** parameter. The **InputObject** parameter passes the variable `$A` to the
+expression. In effect, the command being processed during the trace is
+`Get-Alias -InputObject $A" or "$A | Get-Alias`.
 
 ## PARAMETERS
 
 ### -ArgumentList
-Specifies the parameters and parameter values for the command being traced.
-The alias for *ArgumentList* is *Args*.
-This feature is especially useful for debugging dynamic parameters.
+
+Specifies the parameters and parameter values for the command being traced. The alias for
+**ArgumentList** is **Args**. This feature is especially useful for debugging dynamic parameters.
+
+For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]
@@ -83,6 +97,7 @@ Accept wildcard characters: False
 ```
 
 ### -Command
+
 Specifies a command that is being processed during the trace.
 
 ```yaml
@@ -98,9 +113,10 @@ Accept wildcard characters: False
 ```
 
 ### -Debugger
-Indicates that the cmdlet sends the trace output to the debugger.
-You can view the output in any user-mode or kernel mode debugger or in Visual Studio.
-This parameter also selects the default trace listener.
+
+Indicates that the cmdlet sends the trace output to the debugger. You can view the output in any
+user-mode or kernel mode debugger or in Visual Studio. This parameter also selects the default trace
+listener.
 
 ```yaml
 Type: SwitchParameter
@@ -115,8 +131,9 @@ Accept wildcard characters: False
 ```
 
 ### -Expression
-Specifies the expression that is being processed during the trace.
-Enclose the expression in braces ({}).
+
+Specifies the expression that is being processed during the trace. Enclose the expression in braces
+(`{}`).
 
 ```yaml
 Type: ScriptBlock
@@ -131,13 +148,14 @@ Accept wildcard characters: False
 ```
 
 ### -FilePath
-Specifies a file that the cmdlet sends the trace output to.
-This parameter also selects the file trace listener.
+
+Specifies a file that the cmdlet sends the trace output to. This parameter also selects the file
+trace listener.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: PSPath
+Aliases: PSPath, Path
 
 Required: False
 Position: Named
@@ -147,9 +165,9 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the command to run without asking for user confirmation.
-Used with the *FilePath* parameter.
-Even using the *Force* parameter, the cmdlet cannot override security restrictions.
+
+Forces the command to run without asking for user confirmation. Used with the **FilePath**
+parameter. Even using the **Force** parameter, the cmdlet cannot override security restrictions.
 
 ```yaml
 Type: SwitchParameter
@@ -164,9 +182,9 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies input to the expression that is being processed during the trace.
 
-You can enter a variable that represents the input that the expression accepts, or pass an object through the pipeline.
+Specifies input to the expression that is being processed during the trace. You can enter a variable
+that represents the input that the expression accepts, or pass an object through the pipeline.
 
 ```yaml
 Type: PSObject
@@ -181,8 +199,9 @@ Accept wildcard characters: False
 ```
 
 ### -ListenerOption
-Specifies optional data to the prefix of each trace message in the output.
-The acceptable values for this parameter are:
+
+Specifies optional data to the prefix of each trace message in the output. The acceptable values for
+this parameter are:
 
 - None
 - LogicalOperationStack
@@ -192,9 +211,10 @@ The acceptable values for this parameter are:
 - ThreadId
 - Callstack
 
-None is the default.
+**None** is the default.
 
-To specify multiple options, separate them with commas, but with no spaces, and enclose them in quotation marks, such as "ProcessID,ThreadID".
+To specify multiple options, separate them with commas, but with no spaces, and enclose them in
+quotation marks, such as "ProcessID,ThreadID".
 
 ```yaml
 Type: TraceOptions
@@ -210,10 +230,10 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of Windows PowerShell components that are traced.
-Enter the name of the trace source of each component.
-Wildcards are permitted.
-To find the trace sources on your computer, type `Get-TraceSource`.
+
+Specifies an array of PowerShell components that are traced. Enter the name of the trace source of
+each component. Wildcards are permitted. To find the trace sources on your computer, type
+`Get-TraceSource`.
 
 ```yaml
 Type: String[]
@@ -228,8 +248,8 @@ Accept wildcard characters: False
 ```
 
 ### -Option
-Determines the type of events that are traced.
-The acceptable values for this parameter are:
+
+Determines the type of events that are traced. The acceptable values for this parameter are:
 
 - None
 - Constructor
@@ -260,7 +280,8 @@ The following values are combinations of other values:
 - Data: (Constructor, Dispose, Finalizer, Property, Verbose, and WriteLine)
 - Errors: (Error and Exception).
 
-To specify multiple options, separate them with commas, but with no spaces, and enclose them in quotation marks, such as "Constructor,Dispose".
+To specify multiple options, separate them with commas, but with no spaces, and enclose them in
+quotation marks, such as "Constructor,Dispose".
 
 ```yaml
 Type: PSTraceSourceOptions
@@ -276,8 +297,9 @@ Accept wildcard characters: False
 ```
 
 ### -PSHost
-Indicates that the cmdlet sends the trace output to the Windows PowerShell host.
-This parameter also selects the PSHost trace listener.
+
+Indicates that the cmdlet sends the trace output to the PowerShell host. This parameter also selects
+the PSHost trace listener.
 
 ```yaml
 Type: SwitchParameter
@@ -292,31 +314,48 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe objects that represent input to the expression to **Trace-Command**.
+
+You can pipe objects that represent input to the expression to `Trace-Command`.
 
 ## OUTPUTS
 
 ### System.Management.Automation.PSObject
+
 Returns the command trace in the debug stream.
 
 ## NOTES
-* Tracing is a method that developers use to debug and refine programs. When tracing, the program generates detailed messages about each step in its internal processing.
-* The Windows PowerShell tracing cmdlets are designed to help Windows PowerShell developers, but they are available to all users. They let you monitor nearly every aspect of the functionality of the shell.
-* To find the Windows PowerShell components that are enabled for tracing, type `Get-Help Get-TraceSource`.
 
-  A trace source is the part of each Windows PowerShell component that manages tracing and generates trace messages for the component.
-To trace a component, you identify its trace source.
+- Tracing is a method that developers use to debug and refine programs. When tracing, the program
+  generates detailed messages about each step in its internal processing.
 
-  A trace listener receives the output of the trace and displays it to the user.
-You can elect to send the trace data to a user-mode or kernel-mode debugger, to the host or console, to a file, or to a custom listener derived from the **System.Diagnostics.TraceListener** class.
+- The PowerShell tracing cmdlets are designed to help PowerShell developers, but they are available
+  to all users. They let you monitor nearly every aspect of the functionality of the shell.
 
-* When you use the commandSet parameter set, Windows PowerShell processes the command just as it would be processed in a pipeline. For example, command discovery is not repeated for each incoming object.
-* The names of the *Name*, *Expression*, *Option*, and *Command* parameters are optional. If you omit the parameter names, the unnamed parameter values must appear in this order: *Name*, *Expression*, *Option* or *Name*, *Command*, *Option*. If you include the parameter names, the parameters can appear in any order.
+- To find the PowerShell components that are enabled for tracing, type `Get-Help Get-TraceSource`.
+
+  A trace source is the part of each PowerShell component that manages tracing and generates trace
+  messages for the component. To trace a component, you identify its trace source.
+
+  A trace listener receives the output of the trace and displays it to the user. You can elect to
+  send the trace data to a user-mode or kernel-mode debugger, to the host or console, to a file, or
+  to a custom listener derived from the **System.Diagnostics.TraceListener** class.
+
+- When you use the commandSet parameter set, PowerShell processes the command just as it would be
+  processed in a pipeline. For example, command discovery is not repeated for each incoming object.
+
+- The names of the **Name**, **Expression**, **Option**, and **Command** parameters are optional. If
+  you omit the parameter names, the unnamed parameter values must appear in this order: **Name**,
+  **Expression**, **Option** or **Name**, **Command**, **Option**. If you include the parameter
+  names, the parameters can appear in any order.
 
 ## RELATED LINKS
 
@@ -327,5 +366,3 @@ You can elect to send the trace data to a user-mode or kernel-mode debugger, to 
 [Set-TraceSource](Set-TraceSource.md)
 
 [Show-Command](Show-Command.md)
-
-

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 03/19/2020
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_arrays?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Arrays
@@ -462,6 +462,9 @@ $a.ForEach({ $_ * $_})
 Just like the `-ArgumentList` parameter of `ForEach-Object`, the `arguments`
 parameter allows the passing of an array of arguments to a script block
 configured to accept them.
+
+For more information about the behavior of **ArgumentList**, see
+[about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 #### ForEach(type convertToType)
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -1,40 +1,40 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 11/28/2017
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_CmdletBindingAttribute
 ---
 # About Functions CmdletBindingAttribute
 
-## SHORT DESCRIPTION
+## Short description
 Describes the attribute that makes a function work like a compiled cmdlet.
 
-## LONG DESCRIPTION
+## Long description
 
-The CmdletBinding attribute is an attribute of functions that makes
-them operate like compiled cmdlets that are written in C#, and it
-provides access to features of cmdlets.
+The **CmdletBinding** attribute is an attribute of functions that makes them
+operate like compiled cmdlets that are written in C#, and it provides access to
+features of cmdlets.
 
-PowerShell binds the parameters of functions that have the
-CmdletBinding attribute in the same way that it binds the parameters of
-compiled cmdlets. The $PSCmdlet automatic variable is available to
-functions with the CmdletBinding attribute, but the $Args variable
-is not available.
+PowerShell binds the parameters of functions that have the **CmdletBinding**
+attribute in the same way that it binds the parameters of compiled cmdlets. The
+`$PSCmdlet` automatic variable is available to functions with the CmdletBinding
+attribute, but the `$Args` variable is not available.
 
-In functions that have the CmdletBinding attribute, unknown parameters
-and positional arguments that have no matching positional parameters
-cause parameter binding to fail.
+In functions that have the **CmdletBinding** attribute, unknown parameters and
+positional arguments that have no matching positional parameters cause
+parameter binding to fail.
 
-Note: Compiled cmdlets use the required Cmdlet attribute, which is similar
-to the CmdletBinding attribute that is described in this topic.
+> [!NOTE]
+> Compiled cmdlets use the required **Cmdlet** attribute, which is similar
+> to the **CmdletBinding** attribute that is described in this topic.
 
-## SYNTAX
+## Syntax
 
-The following example shows the format of a function that specifies all
-the optional arguments of the CmdletBinding attribute. A brief description
-of each argument follows this example.
+The following example shows the format of a function that specifies all the
+optional arguments of the **CmdletBinding** attribute. A brief description of
+each argument follows this example.
 
 ```powershell
 {
@@ -54,65 +54,65 @@ of each argument follows this example.
 
 ## ConfirmImpact
 
-The ConfirmImpact argument specifies when the action of the function
-should be confirmed by a call to the ShouldProcess method. The call to
-the ShouldProcess method displays a confirmation prompt only when the
-ConfirmImpact argument is equal to or greater than the value of the
-$ConfirmPreference preference variable. (The default value of the
-argument is Medium.) Specify this argument only when the
-SupportsShouldProcess argument is also specified.
+The **ConfirmImpact** argument specifies when the action of the function should
+be confirmed by a call to the **ShouldProcess** method. The call to the
+**ShouldProcess** method displays a confirmation prompt only when the
+**ConfirmImpact** argument is equal to or greater than the value of the
+`$ConfirmPreference` preference variable. (The default value of the argument is
+**Medium**.) Specify this argument only when the **SupportsShouldProcess**
+argument is also specified.
 
 For more information about confirmation requests, see [Requesting Confirmation](/powershell/scripting/developer/cmdlet/requesting-confirmation).
 
 ## DefaultParameterSetName
 
-The DefaultParameterSetName argument specifies the name of the parameter
-set that PowerShell will attempt to use when it cannot determine
-which parameter set to use. You can avoid this issue by making the
-unique parameter of each parameter set a mandatory parameter.
+The **DefaultParameterSetName** argument specifies the name of the parameter
+set that PowerShell will attempt to use when it cannot determine which
+parameter set to use. You can avoid this issue by making the unique parameter
+of each parameter set a mandatory parameter.
 
 ## HelpURI
 
-The HelpURI argument specifies the Internet address (Uniform Resource
-Identifier (URI)) of the online version of the help topic that describes
-the function. The value of the HelpURI argument must begin with "http"
-or "https".
+The **HelpURI** argument specifies the Internet address (Uniform Resource
+Identifier (URI)) of the online version of the help topic that describes the
+function. The value of the **HelpURI** argument must begin with "http" or
+"https".
 
-The HelpURI argument value is used for the value of the HelpURI property
-of the CommandInfo object that Get-Command returns for the function.
+The **HelpURI** argument value is used for the value of the **HelpURI**
+property of the **CommandInfo** object that `Get-Command` returns for the
+function.
 
-However, when help files are installed on the computer and the value of
-the first link in the RelatedLinks section of the help file is a URI,
-or the value of the first .Link directive in comment-based help is a URI,
-the URI in the help file is used as the value of the HelpUri property
-of the function.
+However, when help files are installed on the computer and the value of the
+first link in the **RelatedLinks** section of the help file is a URI, or the
+value of the first `.Link` directive in comment-based help is a URI, the URI in
+the help file is used as the value of the **HelpUri** property of the function.
 
-The `Get-Help` cmdlet uses the value of the HelpURI property to locate the
-online version of the function help topic when the Online parameter
-of `Get-Help` is specified in a command.
+The `Get-Help` cmdlet uses the value of the **HelpURI** property to locate the
+online version of the function help topic when the **Online** parameter of
+`Get-Help` is specified in a command.
 
 ## SupportsPaging
 
-The SupportsPaging argument adds the First, Skip, and IncludeTotalCount
-parameters to the function. These parameters allow users to select
-output from a very large result set. This argument is designed for cmdlets
-and functions that return data from large data stores that support data
+The **SupportsPaging** argument adds the **First**, **Skip**, and
+**IncludeTotalCount** parameters to the function. These parameters allow users
+to select output from a very large result set. This argument is designed for
+cmdlets and functions that return data from large data stores that support data
 selection, such as a SQL database.
 
 This argument was introduced in Windows PowerShell 3.0.
 
-* First: Gets only the first 'n' objects.
-* Skip:  Ignores the first 'n' objects and then gets the remaining objects.
-* IncludeTotalCount: Reports the number of objects in the data set (an integer)
-followed by the objects. If the cmdlet cannot determine the total count, it
-returns "Unknown total count".
+- **First**: Gets only the first 'n' objects.
+- **Skip**:  Ignores the first 'n' objects and then gets the remaining objects.
+- **IncludeTotalCount**: Reports the number of objects in the data set (an
+  integer) followed by the objects. If the cmdlet cannot determine the total
+  count, it returns "Unknown total count".
 
-PowerShell includes NewTotalCount, a helper method that gets the
-total count value to return and includes an estimate of the accuracy of the
-total count value.
+PowerShell includes **NewTotalCount**, a helper method that gets the total
+count value to return and includes an estimate of the accuracy of the total
+count value.
 
-The following sample function shows how to add support for the paging parameters
-to an advanced function.
+The following sample function shows how to add support for the paging
+parameters to an advanced function.
 
 ```powershell
 function Get-Numbers {
@@ -135,19 +135,19 @@ function Get-Numbers {
 
 ## SupportsShouldProcess
 
-The SupportsShouldProcess argument adds **Confirm** and **WhatIf** parameters
-to the function. The **Confirm** parameter prompts the user before it runs
-the command on each object in the pipeline. The **WhatIf** parameter lists the
-changes that the command would make, instead of running the command.
+The **SupportsShouldProcess** argument adds **Confirm** and **WhatIf**
+parameters to the function. The **Confirm** parameter prompts the user before
+it runs the command on each object in the pipeline. The **WhatIf** parameter
+lists the changes that the command would make, instead of running the command.
 
 ## PositionalBinding
 
-The PositionalBinding argument determines whether parameters in the function
-are positional by default. The default value is $True. You can use the
-PositionalBinding argument with a value of $False to disable positional
-binding.
+The **PositionalBinding** argument determines whether parameters in the
+function are positional by default. The default value is `$True`. You can use
+the **PositionalBinding** argument with a value of `$False` to disable
+positional binding.
 
-The PositionalBinding argument is introduced in Windows PowerShell 3.0.
+The **PositionalBinding** argument is introduced in Windows PowerShell 3.0.
 
 When parameters are positional, the parameter name is optional.
 PowerShell associates unnamed parameter values with the function parameters
@@ -157,29 +157,30 @@ function command.
 When parameters are not positional (they are "named"), the parameter
 name (or an abbreviation or alias of the name) is required in the command.
 
-When PositionalBinding is $True, function parameters are positional by
-default. PowerShell assigns position number to the parameters in
-the order in which they are declared in the function.
+When **PositionalBinding** is `$True`, function parameters are positional by
+default. PowerShell assigns position number to the parameters in the order in
+which they are declared in the function.
 
-When PositionalBinding is $False, function parameters are not positional
-by default. Unless the Position argument of the Parameter attribute is
+When **PositionalBinding** is `$False`, function parameters are not positional
+by default. Unless the **Position** argument of the **Parameter** attribute is
 declared on the parameter, the parameter name (or an alias or abbreviation)
 must be included when the parameter is used in a function.
 
-The Position argument of the Parameter attribute takes precedence over the
-PositionalBinding default value. You can use the Position argument to specify
-a position value for a parameter. For more information about the Position
-argument, see [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
+The **Position** argument of the **Parameter** attribute takes precedence over
+the **PositionalBinding** default value. You can use the **Position** argument
+to specify a position value for a parameter. For more information about the
+**Position** argument, see
+[about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
 
-## NOTES
+## Notes
 
-The SupportsTransactions argument is not supported in advanced functions.
+The **SupportsTransactions** argument is not supported in advanced functions.
 
-## KEYWORDS
+## Keywords
 
 about_Functions_CmdletBinding_Attribute
 
-## SEE ALSO
+## See also
 
 [about_Functions](about_Functions.md)
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 08/28/2018
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_script_blocks?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Script_Blocks
@@ -64,7 +64,7 @@ example:
 Invoke-Command -ScriptBlock { Get-Process }
 ```
 
-```output
+```Output
 Handles  NPM(K)    PM(K)     WS(K) VM(M)   CPU(s)     Id ProcessName
 -------  ------    -----     ----- -----   ------     -- -----------
 999          28    39100     45020   262    15.88   1844 communicator
@@ -82,7 +82,7 @@ Invoke-Command -ScriptBlock { param($p1, $p2)
 } -ArgumentList "First", "Second"
 ```
 
-```output
+```Output
 p1: First
 p2: Second
 ```
@@ -90,6 +90,9 @@ p2: Second
 The script block in the preceding example uses the `param` keyword to
 create a parameters `$p1` and `$p2`. The string "First" is bound to the
 first parameter (`$p1`) and "Second" is bound to (`$p2`).
+
+For more information about the behavior of **ArgumentList**, see
+[about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 You can use variables to store and execute script blocks. The example below
 stores a script block in a variable and passes it to `Invoke-Command`.
@@ -99,7 +102,7 @@ $a = { Get-Service BITS }
 Invoke-Command -ScriptBlock $a
 ```
 
-```output
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Running  BITS               Background Intelligent Transfer Ser...
@@ -118,7 +121,7 @@ $a ={ param($p1, $p2)
 &$a -p2 "First" -p1 "Second"
 ```
 
-```output
+```Output
 p1: Second
 p2: First
 ```

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 09/09/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_splatting?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Splatting
@@ -9,11 +9,11 @@ title: about_Splatting
 
 # About Splatting
 
-## SHORT DESCRIPTION
+## Short description
 
 Describes how to use splatting to pass parameters to commands in PowerShell.
 
-## LONG DESCRIPTION
+## Long description
 
 Splatting is a method of passing a collection of parameter values to a command
 as unit. PowerShell associates each value in the collection with a command
@@ -30,7 +30,7 @@ functions.
 Beginning in Windows PowerShell 3.0, you can also use splatting to represent
 all parameters of a command.
 
-## SYNTAX
+## Syntax
 
 ```
 <CommandName> <optional parameters> @<HashTable> <optional parameters>
@@ -47,7 +47,7 @@ parameters. You may pass some parameters by using splatting and pass others by
 position or by parameter name. Also, you can splat multiple objects in a single
 command so you don't pass more than one value for each parameter.
 
-## SPLATTING WITH HASH TABLES
+## Splatting with hash tables
 
 Use a hash table to splat parameter name and value pairs. You can use this
 format for all parameter types, including positional and switch parameters.
@@ -80,11 +80,11 @@ $HashArguments = @{
 Copy-Item @HashArguments
 ```
 
-Note: In the first command, the At symbol (@) indicates a hash table, not a
+Note: In the first command, the At symbol (`@`) indicates a hash table, not a
 splatted value. The syntax for hash tables in PowerShell is:
-`@{\<name\>=\<value\>; \<name\>=\<value\>; ...}*`
+`@{<name>=<value>; <name>=<value>; ...}`
 
-## SPLATTING WITH ARRAYS
+## Splatting with arrays
 
 Use an array to splat values for positional parameters, which do not require
 parameter names. The values must be in position-number order in the array.
@@ -111,7 +111,44 @@ $ArrayArguments = "test.txt", "test2.txt"
 Copy-Item @ArrayArguments -WhatIf
 ```
 
-## EXAMPLES
+### Using the ArgumentList parameter
+
+Several cmdlets have an **ArgumentList** parameter that is used to pass
+parameter values to a script block that is executed by the cmdlet. The
+**ArgumentList** parameter takes an array of values that is passed to the
+script block. PowerShell is effectively using array splatting to bind the
+values to the parameters of the script block. When using **ArgumentList**, if
+you need to pass an array as a single object bound to a single parameter, you
+must wrap the array in an array subexpression.
+
+The following example has a script block that takes a single parameter that is
+an array of strings.
+
+```powershell
+$array = 'Hello', 'World!'
+Invoke-Command -ScriptBlock { param([string[]]$words) $words -join ' '} -ArgumentList $array
+```
+
+In this example, only the first item in `$array` is passed to the script script
+block.
+
+```Output
+Hello
+```
+
+```powershell
+$array = 'Hello', 'World!'
+Invoke-Command -ScriptBlock { param([string[]]$words) $words -join ' '} -ArgumentList (,$array)
+```
+
+In this example, `$array` is wrapped in an array subexpress so that the entire
+array is passed to the script block as a single object.
+
+```Output
+Hello World!
+```
+
+## Examples
 
 This example shows how to reuse splatted values in different commands. The
 commands in this example use the `Write-Host` cmdlet to write messages to the
@@ -186,7 +223,7 @@ Test2 -a 1 -b 2 -c 3
 3
 ```
 
-## SPLATTING COMMAND PARAMETERS
+## Splatting command parameters
 
 You can use splatting to represent the parameters of a command. This technique
 is useful when you are creating a proxy function, that is, a function that
@@ -278,7 +315,7 @@ FileVersionInfo    : File:             C:\Windows\System32\WindowsPowerShell
                      Language:         English (United States)
 ```
 
-## NOTES
+## Notes
 
 If you make a function into an advanced function by using either the
 **CmdletBinding** or **Parameter** attributes, the `$args` automatic variable
@@ -289,7 +326,7 @@ PowerShell Desired State Configuration (DSC) was not designed to use splatting.
 You cannot use splatting to pass values into a DSC resource. For more
 information, see Gael Colas' article [Pseudo-Splatting DSC Resources](https://gaelcolas.com/2017/11/05/pseudo-splatting-dsc-resources/).
 
-## SEE ALSO
+## See also
 
 [about_Arrays](about_Arrays.md)
 

--- a/reference/6/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/6/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -203,7 +203,8 @@ the **MemberName** and **ArgumentList** parameters, which are optional.
 
 ### -ArgumentList
 
-Specifies an array of arguments to a method call.
+Specifies an array of arguments to a method call. For more information about the behavior of
+**ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/6/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/6/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -204,7 +204,7 @@ the **MemberName** and **ArgumentList** parameters, which are optional.
 ### -ArgumentList
 
 Specifies an array of arguments to a method call. For more information about the behavior of
-**ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+**ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/6/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Import-Module.md
@@ -584,7 +584,7 @@ Specifies an array of arguments, or parameter values, that are passed to a scrip
 `Import-Module` command. This parameter is valid only when you're importing a script module.
 
 You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information
-about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+about the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/6/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Import-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 02/25/2020
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/import-module?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Import-Module
@@ -583,8 +583,8 @@ Accept wildcard characters: True
 Specifies an array of arguments, or parameter values, that are passed to a script module during the
 `Import-Module` command. This parameter is valid only when you're importing a script module.
 
-You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information,
-see [about_Aliases](About/about_Aliases.md).
+You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information
+about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -758,7 +758,7 @@ To use local variables in a command, use the following command format:
 
 The **param** keyword lists the local variables that are used in the command. **ArgumentList**
 supplies the values of the variables, in the order that they're listed. For more information about
-the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 03/30/2020
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/invoke-command?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-Command
@@ -757,7 +757,8 @@ To use local variables in a command, use the following command format:
 -or- `<local-variable>`
 
 The **param** keyword lists the local variables that are used in the command. **ArgumentList**
-supplies the values of the variables, in the order that they're listed.
+supplies the values of the variables, in the order that they're listed. For more information about
+the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/6/Microsoft.PowerShell.Core/New-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/New-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-module?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-Module
@@ -31,25 +31,32 @@ New-Module [-Name] <String> [-ScriptBlock] <ScriptBlock> [-Function <String[]>] 
 
 ## DESCRIPTION
 
-The **New-Module** cmdlet creates a dynamic module from a script block.
-The members of the dynamic module, such as functions and variables, are immediately available in the session and remain available until you close the session.
+The `New-Module` cmdlet creates a dynamic module from a script block. The members of the dynamic
+module, such as functions and variables, are immediately available in the session and remain
+available until you close the session.
 
-Like static modules, by default, the cmdlets and functions in a dynamic module are exported and the variables and aliases are not.
-However, you can use the Export-ModuleMember cmdlet and the parameters of **New-Module** to override the defaults.
+Like static modules, by default, the cmdlets and functions in a dynamic module are exported and the
+variables and aliases are not. However, you can use the Export-ModuleMember cmdlet and the
+parameters of `New-Module` to override the defaults.
 
-You can also use the *AsCustomObject* parameter of **New-Module** to return the dynamic module as a custom object.
-The members of the modules, such as functions, are implemented as script methods of the custom object instead of being imported into the session.
+You can also use the **AsCustomObject** parameter of `New-Module` to return the dynamic module as a
+custom object. The members of the modules, such as functions, are implemented as script methods of
+the custom object instead of being imported into the session.
 
-Dynamic modules exist only in memory, not on disk.
-Like all modules, the members of dynamic modules run in a private module scope that is a child of the global scope.
-Get-Module cannot get a dynamic module, but Get-Command can get the exported members.
+Dynamic modules exist only in memory, not on disk. Like all modules, the members of dynamic modules
+run in a private module scope that is a child of the global scope. Get-Module cannot get a dynamic
+module, but Get-Command can get the exported members.
 
-To make a dynamic module available to **Get-Module**, pipe a **New-Module** command to Import-Module, or pipe the module object that **New-Module** returns to **Import-Module**.
-This action adds the dynamic module to the **Get-Module** list, but it does not save the module to disk or make it persistent.
+To make a dynamic module available to `Get-Module`, pipe a `New-Module` command to Import-Module, or
+pipe the module object that `New-Module` returns to `Import-Module`. This action adds the dynamic
+module to the `Get-Module` list, but it does not save the module to disk or make it persistent.
 
 ## EXAMPLES
 
 ### Example 1: Create a dynamic module
+
+This example creates a new dynamic module with a function called `Hello`. The command returns a
+module object that represents the new dynamic module.
 
 ```powershell
 New-Module -ScriptBlock {function Hello {"Hello!"}}
@@ -72,10 +79,10 @@ ExportedVariables : {}
 NestedModules     : {}
 ```
 
-This command creates a new dynamic module with a function called Hello.
-The command returns a module object that represents the new dynamic module.
-
 ### Example 2: Working with dynamic modules and Get-Module and Get-Command
+
+This example demonstrates that dynamic modules are not returned by the `Get-Module` cmdlet. The
+members that they export are returned by the `Get-Command` cmdlet.
 
 ```powershell
 new-module -scriptblock {function Hello {"Hello!"}}
@@ -110,10 +117,10 @@ CommandType     Name   Definition
 Function        Hello  "Hello!"
 ```
 
-This example demonstrates that dynamic modules are not returned by the **Get-Module** cmdlet.
-The members that they export are returned by the **Get-Command** cmdlet.
-
 ### Example 3: Export a variable into the current session
+
+This example uses the `Export-ModuleMember` cmdlet to export a variable into the current session.
+Without the `Export-ModuleMember` command, only the function is exported.
 
 ```powershell
 New-Module -ScriptBlock {$SayHelloHelp="Type 'SayHello', a space, and a name."; function SayHello ($name) { "Hello, $name" }; Export-ModuleMember -function SayHello -Variable SayHelloHelp}
@@ -132,12 +139,17 @@ SayHello Jeffrey
 Hello, Jeffrey
 ```
 
-This command uses the **Export-ModuleMember** cmdlet to export a variable into the current session.
-Without the **Export-ModuleMember** command, only the function is exported.
-
 The output shows that both the variable and the function were exported into the session.
 
 ### Example 4: Make a dynamic module available to Get-Module
+
+This example demonstrates that you can make a dynamic module available to `Get-Module` by piping the
+dynamic module to `Import-Module`.
+
+`New-Module` creates a module object that is piped to the `Import-Module` cmdlet. The **Name**
+parameter of `New-Module` assigns a friendly name to the module. Because `Import-Module` does not
+return any objects by default, there is no output from this command. `Get-Module` that the
+**GreetingModule** has been imported into the current session.
 
 ```powershell
 New-Module -ScriptBlock {function Hello {"Hello!"}} -name GreetingModule | Import-Module
@@ -171,21 +183,23 @@ CommandType     Name                                                            
 Function        Hello                                                              "Hello!"
 ```
 
-This command demonstrates that you can make a dynamic module available to **Get-Module** by piping the dynamic module to **Import-Module**.
-
-The first command uses a pipeline operator (|) to send the module object that **New-Module** generates to the **Import-Module** cmdlet.
-The command uses the *Name* parameter of **New-Module** to assign a friendly name to the module.
-Because **Import-Module** does not return any objects by default, there is no output from this command.
-
-The second command uses **Get-Module** to get the modules in the session.
-The result shows that **Get-Module** can get the new dynamic module.
-
-The third command uses the **Get-Command** cmdlet to get the Hello function that the dynamic module exports.
+The `Get-Command` cmdlet shows the `Hello` function that the dynamic module exports.
 
 ### Example 5: Generate a custom object that has exported functions
 
+This example shows how to use the **AsCustomObject** parameter of `New-Module` to generate a custom
+object that has script methods that represent the exported functions.
+
+The `New-Module` cmdlet creates a dynamic module with two functions, `Hello` and `Goodbye`. The
+**AsCustomObject** parameter creates a custom object instead of the **PSModuleInfo** object that
+`New-Module` generates by default. This custom object is saved in the `$m` variable.
+The `$m` variable appears to have no assigned value.
+
 ```powershell
-$m = New-Module -ScriptBlock {function Hello ($name) {"Hello, $name"}; function Goodbye ($name) {"Goodbye, $name"}} -AsCustomObject
+$m = New-Module -ScriptBlock {
+  function Hello ($name) {"Hello, $name"}
+  function Goodbye ($name) {"Goodbye, $name"}
+} -AsCustomObject
 $m
 $m | Get-Member
 ```
@@ -218,22 +232,15 @@ $m.hello("Manoj")
 ```Output
 Hello, Manoj
 ```
-
-This example shows how to use the *AsCustomObject* parameter of **New-Module** to generate a custom object that has script methods that represent the exported functions.
-
-The first command uses the **New-Module** cmdlet to generate a dynamic module with two functions, Hello and Goodbye.
-The command uses the *AsCustomObject* parameter to generate a custom object instead of the PSModuleInfo object that **New-Module** generates by default.
-The command saves the custom object in the $m variable.
-
-The second command attempts to display the value of the $m variable.
-No content appears.
-
-The third command uses a pipeline operator to send the custom object to the **Get-Member** cmdlet, which displays the properties and methods of the custom object.
-The output shows that the object has script methods that represent the Hello and Goodbye functions.
-
-The fourth and fifth commands use the script method format to call the Hello and Goodbye functions.
+Piping `$m` to the `Get-Member` cmdlet displays the properties and methods of the custom object. The
+output shows that the object has script methods that represent the `Hello` and `Goodbye` functions.
+Finally, we call these script methods and display the results.
 
 ### Example 6: Get the results of the script block
+
+This example uses the **ReturnResult** parameter to request the results of running the script block
+instead of requesting a module object. The script block in the new module defines the `SayHello`
+function and then calls the function.
 
 ```powershell
 New-Module -ScriptBlock {function SayHello {"Hello, World!"}; SayHello} -ReturnResult
@@ -243,15 +250,12 @@ New-Module -ScriptBlock {function SayHello {"Hello, World!"}; SayHello} -ReturnR
 Hello, World!
 ```
 
-This command uses the *ReturnResult* parameter to request the results of running the script block instead of requesting a module object.
-
-The script block in the new module defines the SayHello function and then calls the function.
-
 ## PARAMETERS
 
 ### -ArgumentList
 
-Specifies an array of arguments which are parameter values that are passed to the script block.
+Specifies an array of arguments which are parameter values that are passed to the script block. For
+more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]
@@ -267,11 +271,12 @@ Accept wildcard characters: False
 
 ### -AsCustomObject
 
-Indicates that this cmdlet returns a custom object that represents the dynamic module.
-The module members are implemented as script methods of the custom object, but they are not imported into the session.
-You can save the custom object in a variable and use dot notation to invoke the members.
+Indicates that this cmdlet returns a custom object that represents the dynamic module. The module
+members are implemented as script methods of the custom object, but they are not imported into the
+session. You can save the custom object in a variable and use dot notation to invoke the members.
 
-If the module has multiple members with the same name, such as a function and a variable that are both named A, only one member with each name can be accessed from the custom object.
+If the module has multiple members with the same name, such as a function and a variable that are
+both named A, only one member with each name can be accessed from the custom object.
 
 ```yaml
 Type: SwitchParameter
@@ -288,11 +293,11 @@ Accept wildcard characters: False
 ### -Cmdlet
 
 Specifies an array of cmdlets that this cmdlet exports from the module into the current session.
-Enter a comma-separated list of cmdlets.
-Wildcard characters are permitted.
-By default, all cmdlets in the module are exported.
+Enter a comma-separated list of cmdlets. Wildcard characters are permitted. By default, all cmdlets
+in the module are exported.
 
-You cannot define cmdlets in a script block, but a dynamic module can include cmdlets if it imports the cmdlets from a binary module.
+You cannot define cmdlets in a script block, but a dynamic module can include cmdlets if it imports
+the cmdlets from a binary module.
 
 ```yaml
 Type: String[]
@@ -309,9 +314,8 @@ Accept wildcard characters: False
 ### -Function
 
 Specifies an array of functions that this cmdlet exports from the module into the current session.
-Enter a comma-separated list of functions.
-Wildcard characters are permitted.
-By default, all functions defined in a module are exported.
+Enter a comma-separated list of functions. Wildcard characters are permitted. By default, all
+functions defined in a module are exported.
 
 ```yaml
 Type: String[]
@@ -327,10 +331,10 @@ Accept wildcard characters: True
 
 ### -Name
 
-Specifies a name for the new module.
-You can also pipe a module name to New-Module.
+Specifies a name for the new module. You can also pipe a module name to New-Module.
 
-The default value is an autogenerated name that starts with `__DynamicModule_` and is followed by a GUID that specifies the path of the dynamic module.
+The default value is an autogenerated name that starts with `__DynamicModule_` and is followed by a
+GUID that specifies the path of the dynamic module.
 
 ```yaml
 Type: String
@@ -346,7 +350,8 @@ Accept wildcard characters: False
 
 ### -ReturnResult
 
-Indicates that this cmdlet runs the script block and returns the script block results instead of returning a module object.
+Indicates that this cmdlet runs the script block and returns the script block results instead of
+returning a module object.
 
 ```yaml
 Type: SwitchParameter
@@ -362,9 +367,8 @@ Accept wildcard characters: False
 
 ### -ScriptBlock
 
-Specifies the contents of the dynamic module.
-Enclose the contents in braces ( { } ) to create a script block.
-This parameter is required.
+Specifies the contents of the dynamic module. Enclose the contents in braces (`{}`) to create a
+script block. This parameter is required.
 
 ```yaml
 Type: ScriptBlock
@@ -380,7 +384,10 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -392,14 +399,14 @@ You can pipe a module name to this cmdlet.
 
 ### System.Management.Automation.PSModuleInfo, System.Management.Automation.PSCustomObject, or None
 
-This cmdlet generates a **PSModuleInfo** object, by default.
-If you use the *AsCustomObject* parameter, it generates a **PSCustomObject** object.
-If you use the *ReturnResult* parameter, it returns the result of evaluating the script block in the dynamic module.
+This cmdlet generates a **PSModuleInfo** object, by default. If you use the **AsCustomObject**
+parameter, it generates a **PSCustomObject** object. If you use the **ReturnResult** parameter, it
+returns the result of evaluating the script block in the dynamic module.
 
 ## NOTES
 
-* You can also refer to `New-Module` by its alias, `nmo`.
-  For more information, see [about_Aliases](About/about_Aliases.md).
+You can also refer to `New-Module` by its alias, `nmo`. For more information, see
+[about_Aliases](About/about_Aliases.md).
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Core/New-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/New-Module.md
@@ -255,7 +255,7 @@ Hello, World!
 ### -ArgumentList
 
 Specifies an array of arguments which are parameter values that are passed to the script block. For
-more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+more information about the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/6/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Start-Job.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/09/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/start-job?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Job
@@ -280,8 +280,9 @@ Specifies an array of arguments, or parameter values, for the script that is spe
 **FilePath** parameter or a command specified with the **ScriptBlock** parameter.
 
 Arguments must be passed to **ArgumentList** as single-dimension array argument. For example, a
-comma-separated list. For more information about array dimensions, see
-[about_Arrays](./about/about_arrays.md#rank).
+comma-separated list. For more information about the behavior of **ArgumentList**, see
+[about_Splatting](about_Splatting.md#splatting-with-arrays).
+
 
 ```yaml
 Type: Object[]

--- a/reference/6/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Start-Job.md
@@ -281,7 +281,7 @@ Specifies an array of arguments, or parameter values, for the script that is spe
 
 Arguments must be passed to **ArgumentList** as single-dimension array argument. For example, a
 comma-separated list. For more information about the behavior of **ArgumentList**, see
-[about_Splatting](about_Splatting.md#splatting-with-arrays).
+[about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 
 ```yaml

--- a/reference/6/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/6/Microsoft.PowerShell.Management/Start-Process.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 04/18/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/start-process?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Process

--- a/reference/6/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/New-Object.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 09/12/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-object?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-Object
@@ -211,6 +211,8 @@ constructor takes a single parameter that is an array, you must wrap that parame
 array. For example:
 
 `$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate -ArgumentList (,$bytes)`
+
+For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 The alias for **ArgumentList** is **Args**.
 

--- a/reference/6/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/New-Object.md
@@ -212,7 +212,7 @@ array. For example:
 
 `$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate -ArgumentList (,$bytes)`
 
-For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+For more information about the behavior of **ArgumentList**, see [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md#splatting-with-arrays).
 
 The alias for **ArgumentList** is **Args**.
 

--- a/reference/6/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 04/09/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/trace-command?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Trace-Command
@@ -31,44 +31,58 @@ Trace-Command [-InputObject <PSObject>] [-Name] <String[]> [[-Option] <PSTraceSo
 ```
 
 ## DESCRIPTION
-The **Trace-Command** cmdlet configures and starts a trace of the specified expression or command.
+The `Trace-Command` cmdlet configures and starts a trace of the specified expression or command.
 It works like Set-TraceSource, except that it applies only to the specified command.
 
 ## EXAMPLES
 
 ### Example 1: Trace metadata processing, parameter binding, and an expression
-```
-PS C:\> Trace-Command -Name metadata,parameterbinding,cmdlet -Expression {Get-Process Notepad} -PSHost
+
+This example starts a trace of metadata processing, parameter binding, and cmdlet creation and
+destruction of the `Get-Process Notepad` expression.
+
+```powershell
+Trace-Command -Name metadata,parameterbinding,cmdlet -Expression {Get-Process Notepad} -PSHost
 ```
 
-This command starts a trace of metadata processing, parameter binding, and cmdlet creation and destruction of the `Get-Process Notepad` expression.
-It uses the *Name* parameter to specify the trace sources, the *Expression* parameter to specify the command, and the *PSHost* parameter to send the output to the console.
-Because it does not specify any tracing options or listener options, the command uses the defaults--All for the tracing options, and None for the listener options.
+It uses the **Name** parameter to specify the trace sources, the **Expression** parameter to specify
+the command, and the **PSHost** parameter to send the output to the console. Because it does not
+specify any tracing options or listener options, the command uses the defaults:
+
+- All for the tracing options
+- None for the listener options
 
 ### Example 2: Trace the actions of ParameterBinding operations
+
+This example traces the actions of the **ParameterBinding** operations of PowerShell while it processes
+a `Get-Alias` expression that takes input from the pipeline.
+
+
+```powershell
+$A = "i*"
+Trace-Command ParameterBinding {Get-Alias $Input} -PSHost -InputObject $A
 ```
-PS C:\> $A = "i*"
-PS C:\> Trace-Command ParameterBinding {Get-Alias $Input} -PSHost -InputObject $A
-```
 
-These commands trace the actions of the ParameterBinding operations of PowerShell while it processes a Get-Alias expression that takes input from the pipeline.
+In `Trace-Command`, the **InputObject** parameter passes an object to the expression that is being
+processed during the trace.
 
-In **Trace-Command**, the *InputObject* parameter passes an object to the expression that is being processed during the trace.
+The first command stores the string `i*` in the `$A` variable. The second command uses the
+`Trace-Command` cmdlet with the ParameterBinding trace source. The **PSHost** parameter sends the
+output to the console.
 
-The first command stores the string "i*" in the $A variable.
-The second command uses the **Trace-Command** cmdlet with the ParameterBinding trace source.
-The *PSHost* parameter sends the output to the console.
-
-The expression being processed is `Get-Alias $Input`, where the $Input variable is associated with the *InputObject* parameter.
-The *InputObject* parameter passes the variable $A to the expression.
-In effect, the command being processed during the trace is `Get-Alias -InputObject $A" or "$A | Get-Alias`.
+The expression being processed is `Get-Alias $Input`, where the `$Input` variable is associated with
+the **InputObject** parameter. The **InputObject** parameter passes the variable `$A` to the
+expression. In effect, the command being processed during the trace is
+`Get-Alias -InputObject $A" or "$A | Get-Alias`.
 
 ## PARAMETERS
 
 ### -ArgumentList
-Specifies the parameters and parameter values for the command being traced.
-The alias for *ArgumentList* is *Args*.
-This feature is especially useful for debugging dynamic parameters.
+
+Specifies the parameters and parameter values for the command being traced. The alias for
+**ArgumentList** is **Args**. This feature is especially useful for debugging dynamic parameters.
+
+For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]
@@ -83,6 +97,7 @@ Accept wildcard characters: False
 ```
 
 ### -Command
+
 Specifies a command that is being processed during the trace.
 
 ```yaml
@@ -98,9 +113,10 @@ Accept wildcard characters: False
 ```
 
 ### -Debugger
-Indicates that the cmdlet sends the trace output to the debugger.
-You can view the output in any user-mode or kernel mode debugger or in Visual Studio.
-This parameter also selects the default trace listener.
+
+Indicates that the cmdlet sends the trace output to the debugger. You can view the output in any
+user-mode or kernel mode debugger or in Visual Studio. This parameter also selects the default trace
+listener.
 
 ```yaml
 Type: SwitchParameter
@@ -115,8 +131,9 @@ Accept wildcard characters: False
 ```
 
 ### -Expression
-Specifies the expression that is being processed during the trace.
-Enclose the expression in braces ({}).
+
+Specifies the expression that is being processed during the trace. Enclose the expression in braces
+(`{}`).
 
 ```yaml
 Type: ScriptBlock
@@ -131,8 +148,9 @@ Accept wildcard characters: False
 ```
 
 ### -FilePath
-Specifies a file that the cmdlet sends the trace output to.
-This parameter also selects the file trace listener.
+
+Specifies a file that the cmdlet sends the trace output to. This parameter also selects the file
+trace listener.
 
 ```yaml
 Type: String
@@ -147,9 +165,9 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the command to run without asking for user confirmation.
-Used with the *FilePath* parameter.
-Even using the *Force* parameter, the cmdlet cannot override security restrictions.
+
+Forces the command to run without asking for user confirmation. Used with the **FilePath**
+parameter. Even using the **Force** parameter, the cmdlet cannot override security restrictions.
 
 ```yaml
 Type: SwitchParameter
@@ -164,9 +182,9 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies input to the expression that is being processed during the trace.
 
-You can enter a variable that represents the input that the expression accepts, or pass an object through the pipeline.
+Specifies input to the expression that is being processed during the trace. You can enter a variable
+that represents the input that the expression accepts, or pass an object through the pipeline.
 
 ```yaml
 Type: PSObject
@@ -181,8 +199,9 @@ Accept wildcard characters: False
 ```
 
 ### -ListenerOption
-Specifies optional data to the prefix of each trace message in the output.
-The acceptable values for this parameter are:
+
+Specifies optional data to the prefix of each trace message in the output. The acceptable values for
+this parameter are:
 
 - None
 - LogicalOperationStack
@@ -192,9 +211,10 @@ The acceptable values for this parameter are:
 - ThreadId
 - Callstack
 
-None is the default.
+**None** is the default.
 
-To specify multiple options, separate them with commas, but with no spaces, and enclose them in quotation marks, such as "ProcessID,ThreadID".
+To specify multiple options, separate them with commas, but with no spaces, and enclose them in
+quotation marks, such as "ProcessID,ThreadID".
 
 ```yaml
 Type: TraceOptions
@@ -210,10 +230,10 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of PowerShell components that are traced.
-Enter the name of the trace source of each component.
-Wildcards are permitted.
-To find the trace sources on your computer, type `Get-TraceSource`.
+
+Specifies an array of PowerShell components that are traced. Enter the name of the trace source of
+each component. Wildcards are permitted. To find the trace sources on your computer, type
+`Get-TraceSource`.
 
 ```yaml
 Type: String[]
@@ -228,8 +248,8 @@ Accept wildcard characters: False
 ```
 
 ### -Option
-Determines the type of events that are traced.
-The acceptable values for this parameter are:
+
+Determines the type of events that are traced. The acceptable values for this parameter are:
 
 - None
 - Constructor
@@ -260,7 +280,8 @@ The following values are combinations of other values:
 - Data: (Constructor, Dispose, Finalizer, Property, Verbose, and WriteLine)
 - Errors: (Error and Exception).
 
-To specify multiple options, separate them with commas, but with no spaces, and enclose them in quotation marks, such as "Constructor,Dispose".
+To specify multiple options, separate them with commas, but with no spaces, and enclose them in
+quotation marks, such as "Constructor,Dispose".
 
 ```yaml
 Type: PSTraceSourceOptions
@@ -276,8 +297,9 @@ Accept wildcard characters: False
 ```
 
 ### -PSHost
-Indicates that the cmdlet sends the trace output to the PowerShell host.
-This parameter also selects the PSHost trace listener.
+
+Indicates that the cmdlet sends the trace output to the PowerShell host. This parameter also selects
+the PSHost trace listener.
 
 ```yaml
 Type: SwitchParameter
@@ -292,31 +314,48 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe objects that represent input to the expression to **Trace-Command**.
+
+You can pipe objects that represent input to the expression to `Trace-Command`.
 
 ## OUTPUTS
 
 ### System.Management.Automation.PSObject
+
 Returns the command trace in the debug stream.
 
 ## NOTES
-* Tracing is a method that developers use to debug and refine programs. When tracing, the program generates detailed messages about each step in its internal processing.
-* The PowerShell tracing cmdlets are designed to help PowerShell developers, but they are available to all users. They let you monitor nearly every aspect of the functionality of the shell.
-* To find the PowerShell components that are enabled for tracing, type `Get-Help Get-TraceSource`.
 
-  A trace source is the part of each PowerShell component that manages tracing and generates trace messages for the component.
-To trace a component, you identify its trace source.
+- Tracing is a method that developers use to debug and refine programs. When tracing, the program
+  generates detailed messages about each step in its internal processing.
 
-  A trace listener receives the output of the trace and displays it to the user.
-You can elect to send the trace data to a user-mode or kernel-mode debugger, to the host or console, to a file, or to a custom listener derived from the **System.Diagnostics.TraceListener** class.
+- The PowerShell tracing cmdlets are designed to help PowerShell developers, but they are available
+  to all users. They let you monitor nearly every aspect of the functionality of the shell.
 
-* When you use the commandSet parameter set, PowerShell processes the command just as it would be processed in a pipeline. For example, command discovery is not repeated for each incoming object.
-* The names of the *Name*, *Expression*, *Option*, and *Command* parameters are optional. If you omit the parameter names, the unnamed parameter values must appear in this order: *Name*, *Expression*, *Option* or *Name*, *Command*, *Option*. If you include the parameter names, the parameters can appear in any order.
+- To find the PowerShell components that are enabled for tracing, type `Get-Help Get-TraceSource`.
+
+  A trace source is the part of each PowerShell component that manages tracing and generates trace
+  messages for the component. To trace a component, you identify its trace source.
+
+  A trace listener receives the output of the trace and displays it to the user. You can elect to
+  send the trace data to a user-mode or kernel-mode debugger, to the host or console, to a file, or
+  to a custom listener derived from the **System.Diagnostics.TraceListener** class.
+
+- When you use the commandSet parameter set, PowerShell processes the command just as it would be
+  processed in a pipeline. For example, command discovery is not repeated for each incoming object.
+
+- The names of the **Name**, **Expression**, **Option**, and **Command** parameters are optional. If
+  you omit the parameter names, the unnamed parameter values must appear in this order: **Name**,
+  **Expression**, **Option** or **Name**, **Command**, **Option**. If you include the parameter
+  names, the parameters can appear in any order.
 
 ## RELATED LINKS
 
@@ -325,5 +364,3 @@ You can elect to send the trace data to a user-mode or kernel-mode debugger, to 
 [Measure-Command](Measure-Command.md)
 
 [Set-TraceSource](Set-TraceSource.md)
-
-

--- a/reference/6/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -82,7 +82,8 @@ expression. In effect, the command being processed during the trace is
 Specifies the parameters and parameter values for the command being traced. The alias for
 **ArgumentList** is **Args**. This feature is especially useful for debugging dynamic parameters.
 
-For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+For more information about the behavior of **ArgumentList**, see
+[about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 03/19/2020
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_arrays?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Arrays
@@ -462,6 +462,9 @@ $a.ForEach({ $_ * $_})
 Just like the `-ArgumentList` parameter of `ForEach-Object`, the `arguments`
 parameter allows the passing of an array of arguments to a script block
 configured to accept them.
+
+For more information about the behavior of **ArgumentList**, see
+[about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 #### ForEach(type convertToType)
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -1,40 +1,40 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 11/28/2017
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_CmdletBindingAttribute
 ---
 # About Functions CmdletBindingAttribute
 
-## SHORT DESCRIPTION
+## Short description
 Describes the attribute that makes a function work like a compiled cmdlet.
 
-## LONG DESCRIPTION
+## Long description
 
-The CmdletBinding attribute is an attribute of functions that makes
-them operate like compiled cmdlets that are written in C#, and it
-provides access to features of cmdlets.
+The **CmdletBinding** attribute is an attribute of functions that makes them
+operate like compiled cmdlets that are written in C#, and it provides access to
+features of cmdlets.
 
-PowerShell binds the parameters of functions that have the
-CmdletBinding attribute in the same way that it binds the parameters of
-compiled cmdlets. The $PSCmdlet automatic variable is available to
-functions with the CmdletBinding attribute, but the $Args variable
-is not available.
+PowerShell binds the parameters of functions that have the **CmdletBinding**
+attribute in the same way that it binds the parameters of compiled cmdlets. The
+`$PSCmdlet` automatic variable is available to functions with the CmdletBinding
+attribute, but the `$Args` variable is not available.
 
-In functions that have the CmdletBinding attribute, unknown parameters
-and positional arguments that have no matching positional parameters
-cause parameter binding to fail.
+In functions that have the **CmdletBinding** attribute, unknown parameters and
+positional arguments that have no matching positional parameters cause
+parameter binding to fail.
 
-Note: Compiled cmdlets use the required Cmdlet attribute, which is similar
-to the CmdletBinding attribute that is described in this topic.
+> [!NOTE]
+> Compiled cmdlets use the required **Cmdlet** attribute, which is similar
+> to the **CmdletBinding** attribute that is described in this topic.
 
-## SYNTAX
+## Syntax
 
-The following example shows the format of a function that specifies all
-the optional arguments of the CmdletBinding attribute. A brief description
-of each argument follows this example.
+The following example shows the format of a function that specifies all the
+optional arguments of the **CmdletBinding** attribute. A brief description of
+each argument follows this example.
 
 ```powershell
 {
@@ -54,65 +54,65 @@ of each argument follows this example.
 
 ## ConfirmImpact
 
-The ConfirmImpact argument specifies when the action of the function
-should be confirmed by a call to the ShouldProcess method. The call to
-the ShouldProcess method displays a confirmation prompt only when the
-ConfirmImpact argument is equal to or greater than the value of the
-$ConfirmPreference preference variable. (The default value of the
-argument is Medium.) Specify this argument only when the
-SupportsShouldProcess argument is also specified.
+The **ConfirmImpact** argument specifies when the action of the function should
+be confirmed by a call to the **ShouldProcess** method. The call to the
+**ShouldProcess** method displays a confirmation prompt only when the
+**ConfirmImpact** argument is equal to or greater than the value of the
+`$ConfirmPreference` preference variable. (The default value of the argument is
+**Medium**.) Specify this argument only when the **SupportsShouldProcess**
+argument is also specified.
 
 For more information about confirmation requests, see [Requesting Confirmation](/powershell/scripting/developer/cmdlet/requesting-confirmation).
 
 ## DefaultParameterSetName
 
-The DefaultParameterSetName argument specifies the name of the parameter
-set that PowerShell will attempt to use when it cannot determine
-which parameter set to use. You can avoid this issue by making the
-unique parameter of each parameter set a mandatory parameter.
+The **DefaultParameterSetName** argument specifies the name of the parameter
+set that PowerShell will attempt to use when it cannot determine which
+parameter set to use. You can avoid this issue by making the unique parameter
+of each parameter set a mandatory parameter.
 
 ## HelpURI
 
-The HelpURI argument specifies the Internet address (Uniform Resource
-Identifier (URI)) of the online version of the help topic that describes
-the function. The value of the HelpURI argument must begin with "http"
-or "https".
+The **HelpURI** argument specifies the Internet address (Uniform Resource
+Identifier (URI)) of the online version of the help topic that describes the
+function. The value of the **HelpURI** argument must begin with "http" or
+"https".
 
-The HelpURI argument value is used for the value of the HelpURI property
-of the CommandInfo object that Get-Command returns for the function.
+The **HelpURI** argument value is used for the value of the **HelpURI**
+property of the **CommandInfo** object that `Get-Command` returns for the
+function.
 
-However, when help files are installed on the computer and the value of
-the first link in the RelatedLinks section of the help file is a URI,
-or the value of the first .Link directive in comment-based help is a URI,
-the URI in the help file is used as the value of the HelpUri property
-of the function.
+However, when help files are installed on the computer and the value of the
+first link in the **RelatedLinks** section of the help file is a URI, or the
+value of the first `.Link` directive in comment-based help is a URI, the URI in
+the help file is used as the value of the **HelpUri** property of the function.
 
-The `Get-Help` cmdlet uses the value of the HelpURI property to locate the
-online version of the function help topic when the Online parameter
-of `Get-Help` is specified in a command.
+The `Get-Help` cmdlet uses the value of the **HelpURI** property to locate the
+online version of the function help topic when the **Online** parameter of
+`Get-Help` is specified in a command.
 
 ## SupportsPaging
 
-The SupportsPaging argument adds the First, Skip, and IncludeTotalCount
-parameters to the function. These parameters allow users to select
-output from a very large result set. This argument is designed for cmdlets
-and functions that return data from large data stores that support data
+The **SupportsPaging** argument adds the **First**, **Skip**, and
+**IncludeTotalCount** parameters to the function. These parameters allow users
+to select output from a very large result set. This argument is designed for
+cmdlets and functions that return data from large data stores that support data
 selection, such as a SQL database.
 
 This argument was introduced in Windows PowerShell 3.0.
 
-* First: Gets only the first 'n' objects.
-* Skip:  Ignores the first 'n' objects and then gets the remaining objects.
-* IncludeTotalCount: Reports the number of objects in the data set (an integer)
-followed by the objects. If the cmdlet cannot determine the total count, it
-returns "Unknown total count".
+- **First**: Gets only the first 'n' objects.
+- **Skip**:  Ignores the first 'n' objects and then gets the remaining objects.
+- **IncludeTotalCount**: Reports the number of objects in the data set (an
+  integer) followed by the objects. If the cmdlet cannot determine the total
+  count, it returns "Unknown total count".
 
-PowerShell includes NewTotalCount, a helper method that gets the
-total count value to return and includes an estimate of the accuracy of the
-total count value.
+PowerShell includes **NewTotalCount**, a helper method that gets the total
+count value to return and includes an estimate of the accuracy of the total
+count value.
 
-The following sample function shows how to add support for the paging parameters
-to an advanced function.
+The following sample function shows how to add support for the paging
+parameters to an advanced function.
 
 ```powershell
 function Get-Numbers {
@@ -135,19 +135,19 @@ function Get-Numbers {
 
 ## SupportsShouldProcess
 
-The SupportsShouldProcess argument adds **Confirm** and **WhatIf** parameters
-to the function. The **Confirm** parameter prompts the user before it runs
-the command on each object in the pipeline. The **WhatIf** parameter lists the
-changes that the command would make, instead of running the command.
+The **SupportsShouldProcess** argument adds **Confirm** and **WhatIf**
+parameters to the function. The **Confirm** parameter prompts the user before
+it runs the command on each object in the pipeline. The **WhatIf** parameter
+lists the changes that the command would make, instead of running the command.
 
 ## PositionalBinding
 
-The PositionalBinding argument determines whether parameters in the function
-are positional by default. The default value is $True. You can use the
-PositionalBinding argument with a value of $False to disable positional
-binding.
+The **PositionalBinding** argument determines whether parameters in the
+function are positional by default. The default value is `$True`. You can use
+the **PositionalBinding** argument with a value of `$False` to disable
+positional binding.
 
-The PositionalBinding argument is introduced in Windows PowerShell 3.0.
+The **PositionalBinding** argument is introduced in Windows PowerShell 3.0.
 
 When parameters are positional, the parameter name is optional.
 PowerShell associates unnamed parameter values with the function parameters
@@ -157,29 +157,30 @@ function command.
 When parameters are not positional (they are "named"), the parameter
 name (or an abbreviation or alias of the name) is required in the command.
 
-When PositionalBinding is $True, function parameters are positional by
-default. PowerShell assigns position number to the parameters in
-the order in which they are declared in the function.
+When **PositionalBinding** is `$True`, function parameters are positional by
+default. PowerShell assigns position number to the parameters in the order in
+which they are declared in the function.
 
-When PositionalBinding is $False, function parameters are not positional
-by default. Unless the Position argument of the Parameter attribute is
+When **PositionalBinding** is `$False`, function parameters are not positional
+by default. Unless the **Position** argument of the **Parameter** attribute is
 declared on the parameter, the parameter name (or an alias or abbreviation)
 must be included when the parameter is used in a function.
 
-The Position argument of the Parameter attribute takes precedence over the
-PositionalBinding default value. You can use the Position argument to specify
-a position value for a parameter. For more information about the Position
-argument, see [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
+The **Position** argument of the **Parameter** attribute takes precedence over
+the **PositionalBinding** default value. You can use the **Position** argument
+to specify a position value for a parameter. For more information about the
+**Position** argument, see
+[about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
 
-## NOTES
+## Notes
 
-The SupportsTransactions argument is not supported in advanced functions.
+The **SupportsTransactions** argument is not supported in advanced functions.
 
-## KEYWORDS
+## Keywords
 
 about_Functions_CmdletBinding_Attribute
 
-## SEE ALSO
+## See also
 
 [about_Functions](about_Functions.md)
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 08/28/2018
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_script_blocks?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Script_Blocks
@@ -64,7 +64,7 @@ example:
 Invoke-Command -ScriptBlock { Get-Process }
 ```
 
-```output
+```Output
 Handles  NPM(K)    PM(K)     WS(K) VM(M)   CPU(s)     Id ProcessName
 -------  ------    -----     ----- -----   ------     -- -----------
 999          28    39100     45020   262    15.88   1844 communicator
@@ -82,7 +82,7 @@ Invoke-Command -ScriptBlock { param($p1, $p2)
 } -ArgumentList "First", "Second"
 ```
 
-```output
+```Output
 p1: First
 p2: Second
 ```
@@ -90,6 +90,9 @@ p2: Second
 The script block in the preceding example uses the `param` keyword to
 create a parameters `$p1` and `$p2`. The string "First" is bound to the
 first parameter (`$p1`) and "Second" is bound to (`$p2`).
+
+For more information about the behavior of **ArgumentList**, see
+[about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 You can use variables to store and execute script blocks. The example below
 stores a script block in a variable and passes it to `Invoke-Command`.
@@ -99,7 +102,7 @@ $a = { Get-Service BITS }
 Invoke-Command -ScriptBlock $a
 ```
 
-```output
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Running  BITS               Background Intelligent Transfer Ser...
@@ -118,7 +121,7 @@ $a ={ param($p1, $p2)
 &$a -p2 "First" -p1 "Second"
 ```
 
-```output
+```Output
 p1: Second
 p2: First
 ```

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 09/09/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_splatting?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Splatting
@@ -9,11 +9,11 @@ title: about_Splatting
 
 # About Splatting
 
-## SHORT DESCRIPTION
+## Short description
 
 Describes how to use splatting to pass parameters to commands in PowerShell.
 
-## LONG DESCRIPTION
+## Long description
 
 Splatting is a method of passing a collection of parameter values to a command
 as unit. PowerShell associates each value in the collection with a command
@@ -30,7 +30,7 @@ functions.
 Beginning in Windows PowerShell 3.0, you can also use splatting to represent
 all parameters of a command.
 
-## SYNTAX
+## Syntax
 
 ```
 <CommandName> <optional parameters> @<HashTable> <optional parameters>
@@ -47,7 +47,7 @@ parameters. You may pass some parameters by using splatting and pass others by
 position or by parameter name. Also, you can splat multiple objects in a single
 command so you don't pass more than one value for each parameter.
 
-## SPLATTING WITH HASH TABLES
+## Splatting with hash tables
 
 Use a hash table to splat parameter name and value pairs. You can use this
 format for all parameter types, including positional and switch parameters.
@@ -80,11 +80,11 @@ $HashArguments = @{
 Copy-Item @HashArguments
 ```
 
-Note: In the first command, the At symbol (@) indicates a hash table, not a
+Note: In the first command, the At symbol (`@`) indicates a hash table, not a
 splatted value. The syntax for hash tables in PowerShell is:
-`@{\<name\>=\<value\>; \<name\>=\<value\>; ...}*`
+`@{<name>=<value>; <name>=<value>; ...}`
 
-## SPLATTING WITH ARRAYS
+## Splatting with arrays
 
 Use an array to splat values for positional parameters, which do not require
 parameter names. The values must be in position-number order in the array.
@@ -111,7 +111,44 @@ $ArrayArguments = "test.txt", "test2.txt"
 Copy-Item @ArrayArguments -WhatIf
 ```
 
-## EXAMPLES
+### Using the ArgumentList parameter
+
+Several cmdlets have an **ArgumentList** parameter that is used to pass
+parameter values to a script block that is executed by the cmdlet. The
+**ArgumentList** parameter takes an array of values that is passed to the
+script block. PowerShell is effectively using array splatting to bind the
+values to the parameters of the script block. When using **ArgumentList**, if
+you need to pass an array as a single object bound to a single parameter, you
+must wrap the array in an array subexpression.
+
+The following example has a script block that takes a single parameter that is
+an array of strings.
+
+```powershell
+$array = 'Hello', 'World!'
+Invoke-Command -ScriptBlock { param([string[]]$words) $words -join ' '} -ArgumentList $array
+```
+
+In this example, only the first item in `$array` is passed to the script script
+block.
+
+```Output
+Hello
+```
+
+```powershell
+$array = 'Hello', 'World!'
+Invoke-Command -ScriptBlock { param([string[]]$words) $words -join ' '} -ArgumentList (,$array)
+```
+
+In this example, `$array` is wrapped in an array subexpress so that the entire
+array is passed to the script block as a single object.
+
+```Output
+Hello World!
+```
+
+## Examples
 
 This example shows how to reuse splatted values in different commands. The
 commands in this example use the `Write-Host` cmdlet to write messages to the
@@ -186,7 +223,7 @@ Test2 -a 1 -b 2 -c 3
 3
 ```
 
-## SPLATTING COMMAND PARAMETERS
+## Splatting command parameters
 
 You can use splatting to represent the parameters of a command. This technique
 is useful when you are creating a proxy function, that is, a function that
@@ -278,7 +315,7 @@ FileVersionInfo    : File:             C:\Windows\System32\WindowsPowerShell
                      Language:         English (United States)
 ```
 
-## NOTES
+## Notes
 
 If you make a function into an advanced function by using either the
 **CmdletBinding** or **Parameter** attributes, the `$args` automatic variable
@@ -289,7 +326,7 @@ PowerShell Desired State Configuration (DSC) was not designed to use splatting.
 You cannot use splatting to pass values into a DSC resource. For more
 information, see Gael Colas' article [Pseudo-Splatting DSC Resources](https://gaelcolas.com/2017/11/05/pseudo-splatting-dsc-resources/).
 
-## SEE ALSO
+## See also
 
 [about_Arrays](about_Arrays.md)
 

--- a/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -330,7 +330,7 @@ safe to use here.
 ### -ArgumentList
 
 Specifies an array of arguments to a method call. For more information about the behavior of
-**ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+**ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 11/04/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -329,7 +329,8 @@ safe to use here.
 
 ### -ArgumentList
 
-Specifies an array of arguments to a method call.
+Specifies an array of arguments to a method call. For more information about the behavior of
+**ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/7.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -603,7 +603,7 @@ Specifies an array of arguments, or parameter values, that are passed to a scrip
 `Import-Module` command. This parameter is valid only when you're importing a script module.
 
 You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information
-about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+about the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/7.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 02/25/2020
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/import-module?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Import-Module
@@ -602,8 +602,8 @@ Accept wildcard characters: True
 Specifies an array of arguments, or parameter values, that are passed to a script module during the
 `Import-Module` command. This parameter is valid only when you're importing a script module.
 
-You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information,
-see [about_Aliases](About/about_Aliases.md).
+You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information
+about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/7.0/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 03/30/2020
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/invoke-command?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-Command
@@ -759,7 +759,8 @@ To use local variables in a command, use the following command format:
 -or- `<local-variable>`
 
 The **param** keyword lists the local variables that are used in the command. **ArgumentList**
-supplies the values of the variables, in the order that they're listed.
+supplies the values of the variables, in the order that they're listed. For more information about
+the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/7.0/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -760,7 +760,7 @@ To use local variables in a command, use the following command format:
 
 The **param** keyword lists the local variables that are used in the command. **ArgumentList**
 supplies the values of the variables, in the order that they're listed. For more information about
-the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/7.0/Microsoft.PowerShell.Core/New-Module.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/New-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-module?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-Module
@@ -31,25 +31,32 @@ New-Module [-Name] <String> [-ScriptBlock] <ScriptBlock> [-Function <String[]>] 
 
 ## DESCRIPTION
 
-The **New-Module** cmdlet creates a dynamic module from a script block.
-The members of the dynamic module, such as functions and variables, are immediately available in the session and remain available until you close the session.
+The `New-Module` cmdlet creates a dynamic module from a script block. The members of the dynamic
+module, such as functions and variables, are immediately available in the session and remain
+available until you close the session.
 
-Like static modules, by default, the cmdlets and functions in a dynamic module are exported and the variables and aliases are not.
-However, you can use the Export-ModuleMember cmdlet and the parameters of **New-Module** to override the defaults.
+Like static modules, by default, the cmdlets and functions in a dynamic module are exported and the
+variables and aliases are not. However, you can use the Export-ModuleMember cmdlet and the
+parameters of `New-Module` to override the defaults.
 
-You can also use the *AsCustomObject* parameter of **New-Module** to return the dynamic module as a custom object.
-The members of the modules, such as functions, are implemented as script methods of the custom object instead of being imported into the session.
+You can also use the **AsCustomObject** parameter of `New-Module` to return the dynamic module as a
+custom object. The members of the modules, such as functions, are implemented as script methods of
+the custom object instead of being imported into the session.
 
-Dynamic modules exist only in memory, not on disk.
-Like all modules, the members of dynamic modules run in a private module scope that is a child of the global scope.
-Get-Module cannot get a dynamic module, but Get-Command can get the exported members.
+Dynamic modules exist only in memory, not on disk. Like all modules, the members of dynamic modules
+run in a private module scope that is a child of the global scope. Get-Module cannot get a dynamic
+module, but Get-Command can get the exported members.
 
-To make a dynamic module available to **Get-Module**, pipe a **New-Module** command to Import-Module, or pipe the module object that **New-Module** returns to **Import-Module**.
-This action adds the dynamic module to the **Get-Module** list, but it does not save the module to disk or make it persistent.
+To make a dynamic module available to `Get-Module`, pipe a `New-Module` command to Import-Module, or
+pipe the module object that `New-Module` returns to `Import-Module`. This action adds the dynamic
+module to the `Get-Module` list, but it does not save the module to disk or make it persistent.
 
 ## EXAMPLES
 
 ### Example 1: Create a dynamic module
+
+This example creates a new dynamic module with a function called `Hello`. The command returns a
+module object that represents the new dynamic module.
 
 ```powershell
 New-Module -ScriptBlock {function Hello {"Hello!"}}
@@ -72,10 +79,10 @@ ExportedVariables : {}
 NestedModules     : {}
 ```
 
-This command creates a new dynamic module with a function called Hello.
-The command returns a module object that represents the new dynamic module.
-
 ### Example 2: Working with dynamic modules and Get-Module and Get-Command
+
+This example demonstrates that dynamic modules are not returned by the `Get-Module` cmdlet. The
+members that they export are returned by the `Get-Command` cmdlet.
 
 ```powershell
 new-module -scriptblock {function Hello {"Hello!"}}
@@ -110,10 +117,10 @@ CommandType     Name   Definition
 Function        Hello  "Hello!"
 ```
 
-This example demonstrates that dynamic modules are not returned by the **Get-Module** cmdlet.
-The members that they export are returned by the **Get-Command** cmdlet.
-
 ### Example 3: Export a variable into the current session
+
+This example uses the `Export-ModuleMember` cmdlet to export a variable into the current session.
+Without the `Export-ModuleMember` command, only the function is exported.
 
 ```powershell
 New-Module -ScriptBlock {$SayHelloHelp="Type 'SayHello', a space, and a name."; function SayHello ($name) { "Hello, $name" }; Export-ModuleMember -function SayHello -Variable SayHelloHelp}
@@ -132,12 +139,17 @@ SayHello Jeffrey
 Hello, Jeffrey
 ```
 
-This command uses the **Export-ModuleMember** cmdlet to export a variable into the current session.
-Without the **Export-ModuleMember** command, only the function is exported.
-
 The output shows that both the variable and the function were exported into the session.
 
 ### Example 4: Make a dynamic module available to Get-Module
+
+This example demonstrates that you can make a dynamic module available to `Get-Module` by piping the
+dynamic module to `Import-Module`.
+
+`New-Module` creates a module object that is piped to the `Import-Module` cmdlet. The **Name**
+parameter of `New-Module` assigns a friendly name to the module. Because `Import-Module` does not
+return any objects by default, there is no output from this command. `Get-Module` that the
+**GreetingModule** has been imported into the current session.
 
 ```powershell
 New-Module -ScriptBlock {function Hello {"Hello!"}} -name GreetingModule | Import-Module
@@ -171,21 +183,23 @@ CommandType     Name                                                            
 Function        Hello                                                              "Hello!"
 ```
 
-This command demonstrates that you can make a dynamic module available to **Get-Module** by piping the dynamic module to **Import-Module**.
-
-The first command uses a pipeline operator (|) to send the module object that **New-Module** generates to the **Import-Module** cmdlet.
-The command uses the *Name* parameter of **New-Module** to assign a friendly name to the module.
-Because **Import-Module** does not return any objects by default, there is no output from this command.
-
-The second command uses **Get-Module** to get the modules in the session.
-The result shows that **Get-Module** can get the new dynamic module.
-
-The third command uses the **Get-Command** cmdlet to get the Hello function that the dynamic module exports.
+The `Get-Command` cmdlet shows the `Hello` function that the dynamic module exports.
 
 ### Example 5: Generate a custom object that has exported functions
 
+This example shows how to use the **AsCustomObject** parameter of `New-Module` to generate a custom
+object that has script methods that represent the exported functions.
+
+The `New-Module` cmdlet creates a dynamic module with two functions, `Hello` and `Goodbye`. The
+**AsCustomObject** parameter creates a custom object instead of the **PSModuleInfo** object that
+`New-Module` generates by default. This custom object is saved in the `$m` variable.
+The `$m` variable appears to have no assigned value.
+
 ```powershell
-$m = New-Module -ScriptBlock {function Hello ($name) {"Hello, $name"}; function Goodbye ($name) {"Goodbye, $name"}} -AsCustomObject
+$m = New-Module -ScriptBlock {
+  function Hello ($name) {"Hello, $name"}
+  function Goodbye ($name) {"Goodbye, $name"}
+} -AsCustomObject
 $m
 $m | Get-Member
 ```
@@ -218,22 +232,15 @@ $m.hello("Manoj")
 ```Output
 Hello, Manoj
 ```
-
-This example shows how to use the *AsCustomObject* parameter of **New-Module** to generate a custom object that has script methods that represent the exported functions.
-
-The first command uses the **New-Module** cmdlet to generate a dynamic module with two functions, Hello and Goodbye.
-The command uses the *AsCustomObject* parameter to generate a custom object instead of the PSModuleInfo object that **New-Module** generates by default.
-The command saves the custom object in the $m variable.
-
-The second command attempts to display the value of the $m variable.
-No content appears.
-
-The third command uses a pipeline operator to send the custom object to the **Get-Member** cmdlet, which displays the properties and methods of the custom object.
-The output shows that the object has script methods that represent the Hello and Goodbye functions.
-
-The fourth and fifth commands use the script method format to call the Hello and Goodbye functions.
+Piping `$m` to the `Get-Member` cmdlet displays the properties and methods of the custom object. The
+output shows that the object has script methods that represent the `Hello` and `Goodbye` functions.
+Finally, we call these script methods and display the results.
 
 ### Example 6: Get the results of the script block
+
+This example uses the **ReturnResult** parameter to request the results of running the script block
+instead of requesting a module object. The script block in the new module defines the `SayHello`
+function and then calls the function.
 
 ```powershell
 New-Module -ScriptBlock {function SayHello {"Hello, World!"}; SayHello} -ReturnResult
@@ -243,15 +250,12 @@ New-Module -ScriptBlock {function SayHello {"Hello, World!"}; SayHello} -ReturnR
 Hello, World!
 ```
 
-This command uses the *ReturnResult* parameter to request the results of running the script block instead of requesting a module object.
-
-The script block in the new module defines the SayHello function and then calls the function.
-
 ## PARAMETERS
 
 ### -ArgumentList
 
-Specifies an array of arguments which are parameter values that are passed to the script block.
+Specifies an array of arguments which are parameter values that are passed to the script block. For
+more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]
@@ -267,11 +271,12 @@ Accept wildcard characters: False
 
 ### -AsCustomObject
 
-Indicates that this cmdlet returns a custom object that represents the dynamic module.
-The module members are implemented as script methods of the custom object, but they are not imported into the session.
-You can save the custom object in a variable and use dot notation to invoke the members.
+Indicates that this cmdlet returns a custom object that represents the dynamic module. The module
+members are implemented as script methods of the custom object, but they are not imported into the
+session. You can save the custom object in a variable and use dot notation to invoke the members.
 
-If the module has multiple members with the same name, such as a function and a variable that are both named A, only one member with each name can be accessed from the custom object.
+If the module has multiple members with the same name, such as a function and a variable that are
+both named A, only one member with each name can be accessed from the custom object.
 
 ```yaml
 Type: SwitchParameter
@@ -288,11 +293,11 @@ Accept wildcard characters: False
 ### -Cmdlet
 
 Specifies an array of cmdlets that this cmdlet exports from the module into the current session.
-Enter a comma-separated list of cmdlets.
-Wildcard characters are permitted.
-By default, all cmdlets in the module are exported.
+Enter a comma-separated list of cmdlets. Wildcard characters are permitted. By default, all cmdlets
+in the module are exported.
 
-You cannot define cmdlets in a script block, but a dynamic module can include cmdlets if it imports the cmdlets from a binary module.
+You cannot define cmdlets in a script block, but a dynamic module can include cmdlets if it imports
+the cmdlets from a binary module.
 
 ```yaml
 Type: String[]
@@ -309,9 +314,8 @@ Accept wildcard characters: False
 ### -Function
 
 Specifies an array of functions that this cmdlet exports from the module into the current session.
-Enter a comma-separated list of functions.
-Wildcard characters are permitted.
-By default, all functions defined in a module are exported.
+Enter a comma-separated list of functions. Wildcard characters are permitted. By default, all
+functions defined in a module are exported.
 
 ```yaml
 Type: String[]
@@ -327,10 +331,10 @@ Accept wildcard characters: True
 
 ### -Name
 
-Specifies a name for the new module.
-You can also pipe a module name to New-Module.
+Specifies a name for the new module. You can also pipe a module name to New-Module.
 
-The default value is an autogenerated name that starts with `__DynamicModule_` and is followed by a GUID that specifies the path of the dynamic module.
+The default value is an autogenerated name that starts with `__DynamicModule_` and is followed by a
+GUID that specifies the path of the dynamic module.
 
 ```yaml
 Type: String
@@ -346,7 +350,8 @@ Accept wildcard characters: False
 
 ### -ReturnResult
 
-Indicates that this cmdlet runs the script block and returns the script block results instead of returning a module object.
+Indicates that this cmdlet runs the script block and returns the script block results instead of
+returning a module object.
 
 ```yaml
 Type: SwitchParameter
@@ -362,9 +367,8 @@ Accept wildcard characters: False
 
 ### -ScriptBlock
 
-Specifies the contents of the dynamic module.
-Enclose the contents in braces ( { } ) to create a script block.
-This parameter is required.
+Specifies the contents of the dynamic module. Enclose the contents in braces (`{}`) to create a
+script block. This parameter is required.
 
 ```yaml
 Type: ScriptBlock
@@ -380,7 +384,10 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -392,14 +399,14 @@ You can pipe a module name to this cmdlet.
 
 ### System.Management.Automation.PSModuleInfo, System.Management.Automation.PSCustomObject, or None
 
-This cmdlet generates a **PSModuleInfo** object, by default.
-If you use the *AsCustomObject* parameter, it generates a **PSCustomObject** object.
-If you use the *ReturnResult* parameter, it returns the result of evaluating the script block in the dynamic module.
+This cmdlet generates a **PSModuleInfo** object, by default. If you use the **AsCustomObject**
+parameter, it generates a **PSCustomObject** object. If you use the **ReturnResult** parameter, it
+returns the result of evaluating the script block in the dynamic module.
 
 ## NOTES
 
-* You can also refer to `New-Module` by its alias, `nmo`.
-  For more information, see [about_Aliases](About/about_Aliases.md).
+You can also refer to `New-Module` by its alias, `nmo`. For more information, see
+[about_Aliases](About/about_Aliases.md).
 
 ## RELATED LINKS
 
@@ -410,5 +417,3 @@ If you use the *ReturnResult* parameter, it returns the result of evaluating the
 [Import-Module](Import-Module.md)
 
 [Remove-Module](Remove-Module.md)
-
-

--- a/reference/7.0/Microsoft.PowerShell.Core/New-Module.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/New-Module.md
@@ -255,7 +255,7 @@ Hello, World!
 ### -ArgumentList
 
 Specifies an array of arguments which are parameter values that are passed to the script block. For
-more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+more information about the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/7.0/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Start-Job.md
@@ -329,7 +329,7 @@ Specifies an array of arguments, or parameter values, for the script that is spe
 
 Arguments must be passed to **ArgumentList** as single-dimension array argument. For example, a
 comma-separated list. For more information about the behavior of **ArgumentList**, see
-[about_Splatting](about_Splatting.md#splatting-with-arrays).
+[about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 
 ```yaml

--- a/reference/7.0/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Start-Job.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/09/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/start-job?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Job
@@ -328,8 +328,9 @@ Specifies an array of arguments, or parameter values, for the script that is spe
 **FilePath** parameter or a command specified with the **ScriptBlock** parameter.
 
 Arguments must be passed to **ArgumentList** as single-dimension array argument. For example, a
-comma-separated list. For more information about array dimensions, see
-[about_Arrays](./about/about_arrays.md#rank).
+comma-separated list. For more information about the behavior of **ArgumentList**, see
+[about_Splatting](about_Splatting.md#splatting-with-arrays).
+
 
 ```yaml
 Type: Object[]

--- a/reference/7.0/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Start-Process.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 04/18/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/start-process?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Process

--- a/reference/7.0/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/export-pssession?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Export-PSSession

--- a/reference/7.0/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/New-Object.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 09/12/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-object?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-Object
@@ -211,6 +211,8 @@ constructor takes a single parameter that is an array, you must wrap that parame
 array. For example:
 
 `$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate -ArgumentList (,$bytes)`
+
+For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 The alias for **ArgumentList** is **Args**.
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/New-Object.md
@@ -212,7 +212,7 @@ array. For example:
 
 `$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate -ArgumentList (,$bytes)`
 
-For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+For more information about the behavior of **ArgumentList**, see [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md#splatting-with-arrays).
 
 The alias for **ArgumentList** is **Args**.
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -82,7 +82,8 @@ expression. In effect, the command being processed during the trace is
 Specifies the parameters and parameter values for the command being traced. The alias for
 **ArgumentList** is **Args**. This feature is especially useful for debugging dynamic parameters.
 
-For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+For more information about the behavior of **ArgumentList**, see
+[about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/7.0/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 04/09/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/trace-command?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Trace-Command
@@ -31,44 +31,58 @@ Trace-Command [-InputObject <PSObject>] [-Name] <String[]> [[-Option] <PSTraceSo
 ```
 
 ## DESCRIPTION
-The **Trace-Command** cmdlet configures and starts a trace of the specified expression or command.
+The `Trace-Command` cmdlet configures and starts a trace of the specified expression or command.
 It works like Set-TraceSource, except that it applies only to the specified command.
 
 ## EXAMPLES
 
 ### Example 1: Trace metadata processing, parameter binding, and an expression
-```
-PS C:\> Trace-Command -Name metadata,parameterbinding,cmdlet -Expression {Get-Process Notepad} -PSHost
+
+This example starts a trace of metadata processing, parameter binding, and cmdlet creation and
+destruction of the `Get-Process Notepad` expression.
+
+```powershell
+Trace-Command -Name metadata,parameterbinding,cmdlet -Expression {Get-Process Notepad} -PSHost
 ```
 
-This command starts a trace of metadata processing, parameter binding, and cmdlet creation and destruction of the `Get-Process Notepad` expression.
-It uses the *Name* parameter to specify the trace sources, the *Expression* parameter to specify the command, and the *PSHost* parameter to send the output to the console.
-Because it does not specify any tracing options or listener options, the command uses the defaults--All for the tracing options, and None for the listener options.
+It uses the **Name** parameter to specify the trace sources, the **Expression** parameter to specify
+the command, and the **PSHost** parameter to send the output to the console. Because it does not
+specify any tracing options or listener options, the command uses the defaults:
+
+- All for the tracing options
+- None for the listener options
 
 ### Example 2: Trace the actions of ParameterBinding operations
+
+This example traces the actions of the **ParameterBinding** operations of PowerShell while it processes
+a `Get-Alias` expression that takes input from the pipeline.
+
+
+```powershell
+$A = "i*"
+Trace-Command ParameterBinding {Get-Alias $Input} -PSHost -InputObject $A
 ```
-PS C:\> $A = "i*"
-PS C:\> Trace-Command ParameterBinding {Get-Alias $Input} -PSHost -InputObject $A
-```
 
-These commands trace the actions of the ParameterBinding operations of PowerShell while it processes a Get-Alias expression that takes input from the pipeline.
+In `Trace-Command`, the **InputObject** parameter passes an object to the expression that is being
+processed during the trace.
 
-In **Trace-Command**, the *InputObject* parameter passes an object to the expression that is being processed during the trace.
+The first command stores the string `i*` in the `$A` variable. The second command uses the
+`Trace-Command` cmdlet with the ParameterBinding trace source. The **PSHost** parameter sends the
+output to the console.
 
-The first command stores the string "i*" in the $A variable.
-The second command uses the **Trace-Command** cmdlet with the ParameterBinding trace source.
-The *PSHost* parameter sends the output to the console.
-
-The expression being processed is `Get-Alias $Input`, where the $Input variable is associated with the *InputObject* parameter.
-The *InputObject* parameter passes the variable $A to the expression.
-In effect, the command being processed during the trace is `Get-Alias -InputObject $A" or "$A | Get-Alias`.
+The expression being processed is `Get-Alias $Input`, where the `$Input` variable is associated with
+the **InputObject** parameter. The **InputObject** parameter passes the variable `$A` to the
+expression. In effect, the command being processed during the trace is
+`Get-Alias -InputObject $A" or "$A | Get-Alias`.
 
 ## PARAMETERS
 
 ### -ArgumentList
-Specifies the parameters and parameter values for the command being traced.
-The alias for *ArgumentList* is *Args*.
-This feature is especially useful for debugging dynamic parameters.
+
+Specifies the parameters and parameter values for the command being traced. The alias for
+**ArgumentList** is **Args**. This feature is especially useful for debugging dynamic parameters.
+
+For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]
@@ -83,6 +97,7 @@ Accept wildcard characters: False
 ```
 
 ### -Command
+
 Specifies a command that is being processed during the trace.
 
 ```yaml
@@ -98,9 +113,10 @@ Accept wildcard characters: False
 ```
 
 ### -Debugger
-Indicates that the cmdlet sends the trace output to the debugger.
-You can view the output in any user-mode or kernel mode debugger or in Visual Studio.
-This parameter also selects the default trace listener.
+
+Indicates that the cmdlet sends the trace output to the debugger. You can view the output in any
+user-mode or kernel mode debugger or in Visual Studio. This parameter also selects the default trace
+listener.
 
 ```yaml
 Type: SwitchParameter
@@ -115,8 +131,9 @@ Accept wildcard characters: False
 ```
 
 ### -Expression
-Specifies the expression that is being processed during the trace.
-Enclose the expression in braces ({}).
+
+Specifies the expression that is being processed during the trace. Enclose the expression in braces
+(`{}`).
 
 ```yaml
 Type: ScriptBlock
@@ -131,8 +148,9 @@ Accept wildcard characters: False
 ```
 
 ### -FilePath
-Specifies a file that the cmdlet sends the trace output to.
-This parameter also selects the file trace listener.
+
+Specifies a file that the cmdlet sends the trace output to. This parameter also selects the file
+trace listener.
 
 ```yaml
 Type: String
@@ -147,9 +165,9 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the command to run without asking for user confirmation.
-Used with the *FilePath* parameter.
-Even using the *Force* parameter, the cmdlet cannot override security restrictions.
+
+Forces the command to run without asking for user confirmation. Used with the **FilePath**
+parameter. Even using the **Force** parameter, the cmdlet cannot override security restrictions.
 
 ```yaml
 Type: SwitchParameter
@@ -164,9 +182,9 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies input to the expression that is being processed during the trace.
 
-You can enter a variable that represents the input that the expression accepts, or pass an object through the pipeline.
+Specifies input to the expression that is being processed during the trace. You can enter a variable
+that represents the input that the expression accepts, or pass an object through the pipeline.
 
 ```yaml
 Type: PSObject
@@ -181,8 +199,9 @@ Accept wildcard characters: False
 ```
 
 ### -ListenerOption
-Specifies optional data to the prefix of each trace message in the output.
-The acceptable values for this parameter are:
+
+Specifies optional data to the prefix of each trace message in the output. The acceptable values for
+this parameter are:
 
 - None
 - LogicalOperationStack
@@ -192,9 +211,10 @@ The acceptable values for this parameter are:
 - ThreadId
 - Callstack
 
-None is the default.
+**None** is the default.
 
-To specify multiple options, separate them with commas, but with no spaces, and enclose them in quotation marks, such as "ProcessID,ThreadID".
+To specify multiple options, separate them with commas, but with no spaces, and enclose them in
+quotation marks, such as "ProcessID,ThreadID".
 
 ```yaml
 Type: TraceOptions
@@ -210,10 +230,10 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of PowerShell components that are traced.
-Enter the name of the trace source of each component.
-Wildcards are permitted.
-To find the trace sources on your computer, type `Get-TraceSource`.
+
+Specifies an array of PowerShell components that are traced. Enter the name of the trace source of
+each component. Wildcards are permitted. To find the trace sources on your computer, type
+`Get-TraceSource`.
 
 ```yaml
 Type: String[]
@@ -228,8 +248,8 @@ Accept wildcard characters: False
 ```
 
 ### -Option
-Determines the type of events that are traced.
-The acceptable values for this parameter are:
+
+Determines the type of events that are traced. The acceptable values for this parameter are:
 
 - None
 - Constructor
@@ -260,7 +280,8 @@ The following values are combinations of other values:
 - Data: (Constructor, Dispose, Finalizer, Property, Verbose, and WriteLine)
 - Errors: (Error and Exception).
 
-To specify multiple options, separate them with commas, but with no spaces, and enclose them in quotation marks, such as "Constructor,Dispose".
+To specify multiple options, separate them with commas, but with no spaces, and enclose them in
+quotation marks, such as "Constructor,Dispose".
 
 ```yaml
 Type: PSTraceSourceOptions
@@ -276,8 +297,9 @@ Accept wildcard characters: False
 ```
 
 ### -PSHost
-Indicates that the cmdlet sends the trace output to the PowerShell host.
-This parameter also selects the PSHost trace listener.
+
+Indicates that the cmdlet sends the trace output to the PowerShell host. This parameter also selects
+the PSHost trace listener.
 
 ```yaml
 Type: SwitchParameter
@@ -292,31 +314,48 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe objects that represent input to the expression to **Trace-Command**.
+
+You can pipe objects that represent input to the expression to `Trace-Command`.
 
 ## OUTPUTS
 
 ### System.Management.Automation.PSObject
+
 Returns the command trace in the debug stream.
 
 ## NOTES
-* Tracing is a method that developers use to debug and refine programs. When tracing, the program generates detailed messages about each step in its internal processing.
-* The PowerShell tracing cmdlets are designed to help PowerShell developers, but they are available to all users. They let you monitor nearly every aspect of the functionality of the shell.
-* To find the PowerShell components that are enabled for tracing, type `Get-Help Get-TraceSource`.
 
-  A trace source is the part of each PowerShell component that manages tracing and generates trace messages for the component.
-To trace a component, you identify its trace source.
+- Tracing is a method that developers use to debug and refine programs. When tracing, the program
+  generates detailed messages about each step in its internal processing.
 
-  A trace listener receives the output of the trace and displays it to the user.
-You can elect to send the trace data to a user-mode or kernel-mode debugger, to the host or console, to a file, or to a custom listener derived from the **System.Diagnostics.TraceListener** class.
+- The PowerShell tracing cmdlets are designed to help PowerShell developers, but they are available
+  to all users. They let you monitor nearly every aspect of the functionality of the shell.
 
-* When you use the commandSet parameter set, PowerShell processes the command just as it would be processed in a pipeline. For example, command discovery is not repeated for each incoming object.
-* The names of the *Name*, *Expression*, *Option*, and *Command* parameters are optional. If you omit the parameter names, the unnamed parameter values must appear in this order: *Name*, *Expression*, *Option* or *Name*, *Command*, *Option*. If you include the parameter names, the parameters can appear in any order.
+- To find the PowerShell components that are enabled for tracing, type `Get-Help Get-TraceSource`.
+
+  A trace source is the part of each PowerShell component that manages tracing and generates trace
+  messages for the component. To trace a component, you identify its trace source.
+
+  A trace listener receives the output of the trace and displays it to the user. You can elect to
+  send the trace data to a user-mode or kernel-mode debugger, to the host or console, to a file, or
+  to a custom listener derived from the **System.Diagnostics.TraceListener** class.
+
+- When you use the commandSet parameter set, PowerShell processes the command just as it would be
+  processed in a pipeline. For example, command discovery is not repeated for each incoming object.
+
+- The names of the **Name**, **Expression**, **Option**, and **Command** parameters are optional. If
+  you omit the parameter names, the unnamed parameter values must appear in this order: **Name**,
+  **Expression**, **Option** or **Name**, **Command**, **Option**. If you include the parameter
+  names, the parameters can appear in any order.
 
 ## RELATED LINKS
 
@@ -325,5 +364,3 @@ You can elect to send the trace data to a user-mode or kernel-mode debugger, to 
 [Measure-Command](Measure-Command.md)
 
 [Set-TraceSource](Set-TraceSource.md)
-
-

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 03/19/2020
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_arrays?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Arrays
@@ -462,6 +462,9 @@ $a.ForEach({ $_ * $_})
 Just like the `-ArgumentList` parameter of `ForEach-Object`, the `arguments`
 parameter allows the passing of an array of arguments to a script block
 configured to accept them.
+
+For more information about the behavior of **ArgumentList**, see
+[about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 #### ForEach(type convertToType)
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -1,40 +1,40 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 11/28/2017
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_CmdletBindingAttribute
 ---
 # About Functions CmdletBindingAttribute
 
-## SHORT DESCRIPTION
+## Short description
 Describes the attribute that makes a function work like a compiled cmdlet.
 
-## LONG DESCRIPTION
+## Long description
 
-The CmdletBinding attribute is an attribute of functions that makes
-them operate like compiled cmdlets that are written in C#, and it
-provides access to features of cmdlets.
+The **CmdletBinding** attribute is an attribute of functions that makes them
+operate like compiled cmdlets that are written in C#, and it provides access to
+features of cmdlets.
 
-PowerShell binds the parameters of functions that have the
-CmdletBinding attribute in the same way that it binds the parameters of
-compiled cmdlets. The $PSCmdlet automatic variable is available to
-functions with the CmdletBinding attribute, but the $Args variable
-is not available.
+PowerShell binds the parameters of functions that have the **CmdletBinding**
+attribute in the same way that it binds the parameters of compiled cmdlets. The
+`$PSCmdlet` automatic variable is available to functions with the CmdletBinding
+attribute, but the `$Args` variable is not available.
 
-In functions that have the CmdletBinding attribute, unknown parameters
-and positional arguments that have no matching positional parameters
-cause parameter binding to fail.
+In functions that have the **CmdletBinding** attribute, unknown parameters and
+positional arguments that have no matching positional parameters cause
+parameter binding to fail.
 
-Note: Compiled cmdlets use the required Cmdlet attribute, which is similar
-to the CmdletBinding attribute that is described in this topic.
+> [!NOTE]
+> Compiled cmdlets use the required **Cmdlet** attribute, which is similar
+> to the **CmdletBinding** attribute that is described in this topic.
 
-## SYNTAX
+## Syntax
 
-The following example shows the format of a function that specifies all
-the optional arguments of the CmdletBinding attribute. A brief description
-of each argument follows this example.
+The following example shows the format of a function that specifies all the
+optional arguments of the **CmdletBinding** attribute. A brief description of
+each argument follows this example.
 
 ```powershell
 {
@@ -54,65 +54,65 @@ of each argument follows this example.
 
 ## ConfirmImpact
 
-The ConfirmImpact argument specifies when the action of the function
-should be confirmed by a call to the ShouldProcess method. The call to
-the ShouldProcess method displays a confirmation prompt only when the
-ConfirmImpact argument is equal to or greater than the value of the
-$ConfirmPreference preference variable. (The default value of the
-argument is Medium.) Specify this argument only when the
-SupportsShouldProcess argument is also specified.
+The **ConfirmImpact** argument specifies when the action of the function should
+be confirmed by a call to the **ShouldProcess** method. The call to the
+**ShouldProcess** method displays a confirmation prompt only when the
+**ConfirmImpact** argument is equal to or greater than the value of the
+`$ConfirmPreference` preference variable. (The default value of the argument is
+**Medium**.) Specify this argument only when the **SupportsShouldProcess**
+argument is also specified.
 
 For more information about confirmation requests, see [Requesting Confirmation](/powershell/scripting/developer/cmdlet/requesting-confirmation).
 
 ## DefaultParameterSetName
 
-The DefaultParameterSetName argument specifies the name of the parameter
-set that PowerShell will attempt to use when it cannot determine
-which parameter set to use. You can avoid this issue by making the
-unique parameter of each parameter set a mandatory parameter.
+The **DefaultParameterSetName** argument specifies the name of the parameter
+set that PowerShell will attempt to use when it cannot determine which
+parameter set to use. You can avoid this issue by making the unique parameter
+of each parameter set a mandatory parameter.
 
 ## HelpURI
 
-The HelpURI argument specifies the Internet address (Uniform Resource
-Identifier (URI)) of the online version of the help topic that describes
-the function. The value of the HelpURI argument must begin with "http"
-or "https".
+The **HelpURI** argument specifies the Internet address (Uniform Resource
+Identifier (URI)) of the online version of the help topic that describes the
+function. The value of the **HelpURI** argument must begin with "http" or
+"https".
 
-The HelpURI argument value is used for the value of the HelpURI property
-of the CommandInfo object that Get-Command returns for the function.
+The **HelpURI** argument value is used for the value of the **HelpURI**
+property of the **CommandInfo** object that `Get-Command` returns for the
+function.
 
-However, when help files are installed on the computer and the value of
-the first link in the RelatedLinks section of the help file is a URI,
-or the value of the first .Link directive in comment-based help is a URI,
-the URI in the help file is used as the value of the HelpUri property
-of the function.
+However, when help files are installed on the computer and the value of the
+first link in the **RelatedLinks** section of the help file is a URI, or the
+value of the first `.Link` directive in comment-based help is a URI, the URI in
+the help file is used as the value of the **HelpUri** property of the function.
 
-The `Get-Help` cmdlet uses the value of the HelpURI property to locate the
-online version of the function help topic when the Online parameter
-of `Get-Help` is specified in a command.
+The `Get-Help` cmdlet uses the value of the **HelpURI** property to locate the
+online version of the function help topic when the **Online** parameter of
+`Get-Help` is specified in a command.
 
 ## SupportsPaging
 
-The SupportsPaging argument adds the First, Skip, and IncludeTotalCount
-parameters to the function. These parameters allow users to select
-output from a very large result set. This argument is designed for cmdlets
-and functions that return data from large data stores that support data
+The **SupportsPaging** argument adds the **First**, **Skip**, and
+**IncludeTotalCount** parameters to the function. These parameters allow users
+to select output from a very large result set. This argument is designed for
+cmdlets and functions that return data from large data stores that support data
 selection, such as a SQL database.
 
 This argument was introduced in Windows PowerShell 3.0.
 
-* First: Gets only the first 'n' objects.
-* Skip:  Ignores the first 'n' objects and then gets the remaining objects.
-* IncludeTotalCount: Reports the number of objects in the data set (an integer)
-followed by the objects. If the cmdlet cannot determine the total count, it
-returns "Unknown total count".
+- **First**: Gets only the first 'n' objects.
+- **Skip**:  Ignores the first 'n' objects and then gets the remaining objects.
+- **IncludeTotalCount**: Reports the number of objects in the data set (an
+  integer) followed by the objects. If the cmdlet cannot determine the total
+  count, it returns "Unknown total count".
 
-PowerShell includes NewTotalCount, a helper method that gets the
-total count value to return and includes an estimate of the accuracy of the
-total count value.
+PowerShell includes **NewTotalCount**, a helper method that gets the total
+count value to return and includes an estimate of the accuracy of the total
+count value.
 
-The following sample function shows how to add support for the paging parameters
-to an advanced function.
+The following sample function shows how to add support for the paging
+parameters to an advanced function.
 
 ```powershell
 function Get-Numbers {
@@ -135,19 +135,19 @@ function Get-Numbers {
 
 ## SupportsShouldProcess
 
-The SupportsShouldProcess argument adds **Confirm** and **WhatIf** parameters
-to the function. The **Confirm** parameter prompts the user before it runs
-the command on each object in the pipeline. The **WhatIf** parameter lists the
-changes that the command would make, instead of running the command.
+The **SupportsShouldProcess** argument adds **Confirm** and **WhatIf**
+parameters to the function. The **Confirm** parameter prompts the user before
+it runs the command on each object in the pipeline. The **WhatIf** parameter
+lists the changes that the command would make, instead of running the command.
 
 ## PositionalBinding
 
-The PositionalBinding argument determines whether parameters in the function
-are positional by default. The default value is $True. You can use the
-PositionalBinding argument with a value of $False to disable positional
-binding.
+The **PositionalBinding** argument determines whether parameters in the
+function are positional by default. The default value is `$True`. You can use
+the **PositionalBinding** argument with a value of `$False` to disable
+positional binding.
 
-The PositionalBinding argument is introduced in Windows PowerShell 3.0.
+The **PositionalBinding** argument is introduced in Windows PowerShell 3.0.
 
 When parameters are positional, the parameter name is optional.
 PowerShell associates unnamed parameter values with the function parameters
@@ -157,29 +157,30 @@ function command.
 When parameters are not positional (they are "named"), the parameter
 name (or an abbreviation or alias of the name) is required in the command.
 
-When PositionalBinding is $True, function parameters are positional by
-default. PowerShell assigns position number to the parameters in
-the order in which they are declared in the function.
+When **PositionalBinding** is `$True`, function parameters are positional by
+default. PowerShell assigns position number to the parameters in the order in
+which they are declared in the function.
 
-When PositionalBinding is $False, function parameters are not positional
-by default. Unless the Position argument of the Parameter attribute is
+When **PositionalBinding** is `$False`, function parameters are not positional
+by default. Unless the **Position** argument of the **Parameter** attribute is
 declared on the parameter, the parameter name (or an alias or abbreviation)
 must be included when the parameter is used in a function.
 
-The Position argument of the Parameter attribute takes precedence over the
-PositionalBinding default value. You can use the Position argument to specify
-a position value for a parameter. For more information about the Position
-argument, see [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
+The **Position** argument of the **Parameter** attribute takes precedence over
+the **PositionalBinding** default value. You can use the **Position** argument
+to specify a position value for a parameter. For more information about the
+**Position** argument, see
+[about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md).
 
-## NOTES
+## Notes
 
-The SupportsTransactions argument is not supported in advanced functions.
+The **SupportsTransactions** argument is not supported in advanced functions.
 
-## KEYWORDS
+## Keywords
 
 about_Functions_CmdletBinding_Attribute
 
-## SEE ALSO
+## See also
 
 [about_Functions](about_Functions.md)
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 08/28/2018
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_script_blocks?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Script_Blocks
@@ -64,7 +64,7 @@ example:
 Invoke-Command -ScriptBlock { Get-Process }
 ```
 
-```output
+```Output
 Handles  NPM(K)    PM(K)     WS(K) VM(M)   CPU(s)     Id ProcessName
 -------  ------    -----     ----- -----   ------     -- -----------
 999          28    39100     45020   262    15.88   1844 communicator
@@ -82,7 +82,7 @@ Invoke-Command -ScriptBlock { param($p1, $p2)
 } -ArgumentList "First", "Second"
 ```
 
-```output
+```Output
 p1: First
 p2: Second
 ```
@@ -90,6 +90,9 @@ p2: Second
 The script block in the preceding example uses the `param` keyword to
 create a parameters `$p1` and `$p2`. The string "First" is bound to the
 first parameter (`$p1`) and "Second" is bound to (`$p2`).
+
+For more information about the behavior of **ArgumentList**, see
+[about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 You can use variables to store and execute script blocks. The example below
 stores a script block in a variable and passes it to `Invoke-Command`.
@@ -99,7 +102,7 @@ $a = { Get-Service BITS }
 Invoke-Command -ScriptBlock $a
 ```
 
-```output
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Running  BITS               Background Intelligent Transfer Ser...
@@ -118,7 +121,7 @@ $a ={ param($p1, $p2)
 &$a -p2 "First" -p1 "Second"
 ```
 
-```output
+```Output
 p1: Second
 p2: First
 ```

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 locale: en-us
-ms.date: 09/09/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_splatting?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Splatting
@@ -9,11 +9,11 @@ title: about_Splatting
 
 # About Splatting
 
-## SHORT DESCRIPTION
+## Short description
 
 Describes how to use splatting to pass parameters to commands in PowerShell.
 
-## LONG DESCRIPTION
+## Long description
 
 Splatting is a method of passing a collection of parameter values to a command
 as unit. PowerShell associates each value in the collection with a command
@@ -30,7 +30,7 @@ functions.
 Beginning in Windows PowerShell 3.0, you can also use splatting to represent
 all parameters of a command.
 
-## SYNTAX
+## Syntax
 
 ```
 <CommandName> <optional parameters> @<HashTable> <optional parameters>
@@ -47,7 +47,7 @@ parameters. You may pass some parameters by using splatting and pass others by
 position or by parameter name. Also, you can splat multiple objects in a single
 command so you don't pass more than one value for each parameter.
 
-## SPLATTING WITH HASH TABLES
+## Splatting with hash tables
 
 Use a hash table to splat parameter name and value pairs. You can use this
 format for all parameter types, including positional and switch parameters.
@@ -80,11 +80,11 @@ $HashArguments = @{
 Copy-Item @HashArguments
 ```
 
-Note: In the first command, the At symbol (@) indicates a hash table, not a
+Note: In the first command, the At symbol (`@`) indicates a hash table, not a
 splatted value. The syntax for hash tables in PowerShell is:
-`@{\<name\>=\<value\>; \<name\>=\<value\>; ...}*`
+`@{<name>=<value>; <name>=<value>; ...}`
 
-## SPLATTING WITH ARRAYS
+## Splatting with arrays
 
 Use an array to splat values for positional parameters, which do not require
 parameter names. The values must be in position-number order in the array.
@@ -111,7 +111,44 @@ $ArrayArguments = "test.txt", "test2.txt"
 Copy-Item @ArrayArguments -WhatIf
 ```
 
-## EXAMPLES
+### Using the ArgumentList parameter
+
+Several cmdlets have an **ArgumentList** parameter that is used to pass
+parameter values to a script block that is executed by the cmdlet. The
+**ArgumentList** parameter takes an array of values that is passed to the
+script block. PowerShell is effectively using array splatting to bind the
+values to the parameters of the script block. When using **ArgumentList**, if
+you need to pass an array as a single object bound to a single parameter, you
+must wrap the array in an array subexpression.
+
+The following example has a script block that takes a single parameter that is
+an array of strings.
+
+```powershell
+$array = 'Hello', 'World!'
+Invoke-Command -ScriptBlock { param([string[]]$words) $words -join ' '} -ArgumentList $array
+```
+
+In this example, only the first item in `$array` is passed to the script script
+block.
+
+```Output
+Hello
+```
+
+```powershell
+$array = 'Hello', 'World!'
+Invoke-Command -ScriptBlock { param([string[]]$words) $words -join ' '} -ArgumentList (,$array)
+```
+
+In this example, `$array` is wrapped in an array subexpress so that the entire
+array is passed to the script block as a single object.
+
+```Output
+Hello World!
+```
+
+## Examples
 
 This example shows how to reuse splatted values in different commands. The
 commands in this example use the `Write-Host` cmdlet to write messages to the
@@ -186,7 +223,7 @@ Test2 -a 1 -b 2 -c 3
 3
 ```
 
-## SPLATTING COMMAND PARAMETERS
+## Splatting command parameters
 
 You can use splatting to represent the parameters of a command. This technique
 is useful when you are creating a proxy function, that is, a function that
@@ -278,7 +315,7 @@ FileVersionInfo    : File:             C:\Windows\System32\WindowsPowerShell
                      Language:         English (United States)
 ```
 
-## NOTES
+## Notes
 
 If you make a function into an advanced function by using either the
 **CmdletBinding** or **Parameter** attributes, the `$args` automatic variable
@@ -289,7 +326,7 @@ PowerShell Desired State Configuration (DSC) was not designed to use splatting.
 You cannot use splatting to pass values into a DSC resource. For more
 information, see Gael Colas' article [Pseudo-Splatting DSC Resources](https://gaelcolas.com/2017/11/05/pseudo-splatting-dsc-resources/).
 
-## SEE ALSO
+## See also
 
 [about_Arrays](about_Arrays.md)
 

--- a/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 11/04/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -329,7 +329,8 @@ safe to use here.
 
 ### -ArgumentList
 
-Specifies an array of arguments to a method call.
+Specifies an array of arguments to a method call. For more information about the behavior of
+**ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -330,7 +330,7 @@ safe to use here.
 ### -ArgumentList
 
 Specifies an array of arguments to a method call. For more information about the behavior of
-**ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+**ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/7.1/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Import-Module.md
@@ -603,7 +603,7 @@ Specifies an array of arguments, or parameter values, that are passed to a scrip
 `Import-Module` command. This parameter is valid only when you're importing a script module.
 
 You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information
-about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+about the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/7.1/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Import-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 02/25/2020
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/import-module?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Import-Module
@@ -602,8 +602,8 @@ Accept wildcard characters: True
 Specifies an array of arguments, or parameter values, that are passed to a script module during the
 `Import-Module` command. This parameter is valid only when you're importing a script module.
 
-You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information,
-see [about_Aliases](About/about_Aliases.md).
+You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information
+about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/7.1/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 03/30/2020
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/invoke-command?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-Command
@@ -759,7 +759,8 @@ To use local variables in a command, use the following command format:
 -or- `<local-variable>`
 
 The **param** keyword lists the local variables that are used in the command. **ArgumentList**
-supplies the values of the variables, in the order that they're listed.
+supplies the values of the variables, in the order that they're listed. For more information about
+the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/7.1/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -760,7 +760,7 @@ To use local variables in a command, use the following command format:
 
 The **param** keyword lists the local variables that are used in the command. **ArgumentList**
 supplies the values of the variables, in the order that they're listed. For more information about
-the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/7.1/Microsoft.PowerShell.Core/New-Module.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/New-Module.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-module?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-Module
@@ -31,25 +31,32 @@ New-Module [-Name] <String> [-ScriptBlock] <ScriptBlock> [-Function <String[]>] 
 
 ## DESCRIPTION
 
-The **New-Module** cmdlet creates a dynamic module from a script block.
-The members of the dynamic module, such as functions and variables, are immediately available in the session and remain available until you close the session.
+The `New-Module` cmdlet creates a dynamic module from a script block. The members of the dynamic
+module, such as functions and variables, are immediately available in the session and remain
+available until you close the session.
 
-Like static modules, by default, the cmdlets and functions in a dynamic module are exported and the variables and aliases are not.
-However, you can use the Export-ModuleMember cmdlet and the parameters of **New-Module** to override the defaults.
+Like static modules, by default, the cmdlets and functions in a dynamic module are exported and the
+variables and aliases are not. However, you can use the Export-ModuleMember cmdlet and the
+parameters of `New-Module` to override the defaults.
 
-You can also use the *AsCustomObject* parameter of **New-Module** to return the dynamic module as a custom object.
-The members of the modules, such as functions, are implemented as script methods of the custom object instead of being imported into the session.
+You can also use the **AsCustomObject** parameter of `New-Module` to return the dynamic module as a
+custom object. The members of the modules, such as functions, are implemented as script methods of
+the custom object instead of being imported into the session.
 
-Dynamic modules exist only in memory, not on disk.
-Like all modules, the members of dynamic modules run in a private module scope that is a child of the global scope.
-Get-Module cannot get a dynamic module, but Get-Command can get the exported members.
+Dynamic modules exist only in memory, not on disk. Like all modules, the members of dynamic modules
+run in a private module scope that is a child of the global scope. Get-Module cannot get a dynamic
+module, but Get-Command can get the exported members.
 
-To make a dynamic module available to **Get-Module**, pipe a **New-Module** command to Import-Module, or pipe the module object that **New-Module** returns to **Import-Module**.
-This action adds the dynamic module to the **Get-Module** list, but it does not save the module to disk or make it persistent.
+To make a dynamic module available to `Get-Module`, pipe a `New-Module` command to Import-Module, or
+pipe the module object that `New-Module` returns to `Import-Module`. This action adds the dynamic
+module to the `Get-Module` list, but it does not save the module to disk or make it persistent.
 
 ## EXAMPLES
 
 ### Example 1: Create a dynamic module
+
+This example creates a new dynamic module with a function called `Hello`. The command returns a
+module object that represents the new dynamic module.
 
 ```powershell
 New-Module -ScriptBlock {function Hello {"Hello!"}}
@@ -72,10 +79,10 @@ ExportedVariables : {}
 NestedModules     : {}
 ```
 
-This command creates a new dynamic module with a function called Hello.
-The command returns a module object that represents the new dynamic module.
-
 ### Example 2: Working with dynamic modules and Get-Module and Get-Command
+
+This example demonstrates that dynamic modules are not returned by the `Get-Module` cmdlet. The
+members that they export are returned by the `Get-Command` cmdlet.
 
 ```powershell
 new-module -scriptblock {function Hello {"Hello!"}}
@@ -110,10 +117,10 @@ CommandType     Name   Definition
 Function        Hello  "Hello!"
 ```
 
-This example demonstrates that dynamic modules are not returned by the **Get-Module** cmdlet.
-The members that they export are returned by the **Get-Command** cmdlet.
-
 ### Example 3: Export a variable into the current session
+
+This example uses the `Export-ModuleMember` cmdlet to export a variable into the current session.
+Without the `Export-ModuleMember` command, only the function is exported.
 
 ```powershell
 New-Module -ScriptBlock {$SayHelloHelp="Type 'SayHello', a space, and a name."; function SayHello ($name) { "Hello, $name" }; Export-ModuleMember -function SayHello -Variable SayHelloHelp}
@@ -132,12 +139,17 @@ SayHello Jeffrey
 Hello, Jeffrey
 ```
 
-This command uses the **Export-ModuleMember** cmdlet to export a variable into the current session.
-Without the **Export-ModuleMember** command, only the function is exported.
-
 The output shows that both the variable and the function were exported into the session.
 
 ### Example 4: Make a dynamic module available to Get-Module
+
+This example demonstrates that you can make a dynamic module available to `Get-Module` by piping the
+dynamic module to `Import-Module`.
+
+`New-Module` creates a module object that is piped to the `Import-Module` cmdlet. The **Name**
+parameter of `New-Module` assigns a friendly name to the module. Because `Import-Module` does not
+return any objects by default, there is no output from this command. `Get-Module` that the
+**GreetingModule** has been imported into the current session.
 
 ```powershell
 New-Module -ScriptBlock {function Hello {"Hello!"}} -name GreetingModule | Import-Module
@@ -171,21 +183,23 @@ CommandType     Name                                                            
 Function        Hello                                                              "Hello!"
 ```
 
-This command demonstrates that you can make a dynamic module available to **Get-Module** by piping the dynamic module to **Import-Module**.
-
-The first command uses a pipeline operator (|) to send the module object that **New-Module** generates to the **Import-Module** cmdlet.
-The command uses the *Name* parameter of **New-Module** to assign a friendly name to the module.
-Because **Import-Module** does not return any objects by default, there is no output from this command.
-
-The second command uses **Get-Module** to get the modules in the session.
-The result shows that **Get-Module** can get the new dynamic module.
-
-The third command uses the **Get-Command** cmdlet to get the Hello function that the dynamic module exports.
+The `Get-Command` cmdlet shows the `Hello` function that the dynamic module exports.
 
 ### Example 5: Generate a custom object that has exported functions
 
+This example shows how to use the **AsCustomObject** parameter of `New-Module` to generate a custom
+object that has script methods that represent the exported functions.
+
+The `New-Module` cmdlet creates a dynamic module with two functions, `Hello` and `Goodbye`. The
+**AsCustomObject** parameter creates a custom object instead of the **PSModuleInfo** object that
+`New-Module` generates by default. This custom object is saved in the `$m` variable.
+The `$m` variable appears to have no assigned value.
+
 ```powershell
-$m = New-Module -ScriptBlock {function Hello ($name) {"Hello, $name"}; function Goodbye ($name) {"Goodbye, $name"}} -AsCustomObject
+$m = New-Module -ScriptBlock {
+  function Hello ($name) {"Hello, $name"}
+  function Goodbye ($name) {"Goodbye, $name"}
+} -AsCustomObject
 $m
 $m | Get-Member
 ```
@@ -218,22 +232,15 @@ $m.hello("Manoj")
 ```Output
 Hello, Manoj
 ```
-
-This example shows how to use the *AsCustomObject* parameter of **New-Module** to generate a custom object that has script methods that represent the exported functions.
-
-The first command uses the **New-Module** cmdlet to generate a dynamic module with two functions, Hello and Goodbye.
-The command uses the *AsCustomObject* parameter to generate a custom object instead of the PSModuleInfo object that **New-Module** generates by default.
-The command saves the custom object in the $m variable.
-
-The second command attempts to display the value of the $m variable.
-No content appears.
-
-The third command uses a pipeline operator to send the custom object to the **Get-Member** cmdlet, which displays the properties and methods of the custom object.
-The output shows that the object has script methods that represent the Hello and Goodbye functions.
-
-The fourth and fifth commands use the script method format to call the Hello and Goodbye functions.
+Piping `$m` to the `Get-Member` cmdlet displays the properties and methods of the custom object. The
+output shows that the object has script methods that represent the `Hello` and `Goodbye` functions.
+Finally, we call these script methods and display the results.
 
 ### Example 6: Get the results of the script block
+
+This example uses the **ReturnResult** parameter to request the results of running the script block
+instead of requesting a module object. The script block in the new module defines the `SayHello`
+function and then calls the function.
 
 ```powershell
 New-Module -ScriptBlock {function SayHello {"Hello, World!"}; SayHello} -ReturnResult
@@ -243,15 +250,12 @@ New-Module -ScriptBlock {function SayHello {"Hello, World!"}; SayHello} -ReturnR
 Hello, World!
 ```
 
-This command uses the *ReturnResult* parameter to request the results of running the script block instead of requesting a module object.
-
-The script block in the new module defines the SayHello function and then calls the function.
-
 ## PARAMETERS
 
 ### -ArgumentList
 
-Specifies an array of arguments which are parameter values that are passed to the script block.
+Specifies an array of arguments which are parameter values that are passed to the script block. For
+more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]
@@ -267,11 +271,12 @@ Accept wildcard characters: False
 
 ### -AsCustomObject
 
-Indicates that this cmdlet returns a custom object that represents the dynamic module.
-The module members are implemented as script methods of the custom object, but they are not imported into the session.
-You can save the custom object in a variable and use dot notation to invoke the members.
+Indicates that this cmdlet returns a custom object that represents the dynamic module. The module
+members are implemented as script methods of the custom object, but they are not imported into the
+session. You can save the custom object in a variable and use dot notation to invoke the members.
 
-If the module has multiple members with the same name, such as a function and a variable that are both named A, only one member with each name can be accessed from the custom object.
+If the module has multiple members with the same name, such as a function and a variable that are
+both named A, only one member with each name can be accessed from the custom object.
 
 ```yaml
 Type: SwitchParameter
@@ -288,11 +293,11 @@ Accept wildcard characters: False
 ### -Cmdlet
 
 Specifies an array of cmdlets that this cmdlet exports from the module into the current session.
-Enter a comma-separated list of cmdlets.
-Wildcard characters are permitted.
-By default, all cmdlets in the module are exported.
+Enter a comma-separated list of cmdlets. Wildcard characters are permitted. By default, all cmdlets
+in the module are exported.
 
-You cannot define cmdlets in a script block, but a dynamic module can include cmdlets if it imports the cmdlets from a binary module.
+You cannot define cmdlets in a script block, but a dynamic module can include cmdlets if it imports
+the cmdlets from a binary module.
 
 ```yaml
 Type: String[]
@@ -309,9 +314,8 @@ Accept wildcard characters: False
 ### -Function
 
 Specifies an array of functions that this cmdlet exports from the module into the current session.
-Enter a comma-separated list of functions.
-Wildcard characters are permitted.
-By default, all functions defined in a module are exported.
+Enter a comma-separated list of functions. Wildcard characters are permitted. By default, all
+functions defined in a module are exported.
 
 ```yaml
 Type: String[]
@@ -327,10 +331,10 @@ Accept wildcard characters: True
 
 ### -Name
 
-Specifies a name for the new module.
-You can also pipe a module name to New-Module.
+Specifies a name for the new module. You can also pipe a module name to New-Module.
 
-The default value is an autogenerated name that starts with `__DynamicModule_` and is followed by a GUID that specifies the path of the dynamic module.
+The default value is an autogenerated name that starts with `__DynamicModule_` and is followed by a
+GUID that specifies the path of the dynamic module.
 
 ```yaml
 Type: String
@@ -346,7 +350,8 @@ Accept wildcard characters: False
 
 ### -ReturnResult
 
-Indicates that this cmdlet runs the script block and returns the script block results instead of returning a module object.
+Indicates that this cmdlet runs the script block and returns the script block results instead of
+returning a module object.
 
 ```yaml
 Type: SwitchParameter
@@ -362,9 +367,8 @@ Accept wildcard characters: False
 
 ### -ScriptBlock
 
-Specifies the contents of the dynamic module.
-Enclose the contents in braces ( { } ) to create a script block.
-This parameter is required.
+Specifies the contents of the dynamic module. Enclose the contents in braces (`{}`) to create a
+script block. This parameter is required.
 
 ```yaml
 Type: ScriptBlock
@@ -380,7 +384,10 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -392,14 +399,14 @@ You can pipe a module name to this cmdlet.
 
 ### System.Management.Automation.PSModuleInfo, System.Management.Automation.PSCustomObject, or None
 
-This cmdlet generates a **PSModuleInfo** object, by default.
-If you use the *AsCustomObject* parameter, it generates a **PSCustomObject** object.
-If you use the *ReturnResult* parameter, it returns the result of evaluating the script block in the dynamic module.
+This cmdlet generates a **PSModuleInfo** object, by default. If you use the **AsCustomObject**
+parameter, it generates a **PSCustomObject** object. If you use the **ReturnResult** parameter, it
+returns the result of evaluating the script block in the dynamic module.
 
 ## NOTES
 
-* You can also refer to `New-Module` by its alias, `nmo`.
-  For more information, see [about_Aliases](About/about_Aliases.md).
+You can also refer to `New-Module` by its alias, `nmo`. For more information, see
+[about_Aliases](About/about_Aliases.md).
 
 ## RELATED LINKS
 
@@ -410,5 +417,3 @@ If you use the *ReturnResult* parameter, it returns the result of evaluating the
 [Import-Module](Import-Module.md)
 
 [Remove-Module](Remove-Module.md)
-
-

--- a/reference/7.1/Microsoft.PowerShell.Core/New-Module.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/New-Module.md
@@ -255,7 +255,7 @@ Hello, World!
 ### -ArgumentList
 
 Specifies an array of arguments which are parameter values that are passed to the script block. For
-more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+more information about the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/7.1/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Start-Job.md
@@ -329,7 +329,7 @@ Specifies an array of arguments, or parameter values, for the script that is spe
 
 Arguments must be passed to **ArgumentList** as single-dimension array argument. For example, a
 comma-separated list. For more information about the behavior of **ArgumentList**, see
-[about_Splatting](about_Splatting.md#splatting-with-arrays).
+[about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 
 ```yaml

--- a/reference/7.1/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Start-Job.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/09/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/start-job?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Job
@@ -328,8 +328,9 @@ Specifies an array of arguments, or parameter values, for the script that is spe
 **FilePath** parameter or a command specified with the **ScriptBlock** parameter.
 
 Arguments must be passed to **ArgumentList** as single-dimension array argument. For example, a
-comma-separated list. For more information about array dimensions, see
-[about_Arrays](./about/about_arrays.md#rank).
+comma-separated list. For more information about the behavior of **ArgumentList**, see
+[about_Splatting](about_Splatting.md#splatting-with-arrays).
+
 
 ```yaml
 Type: Object[]

--- a/reference/7.1/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Start-Process.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 04/18/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/start-process?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Process

--- a/reference/7.1/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/New-Object.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 09/12/2019
+ms.date: 04/08/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/new-object?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-Object
@@ -211,6 +211,8 @@ constructor takes a single parameter that is an array, you must wrap that parame
 array. For example:
 
 `$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate -ArgumentList (,$bytes)`
+
+For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 The alias for **ArgumentList** is **Args**.
 

--- a/reference/7.1/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/New-Object.md
@@ -212,7 +212,7 @@ array. For example:
 
 `$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate -ArgumentList (,$bytes)`
 
-For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+For more information about the behavior of **ArgumentList**, see [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md#splatting-with-arrays).
 
 The alias for **ArgumentList** is **Args**.
 

--- a/reference/7.1/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -82,7 +82,8 @@ expression. In effect, the command being processed during the trace is
 Specifies the parameters and parameter values for the command being traced. The alias for
 **ArgumentList** is **Args**. This feature is especially useful for debugging dynamic parameters.
 
-For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
+For more information about the behavior of **ArgumentList**, see
+[about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]

--- a/reference/7.1/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 04/09/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/trace-command?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Trace-Command
@@ -31,44 +31,58 @@ Trace-Command [-InputObject <PSObject>] [-Name] <String[]> [[-Option] <PSTraceSo
 ```
 
 ## DESCRIPTION
-The **Trace-Command** cmdlet configures and starts a trace of the specified expression or command.
+The `Trace-Command` cmdlet configures and starts a trace of the specified expression or command.
 It works like Set-TraceSource, except that it applies only to the specified command.
 
 ## EXAMPLES
 
 ### Example 1: Trace metadata processing, parameter binding, and an expression
-```
-PS C:\> Trace-Command -Name metadata,parameterbinding,cmdlet -Expression {Get-Process Notepad} -PSHost
+
+This example starts a trace of metadata processing, parameter binding, and cmdlet creation and
+destruction of the `Get-Process Notepad` expression.
+
+```powershell
+Trace-Command -Name metadata,parameterbinding,cmdlet -Expression {Get-Process Notepad} -PSHost
 ```
 
-This command starts a trace of metadata processing, parameter binding, and cmdlet creation and destruction of the `Get-Process Notepad` expression.
-It uses the *Name* parameter to specify the trace sources, the *Expression* parameter to specify the command, and the *PSHost* parameter to send the output to the console.
-Because it does not specify any tracing options or listener options, the command uses the defaults--All for the tracing options, and None for the listener options.
+It uses the **Name** parameter to specify the trace sources, the **Expression** parameter to specify
+the command, and the **PSHost** parameter to send the output to the console. Because it does not
+specify any tracing options or listener options, the command uses the defaults:
+
+- All for the tracing options
+- None for the listener options
 
 ### Example 2: Trace the actions of ParameterBinding operations
+
+This example traces the actions of the **ParameterBinding** operations of PowerShell while it processes
+a `Get-Alias` expression that takes input from the pipeline.
+
+
+```powershell
+$A = "i*"
+Trace-Command ParameterBinding {Get-Alias $Input} -PSHost -InputObject $A
 ```
-PS C:\> $A = "i*"
-PS C:\> Trace-Command ParameterBinding {Get-Alias $Input} -PSHost -InputObject $A
-```
 
-These commands trace the actions of the ParameterBinding operations of PowerShell while it processes a Get-Alias expression that takes input from the pipeline.
+In `Trace-Command`, the **InputObject** parameter passes an object to the expression that is being
+processed during the trace.
 
-In **Trace-Command**, the *InputObject* parameter passes an object to the expression that is being processed during the trace.
+The first command stores the string `i*` in the `$A` variable. The second command uses the
+`Trace-Command` cmdlet with the ParameterBinding trace source. The **PSHost** parameter sends the
+output to the console.
 
-The first command stores the string "i*" in the $A variable.
-The second command uses the **Trace-Command** cmdlet with the ParameterBinding trace source.
-The *PSHost* parameter sends the output to the console.
-
-The expression being processed is `Get-Alias $Input`, where the $Input variable is associated with the *InputObject* parameter.
-The *InputObject* parameter passes the variable $A to the expression.
-In effect, the command being processed during the trace is `Get-Alias -InputObject $A" or "$A | Get-Alias`.
+The expression being processed is `Get-Alias $Input`, where the `$Input` variable is associated with
+the **InputObject** parameter. The **InputObject** parameter passes the variable `$A` to the
+expression. In effect, the command being processed during the trace is
+`Get-Alias -InputObject $A" or "$A | Get-Alias`.
 
 ## PARAMETERS
 
 ### -ArgumentList
-Specifies the parameters and parameter values for the command being traced.
-The alias for *ArgumentList* is *Args*.
-This feature is especially useful for debugging dynamic parameters.
+
+Specifies the parameters and parameter values for the command being traced. The alias for
+**ArgumentList** is **Args**. This feature is especially useful for debugging dynamic parameters.
+
+For more information about the behavior of **ArgumentList**, see [about_Splatting](about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: Object[]
@@ -83,6 +97,7 @@ Accept wildcard characters: False
 ```
 
 ### -Command
+
 Specifies a command that is being processed during the trace.
 
 ```yaml
@@ -98,9 +113,10 @@ Accept wildcard characters: False
 ```
 
 ### -Debugger
-Indicates that the cmdlet sends the trace output to the debugger.
-You can view the output in any user-mode or kernel mode debugger or in Visual Studio.
-This parameter also selects the default trace listener.
+
+Indicates that the cmdlet sends the trace output to the debugger. You can view the output in any
+user-mode or kernel mode debugger or in Visual Studio. This parameter also selects the default trace
+listener.
 
 ```yaml
 Type: SwitchParameter
@@ -115,8 +131,9 @@ Accept wildcard characters: False
 ```
 
 ### -Expression
-Specifies the expression that is being processed during the trace.
-Enclose the expression in braces ({}).
+
+Specifies the expression that is being processed during the trace. Enclose the expression in braces
+(`{}`).
 
 ```yaml
 Type: ScriptBlock
@@ -131,8 +148,9 @@ Accept wildcard characters: False
 ```
 
 ### -FilePath
-Specifies a file that the cmdlet sends the trace output to.
-This parameter also selects the file trace listener.
+
+Specifies a file that the cmdlet sends the trace output to. This parameter also selects the file
+trace listener.
 
 ```yaml
 Type: String
@@ -147,9 +165,9 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the command to run without asking for user confirmation.
-Used with the *FilePath* parameter.
-Even using the *Force* parameter, the cmdlet cannot override security restrictions.
+
+Forces the command to run without asking for user confirmation. Used with the **FilePath**
+parameter. Even using the **Force** parameter, the cmdlet cannot override security restrictions.
 
 ```yaml
 Type: SwitchParameter
@@ -164,9 +182,9 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies input to the expression that is being processed during the trace.
 
-You can enter a variable that represents the input that the expression accepts, or pass an object through the pipeline.
+Specifies input to the expression that is being processed during the trace. You can enter a variable
+that represents the input that the expression accepts, or pass an object through the pipeline.
 
 ```yaml
 Type: PSObject
@@ -181,8 +199,9 @@ Accept wildcard characters: False
 ```
 
 ### -ListenerOption
-Specifies optional data to the prefix of each trace message in the output.
-The acceptable values for this parameter are:
+
+Specifies optional data to the prefix of each trace message in the output. The acceptable values for
+this parameter are:
 
 - None
 - LogicalOperationStack
@@ -192,9 +211,10 @@ The acceptable values for this parameter are:
 - ThreadId
 - Callstack
 
-None is the default.
+**None** is the default.
 
-To specify multiple options, separate them with commas, but with no spaces, and enclose them in quotation marks, such as "ProcessID,ThreadID".
+To specify multiple options, separate them with commas, but with no spaces, and enclose them in
+quotation marks, such as "ProcessID,ThreadID".
 
 ```yaml
 Type: TraceOptions
@@ -210,10 +230,10 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of PowerShell components that are traced.
-Enter the name of the trace source of each component.
-Wildcards are permitted.
-To find the trace sources on your computer, type `Get-TraceSource`.
+
+Specifies an array of PowerShell components that are traced. Enter the name of the trace source of
+each component. Wildcards are permitted. To find the trace sources on your computer, type
+`Get-TraceSource`.
 
 ```yaml
 Type: String[]
@@ -228,8 +248,8 @@ Accept wildcard characters: False
 ```
 
 ### -Option
-Determines the type of events that are traced.
-The acceptable values for this parameter are:
+
+Determines the type of events that are traced. The acceptable values for this parameter are:
 
 - None
 - Constructor
@@ -260,7 +280,8 @@ The following values are combinations of other values:
 - Data: (Constructor, Dispose, Finalizer, Property, Verbose, and WriteLine)
 - Errors: (Error and Exception).
 
-To specify multiple options, separate them with commas, but with no spaces, and enclose them in quotation marks, such as "Constructor,Dispose".
+To specify multiple options, separate them with commas, but with no spaces, and enclose them in
+quotation marks, such as "Constructor,Dispose".
 
 ```yaml
 Type: PSTraceSourceOptions
@@ -276,8 +297,9 @@ Accept wildcard characters: False
 ```
 
 ### -PSHost
-Indicates that the cmdlet sends the trace output to the PowerShell host.
-This parameter also selects the PSHost trace listener.
+
+Indicates that the cmdlet sends the trace output to the PowerShell host. This parameter also selects
+the PSHost trace listener.
 
 ```yaml
 Type: SwitchParameter
@@ -292,31 +314,48 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe objects that represent input to the expression to **Trace-Command**.
+
+You can pipe objects that represent input to the expression to `Trace-Command`.
 
 ## OUTPUTS
 
 ### System.Management.Automation.PSObject
+
 Returns the command trace in the debug stream.
 
 ## NOTES
-* Tracing is a method that developers use to debug and refine programs. When tracing, the program generates detailed messages about each step in its internal processing.
-* The PowerShell tracing cmdlets are designed to help PowerShell developers, but they are available to all users. They let you monitor nearly every aspect of the functionality of the shell.
-* To find the PowerShell components that are enabled for tracing, type `Get-Help Get-TraceSource`.
 
-  A trace source is the part of each PowerShell component that manages tracing and generates trace messages for the component.
-To trace a component, you identify its trace source.
+- Tracing is a method that developers use to debug and refine programs. When tracing, the program
+  generates detailed messages about each step in its internal processing.
 
-  A trace listener receives the output of the trace and displays it to the user.
-You can elect to send the trace data to a user-mode or kernel-mode debugger, to the host or console, to a file, or to a custom listener derived from the **System.Diagnostics.TraceListener** class.
+- The PowerShell tracing cmdlets are designed to help PowerShell developers, but they are available
+  to all users. They let you monitor nearly every aspect of the functionality of the shell.
 
-* When you use the commandSet parameter set, PowerShell processes the command just as it would be processed in a pipeline. For example, command discovery is not repeated for each incoming object.
-* The names of the *Name*, *Expression*, *Option*, and *Command* parameters are optional. If you omit the parameter names, the unnamed parameter values must appear in this order: *Name*, *Expression*, *Option* or *Name*, *Command*, *Option*. If you include the parameter names, the parameters can appear in any order.
+- To find the PowerShell components that are enabled for tracing, type `Get-Help Get-TraceSource`.
+
+  A trace source is the part of each PowerShell component that manages tracing and generates trace
+  messages for the component. To trace a component, you identify its trace source.
+
+  A trace listener receives the output of the trace and displays it to the user. You can elect to
+  send the trace data to a user-mode or kernel-mode debugger, to the host or console, to a file, or
+  to a custom listener derived from the **System.Diagnostics.TraceListener** class.
+
+- When you use the commandSet parameter set, PowerShell processes the command just as it would be
+  processed in a pipeline. For example, command discovery is not repeated for each incoming object.
+
+- The names of the **Name**, **Expression**, **Option**, and **Command** parameters are optional. If
+  you omit the parameter names, the unnamed parameter values must appear in this order: **Name**,
+  **Expression**, **Option** or **Name**, **Command**, **Option**. If you include the parameter
+  names, the parameters can appear in any order.
 
 ## RELATED LINKS
 
@@ -325,5 +364,3 @@ You can elect to send the trace data to a user-mode or kernel-mode debugger, to 
 [Measure-Command](Measure-Command.md)
 
 [Set-TraceSource](Set-TraceSource.md)
-
-


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes [AB#1705965](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1705965) - Fixes #4945 - argumentlist works like splatting

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
