### PR TITLE
FIXES 4870 - Updates New-Item 

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
@@ -152,7 +152,7 @@ Mode                LastWriteTime         Length Name
 ```
 
 > [!NOTE]
-> When using `New-Item` with the `-FOrce` switch to create registry keys, the command will behave
+> When using `New-Item` with the `-Force` switch to create registry keys, the command will behave
 > the same as when overwriting a file. If the registry key already exists, the key and all
 > properties and values will be overwritten with an empty registry key.
 
@@ -179,8 +179,8 @@ Accept wildcard characters: False
 ### -Force
 
 Forces this cmdlet to create an item that writes over an existing read-only item. Implementation
-varies from provider to provider. For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
-Even using the **Force** parameter, the cmdlet cannot override security restrictions.
+varies from provider to provider. Even using the **Force** parameter, the cmdlet cannot override
+security restrictions.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
@@ -151,6 +151,11 @@ Mode                LastWriteTime         Length Name
 -a----         5/1/2020   8:32 AM              0 TestFile.txt
 ```
 
+> [!NOTE]
+> When using `New-Item` with the `-FOrce` switch to create registry keys, the command will behave
+> the same as when overwriting a file. If the registry key already exists, the key and all
+> properties and values will be overwritten with an empty registry key.
+
 ## PARAMETERS
 
 ### -Credential

--- a/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
@@ -105,6 +105,52 @@ you can use it to create multiple items.
 New-Item -ItemType "file" -Path "c:\ps-test\test.txt", "c:\ps-test\Logs\test.log"
 ```
 
+### Example 6: Use the -Force parameter to attempt to recreate folders
+
+This example creates a folder with a file inside. Then, attempts to create the same folder using
+`-Force`. It will not overwrite the folder but simply return the existing folder object with the
+file created intact.
+
+```powershell
+PS> New-Item -Path .\TestFolder -ItemType Directory
+PS> New-Item -Path .\TestFolder\TestFile.txt -ItemType File
+
+PS> New-Item -Path .\TestFolder -ItemType Directory -Force
+
+    Directory: C:\
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+d-----         5/1/2020   8:03 AM                TestFolder
+
+PS> Get-ChildItem .\TestFolder\
+
+    Directory: C:\TestFolder
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----         5/1/2020   8:03 AM              0 TestFile.txt
+```
+
+### Example 7: Use the -Force parameter to overwrite existing files
+
+This example creates a file with a value and then recreates the file using `-Force`. This overwrites
+The existing file and it will lose it's content as you can see by the length property
+
+```powershell
+PS> New-Item ./TestFile.txt -ItemType File -Value 'This is just a test file'
+
+    Directory: C:\Source\Test
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----         5/1/2020   8:32 AM             24 TestFile.txt
+
+New-Item ./TestFile.txt -ItemType File -Force
+
+    Directory: C:\Source\Test
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----         5/1/2020   8:32 AM              0 TestFile.txt
+```
+
 ## PARAMETERS
 
 ### -Credential

--- a/reference/6/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/6/Microsoft.PowerShell.Management/New-Item.md
@@ -155,6 +155,52 @@ SymbolicLink {.\Notice.txt}
 In this example, **Target** is an alias for the **Value** parameter. The target of the symbolic link
 can be a relative path. Prior to PowerShell v6.2, the target must be a fully-qualified path.
 
+### Example 8: Use the -Force parameter to attempt to recreate folders
+
+This example creates a folder with a file inside. Then, attempts to create the same folder using
+`-Force`. It will not overwrite the folder but simply return the existing folder object with the
+file created intact.
+
+```powershell
+PS> New-Item -Path .\TestFolder -ItemType Directory
+PS> New-Item -Path .\TestFolder\TestFile.txt -ItemType File
+
+PS> New-Item -Path .\TestFolder -ItemType Directory -Force
+
+    Directory: C:\
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+d-----         5/1/2020   8:03 AM                TestFolder
+
+PS> Get-ChildItem .\TestFolder\
+
+    Directory: C:\TestFolder
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----         5/1/2020   8:03 AM              0 TestFile.txt
+```
+
+### Example 9: Use the -Force parameter to overwrite existing files
+
+This example creates a file with a value and then recreates the file using `-Force`. This overwrites
+The existing file and it will lose it's content as you can see by the length property
+
+```powershell
+PS> New-Item ./TestFile.txt -ItemType File -Value 'This is just a test file'
+
+    Directory: C:\Source\Test
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----         5/1/2020   8:32 AM             24 TestFile.txt
+
+New-Item ./TestFile.txt -ItemType File -Force
+
+    Directory: C:\Source\Test
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----         5/1/2020   8:32 AM              0 TestFile.txt
+```
+
 ## PARAMETERS
 
 ### -Credential

--- a/reference/6/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/6/Microsoft.PowerShell.Management/New-Item.md
@@ -202,7 +202,7 @@ Mode                LastWriteTime         Length Name
 ```
 
 > [!NOTE]
