### PR TITLE
Updated About_Pwsh and About_PowerShell_exe for -File Parameter with Batch Scripts

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PowerShell_exe.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PowerShell_exe.md
@@ -137,6 +137,12 @@ because it has no special meaning to the current **cmd.exe** shell. The
 `$env:windir` style of environment variable reference _can_ be used inside a
 **Command** parameter, since there it will be interpreted as PowerShell code.
 
+Similarly, if you want to execute the same command from a **Batch script**, you 
+would use `%~dp0` instead of `.\` or `$PSScriptRoot` to represent the current 
+execution directory: `powershell.exe -File %~dp0test.ps1 -TestParam %windir%`. 
+If you instead used `.\test.ps1`, PowerShell would throw an error because it 
+cannot find the literal path `.\test.ps1`
+
 When the value of **File** is a file path, **File** _must_ be the last
 parameter in the command because any characters typed after the **File**
 parameter name are interpreted as the script file path followed by the script

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -78,6 +78,12 @@ because it has no special meaning to the current **cmd.exe** shell. The
 `$env:windir` style of environment variable reference _can_ be used inside a
 **Command** parameter, since there it is interpreted as PowerShell code.
 
+Similarly, if you want to execute the same command from a **Batch script**, you 
+would use `%~dp0` instead of `.\` or `$PSScriptRoot` to represent the current 
+execution directory: `powershell.exe -File %~dp0test.ps1 -TestParam %windir%`. 
+If you instead used `.\test.ps1`, PowerShell would throw an error because it 
+cannot find the literal path `.\test.ps1`
+
 ### -Command | -c
 
 Executes the specified commands (and any parameters) as though they were typed

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -80,7 +80,7 @@ because it has no special meaning to the current **cmd.exe** shell. The
 
 Similarly, if you want to execute the same command from a **Batch script**, you 
 would use `%~dp0` instead of `.\` or `$PSScriptRoot` to represent the current 
-execution directory: `powershell.exe -File %~dp0test.ps1 -TestParam %windir%`. 
+execution directory: `pwsh -File %~dp0test.ps1 -TestParam %windir%`. 
 If you instead used `.\test.ps1`, PowerShell would throw an error because it 
 cannot find the literal path `.\test.ps1`
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -81,6 +81,12 @@ because it has no special meaning to the current **cmd.exe** shell. The
 `$env:windir` style of environment variable reference _can_ be used inside a
 **Command** parameter, since there it is interpreted as PowerShell code.
 
+Similarly, if you want to execute the same command from a **Batch script**, you 
+would use `%~dp0` instead of `.\` or `$PSScriptRoot` to represent the current 
+execution directory: `pwsh -File %~dp0test.ps1 -TestParam %windir%`. 
+If you instead used `.\test.ps1`, PowerShell would throw an error because it 
+cannot find the literal path `.\test.ps1`
+
 ### -Command | -c
 
 Executes the specified commands (and any parameters) as though they were typed

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -81,6 +81,12 @@ because it has no special meaning to the current **cmd.exe** shell. The
 `$env:windir` style of environment variable reference _can_ be used inside a
 **Command** parameter, since there it is interpreted as PowerShell code.
 
+Similarly, if you want to execute the same command from a **Batch script**, you 
+would use `%~dp0` instead of `.\` or `$PSScriptRoot` to represent the current 
+execution directory: `pwsh -File %~dp0test.ps1 -TestParam %windir%`. If you instead 
+used `.\test.ps1`, PowerShell would throw an error because it cannot find the literal 
+path `.\test.ps1`
+
 ### -Command | -c
 
 Executes the specified commands (and any parameters) as though they were typed


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Added a scenario to the `-File` parameter for `PowerShell.exe` and `Pwsh.exe` which clarifies that when using Batch scripts, you cannot use `.\` or `$PSScriptRoot` to represent the current working/execution directory and instead have to use `%~dp0`.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [X] Version 7.1 preview content
- [X] Version 7.0 content
- [X] Version 6 content
- [X] Version 5.1 content

**Conceptual content**
- [X] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
