### PR TITLE
Add example for using parameters and variables in Script resource

### DIFF
--- a/reference/docs-conceptual/dsc/reference/resources/windows/scriptResource.md
+++ b/reference/docs-conceptual/dsc/reference/resources/windows/scriptResource.md
@@ -154,9 +154,10 @@ Configuration ScriptTest
 
 ### Example 3: Utilizing parameters in a Script resource
 
-This example accesses parameters from within the Script resource by making use of the using-scope. Please note that ConfigurationData can be
-accessed in a similar way. Like example 2, a version is expected to be stored inside a local file on the target node. Both the local
-file path as well as the version are configurable however, decoupling code from configuration data.
+This example accesses parameters from within the Script resource by making use of the using-scope.
+Please note that ConfigurationData can be accessed in a similar way. Like example 2, a version is
+expected to be stored inside a local file on the target node. Both the local file path as well as
+the version are configurable however, decoupling code from configuration data.
 
 ```powershell
 Configuration ScriptTest
@@ -201,8 +202,9 @@ Configuration ScriptTest
 }
 ```
 
-The resulting MOF file include the variables and their values accessed through the using-scope. They are injected into each scriptblock which
-uses the variables (Test and Set scripts removed for brevity):
+The resulting MOF file include the variables and their values accessed through the using-scope.
+They are injected into each scriptblock which uses the variables
+(Test and Set scripts removed for brevity):
 
 ```code
 instance of MSFT_ScriptResource as $MSFT_ScriptResource1ref

--- a/reference/docs-conceptual/dsc/reference/resources/windows/scriptResource.md
+++ b/reference/docs-conceptual/dsc/reference/resources/windows/scriptResource.md
@@ -151,3 +151,64 @@ Configuration ScriptTest
     }
 }
 ```
+
+### Example 3: Utilizing parameters in a Script resource
+
+This example accesses parameters from within the Script resource by making use of the using-scope. Please note that ConfigurationData can be
+accessed in a similar way. Like example 2, a version is expected to be stored inside a local file on the target node. Both the local
+file path as well as the version are configurable however, decoupling code from configuration data.
+
+```powershell
+Configuration ScriptTest
+{
+    param
+    (
+        [Version]
+        $Version,
+
+        [string]
+        $FilePath
+    )
+
+    Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
+
+    Node localhost
+    {
+        Script UpdateConfigurationVersion
+        {
+            GetScript = {
+                $currentVersion = Get-Content -Path $using:FilePath
+                return @{ 'Result' = "$currentVersion" }
+            }
+            TestScript = {
+                # Create and invoke a scriptblock using the $GetScript automatic variable, which contains a string representation of the GetScript.
+                $state = [scriptblock]::Create($GetScript).Invoke()
+
+                if( $state['Result'] -eq $using:Version )
+                {
+                    Write-Verbose -Message ('{0} -eq {1}' -f $state['Result'],$using:version)
+                    return $true
+                }
+
+                Write-Verbose -Message ('Version up-to-date: {0}' -f $using:version)
+                return $false
+            }
+            SetScript = {
+                Set-Content -Path $using:FilePath -Value $using:Version
+            }
+        }
+    }
+}
+```
+
+The resulting MOF file include the variables and their values accessed through the using-scope. They are injected into each scriptblock which
+uses the variables (Test and Set scripts removed for brevity):
+
+```code
+instance of MSFT_ScriptResource as $MSFT_ScriptResource1ref
+{
+ GetScript = "$FilePath ='C:\\Config.ini'\n\n $currentVersion = Get-Content -Path $FilePath\n return @{ 'Result' = \"$currentVersion\" }\n";
+ TestScript = ...;
+ SetScript = ...;
+};
+```

--- a/reference/docs-conceptual/dsc/reference/resources/windows/scriptResource.md
+++ b/reference/docs-conceptual/dsc/reference/resources/windows/scriptResource.md
@@ -154,10 +154,10 @@ Configuration ScriptTest
 
 ### Example 3: Utilizing parameters in a Script resource
 
-This example accesses parameters from within the Script resource by making use of the using-scope.
-Please note that ConfigurationData can be accessed in a similar way. Like example 2, a version is
-expected to be stored inside a local file on the target node. Both the local file path as well as
-the version are configurable however, decoupling code from configuration data.
+This example accesses parameters from within the Script resource by making use of the `using`
+scope. Please note that **ConfigurationData** can be accessed in a similar way. Like example 2, a
+version is expected to be stored inside a local file on the target node. Both the local file
+path as well as the version are configurable however, decoupling code from configuration data.
 
 ```powershell
 Configuration ScriptTest
@@ -202,11 +202,11 @@ Configuration ScriptTest
 }
 ```
 
-The resulting MOF file includes the variables and their values accessed through the using-scope.
-They are injected into each scriptblock which uses the variables
-(Test and Set scripts removed for brevity):
+The resulting MOF file includes the variables and their values accessed through the `using` scope.
+They are injected into each scriptblock which uses the variables. Test and Set scripts have been
+removed for brevity:
 
-```code
+```Output
 instance of MSFT_ScriptResource as $MSFT_ScriptResource1ref
 {
  GetScript = "$FilePath ='C:\\Config.ini'\n\n $currentVersion = Get-Content -Path $FilePath\n return @{ 'Result' = \"$currentVersion\" }\n";

--- a/reference/docs-conceptual/dsc/reference/resources/windows/scriptResource.md
+++ b/reference/docs-conceptual/dsc/reference/resources/windows/scriptResource.md
@@ -202,7 +202,7 @@ Configuration ScriptTest
 }
 ```
 
-The resulting MOF file include the variables and their values accessed through the using-scope.
+The resulting MOF file includes the variables and their values accessed through the using-scope.
 They are injected into each scriptblock which uses the variables
 (Test and Set scripts removed for brevity):
 


### PR DESCRIPTION
# PR Summary
Added more concise example for using parameters in Script resource in addition to the existing example 2.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [x] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