-> When using `New-Item` with the `-FOrce` switch to create registry keys, the command will behave
+> When using `New-Item` with the `-Force` switch to create registry keys, the command will behave
 > the same as when overwriting a file. If the registry key already exists, the key and all
 > properties and values will be overwritten with an empty registry key.
 
@@ -229,8 +229,8 @@ Accept wildcard characters: False
 ### -Force
 
 Forces this cmdlet to create an item that writes over an existing read-only item. Implementation
-varies from provider to provider. For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
-Even using the **Force** parameter, the cmdlet cannot override security restrictions.
+varies from provider to provider. Even using the **Force** parameter, the cmdlet cannot override
+security restrictions.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/6/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/6/Microsoft.PowerShell.Management/New-Item.md
@@ -201,6 +201,11 @@ Mode                LastWriteTime         Length Name
 -a----         5/1/2020   8:32 AM              0 TestFile.txt
 ```
 
+> [!NOTE]
+> When using `New-Item` with the `-FOrce` switch to create registry keys, the command will behave
+> the same as when overwriting a file. If the registry key already exists, the key and all
+> properties and values will be overwritten with an empty registry key.
+
 ## PARAMETERS
 
 ### -Credential

--- a/reference/7.0/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/New-Item.md
@@ -155,6 +155,52 @@ SymbolicLink {.\Notice.txt}
 In this example, **Target** is an alias for the **Value** parameter. The target of the symbolic link
 can be a relative path. Prior to PowerShell v6.2, the target must be a fully-qualified path.
 
+### Example 8: Use the -Force parameter to attempt to recreate folders
+
+This example creates a folder with a file inside. Then, attempts to create the same folder using
+`-Force`. It will not overwrite the folder but simply return the existing folder object with the
+file created intact.
+
+```powershell
+PS> New-Item -Path .\TestFolder -ItemType Directory
+PS> New-Item -Path .\TestFolder\TestFile.txt -ItemType File
+
+PS> New-Item -Path .\TestFolder -ItemType Directory -Force
+
+    Directory: C:\
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+d-----         5/1/2020   8:03 AM                TestFolder
+
+PS> Get-ChildItem .\TestFolder\
+
+    Directory: C:\TestFolder
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----         5/1/2020   8:03 AM              0 TestFile.txt
+```
+
+### Example 9: Use the -Force parameter to overwrite existing files
+
+This example creates a file with a value and then recreates the file using `-Force`. This overwrites
+The existing file and it will lose it's content as you can see by the length property
+
+```powershell
+PS> New-Item ./TestFile.txt -ItemType File -Value 'This is just a test file'
+
+    Directory: C:\Source\Test
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----         5/1/2020   8:32 AM             24 TestFile.txt
+
+New-Item ./TestFile.txt -ItemType File -Force
+
+    Directory: C:\Source\Test
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----         5/1/2020   8:32 AM              0 TestFile.txt
+```
+
 ## PARAMETERS
 
 ### -Credential

--- a/reference/7.0/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/New-Item.md
@@ -202,7 +202,7 @@ Mode                LastWriteTime         Length Name
 ```
 
 > [!NOTE]
