### PR TITLE
Fixes #6198 - ValidateScript throws on $null value

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 05/06/2020
+ms.date: 06/24/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_Advanced_Parameters
@@ -629,6 +629,11 @@ than or equal to the current date and time.
 ```powershell
 [DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
 ```
+
+> [!NOTE]
+> If you use **ValidateScript**, you cannot pass a `$null` value to the
+> parameter. When you pass a null value **ValidateScript** can't validate the
+> argument.
 
 ### ValidateSet attribute
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 05/06/2020
+ms.date: 06/24/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_Advanced_Parameters
@@ -644,6 +644,11 @@ than or equal to the current date and time.
 ```powershell
 [DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
 ```
+
+> [!NOTE]
+> If you use **ValidateScript**, you cannot pass a `$null` value to the
+> parameter. When you pass a null value **ValidateScript** can't validate the
+> argument.
 
 ### ValidateSet attribute
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 05/06/2020
+ms.date: 06/24/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_Advanced_Parameters
@@ -416,7 +416,7 @@ that appears when a mandatory parameter value is missing from a command. This
 argument has no effect on optional parameters.
 
 The following example declares a mandatory **ComputerName** parameter and a
-help message that explains the expected parameter value. 
+help message that explains the expected parameter value.
 
 If there is no other [comment-based help](./about_comment_based_help.md) syntax
 for the function (for example, `.SYNOPSIS`) then this message also shows up in
@@ -639,6 +639,11 @@ than or equal to the current date and time.
 ```powershell
 [DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
 ```
+
+> [!NOTE]
+> If you use **ValidateScript**, you cannot pass a `$null` value to the
+> parameter. When you pass a null value **ValidateScript** can't validate the
+> argument.
 
 ### ValidateSet attribute
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 05/06/2020
+ms.date: 06/24/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_Advanced_Parameters
@@ -639,6 +639,11 @@ than or equal to the current date and time.
 ```powershell
 [DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
 ```
+
+> [!NOTE]
+> If you use **ValidateScript**, you cannot pass a `$null` value to the
+> parameter. When you pass a null value **ValidateScript** can't validate the
+> argument.
 
 ### ValidateSet attribute
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fixes [AB#1740908](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1740908) - Fixes #6198 - ValidateScript throws on $null value
Closes https://github.com/PowerShell/PowerShell/issues/12557

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
