### PR TITLE
Fixes #6155 - clarify how objects are compared

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -3,20 +3,17 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2020
+ms.date: 06/18/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/compare-object?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Compare-Object
 ---
-
 # Compare-Object
 
-## SYNOPSIS
+## Synopsis
 Compares two sets of objects.
 
-## SYNTAX
-
-### All
+## Syntax
 
 ```
 Compare-Object [-ReferenceObject] <PSObject[]> [-DifferenceObject] <PSObject[]>
@@ -24,10 +21,15 @@ Compare-Object [-ReferenceObject] <PSObject[]> [-DifferenceObject] <PSObject[]>
  [-Culture <String>] [-CaseSensitive] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Compare-Object` cmdlet compares two sets of objects. One set of objects is the **reference**,
 and the other set of objects is the **difference**.
+
+`Compare-Object` checks for available methods of comparing a whole object. If it can't find a
+suitable method, it call the **ToString()** methods of the input objects and compares the string
+results. You can provide one or more properties to be used for comparison. When properties are
+provided, the cmdlet compares the values of those properties only.
 
 The result of the comparison indicates whether a property value appeared only in the **reference**
 object (`<=`) or only in the **difference** object (`=>`). If the **IncludeEqual** parameter is
@@ -36,28 +38,22 @@ used, (`==`) indicates the value is in both objects.
 If the **reference** or the **difference** objects are null (`$null`), `Compare-Object` generates a
 terminating error.
 
-For simple objects, like strings or numbers, the cmdlet compares the values of the objects. For
-complex objects, you must provide one or more properties to be used for comparison. If you do
-provide a property, the cmdlet checks for **IComparable** interfaces to perform the comparison. If
-that fails, the objects are converted to strings and the string values are compared.
-
 Some examples use splatting to reduce the line length of the code samples. For more information, see
 [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).
 
-The examples use two text files, with each value on a separate line.
+## Examples
+
+### Example 1 - Compare the content of two text files
+
+This example compares the contents of two text files. The example uses the following two text files,
+with each value on a separate line.
 
 - `Testfile1.txt` contains the values: dog, squirrel, and bird.
 - `Testfile2.txt` contains the values: cat, bird, and racoon.
 
-## EXAMPLES
-
-### Example 1: Compare the content of two text files
-
-This example compares the contents of two text files. The output displays only the lines that are
-different between the files. `Testfile1.txt` is the **reference** object (`<=`) and
-`Testfile2.txt`is the **difference** object (`=>`).
-
-Lines with content that appear in both files aren't displayed.
+The output displays only the lines that are different between the files. `Testfile1.txt` is the
+**reference** object (`<=`) and `Testfile2.txt`is the **difference** object (`=>`). Lines with
+content that appear in both files aren't displayed.
 
 ```powershell
 Compare-Object -ReferenceObject (Get-Content -Path C:\Test\Testfile1.txt) -DifferenceObject (Get-Content -Path C:\Test\Testfile2.txt)
@@ -72,33 +68,7 @@ dog         <=
 squirrel    <=
 ```
 
-### Example 2: Compare each line of content in two text files
-
-This example uses the **IncludeEqual** to compare each line of content in two text files. All the
-lines of content from both files are displayed.
-
-The **SideIndicator** specifies if the line appears in the `Testfile1.txt` **reference** object
-(`<=`), `Testfile2.txt` **difference** object (`=>`), or both files (`==`).
-
-```powershell
-$objects = @{
-  ReferenceObject = (Get-Content -Path C:\Test\Testfile1.txt)
-  DifferenceObject = (Get-Content -Path C:\Test\Testfile2.txt)
-}
-Compare-Object @objects -IncludeEqual
-```
-
-```Output
-InputObject SideIndicator
------------ -------------
-bird        ==
-cat         =>
-racoon      =>
-dog         <=
-squirrel    <=
-```
-
-### Example 3: Compare each line of content and exclude the differences
+### Example 2 - Compare each line of content and exclude the differences
 
 This example uses the **IncludeEqual** and **ExcludeDifferent** parameters to compare each line of
 content in two text files.