-> When using `New-Item` with the `-FOrce` switch to create registry keys, the command will behave
+> When using `New-Item` with the `-Force` switch to create registry keys, the command will behave
 > the same as when overwriting a file. If the registry key already exists, the key and all
 > properties and values will be overwritten with an empty registry key.
 
@@ -229,8 +229,8 @@ Accept wildcard characters: False
 ### -Force
 
 Forces this cmdlet to create an item that writes over an existing read-only item. Implementation
-varies from provider to provider. For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
-Even using the **Force** parameter, the cmdlet cannot override security restrictions.
+varies from provider to provider. Even using the **Force** parameter, the cmdlet cannot override
+security restrictions.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/7.0/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/New-Item.md
@@ -201,6 +201,11 @@ Mode                LastWriteTime         Length Name
 -a----         5/1/2020   8:32 AM              0 TestFile.txt
 ```
 
+> [!NOTE]
+> When using `New-Item` with the `-FOrce` switch to create registry keys, the command will behave
+> the same as when overwriting a file. If the registry key already exists, the key and all
+> properties and values will be overwritten with an empty registry key.
+
 ## PARAMETERS
 
 ### -Credential

--- a/reference/7.1/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/New-Item.md
@@ -155,6 +155,52 @@ SymbolicLink {.\Notice.txt}
 In this example, **Target** is an alias for the **Value** parameter. The target of the symbolic link
 can be a relative path. Prior to PowerShell v6.2, the target must be a fully-qualified path.
 
+### Example 8: Use the -Force parameter to attempt to recreate folders
+
+This example creates a folder with a file inside. Then, attempts to create the same folder using
+`-Force`. It will not overwrite the folder but simply return the existing folder object with the
+file created intact.
+
+```powershell
+PS> New-Item -Path .\TestFolder -ItemType Directory
+PS> New-Item -Path .\TestFolder\TestFile.txt -ItemType File
+
+PS> New-Item -Path .\TestFolder -ItemType Directory -Force
+
+    Directory: C:\
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+d-----         5/1/2020   8:03 AM                TestFolder
+
+PS> Get-ChildItem .\TestFolder\
+
+    Directory: C:\TestFolder
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----         5/1/2020   8:03 AM              0 TestFile.txt
+```
+
+### Example 9: Use the -Force parameter to overwrite existing files
+
+This example creates a file with a value and then recreates the file using `-Force`. This overwrites
+The existing file and it will lose it's content as you can see by the length property
+
+```powershell
+PS> New-Item ./TestFile.txt -ItemType File -Value 'This is just a test file'
+
+    Directory: C:\Source\Test
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----         5/1/2020   8:32 AM             24 TestFile.txt
+
+New-Item ./TestFile.txt -ItemType File -Force
+
+    Directory: C:\Source\Test
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----         5/1/2020   8:32 AM              0 TestFile.txt
+```
+
 ## PARAMETERS
 
 ### -Credential

--- a/reference/7.1/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/New-Item.md
@@ -202,7 +202,7 @@ Mode                LastWriteTime         Length Name
 ```
 
 > [!NOTE]
-> When using `New-Item` with the `-FOrce` switch to create registry keys, the command will behave
+> When using `New-Item` with the `-Force` switch to create registry keys, the command will behave
 > the same as when overwriting a file. If the registry key already exists, the key and all
 > properties and values will be overwritten with an empty registry key.
 
@@ -229,8 +229,8 @@ Accept wildcard characters: False
 ### -Force
 
 Forces this cmdlet to create an item that writes over an existing read-only item. Implementation
