### PR TITLE
Change ParameterSet names to match Import-CSV

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -38,7 +38,7 @@ Export-Csv [-Path] <string> [[-UseCulture]] -InputObject <psobject> [-Force] [-N
 ### DelimiterLiteralPath
 
 ```
-Export-Csv [-LiteralPath] <string> [[-Delimiter] <char>] -InputObject <psobject> [-Force]
+Export-Csv [[-Delimiter] <char>] [-LiteralPath] <string> -InputObject <psobject> [-Force]
  [-NoClobber] [-Encoding <Encoding>] [-Append] [-IncludeTypeInformation] [-NoTypeInformation]
  [-QuoteFields <string[]>] [-UseQuotes {Never | Always | AsNeeded}] [-WhatIf] [-Confirm]
  [<CommonParameters>]
@@ -47,7 +47,7 @@ Export-Csv [-LiteralPath] <string> [[-Delimiter] <char>] -InputObject <psobject>
 ### CultureLiteralPath
 
 ```
-Export-Csv [-LiteralPath] <string> [[-UseCulture]] -InputObject <psobject> [-Force] [-NoClobber]
+Export-Csv [[-UseCulture]] [-LiteralPath] <string> -InputObject <psobject> [-Force] [-NoClobber]
  [-Encoding <Encoding>] [-Append] [-IncludeTypeInformation] [-NoTypeInformation] [-QuoteFields <string[]>]
  [-UseQuotes {Never | Always | AsNeeded}] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
@@ -604,8 +604,8 @@ Type: SwitchParameter
 Parameter Sets: CulturePath, CultureLiteralPath
 Aliases:
 
-Required: False
-Position: Named
+Required: True
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/reference/7.1/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -17,21 +17,39 @@ file.
 
 ## SYNTAX
 
-### Delimiter (Default)
+### DelimiterPath (Default)
 
 ```
-Export-Csv -InputObject <PSObject> [[-Path] <String>] [-LiteralPath <String>] [-Force] [-NoClobber]
- [-Encoding <Encoding>] [-Append] [[-Delimiter] <Char>] [-IncludeTypeInformation]
- [-NoTypeInformation] [-QuoteFields <String[]>] [-UseQuotes <QuoteKind>] [-WhatIf] [-Confirm]
+Export-Csv [-Path] <string> [[-Delimiter] <char>] -InputObject <psobject> [-Force] [-NoClobber]
+ [-Encoding <Encoding>] [-Append] [-IncludeTypeInformation] [-NoTypeInformation]
+ [-QuoteFields <string[]>] [-UseQuotes {Never | Always | AsNeeded}] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
-### UseCulture
+### CulturePath
 
 ```
-Export-Csv -InputObject <PSObject> [[-Path] <String>] [-LiteralPath <String>] [-Force] [-NoClobber]
- [-Encoding <Encoding>] [-Append] [-UseCulture] [-IncludeTypeInformation] [-NoTypeInformation]
- [-QuoteFields <String[]>] [-UseQuotes <QuoteKind>] [-WhatIf] [-Confirm]  [<CommonParameters>]
+Export-Csv [-Path] <string> [[-UseCulture]] -InputObject <psobject> [-Force] [-NoClobber]
+ [-Encoding <Encoding>] [-Append] [-IncludeTypeInformation] [-NoTypeInformation]
+ [-QuoteFields <string[]>] [-UseQuotes {Never | Always | AsNeeded}] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### DelimiterLiteralPath
+
+```
+Export-Csv [-LiteralPath] <string> [[-Delimiter] <char>] -InputObject <psobject> [-Force]
+ [-NoClobber] [-Encoding <Encoding>] [-Append] [-IncludeTypeInformation] [-NoTypeInformation]
+ [-QuoteFields <string[]>] [-UseQuotes {Never | Always | AsNeeded}] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### CultureLiteralPath
+
+```
+Export-Csv [-LiteralPath] <string> [[-UseCulture]] -InputObject <psobject> [-Force] [-NoClobber]
+ [-Encoding <Encoding>] [-Append] [-IncludeTypeInformation] [-NoTypeInformation] [-QuoteFields <string[]>]
+ [-UseQuotes {Never | Always | AsNeeded}] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -407,7 +425,7 @@ character, such as a colon (`:`). To specify a semicolon (`;`), enclose it in qu
 
 ```yaml
 Type: Char
-Parameter Sets: Delimiter
+Parameter Sets: DelimiterPath, DelimiterLiteralPath
 Aliases:
 
 Required: False
@@ -516,10 +534,10 @@ PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: DelimiterLiteralPath, CultureLiteralPath
 Aliases: PSPath, LP
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -566,10 +584,10 @@ A required parameter that specifies the location to save the CSV output file.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: DelimiterPath, CulturePath
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False
@@ -583,7 +601,7 @@ for a culture, use the following command: `(Get-Culture).TextInfo.ListSeparator`
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UseCulture
+Parameter Sets: CulturePath, CultureLiteralPath
 Aliases:
 
 Required: False


### PR DESCRIPTION
- Introduce DelimiterPath as replacement for Delimiter
- Introduce DelimiterLiteralPath
- Introduce CulturePath as replacement for UseCulture
- Introduce CultureLiteralPath

# PR Summary
Change ParameterSet names to match Import-CSV. Path and LiteralPath can no longer be specified at the same time.

## PR Context
Necessary documentation for https://github.com/PowerShell/PowerShell/pull/12715


Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
