### PR TITLE
Fixes #6168 Bad UFormat Value in v 5.1 Get-Date 

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -492,7 +492,6 @@ The valid **UFormat specifiers** are displayed in the following table:
 | `%D` | Date in mm/dd/yy format                                                 | 06/27/19                 |
 | `%d` | Day of the month - 2 digits                                             | 05                       |
 | `%e` | Day of the month - digit preceded by a space                            | \<space\>5               |
-| `%F` | Date in YYYY-mm-dd format, equal to %Y-%m-%d (the ISO 8601 date format) | 2019-06-27               |
 | `%G` | Same as 'Y'                                                             |                          |
 | `%g` | Same as 'y'                                                             |                          |
 | `%H` | Hour in 24-hour format                                                  | 17                       |


### PR DESCRIPTION
# PR Summary

Customer notices that our documentation had a valued copied from the later versions and it wasnt' available in the 5.1 version. 

## PR Context

Fixes #6168 
Fixes [AB#1738659](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1738659)

Select the type(s) of documents being changed.

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [x] Version 5.1 content

**Conceptual content**
- [ ] Fundamental conceptual articles
- [ ] Script sample articles
- [ ] DSC articles
- [ ] Gallery articles
- [ ] JEA articles
- [ ] WMF articles
- [ ] SDK articles
- [ ] Community content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