-varies from provider to provider. For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
-Even using the **Force** parameter, the cmdlet cannot override security restrictions.
+varies from provider to provider. Even using the **Force** parameter, the cmdlet cannot override
+security restrictions.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/7.1/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/New-Item.md
@@ -201,6 +201,11 @@ Mode                LastWriteTime         Length Name
 -a----         5/1/2020   8:32 AM              0 TestFile.txt
 ```
 
+> [!NOTE]
+> When using `New-Item` with the `-FOrce` switch to create registry keys, the command will behave
+> the same as when overwriting a file. If the registry key already exists, the key and all
+> properties and values will be overwritten with an empty registry key.
+
 ## PARAMETERS
 
 ### -Credential

--- a/reference/docs-conceptual/samples/Working-with-Files-and-Folders.md
+++ b/reference/docs-conceptual/samples/Working-with-Files-and-Folders.md
@@ -5,25 +5,35 @@ title:  Working with Files and Folders
 ---
 # Working with Files and Folders
 
-Navigating through Windows PowerShell drives and manipulating the items on them is similar to manipulating files and folders on Windows physical disk drives. This section discusses how to deal with specific file and folder manipulation tasks using PowerShell.
+Navigating through Windows PowerShell drives and manipulating the items on them is similar to
+manipulating files and folders on Windows physical disk drives. This section discusses how to deal
+with specific file and folder manipulation tasks using PowerShell.
 
 ## Listing All the Files and Folders Within a Folder
 
-You can get all items directly within a folder by using **Get-ChildItem**. Add the optional **Force** parameter to display hidden or system items. For example, this command displays the direct contents of Windows PowerShell Drive C (which is the same as the Windows physical drive C):
+You can get all items directly within a folder by using `Get-ChildItem`. Add the optional
+**Force** parameter to display hidden or system items. For example, this command displays the direct
+contents of Windows PowerShell Drive C (which is the same as the Windows physical drive C):
 
 ```powershell
 Get-ChildItem -Path C:\ -Force
 ```
 
-The command lists only the directly contained items, much like using Cmd.exe's **DIR** command or **ls** in a UNIX shell. In order to show contained items, you need to specify the **-Recurse** parameter as well. (This can take an extremely long time to complete.) To list everything on the C drive:
+The command lists only the directly contained items, much like using `Cmd.exe`'s `DIR` command or
+`ls` in a UNIX shell. In order to show contained items, you need to specify the `-Recurse`
+parameter as well. (This can take an extremely long time to complete.) To list everything on the C
+drive:
 
 ```powershell
 Get-ChildItem -Path C:\ -Force -Recurse
 ```
 
-**Get-ChildItem** can filter items with its **Path**, **Filter**, **Include**, and **Exclude** parameters, but those are typically based only on name. You can perform complex filtering based on other properties of items by using **Where-Object**.
+`Get-ChildItem` can filter items with its **Path**, **Filter**, **Include**, and **Exclude**
+parameters, but those are typically based only on name. You can perform complex filtering based on
+other properties of items by using `Where-Object`.
 
-The following command finds all executables within the Program Files folder that were last modified after October 1, 2005 and which are neither smaller than 1 megabyte nor larger than 10 megabytes:
+The following command finds all executables within the Program Files folder that were last modified
+after October 1, 2005 and which are neither smaller than 1 megabyte nor larger than 10 megabytes:
 
 ```powershell
 Get-ChildItem -Path $env:ProgramFiles -Recurse -Include *.exe | Where-Object -FilterScript {($_.LastWriteTime -gt '2005-10-01') -and ($_.Length -ge 1mb) -and ($_.Length -le 10mb)}
@@ -31,13 +41,14 @@ Get-ChildItem -Path $env:ProgramFiles -Recurse -Include *.exe | Where-Object -Fi
 
 ## Copying Files and Folders
 
