### PR TITLE
Updating to use latest version of Pester in Build

### DIFF
--- a/ci-steps.yml
+++ b/ci-steps.yml
@@ -29,7 +29,7 @@ steps:
 
   # We run tests on Windows PowerShell. Changing to PowerShell core would need changes to the tests
 - powershell: |
-    Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -RequiredVersion 4.10.1
+    Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck
     Import-Module "$(Build.SourcesDirectory)/tests/PowerShellDocsTests.psm1" -Force
     Invoke-Test
   displayName: Test


### PR DESCRIPTION
# PR Summary

The release of Pester 5.0 broke the build pipeline here. A new patch release is supposed to fix it. This is testing that. If build passes, please merge. 

## PR Context

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
