### PR TITLE
Sample code as written produces an error.

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -219,7 +219,7 @@ function prompt {
   $principal = [Security.Principal.WindowsPrincipal] $identity
 
   $(if (Test-Path variable:/PSDebugContext) { '[DBG]: ' }
-    elseif($principal.IsInRole([Security.Principal.WindowsBuiltInRole]
+    elseif($principal.IsInRole([Security.Principal.WindowsBuiltInRole] `
       "Administrator")) { "[ADMIN]: " }
     else { '' }
   ) + 'PS ' + $(Get-Location) +


### PR DESCRIPTION
We either need a backtick at the end of the line, or to collapse the following line.
```powershell
    elseif($principal.IsInRole([Security.Principal.WindowsBuiltInRole]  
```
becomes
```powershell
    elseif($principal.IsInRole([Security.Principal.WindowsBuiltInRole] `
```
or
```powershell
    elseif($principal.IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) { "[ADMIN]: " }
```

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.x preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [x] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
