### PR TITLE
Updated PSEdition description.

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -506,11 +506,13 @@ following items:
 | Property                  | Description                                   |
 | ------------------------- | --------------------------------------------- |
 | **PSVersion**             | The PowerShell version number                 |
-| **PSEdition**             | This property has the value of 'Desktop', for |
-|                           | Windows Server and Windows client versions.   |
+| **PSEdition**             | This property has the value of 'Desktop' for  |
+|                           | PowerShell 4 and below as well as PowerShell  |
+|                           | 5.1 on full-featured Windows editions.        |
 |                           | This property has the value of 'Core' for     |
-|                           | PowerShell running under Nano Server or       |
-|                           | Windows IOT.                                  |
+|                           | PowerShell 6 and above as well as PowerShell  |
+|                           | PowerShell 5.1 on reduced-footprint editions  |
+|                           | like Windows Nano Server or Windows IoT.      |
 | **GitCommitId**           | The commit Id of the source files, in GitHub, |
 | **OS**                    | Description of the operating system that      |
 |                           | PowerShell is running on.                     |


### PR DESCRIPTION
Updated the PSEdition property description of the PSVersionTable variable.

# PR Summary
The previous description implied that full featured Windows editions could not have a 'Core' value.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
