### PR TITLE
add calls to Get-TargetResource

### DIFF
--- a/reference/docs-conceptual/dsc/resources/authoringResourceMOF.md
+++ b/reference/docs-conceptual/dsc/resources/authoringResourceMOF.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/12/2017
+ms.date:  06/16/2020
 keywords:  dsc,powershell,configuration,setup
 title:  Writing a custom DSC resource with MOF
 ---
@@ -154,6 +154,9 @@ function Set-TargetResource
         [string[]]$Protocol
     )
 
+    <# Get the current state #>
+    $currentState = Get-TargetResource -Ensure $Ensure -Name $Name -PhysicalPath $PhysicalPath -State $State -ApplicationPool $ApplicationPool -BindingInfo $BindingInfo -Protocol $Protocol
+    
     <# If Ensure is set to "Present" and the website specified in the mandatory input parameters does not exist, then create it using the specified parameter values #>
     <# Else, if Ensure is set to "Present" and the website does exist, then update its properties to match the values provided in the non-mandatory parameter values #>
     <# Else, if Ensure is set to "Absent" and the website does not exist, then do nothing #>
@@ -198,6 +201,9 @@ $BindingData,
 $ApplicationPool
 )
 
+<# Get the current state #>
+$currentState = Get-TargetResource -Ensure $Ensure -Name $Name -PhysicalPath $PhysicalPath -State $State -ApplicationPool $ApplicationPool -BindingInfo $BindingInfo -Protocol $Protocol
+    
 #Write-Verbose "Use this cmdlet to deliver information about command processing."
 
 #Write-Debug "Use this cmdlet to write debug information while troubleshooting."

--- a/reference/docs-conceptual/dsc/resources/authoringResourceMOF.md
+++ b/reference/docs-conceptual/dsc/resources/authoringResourceMOF.md
@@ -154,9 +154,6 @@ function Set-TargetResource
         [string[]]$Protocol
     )
 
-    <# Get the current state #>
-    $currentState = Get-TargetResource -Ensure $Ensure -Name $Name -PhysicalPath $PhysicalPath -State $State -ApplicationPool $ApplicationPool -BindingInfo $BindingInfo -Protocol $Protocol
-    
     <# If Ensure is set to "Present" and the website specified in the mandatory input parameters does not exist, then create it using the specified parameter values #>
     <# Else, if Ensure is set to "Present" and the website does exist, then update its properties to match the values provided in the non-mandatory parameter values #>
     <# Else, if Ensure is set to "Absent" and the website does not exist, then do nothing #>


### PR DESCRIPTION
Make it clear that Get-TargetResource is often called by Set-TargetResource and Test-TargetResource.

# PR Summary
<!-- Summarize your changes and list related issues here -->
It wasn't obvious to me from this doc how to implement `Test-ResourceTarget` and I found out by looking at a few DSC Resources on github that `Get-ResourceTarget` is often used to drive `Set-ResourceTarget` and for comparison in `Test-ResourceTarget`. I think adding this to the page gives the user a clue 

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [X] Version 5.1 content
(I do not know what other versions this affects, I am in an archaic development environment :D)

**Conceptual content**
- [ ] Fundamental conceptual articles
- [X] Script sample articles
- [X] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
