### PR TITLE
Add details on Ubuntu 20.04 support to fix #5906

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
@@ -177,7 +177,9 @@ Installation is supported via `snapd`. For instructions, see [Snap Package][snap
 
 ## Ubuntu 20.04
 
-Ubuntu 20.04 which is an LTS release & PowerShell is not currently supported on this version, although support for this version is being considered for the 7.1 release of PowerShell. Please upvote this request if you would like 20.04 support https://github.com/PowerShell/PowerShell/issues/12626 
+Ubuntu 20.04 is an LTS release. PowerShell does not currently support this version. Support for this
+version is being considered for the PowerShell 7.1 release. Please upvote this [request](https://github.com/PowerShell/PowerShell/issues/12626)
+if you would like support for Ubuntu 20.04.
 
 ## Debian 8
 

--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Linux.md
@@ -54,6 +54,10 @@ Alternate install methods
 - Binary Archives
 - .NET Global tool
 
+Not currently supported 
+
+- Ubuntu 20.04
+
 ## Ubuntu 16.04
 
 ### Installation via Package Repository - Ubuntu 16.04
@@ -170,6 +174,10 @@ Installation is supported via `snapd`. For instructions, see [Snap Package][snap
 
 > [!NOTE]
 > Ubuntu 19.04 is an [interim release](https://www.ubuntu.com/about/release-cycle) that's [community supported](../powershell-support-lifecycle.md).
+
+## Ubuntu 20.04
+
+Ubuntu 20.04 which is an LTS release & PowerShell is not currently supported on this version, although support for this version is being considered for the 7.1 release of PowerShell. Please upvote this request if you would like 20.04 support https://github.com/PowerShell/PowerShell/issues/12626 
 
 ## Debian 8
 


### PR DESCRIPTION
# PR Summary
Fixes #5906 by adding a placeholder for eventual Ubuntu 20.04 support and details that 20.04 is not a currently supported release

## PR Context
There is no information on Ubuntu 20.04 support (or current lack of it) & therefore it makes sense to add at least some information so that users understand the current situation for this distribution

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [x] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
