### PR TITLE
Install-PackageProvider docs missing the word tag in description

### DIFF
--- a/reference/5.1/PackageManagement/Install-PackageProvider.md
+++ b/reference/5.1/PackageManagement/Install-PackageProvider.md
@@ -35,7 +35,7 @@ Install-PackageProvider [-Scope <String>] [-InputObject] <SoftwareIdentity[]> [-
 
 ## DESCRIPTION
 The **Install-PackageProvider** cmdlet installs matching Package Management providers that are available in package sources registered with **PowerShellGet**.
-By default, this includes modules available in the Windows PowerShell Gallery with the **PackageManagement**.
+By default, this includes modules available in the Windows PowerShell Gallery with the **PackageManagement** tag.
 The **PowerShellGet** Package Management provider is used for finding providers in these repositories.
 
 This cmdlet also installs matching Package Management providers that are available using the Package Management bootstrapping application.

--- a/reference/6/PackageManagement/Install-PackageProvider.md
+++ b/reference/6/PackageManagement/Install-PackageProvider.md
@@ -35,7 +35,7 @@ Install-PackageProvider [-Scope <String>] [-InputObject] <SoftwareIdentity[]> [-
 ## DESCRIPTION
 
 The **Install-PackageProvider** cmdlet installs matching Package Management providers that are available in package sources registered with **PowerShellGet**.
-By default, this includes modules available in the PowerShell Gallery with the **PackageManagement**.
+By default, this includes modules available in the PowerShell Gallery with the **PackageManagement** tag.
 The **PowerShellGet** Package Management provider is used for finding providers in these repositories.
 
 This cmdlet also installs matching Package Management providers that are available using the Package Management bootstrapping application.

--- a/reference/7.0/PackageManagement/Install-PackageProvider.md
+++ b/reference/7.0/PackageManagement/Install-PackageProvider.md
@@ -35,7 +35,7 @@ Install-PackageProvider [-Scope <String>] [-InputObject] <SoftwareIdentity[]> [-
 ## DESCRIPTION
 
 The **Install-PackageProvider** cmdlet installs matching Package Management providers that are available in package sources registered with **PowerShellGet**.
-By default, this includes modules available in the PowerShell Gallery with the **PackageManagement**.
+By default, this includes modules available in the PowerShell Gallery with the **PackageManagement** tag.
 The **PowerShellGet** Package Management provider is used for finding providers in these repositories.
 
 This cmdlet also installs matching Package Management providers that are available using the Package Management bootstrapping application.

--- a/reference/7.1/PackageManagement/Install-PackageProvider.md
+++ b/reference/7.1/PackageManagement/Install-PackageProvider.md
@@ -35,7 +35,7 @@ Install-PackageProvider [-Scope <String>] [-InputObject] <SoftwareIdentity[]> [-
 ## DESCRIPTION
 
 The **Install-PackageProvider** cmdlet installs matching Package Management providers that are available in package sources registered with **PowerShellGet**.
-By default, this includes modules available in the PowerShell Gallery with the **PackageManagement**.
+By default, this includes modules available in the PowerShell Gallery with the **PackageManagement** tag.
 The **PowerShellGet** Package Management provider is used for finding providers in these repositories.
 
 This cmdlet also installs matching Package Management providers that are available using the Package Management bootstrapping application.


### PR DESCRIPTION
# PR Summary
Noticed that the word tag was missing from th description

## PR Context
Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [X] Version 7.1 preview content
- [X] Version 7.0 content
- [X] Version 6 content
- [X] Version 5.1 content

**Conceptual content**
- [X] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
