### PR TITLE
Fix version number in docs about 5.1

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
@@ -360,7 +360,7 @@ and [Unblock-File](../../Microsoft.PowerShell.Utility/Unblock-File.md).
 
 ## Execution policy on Windows Server Core and Window Nano Server
 
-When PowerShell 6 is run on Windows Server Core or Windows Nano Server under
+When PowerShell 5.1 is run on Windows Server Core or Windows Nano Server under
 certain conditions, execution policies can fail with the following error:
 
 ```Output


### PR DESCRIPTION
# PR Summary

fix version number in docs about 5.1

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content. Changes to cmdlet
reference should be made to all versions where applicable. The /docs-conceptual folder tree does
not have version folders.
-->

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [x] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
