### PR TITLE
working-with-local-psrepositories.md: Don't encourage users to paste secrets in plain-text into the console

### DIFF
--- a/reference/docs-conceptual/gallery/how-to/working-with-local-psrepositories.md
+++ b/reference/docs-conceptual/gallery/how-to/working-with-local-psrepositories.md
@@ -120,17 +120,17 @@ Examples:
 
 ```powershell
 # Publish to a NuGet Server repository using my NuGetAPI key
-Publish-Module -Path 'c:\projects\MyModule' -Repository LocalPsRepo -NuGetApiKey 'oy2bi4avlkjolp6bme6azdyssn6ps3iu7ib2qpiudrtbji'
+Publish-Module -Path 'c:\projects\MyModule' -Repository LocalPsRepo -NuGetApiKey $nuGetApiKey
 ```
+
+> [!IMPORTANT]
+> To ensure security, API keys should not be hard-coded in scripts. Use a secure key management
+> system. When executing a command manually, API keys should not be passed as plain-text to avoid it being logged, the `Read-Host` cmdlet can be used to safely pass the value of the API key.
 
 ```powershell
 # Publish to a file share repo - the NuGet API key must be a non-blank string
 Publish-Module -Path 'c:\projects\MyModule' -Repository LocalPsRepo -NuGetApiKey 'AnyStringWillDo'
 ```
-
-> [!IMPORTANT]
-> To ensure security, API keys should not be hard-coded in scripts. Use a secure key management
-> system.
 
 ### Publishing a module from the PSGallery
 
@@ -203,8 +203,14 @@ After running these commands, you are ready to publish PowerShellGet to your loc
 
 ```powershell
 # Publish to a NuGet Server repository using my NuGetAPI key
-Publish-Module -Path 'F:\OfflinePowershellGet' -Repository LocalPsRepo -NuGetApiKey 'oy2bi4avlkjolp6bme6azdyssn6ps3iu7ib2qpiudrtbji'
+Publish-Module -Path 'F:\OfflinePowershellGet' -Repository LocalPsRepo -NuGetApiKey $nuGetApiKey
+```
 
+> [!IMPORTANT]
+> To ensure security, API keys should not be hard-coded in scripts. Use a secure key management
+> system. When executing a command manually, API keys should not be passed as plain-text to avoid it being logged, the `Read-Host` cmdlet can be used to safely pass the value of the API key.
+
+```powershell
 # Publish to a file share repo - the NuGet API key must be a non-blank string
 Publish-Module -Path 'F:\OfflinePowerShellGet' -Repository LocalPsRepo -NuGetApiKey 'AnyStringWillDo'
 ```
@@ -213,10 +219,6 @@ Publish-Module -Path 'F:\OfflinePowerShellGet' -Repository LocalPsRepo -NuGetApi
 
 You can also use packaging solutions like Azure Artifacts to host a private or public PowerShellGet
 repository. For more information and instructions, see the [Azure Artifacts documentation](https://docs.microsoft.com/azure/devops/artifacts/tutorials/private-powershell-library).
-
-> [!IMPORTANT]
-> To ensure security, API keys should not be hard-coded in scripts. Use a secure key management
-> system.
 
 <!-- external links -->
 [OfflinePowerShellGetDeploy]: https://www.powershellgallery.com/packages/OfflinePowerShellGetDeploy/0.1.1


### PR DESCRIPTION
# PR Summary


Pasting secrets in plain text into the console is bad and with most versions of PSReadline, the command will get logged as plaint text into the unprotected PowerShell history file.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [x] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
