### PR TITLE
incorrect_code.md

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -93,7 +93,7 @@ Objects that are piped to `Measure-Command` are available to the script block th
 ```powershell
 # Perform a simple operation to demonstrate the InputObject parameter
 # Note that no output is displayed.
-10, 20, 50 | Measure-Command -Expression { for ($i=0; $i -lt $_ i++) {$i} }
+10, 20, 50 | Measure-Command -Expression { for ($i=0; $i -lt $_; $i++) {$i} }
 ```
 
 ```Output


### PR DESCRIPTION
In Example 3: Piping input to Measure-Command, in the code it misses the ";" and the "$" when calling the $i variable, so if you execute the command, it will throw sintax error

The command should be:
10, 20, 50 | Measure-Command -Expression {for ($i=0; $i -lt $_; $i++) {$i}}

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
