### PR TITLE
adding an example to the Parameter section

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -229,6 +229,15 @@ you use both a syntax comment and a Parameter keyword, the description
 associated with the Parameter keyword is used, and the syntax comment is
 ignored.
 
+```
+function Verb-Noun {
+    [CmdletBinding()]
+    param (
+        #This is the same as .Parameter
+        [string]$Computername
+    )
+```
+
 ### .EXAMPLE
 
 A sample command that uses the function or script, optionally followed by


### PR DESCRIPTION
I feel it gets glossed over.
Other colleagues have missed it

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