@@ -120,33 +90,9 @@ InputObject SideIndicator
 bird        ==
 ```
 
-### Example 4: Compare two sets of process objects
+<a id="ex3" />
 
-This example compares two sets of objects that contain the computer's running processes.
-
-```powershell
-$Processes_Before = Get-Process
-notepad.exe
-$Processes_After = Get-Process
-Compare-Object -ReferenceObject $Processes_Before -DifferenceObject $Processes_After
-```
-
-```Output
-InputObject                            SideIndicator
------------                            -------------
-System.Diagnostics.Process (notepad)   =>
-```
-
-First, `Get-Process` gets a list of running processes and stores them in the `$Processes_Before`
-variable then the `notepad.exe` application is started. Next, `Get-Process` gets an updated list of
-running processes and stores them in the `$Processes_After` variable.
-
-`Compare-Object` compares the two sets of process objects. The output displays the difference,
-**notepad.exe**, from the `$Processes_After` object.
-
-<a name="ex5" />
-
-### Example 5: Show the difference when using the PassThru parameter
+### Example 3 - Show the difference when using the PassThru parameter
 
 Normally, `Compare-Object` returns a **PSCustomObject** type with the following properties:
 
@@ -222,12 +168,29 @@ output displayed by the default format for **System.Boolean** objects didn't dis
 **SideIndicator** property. However, the returned **System.Boolean** object has the added
 **NoteProperty**.
 
-### Example 6 - Comparing complex objects
+### Example 4 - Compare two simple objects using properties
+
+In this example, we compare two different string that have the same length.
+
+```powershell
+Compare-Object -ReferenceObject 'abc' -DifferenceObject 'xyz' -Property Length -IncludeEqual
+```
+
+```Output
+Length SideIndicator
+------ -------------
+     3 ==
+```
+
+### Example 5 - Comparing complex objects using properties
 
 This example shows the behavior when comparing complex objects. In this example we store two
 different process objects for different instances of PowerShell. Both variables contain process
 objects with the same name. When the objects are compared without specifying the **Property**
-parameter, the cmdlet considers the objects to be equal.
+parameter, the cmdlet considers the objects to be equal. Notice that the value of the
+**InputObject** is the same as the result of the **ToString()** method. Since the
+**System.Diagnostics.Process** class does not have the **IComparable** interface, the cmdlet
+converts the objects to strings then compares the results.
 
 ```powershell
 PS> Get-Process pwsh
@@ -239,6 +202,10 @@ PS> Get-Process pwsh
 
 PS> $a = Get-Process -Id 11168
 PS> $b = Get-Process -Id 17600
+PS> $a.ToString()
+System.Diagnostics.Process (pwsh)
+PS> $b.ToString()
+System.Diagnostics.Process (pwsh)
 PS> Compare-Object $a $b -IncludeEqual
 
 InputObject                       SideIndicator
@@ -255,7 +222,39 @@ pwsh        11168 36.203125 <=
 
 When you specify properties to be compared, the cmdlet shows the differences.
 
-## PARAMETERS
+### Example 6 - Comparing complex objects that implement IComparable
+
+If the object implements **IComparable**, the cmdlet searches for ways to compare the objects.If the
+objects are different types, the **Difference** object is converted to the type of the
+**ReferenceObject** then compared.
+
+In this example, we are comparing a string to a **TimeSpan** object. In the first case, the string
+is converted to a **TimeSpan** so the objects are equal.
+
+```powershell
+Compare-Object ([TimeSpan]"0:0:1") "0:0:1" -IncludeEqual
+```
+
+```Output
+InputObject SideIndicator
+----------- -------------
+00:00:01    ==
+```
+
+```powershell
+Compare-Object "0:0:1" ([TimeSpan]"0:0:1")
+```
+
+```Output
+InputObject SideIndicator
+----------- -------------
+00:00:01    =>
+0:0:1       <=
+```
+
+In the second case, the **TimeSpan** is converted to a string so the object are different.
+
+## Parameters
 
 ### -CaseSensitive
 
@@ -418,15 +417,16 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.PSObject
 
 You can send an object down the pipeline to the **DifferenceObject** parameter.
 
-## OUTPUTS
+## Outputs
 
 ### None
 
@@ -442,14 +442,14 @@ When you use the **PassThru** parameter, the **Type** of the object is not chang
 of the object returned has an added **NoteProperty** named **SideIndicator**. **SideIndicator**
 shows which input object the output belongs to.
 
-## NOTES
+## Notes
 
 When using the **PassThru** parameter, the output displayed in the console may not include the
 **SideIndicator** property. The default format view of the for the object type output by
 `Compare-Object` does not include the **SideIndicator** property. For more information see
