### PR TITLE
Fixes #6187 - Updates about_Comparison_Operators

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -267,9 +267,6 @@ Server
 Description: Matches a string using regular expressions. When the input is
 scalar, it populates the `$Matches` automatic variable.
 
-The match operators search only in strings. They cannot search in arrays of
-integers or other objects.
-
 If the input is a collection, the `-match` and `-notmatch` operators return
 the matching members of that collection, but the operator does not populate
 the `$Matches` variable.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -267,9 +267,6 @@ Server
 Description: Matches a string using regular expressions. When the input is
 scalar, it populates the `$Matches` automatic variable.
 
-The match operators search only in strings. They cannot search in arrays of
-integers or other objects.
-
 If the input is a collection, the `-match` and `-notmatch` operators return
 the matching members of that collection, but the operator does not populate
 the `$Matches` variable.

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -265,7 +265,7 @@ Server
 ### -match
 
 Description: Matches a string using regular expressions. When the input is
-scalar, it populates the `$Matches` automatic variable.s
+scalar, it populates the `$Matches` automatic variable.
 
 If the input is a collection, the `-match` and `-notmatch` operators return
 the matching members of that collection, but the operator does not populate

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -265,10 +265,7 @@ Server
 ### -match
 
 Description: Matches a string using regular expressions. When the input is
-scalar, it populates the `$Matches` automatic variable.
-
-The match operators search only in strings. They cannot search in arrays of
-integers or other objects.
+scalar, it populates the `$Matches` automatic variable.s
 
 If the input is a collection, the `-match` and `-notmatch` operators return
 the matching members of that collection, but the operator does not populate

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -267,9 +267,6 @@ Server
 Description: Matches a string using regular expressions. When the input is
 scalar, it populates the `$Matches` automatic variable.
 
-The match operators search only in strings. They cannot search in arrays of
-integers or other objects.
-
 If the input is a collection, the `-match` and `-notmatch` operators return
 the matching members of that collection, but the operator does not populate
 the `$Matches` variable.


### PR DESCRIPTION
# PR Summary

Customer noticed there was a misleading sentence in about_comparison_operators

My Solution was to remove the misleading sentence entirely. I don't believe it adds anything and the surrounding material is informationally complete.

## PR Context

Fixes #6187 
Fixes [AB#1739706](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1739706)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
