### PR TITLE
Fixes #4513 - multiple script blocks ForEach-Object

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -368,7 +368,7 @@ Accept wildcard characters: True
 
 ### -Process
 
-Specifies the operation that is performed on each input object. This script block is for every
+Specifies the operation that is performed on each input object. This script block is run for every
 object in the pipeline. For more information about the `process` block, see
 [about_Functions](about/about_functions.md#piping-objects-to-functions).
 

--- a/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -50,7 +50,7 @@ Starting in Windows PowerShell 3.0, there are two different ways to construct a 
 
   > [!NOTE]
   > The script blocks run in the caller's scope. Therefore the blocks have access to variables in
-  > that scope and can create new variable that persist in that scope after the cmdlet completes.
+  > that scope and can create new variables that persist in that scope after the cmdlet completes.
 
 - **Operation statement**. You can also write an operation statement, which is much more like
   natural language. You can use the operation statement to specify a property value or call a
@@ -60,12 +60,6 @@ Starting in Windows PowerShell 3.0, there are two different ways to construct a 
   process on the computer.
 
   `Get-Process | ForEach-Object ProcessName`
-
-  When using the script block format, in addition to using the script block that describes the
-  operations that are performed on each input object, you can provide two additional script blocks.
-  The Begin script block, which is the value of the **Begin** parameter, runs before this cmdlet
-  processes the first input object. The End script block, which is the value of the **End**
-  parameter, runs after this cmdlet processes the last input object.
 
 ## EXAMPLES
 
@@ -249,7 +243,7 @@ end
 
 ### Example 10: Run multiple script blocks for each pipeline item
 
-As shown in the previous example, multiple script block passed using the **Process** parameter get
+As shown in the previous example, multiple script blocks passed using the **Process** parameter get
 mapped to the **Begin** and **End** parameters. To avoid this mapping, you must provide explicit
 values for the **Begin** and **End** parameters.
 
@@ -374,8 +368,8 @@ Accept wildcard characters: True
 
 ### -Process
 
-Specifies the operation that is performed on each input object. This script block is only run once
-for the entire pipeline. For more information about the `process` block, see
+Specifies the operation that is performed on each input object. This script block is for every
+object in the pipeline. For more information about the `process` block, see
 [about_Functions](about/about_functions.md#piping-objects-to-functions).
 
 When you provide multiple script blocks to the **Process** parameter, the first script block is

--- a/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 04/08/2020
+ms.date: 04/09/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -18,32 +18,39 @@ Performs an operation against each item in a collection of input objects.
 ### ScriptBlockSet (Default)
 
 ```
-ForEach-Object [-InputObject <PSObject>] [-Begin <ScriptBlock>] [-Process] <ScriptBlock[]> [-End <ScriptBlock>]
- [-RemainingScripts <ScriptBlock[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ForEach-Object [-InputObject <PSObject>] [-Begin <ScriptBlock>] [-Process] <ScriptBlock[]>
+ [-End <ScriptBlock>] [-RemainingScripts <ScriptBlock[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PropertyAndMethodSet
 
 ```
-ForEach-Object [-InputObject <PSObject>] [-MemberName] <String> [-ArgumentList <Object[]>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ForEach-Object [-InputObject <PSObject>] [-MemberName] <String> [-ArgumentList <Object[]>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `ForEach-Object` cmdlet performs an operation on each item in a collection of input objects.
-The input objects can be piped to the cmdlet or specified by using the **InputObject** parameter.
+The `ForEach-Object` cmdlet performs an operation on each item in a collection of input objects. The
+input objects can be piped to the cmdlet or specified by using the **InputObject** parameter.
 
 Starting in Windows PowerShell 3.0, there are two different ways to construct a `ForEach-Object` command.
 
 - **Script block**. You can use a script block to specify the operation. Within the script block,
   use the `$_` variable to represent the current object. The script block is the value of the
-  *Process* parameter. The script block can contain any PowerShell script.
+  **Process** parameter. The script block can contain any PowerShell script.
 
   For example, the following command gets the value of the **ProcessName** property of each process
   on the computer.
 
   `Get-Process | ForEach-Object {$_.ProcessName}`
+
+  `ForEach-Object` supports the `begin`, `process`, and `end` blocks as described in
+  [about_functions](about/about_functions.md#piping-objects-to-functions).
+
+  > [!NOTE]
+  > The script blocks run in the caller's scope. Therefore the blocks have access to variables in
+  > that scope and can create new variable that persist in that scope after the cmdlet completes.
 
 - **Operation statement**. You can also write an operation statement, which is much more like
   natural language. You can use the operation statement to specify a property value or call a
@@ -112,7 +119,8 @@ This example changes the value of the **RemotePath** registry entry in all of th
 `HKCU:\Network` key to uppercase text.
 
 ```powershell
-Get-ItemProperty -Path HKCU:\Network\* | ForEach-Object {Set-ItemProperty -Path $_.PSPath -Name RemotePath -Value $_.RemotePath.ToUpper();}
+Get-ItemProperty -Path HKCU:\Network\* |
+  ForEach-Object {Set-ItemProperty -Path $_.PSPath -Name RemotePath -Value $_.RemotePath.ToUpper();}
 ```
 
 You can use this format to change the form or content of a registry entry value.
@@ -147,7 +155,8 @@ Hello
 Hello
 ```
 
-Because PowerShell treats null as an explicit placeholder, the `ForEach-Object` cmdlet generates a value for `$Null`, just as it does for other objects that you pipe to it.
+Because PowerShell treats null as an explicit placeholder, the `ForEach-Object` cmdlet generates a
+value for `$Null`, just as it does for other objects that you pipe to it.
 
 
 ### Example 6: Get property values
@@ -199,6 +208,64 @@ The second command uses the **MemberName** parameter to specify the **Split** me
 The third command uses the **Foreach** alias of the `ForEach-Object` cmdlet and omits the names of
 the **MemberName** and **ArgumentList** parameters, which are optional.
 
+### Example 8: Using ForeEach-Object with two script blocks
+
+In this example we pass two script blocks positionally. All the script blocks bind to the
+**Process** parameter. However, they are treated as if they had been passed to the **Begin** and
+**Process** parameters.
+
+```powershell
+1..2 | ForEach-Object { 'begin' } { 'process' }
+```
+
+```Output
+begin
+process
+process
+```
+
+### Example 9: Using ForeEach-Object with more than two script blocks
+
+In this example we pass two script blocks positionally. All the script blocks bind to the
+**Process** parameter. However, they are treated as if they had been passed to the **Begin**,
+**Process**, and **End** parameters.
+
+```powershell
+1..2 | ForEach-Object { 'begin' } { 'process A' }  { 'process B' }  { 'end' }
+```
+
+```Output
+begin
+process A
+process B
+process A
+process B
+end
+```
+
+> [!NOTE]
+> The first script block is always mapped to the `begin` block, the last block is mapped to the
+> `end` block, and the blocks in between are all mapped to the `process` block.
+
+### Example 10: Run multiple script blocks for each pipeline item
+
+As shown in the previous example, multiple script block passed using the **Process** parameter get
+mapped to the **Begin** and **End** parameters. To avoid this mapping, you must provide explicit
+values for the **Begin** and **End** parameters.
+
+```powershell
+1..2 | ForEach-Object -Begin $null -Process { 'one' }, { 'two' }, { 'three' } -End $null
+```
+
+```Output
+one
+two
+three
+one
+two
+three
+```
+
 ## PARAMETERS
 
 ### -ArgumentList
@@ -222,7 +289,9 @@ Accept wildcard characters: False
 
 ### -Begin
 
-Specifies a script block that runs before this cmdlet processes any input objects.
+Specifies a script block that runs before this cmdlet processes any input objects. This script block
+is only run once for the entire pipeline. For more information about the `begin` block, see
+[about_Functions](about/about_functions.md#piping-objects-to-functions).
 
 ```yaml
 Type: ScriptBlock
@@ -238,7 +307,9 @@ Accept wildcard characters: False
 
 ### -End
 
-Specifies a script block that runs after this cmdlet processes all input objects.
+Specifies a script block that runs after this cmdlet processes all input objects. This script block
+is only run once for the entire pipeline. For more information about the `end` block, see
+[about_Functions](about/about_functions.md#piping-objects-to-functions).
 
 ```yaml
 Type: ScriptBlock
@@ -303,8 +374,15 @@ Accept wildcard characters: True
 
 ### -Process
 
-Specifies the operation that is performed on each input object. Enter a script block that describes
-the operation.
+Specifies the operation that is performed on each input object. This script block is only run once
+for the entire pipeline. For more information about the `process` block, see
+[about_Functions](about/about_functions.md#piping-objects-to-functions).
+
+When you provide multiple script blocks to the **Process** parameter, the first script block is
+always mapped to the `begin` block. If there are only two script blocks, the second block is mapped
+to the `process` block. If there are three or more script blocks, first script block is always
+mapped to the `begin` block, the last block is mapped to the `end` block, and the blocks in between
+are all mapped to the `process` block.
 
 ```yaml
 Type: ScriptBlock[]
@@ -372,7 +450,8 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -389,7 +468,8 @@ This cmdlet returns objects that are determined by the input.
 ## NOTES
 
 - The `ForEach-Object` cmdlet works much like the **Foreach** statement, except that you cannot pipe
-  input to a **Foreach** statement. For more information about the **Foreach** statement, see [about_Foreach](./About/about_Foreach.md).
+  input to a **Foreach** statement. For more information about the **Foreach** statement, see
+  [about_Foreach](./About/about_Foreach.md).
 
 - Starting in PowerShell 4.0, `Where` and `ForEach` methods were added for use with collections. You
   can read more about these new methods here [about_arrays](./About/about_Arrays.md)

--- a/reference/6/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/6/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -368,7 +368,7 @@ Accept wildcard characters: True
 
 ### -Process
 
-Specifies the operation that is performed on each input object. This script block is for every
+Specifies the operation that is performed on each input object. This script block is run for every
 object in the pipeline. For more information about the `process` block, see
 [about_Functions](about/about_functions.md#piping-objects-to-functions).
 

--- a/reference/6/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/6/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -50,7 +50,7 @@ Starting in Windows PowerShell 3.0, there are two different ways to construct a 
 
   > [!NOTE]
   > The script blocks run in the caller's scope. Therefore the blocks have access to variables in
-  > that scope and can create new variable that persist in that scope after the cmdlet completes.
+  > that scope and can create new variables that persist in that scope after the cmdlet completes.
 
 - **Operation statement**. You can also write an operation statement, which is much more like
   natural language. You can use the operation statement to specify a property value or call a
@@ -60,12 +60,6 @@ Starting in Windows PowerShell 3.0, there are two different ways to construct a 
   process on the computer.
 
   `Get-Process | ForEach-Object ProcessName`
-
-  When using the script block format, in addition to using the script block that describes the
-  operations that are performed on each input object, you can provide two additional script blocks.
-  The Begin script block, which is the value of the **Begin** parameter, runs before this cmdlet
-  processes the first input object. The End script block, which is the value of the **End**
-  parameter, runs after this cmdlet processes the last input object.
 
 ## EXAMPLES
 
@@ -249,7 +243,7 @@ end
 
 ### Example 10: Run multiple script blocks for each pipeline item
 
-As shown in the previous example, multiple script block passed using the **Process** parameter get
+As shown in the previous example, multiple script blocks passed using the **Process** parameter get
 mapped to the **Begin** and **End** parameters. To avoid this mapping, you must provide explicit
 values for the **Begin** and **End** parameters.
 
@@ -374,8 +368,8 @@ Accept wildcard characters: True
 
 ### -Process
 
-Specifies the operation that is performed on each input object. This script block is only run once
-for the entire pipeline. For more information about the `process` block, see
+Specifies the operation that is performed on each input object. This script block is for every
+object in the pipeline. For more information about the `process` block, see
 [about_Functions](about/about_functions.md#piping-objects-to-functions).
 
 When you provide multiple script blocks to the **Process** parameter, the first script block is

--- a/reference/6/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/6/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 04/08/2020
+ms.date: 04/09/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -18,32 +18,39 @@ Performs an operation against each item in a collection of input objects.
 ### ScriptBlockSet (Default)
 
 ```
-ForEach-Object [-InputObject <PSObject>] [-Begin <ScriptBlock>] [-Process] <ScriptBlock[]> [-End <ScriptBlock>]
- [-RemainingScripts <ScriptBlock[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ForEach-Object [-InputObject <PSObject>] [-Begin <ScriptBlock>] [-Process] <ScriptBlock[]>
+ [-End <ScriptBlock>] [-RemainingScripts <ScriptBlock[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PropertyAndMethodSet
 
 ```
-ForEach-Object [-InputObject <PSObject>] [-MemberName] <String> [-ArgumentList <Object[]>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ForEach-Object [-InputObject <PSObject>] [-MemberName] <String> [-ArgumentList <Object[]>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `ForEach-Object` cmdlet performs an operation on each item in a collection of input objects.
-The input objects can be piped to the cmdlet or specified by using the **InputObject** parameter.
+The `ForEach-Object` cmdlet performs an operation on each item in a collection of input objects. The
+input objects can be piped to the cmdlet or specified by using the **InputObject** parameter.
 
 Starting in Windows PowerShell 3.0, there are two different ways to construct a `ForEach-Object` command.
 
 - **Script block**. You can use a script block to specify the operation. Within the script block,
   use the `$_` variable to represent the current object. The script block is the value of the
-  *Process* parameter. The script block can contain any PowerShell script.
+  **Process** parameter. The script block can contain any PowerShell script.
 
   For example, the following command gets the value of the **ProcessName** property of each process
   on the computer.
 
   `Get-Process | ForEach-Object {$_.ProcessName}`
+
+  `ForEach-Object` supports the `begin`, `process`, and `end` blocks as described in
+  [about_functions](about/about_functions.md#piping-objects-to-functions).
+
+  > [!NOTE]
+  > The script blocks run in the caller's scope. Therefore the blocks have access to variables in
+  > that scope and can create new variable that persist in that scope after the cmdlet completes.
 
 - **Operation statement**. You can also write an operation statement, which is much more like
   natural language. You can use the operation statement to specify a property value or call a
@@ -112,7 +119,8 @@ This example changes the value of the **RemotePath** registry entry in all of th
 `HKCU:\Network` key to uppercase text.
 
 ```powershell
-Get-ItemProperty -Path HKCU:\Network\* | ForEach-Object {Set-ItemProperty -Path $_.PSPath -Name RemotePath -Value $_.RemotePath.ToUpper();}
+Get-ItemProperty -Path HKCU:\Network\* |
+  ForEach-Object {Set-ItemProperty -Path $_.PSPath -Name RemotePath -Value $_.RemotePath.ToUpper();}
 ```
 
 You can use this format to change the form or content of a registry entry value.
@@ -147,7 +155,8 @@ Hello
 Hello
 ```
 
-Because PowerShell treats null as an explicit placeholder, the `ForEach-Object` cmdlet generates a value for `$Null`, just as it does for other objects that you pipe to it.
+Because PowerShell treats null as an explicit placeholder, the `ForEach-Object` cmdlet generates a
+value for `$Null`, just as it does for other objects that you pipe to it.
 
 
 ### Example 6: Get property values
@@ -199,6 +208,64 @@ The second command uses the **MemberName** parameter to specify the **Split** me
 The third command uses the **Foreach** alias of the `ForEach-Object` cmdlet and omits the names of
 the **MemberName** and **ArgumentList** parameters, which are optional.
 
+### Example 8: Using ForeEach-Object with two script blocks
+
+In this example we pass two script blocks positionally. All the script blocks bind to the
+**Process** parameter. However, they are treated as if they had been passed to the **Begin** and
+**Process** parameters.
+
+```powershell
+1..2 | ForEach-Object { 'begin' } { 'process' }
+```
+
+```Output
+begin
+process
+process
+```
+
+### Example 9: Using ForeEach-Object with more than two script blocks
+
+In this example we pass two script blocks positionally. All the script blocks bind to the
+**Process** parameter. However, they are treated as if they had been passed to the **Begin**,
+**Process**, and **End** parameters.
+
+```powershell
+1..2 | ForEach-Object { 'begin' } { 'process A' }  { 'process B' }  { 'end' }
+```
+
+```Output
+begin
+process A
+process B
+process A
+process B
+end
+```
+
+> [!NOTE]
+> The first script block is always mapped to the `begin` block, the last block is mapped to the
+> `end` block, and the blocks in between are all mapped to the `process` block.
+
+### Example 10: Run multiple script blocks for each pipeline item
+
+As shown in the previous example, multiple script block passed using the **Process** parameter get
+mapped to the **Begin** and **End** parameters. To avoid this mapping, you must provide explicit
+values for the **Begin** and **End** parameters.
+
+```powershell
+1..2 | ForEach-Object -Begin $null -Process { 'one' }, { 'two' }, { 'three' } -End $null
+```
+
+```Output
+one
+two
+three
+one
+two
+three
+```
+
 ## PARAMETERS
 
 ### -ArgumentList
@@ -222,7 +289,9 @@ Accept wildcard characters: False
 
 ### -Begin
 
-Specifies a script block that runs before this cmdlet processes any input objects.
+Specifies a script block that runs before this cmdlet processes any input objects. This script block
+is only run once for the entire pipeline. For more information about the `begin` block, see
+[about_Functions](about/about_functions.md#piping-objects-to-functions).
 
 ```yaml
 Type: ScriptBlock
@@ -238,7 +307,9 @@ Accept wildcard characters: False
 
 ### -End
 
-Specifies a script block that runs after this cmdlet processes all input objects.
+Specifies a script block that runs after this cmdlet processes all input objects. This script block
+is only run once for the entire pipeline. For more information about the `end` block, see
+[about_Functions](about/about_functions.md#piping-objects-to-functions).
 
 ```yaml
 Type: ScriptBlock
@@ -303,8 +374,15 @@ Accept wildcard characters: True
 
 ### -Process
 
-Specifies the operation that is performed on each input object. Enter a script block that describes
-the operation.
+Specifies the operation that is performed on each input object. This script block is only run once
+for the entire pipeline. For more information about the `process` block, see
+[about_Functions](about/about_functions.md#piping-objects-to-functions).
+
+When you provide multiple script blocks to the **Process** parameter, the first script block is
+always mapped to the `begin` block. If there are only two script blocks, the second block is mapped
+to the `process` block. If there are three or more script blocks, first script block is always
+mapped to the `begin` block, the last block is mapped to the `end` block, and the blocks in between
+are all mapped to the `process` block.
 
 ```yaml
 Type: ScriptBlock[]
@@ -372,7 +450,8 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -389,7 +468,8 @@ This cmdlet returns objects that are determined by the input.
 ## NOTES
 
 - The `ForEach-Object` cmdlet works much like the **Foreach** statement, except that you cannot pipe
-  input to a **Foreach** statement. For more information about the **Foreach** statement, see [about_Foreach](./About/about_Foreach.md).
+  input to a **Foreach** statement. For more information about the **Foreach** statement, see
+  [about_Foreach](./About/about_Foreach.md).
 
 - Starting in PowerShell 4.0, `Where` and `ForEach` methods were added for use with collections. You
   can read more about these new methods here [about_arrays](./About/about_Arrays.md)

--- a/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -494,7 +494,7 @@ Accept wildcard characters: True
 
 ### -Process
 
-Specifies the operation that is performed on each input object. This script block is for every
+Specifies the operation that is performed on each input object. This script block is run for every
 object in the pipeline. For more information about the `process` block, see
 [about_Functions](about/about_functions.md#piping-objects-to-functions).
 

--- a/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -57,7 +57,7 @@ Starting in Windows PowerShell 3.0, there are two different ways to construct a 
 
   > [!NOTE]
   > The script blocks run in the caller's scope. Therefore the blocks have access to variables in
-  > that scope and can create new variable that persist in that scope after the cmdlet completes.
+  > that scope and can create new variables that persist in that scope after the cmdlet completes.
 
 - **Operation statement**. You can also write an operation statement, which is much more like
   natural language. You can use the operation statement to specify a property value or call a
@@ -67,12 +67,6 @@ Starting in Windows PowerShell 3.0, there are two different ways to construct a 
   process on the computer.
 
   `Get-Process | ForEach-Object ProcessName`
-
-  When using the script block format, in addition to using the script block that describes the
-  operations that are performed on each input object, you can provide two additional script blocks.
-  The Begin script block, which is the value of the **Begin** parameter, runs before this cmdlet
-  processes the first input object. The End script block, which is the value of the **End**
-  parameter, runs after this cmdlet processes the last input object.
 
 - **Parallel running script block**. Beginning with PowerShell 7.0, a third parameter set is
   available that runs each script block in parallel. There is a `-ThrottleLimit` parameter that
@@ -265,7 +259,7 @@ end
 
 ### Example 10: Run multiple script blocks for each pipeline item
 
-As shown in the previous example, multiple script block passed using the **Process** parameter get
+As shown in the previous example, multiple script blocks passed using the **Process** parameter get
 mapped to the **Begin** and **End** parameters. To avoid this mapping, you must provide explicit
 values for the **Begin** and **End** parameters.
 
@@ -500,8 +494,8 @@ Accept wildcard characters: True
 
 ### -Process
 
-Specifies the operation that is performed on each input object. This script block is only run once
-for the entire pipeline. For more information about the `process` block, see
+Specifies the operation that is performed on each input object. This script block is for every
+object in the pipeline. For more information about the `process` block, see
 [about_Functions](about/about_functions.md#piping-objects-to-functions).
 
 When you provide multiple script blocks to the **Process** parameter, the first script block is

--- a/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 04/08/2020
+ms.date: 04/09/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -38,19 +38,26 @@ ForEach-Object -Parallel <scriptblock> [-InputObject <PSObject>] [-ThrottleLimit
 
 ## DESCRIPTION
 
-The `ForEach-Object` cmdlet performs an operation on each item in a collection of input objects.
-The input objects can be piped to the cmdlet or specified by using the **InputObject** parameter.
+The `ForEach-Object` cmdlet performs an operation on each item in a collection of input objects. The
+input objects can be piped to the cmdlet or specified by using the **InputObject** parameter.
 
 Starting in Windows PowerShell 3.0, there are two different ways to construct a `ForEach-Object` command.
 
 - **Script block**. You can use a script block to specify the operation. Within the script block,
   use the `$_` variable to represent the current object. The script block is the value of the
-  *Process* parameter. The script block can contain any PowerShell script.
+  **Process** parameter. The script block can contain any PowerShell script.
 
   For example, the following command gets the value of the **ProcessName** property of each process
   on the computer.
 
   `Get-Process | ForEach-Object {$_.ProcessName}`
+
+  `ForEach-Object` supports the `begin`, `process`, and `end` blocks as described in
+  [about_functions](about/about_functions.md#piping-objects-to-functions).
+
+  > [!NOTE]
+  > The script blocks run in the caller's scope. Therefore the blocks have access to variables in
+  > that scope and can create new variable that persist in that scope after the cmdlet completes.
 
 - **Operation statement**. You can also write an operation statement, which is much more like
   natural language. You can use the operation statement to specify a property value or call a
@@ -128,7 +135,8 @@ This example changes the value of the **RemotePath** registry entry in all of th
 `HKCU:\Network` key to uppercase text.
 
 ```powershell
-Get-ItemProperty -Path HKCU:\Network\* | ForEach-Object {Set-ItemProperty -Path $_.PSPath -Name RemotePath -Value $_.RemotePath.ToUpper();}
+Get-ItemProperty -Path HKCU:\Network\* |
+  ForEach-Object {Set-ItemProperty -Path $_.PSPath -Name RemotePath -Value $_.RemotePath.ToUpper();}
 ```
 
 You can use this format to change the form or content of a registry entry value.
@@ -163,7 +171,8 @@ Hello
 Hello
 ```
 
-Because PowerShell treats null as an explicit placeholder, the `ForEach-Object` cmdlet generates a value for `$Null`, just as it does for other objects that you pipe to it.
+Because PowerShell treats null as an explicit placeholder, the `ForEach-Object` cmdlet generates a
+value for `$Null`, just as it does for other objects that you pipe to it.
 
 
 ### Example 6: Get property values
@@ -215,7 +224,65 @@ The second command uses the **MemberName** parameter to specify the **Split** me
 The third command uses the **Foreach** alias of the `ForEach-Object` cmdlet and omits the names of
 the **MemberName** and **ArgumentList** parameters, which are optional.
 
-### Example 8: Run slow script in parallel batches
+### Example 8: Using ForeEach-Object with two script blocks
+
+In this example we pass two script blocks positionally. All the script blocks bind to the
+**Process** parameter. However, they are treated as if they had been passed to the **Begin** and
+**Process** parameters.
+
+```powershell
+1..2 | ForEach-Object { 'begin' } { 'process' }
+```
+
+```Output
+begin
+process
+process
+```
+
+### Example 9: Using ForeEach-Object with more than two script blocks
+
+In this example we pass two script blocks positionally. All the script blocks bind to the
+**Process** parameter. However, they are treated as if they had been passed to the **Begin**,
+**Process**, and **End** parameters.
+
+```powershell
+1..2 | ForEach-Object { 'begin' } { 'process A' }  { 'process B' }  { 'end' }
+```
+
+```Output
+begin
+process A
+process B
+process A
+process B
+end
+```
+
+> [!NOTE]
+> The first script block is always mapped to the `begin` block, the last block is mapped to the
+> `end` block, and the blocks in between are all mapped to the `process` block.
+
+### Example 10: Run multiple script blocks for each pipeline item
+
+As shown in the previous example, multiple script block passed using the **Process** parameter get
+mapped to the **Begin** and **End** parameters. To avoid this mapping, you must provide explicit
+values for the **Begin** and **End** parameters.
+
+```powershell
+1..2 | ForEach-Object -Begin $null -Process { 'one' }, { 'two' }, { 'three' } -End $null
+```
+
+```Output
+one
+two
+three
+one
+two
+three
+```
+
+### Example 11: Run slow script in parallel batches
 
 This example runs a simple script block that evaluates a string and sleeps for one second.
 
@@ -348,7 +415,9 @@ Accept wildcard characters: False
 
 ### -Begin
 
-Specifies a script block that runs before this cmdlet processes any input objects.
+Specifies a script block that runs before this cmdlet processes any input objects. This script block
+is only run once for the entire pipeline. For more information about the `begin` block, see
+[about_Functions](about/about_functions.md#piping-objects-to-functions).
 
 ```yaml
 Type: ScriptBlock
@@ -364,7 +433,9 @@ Accept wildcard characters: False
 
 ### -End
 
-Specifies a script block that runs after this cmdlet processes all input objects.
+Specifies a script block that runs after this cmdlet processes all input objects. This script block
+is only run once for the entire pipeline. For more information about the `end` block, see
+[about_Functions](about/about_functions.md#piping-objects-to-functions).
 
 ```yaml
 Type: ScriptBlock
@@ -429,8 +500,15 @@ Accept wildcard characters: True
 
 ### -Process
 
-Specifies the operation that is performed on each input object. Enter a script block that describes
-the operation.
+Specifies the operation that is performed on each input object. This script block is only run once
+for the entire pipeline. For more information about the `process` block, see
+[about_Functions](about/about_functions.md#piping-objects-to-functions).
+
+When you provide multiple script blocks to the **Process** parameter, the first script block is
+always mapped to the `begin` block. If there are only two script blocks, the second block is mapped
+to the `process` block. If there are three or more script blocks, first script block is always
+mapped to the `begin` block, the last block is mapped to the `end` block, and the blocks in between
+are all mapped to the `process` block.
 
 ```yaml
 Type: ScriptBlock[]
@@ -579,7 +657,8 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -596,7 +675,8 @@ This cmdlet returns objects that are determined by the input.
 ## NOTES
 
 - The `ForEach-Object` cmdlet works much like the **Foreach** statement, except that you cannot pipe
-  input to a **Foreach** statement. For more information about the **Foreach** statement, see [about_Foreach](./About/about_Foreach.md).
+  input to a **Foreach** statement. For more information about the **Foreach** statement, see
+  [about_Foreach](./About/about_Foreach.md).
 
 - Starting in PowerShell 4.0, `Where` and `ForEach` methods were added for use with collections. You
   can read more about these new methods here [about_arrays](./About/about_Arrays.md)

--- a/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -494,7 +494,7 @@ Accept wildcard characters: True
 
 ### -Process
 
-Specifies the operation that is performed on each input object. This script block is for every
+Specifies the operation that is performed on each input object. This script block is run for every
 object in the pipeline. For more information about the `process` block, see
 [about_Functions](about/about_functions.md#piping-objects-to-functions).
 

--- a/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 04/08/2020
+ms.date: 04/09/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -38,19 +38,26 @@ ForEach-Object -Parallel <scriptblock> [-InputObject <PSObject>] [-ThrottleLimit
 
 ## DESCRIPTION
 
-The `ForEach-Object` cmdlet performs an operation on each item in a collection of input objects.
-The input objects can be piped to the cmdlet or specified by using the **InputObject** parameter.
+The `ForEach-Object` cmdlet performs an operation on each item in a collection of input objects. The
+input objects can be piped to the cmdlet or specified by using the **InputObject** parameter.
 
 Starting in Windows PowerShell 3.0, there are two different ways to construct a `ForEach-Object` command.
 
 - **Script block**. You can use a script block to specify the operation. Within the script block,
   use the `$_` variable to represent the current object. The script block is the value of the
-  *Process* parameter. The script block can contain any PowerShell script.
+  **Process** parameter. The script block can contain any PowerShell script.
 
   For example, the following command gets the value of the **ProcessName** property of each process
   on the computer.
 
   `Get-Process | ForEach-Object {$_.ProcessName}`
+
+  `ForEach-Object` supports the `begin`, `process`, and `end` blocks as described in
+  [about_functions](about/about_functions.md#piping-objects-to-functions).
+
+  > [!NOTE]
+  > The script blocks run in the caller's scope. Therefore the blocks have access to variables in
+  > that scope and can create new variable that persist in that scope after the cmdlet completes.
 
 - **Operation statement**. You can also write an operation statement, which is much more like
   natural language. You can use the operation statement to specify a property value or call a
@@ -128,7 +135,8 @@ This example changes the value of the **RemotePath** registry entry in all of th
 `HKCU:\Network` key to uppercase text.
 
 ```powershell
-Get-ItemProperty -Path HKCU:\Network\* | ForEach-Object {Set-ItemProperty -Path $_.PSPath -Name RemotePath -Value $_.RemotePath.ToUpper();}
+Get-ItemProperty -Path HKCU:\Network\* |
+  ForEach-Object {Set-ItemProperty -Path $_.PSPath -Name RemotePath -Value $_.RemotePath.ToUpper();}
 ```
 
 You can use this format to change the form or content of a registry entry value.
@@ -163,7 +171,8 @@ Hello
 Hello
 ```
 
-Because PowerShell treats null as an explicit placeholder, the `ForEach-Object` cmdlet generates a value for `$Null`, just as it does for other objects that you pipe to it.
+Because PowerShell treats null as an explicit placeholder, the `ForEach-Object` cmdlet generates a
+value for `$Null`, just as it does for other objects that you pipe to it.
 
 
 ### Example 6: Get property values
@@ -215,7 +224,65 @@ The second command uses the **MemberName** parameter to specify the **Split** me
 The third command uses the **Foreach** alias of the `ForEach-Object` cmdlet and omits the names of
 the **MemberName** and **ArgumentList** parameters, which are optional.
 
-### Example 8: Run slow script in parallel batches
+### Example 8: Using ForeEach-Object with two script blocks
+
+In this example we pass two script blocks positionally. All the script blocks bind to the
+**Process** parameter. However, they are treated as if they had been passed to the **Begin** and
+**Process** parameters.
+
+```powershell
+1..2 | ForEach-Object { 'begin' } { 'process' }
+```
+
+```Output
+begin
+process
+process
+```
+
+### Example 9: Using ForeEach-Object with more than two script blocks
+
+In this example we pass two script blocks positionally. All the script blocks bind to the
+**Process** parameter. However, they are treated as if they had been passed to the **Begin**,
+**Process**, and **End** parameters.
+
+```powershell
+1..2 | ForEach-Object { 'begin' } { 'process A' }  { 'process B' }  { 'end' }
+```
+
+```Output
+begin
+process A
+process B
+process A
+process B
+end
+```
+
+> [!NOTE]
+> The first script block is always mapped to the `begin` block, the last block is mapped to the
+> `end` block, and the blocks in between are all mapped to the `process` block.
+
+### Example 10: Run multiple script blocks for each pipeline item
+
+As shown in the previous example, multiple script block passed using the **Process** parameter get
+mapped to the **Begin** and **End** parameters. To avoid this mapping, you must provide explicit
+values for the **Begin** and **End** parameters.
+
+```powershell
+1..2 | ForEach-Object -Begin $null -Process { 'one' }, { 'two' }, { 'three' } -End $null
+```
+
+```Output
+one
+two
+three
+one
+two
+three
+```
+
+### Example 11: Run slow script in parallel batches
 
 This example runs a simple script block that evaluates a string and sleeps for one second.
 
@@ -348,7 +415,9 @@ Accept wildcard characters: False
 
 ### -Begin
 
-Specifies a script block that runs before this cmdlet processes any input objects.
+Specifies a script block that runs before this cmdlet processes any input objects. This script block
+is only run once for the entire pipeline. For more information about the `begin` block, see
+[about_Functions](about/about_functions.md#piping-objects-to-functions).
 
 ```yaml
 Type: ScriptBlock
@@ -364,7 +433,9 @@ Accept wildcard characters: False
 
 ### -End
 
-Specifies a script block that runs after this cmdlet processes all input objects.
+Specifies a script block that runs after this cmdlet processes all input objects. This script block
+is only run once for the entire pipeline. For more information about the `end` block, see
+[about_Functions](about/about_functions.md#piping-objects-to-functions).
 
 ```yaml
 Type: ScriptBlock
@@ -429,8 +500,15 @@ Accept wildcard characters: True
 
 ### -Process
 
-Specifies the operation that is performed on each input object. Enter a script block that describes
-the operation.
+Specifies the operation that is performed on each input object. This script block is only run once
+for the entire pipeline. For more information about the `process` block, see
+[about_Functions](about/about_functions.md#piping-objects-to-functions).
+
+When you provide multiple script blocks to the **Process** parameter, the first script block is
+always mapped to the `begin` block. If there are only two script blocks, the second block is mapped
+to the `process` block. If there are three or more script blocks, first script block is always
+mapped to the `begin` block, the last block is mapped to the `end` block, and the blocks in between
+are all mapped to the `process` block.
 
 ```yaml
 Type: ScriptBlock[]
@@ -579,7 +657,8 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -596,7 +675,8 @@ This cmdlet returns objects that are determined by the input.
 ## NOTES
 
 - The `ForEach-Object` cmdlet works much like the **Foreach** statement, except that you cannot pipe
-  input to a **Foreach** statement. For more information about the **Foreach** statement, see [about_Foreach](./About/about_Foreach.md).
+  input to a **Foreach** statement. For more information about the **Foreach** statement, see
+  [about_Foreach](./About/about_Foreach.md).
 
 - Starting in PowerShell 4.0, `Where` and `ForEach` methods were added for use with collections. You
   can read more about these new methods here [about_arrays](./About/about_Arrays.md)

--- a/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -57,7 +57,7 @@ Starting in Windows PowerShell 3.0, there are two different ways to construct a 
 
   > [!NOTE]
   > The script blocks run in the caller's scope. Therefore the blocks have access to variables in
-  > that scope and can create new variable that persist in that scope after the cmdlet completes.
+  > that scope and can create new variables that persist in that scope after the cmdlet completes.
 
 - **Operation statement**. You can also write an operation statement, which is much more like
   natural language. You can use the operation statement to specify a property value or call a
@@ -67,12 +67,6 @@ Starting in Windows PowerShell 3.0, there are two different ways to construct a 
   process on the computer.
 
   `Get-Process | ForEach-Object ProcessName`
-
-  When using the script block format, in addition to using the script block that describes the
-  operations that are performed on each input object, you can provide two additional script blocks.
-  The Begin script block, which is the value of the **Begin** parameter, runs before this cmdlet
-  processes the first input object. The End script block, which is the value of the **End**
-  parameter, runs after this cmdlet processes the last input object.
 
 - **Parallel running script block**. Beginning with PowerShell 7.0, a third parameter set is
   available that runs each script block in parallel. There is a `-ThrottleLimit` parameter that
@@ -265,7 +259,7 @@ end
 
 ### Example 10: Run multiple script blocks for each pipeline item
 
-As shown in the previous example, multiple script block passed using the **Process** parameter get
+As shown in the previous example, multiple script blocks passed using the **Process** parameter get
 mapped to the **Begin** and **End** parameters. To avoid this mapping, you must provide explicit
 values for the **Begin** and **End** parameters.
 
@@ -500,8 +494,8 @@ Accept wildcard characters: True
 
 ### -Process
 
-Specifies the operation that is performed on each input object. This script block is only run once
-for the entire pipeline. For more information about the `process` block, see
+Specifies the operation that is performed on each input object. This script block is for every
+object in the pipeline. For more information about the `process` block, see
 [about_Functions](about/about_functions.md#piping-objects-to-functions).
 
 When you provide multiple script blocks to the **Process** parameter, the first script block is


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes [AB#1706195](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1706195) - Fixes #4513 - multiple script blocks ForEach-Object
## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
