### PR TITLE
PS isn't assigning multiple vars to single value

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -837,6 +837,18 @@ $d, $e, $f = $c
 This command assigns the value 3 to the $d variable, the value 4 to the $e
 variable, and the value 5 to the $f variable.
 
+If the assignment value contains less elements than variables, all the
+remaining elements at the end are not assigned any values. For example, the
+following command contains three variables and two values:
+
+```powershell
+$a, $b, $c = 1, 2
+```
+
+Therefore, PowerShell assigns the value 1 to the $a variable and
+the value 2 to the $b variable. It will not assign any value to the $c
+variable.
+
 You can also assign a single value to multiple variables by chaining the
 variables. For example, the following command assigns a value of "three" to
 all four variables:

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -838,7 +838,7 @@ This command assigns the value 3 to the $d variable, the value 4 to the $e
 variable, and the value 5 to the $f variable.
 
 If the assignment value contains less elements than variables, all the
-remaining elements at the end are not assigned any values. For example, the
+remaining variables at the end are not assigned any values. For example, the
 following command contains three variables and two values:
 
 ```powershell


### PR DESCRIPTION
If the assignment value contains less elements than variables, all the remaining elements are not assigned any values. For example, the following command contains three variables and two values:

```powershell
$a, $b, $c = 1, 2
```

Therefore, PowerShell assigns the value 1 to the $a variable and
the value 2 to the $b variable. It will not assign any value to the $c
variable.

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.x preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual articles**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
