### PR TITLE
Clean up double wrapped keyboard shortcut

### DIFF
--- a/reference/docs-conceptual/windows-powershell/ise/Keyboard-Shortcuts-for-the-Windows-PowerShell-ISE.md
+++ b/reference/docs-conceptual/windows-powershell/ise/Keyboard-Shortcuts-for-the-Windows-PowerShell-ISE.md
@@ -74,7 +74,7 @@ You can use the following keyboard shortcuts when you debug scripts.
 | **Run/Continue**           | <kbd>F5</kbd>                                  | Script Pane, when debugging a script |
 | **Step Into**              | <kbd>F11</kbd>                                 | Script Pane, when debugging a script |
 | **Step Over**              | <kbd>F10</kbd>                                 | Script Pane, when debugging a script |
-| **Step Out**               | <kbd>SHIFT</kbd>+<kbd><kbd>F11</kbd></kbd>     | Script Pane, when debugging a script |
+| **Step Out**               | <kbd>SHIFT</kbd>+<kbd>F11</kbd>                | Script Pane, when debugging a script |
 | **Display Call Stack**     | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>D</kbd>  | Script Pane, when debugging a script |
 | **List Breakpoints**       | <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>L</kbd>  | Script Pane, when debugging a script |
 | **Toggle Breakpoint**      | <kbd>F9</kbd>                                  | Script Pane, when debugging a script |


### PR DESCRIPTION
F11 on Step Out got double wrapped in `<kbd></kbd>`.


**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [X] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