-Copying is done with **Copy-Item**. The following command backs up C:\\boot.ini to C:\\boot.bak:
+Copying is done with `Copy-Item`. The following command backs up C:\\boot.ini to C:\\boot.bak:
 
 ```powershell
 Copy-Item -Path C:\boot.ini -Destination C:\boot.bak
 ```
 
-If the destination file already exists, the copy attempt fails. To overwrite a pre-existing destination, use the **Force** parameter:
+If the destination file already exists, the copy attempt fails. To overwrite a pre-existing
+destination, use the **Force** parameter:
 
 ```powershell
 Copy-Item -Path C:\boot.ini -Destination C:\boot.bak -Force
@@ -45,19 +56,23 @@ Copy-Item -Path C:\boot.ini -Destination C:\boot.bak -Force
 
 This command works even when the destination is read-only.
 
-Folder copying works the same way. This command copies the folder C:\\temp\\test1 to the new folder C:\\temp\\DeleteMe recursively:
+Folder copying works the same way. This command copies the folder `C:\temp\test1` to the new folder
+`C:\temp\DeleteMe` recursively:
 
 ```powershell
 Copy-Item C:\temp\test1 -Recurse C:\temp\DeleteMe
 ```
 
-You can also copy a selection of items. The following command copies all .txt files contained anywhere in c:\\data to c:\\temp\\text:
+You can also copy a selection of items. The following command copies all .txt files contained
+anywhere in `C:\data` to `C:\temp\text`:
 
 ```powershell
 Copy-Item -Filter *.txt -Path c:\data -Recurse -Destination C:\temp\text
 ```
 
-You can still use other tools to perform file system copies. XCOPY, ROBOCOPY, and COM objects, such as the **Scripting.FileSystemObject,** all work in Windows PowerShell. For example, you can use the Windows Script Host **Scripting.FileSystem COM** class to back up C:\\boot.ini to C:\\boot.bak:
+You can still use other tools to perform file system copies. XCOPY, ROBOCOPY, and COM objects, such
+as the **Scripting.FileSystemObject,** all work in Windows PowerShell. For example, you can use the
+Windows Script Host **Scripting.FileSystem COM** class to back up `C:\boot.ini` to `C:\boot.bak`:
 
 ```powershell
 (New-Object -ComObject Scripting.FileSystemObject).CopyFile('C:\boot.ini', 'C:\boot.bak')
@@ -65,29 +80,40 @@ You can still use other tools to perform file system copies. XCOPY, ROBOCOPY, an
 
 ## Creating Files and Folders
 
-Creating new items works the same on all Windows PowerShell providers. If a Windows PowerShell provider has more than one type of item—for example, the FileSystem Windows PowerShell provider distinguishes between directories and files—you need to specify the item type.
+Creating new items works the same on all Windows PowerShell providers. If a Windows PowerShell
+provider has more than one type of item—for example, the FileSystem Windows PowerShell provider
+distinguishes between directories and files—you need to specify the item type.
 
-This command creates a new folder C:\\temp\\New Folder:
+This command creates a new folder `C:\temp\New Folder`:
 
 ```powershell
 New-Item -Path 'C:\temp\New Folder' -ItemType Directory
 ```
 
-This command creates a new empty file C:\\temp\\New Folder\\file.txt
+This command creates a new empty file `C:\temp\New Folder\file.txt`
 
 ```powershell
 New-Item -Path 'C:\temp\New Folder\file.txt' -ItemType File
 ```
 
+> [!IMPORTANT]
+> When using the **Force** switch with the `New-Item` command to create a folder, and the folder
+> already exists, it _won't_ overwrite or replace the folder. It will simply return the existing
+> folder object. However, if you use `New-Item -Force` on a file that already exists, the file _will_
+> be completely overwritten.
+
 ## Removing All Files and Folders Within a Folder
 
