### PR TITLE
Fix some grammar (specifically, "a" to "an" before "SQL")

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -97,7 +97,7 @@ The **SupportsPaging** argument adds the **First**, **Skip**, and
 **IncludeTotalCount** parameters to the function. These parameters allow users
 to select output from a very large result set. This argument is designed for
 cmdlets and functions that return data from large data stores that support data
-selection, such as a SQL database.
+selection, such as an SQL database.
 
 This argument was introduced in Windows PowerShell 3.0.
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -97,7 +97,7 @@ The **SupportsPaging** argument adds the **First**, **Skip**, and
 **IncludeTotalCount** parameters to the function. These parameters allow users
 to select output from a very large result set. This argument is designed for
 cmdlets and functions that return data from large data stores that support data
-selection, such as a SQL database.
+selection, such as an SQL database.
 
 This argument was introduced in Windows PowerShell 3.0.
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -97,7 +97,7 @@ The **SupportsPaging** argument adds the **First**, **Skip**, and
 **IncludeTotalCount** parameters to the function. These parameters allow users
 to select output from a very large result set. This argument is designed for
 cmdlets and functions that return data from large data stores that support data
-selection, such as a SQL database.
+selection, such as an SQL database.
 
 This argument was introduced in Windows PowerShell 3.0.
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -97,7 +97,7 @@ The **SupportsPaging** argument adds the **First**, **Skip**, and
 **IncludeTotalCount** parameters to the function. These parameters allow users
 to select output from a very large result set. This argument is designed for
 cmdlets and functions that return data from large data stores that support data
-selection, such as a SQL database.
+selection, such as an SQL database.
 
 This argument was introduced in Windows PowerShell 3.0.
 


### PR DESCRIPTION
# PR Summary
Changed "a" to "an" before "SQL" in about_Functions_CmdletBindingAttribute

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
