### PR TITLE
FIXES #5932 - Rephrase for Convertto-(JSON, CML, HTML, CSV) cmdlets to .NET

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -12,7 +12,7 @@ title: ConvertTo-Csv
 # ConvertTo-Csv
 
 ## SYNOPSIS
-Converts objects into a series of comma-separated value (CSV) strings.
+Converts .NET objects into a series of comma-separated value (CSV) strings.
 
 ## SYNTAX
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -11,7 +11,7 @@ title: ConvertTo-Html
 # ConvertTo-Html
 
 ## SYNOPSIS
-Converts Microsoft .NET Framework objects into HTML that can be displayed in a Web browser.
+Converts .NET objects into HTML that can be displayed in a Web browser.
 
 ## SYNTAX
 
@@ -32,7 +32,7 @@ ConvertTo-Html [-InputObject <PSObject>] [[-Property] <Object[]>] [-As <String>]
 
 ## DESCRIPTION
 
-The `ConvertTo-Html` cmdlet converts .NET Framework objects into HTML that can be displayed in a
+The `ConvertTo-Html` cmdlet converts .NET objects into HTML that can be displayed in a
 Web browser. You can use this cmdlet to display the output of a command in a Web page.
 
 You can use the parameters of `ConvertTo-Html` to select object properties, to specify a table or

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Json.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Json.md
@@ -22,7 +22,7 @@ ConvertTo-Json [-InputObject] <Object> [-Depth <Int32>] [-Compress]
 
 ## DESCRIPTION
 
