### PR TITLE
Fix Example 3

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
@@ -45,7 +45,8 @@ It uses the *Credential* parameter to specify a user account that has permission
 
 ### Example 3: Reset the password on a remote computer
 ```
-PS C:\> Invoke-Command -ComputerName "Server01" -ScriptBlock {Reset-ComputerMachinePassword}
+$cred = Get-Credential
+PS C:\> Invoke-Command -ComputerName "Server01" -ScriptBlock {Reset-ComputerMachinePassword -Credential $using:cred}
 ```
 
 This command uses the Invoke-Command cmdlet to run a **Reset-ComputerMachinePassword** command on the Server01 remote computer.


### PR DESCRIPTION
Example 3: Leveraging WinRM is subject to Double Hop, therefore without passing in a credential or delegating credentials the command as previous shown will always fail.

# PR Summary

Updated Example 3 within Reset-ComputerMachinePassword.md

## PR Context

Only applicable to PowerShell 5.1 version

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.x preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ x] Version 5.1 content

**Conceptual articles**
- [ x] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [x ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x ] PR has a meaningful title
- [x ] PR is targeted at the _staging_ branch
- [x ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