-[Example 5](#ex5) in this article.
+[Example 3](#ex3) in this article.
 
-## RELATED LINKS
+## Related links
 
 [ForEach-Object](../Microsoft.PowerShell.Core/ForEach-Object.md)
 

--- a/reference/6/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -3,20 +3,17 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2020
+ms.date: 06/18/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/compare-object?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Compare-Object
 ---
-
 # Compare-Object
 
-## SYNOPSIS
+## Synopsis
 Compares two sets of objects.
 
-## SYNTAX
-
-### All
+## Syntax
 
 ```
 Compare-Object [-ReferenceObject] <PSObject[]> [-DifferenceObject] <PSObject[]>
@@ -24,10 +21,15 @@ Compare-Object [-ReferenceObject] <PSObject[]> [-DifferenceObject] <PSObject[]>
  [-Culture <String>] [-CaseSensitive] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Compare-Object` cmdlet compares two sets of objects. One set of objects is the **reference**,
 and the other set of objects is the **difference**.
+
+`Compare-Object` checks for available methods of comparing a whole object. If it can't find a
+suitable method, it call the **ToString()** methods of the input objects and compares the string
+results. You can provide one or more properties to be used for comparison. When properties are
+provided, the cmdlet compares the values of those properties only.
 
 The result of the comparison indicates whether a property value appeared only in the **reference**
 object (`<=`) or only in the **difference** object (`=>`). If the **IncludeEqual** parameter is
@@ -36,28 +38,22 @@ used, (`==`) indicates the value is in both objects.
 If the **reference** or the **difference** objects are null (`$null`), `Compare-Object` generates a
 terminating error.
 
-For simple objects, like strings or numbers, the cmdlet compares the values of the objects. For
-complex objects, you must provide one or more properties to be used for comparison. If you do
-provide a property, the cmdlet checks for **IComparable** interfaces to perform the comparison. If
-that fails, the objects are converted to strings and the string values are compared.
-
 Some examples use splatting to reduce the line length of the code samples. For more information, see
 [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).
 
-The examples use two text files, with each value on a separate line.
+## Examples
+
+### Example 1 - Compare the content of two text files
+
+This example compares the contents of two text files. The example uses the following two text files,
+with each value on a separate line.
 
 - `Testfile1.txt` contains the values: dog, squirrel, and bird.
 - `Testfile2.txt` contains the values: cat, bird, and racoon.
 
-## EXAMPLES
-
-### Example 1: Compare the content of two text files
-
-This example compares the contents of two text files. The output displays only the lines that are
-different between the files. `Testfile1.txt` is the **reference** object (`<=`) and
-`Testfile2.txt`is the **difference** object (`=>`).
-
-Lines with content that appear in both files aren't displayed.
+The output displays only the lines that are different between the files. `Testfile1.txt` is the
+**reference** object (`<=`) and `Testfile2.txt`is the **difference** object (`=>`). Lines with
+content that appear in both files aren't displayed.
 
 ```powershell
 Compare-Object -ReferenceObject (Get-Content -Path C:\Test\Testfile1.txt) -DifferenceObject (Get-Content -Path C:\Test\Testfile2.txt)
@@ -72,33 +68,7 @@ dog         <=
 squirrel    <=
 ```
 
-### Example 2: Compare each line of content in two text files
-
-This example uses the **IncludeEqual** to compare each line of content in two text files. All the
-lines of content from both files are displayed.
-
-The **SideIndicator** specifies if the line appears in the `Testfile1.txt` **reference** object
-(`<=`), `Testfile2.txt` **difference** object (`=>`), or both files (`==`).
-
-```powershell
-$objects = @{
-  ReferenceObject = (Get-Content -Path C:\Test\Testfile1.txt)
-  DifferenceObject = (Get-Content -Path C:\Test\Testfile2.txt)
-}
-Compare-Object @objects -IncludeEqual
-```
-
-```Output
-InputObject SideIndicator
------------ -------------
-bird        ==
-cat         =>
-racoon      =>
-dog         <=
-squirrel    <=
-```
-
-### Example 3: Compare each line of content and exclude the differences
+### Example 2 - Compare each line of content and exclude the differences
 
 This example uses the **IncludeEqual** and **ExcludeDifferent** parameters to compare each line of
 content in two text files.
@@ -120,33 +90,9 @@ InputObject SideIndicator
 bird        ==
 ```
 
-### Example 4: Compare two sets of process objects
+<a id="ex3" />
 
-This example compares two sets of objects that contain the computer's running processes.
-
-```powershell
-$Processes_Before = Get-Process
-notepad.exe
-$Processes_After = Get-Process
-Compare-Object -ReferenceObject $Processes_Before -DifferenceObject $Processes_After
-```
-
-```Output
-InputObject                            SideIndicator
------------                            -------------
-System.Diagnostics.Process (notepad)   =>
-```
-
-First, `Get-Process` gets a list of running processes and stores them in the `$Processes_Before`
-variable then the `notepad.exe` application is started. Next, `Get-Process` gets an updated list of
-running processes and stores them in the `$Processes_After` variable.
-
-`Compare-Object` compares the two sets of process objects. The output displays the difference,
-**notepad.exe**, from the `$Processes_After` object.
-
-<a name="ex5" />
-
-### Example 5: Show the difference when using the PassThru parameter
+### Example 3 - Show the difference when using the PassThru parameter
 
 Normally, `Compare-Object` returns a **PSCustomObject** type with the following properties:
 
@@ -222,12 +168,29 @@ output displayed by the default format for **System.Boolean** objects didn't dis
 **SideIndicator** property. However, the returned **System.Boolean** object has the added
 **NoteProperty**.
 
-### Example 6 - Comparing complex objects
+### Example 4 - Compare two simple objects using properties
+
+In this example, we compare two different string that have the same length.
+
+```powershell
+Compare-Object -ReferenceObject 'abc' -DifferenceObject 'xyz' -Property Length -IncludeEqual
+```
+
+```Output
+Length SideIndicator
+------ -------------
+     3 ==
+```
+
+### Example 5 - Comparing complex objects using properties
 
 This example shows the behavior when comparing complex objects. In this example we store two
 different process objects for different instances of PowerShell. Both variables contain process
 objects with the same name. When the objects are compared without specifying the **Property**
-parameter, the cmdlet considers the objects to be equal.
+parameter, the cmdlet considers the objects to be equal. Notice that the value of the
+**InputObject** is the same as the result of the **ToString()** method. Since the
+**System.Diagnostics.Process** class does not have the **IComparable** interface, the cmdlet
+converts the objects to strings then compares the results.
 
 ```powershell
 PS> Get-Process pwsh
@@ -239,6 +202,10 @@ PS> Get-Process pwsh
 
 PS> $a = Get-Process -Id 11168
 PS> $b = Get-Process -Id 17600
+PS> $a.ToString()
+System.Diagnostics.Process (pwsh)
+PS> $b.ToString()
+System.Diagnostics.Process (pwsh)
 PS> Compare-Object $a $b -IncludeEqual
 
 InputObject                       SideIndicator
@@ -255,7 +222,39 @@ pwsh        11168 36.203125 <=
 
 When you specify properties to be compared, the cmdlet shows the differences.
 
-## PARAMETERS
+### Example 6 - Comparing complex objects that implement IComparable
+
+If the object implements **IComparable**, the cmdlet searches for ways to compare the objects.If the
+objects are different types, the **Difference** object is converted to the type of the
+**ReferenceObject** then compared.
+
+In this example, we are comparing a string to a **TimeSpan** object. In the first case, the string
+is converted to a **TimeSpan** so the objects are equal.
+
+```powershell
+Compare-Object ([TimeSpan]"0:0:1") "0:0:1" -IncludeEqual
+```
+
+```Output
+InputObject SideIndicator
+----------- -------------
+00:00:01    ==
+```
+
+```powershell
+Compare-Object "0:0:1" ([TimeSpan]"0:0:1")
+```
+
+```Output
+InputObject SideIndicator
+----------- -------------
+00:00:01    =>
+0:0:1       <=
+```
+
+In the second case, the **TimeSpan** is converted to a string so the object are different.
+
+## Parameters
 
 ### -CaseSensitive
 
@@ -418,15 +417,16 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.PSObject
 
 You can send an object down the pipeline to the **DifferenceObject** parameter.
 
-## OUTPUTS
+## Outputs
 
 ### None
 
@@ -442,14 +442,14 @@ When you use the **PassThru** parameter, the **Type** of the object is not chang
 of the object returned has an added **NoteProperty** named **SideIndicator**. **SideIndicator**
 shows which input object the output belongs to.
 
-## NOTES
+## Notes
 
 When using the **PassThru** parameter, the output displayed in the console may not include the
 **SideIndicator** property. The default format view of the for the object type output by
 `Compare-Object` does not include the **SideIndicator** property. For more information see
-[Example 5](#ex5) in this article.
+[Example 3](#ex3) in this article.
 
-## RELATED LINKS
+## Related links
 
 [ForEach-Object](../Microsoft.PowerShell.Core/ForEach-Object.md)
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -3,20 +3,17 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/23/2020
+ms.date: 06/18/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/compare-object?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Compare-Object
 ---
-
 # Compare-Object
 
-## SYNOPSIS
+## Synopsis
 Compares two sets of objects.
 
-## SYNTAX
-
-### All
+## Syntax
 
 ```
 Compare-Object [-ReferenceObject] <PSObject[]> [-DifferenceObject] <PSObject[]>
@@ -24,10 +21,15 @@ Compare-Object [-ReferenceObject] <PSObject[]> [-DifferenceObject] <PSObject[]>
  [-Culture <String>] [-CaseSensitive] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Compare-Object` cmdlet compares two sets of objects. One set of objects is the **reference**,
 and the other set of objects is the **difference**.
+
+`Compare-Object` checks for available methods of comparing a whole object. If it can't find a
+suitable method, it call the **ToString()** methods of the input objects and compares the string
+results. You can provide one or more properties to be used for comparison. When properties are
+provided, the cmdlet compares the values of those properties only.
 
 The result of the comparison indicates whether a property value appeared only in the **reference**
 object (`<=`) or only in the **difference** object (`=>`). If the **IncludeEqual** parameter is
@@ -36,28 +38,22 @@ used, (`==`) indicates the value is in both objects.
 If the **reference** or the **difference** objects are null (`$null`), `Compare-Object` generates a
 terminating error.
 
-For simple objects, like strings or numbers, the cmdlet compares the values of the objects. For
-complex objects, you must provide one or more properties to be used for comparison. If you do
-provide a property, the cmdlet checks for **IComparable** interfaces to perform the comparison. If
-that fails, the objects are converted to strings and the string values are compared.
-
 Some examples use splatting to reduce the line length of the code samples. For more information, see
 [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).
 
-The examples use two text files, with each value on a separate line.
+## Examples
+
+### Example 1 - Compare the content of two text files
+
+This example compares the contents of two text files. The example uses the following two text files,
+with each value on a separate line.
 
 - `Testfile1.txt` contains the values: dog, squirrel, and bird.
 - `Testfile2.txt` contains the values: cat, bird, and racoon.
 
-## EXAMPLES
-
-### Example 1: Compare the content of two text files
-
-This example compares the contents of two text files. The output displays only the lines that are
-different between the files. `Testfile1.txt` is the **reference** object (`<=`) and
-`Testfile2.txt`is the **difference** object (`=>`).
-
-Lines with content that appear in both files aren't displayed.
+The output displays only the lines that are different between the files. `Testfile1.txt` is the
+**reference** object (`<=`) and `Testfile2.txt`is the **difference** object (`=>`). Lines with
+content that appear in both files aren't displayed.
 
 ```powershell
 Compare-Object -ReferenceObject (Get-Content -Path C:\Test\Testfile1.txt) -DifferenceObject (Get-Content -Path C:\Test\Testfile2.txt)
@@ -72,33 +68,7 @@ dog         <=
 squirrel    <=
 ```
 
-### Example 2: Compare each line of content in two text files
-
-This example uses the **IncludeEqual** to compare each line of content in two text files. All the
-lines of content from both files are displayed.
-
-The **SideIndicator** specifies if the line appears in the `Testfile1.txt` **reference** object
-(`<=`), `Testfile2.txt` **difference** object (`=>`), or both files (`==`).
-
-```powershell
-$objects = @{
-  ReferenceObject = (Get-Content -Path C:\Test\Testfile1.txt)
-  DifferenceObject = (Get-Content -Path C:\Test\Testfile2.txt)
-}
-Compare-Object @objects -IncludeEqual
-```
-
-```Output
-InputObject SideIndicator
------------ -------------
-bird        ==
-cat         =>
-racoon      =>
-dog         <=
-squirrel    <=
-```
-
-### Example 3: Compare each line of content and exclude the differences
+### Example 2 - Compare each line of content and exclude the differences
 
 This example uses the **IncludeEqual** and **ExcludeDifferent** parameters to compare each line of
 content in two text files.
@@ -120,33 +90,9 @@ InputObject SideIndicator
 bird        ==
 ```
 
-### Example 4: Compare two sets of process objects
+<a id="ex3" />
 
-This example compares two sets of objects that contain the computer's running processes.
-
-```powershell
-$Processes_Before = Get-Process
-notepad.exe
-$Processes_After = Get-Process
-Compare-Object -ReferenceObject $Processes_Before -DifferenceObject $Processes_After
-```
-
-```Output
-InputObject                            SideIndicator
------------                            -------------
-System.Diagnostics.Process (notepad)   =>
-```
-
-First, `Get-Process` gets a list of running processes and stores them in the `$Processes_Before`
-variable then the `notepad.exe` application is started. Next, `Get-Process` gets an updated list of
-running processes and stores them in the `$Processes_After` variable.
-
-`Compare-Object` compares the two sets of process objects. The output displays the difference,
-**notepad.exe**, from the `$Processes_After` object.
-
-<a name="ex5" />
-
-### Example 5: Show the difference when using the PassThru parameter
+### Example 3 - Show the difference when using the PassThru parameter
 
 Normally, `Compare-Object` returns a **PSCustomObject** type with the following properties:
 
@@ -222,12 +168,29 @@ output displayed by the default format for **System.Boolean** objects didn't dis
 **SideIndicator** property. However, the returned **System.Boolean** object has the added
 **NoteProperty**.
 
-### Example 6 - Comparing complex objects
+### Example 4 - Compare two simple objects using properties
+
+In this example, we compare two different string that have the same length.
+
+```powershell
+Compare-Object -ReferenceObject 'abc' -DifferenceObject 'xyz' -Property Length -IncludeEqual
+```
+
+```Output
+Length SideIndicator
+------ -------------
+     3 ==
+```
+
+### Example 5 - Comparing complex objects using properties
 
 This example shows the behavior when comparing complex objects. In this example we store two
 different process objects for different instances of PowerShell. Both variables contain process
 objects with the same name. When the objects are compared without specifying the **Property**
-parameter, the cmdlet considers the objects to be equal.
+parameter, the cmdlet considers the objects to be equal. Notice that the value of the
+**InputObject** is the same as the result of the **ToString()** method. Since the
+**System.Diagnostics.Process** class does not have the **IComparable** interface, the cmdlet
+converts the objects to strings then compares the results.
 
 ```powershell
 PS> Get-Process pwsh
@@ -239,6 +202,10 @@ PS> Get-Process pwsh
 
 PS> $a = Get-Process -Id 11168
 PS> $b = Get-Process -Id 17600
+PS> $a.ToString()
+System.Diagnostics.Process (pwsh)
+PS> $b.ToString()
+System.Diagnostics.Process (pwsh)
 PS> Compare-Object $a $b -IncludeEqual
 
 InputObject                       SideIndicator
@@ -255,7 +222,39 @@ pwsh        11168 36.203125 <=
 
 When you specify properties to be compared, the cmdlet shows the differences.
 
-## PARAMETERS
+### Example 6 - Comparing complex objects that implement IComparable
+
+If the object implements **IComparable**, the cmdlet searches for ways to compare the objects.If the
+objects are different types, the **Difference** object is converted to the type of the
+**ReferenceObject** then compared.
+
+In this example, we are comparing a string to a **TimeSpan** object. In the first case, the string
+is converted to a **TimeSpan** so the objects are equal.
+
+```powershell
+Compare-Object ([TimeSpan]"0:0:1") "0:0:1" -IncludeEqual
+```
+
+```Output
+InputObject SideIndicator
+----------- -------------
+00:00:01    ==
+```
+
+```powershell
+Compare-Object "0:0:1" ([TimeSpan]"0:0:1")
+```
+
+```Output
+InputObject SideIndicator
+----------- -------------
+00:00:01    =>
+0:0:1       <=
+```
+
+In the second case, the **TimeSpan** is converted to a string so the object are different.
+
+## Parameters
 
 ### -CaseSensitive
 
@@ -418,15 +417,16 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.PSObject
 
 You can send an object down the pipeline to the **DifferenceObject** parameter.
 
-## OUTPUTS
+## Outputs
 
 ### None
 
@@ -442,14 +442,14 @@ When you use the **PassThru** parameter, the **Type** of the object is not chang
 of the object returned has an added **NoteProperty** named **SideIndicator**. **SideIndicator**
 shows which input object the output belongs to.
 
-## NOTES
+## Notes
 
 When using the **PassThru** parameter, the output displayed in the console may not include the
 **SideIndicator** property. The default format view of the for the object type output by
 `Compare-Object` does not include the **SideIndicator** property. For more information see
-[Example 5](#ex5) in this article.
+[Example 3](#ex3) in this article.
 
-## RELATED LINKS
+## Related links
 
 [ForEach-Object](../Microsoft.PowerShell.Core/ForEach-Object.md)
 

--- a/reference/7.1/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -3,17 +3,17 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 05/07/2020
+ms.date: 06/18/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/compare-object?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Compare-Object
 ---
 # Compare-Object
 
-## SYNOPSIS
+## Synopsis
 Compares two sets of objects.
 
-## SYNTAX
+## Syntax
 
 ```
 Compare-Object [-ReferenceObject] <PSObject[]> [-DifferenceObject] <PSObject[]>
@@ -21,10 +21,15 @@ Compare-Object [-ReferenceObject] <PSObject[]> [-DifferenceObject] <PSObject[]>
  [-Culture <String>] [-CaseSensitive] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Compare-Object` cmdlet compares two sets of objects. One set of objects is the **reference**,
 and the other set of objects is the **difference**.
+
+`Compare-Object` checks for available methods of comparing a whole object. If it can't find a
+suitable method, it call the **ToString()** methods of the input objects and compares the string
+results. You can provide one or more properties to be used for comparison. When properties are
+provided, the cmdlet compares the values of those properties only.
 
 The result of the comparison indicates whether a property value appeared only in the **reference**
 object (`<=`) or only in the **difference** object (`=>`). If the **IncludeEqual** parameter is
@@ -33,28 +38,22 @@ used, (`==`) indicates the value is in both objects.
 If the **reference** or the **difference** objects are null (`$null`), `Compare-Object` generates a
 terminating error.
 
-For simple objects, like strings or numbers, the cmdlet compares the values of the objects. For
-complex objects, you must provide one or more properties to be used for comparison. If you do
-provide a property, the cmdlet checks for **IComparable** interfaces to perform the comparison. If
-that fails, the objects are converted to strings and the string values are compared.
-
 Some examples use splatting to reduce the line length of the code samples. For more information, see
 [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).
 
-The examples use two text files, with each value on a separate line.
+## Examples
+
+### Example 1 - Compare the content of two text files
+
+This example compares the contents of two text files. The example uses the following two text files,
+with each value on a separate line.
 
 - `Testfile1.txt` contains the values: dog, squirrel, and bird.
 - `Testfile2.txt` contains the values: cat, bird, and racoon.
 
-## EXAMPLES
-
-### Example 1: Compare the content of two text files
-
-This example compares the contents of two text files. The output displays only the lines that are
-different between the files. `Testfile1.txt` is the **reference** object (`<=`) and
-`Testfile2.txt`is the **difference** object (`=>`).
-
-Lines with content that appear in both files aren't displayed.
+The output displays only the lines that are different between the files. `Testfile1.txt` is the
+**reference** object (`<=`) and `Testfile2.txt`is the **difference** object (`=>`). Lines with
+content that appear in both files aren't displayed.
 
 ```powershell
 Compare-Object -ReferenceObject (Get-Content -Path C:\Test\Testfile1.txt) -DifferenceObject (Get-Content -Path C:\Test\Testfile2.txt)
@@ -69,33 +68,7 @@ dog         <=
 squirrel    <=
 ```
 
-### Example 2: Compare each line of content in two text files
-
-This example uses the **IncludeEqual** to compare each line of content in two text files. All the
-lines of content from both files are displayed.
-
-The **SideIndicator** specifies if the line appears in the `Testfile1.txt` **reference** object
-(`<=`), `Testfile2.txt` **difference** object (`=>`), or both files (`==`).
-
-```powershell
-$objects = @{
-  ReferenceObject = (Get-Content -Path C:\Test\Testfile1.txt)
-  DifferenceObject = (Get-Content -Path C:\Test\Testfile2.txt)
-}
-Compare-Object @objects -IncludeEqual
-```
-
-```Output
-InputObject SideIndicator
------------ -------------
-bird        ==
-cat         =>
-racoon      =>
-dog         <=
-squirrel    <=
-```
-
-### Example 3: Compare each line of content and exclude the differences
+### Example 2 - Compare each line of content and exclude the differences
 
 This example uses the **ExcludeDifferent** parameter to compare each line of
 content in two text files.
@@ -118,33 +91,9 @@ InputObject SideIndicator
 bird        ==
 ```
 
-### Example 4: Compare two sets of process objects
+<a id="ex3" />
 
-This example compares two sets of objects that contain the computer's running processes.
-
-```powershell
-$Processes_Before = Get-Process
-notepad.exe
-$Processes_After = Get-Process
-Compare-Object -ReferenceObject $Processes_Before -DifferenceObject $Processes_After
-```
-
-```Output
-InputObject                            SideIndicator
------------                            -------------
-System.Diagnostics.Process (notepad)   =>
-```
-
-First, `Get-Process` gets a list of running processes and stores them in the `$Processes_Before`
-variable then the `notepad.exe` application is started. Next, `Get-Process` gets an updated list of
-running processes and stores them in the `$Processes_After` variable.
-
-`Compare-Object` compares the two sets of process objects. The output displays the difference,
-**notepad.exe**, from the `$Processes_After` object.
-
-<a name="ex5" />
-
-### Example 5: Show the difference when using the PassThru parameter
+### Example 3 - Show the difference when using the PassThru parameter
 
 Normally, `Compare-Object` returns a **PSCustomObject** type with the following properties:
 
@@ -220,12 +169,29 @@ output displayed by the default format for **System.Boolean** objects didn't dis
 **SideIndicator** property. However, the returned **System.Boolean** object has the added
 **NoteProperty**.
 
-### Example 6 - Comparing complex objects
+### Example 4 - Compare two simple objects using properties
+
+In this example, we compare two different string that have the same length.
+
+```powershell
+Compare-Object -ReferenceObject 'abc' -DifferenceObject 'xyz' -Property Length -IncludeEqual
+```
+
+```Output
+Length SideIndicator
+------ -------------
+     3 ==
+```
+
+### Example 5 - Comparing complex objects using properties
 
 This example shows the behavior when comparing complex objects. In this example we store two
 different process objects for different instances of PowerShell. Both variables contain process
 objects with the same name. When the objects are compared without specifying the **Property**
-parameter, the cmdlet considers the objects to be equal.
+parameter, the cmdlet considers the objects to be equal. Notice that the value of the
+**InputObject** is the same as the result of the **ToString()** method. Since the
+**System.Diagnostics.Process** class does not have the **IComparable** interface, the cmdlet
+converts the objects to strings then compares the results.
 
 ```powershell
 PS> Get-Process pwsh
@@ -237,6 +203,10 @@ PS> Get-Process pwsh
 
 PS> $a = Get-Process -Id 11168
 PS> $b = Get-Process -Id 17600
+PS> $a.ToString()
+System.Diagnostics.Process (pwsh)
+PS> $b.ToString()
+System.Diagnostics.Process (pwsh)
 PS> Compare-Object $a $b -IncludeEqual
 
 InputObject                       SideIndicator
@@ -253,7 +223,39 @@ pwsh        11168 36.203125 <=
 
 When you specify properties to be compared, the cmdlet shows the differences.
 
-## PARAMETERS
+### Example 6 - Comparing complex objects that implement IComparable
+
+If the object implements **IComparable**, the cmdlet searches for ways to compare the objects.If the
+objects are different types, the **Difference** object is converted to the type of the
+**ReferenceObject** then compared.
+
+In this example, we are comparing a string to a **TimeSpan** object. In the first case, the string
+is converted to a **TimeSpan** so the objects are equal.
+
+```powershell
+Compare-Object ([TimeSpan]"0:0:1") "0:0:1" -IncludeEqual
+```
+
+```Output
+InputObject SideIndicator
+----------- -------------
+00:00:01    ==
+```
+
+```powershell
+Compare-Object "0:0:1" ([TimeSpan]"0:0:1")
+```
+
+```Output
+InputObject SideIndicator
+----------- -------------
+00:00:01    =>
+0:0:1       <=
+```
+
+In the second case, the **TimeSpan** is converted to a string so the object are different.
+
+## Parameters
 
 ### -CaseSensitive
 
@@ -308,8 +310,8 @@ Accept wildcard characters: False
 Indicates that this cmdlet displays only the characteristics of compared objects that are equal. The
 differences between the objects are discarded.
 
-If **ExcludeDifferent** is specified without **IncludeEqual**, **IncludeEqual** is inferred. To
-override, pass **$false** to **IncludeEqual**.
+As of PowerShell 7.1, when using the **ExcludeDifferent** parameter, **IncludeEqual** is inferred
+and the output only contains objects that are equal.
 
 ```yaml
 Type: SwitchParameter
@@ -412,17 +414,18 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction,
--InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and
--WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.PSObject
 
 You can send an object down the pipeline to the **DifferenceObject** parameter.
 
-## OUTPUTS
+## Outputs
 
 ### None
 
@@ -438,14 +441,14 @@ When you use the **PassThru** parameter, the **Type** of the object is not chang
 of the object returned has an added **NoteProperty** named **SideIndicator**. **SideIndicator**
 shows which input object the output belongs to.
 
-## NOTES
+## Notes
 
 When using the **PassThru** parameter, the output displayed in the console may not include the
 **SideIndicator** property. The default format view of the for the object type output by
 `Compare-Object` does not include the **SideIndicator** property. For more information see
-[Example 5](#ex5) in this article.
+[Example 3](#ex3) in this article.
 
-## RELATED LINKS
+## Related links
 
 [ForEach-Object](../Microsoft.PowerShell.Core/ForEach-Object.md)
 
@@ -464,4 +467,3 @@ When using the **PassThru** parameter, the output displayed in the console may n
 [Where-Object](../Microsoft.PowerShell.Core/Where-Object.md)
 
 [Get-Process](../Microsoft.PowerShell.Management/Get-Process.md)
-


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes [AB#1738428](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1738428) - Fixes #6155 - clarify how objects are compared

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
