### PR TITLE
FIXES #4292 Adds link to about_Using

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -834,7 +834,7 @@ class MyComparableBar : bar, System.IComparable
 
 `Import-Module` and the `#requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes are not imported. The
-`using module` statement imports the classes defined in the module. If the
+[using module](./about_Using) statement imports the classes defined in the module. If the
 module isn't loaded in the current session, the `using` statement fails.
 
 ## The PSReference type is not supported with class members

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -834,8 +834,9 @@ class MyComparableBar : bar, System.IComparable
 
 `Import-Module` and the `#requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes are not imported. The
-[using module](./about_Using) statement imports the classes defined in the module. If the
-module isn't loaded in the current session, the `using` statement fails.
+`using module` statement imports the classes defined in the module. If the
+module isn't loaded in the current session, the `using` statement fails. For
+more information about the `using` statement, see [about_Using](about_Using).
 
 ## The PSReference type is not supported with class members
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -836,7 +836,7 @@ class MyComparableBar : bar, System.IComparable
 aliases, and variables, as defined by the module. Classes are not imported. The
 `using module` statement imports the classes defined in the module. If the
 module isn't loaded in the current session, the `using` statement fails. For
-more information about the `using` statement, see [about_Using](about_Using).
+more information about the `using` statement, see [about_Using](about_Using.md).
 
 ## The PSReference type is not supported with class members
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -834,7 +834,7 @@ class MyComparableBar : bar, System.IComparable
 
 `Import-Module` and the `#requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes are not imported. The
-`using module` statement imports the classes defined in the module. If the
+[using module](./about_Using) statement imports the classes defined in the module. If the
 module isn't loaded in the current session, the `using` statement fails.
 
 ## The PSReference type is not supported with class members

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -834,8 +834,9 @@ class MyComparableBar : bar, System.IComparable
 
 `Import-Module` and the `#requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes are not imported. The
-[using module](./about_Using) statement imports the classes defined in the module. If the
-module isn't loaded in the current session, the `using` statement fails.
+`using module` statement imports the classes defined in the module. If the
+module isn't loaded in the current session, the `using` statement fails. For
+more information about the `using` statement, see [about_Using](about_Using).
 
 ## The PSReference type is not supported with class members
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -836,7 +836,7 @@ class MyComparableBar : bar, System.IComparable
 aliases, and variables, as defined by the module. Classes are not imported. The
 `using module` statement imports the classes defined in the module. If the
 module isn't loaded in the current session, the `using` statement fails. For
-more information about the `using` statement, see [about_Using](about_Using).
+more information about the `using` statement, see [about_Using](about_Using.md).
 
 ## The PSReference type is not supported with class members
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -834,7 +834,7 @@ class MyComparableBar : bar, System.IComparable
 
 `Import-Module` and the `#requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes are not imported. The
-`using module` statement imports the classes defined in the module. If the
+[using module](./about_Using) statement imports the classes defined in the module. If the
 module isn't loaded in the current session, the `using` statement fails.
 
 ## The PSReference type is not supported with class members

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -834,8 +834,9 @@ class MyComparableBar : bar, System.IComparable
 
 `Import-Module` and the `#requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes are not imported. The
-[using module](./about_Using) statement imports the classes defined in the module. If the
-module isn't loaded in the current session, the `using` statement fails.
+`using module` statement imports the classes defined in the module. If the
+module isn't loaded in the current session, the `using` statement fails. For
+more information about the `using` statement, see [about_Using](about_Using).
 
 ## The PSReference type is not supported with class members
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -836,7 +836,7 @@ class MyComparableBar : bar, System.IComparable
 aliases, and variables, as defined by the module. Classes are not imported. The
 `using module` statement imports the classes defined in the module. If the
 module isn't loaded in the current session, the `using` statement fails. For
-more information about the `using` statement, see [about_Using](about_Using).
+more information about the `using` statement, see [about_Using](about_Using.md).
 
 ## The PSReference type is not supported with class members
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -834,7 +834,7 @@ class MyComparableBar : bar, System.IComparable
 
 `Import-Module` and the `#requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes are not imported. The
-`using module` statement imports the classes defined in the module. If the
+[using module](./about_Using) statement imports the classes defined in the module. If the
 module isn't loaded in the current session, the `using` statement fails.
 
 ## The PSReference type is not supported with class members

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -834,8 +834,9 @@ class MyComparableBar : bar, System.IComparable
 
 `Import-Module` and the `#requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes are not imported. The
-[using module](./about_Using) statement imports the classes defined in the module. If the
-module isn't loaded in the current session, the `using` statement fails.
+`using module` statement imports the classes defined in the module. If the
+module isn't loaded in the current session, the `using` statement fails. For
+more information about the `using` statement, see [about_Using](about_Using).
 
 ## The PSReference type is not supported with class members
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -836,7 +836,7 @@ class MyComparableBar : bar, System.IComparable
 aliases, and variables, as defined by the module. Classes are not imported. The
 `using module` statement imports the classes defined in the module. If the
 module isn't loaded in the current session, the `using` statement fails. For
-more information about the `using` statement, see [about_Using](about_Using).
+more information about the `using` statement, see [about_Using](about_Using.md).
 
 ## The PSReference type is not supported with class members
 


### PR DESCRIPTION
# PR Summary

Customer thought it would be good to have an example of importing class modules. However, after discussion, this is beyond the scope of this doc and may be added to another later on, but adding a link to the about_Using article will be helpful. 

## PR Context

Fixes #4292 
Fixes [AB#1718348](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1718348)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
