### PR TITLE
FIXES #5609 - Adds information about new runspace behavior in Foreach -Parallel in 7.1

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 04/09/2020
+ms.date: 04/30/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object

--- a/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -74,11 +74,12 @@ Starting in Windows PowerShell 3.0, there are two different ways to construct a 
   represent the current input object in the script block. Use the `$using:` keyword to pass variable
   references to the running script.
 
-  In PowerShell 7, a new runspace is created for each loop iteration to ensure max isolation. This
-  can be a large performance and resource hit if the work you are doing is small compared to
+  In PowerShell 7, a new runspace is created for each loop iteration to ensure maximum isolation.
+  This can be a large performance and resource hit if the work you are doing is small compared to
   creating new runspaces or if there are a lot of iterations performing significant work. As of
-  PowerShell 7.1 preview release 2, runspaces from a runspace pool are reused by default. However,
-  you can still create a runspace for each iteration using the **UseNewRunspace** switch.
+  PowerShell 7.1, runspaces from a runspace pool are reused by default. The runspace size is
+  specified by the **ThrottleLimit** parameter. The default runspace pool size is 5. You can still
+  create a new runspace for each iteration using the **UseNewRunspace** switch.
 
   By default, the parallel scriptblocks use the current working directory of the caller that started
   the parallel tasks.
@@ -599,12 +600,12 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -UseNewRunspace(preview)
+### -UseNewRunspace
 
 Causes the parallel invocation to create a new runspace for every loop iteration instead of reusing
 runspaces from the a runspace pool.
 
-This parameter was introduced in PowerShell 7.1 preview release 2.
+This parameter was introduced in PowerShell 7.1
 
 ```yml
 Type: SwitchParameter

--- a/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -33,7 +33,7 @@ ForEach-Object [-InputObject <PSObject>] [-MemberName] <String> [-ArgumentList <
 
 ```
 ForEach-Object -Parallel <scriptblock> [-InputObject <PSObject>] [-ThrottleLimit <int>]
- [-TimeoutSeconds <int>]  [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-UseNewRunspace] [-TimeoutSeconds <int>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -73,6 +73,12 @@ Starting in Windows PowerShell 3.0, there are two different ways to construct a 
   limits the number of parallel scripts running at a time. As before, use the `$_` variable to
   represent the current input object in the script block. Use the `$using:` keyword to pass variable
   references to the running script.
+
+  In PowerShell 7, a new runspace is created for each loop iteration to ensure max isolation. This
+  can be a large performance and resource hit if the work you are doing is small compared to
+  creating new runspaces or if there are a lot of iterations performing significant work. As of
+  PowerShell 7.1 preview release 2, runspaces from a runspace pool are reused by default. However,
+  you can still create a runspace for each iteration using the **UseNewRunspace** switch.
 
   By default, the parallel scriptblocks use the current working directory of the caller that started
   the parallel tasks.
@@ -167,7 +173,6 @@ Hello
 
 Because PowerShell treats null as an explicit placeholder, the `ForEach-Object` cmdlet generates a
 value for `$Null`, just as it does for other objects that you pipe to it.
-
 
 ### Example 6: Get property values
 
@@ -590,6 +595,25 @@ Aliases:
 Required: False
 Position: Named
 Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseNewRunspace(preview)
+
+Causes the parallel invocation to create a new runspace for every loop iteration instead of reusing
+runspaces from the a runspace pool.
+
+This parameter was introduced in PowerShell 7.1 preview release 2.
+
+```yml
+Type: SwitchParameter
+Parameter Sets: ParallelParameterSet
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -77,7 +77,7 @@ Starting in Windows PowerShell 3.0, there are two different ways to construct a 
   In PowerShell 7, a new runspace is created for each loop iteration to ensure maximum isolation.
   This can be a large performance and resource hit if the work you are doing is small compared to
   creating new runspaces or if there are a lot of iterations performing significant work. As of
-  PowerShell 7.1, runspaces from a runspace pool are reused by default. The runspace size is
+  PowerShell 7.1, runspaces from a runspace pool are reused by default. The runspace pool size is
   specified by the **ThrottleLimit** parameter. The default runspace pool size is 5. You can still
   create a new runspace for each iteration using the **UseNewRunspace** switch.
 


### PR DESCRIPTION
# PR Summary
In PowerShell 7, a new runspace is created for every loop iteration when running Foreach-Object -Parallel. In PowerShell 7.1 preview release 2, in the same scenario, loops reuse runspaces from a runspace pool unless you specify you want to create new runspaces using the `-UseNewRunspace` switch parameter. 

## PR Context
Fixes #5609 
Fixes [AB#1714575](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1714575)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
