### PR TITLE
Fixes #5897 - Sets powershell.exe to always 5.1 content

### DIFF
--- a/reference/docs-conceptual/components/console/PowerShell.exe-Command-Line-Help.md
+++ b/reference/docs-conceptual/components/console/PowerShell.exe-Command-Line-Help.md
@@ -10,6 +10,6 @@ You can use command line options to run PowerShell from the command line of anot
 
 The command line options allow you to customize the configuration of the PowerShell session and control the input.
 
-For a full list of options for Windows PowerShell (powershell.exe), see [about_PowerShell_exe](/powershell/module/Microsoft.PowerShell.Core/About/about_PowerShell_exe).
+For a full list of options for Windows PowerShell (powershell.exe), see [about_PowerShell_exe](/powershell/module/Microsoft.PowerShell.Core/About/about_PowerShell_exe?view=powershell-5.1).
 
 For a full list of options for PowerShell Core (pwsh), see [about_pwsh](/powershell/module/Microsoft.PowerShell.Core/About/about_pwsh).


### PR DESCRIPTION
# PR Summary
Fixes [AB#1718827](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1718827)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [X] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
