### PR TITLE
C200435,200436 - Escaping @ character to avoid localization content

### DIFF
--- a/reference/docs-conceptual/whats-new/Migrating-from-Windows-PowerShell-51-to-PowerShell-7.md
+++ b/reference/docs-conceptual/whats-new/Migrating-from-Windows-PowerShell-51-to-PowerShell-7.md
@@ -223,7 +223,7 @@ Enter-PSSession -HostName <Computer> -UserName <Username>
 ```
 
 Alternatively, when using the **HostName** parameter, provide the username information followed by
-the at sign ('\@'), followed by the computer name.
+the at sign (`@`), followed by the computer name.
 
 ```powershell
 Enter-PSSession -HostName <Username>@<Computer>

--- a/reference/docs-conceptual/whats-new/Migrating-from-Windows-PowerShell-51-to-PowerShell-7.md
+++ b/reference/docs-conceptual/whats-new/Migrating-from-Windows-PowerShell-51-to-PowerShell-7.md
@@ -223,7 +223,7 @@ Enter-PSSession -HostName <Computer> -UserName <Username>
 ```
 
 Alternatively, when using the **HostName** parameter, provide the username information followed by
-the at sign ('@'), followed by the computer name.
+the at sign ('\@'), followed by the computer name.
 
 ```powershell
 Enter-PSSession -HostName <Username>@<Computer>


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Unescaped @ is breaking correct rendering on LOC pages.