### PR TITLE
update to compare-object doc

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -29,7 +29,7 @@ Compare-Object [-ReferenceObject] <PSObject[]> [-DifferenceObject] <PSObject[]>
 The `Compare-Object` cmdlet compares two sets of objects. One set of objects is the **reference**,
 and the other set of objects is the **difference**.
 
-Normally, the objects in both sets are *sorted first*, and then *converted to strings*, if they are not strings already.  The objects are then compared as strings.  This is true even for Process objects.  There are some rare exceptions, like DateTime objects (output by Get-Date), that could be compared in a different way.  The properties of the objects are not looked at for comparison, unless the -Property parameter is used.
+Normally, the objects in both sets are *sorted first*, and then *converted to strings*, if they are not strings already.  The objects are then compared as strings.  This is true even for Process objects.  There are some rare exceptions, like DateTime objects (output by Get-Date), that could be compared in a different way.  The properties of the objects are not looked at for comparison, unless the -Property parameter is used.  Also, since both sets are sorted, text files with lines in different orders will be considered equal by Compare-Object.
 
 If the -Property parameter is used, the properties given will be used for comparison.
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -29,6 +29,10 @@ Compare-Object [-ReferenceObject] <PSObject[]> [-DifferenceObject] <PSObject[]>
 The `Compare-Object` cmdlet compares two sets of objects. One set of objects is the **reference**,
 and the other set of objects is the **difference**.
 
+Normally, the objects in both sets are *sorted first*, and then *converted to strings*, if they are not strings already.  The objects are then compared as strings.  This is true even for Process objects.  There are some rare exceptions, like DateTime objects (output by Get-Date), that could be compared in a different way.  The properties of the objects are not looked at for comparison, unless the -Property parameter is used.
+
+If the -Property parameter is used, the properties given will be used for comparison.
+
 The result of the comparison indicates whether a property value appeared only in the **reference**
 object (`<=`) or only in the **difference** object (`=>`). If the **IncludeEqual** parameter is
 used, (`==`) indicates the value is in both objects.


### PR DESCRIPTION
Trying to clear up confusion on how compare-object works.  The properties of objects will not be looked at, unless the -property parameter is used.

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
