### PR TITLE
FIXES #2341 - Updates PowerShell formatting information

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -310,6 +310,9 @@ LCID Name  Calendar                               DisplayName
 
 ## The XML in Format.ps1xml files
 
+The full schema definition can be found in [Format.xsd](https://github.com/PowerShell/PowerShell/blob/master/src/Schemas/Format.xsd)
+in the PowerShell source code repository on GitHub.
+
 The **ViewDefinitions** section of each `Format.ps1xml` file contains the
 `<View>` tags that define each view. A typical `<View>` tag includes the
 following tags:

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -31,51 +31,61 @@ Export-FormatData -InputObject <ExtendedTypeDefinition[]> -LiteralPath <String> 
 ```
 
 ## DESCRIPTION
-The **Export-FormatData** cmdlet creates Windows PowerShell formatting files (format.ps1xml) from the formatting objects in the current session.
-It takes the **ExtendedTypeDefinition** objects that Get-FormatData returns and saves them in a file in XML format.
 
-Windows PowerShell uses the data in formatting files (format.ps1xml) to generate the default display of Microsoft .NET Framework objects in the session.
-You can view and edit the formatting files and use the Update-FormatData cmdlet to add the formatting data to a session.
+The `Export-FormatData` cmdlet creates Windows PowerShell formatting files (format.ps1xml) from
+the formatting objects in the current session. It takes the **ExtendedTypeDefinition** objects that
+`Get-FormatData` returns and saves them in a file in XML format.
 
-For more information about formatting files in Windows PowerShell, see about_Format.ps1xml.
+Windows PowerShell uses the data in formatting files (format.ps1xml) to generate the default display
+of Microsoft .NET Framework objects in the session. You can view and edit the formatting files and
+use the Update-FormatData cmdlet to add the formatting data to a session.
+
+For more information about formatting files in Windows PowerShell, see [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
 
 ## EXAMPLES
 
 ### Example 1: Export session format data
 
-```
-PS C:\> Get-FormatData -TypeName "*" | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
+```powershell
+Get-FormatData -TypeName "*" | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
 ```
 
 This command exports all of the format data in the session to the AllFormat.ps1xml file.
 
-The command uses the Get-FormatData cmdlet to get the format data in the session.
-A value of \* (all) for the *TypeName* parameter directs the cmdlet to get all of the data in the session.
+The command uses the `Get-FormatData` cmdlet to get the format data in the session. A value of `*`
+(all) for the **TypeName** parameter directs the cmdlet to get all of the data in the session.
 
-The command uses a pipeline operator (|) to send the format data from the **Get-FormatData** command to the **Export-FormatData** cmdlet, which exports the format data to the AllFormat.ps1 file.
+The command uses a pipeline operator (`|`) to send the format data from the `Get-FormatData` command
+to the `Export-FormatData` cmdlet, which exports the format data to the AllFormat.ps1 file.
 
-The **Export-FormatData** command uses the *IncludeScriptBlock* parameter to include script blocks in the format data in the file.
+The `Export-FormatData` command uses the **IncludeScriptBlock** parameter to include script blocks
+in the format data in the file.
 
 ### Example 2: Export format data for a type
 
+```powershell
+$F = Get-FormatData -TypeName "helpinfoshort"
+Export-FormatData -InputObject $F -Path "c:\test\help.format.ps1xml" -IncludeScriptBlock
 ```
-PS C:\> $F = Get-FormatData -TypeName "helpinfoshort"
-PS C:\> Export-FormatData -InputObject $F -Path "c:\test\help.format.ps1xml" -IncludeScriptBlock
-```
 
-These commands export the format data for the HelpInfoShort type to the Help.format.ps1xml file.
+These commands export the format data for the **HelpInfoShort** type to the Help.format.ps1xml file.
 
-The first command uses the **Get-FormatData** cmdlet to get the format data for the HelpInfoShort type, and it saves it in the $F variable.
+The first command uses the `Get-FormatData` cmdlet to get the format data for the **HelpInfoShort**
+type, and it saves it in the `$F` variable.
 
-The second command uses the *InputObject* parameter of the **Export-FormatData** cmdlet to enter the format data saved in the $F variable.
-It also uses the *IncludeScriptBlock* parameter to include script blocks in the output.
+The second command uses the **InputObject** parameter of the `Export-FormatData` cmdlet to enter the
+format data saved in the `$F` variable. It also uses the **IncludeScriptBlock** parameter to include
+script blocks in the output.
 
 ### Example 3: Export format data without a script block
 
+```powershell
+Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path process.format.ps1xml
+Update-FormatData -PrependPath ".\process.format.ps1xml"
+Get-Process p*
 ```
-PS C:\> Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path process.format.ps1xml
-PS C:\> Update-FormatData -PrependPath ".\process.format.ps1xml"
-PS C:\> Get-Process p*
+
+```Output
 Handles  NPM(K)  PM(K)  WS(K) VM(M)   CPU(s)    Id ProcessName
 -------  ------  -----  ----- -----   ------    -- -----------
 323                                       5600 powershell
@@ -83,23 +93,29 @@ Handles  NPM(K)  PM(K)  WS(K) VM(M)   CPU(s)    Id ProcessName
 138                                       4076 PresentationFontCache
 ```
 
-This example shows the effect of omitting the *IncludeScriptBlock* parameter from an **Export-FormatData** command.
+This example shows the effect of omitting the **IncludeScriptBlock** parameter from an
+`Export-FormatData` command.
 
-The first command uses the Get-FormatData cmdlet to get the format data for the **System.Diagnostics.Process** object that the Get-Process cmdlet returns.
-The command uses a pipeline operator (|) to send the formatting data to the **Export-FormatData** cmdlet, which exports it to the Process.format.ps1xml file in the current directory.
+The first command uses the `Get-FormatData` cmdlet to get the format data for the
+**System.Diagnostics.Process** object that the Get-Process cmdlet returns. The command uses a
+pipeline operator (`|`) to send the formatting data to the `Export-FormatData` cmdlet, which exports
+it to the Process.format.ps1xml file in the current directory.
 
-In this case, the **Export-FormatData** command does not use the *IncludeScriptBlock* parameter.
+In this case, the `Export-FormatData` command does not use the **IncludeScriptBlock** parameter.
 
-The second command uses the Update-FormatData cmdlet to add the Process.format.ps1xml file to the current session.
-The command uses the *PrependPath* parameter to ensure that the formatting data for process objects in the Process.format.ps1xml file is found before the standard formatting data for process objects.
+The second command uses the `Update-FormatData` cmdlet to add the Process.format.ps1xml file to the
+current session. The command uses the **PrependPath** parameter to ensure that the formatting data for
+process objects in the Process.format.ps1xml file is found before the standard formatting data for
+process objects.
 
-The third command shows the effects of this change.
-The command uses the **Get-Process** cmdlet to get processes that have names that begin with P.
-The output shows that property values that are calculated by using script blocks are missing from the display.
+The third command shows the effects of this change. The command uses the `Get-Process` cmdlet to
+get processes that have names that begin with P. The output shows that property values that are
+calculated by using script blocks are missing from the display.
 
 ## PARAMETERS
 
 ### -Force
+
 Forces the command to run without asking for user confirmation.
 
 ```yaml
@@ -115,6 +131,7 @@ Accept wildcard characters: False
 ```
 
 ### -IncludeScriptBlock
+
 Indicates whether script blocks in the format data are exported.
 
 Because script blocks contain code and can be used maliciously, they are not exported by default.
@@ -132,9 +149,10 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies the format data objects to be exported.
-Enter a variable that contains the objects or a command that gets the objects, such as a **Get-FormatData** command.
-You can also pipe the objects from **Get-FormatData** to **Export-FormatData**.
+
+Specifies the format data objects to be exported. Enter a variable that contains the objects or a
+command that gets the objects, such as a `Get-FormatData` command. You can also pipe the objects
+from `Get-FormatData` to `Export-FormatData`.
 
 ```yaml
 Type: ExtendedTypeDefinition[]
@@ -149,11 +167,11 @@ Accept wildcard characters: False
 ```
 
 ### -LiteralPath
-Specifies a location for the output file.
-Unlike the *Path* parameter, the value of *LiteralPath* is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+
+Specifies a location for the output file. Unlike the **Path** parameter, the value of
+**LiteralPath** is used exactly as it is typed. No characters are interpreted as wildcards. If the
+path includes escape characters, enclose it in single quotation marks. Single quotation marks tell
+Windows PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -168,10 +186,11 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Indicates that the cmdlet does not overwrite existing files.
-By default, **Export-FormatData** overwrites files without warning unless the file has the read-only attribute.
 
-To direct **Export-FormatData** to overwrite read-only files, use the *Force* parameter.
+Indicates that the cmdlet does not overwrite existing files. By default, `Export-FormatData`
+overwrites files without warning unless the file has the read-only attribute.
+
+To direct `Export-FormatData` to overwrite read-only files, use the **Force** parameter.
 
 ```yaml
 Type: SwitchParameter
@@ -186,15 +205,17 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specifies a location for the output file.
 Enter a path (optional) and file name with a format.ps1xml file name extension.
-If you omit the path, **Export-FormatData** creates the file in the current directory.
+If you omit the path, `Export-FormatData` creates the file in the current directory.
 
-If you use a file name extension other than .ps1xml, the **Update-FormatData** cmdlet will not recognize the file.
+If you use a file name extension other than .ps1xml, the `Update-FormatData` cmdlet will not
+recognize the file.
 
-If you specify an existing file, **Export-FormatData** overwrites the file without warning, unless the file has the read-only attribute.
-To overwrite a read-only file, use the *Force* parameter.
-To prevent files from being overwritten, use the *NoClobber* parameter.
+If you specify an existing file, `Export-FormatData` overwrites the file without warning, unless
+the file has the read-only attribute. To overwrite a read-only file, use the **Force** parameter. To
+prevent files from being overwritten, use the **NoClobber** parameter.
 
 ```yaml
 Type: String
@@ -209,24 +230,29 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.ExtendedTypeDefinition
-You can pipe **ExtendedTypeDefinition** objects from **Get-FormatData** to **Export-FormatData**.
+
+You can pipe **ExtendedTypeDefinition** objects from `Get-FormatData` to `Export-FormatData`.
 
 ## OUTPUTS
 
 ### None
-**Export-FormatData** does not return any objects.
+
+`Export-FormatData` does not return any objects.
 It generates a file and saves it in the specified path.
 
 ## NOTES
 
-* To use any formatting file, including an exported formatting file, the execution policy for the session must allow scripts and configuration files to run. For more information, see about_Execution_Policies.
-
-*
+- To use any formatting file, including an exported formatting file, the execution policy for the
+  session must allow scripts and configuration files to run. For more information, see
+  about_Execution_Policies.
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -252,7 +252,7 @@ It generates a file and saves it in the specified path.
 
 - To use any formatting file, including an exported formatting file, the execution policy for the
   session must allow scripts and configuration files to run. For more information, see
-  about_Execution_Policies.
+  [about_Execution_Policies](../Microsoft.PowerShell.Core/About/about_Execution_Policies.md).
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -22,73 +22,84 @@ Update-FormatData [[-AppendPath] <String[]>] [-PrependPath <String[]>] [-WhatIf]
 ```
 
 ## DESCRIPTION
-The **Update-FormatData** cmdlet reloads the formatting data from formatting files into the current session.
-This cmdlet lets you update the formatting data without restarting Windows PowerShell.
 
-Without parameters, **Update-FormatData** reloads the formatting files that it loaded previously.
-You can use the parameters of **Update-FormatData** to add new formatting files to the session.
+The `Update-FormatData` cmdlet reloads the formatting data from formatting files into the current
+session. This cmdlet lets you update the formatting data without restarting PowerShell.
 
-Formatting files are text files in XML format with the format.ps1xml file name extension.
-The formatting data in the files defines the display of Microsoft .NET Framework objects in the session.
+Without parameters, `Update-FormatData` reloads the formatting files that it loaded previously.
+You can use the parameters of `Update-FormatData` to add new formatting files to the session.
 
-When Windows PowerShell starts, it loads the format data from the formatting files in the Windows PowerShell installation directory ($pshome) into the session.
-You can use **Update-FormatData** to reload the formatting data into the current session without restarting Windows PowerShell.
-This is useful when you have added or changed a formatting file, but do not want to interrupt the session.
+Formatting files are text files in XML format with the `format.ps1xml` file name extension. The
+formatting data in the files defines the display of Microsoft .NET Framework objects in the session.
 
-For more information about formatting files in Windows PowerShell, see about_Format.ps1xml.
+When Windows PowerShell starts, it loads the format data from the formatting files in the PowerShell
+installation directory (`$pshome`) into the session. You can use `Update-FormatData` to reload the
+formatting data into the current session without restarting PowerShell. This is useful when you have
+added or changed a formatting file, but do not want to interrupt the session.
+
+For more information about formatting files in PowerShell, see [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
 
 ## EXAMPLES
 
 ### Example 1: Reload previously loaded formatting files
 
-```
-PS C:\> Update-FormatData
+```powershell
+Update-FormatData
 ```
 
 This command reloads the formatting files that it loaded previously.
 
 ### Example 2: Reload formatting files and trace and log formatting files
 
+```powershell
+Update-FormatData -AppendPath "trace.format.ps1xml, log.format.ps1xml"
 ```
-PS C:\> Update-FormatData -AppendPath "trace.format.ps1xml, log.format.ps1xml"
-```
 
-This command reloads the formatting files into the session, including two new files, Trace.format.ps1xml and Log.format.ps1xml.
+This command reloads the formatting files into the session, including two new files,
+Trace.format.ps1xml and Log.format.ps1xml.
 
-Because the command uses the *AppendPath* parameter, the formatting data in the new files is loaded after the formatting data from the built-in files.
+Because the command uses the **AppendPath** parameter, the formatting data in the new files is loaded
+after the formatting data from the built-in files.
 
-The *AppendPath* parameter is used because the new files contain formatting data for objects that are not referenced in the built-in files.
+The **AppendPath** parameter is used because the new files contain formatting data for objects that
+are not referenced in the built-in files.
 
 ### Example 3: Edit a formatting file and reload it
 
-```
-PS C:\> Update-FormatData -PrependPath "c:\test\NewFiles.format.ps1xml"
+```powershell
+Update-FormatData -PrependPath "c:\test\NewFiles.format.ps1xml"
 
 # Edit the NewFiles.format.ps1 file.
 
-PS C:\> Update-FormatData
+Update-FormatData
 ```
 
 This example shows how to reload a formatting file after you have edited it.
 
-The first command adds the NewFiles.format.ps1xml file to the session.
-It uses the *PrependPath* parameter because the file contains formatting data for objects that are referenced in the built-in files.
+The first command adds the NewFiles.format.ps1xml file to the session. It uses the **PrependPath**
+parameter because the file contains formatting data for objects that are referenced in the built-in
+files.
 
-After adding the NewFiles.format.ps1xml file and testing it in these sessions, the author edits the file.
+After adding the NewFiles.format.ps1xml file and testing it in these sessions, the author edits the
+file.
 
-The second command uses the **Update-FormatData** cmdlet to reload the formatting files.
-Because the NewFiles.format.ps1xml file was previously loaded, **Update-FormatData** automatically reloads it without using parameters.
+The second command uses the `Update-FormatData` cmdlet to reload the formatting files. Because the
+NewFiles.format.ps1xml file was previously loaded, `Update-FormatData` automatically reloads it
+without using parameters.
 
 ## PARAMETERS
 
 ### -AppendPath
-Specifies formatting files that this cmdlet adds to the session.
-The files are loaded after Windows PowerShell loads the built-in formatting files.
 
-When formatting .NET objects, Windows PowerShell uses the first formatting definition that it finds for each .NET type.
-If you use the *AppendPath* parameter, Windows PowerShell searches the data from the built-in files before it encounters the formatting data that you are adding.
+Specifies formatting files that this cmdlet adds to the session. The files are loaded after
+PowerShell loads the built-in formatting files.
 
-Use this parameter to add a file that formats a .NET object that is not referenced in the built-in formatting files.
+When formatting .NET objects,Windows PowerShell uses the first formatting definition that it finds
+for each .NET type. If you use the **AppendPath** parameter, Windows PowerShell searches the data
+from the built-in files before it encounters the formatting data that you are adding.
+
+Use this parameter to add a file that formats a .NET object that is not referenced in the built-in
+formatting files.
 
 ```yaml
 Type: String[]
@@ -103,13 +114,16 @@ Accept wildcard characters: False
 ```
 
 ### -PrependPath
-Specifies formatting files that this cmdlet adds to the session.
-The files are loaded before Windows PowerShell loads the built-in formatting files.
 
-When formatting .NET objects, Windows PowerShell uses the first formatting definition that it finds for each .NET type.
-If you use the *PrependPath* parameter, Windows PowerShell searches the data from the files that you are adding before it encounters the formatting data from the built-in files.
+Specifies formatting files that this cmdlet adds to the session. The files are loaded before
+PowerShell loads the built-in formatting files.
 
-Use this parameter to add a file that formats a .NET object that is also referenced in the built-in formatting files.
+When formatting .NET objects, Windows PowerShell uses the first formatting definition that it finds
+for each .NET type. If you use the **PrependPath** parameter, Windows PowerShell searches the data
+from the files that you are adding before it encounters the formatting data from the built-in files.
+
+Use this parameter to add a file that formats a .NET object that is also referenced in the built-in
+formatting files.
 
 ```yaml
 Type: String[]
@@ -124,6 +138,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -139,6 +154,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -155,23 +171,29 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains the append path to **Update-FormatData**.
+
+You can pipe a string that contains the append path to `Update-FormatData`.
 
 ## OUTPUTS
 
 ### None
+
 The cmdlet does not return any output.
 
 ## NOTES
 
-* **Update-FormatData** also updates the formatting data for commands in the session that were imported from modules. If the formatting file for a module changes, you can run an **Update-FormatData** command to update the formatting data for imported commands. You do not need to import the module again.
-
-*
+- `Update-FormatData` also updates the formatting data for commands in the session that were
+  imported from modules. If the formatting file for a module changes, you can run an
+  `Update-FormatData` command to update the formatting data for imported commands. You do not need
+  to import the module again.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -214,6 +214,9 @@ LCID  Name   Calendar                                DisplayName
 
 ## The XML in Format.ps1xml files
 
+The full schema definition can be found in [Format.xsd](https://github.com/PowerShell/PowerShell/blob/master/src/Schemas/Format.xsd)
+in the PowerShell source code repository on GitHub.
+
 The **ViewDefinitions** section of each `Format.ps1xml` file contains the
 `<View>` tags that define each view. A typical `<View>` tag includes the
 following tags:

--- a/reference/6/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -251,7 +251,7 @@ It generates a file and saves it in the specified path.
 
 - To use any formatting file, including an exported formatting file, the execution policy for the
   session must allow scripts and configuration files to run. For more information, see
-  about_Execution_Policies.
+  [about_Execution_Policies](../Microsoft.PowerShell.Core/About/about_Execution_Policies.md).
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -46,7 +46,7 @@ For more information about formatting files in PowerShell, see [about_Format.ps1
 ### Example 1: Export session format data
 
 ```powershell
-Get-FormatData -TypeName "*" | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
+Get-FormatData -TypeName "*" -PowerShellVersion 5.1 | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
 ```
 
 This command exports all of the format data in the session to the AllFormat.ps1xml file.
@@ -63,7 +63,7 @@ in the format data in the file.
 ### Example 2: Export format data for a type
 
 ```powershell
-$F = Get-FormatData -TypeName "helpinfoshort"
+$F = Get-FormatData -TypeName "helpinfoshort" -PowerShellVersion 5.1
 Export-FormatData -InputObject $F -Path "c:\test\help.format.ps1xml" -IncludeScriptBlock
 ```
 
@@ -79,7 +79,7 @@ script blocks in the output.
 ### Example 3: Export format data without a script block
 
 ```powershell
-Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path process.format.ps1xml
+Get-FormatData -TypeName "System.Diagnostics.Process" -PowerShellVersion 5.1 | Export-FormatData -Path process.format.ps1xml
 Update-FormatData -PrependPath ".\process.format.ps1xml"
 Get-Process p*
 ```

--- a/reference/6/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -31,51 +31,60 @@ Export-FormatData -InputObject <ExtendedTypeDefinition[]> -LiteralPath <String> 
 
 ## DESCRIPTION
 
-The **Export-FormatData** cmdlet creates PowerShell formatting files (format.ps1xml) from the formatting objects in the current session.
-It takes the **ExtendedTypeDefinition** objects that Get-FormatData returns and saves them in a file in XML format.
+The `Export-FormatData` cmdlet creates PowerShell formatting files (format.ps1xml) from
+the formatting objects in the current session. It takes the **ExtendedTypeDefinition** objects that
+`Get-FormatData` returns and saves them in a file in XML format.
 
-PowerShell uses the data in formatting files (format.ps1xml) to generate the default display of Microsoft .NET Framework objects in the session.
-You can view and edit the formatting files and use the Update-FormatData cmdlet to add the formatting data to a session.
+PowerShell uses the data in formatting files (format.ps1xml) to generate the default display
+of Microsoft .NET Framework objects in the session. You can view and edit the formatting files and
+use the Update-FormatData cmdlet to add the formatting data to a session.
 
-For more information about formatting files in PowerShell, see about_Format.ps1xml.
+For more information about formatting files in PowerShell, see [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
 
 ## EXAMPLES
 
 ### Example 1: Export session format data
 
-```
-PS C:\> Get-FormatData -TypeName "*" | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
+```powershell
+Get-FormatData -TypeName "*" | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
 ```
 
 This command exports all of the format data in the session to the AllFormat.ps1xml file.
 
-The command uses the Get-FormatData cmdlet to get the format data in the session.
-A value of \* (all) for the *TypeName* parameter directs the cmdlet to get all of the data in the session.
+The command uses the `Get-FormatData` cmdlet to get the format data in the session. A value of `*`
+(all) for the **TypeName** parameter directs the cmdlet to get all of the data in the session.
 
-The command uses a pipeline operator (|) to send the format data from the **Get-FormatData** command to the **Export-FormatData** cmdlet, which exports the format data to the AllFormat.ps1 file.
+The command uses a pipeline operator (`|`) to send the format data from the `Get-FormatData` command
+to the `Export-FormatData` cmdlet, which exports the format data to the AllFormat.ps1 file.
 
-The **Export-FormatData** command uses the *IncludeScriptBlock* parameter to include script blocks in the format data in the file.
+The `Export-FormatData` command uses the **IncludeScriptBlock** parameter to include script blocks
+in the format data in the file.
 
 ### Example 2: Export format data for a type
 
+```powershell
+$F = Get-FormatData -TypeName "helpinfoshort"
+Export-FormatData -InputObject $F -Path "c:\test\help.format.ps1xml" -IncludeScriptBlock
 ```
-PS C:\> $F = Get-FormatData -TypeName "helpinfoshort"
-PS C:\> Export-FormatData -InputObject $F -Path "c:\test\help.format.ps1xml" -IncludeScriptBlock
-```
 
-These commands export the format data for the HelpInfoShort type to the Help.format.ps1xml file.
+These commands export the format data for the **HelpInfoShort** type to the Help.format.ps1xml file.
 
-The first command uses the **Get-FormatData** cmdlet to get the format data for the HelpInfoShort type, and it saves it in the $F variable.
+The first command uses the `Get-FormatData` cmdlet to get the format data for the **HelpInfoShort**
+type, and it saves it in the `$F` variable.
 
-The second command uses the *InputObject* parameter of the **Export-FormatData** cmdlet to enter the format data saved in the $F variable.
-It also uses the *IncludeScriptBlock* parameter to include script blocks in the output.
+The second command uses the **InputObject** parameter of the `Export-FormatData` cmdlet to enter the
+format data saved in the `$F` variable. It also uses the **IncludeScriptBlock** parameter to include
+script blocks in the output.
 
 ### Example 3: Export format data without a script block
 
+```powershell
+Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path process.format.ps1xml
+Update-FormatData -PrependPath ".\process.format.ps1xml"
+Get-Process p*
 ```
-PS C:\> Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path process.format.ps1xml
-PS C:\> Update-FormatData -PrependPath ".\process.format.ps1xml"
-PS C:\> Get-Process p*
+
+```Output
 Handles  NPM(K)  PM(K)  WS(K) VM(M)   CPU(s)    Id ProcessName
 -------  ------  -----  ----- -----   ------    -- -----------
 323                                       5600 powershell
@@ -83,19 +92,24 @@ Handles  NPM(K)  PM(K)  WS(K) VM(M)   CPU(s)    Id ProcessName
 138                                       4076 PresentationFontCache
 ```
 
-This example shows the effect of omitting the *IncludeScriptBlock* parameter from an **Export-FormatData** command.
+This example shows the effect of omitting the **IncludeScriptBlock** parameter from an
+`Export-FormatData` command.
 
-The first command uses the Get-FormatData cmdlet to get the format data for the **System.Diagnostics.Process** object that the Get-Process cmdlet returns.
-The command uses a pipeline operator (|) to send the formatting data to the **Export-FormatData** cmdlet, which exports it to the Process.format.ps1xml file in the current directory.
+The first command uses the `Get-FormatData` cmdlet to get the format data for the
+**System.Diagnostics.Process** object that the Get-Process cmdlet returns. The command uses a
+pipeline operator (`|`) to send the formatting data to the `Export-FormatData` cmdlet, which exports
+it to the Process.format.ps1xml file in the current directory.
 
-In this case, the **Export-FormatData** command does not use the *IncludeScriptBlock* parameter.
+In this case, the `Export-FormatData` command does not use the **IncludeScriptBlock** parameter.
 
-The second command uses the Update-FormatData cmdlet to add the Process.format.ps1xml file to the current session.
-The command uses the *PrependPath* parameter to ensure that the formatting data for process objects in the Process.format.ps1xml file is found before the standard formatting data for process objects.
+The second command uses the `Update-FormatData` cmdlet to add the Process.format.ps1xml file to the
+current session. The command uses the **PrependPath** parameter to ensure that the formatting data for
+process objects in the Process.format.ps1xml file is found before the standard formatting data for
+process objects.
 
-The third command shows the effects of this change.
-The command uses the **Get-Process** cmdlet to get processes that have names that begin with P.
-The output shows that property values that are calculated by using script blocks are missing from the display.
+The third command shows the effects of this change. The command uses the `Get-Process` cmdlet to
+get processes that have names that begin with P. The output shows that property values that are
+calculated by using script blocks are missing from the display.
 
 ## PARAMETERS
 
@@ -135,9 +149,9 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the format data objects to be exported.
-Enter a variable that contains the objects or a command that gets the objects, such as a **Get-FormatData** command.
-You can also pipe the objects from **Get-FormatData** to **Export-FormatData**.
+Specifies the format data objects to be exported. Enter a variable that contains the objects or a
+command that gets the objects, such as a `Get-FormatData` command. You can also pipe the objects
+from `Get-FormatData` to `Export-FormatData`.
 
 ```yaml
 Type: ExtendedTypeDefinition[]
@@ -153,11 +167,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies a location for the output file.
-Unlike the *Path* parameter, the value of *LiteralPath* is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies a location for the output file. Unlike the **Path** parameter, the value of
+**LiteralPath** is used exactly as it is typed. No characters are interpreted as wildcards. If the
+path includes escape characters, enclose it in single quotation marks. Single quotation marks tell
+PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -173,10 +186,10 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Indicates that the cmdlet does not overwrite existing files.
-By default, **Export-FormatData** overwrites files without warning unless the file has the read-only attribute.
+Indicates that the cmdlet does not overwrite existing files. By default, `Export-FormatData`
+overwrites files without warning unless the file has the read-only attribute.
 
-To direct **Export-FormatData** to overwrite read-only files, use the *Force* parameter.
+To direct `Export-FormatData` to overwrite read-only files, use the **Force** parameter.
 
 ```yaml
 Type: SwitchParameter
@@ -194,13 +207,14 @@ Accept wildcard characters: False
 
 Specifies a location for the output file.
 Enter a path (optional) and file name with a format.ps1xml file name extension.
-If you omit the path, **Export-FormatData** creates the file in the current directory.
+If you omit the path, `Export-FormatData` creates the file in the current directory.
 
-If you use a file name extension other than .ps1xml, the **Update-FormatData** cmdlet will not recognize the file.
+If you use a file name extension other than .ps1xml, the `Update-FormatData` cmdlet will not
+recognize the file.
 
-If you specify an existing file, **Export-FormatData** overwrites the file without warning, unless the file has the read-only attribute.
-To overwrite a read-only file, use the *Force* parameter.
-To prevent files from being overwritten, use the *NoClobber* parameter.
+If you specify an existing file, `Export-FormatData` overwrites the file without warning, unless
+the file has the read-only attribute. To overwrite a read-only file, use the **Force** parameter. To
+prevent files from being overwritten, use the **NoClobber** parameter.
 
 ```yaml
 Type: String
@@ -216,26 +230,28 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.ExtendedTypeDefinition
 
-You can pipe **ExtendedTypeDefinition** objects from **Get-FormatData** to **Export-FormatData**.
+You can pipe **ExtendedTypeDefinition** objects from `Get-FormatData` to `Export-FormatData`.
 
 ## OUTPUTS
 
 ### None
 
-**Export-FormatData** does not return any objects.
+`Export-FormatData` does not return any objects.
 It generates a file and saves it in the specified path.
 
 ## NOTES
 
-* To use any formatting file, including an exported formatting file, the execution policy for the session must allow scripts and configuration files to run. For more information, see about_Execution_Policies.
-
-*
+- To use any formatting file, including an exported formatting file, the execution policy for the
+  session must allow scripts and configuration files to run. For more information, see
+  about_Execution_Policies.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -41,8 +41,14 @@ For more information about formatting files in PowerShell, see
 This example gets all the formatting data in the session.
 
 ```powershell
-Get-FormatData
+Get-FormatData -PowerShellVersion 5.1
 ```
+
+> [!IMPORTANT]
+> To ensure that the complete type formatting information is returned, you should always include the
+> **PowerShellVersion** parameter with the value `5.1` when using a local invocation of
+> `Get-FormatData`. If the parameter and value are omitted, you may not get all the correct type
+> information.
 
 ### Example 2: Get formatting data by type name
 
@@ -50,7 +56,7 @@ This example gets the formatting data items whose names begin with
 `System.Management.Automation.Cmd`.
 
 ```powershell
-Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
+Get-FormatData -TypeName 'System.Management.Automation.Cmd*' -PowerShellVersion 5.1
 ```
 
 ### Example 3: Examine a formatting data object
@@ -58,7 +64,7 @@ Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
 This example shows how to get a formatting data object and examine its properties.
 
 ```powershell
-$F = Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
+$F = Get-FormatData -TypeName 'System.Management.Automation.Cmd*' -PowerShellVersion 5.1
 $F
 ```
 
@@ -103,9 +109,9 @@ This example shows how to use `Get-FormatData` and `Export-FormatData` to export
 data that is added by a module.
 
 ```powershell
-$A = Get-FormatData
+$A = Get-FormatData -PowerShellVersion 5.1
 Import-Module bitstransfer
-$B = Get-FormatData
+$B = Get-FormatData -PowerShellVersion 5.1
 Compare-Object $A $B
 ```
 
@@ -148,11 +154,6 @@ TypeNames                               FormatViewDefinition
 ---------                               --------------------
 {Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
 ```
-
-> [!IMPORTANT]
-> To ensure that the complete type formatting information is returned, you should always include the
-> **PowerShellVersion** parameter with the appropriate version. If the parameter and value are
-> omitted, you may not get all the correct type information.
 
 ## PARAMETERS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -22,73 +22,85 @@ Update-FormatData [[-AppendPath] <String[]>] [-PrependPath <String[]>] [-WhatIf]
 ```
 
 ## DESCRIPTION
-The **Update-FormatData** cmdlet reloads the formatting data from formatting files into the current session.
-This cmdlet lets you update the formatting data without restarting PowerShell.
 
-Without parameters, **Update-FormatData** reloads the formatting files that it loaded previously.
-You can use the parameters of **Update-FormatData** to add new formatting files to the session.
+The `Update-FormatData` cmdlet reloads the formatting data from formatting files into the current
+session. This cmdlet lets you update the formatting data without restarting PowerShell.
 
-Formatting files are text files in XML format with the format.ps1xml file name extension.
-The formatting data in the files defines the display of Microsoft .NET Framework objects in the session.
+Without parameters, `Update-FormatData` reloads the formatting files that it loaded previously.
+You can use the parameters of `Update-FormatData` to add new formatting files to the session.
 
-When PowerShell starts, it loads the format data from the formatting files in the PowerShell installation directory ($pshome) into the session.
-You can use **Update-FormatData** to reload the formatting data into the current session without restarting PowerShell.
-This is useful when you have added or changed a formatting file, but do not want to interrupt the session.
+Formatting files are text files in XML format with the `format.ps1xml` file name extension. The
+formatting data in the files defines the display of Microsoft .NET Framework objects in the session.
 
-For more information about formatting files in PowerShell, see about_Format.ps1xml.
+When PowerShell starts, it loads the format data from the PowerShell source code. However, you can
+create custom format.ps1xml files to update formatting in the current session. You can use
+`Update-FormatData` to reload the formatting data into the current session without restarting
+PowerShell. This is useful when you have added or changed a formatting file, but do not want to
+interrupt the session.
+
+For more information about formatting files in PowerShell, see [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
 
 ## EXAMPLES
 
 ### Example 1: Reload previously loaded formatting files
 
-```
-PS C:\> Update-FormatData
+```powershell
+Update-FormatData
 ```
 
 This command reloads the formatting files that it loaded previously.
 
 ### Example 2: Reload formatting files and trace and log formatting files
 
+```powershell
+Update-FormatData -AppendPath "trace.format.ps1xml, log.format.ps1xml"
 ```
-PS C:\> Update-FormatData -AppendPath "trace.format.ps1xml, log.format.ps1xml"
-```
 
-This command reloads the formatting files into the session, including two new files, Trace.format.ps1xml and Log.format.ps1xml.
+This command reloads the formatting files into the session, including two new files,
+Trace.format.ps1xml and Log.format.ps1xml.
 
-Because the command uses the *AppendPath* parameter, the formatting data in the new files is loaded after the formatting data from the built-in files.
+Because the command uses the **AppendPath** parameter, the formatting data in the new files is loaded
+after the formatting data from the built-in files.
 
-The *AppendPath* parameter is used because the new files contain formatting data for objects that are not referenced in the built-in files.
+The **AppendPath** parameter is used because the new files contain formatting data for objects that
+are not referenced in the built-in files.
 
 ### Example 3: Edit a formatting file and reload it
 
-```
-PS C:\> Update-FormatData -PrependPath "c:\test\NewFiles.format.ps1xml"
+```powershell
+Update-FormatData -PrependPath "c:\test\NewFiles.format.ps1xml"
 
 # Edit the NewFiles.format.ps1 file.
 
-PS C:\> Update-FormatData
+Update-FormatData
 ```
 
 This example shows how to reload a formatting file after you have edited it.
 
-The first command adds the NewFiles.format.ps1xml file to the session.
-It uses the *PrependPath* parameter because the file contains formatting data for objects that are referenced in the built-in files.
+The first command adds the NewFiles.format.ps1xml file to the session. It uses the **PrependPath**
+parameter because the file contains formatting data for objects that are referenced in the built-in
+files.
 
-After adding the NewFiles.format.ps1xml file and testing it in these sessions, the author edits the file.
+After adding the NewFiles.format.ps1xml file and testing it in these sessions, the author edits the
+file.
 
-The second command uses the **Update-FormatData** cmdlet to reload the formatting files.
-Because the NewFiles.format.ps1xml file was previously loaded, **Update-FormatData** automatically reloads it without using parameters.
+The second command uses the `Update-FormatData` cmdlet to reload the formatting files. Because the
+NewFiles.format.ps1xml file was previously loaded, `Update-FormatData` automatically reloads it
+without using parameters.
 
 ## PARAMETERS
 
 ### -AppendPath
-Specifies formatting files that this cmdlet adds to the session.
-The files are loaded after PowerShell loads the built-in formatting files.
 
-When formatting .NET objects, PowerShell uses the first formatting definition that it finds for each .NET type.
-If you use the *AppendPath* parameter, PowerShell searches the data from the built-in files before it encounters the formatting data that you are adding.
+Specifies formatting files that this cmdlet adds to the session. The files are loaded after
+PowerShell loads the built-in formatting files.
 
-Use this parameter to add a file that formats a .NET object that is not referenced in the built-in formatting files.
+When formatting .NET objects, PowerShell uses the first formatting definition that it finds for each
+.NET type. If you use the **AppendPath** parameter, PowerShell searches the data from the built-in
+files before it encounters the formatting data that you are adding.
+
+Use this parameter to add a file that formats a .NET object that is not referenced in the built-in
+formatting files.
 
 ```yaml
 Type: String[]
@@ -103,13 +115,16 @@ Accept wildcard characters: False
 ```
 
 ### -PrependPath
-Specifies formatting files that this cmdlet adds to the session.
-The files are loaded before PowerShell loads the built-in formatting files.
 
-When formatting .NET objects, PowerShell uses the first formatting definition that it finds for each .NET type.
-If you use the *PrependPath* parameter, PowerShell searches the data from the files that you are adding before it encounters the formatting data from the built-in files.
+Specifies formatting files that this cmdlet adds to the session. The files are loaded before
+PowerShell loads the built-in formatting files.
 
-Use this parameter to add a file that formats a .NET object that is also referenced in the built-in formatting files.
+When formatting .NET objects, PowerShell uses the first formatting definition that it finds for each
+.NET type. If you use the **PrependPath** parameter, PowerShell searches the data from the files that
+you are adding before it encounters the formatting data from the built-in files.
+
+Use this parameter to add a file that formats a .NET object that is also referenced in the built-in
+formatting files.
 
 ```yaml
 Type: String[]
@@ -124,6 +139,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -139,6 +155,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -155,23 +172,29 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains the append path to **Update-FormatData**.
+
+You can pipe a string that contains the append path to `Update-FormatData`.
 
 ## OUTPUTS
 
 ### None
+
 The cmdlet does not return any output.
 
 ## NOTES
 
-* **Update-FormatData** also updates the formatting data for commands in the session that were imported from modules. If the formatting file for a module changes, you can run an **Update-FormatData** command to update the formatting data for imported commands. You do not need to import the module again.
-
-*
+- `Update-FormatData` also updates the formatting data for commands in the session that were
+  imported from modules. If the formatting file for a module changes, you can run an
+  `Update-FormatData` command to update the formatting data for imported commands. You do not need
+  to import the module again.
 
 ## RELATED LINKS
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -214,6 +214,9 @@ LCID  Name   Calendar                                DisplayName
 
 ## The XML in Format.ps1xml files
 
+The full schema definition can be found in [Format.xsd](https://github.com/PowerShell/PowerShell/blob/master/src/Schemas/Format.xsd)
+in the PowerShell source code repository on GitHub.
+
 The **ViewDefinitions** section of each `Format.ps1xml` file contains the
 `<View>` tags that define each view. A typical `<View>` tag includes the
 following tags:

--- a/reference/7.0/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -251,7 +251,7 @@ It generates a file and saves it in the specified path.
 
 - To use any formatting file, including an exported formatting file, the execution policy for the
   session must allow scripts and configuration files to run. For more information, see
-  about_Execution_Policies.
+  [about_Execution_Policies](../Microsoft.PowerShell.Core/About/about_Execution_Policies.md).
 
 ## RELATED LINKS
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -46,7 +46,7 @@ For more information about formatting files in PowerShell, see [about_Format.ps1
 ### Example 1: Export session format data
 
 ```powershell
-Get-FormatData -TypeName "*" | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
+Get-FormatData -TypeName "*" -PowerShellVersion 5.1 | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
 ```
 
 This command exports all of the format data in the session to the AllFormat.ps1xml file.
@@ -63,7 +63,7 @@ in the format data in the file.
 ### Example 2: Export format data for a type
 
 ```powershell
-$F = Get-FormatData -TypeName "helpinfoshort"
+$F = Get-FormatData -TypeName "helpinfoshort" -PowerShellVersion 5.1
 Export-FormatData -InputObject $F -Path "c:\test\help.format.ps1xml" -IncludeScriptBlock
 ```
 
@@ -79,7 +79,7 @@ script blocks in the output.
 ### Example 3: Export format data without a script block
 
 ```powershell
-Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path process.format.ps1xml
+Get-FormatData -TypeName "System.Diagnostics.Process" -PowerShellVersion 5.1 | Export-FormatData -Path process.format.ps1xml
 Update-FormatData -PrependPath ".\process.format.ps1xml"
 Get-Process p*
 ```

--- a/reference/7.0/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -31,51 +31,60 @@ Export-FormatData -InputObject <ExtendedTypeDefinition[]> -LiteralPath <String> 
 
 ## DESCRIPTION
 
-The **Export-FormatData** cmdlet creates PowerShell formatting files (format.ps1xml) from the formatting objects in the current session.
-It takes the **ExtendedTypeDefinition** objects that Get-FormatData returns and saves them in a file in XML format.
+The `Export-FormatData` cmdlet creates PowerShell formatting files (format.ps1xml) from
+the formatting objects in the current session. It takes the **ExtendedTypeDefinition** objects that
+`Get-FormatData` returns and saves them in a file in XML format.
 
-PowerShell uses the data in formatting files (format.ps1xml) to generate the default display of Microsoft .NET Framework objects in the session.
-You can view and edit the formatting files and use the Update-FormatData cmdlet to add the formatting data to a session.
+PowerShell uses the data in formatting files (format.ps1xml) to generate the default display
+of Microsoft .NET Framework objects in the session. You can view and edit the formatting files and
+use the Update-FormatData cmdlet to add the formatting data to a session.
 
-For more information about formatting files in PowerShell, see about_Format.ps1xml.
+For more information about formatting files in PowerShell, see [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
 
 ## EXAMPLES
 
 ### Example 1: Export session format data
 
-```
-PS C:\> Get-FormatData -TypeName "*" | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
+```powershell
+Get-FormatData -TypeName "*" | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
 ```
 
 This command exports all of the format data in the session to the AllFormat.ps1xml file.
 
-The command uses the Get-FormatData cmdlet to get the format data in the session.
-A value of \* (all) for the *TypeName* parameter directs the cmdlet to get all of the data in the session.
+The command uses the `Get-FormatData` cmdlet to get the format data in the session. A value of `*`
+(all) for the **TypeName** parameter directs the cmdlet to get all of the data in the session.
 
-The command uses a pipeline operator (|) to send the format data from the **Get-FormatData** command to the **Export-FormatData** cmdlet, which exports the format data to the AllFormat.ps1 file.
+The command uses a pipeline operator (`|`) to send the format data from the `Get-FormatData` command
+to the `Export-FormatData` cmdlet, which exports the format data to the AllFormat.ps1 file.
 
-The **Export-FormatData** command uses the *IncludeScriptBlock* parameter to include script blocks in the format data in the file.
+The `Export-FormatData` command uses the **IncludeScriptBlock** parameter to include script blocks
+in the format data in the file.
 
 ### Example 2: Export format data for a type
 
+```powershell
+$F = Get-FormatData -TypeName "helpinfoshort"
+Export-FormatData -InputObject $F -Path "c:\test\help.format.ps1xml" -IncludeScriptBlock
 ```
-PS C:\> $F = Get-FormatData -TypeName "helpinfoshort"
-PS C:\> Export-FormatData -InputObject $F -Path "c:\test\help.format.ps1xml" -IncludeScriptBlock
-```
 
-These commands export the format data for the HelpInfoShort type to the Help.format.ps1xml file.
+These commands export the format data for the **HelpInfoShort** type to the Help.format.ps1xml file.
 
-The first command uses the **Get-FormatData** cmdlet to get the format data for the HelpInfoShort type, and it saves it in the $F variable.
+The first command uses the `Get-FormatData` cmdlet to get the format data for the **HelpInfoShort**
+type, and it saves it in the `$F` variable.
 
-The second command uses the *InputObject* parameter of the **Export-FormatData** cmdlet to enter the format data saved in the $F variable.
-It also uses the *IncludeScriptBlock* parameter to include script blocks in the output.
+The second command uses the **InputObject** parameter of the `Export-FormatData` cmdlet to enter the
+format data saved in the `$F` variable. It also uses the **IncludeScriptBlock** parameter to include
+script blocks in the output.
 
 ### Example 3: Export format data without a script block
 
+```powershell
+Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path process.format.ps1xml
+Update-FormatData -PrependPath ".\process.format.ps1xml"
+Get-Process p*
 ```
-PS C:\> Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path process.format.ps1xml
-PS C:\> Update-FormatData -PrependPath ".\process.format.ps1xml"
-PS C:\> Get-Process p*
+
+```Output
 Handles  NPM(K)  PM(K)  WS(K) VM(M)   CPU(s)    Id ProcessName
 -------  ------  -----  ----- -----   ------    -- -----------
 323                                       5600 powershell
@@ -83,19 +92,24 @@ Handles  NPM(K)  PM(K)  WS(K) VM(M)   CPU(s)    Id ProcessName
 138                                       4076 PresentationFontCache
 ```
 
-This example shows the effect of omitting the *IncludeScriptBlock* parameter from an **Export-FormatData** command.
+This example shows the effect of omitting the **IncludeScriptBlock** parameter from an
+`Export-FormatData` command.
 
-The first command uses the Get-FormatData cmdlet to get the format data for the **System.Diagnostics.Process** object that the Get-Process cmdlet returns.
-The command uses a pipeline operator (|) to send the formatting data to the **Export-FormatData** cmdlet, which exports it to the Process.format.ps1xml file in the current directory.
+The first command uses the `Get-FormatData` cmdlet to get the format data for the
+**System.Diagnostics.Process** object that the Get-Process cmdlet returns. The command uses a
+pipeline operator (`|`) to send the formatting data to the `Export-FormatData` cmdlet, which exports
+it to the Process.format.ps1xml file in the current directory.
 
-In this case, the **Export-FormatData** command does not use the *IncludeScriptBlock* parameter.
+In this case, the `Export-FormatData` command does not use the **IncludeScriptBlock** parameter.
 
-The second command uses the Update-FormatData cmdlet to add the Process.format.ps1xml file to the current session.
-The command uses the *PrependPath* parameter to ensure that the formatting data for process objects in the Process.format.ps1xml file is found before the standard formatting data for process objects.
+The second command uses the `Update-FormatData` cmdlet to add the Process.format.ps1xml file to the
+current session. The command uses the **PrependPath** parameter to ensure that the formatting data for
+process objects in the Process.format.ps1xml file is found before the standard formatting data for
+process objects.
 
-The third command shows the effects of this change.
-The command uses the **Get-Process** cmdlet to get processes that have names that begin with P.
-The output shows that property values that are calculated by using script blocks are missing from the display.
+The third command shows the effects of this change. The command uses the `Get-Process` cmdlet to
+get processes that have names that begin with P. The output shows that property values that are
+calculated by using script blocks are missing from the display.
 
 ## PARAMETERS
 
@@ -135,9 +149,9 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the format data objects to be exported.
-Enter a variable that contains the objects or a command that gets the objects, such as a **Get-FormatData** command.
-You can also pipe the objects from **Get-FormatData** to **Export-FormatData**.
+Specifies the format data objects to be exported. Enter a variable that contains the objects or a
+command that gets the objects, such as a `Get-FormatData` command. You can also pipe the objects
+from `Get-FormatData` to `Export-FormatData`.
 
 ```yaml
 Type: ExtendedTypeDefinition[]
@@ -153,11 +167,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies a location for the output file.
-Unlike the *Path* parameter, the value of *LiteralPath* is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies a location for the output file. Unlike the **Path** parameter, the value of
+**LiteralPath** is used exactly as it is typed. No characters are interpreted as wildcards. If the
+path includes escape characters, enclose it in single quotation marks. Single quotation marks tell
+PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -173,10 +186,10 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Indicates that the cmdlet does not overwrite existing files.
-By default, **Export-FormatData** overwrites files without warning unless the file has the read-only attribute.
+Indicates that the cmdlet does not overwrite existing files. By default, `Export-FormatData`
+overwrites files without warning unless the file has the read-only attribute.
 
-To direct **Export-FormatData** to overwrite read-only files, use the *Force* parameter.
+To direct `Export-FormatData` to overwrite read-only files, use the **Force** parameter.
 
 ```yaml
 Type: SwitchParameter
@@ -194,13 +207,14 @@ Accept wildcard characters: False
 
 Specifies a location for the output file.
 Enter a path (optional) and file name with a format.ps1xml file name extension.
-If you omit the path, **Export-FormatData** creates the file in the current directory.
+If you omit the path, `Export-FormatData` creates the file in the current directory.
 
-If you use a file name extension other than .ps1xml, the **Update-FormatData** cmdlet will not recognize the file.
+If you use a file name extension other than .ps1xml, the `Update-FormatData` cmdlet will not
+recognize the file.
 
-If you specify an existing file, **Export-FormatData** overwrites the file without warning, unless the file has the read-only attribute.
-To overwrite a read-only file, use the *Force* parameter.
-To prevent files from being overwritten, use the *NoClobber* parameter.
+If you specify an existing file, `Export-FormatData` overwrites the file without warning, unless
+the file has the read-only attribute. To overwrite a read-only file, use the **Force** parameter. To
+prevent files from being overwritten, use the **NoClobber** parameter.
 
 ```yaml
 Type: String
@@ -216,26 +230,28 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.ExtendedTypeDefinition
 
-You can pipe **ExtendedTypeDefinition** objects from **Get-FormatData** to **Export-FormatData**.
+You can pipe **ExtendedTypeDefinition** objects from `Get-FormatData` to `Export-FormatData`.
 
 ## OUTPUTS
 
 ### None
 
-**Export-FormatData** does not return any objects.
+`Export-FormatData` does not return any objects.
 It generates a file and saves it in the specified path.
 
 ## NOTES
 
-* To use any formatting file, including an exported formatting file, the execution policy for the session must allow scripts and configuration files to run. For more information, see about_Execution_Policies.
-
-*
+- To use any formatting file, including an exported formatting file, the execution policy for the
+  session must allow scripts and configuration files to run. For more information, see
+  about_Execution_Policies.
 
 ## RELATED LINKS
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -41,8 +41,14 @@ For more information about formatting files in PowerShell, see
 This example gets all the formatting data in the session.
 
 ```powershell
-Get-FormatData
+Get-FormatData -PowerShellVersion 5.1
 ```
+
+> [!IMPORTANT]
+> To ensure that the complete type formatting information is returned, you should always include the
+> **PowerShellVersion** parameter with the value `5.1` when using a local invocation of
+> `Get-FormatData`. If the parameter and value are omitted, you may not get all the correct type
+> information.
 
 ### Example 2: Get formatting data by type name
 
@@ -50,7 +56,7 @@ This example gets the formatting data items whose names begin with
 `System.Management.Automation.Cmd`.
 
 ```powershell
-Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
+Get-FormatData -TypeName 'System.Management.Automation.Cmd*' -PowerShellVersion 5.1
 ```
 
 ### Example 3: Examine a formatting data object
@@ -58,7 +64,7 @@ Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
 This example shows how to get a formatting data object and examine its properties.
 
 ```powershell
-$F = Get-FormatData -TypeName 'System.Management.Automation.Cmd*'
+$F = Get-FormatData -TypeName 'System.Management.Automation.Cmd*' -PowerShellVersion 5.1
 $F
 ```
 
@@ -103,9 +109,9 @@ This example shows how to use `Get-FormatData` and `Export-FormatData` to export
 data that is added by a module.
 
 ```powershell
-$A = Get-FormatData
+$A = Get-FormatData -PowerShellVersion 5.1
 Import-Module bitstransfer
-$B = Get-FormatData
+$B = Get-FormatData -PowerShellVersion 5.1
 Compare-Object $A $B
 ```
 
@@ -148,11 +154,6 @@ TypeNames                               FormatViewDefinition
 ---------                               --------------------
 {Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
 ```
-
-> [!IMPORTANT]
-> To ensure that the complete type formatting information is returned, you should always include the
-> **PowerShellVersion** parameter with the appropriate version. If the parameter and value are
-> omitted, you may not get all the correct type information.
 
 ## PARAMETERS
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -22,73 +22,85 @@ Update-FormatData [[-AppendPath] <String[]>] [-PrependPath <String[]>] [-WhatIf]
 ```
 
 ## DESCRIPTION
-The **Update-FormatData** cmdlet reloads the formatting data from formatting files into the current session.
-This cmdlet lets you update the formatting data without restarting PowerShell.
 
-Without parameters, **Update-FormatData** reloads the formatting files that it loaded previously.
-You can use the parameters of **Update-FormatData** to add new formatting files to the session.
+The `Update-FormatData` cmdlet reloads the formatting data from formatting files into the current
+session. This cmdlet lets you update the formatting data without restarting PowerShell.
 
-Formatting files are text files in XML format with the format.ps1xml file name extension.
-The formatting data in the files defines the display of Microsoft .NET Framework objects in the session.
+Without parameters, `Update-FormatData` reloads the formatting files that it loaded previously.
+You can use the parameters of `Update-FormatData` to add new formatting files to the session.
 
-When PowerShell starts, it loads the format data from the formatting files in the PowerShell installation directory ($pshome) into the session.
-You can use **Update-FormatData** to reload the formatting data into the current session without restarting PowerShell.
-This is useful when you have added or changed a formatting file, but do not want to interrupt the session.
+Formatting files are text files in XML format with the `format.ps1xml` file name extension. The
+formatting data in the files defines the display of Microsoft .NET Framework objects in the session.
 
-For more information about formatting files in PowerShell, see about_Format.ps1xml.
+When PowerShell starts, it loads the format data from the PowerShell source code. However, you can
+create custom format.ps1xml files to update formatting in the current session. You can use
+`Update-FormatData` to reload the formatting data into the current session without restarting
+PowerShell. This is useful when you have added or changed a formatting file, but do not want to
+interrupt the session.
+
+For more information about formatting files in PowerShell, see [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
 
 ## EXAMPLES
 
 ### Example 1: Reload previously loaded formatting files
 
-```
-PS C:\> Update-FormatData
+```powershell
+Update-FormatData
 ```
 
 This command reloads the formatting files that it loaded previously.
 
 ### Example 2: Reload formatting files and trace and log formatting files
 
+```powershell
+Update-FormatData -AppendPath "trace.format.ps1xml, log.format.ps1xml"
 ```
-PS C:\> Update-FormatData -AppendPath "trace.format.ps1xml, log.format.ps1xml"
-```
 
-This command reloads the formatting files into the session, including two new files, Trace.format.ps1xml and Log.format.ps1xml.
+This command reloads the formatting files into the session, including two new files,
+Trace.format.ps1xml and Log.format.ps1xml.
 
-Because the command uses the *AppendPath* parameter, the formatting data in the new files is loaded after the formatting data from the built-in files.
+Because the command uses the **AppendPath** parameter, the formatting data in the new files is loaded
+after the formatting data from the built-in files.
 
-The *AppendPath* parameter is used because the new files contain formatting data for objects that are not referenced in the built-in files.
+The **AppendPath** parameter is used because the new files contain formatting data for objects that
+are not referenced in the built-in files.
 
 ### Example 3: Edit a formatting file and reload it
 
-```
-PS C:\> Update-FormatData -PrependPath "c:\test\NewFiles.format.ps1xml"
+```powershell
+Update-FormatData -PrependPath "c:\test\NewFiles.format.ps1xml"
 
 # Edit the NewFiles.format.ps1 file.
 
-PS C:\> Update-FormatData
+Update-FormatData
 ```
 
 This example shows how to reload a formatting file after you have edited it.
 
-The first command adds the NewFiles.format.ps1xml file to the session.
-It uses the *PrependPath* parameter because the file contains formatting data for objects that are referenced in the built-in files.
+The first command adds the NewFiles.format.ps1xml file to the session. It uses the **PrependPath**
+parameter because the file contains formatting data for objects that are referenced in the built-in
+files.
 
-After adding the NewFiles.format.ps1xml file and testing it in these sessions, the author edits the file.
+After adding the NewFiles.format.ps1xml file and testing it in these sessions, the author edits the
+file.
 
-The second command uses the **Update-FormatData** cmdlet to reload the formatting files.
-Because the NewFiles.format.ps1xml file was previously loaded, **Update-FormatData** automatically reloads it without using parameters.
+The second command uses the `Update-FormatData` cmdlet to reload the formatting files. Because the
+NewFiles.format.ps1xml file was previously loaded, `Update-FormatData` automatically reloads it
+without using parameters.
 
 ## PARAMETERS
 
 ### -AppendPath
-Specifies formatting files that this cmdlet adds to the session.
-The files are loaded after PowerShell loads the built-in formatting files.
 
-When formatting .NET objects, PowerShell uses the first formatting definition that it finds for each .NET type.
-If you use the *AppendPath* parameter, PowerShell searches the data from the built-in files before it encounters the formatting data that you are adding.
+Specifies formatting files that this cmdlet adds to the session. The files are loaded after
+PowerShell loads the built-in formatting files.
 
-Use this parameter to add a file that formats a .NET object that is not referenced in the built-in formatting files.
+When formatting .NET objects, PowerShell uses the first formatting definition that it finds for each
+.NET type. If you use the **AppendPath** parameter, PowerShell searches the data from the built-in
+files before it encounters the formatting data that you are adding.
+
+Use this parameter to add a file that formats a .NET object that is not referenced in the built-in
+formatting files.
 
 ```yaml
 Type: String[]
@@ -103,13 +115,16 @@ Accept wildcard characters: False
 ```
 
 ### -PrependPath
-Specifies formatting files that this cmdlet adds to the session.
-The files are loaded before PowerShell loads the built-in formatting files.
 
-When formatting .NET objects, PowerShell uses the first formatting definition that it finds for each .NET type.
-If you use the *PrependPath* parameter, PowerShell searches the data from the files that you are adding before it encounters the formatting data from the built-in files.
+Specifies formatting files that this cmdlet adds to the session. The files are loaded before
+PowerShell loads the built-in formatting files.
 
-Use this parameter to add a file that formats a .NET object that is also referenced in the built-in formatting files.
+When formatting .NET objects, PowerShell uses the first formatting definition that it finds for each
+.NET type. If you use the **PrependPath** parameter, PowerShell searches the data from the files that
+you are adding before it encounters the formatting data from the built-in files.
+
+Use this parameter to add a file that formats a .NET object that is also referenced in the built-in
+formatting files.
 
 ```yaml
 Type: String[]
@@ -124,6 +139,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -139,6 +155,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -155,23 +172,29 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains the append path to **Update-FormatData**.
+
+You can pipe a string that contains the append path to `Update-FormatData`.
 
 ## OUTPUTS
 
 ### None
+
 The cmdlet does not return any output.
 
 ## NOTES
 
-* **Update-FormatData** also updates the formatting data for commands in the session that were imported from modules. If the formatting file for a module changes, you can run an **Update-FormatData** command to update the formatting data for imported commands. You do not need to import the module again.
-
-*
+- `Update-FormatData` also updates the formatting data for commands in the session that were
+  imported from modules. If the formatting file for a module changes, you can run an
+  `Update-FormatData` command to update the formatting data for imported commands. You do not need
+  to import the module again.
 
 ## RELATED LINKS
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -214,6 +214,9 @@ LCID  Name   Calendar                                DisplayName
 
 ## The XML in Format.ps1xml files
 
+The full schema definition can be found in [Format.xsd](https://github.com/PowerShell/PowerShell/blob/master/src/Schemas/Format.xsd)
+in the PowerShell source code repository on GitHub.
+
 The **ViewDefinitions** section of each `Format.ps1xml` file contains the
 `<View>` tags that define each view. A typical `<View>` tag includes the
 following tags:

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -437,4 +437,3 @@ Update-FormatData -AppendPath ./Mygciview.Format.ps1xml
 [Update-FormatData](../../Microsoft.PowerShell.Utility/Update-FormatData.md)
 
 [Writing a PowerShell Formatting File](/powershell/scripting/developer/format/writing-a-powershell-formatting-file)
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -31,51 +31,60 @@ Export-FormatData -InputObject <ExtendedTypeDefinition[]> -LiteralPath <String> 
 
 ## DESCRIPTION
 
-The **Export-FormatData** cmdlet creates PowerShell formatting files (format.ps1xml) from the formatting objects in the current session.
-It takes the **ExtendedTypeDefinition** objects that Get-FormatData returns and saves them in a file in XML format.
+The `Export-FormatData` cmdlet creates PowerShell formatting files (format.ps1xml) from
+the formatting objects in the current session. It takes the **ExtendedTypeDefinition** objects that
+`Get-FormatData` returns and saves them in a file in XML format.
 
-PowerShell uses the data in formatting files (format.ps1xml) to generate the default display of Microsoft .NET Framework objects in the session.
-You can view and edit the formatting files and use the Update-FormatData cmdlet to add the formatting data to a session.
+PowerShell uses the data in formatting files (format.ps1xml) to generate the default display
+of Microsoft .NET Framework objects in the session. You can view and edit the formatting files and
+use the Update-FormatData cmdlet to add the formatting data to a session.
 
-For more information about formatting files in PowerShell, see about_Format.ps1xml.
+For more information about formatting files in PowerShell, see [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
 
 ## EXAMPLES
 
 ### Example 1: Export session format data
 
-```
-PS C:\> Get-FormatData -TypeName "*" | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
+```powershell
+Get-FormatData -TypeName "*" | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
 ```
 
 This command exports all of the format data in the session to the AllFormat.ps1xml file.
 
-The command uses the Get-FormatData cmdlet to get the format data in the session.
-A value of \* (all) for the *TypeName* parameter directs the cmdlet to get all of the data in the session.
+The command uses the `Get-FormatData` cmdlet to get the format data in the session. A value of `*`
+(all) for the **TypeName** parameter directs the cmdlet to get all of the data in the session.
 
-The command uses a pipeline operator (|) to send the format data from the **Get-FormatData** command to the **Export-FormatData** cmdlet, which exports the format data to the AllFormat.ps1 file.
+The command uses a pipeline operator (`|`) to send the format data from the `Get-FormatData` command
+to the `Export-FormatData` cmdlet, which exports the format data to the AllFormat.ps1 file.
 
-The **Export-FormatData** command uses the *IncludeScriptBlock* parameter to include script blocks in the format data in the file.
+The `Export-FormatData` command uses the **IncludeScriptBlock** parameter to include script blocks
+in the format data in the file.
 
 ### Example 2: Export format data for a type
 
+```powershell
+$F = Get-FormatData -TypeName "helpinfoshort"
+Export-FormatData -InputObject $F -Path "c:\test\help.format.ps1xml" -IncludeScriptBlock
 ```
-PS C:\> $F = Get-FormatData -TypeName "helpinfoshort"
-PS C:\> Export-FormatData -InputObject $F -Path "c:\test\help.format.ps1xml" -IncludeScriptBlock
-```
 
-These commands export the format data for the HelpInfoShort type to the Help.format.ps1xml file.
+These commands export the format data for the **HelpInfoShort** type to the Help.format.ps1xml file.
 
-The first command uses the **Get-FormatData** cmdlet to get the format data for the HelpInfoShort type, and it saves it in the $F variable.
+The first command uses the `Get-FormatData` cmdlet to get the format data for the **HelpInfoShort**
+type, and it saves it in the `$F` variable.
 
-The second command uses the *InputObject* parameter of the **Export-FormatData** cmdlet to enter the format data saved in the $F variable.
-It also uses the *IncludeScriptBlock* parameter to include script blocks in the output.
+The second command uses the **InputObject** parameter of the `Export-FormatData` cmdlet to enter the
+format data saved in the `$F` variable. It also uses the **IncludeScriptBlock** parameter to include
+script blocks in the output.
 
 ### Example 3: Export format data without a script block
 
+```powershell
+Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path process.format.ps1xml
+Update-FormatData -PrependPath ".\process.format.ps1xml"
+Get-Process p*
 ```
-PS C:\> Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path process.format.ps1xml
-PS C:\> Update-FormatData -PrependPath ".\process.format.ps1xml"
-PS C:\> Get-Process p*
+
+```Output
 Handles  NPM(K)  PM(K)  WS(K) VM(M)   CPU(s)    Id ProcessName
 -------  ------  -----  ----- -----   ------    -- -----------
 323                                       5600 powershell
@@ -83,19 +92,24 @@ Handles  NPM(K)  PM(K)  WS(K) VM(M)   CPU(s)    Id ProcessName
 138                                       4076 PresentationFontCache
 ```
 
-This example shows the effect of omitting the *IncludeScriptBlock* parameter from an **Export-FormatData** command.
+This example shows the effect of omitting the **IncludeScriptBlock** parameter from an
+`Export-FormatData` command.
 
-The first command uses the Get-FormatData cmdlet to get the format data for the **System.Diagnostics.Process** object that the Get-Process cmdlet returns.
-The command uses a pipeline operator (|) to send the formatting data to the **Export-FormatData** cmdlet, which exports it to the Process.format.ps1xml file in the current directory.
+The first command uses the `Get-FormatData` cmdlet to get the format data for the
+**System.Diagnostics.Process** object that the Get-Process cmdlet returns. The command uses a
+pipeline operator (`|`) to send the formatting data to the `Export-FormatData` cmdlet, which exports
+it to the Process.format.ps1xml file in the current directory.
 
-In this case, the **Export-FormatData** command does not use the *IncludeScriptBlock* parameter.
+In this case, the `Export-FormatData` command does not use the **IncludeScriptBlock** parameter.
 
-The second command uses the Update-FormatData cmdlet to add the Process.format.ps1xml file to the current session.
-The command uses the *PrependPath* parameter to ensure that the formatting data for process objects in the Process.format.ps1xml file is found before the standard formatting data for process objects.
+The second command uses the `Update-FormatData` cmdlet to add the Process.format.ps1xml file to the
+current session. The command uses the **PrependPath** parameter to ensure that the formatting data for
+process objects in the Process.format.ps1xml file is found before the standard formatting data for
+process objects.
 
-The third command shows the effects of this change.
-The command uses the **Get-Process** cmdlet to get processes that have names that begin with P.
-The output shows that property values that are calculated by using script blocks are missing from the display.
+The third command shows the effects of this change. The command uses the `Get-Process` cmdlet to
+get processes that have names that begin with P. The output shows that property values that are
+calculated by using script blocks are missing from the display.
 
 ## PARAMETERS
 
@@ -135,9 +149,9 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the format data objects to be exported.
-Enter a variable that contains the objects or a command that gets the objects, such as a **Get-FormatData** command.
-You can also pipe the objects from **Get-FormatData** to **Export-FormatData**.
+Specifies the format data objects to be exported. Enter a variable that contains the objects or a
+command that gets the objects, such as a `Get-FormatData` command. You can also pipe the objects
+from `Get-FormatData` to `Export-FormatData`.
 
 ```yaml
 Type: ExtendedTypeDefinition[]
@@ -153,11 +167,10 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies a location for the output file.
-Unlike the *Path* parameter, the value of *LiteralPath* is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Specifies a location for the output file. Unlike the **Path** parameter, the value of
+**LiteralPath** is used exactly as it is typed. No characters are interpreted as wildcards. If the
+path includes escape characters, enclose it in single quotation marks. Single quotation marks tell
+PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -173,10 +186,10 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Indicates that the cmdlet does not overwrite existing files.
-By default, **Export-FormatData** overwrites files without warning unless the file has the read-only attribute.
+Indicates that the cmdlet does not overwrite existing files. By default, `Export-FormatData`
+overwrites files without warning unless the file has the read-only attribute.
 
-To direct **Export-FormatData** to overwrite read-only files, use the *Force* parameter.
+To direct `Export-FormatData` to overwrite read-only files, use the **Force** parameter.
 
 ```yaml
 Type: SwitchParameter
@@ -194,13 +207,14 @@ Accept wildcard characters: False
 
 Specifies a location for the output file.
 Enter a path (optional) and file name with a format.ps1xml file name extension.
-If you omit the path, **Export-FormatData** creates the file in the current directory.
+If you omit the path, `Export-FormatData` creates the file in the current directory.
 
-If you use a file name extension other than .ps1xml, the **Update-FormatData** cmdlet will not recognize the file.
+If you use a file name extension other than .ps1xml, the `Update-FormatData` cmdlet will not
+recognize the file.
 
-If you specify an existing file, **Export-FormatData** overwrites the file without warning, unless the file has the read-only attribute.
-To overwrite a read-only file, use the *Force* parameter.
-To prevent files from being overwritten, use the *NoClobber* parameter.
+If you specify an existing file, `Export-FormatData` overwrites the file without warning, unless
+the file has the read-only attribute. To overwrite a read-only file, use the **Force** parameter. To
+prevent files from being overwritten, use the **NoClobber** parameter.
 
 ```yaml
 Type: String
@@ -216,30 +230,31 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.ExtendedTypeDefinition
 
-You can pipe **ExtendedTypeDefinition** objects from **Get-FormatData** to **Export-FormatData**.
+You can pipe **ExtendedTypeDefinition** objects from `Get-FormatData` to `Export-FormatData`.
 
 ## OUTPUTS
 
 ### None
 
-**Export-FormatData** does not return any objects.
+`Export-FormatData` does not return any objects.
 It generates a file and saves it in the specified path.
 
 ## NOTES
 
-* To use any formatting file, including an exported formatting file, the execution policy for the session must allow scripts and configuration files to run. For more information, see about_Execution_Policies.
-
-*
+- To use any formatting file, including an exported formatting file, the execution policy for the
+  session must allow scripts and configuration files to run. For more information, see
+  about_Execution_Policies.
 
 ## RELATED LINKS
 
 [Get-FormatData](Get-FormatData.md)
 
 [Update-FormatData](Update-FormatData.md)
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -251,7 +251,7 @@ It generates a file and saves it in the specified path.
 
 - To use any formatting file, including an exported formatting file, the execution policy for the
   session must allow scripts and configuration files to run. For more information, see
-  about_Execution_Policies.
+  [about_Execution_Policies](../Microsoft.PowerShell.Core/About/about_Execution_Policies.md).
 
 ## RELATED LINKS
 

--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -149,11 +149,6 @@ TypeNames                               FormatViewDefinition
 {Microsoft.Powershell.Utility.FileHash} {Microsoft.Powershell.Utility.FileHash}
 ```
 
-> [!IMPORTANT]
-> To ensure that the complete type formatting information is returned, you should always include the
-> **PowerShellVersion** parameter with the appropriate version. If the parameter and value are
-> omitted, you may not get all the correct type information.
-
 ## PARAMETERS
 
 ### -PowerShellVersion
@@ -218,4 +213,3 @@ You cannot pipe input to this cmdlet.
 [Export-FormatData](Export-FormatData.md)
 
 [Update-FormatData](Update-FormatData.md)
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -22,73 +22,85 @@ Update-FormatData [[-AppendPath] <String[]>] [-PrependPath <String[]>] [-WhatIf]
 ```
 
 ## DESCRIPTION
-The **Update-FormatData** cmdlet reloads the formatting data from formatting files into the current session.
-This cmdlet lets you update the formatting data without restarting PowerShell.
 
-Without parameters, **Update-FormatData** reloads the formatting files that it loaded previously.
-You can use the parameters of **Update-FormatData** to add new formatting files to the session.
+The `Update-FormatData` cmdlet reloads the formatting data from formatting files into the current
+session. This cmdlet lets you update the formatting data without restarting PowerShell.
 
-Formatting files are text files in XML format with the format.ps1xml file name extension.
-The formatting data in the files defines the display of Microsoft .NET Framework objects in the session.
+Without parameters, `Update-FormatData` reloads the formatting files that it loaded previously.
+You can use the parameters of `Update-FormatData` to add new formatting files to the session.
 
-When PowerShell starts, it loads the format data from the formatting files in the PowerShell installation directory ($pshome) into the session.
-You can use **Update-FormatData** to reload the formatting data into the current session without restarting PowerShell.
-This is useful when you have added or changed a formatting file, but do not want to interrupt the session.
+Formatting files are text files in XML format with the `format.ps1xml` file name extension. The
+formatting data in the files defines the display of Microsoft .NET Framework objects in the session.
 
-For more information about formatting files in PowerShell, see about_Format.ps1xml.
+When PowerShell starts, it loads the format data from the PowerShell source code. However, you can
+create custom format.ps1xml files to update formatting in the current session. You can use
+`Update-FormatData` to reload the formatting data into the current session without restarting
+PowerShell. This is useful when you have added or changed a formatting file, but do not want to
+interrupt the session.
+
+For more information about formatting files in PowerShell, see [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
 
 ## EXAMPLES
 
 ### Example 1: Reload previously loaded formatting files
 
-```
-PS C:\> Update-FormatData
+```powershell
+Update-FormatData
 ```
 
 This command reloads the formatting files that it loaded previously.
 
 ### Example 2: Reload formatting files and trace and log formatting files
 
+```powershell
+Update-FormatData -AppendPath "trace.format.ps1xml, log.format.ps1xml"
 ```
-PS C:\> Update-FormatData -AppendPath "trace.format.ps1xml, log.format.ps1xml"
-```
 
-This command reloads the formatting files into the session, including two new files, Trace.format.ps1xml and Log.format.ps1xml.
+This command reloads the formatting files into the session, including two new files,
+Trace.format.ps1xml and Log.format.ps1xml.
 
-Because the command uses the *AppendPath* parameter, the formatting data in the new files is loaded after the formatting data from the built-in files.
+Because the command uses the **AppendPath** parameter, the formatting data in the new files is loaded
+after the formatting data from the built-in files.
 
-The *AppendPath* parameter is used because the new files contain formatting data for objects that are not referenced in the built-in files.
+The **AppendPath** parameter is used because the new files contain formatting data for objects that
+are not referenced in the built-in files.
 
 ### Example 3: Edit a formatting file and reload it
 
-```
-PS C:\> Update-FormatData -PrependPath "c:\test\NewFiles.format.ps1xml"
+```powershell
+Update-FormatData -PrependPath "c:\test\NewFiles.format.ps1xml"
 
 # Edit the NewFiles.format.ps1 file.
 
-PS C:\> Update-FormatData
+Update-FormatData
 ```
 
 This example shows how to reload a formatting file after you have edited it.
 
-The first command adds the NewFiles.format.ps1xml file to the session.
-It uses the *PrependPath* parameter because the file contains formatting data for objects that are referenced in the built-in files.
+The first command adds the NewFiles.format.ps1xml file to the session. It uses the **PrependPath**
+parameter because the file contains formatting data for objects that are referenced in the built-in
+files.
 
-After adding the NewFiles.format.ps1xml file and testing it in these sessions, the author edits the file.
+After adding the NewFiles.format.ps1xml file and testing it in these sessions, the author edits the
+file.
 
-The second command uses the **Update-FormatData** cmdlet to reload the formatting files.
-Because the NewFiles.format.ps1xml file was previously loaded, **Update-FormatData** automatically reloads it without using parameters.
+The second command uses the `Update-FormatData` cmdlet to reload the formatting files. Because the
+NewFiles.format.ps1xml file was previously loaded, `Update-FormatData` automatically reloads it
+without using parameters.
 
 ## PARAMETERS
 
 ### -AppendPath
-Specifies formatting files that this cmdlet adds to the session.
-The files are loaded after PowerShell loads the built-in formatting files.
 
-When formatting .NET objects, PowerShell uses the first formatting definition that it finds for each .NET type.
-If you use the *AppendPath* parameter, PowerShell searches the data from the built-in files before it encounters the formatting data that you are adding.
+Specifies formatting files that this cmdlet adds to the session. The files are loaded after
+PowerShell loads the built-in formatting files.
 
-Use this parameter to add a file that formats a .NET object that is not referenced in the built-in formatting files.
+When formatting .NET objects, PowerShell uses the first formatting definition that it finds for each
+.NET type. If you use the **AppendPath** parameter, PowerShell searches the data from the built-in
+files before it encounters the formatting data that you are adding.
+
+Use this parameter to add a file that formats a .NET object that is not referenced in the built-in
+formatting files.
 
 ```yaml
 Type: String[]
@@ -103,13 +115,16 @@ Accept wildcard characters: False
 ```
 
 ### -PrependPath
-Specifies formatting files that this cmdlet adds to the session.
-The files are loaded before PowerShell loads the built-in formatting files.
 
-When formatting .NET objects, PowerShell uses the first formatting definition that it finds for each .NET type.
-If you use the *PrependPath* parameter, PowerShell searches the data from the files that you are adding before it encounters the formatting data from the built-in files.
+Specifies formatting files that this cmdlet adds to the session. The files are loaded before
+PowerShell loads the built-in formatting files.
 
-Use this parameter to add a file that formats a .NET object that is also referenced in the built-in formatting files.
+When formatting .NET objects, PowerShell uses the first formatting definition that it finds for each
+.NET type. If you use the **PrependPath** parameter, PowerShell searches the data from the files that
+you are adding before it encounters the formatting data from the built-in files.
+
+Use this parameter to add a file that formats a .NET object that is also referenced in the built-in
+formatting files.
 
 ```yaml
 Type: String[]
@@ -124,6 +139,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -139,6 +155,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -155,27 +172,32 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains the append path to **Update-FormatData**.
+
+You can pipe a string that contains the append path to `Update-FormatData`.
 
 ## OUTPUTS
 
 ### None
+
 The cmdlet does not return any output.
 
 ## NOTES
 
-* **Update-FormatData** also updates the formatting data for commands in the session that were imported from modules. If the formatting file for a module changes, you can run an **Update-FormatData** command to update the formatting data for imported commands. You do not need to import the module again.
-
-*
+- `Update-FormatData` also updates the formatting data for commands in the session that were
+  imported from modules. If the formatting file for a module changes, you can run an
+  `Update-FormatData` command to update the formatting data for imported commands. You do not need
+  to import the module again.
 
 ## RELATED LINKS
 
 [Get-FormatData](Get-FormatData.md)
 
 [Export-FormatData](Export-FormatData.md)
-


### PR DESCRIPTION
# PR Summary

There are multiple updates pertaining to format.ps1xml including about topics, and `*-FormatData` cmdlets.

## PR Context

Fixes #2341 

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
