### PR TITLE
Fixes #4497 - stream output in classes

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -245,6 +245,12 @@ code.
 > This is fundamentally different from how PowerShell functions handle output,
 > where everything goes to the pipeline.
 
+Non-terminating errors written to the error stream from inside a class method
+are not passed through. You must use `throw` to surface a terminating error.
+Using the `Write-*` cmdlets, you can still write to PowerShell's output streams
+from within a class method. However, this should be avoided so that the method
+emits objects using only the `return` statement.
+
 ### Method output
 
 This example demonstrates no accidental output to the pipeline from class
@@ -274,11 +280,8 @@ class FunWithIntegers
 }
 
 $ints = [FunWithIntegers]::new()
-
 $ints.GetOddIntegers()
-
 $ints.GetEvenIntegers()
-
 $ints.SayHello()
 ```
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -245,6 +245,12 @@ code.
 > This is fundamentally different from how PowerShell functions handle output,
 > where everything goes to the pipeline.
 
+Non-terminating errors written to the error stream from inside a class method
+are not passed through. You must use `throw` to surface a terminating error.
+Using the `Write-*` cmdlets, you can still write to PowerShell's output streams
+from within a class method. However, this should be avoided so that the method
+emits objects using only the `return` statement.
+
 ### Method output
 
 This example demonstrates no accidental output to the pipeline from class
@@ -274,11 +280,8 @@ class FunWithIntegers
 }
 
 $ints = [FunWithIntegers]::new()
-
 $ints.GetOddIntegers()
-
 $ints.GetEvenIntegers()
-
 $ints.SayHello()
 ```
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -245,6 +245,12 @@ code.
 > This is fundamentally different from how PowerShell functions handle output,
 > where everything goes to the pipeline.
 
+Non-terminating errors written to the error stream from inside a class method
+are not passed through. You must use `throw` to surface a terminating error.
+Using the `Write-*` cmdlets, you can still write to PowerShell's output streams
+from within a class method. However, this should be avoided so that the method
+emits objects using only the `return` statement.
+
 ### Method output
 
 This example demonstrates no accidental output to the pipeline from class
@@ -274,11 +280,8 @@ class FunWithIntegers
 }
 
 $ints = [FunWithIntegers]::new()
-
 $ints.GetOddIntegers()
-
 $ints.GetEvenIntegers()
-
 $ints.SayHello()
 ```
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -245,6 +245,12 @@ code.
 > This is fundamentally different from how PowerShell functions handle output,
 > where everything goes to the pipeline.
 
+Non-terminating errors written to the error stream from inside a class method
+are not passed through. You must use `throw` to surface a terminating error.
+Using the `Write-*` cmdlets, you can still write to PowerShell's output streams
+from within a class method. However, this should be avoided so that the method
+emits objects using only the `return` statement.
+
 ### Method output
 
 This example demonstrates no accidental output to the pipeline from class
@@ -274,11 +280,8 @@ class FunWithIntegers
 }
 
 $ints = [FunWithIntegers]::new()
-
 $ints.GetOddIntegers()
-
 $ints.GetEvenIntegers()
-
 $ints.SayHello()
 ```
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes [AB#1706172](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1706172) - Fixes #4497 - stream output in classes

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
