### PR TITLE
Fixes $5975 - Adds Support for BigEndianUTF32 support for pwsh 7.1 Cmdlets

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Add-Content.md
@@ -218,6 +218,7 @@ The acceptable values for this parameter are as follows:
 
 - **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
 - **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
+- **BigEndianUTF32**: Encodes in UTF-32 format using the big-endian byte order.
 - **OEM**: Uses the default encoding for MS-DOS and console programs.
 - **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
 - **UTF7**: Encodes in UTF-7 format.
@@ -235,7 +236,7 @@ pages (like `-Encoding 1251`) or string names of registered code pages (like
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
+Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
 
 Required: False
 Position: Named

--- a/reference/7.1/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Get-Content.md
@@ -533,6 +533,7 @@ The acceptable values for this parameter are as follows:
 
 - **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
 - **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
+- **BigEndianUTF32**: Encodes in UTF-32 format using the big-endian byte order.
 - **OEM**: Uses the default encoding for MS-DOS and console programs.
 - **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
 - **UTF7**: Encodes in UTF-7 format.
@@ -559,7 +560,7 @@ pages (like `-Encoding 1251`) or string names of registered code pages (like
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
+Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
 
 Required: False
 Position: Named

--- a/reference/7.1/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Set-Content.md
@@ -196,6 +196,7 @@ The acceptable values for this parameter are as follows:
 
 - **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
 - **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
+- **BigEndianUTF32**: Encodes in UTF-32 format using the big-endian byte order.
 - **OEM**: Uses the default encoding for MS-DOS and console programs.
 - **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
 - **UTF7**: Encodes in UTF-7 format.
@@ -213,7 +214,7 @@ pages (like `-Encoding 1251`) or string names of registered code pages (like
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
+Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
 
 Required: False
 Position: Named

--- a/reference/7.1/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -195,6 +195,7 @@ The acceptable values for this parameter are as follows:
 
 - **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
 - **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
+- **BigEndianUTF32**: Encodes in UTF-32 format using the big-endian byte order.
 - **OEM**: Uses the default encoding for MS-DOS and console programs.
 - **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
 - **UTF7**: Encodes in UTF-7 format.
@@ -212,7 +213,7 @@ pages (like `-Encoding 1251`) or string names of registered code pages (like
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
+Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
 
 Required: False
 Position: Named

--- a/reference/7.1/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -425,6 +425,7 @@ The acceptable values for this parameter are as follows:
 
 - **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
 - **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
+- **BigEndianUTF32**: Encodes in UTF-32 format using the big-endian byte order.
 - **OEM**: Uses the default encoding for MS-DOS and console programs.
 - **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
 - **UTF7**: Encodes in UTF-7 format.
@@ -442,7 +443,7 @@ pages (like `-Encoding 1251`) or string names of registered code pages (like
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
+Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
 
 Required: False
 Position: Named

--- a/reference/7.1/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -288,6 +288,7 @@ The acceptable values for this parameter are as follows:
 
 - **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
 - **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
+- **BigEndianUTF32**: Encodes in UTF-32 format using the big-endian byte order.
 - **OEM**: Uses the default encoding for MS-DOS and console programs.
 - **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
 - **UTF7**: Encodes in UTF-7 format.
@@ -305,7 +306,7 @@ pages (like `-Encoding 1251`) or string names of registered code pages (like
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
+Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
 
 Required: False
 Position: Named

--- a/reference/7.1/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -183,7 +183,7 @@ pages (like `-Encoding 1251`) or string names of registered code pages (like
 Type: Encoding
 Parameter Sets: ByInputObject
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
+Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
 
 Required: False
 Position: Named

--- a/reference/7.1/Microsoft.PowerShell.Utility/Import-Csv.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Import-Csv.md
@@ -340,6 +340,7 @@ The acceptable values for this parameter are as follows:
 
 - **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
 - **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
+- **BigEndianUTF32**: Encodes in UTF-32 format using the big-endian byte order.
 - **OEM**: Uses the default encoding for MS-DOS and console programs.
 - **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
 - **UTF7**: Encodes in UTF-7 format.
@@ -357,7 +358,7 @@ pages (like `-Encoding 1251`) or string names of registered code pages (like
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
+Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
 
 Required: False
 Position: Named

--- a/reference/7.1/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Out-File.md
@@ -158,6 +158,7 @@ The acceptable values for this parameter are as follows:
 
 - **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
 - **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
+- **BigEndianUTF32**: Encodes in UTF-32 format using the big-endian byte order.
 - **OEM**: Uses the default encoding for MS-DOS and console programs.
 - **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
 - **UTF7**: Encodes in UTF-7 format.
@@ -175,7 +176,7 @@ pages (like `-Encoding 1251`) or string names of registered code pages (like
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
+Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
 
 Required: False
 Position: 1

--- a/reference/7.1/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Select-String.md
@@ -455,6 +455,7 @@ The acceptable values for this parameter are as follows:
 
 - **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
 - **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
+- **BigEndianUTF32**: Encodes in UTF-32 format using the big-endian byte order.
 - **OEM**: Uses the default encoding for MS-DOS and console programs.
 - **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
 - **UTF7**: Encodes in UTF-7 format.
@@ -472,7 +473,7 @@ pages (like `-Encoding 1251`) or string names of registered code pages (like
 Type: Encoding
 Parameter Sets: (All)
 Aliases:
-Accepted values: ASCII, BigEndianUnicode, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
+Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
 
 Required: False
 Position: Named

--- a/reference/7.1/Microsoft.PowerShell.Utility/Send-MailMessage.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Send-MailMessage.md
@@ -242,6 +242,7 @@ The acceptable values for this parameter are as follows:
 
 - **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
 - **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
+- **BigEndianUTF32**: Encodes in UTF-32 format using the big-endian byte order.
 - **OEM**: Uses the default encoding for MS-DOS and console programs.
 - **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
 - **UTF7**: Encodes in UTF-7 format.
@@ -259,7 +260,7 @@ pages (like `-Encoding 1251`) or string names of registered code pages (like
 Type: Encoding
 Parameter Sets: (All)
 Aliases: BE
-Accepted values: ASCII, BigEndianUnicode, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
+Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UTF8, UTF8BOM, UTF8NoBOM, UTF32
 
 Required: False
 Position: Named


### PR DESCRIPTION
# PR Summary

As of PowerShell 7.1, Amny cmdlets with **Encoding** parameters now have `BigEndianUTF32` as an option. This updates multiple cmdlet docs in PowerShell 7.1

## PR Context

Fixes #5975 

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
