### PR TITLE
FIXES #6108 Updates Invoke-RestMethod

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -411,7 +411,7 @@ be used together.
 
 Example:
 
-`Invoke-WebRequest -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
+`Invoke-RestMethod -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
 
 This makes a `TEST` HTTP request to the API.
 
@@ -871,7 +871,7 @@ Accept wildcard characters: False
 Specifies a variable for which this cmdlet creates a web request session and saves it in the value.
 Enter a variable name without the dollar sign (`$`) symbol.
 
-When you specify a session variable, `Invoke-WebRequest` creates a web request session object and
+When you specify a session variable, `Invoke-RestMethod` creates a web request session object and
 assigns it to a variable with the specified name in your PowerShell session. You can use the
 variable in your session as soon as the command completes.
 
@@ -1139,7 +1139,7 @@ maximum redirection value, and the user agent string. You can use it to share st
 web requests.
 
 To create a web request session, enter a variable name, without a dollar sign, in the value of the
-**SessionVariable** parameter of an `Invoke-WebRequest` command. `Invoke-WebRequest` creates the
+**SessionVariable** parameter of an `Invoke-RestMethod` command. `Invoke-RestMethod` creates the
 session and saves it in the variable. In subsequent commands, use the variable as the value of the
 **WebSession** parameter.
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -414,7 +414,7 @@ be used together.
 
 Example:
 
-`Invoke-WebRequest -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
+`Invoke-RestMethod -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
 
 This makes a `TEST` HTTP request to the API.
 
@@ -874,7 +874,7 @@ Accept wildcard characters: False
 Specifies a variable for which this cmdlet creates a web request session and saves it in the value.
 Enter a variable name without the dollar sign (`$`) symbol.
 
-When you specify a session variable, `Invoke-WebRequest` creates a web request session object and
+When you specify a session variable, `Invoke-RestMethod` creates a web request session object and
 assigns it to a variable with the specified name in your PowerShell session. You can use the
 variable in your session as soon as the command completes.
 
@@ -1183,7 +1183,7 @@ maximum redirection value, and the user agent string. You can use it to share st
 web requests.
 
 To create a web request session, enter a variable name, without a dollar sign, in the value of the
-**SessionVariable** parameter of an `Invoke-WebRequest` command. `Invoke-WebRequest` creates the
+**SessionVariable** parameter of an `Invoke-RestMethod` command. `Invoke-RestMethod` creates the
 session and saves it in the variable. In subsequent commands, use the variable as the value of the
 **WebSession** parameter.
 

--- a/reference/7.1/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -414,7 +414,7 @@ be used together.
 
 Example:
 
-`Invoke-WebRequest -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
+`Invoke-RestMethod -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
 
 This makes a `TEST` HTTP request to the API.
 
@@ -875,7 +875,7 @@ Accept wildcard characters: False
 Specifies a variable for which this cmdlet creates a web request session and saves it in the value.
 Enter a variable name without the dollar sign (`$`) symbol.
 
-When you specify a session variable, `Invoke-WebRequest` creates a web request session object and
+When you specify a session variable, `Invoke-RestMethod` creates a web request session object and
 assigns it to a variable with the specified name in your PowerShell session. You can use the
 variable in your session as soon as the command completes.
 
@@ -1184,7 +1184,7 @@ maximum redirection value, and the user agent string. You can use it to share st
 web requests.
 
 To create a web request session, enter a variable name, without a dollar sign, in the value of the
-**SessionVariable** parameter of an `Invoke-WebRequest` command. `Invoke-WebRequest` creates the
+**SessionVariable** parameter of an `Invoke-RestMethod` command. `Invoke-RestMethod` creates the
 session and saves it in the variable. In subsequent commands, use the variable as the value of the
 **WebSession** parameter.
 


### PR DESCRIPTION
# PR Summary

Customer noticed some parameter documentation was referencing `Invoke-WebRequest` and needed to be changed to `Invoke-RestMethod`

## PR Context

Fixes #6108 
Fixes [AB#1733236](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1733236)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
