### PR TITLE
FIXES #5896 - Updates Set-Clipboard

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -190,7 +190,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
+In rare cases when using `Set-Clipboard` with a high number of values in rapid succession, like in a
+loop, you might sporadically get a blank value from the clipboard. This can be fixed by using
+`Start-Sleep -Milliseconds 1` in the loop.
+
 ## RELATED LINKS
 
 [Get-Clipboard](Get-Clipboard.md)
-

--- a/reference/7.0/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -98,6 +98,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
+In rare cases when using `Set-Clipboard` with a high number of values in rapid succession, like in a
+loop, you might sporadically get a blank value from the clipboard. This can be fixed by using
+`Start-Sleep -Milliseconds 1` in the loop.
+
 ## RELATED LINKS
 
 [Get-Clipboard](Get-Clipboard.md)

--- a/reference/7.1/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -98,6 +98,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
+In rare cases when using `Set-Clipboard` with a high number of values in rapid succession, like in a
+loop, you might sporadically get a blank value from the clipboard. This can be fixed by using
+`Start-Sleep -Milliseconds 1` in the loop.
+
 ## RELATED LINKS
 
 [Get-Clipboard](Get-Clipboard.md)


### PR DESCRIPTION
# PR Summary

There is behavior in the .NET framework clipboard that could cause the clipboard to be flushed when being set a high number of times rapidly like in a loop. Adds, this information as well as a mitigation in the notes section.

## PR Context

Fixes #5896 
Fixes [AB#1718616](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1718616)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [ ] Version 6 content
- [x] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
