### PR TITLE
Update broken paths on README.md and Installing-PowerShell.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Each of the following top-level folders in this repo contain a DocSet that is pu
       Configuration feature
     - [gallery/](https://docs.microsoft.com/powershell/scripting/gallery) is for the
       [PowerShell Gallery](https://www.powershellgallery.com/)
-    - [jea/](https://docs.microsoft.com/powershell/scripting/jea/) is for the Just Enough
+    - [jea/](https://docs.microsoft.com/powershell/scripting/learn/remoting/jea/overview) is for the Just Enough
       Administration feature
-    - [wmf/](https://docs.microsoft.com/powershell/scripting/wmf/overview) contains release notes
+    - [wmf/](https://docs.microsoft.com/powershell/scripting/windows-powershell/wmf/overview) contains release notes
       for the Windows Management Framework, the package used to distribute new versions of
       PowerShell to previous versions of Windows.
 

--- a/reference/docs-conceptual/install/Installing-PowerShell.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell.md
@@ -23,4 +23,4 @@ experimental platforms.
 ## Windows PowerShell
 
 For more information about installing the legacy versions of PowerShell on Windows, see
-[Installing Windows PowerShell](installing-windows-powershell.md).
+[Installing Windows PowerShell](../windows-powershell/install/Installing-Windows-PowerShell.md).


### PR DESCRIPTION
# PR Summary
'Installing Windows PowerShell' link is broken and returns '404 - Content Not Found' error. I updated the link with the correct path:
reference/docs-conceptual/windows-powershell/install/Installing-Windows-PowerShell.md

jea/ and wmf/ links have outdated paths on the PowerShell-Docs/README.md and return '404 - Content Not Found' errors. I updated both links with the correct path.

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [X] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [X] JEA articles
- [X] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
