### PR TITLE
wrong code example ">>" needs to be removed

### DIFF
--- a/reference/docs-conceptual/learn/ps101/04-pipelines.md
+++ b/reference/docs-conceptual/learn/ps101/04-pipelines.md
@@ -469,8 +469,8 @@ Create a custom object to test pipeline input by property name for the **Name** 
 
 ```powershell
 $CustomObject = [pscustomobject]@{
->> Name = 'w32time'
->> }
+ Name = 'w32time'
+ }
 ```
 
 The contents of the **CustomObject** variable is a **PSCustomObject** object type and it contains a


### PR DESCRIPTION
the example code doesn't work. ">>" needs to be removed to make it work

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [x ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