-The `ConvertTo-Json` cmdlet converts any object to a string in JavaScript Object Notation (JSON)
+The `ConvertTo-Json` cmdlet converts any .NET object to a string in JavaScript Object Notation (JSON)
 format. The properties are converted to field names, the field values are converted to property
 values, and the methods are removed.
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -23,7 +23,7 @@ ConvertTo-Xml [-Depth <Int32>] [-InputObject] <PSObject> [-NoTypeInformation] [-
 ## DESCRIPTION
 
 The `ConvertTo-Xml` cmdlet creates an [XML-based](/dotnet/api/system.xml.xmldocument) representation
-of one or more Microsoft .NET Framework objects. To use this cmdlet, pipe one or more objects to the
+of one or more .NET objects. To use this cmdlet, pipe one or more objects to the
 cmdlet, or use the **InputObject** parameter to specify the object.
 
 When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit

--- a/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -11,7 +11,7 @@ title: ConvertTo-Csv
 # ConvertTo-Csv
 
 ## SYNOPSIS
-Converts objects into a series of character-separated value (CSV) strings.
+Converts .NET objects into a series of character-separated value (CSV) strings.
 
 ## SYNTAX
 

--- a/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -11,7 +11,7 @@ title: ConvertTo-Html
 # ConvertTo-Html
 
 ## SYNOPSIS
-Converts Microsoft .NET Framework objects into HTML that can be displayed in a Web browser.
+Converts .NET objects into HTML that can be displayed in a Web browser.
 
 ## SYNTAX
 
@@ -33,7 +33,7 @@ ConvertTo-Html [-InputObject <PSObject>] [[-Property] <Object[]>] [-As <String>]
 
 ## DESCRIPTION
 
-The `ConvertTo-Html` cmdlet converts .NET Framework objects into HTML that can be displayed in a
+The `ConvertTo-Html` cmdlet converts .NET objects into HTML that can be displayed in a
 Web browser. You can use this cmdlet to display the output of a command in a Web page.
 
 You can use the parameters of `ConvertTo-Html` to select object properties, to specify a table or

--- a/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Json.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Json.md
@@ -23,7 +23,7 @@ ConvertTo-Json [-InputObject] <Object> [-Depth <Int32>] [-Compress]
 
 ## DESCRIPTION
 
-The `ConvertTo-Json` cmdlet converts any object to a string in JavaScript Object Notation (JSON)
+The `ConvertTo-Json` cmdlet converts any .NET object to a string in JavaScript Object Notation (JSON)
 format. The properties are converted to field names, the field values are converted to property
 values, and the methods are removed.
 

--- a/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -23,7 +23,7 @@ ConvertTo-Xml [-Depth <Int32>] [-InputObject] <PSObject> [-NoTypeInformation] [-
 ## DESCRIPTION
 
 The `ConvertTo-Xml` cmdlet creates an [XML-based](/dotnet/api/system.xml.xmldocument) representation
-of one or more Microsoft .NET Framework objects. To use this cmdlet, pipe one or more objects to the
+of one or more more .NET objects. To use this cmdlet, pipe one or more objects to the
 cmdlet, or use the **InputObject** parameter to specify the object.
 
 When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit

--- a/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -12,7 +12,7 @@ title: ConvertTo-Csv
 # ConvertTo-Csv
 
 ## SYNOPSIS
-Converts objects into a series of character-separated value (CSV) strings.
+Converts .NET objects into a series of character-separated value (CSV) strings.
 
 ## SYNTAX
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -11,7 +11,7 @@ title: ConvertTo-Html
 # ConvertTo-Html
 
 ## SYNOPSIS
-Converts Microsoft .NET Framework objects into HTML that can be displayed in a Web browser.
+Converts .NET Framework into HTML that can be displayed in a Web browser.
 
 ## SYNTAX
 
@@ -33,7 +33,7 @@ ConvertTo-Html [-InputObject <PSObject>] [[-Property] <Object[]>] [-As <String>]
 
 ## DESCRIPTION
 
-The `ConvertTo-Html` cmdlet converts .NET Framework objects into HTML that can be displayed in a
+The `ConvertTo-Html` cmdlet converts .NET objects into HTML that can be displayed in a
 Web browser. You can use this cmdlet to display the output of a command in a Web page.
 
 You can use the parameters of `ConvertTo-Html` to select object properties, to specify a table or

--- a/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Json.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Json.md
@@ -23,7 +23,7 @@ ConvertTo-Json [-InputObject] <Object> [-Depth <Int32>] [-Compress]
 
 ## DESCRIPTION
 
-The `ConvertTo-Json` cmdlet converts any object to a string in JavaScript Object Notation (JSON)
+The `ConvertTo-Json` cmdlet converts any .NET object to a string in JavaScript Object Notation (JSON)
 format. The properties are converted to field names, the field values are converted to property
 values, and the methods are removed.
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -23,7 +23,7 @@ ConvertTo-Xml [-Depth <Int32>] [-InputObject] <PSObject> [-NoTypeInformation] [-
 ## DESCRIPTION
 
 The `ConvertTo-Xml` cmdlet creates an [XML-based](/dotnet/api/system.xml.xmldocument) representation
-of one or more Microsoft .NET Framework objects. To use this cmdlet, pipe one or more objects to the
+of one or more more .NET objects. To use this cmdlet, pipe one or more objects to the
 cmdlet, or use the **InputObject** parameter to specify the object.
 
 When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit

--- a/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -12,7 +12,7 @@ title: ConvertTo-Csv
 # ConvertTo-Csv
 
 ## SYNOPSIS
-Converts objects into a series of character-separated value (CSV) strings.
+Converts .NET objects into a series of character-separated value (CSV) strings.
 
 ## SYNTAX
 

--- a/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -11,7 +11,7 @@ title: ConvertTo-Html
 # ConvertTo-Html
 
 ## SYNOPSIS
-Converts Microsoft .NET Framework objects into HTML that can be displayed in a Web browser.
+Converts .NET objects into HTML that can be displayed in a Web browser.
 
 ## SYNTAX
 
@@ -33,7 +33,7 @@ ConvertTo-Html [-InputObject <PSObject>] [[-Property] <Object[]>] [-As <String>]
 
 ## DESCRIPTION
 
-The `ConvertTo-Html` cmdlet converts .NET Framework objects into HTML that can be displayed in a
+The `ConvertTo-Html` cmdlet converts .NET objects into HTML that can be displayed in a
 Web browser. You can use this cmdlet to display the output of a command in a Web page.
 
 You can use the parameters of `ConvertTo-Html` to select object properties, to specify a table or

--- a/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Json.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Json.md
@@ -23,7 +23,7 @@ ConvertTo-Json [-InputObject] <Object> [-Depth <Int32>] [-Compress]
 
 ## DESCRIPTION
 
-The `ConvertTo-Json` cmdlet converts any object to a string in JavaScript Object Notation (JSON)
+The `ConvertTo-Json` cmdlet converts any .NET object to a string in JavaScript Object Notation (JSON)
 format. The properties are converted to field names, the field values are converted to property
 values, and the methods are removed.
 

--- a/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -23,7 +23,7 @@ ConvertTo-Xml [-Depth <Int32>] [-InputObject] <PSObject> [-NoTypeInformation] [-
 ## DESCRIPTION
 
 The `ConvertTo-Xml` cmdlet creates an [XML-based](/dotnet/api/system.xml.xmldocument) representation
-of one or more Microsoft .NET Framework objects. To use this cmdlet, pipe one or more objects to the
+of one or more more .NET objects. To use this cmdlet, pipe one or more objects to the
 cmdlet, or use the **InputObject** parameter to specify the object.
 
 When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit


### PR DESCRIPTION
# PR Summary

Customer noticed that phrasing in some `ConvertTo- `  cmdlets had verbage for Microsoft .NET Framework which isn't platform agnostic. This PR addresses that issue by changing verbage to ".NET" which is platform agnostic as well as adds that verbage to some of the docs to make it more consistent accross the similar docs. 

## PR Context

Fixes #5932 
Fixes [AB#1721204](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1721204)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