-You can remove contained items using **Remove-Item**, but you will be prompted to confirm the removal if the item contains anything else. For example, if you attempt to delete the folder C:\\temp\\DeleteMe that contains other items, Windows PowerShell prompts you for confirmation before deleting the folder:
+You can remove contained items using `Remove-Item`, but you will be prompted to confirm the
+removal if the item contains anything else. For example, if you attempt to delete the folder
+`C:\temp\DeleteMe` that contains other items, Windows PowerShell prompts you for confirmation before
+deleting the folder:
 
 ```
 Remove-Item -Path C:\temp\DeleteMe
 
 Confirm
-The item at C:\temp\DeleteMe has children and the -recurse parameter was not
+The item at C:\temp\DeleteMe has children and the Recurse parameter was not
 specified. If you continue, all children will be removed with the item. Are you
 sure you want to continue?
 [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help
@@ -102,19 +128,23 @@ Remove-Item -Path C:\temp\DeleteMe -Recurse
 
 ## Mapping a Local Folder as a drive
 
-You can also map a local folder, using the **New-PSDrive** command. The following command creates a local drive P: rooted in the local Program Files directory, visible only from the PowerShell session:
+You can also map a local folder, using the `New-PSDrive` command. The following command creates a
+local drive `P:` rooted in the local Program Files directory, visible only from the PowerShell
+session:
 
 ```powershell
 New-PSDrive -Name P -Root $env:ProgramFiles -PSProvider FileSystem
 ```
 
-Just as with network drives, drives mapped within Windows PowerShell are immediately visible to the Windows PowerShell shell.
-In order to create a mapped drive visible from File Explorer, the parameter **-Persist** is needed. However, only remote paths can be used with Persist.
-
+Just as with network drives, drives mapped within Windows PowerShell are immediately visible to the
+Windows PowerShell shell. In order to create a mapped drive visible from File Explorer, the
+parameter `-Persist` is needed. However, only remote paths can be used with Persist.
 
 ## Reading a Text File into an Array
 
-One of the more common storage formats for text data is in a file with separate lines treated as distinct data elements. The **Get-Content** cmdlet can be used to read an entire file in one step, as shown here:
+One of the more common storage formats for text data is in a file with separate lines treated as
+distinct data elements. The `Get-Content` cmdlet can be used to read an entire file in one step,
+as shown here:
 
 ```
 PS> Get-Content -Path C:\boot.ini
@@ -128,17 +158,21 @@ multi(0)disk(0)rdisk(0)partition(1)\WINDOWS=" Microsoft Windows XP Professional
 with Data Execution Prevention" /noexecute=optin /fastdetect
 ```
 
-**Get-Content** already treats the data read from the file as an array, with one element per line of file content. You can confirm this by checking the **Length** of the returned content:
+`Get-Content` already treats the data read from the file as an array, with one element per line of
+file content. You can confirm this by checking the **Length** of the returned content:
 
 ```
 PS> (Get-Content -Path C:\boot.ini).Length
 6
 ```
 
-This command is most useful for getting lists of information into Windows PowerShell directly. For example, you might store a list of computer names or IP addresses in a file C:\\temp\\domainMembers.txt, with one name on each line of the file. You can use **Get-Content** to retrieve the file contents and put them in the variable **$Computers**:
+This command is most useful for getting lists of information into Windows PowerShell directly. For
+example, you might store a list of computer names or IP addresses in a file
+`C:\temp\domainMembers.txt`, with one name on each line of the file. You can use `Get-Content` to
+retrieve the file contents and put them in the variable `$Computers`:
 
 ```powershell
 $Computers = Get-Content -Path C:\temp\DomainMembers.txt
 ```
 
-**$Computers** is now an array containing a computer name in each element.
+`$Computers` is now an array containing a computer name in each element.


### PR DESCRIPTION
# PR Summary
Customer noted that there was inadequate documentation about creating folders with `New-Item` and the **Force** parameter. This this should add clarity for future reference.

## PR Context

Fixes #4870 
Fixes [AB#1715078](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1715078)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
