### PR TITLE
Update incorrect usage explanation for Write-Host

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Host.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Host.md
@@ -105,8 +105,7 @@ Write-Host "I won't print" 6>$null
 
 ```
 
-This command displays the string "Red on white text." The text is 'red', as defined by the `ForegroundColor` parameter.
-The background is 'white', as defined by the `BackgroundColor` parameter.
+These commands suppress output from Write-Host. The first command uses the `Ignore` argument for the `-InformationAction` parameter. The second command uses output redirection to `$null` to suppress output.
 
 ## PARAMETERS
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Host.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Host.md
@@ -105,7 +105,7 @@ Write-Host "I won't print" 6>$null
 
 ```
 
-These commands suppress output from Write-Host. The first command uses the `Ignore` argument for the `-InformationAction` parameter. The second command uses output redirection to `$null` to suppress output.
+These commands effectively suppress output of the Write-Host cmdlet. The first one uses the InformationAction parameter with the Ignore Value to suppress output to the information stream. The second example redirects the information stream of the command to the $null variable and thereby suppresses it.
 
 ## PARAMETERS
 


### PR DESCRIPTION
# PR Summary
The explanation for sample suppression of Write-Host is incorrect.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.x preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [x] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
