### PR TITLE
Adds note to Test-Connection for param rename

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
@@ -227,6 +227,9 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+> [!NOTE]
+> The **ComputerName** parameter is renamed to **TargetName** in PowerShell 6.0 and above.
+
 ### -Count
 
 Specifies the number of echo requests to send. The default value is 4.

--- a/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
@@ -215,6 +215,9 @@ format. Wildcard characters are not permitted. This parameter is required.
 This parameter doesn't rely on PowerShell remoting. You can use the **ComputerName** parameter even
 if your computer isn't configured to run remote commands.
 
+> [!NOTE]
+> The **ComputerName** parameter is renamed to **TargetName** in PowerShell 6.0 and above.
+
 ```yaml
 Type: String[]
 Parameter Sets: (All)
@@ -226,9 +229,6 @@ Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
-
-> [!NOTE]
-> The **ComputerName** parameter is renamed to **TargetName** in PowerShell 6.0 and above.
 
 ### -Count
 


### PR DESCRIPTION
# PR Summary

Adds not to clarify parameter rename in `Test-Connection` in PowerShell v 5.1

## PR Context

No link

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [x] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
