### PR TITLE
Fixes #5979 - Updates Start/Restart-Computer

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/6/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -370,8 +370,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-- `Restart-Computer` only work on computers running Windows and requires WinRM and WMI to shutdown a
-  system, including the local system.
+- `Restart-Computer` only works on computers running Windows and requires WinRM and WMI to shutdown
+  a system, including the local system.
 - `Restart-Computer` uses the [Win32Shutdown method](/windows/desktop/CIMWin32Prov/win32shutdown-method-in-class-win32-operatingsystem)
   of the Windows Management Instrumentation (WMI) [Win32_OperatingSystem](/windows/desktop/CIMWin32Prov/win32-operatingsystem)
   class.

--- a/reference/6/Microsoft.PowerShell.Management/Stop-Computer.md
+++ b/reference/6/Microsoft.PowerShell.Management/Stop-Computer.md
@@ -261,7 +261,8 @@ You can't pipe input to this cmdlet.
 
 ## NOTES
 
-This cmdlet uses the **Win32Shutdown** method of the **Win32_OperatingSystem** WMI class.
+This cmdlet only works on Windows and uses the **Win32Shutdown** method of the
+**Win32_OperatingSystem** WMI class.
 
 ## RELATED LINKS
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -370,8 +370,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-- `Restart-Computer` only work on computers running Windows and requires WinRM and WMI to shutdown a
-  system, including the local system.
+- `Restart-Computer` only works on computers running Windows and requires WinRM and WMI to shutdown
+  a system, including the local system.
 - `Restart-Computer` uses the [Win32Shutdown method](/windows/desktop/CIMWin32Prov/win32shutdown-method-in-class-win32-operatingsystem)
   of the Windows Management Instrumentation (WMI) [Win32_OperatingSystem](/windows/desktop/CIMWin32Prov/win32-operatingsystem)
   class.

--- a/reference/7.0/Microsoft.PowerShell.Management/Stop-Computer.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Stop-Computer.md
@@ -261,7 +261,8 @@ You can't pipe input to this cmdlet.
 
 ## NOTES
 
-This cmdlet uses the **Win32Shutdown** method of the **Win32_OperatingSystem** WMI class.
+This cmdlet only works on Windows and uses the **Win32Shutdown** method of the
+**Win32_OperatingSystem** WMI class.
 
 ## RELATED LINKS
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -370,11 +370,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-- `Restart-Computer` only work on computers running Windows and requires WinRM and WMI to shutdown a
-  system, including the local system.
-- `Restart-Computer` uses the [Win32Shutdown method](/windows/desktop/CIMWin32Prov/win32shutdown-method-in-class-win32-operatingsystem)
+- In Windows, `Restart-Computer` uses the [Win32Shutdown method](/windows/desktop/CIMWin32Prov/win32shutdown-method-in-class-win32-operatingsystem)
   of the Windows Management Instrumentation (WMI) [Win32_OperatingSystem](/windows/desktop/CIMWin32Prov/win32-operatingsystem)
   class.
+- On Linux and Mac OS, `Restart-Computer` uses the `/sbin/shutdown` bash tool.
 
 ## RELATED LINKS
 

--- a/reference/docs-conceptual/whats-new/cmdlet-versions.md
+++ b/reference/docs-conceptual/whats-new/cmdlet-versions.md
@@ -255,7 +255,7 @@ This is a work in progress. Please help us keep this information fresh.
 | Rename-ItemProperty           | &check; | &check; | &check; | &check; |                                  |
 | Reset-ComputerMachinePassword | &check; |         |         |         | Windows only                     |
 | Resolve-Path                  | &check; | &check; | &check; | &check; |                                  |
-| Restart-Computer              | &check; | &check; | &check; | &check; |                                  |
+| Restart-Computer              | &check; | &check; | &check; | &check; | Added Linux/macOS support in 7.1 |
 | Restart-Service               | &check; | &check; | &check; | &check; | Windows only                     |
 | Restore-Computer              | &check; |         |         |         | Windows only                     |
 | Resume-Service                | &check; | &check; | &check; | &check; | Windows only                     |
@@ -273,7 +273,7 @@ This is a work in progress. Please help us keep this information fresh.
 | Start-Process                 | &check; | &check; | &check; | &check; |                                  |
 | Start-Service                 | &check; | &check; | &check; | &check; | Windows only                     |
 | Start-Transaction             | &check; |         |         |         | Windows only                     |
-| Stop-Computer                 | &check; | &check; | &check; | &check; | Added Linux/macOS support in 7.0 |
+| Stop-Computer                 | &check; | &check; | &check; | &check; | Added Linux/macOS support in 7.1 |
 | Stop-Process                  | &check; | &check; | &check; | &check; |                                  |
 | Stop-Service                  | &check; | &check; | &check; | &check; | Windows only                     |
 | Suspend-Service               | &check; | &check; | &check; | &check; | Windows only                     |


### PR DESCRIPTION

# PR Summary

`Restart-Computer` and `Start-Computer` now work in PowerShell 7.1. This removed some misinformation on `Stop-Computer` in PowerShell V 7 docs. 

## PR Context
Fixes #5979 

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [x] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
