### PR TITLE
Add the UnixTimeSeconds parameter to the Get-Date command and removes the FromUnixTime parameter

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -236,7 +236,7 @@ directory is created.
 This example is a Unix time (it is represented by the number of seconds since 1970-01-01 0:00:00) to DateTime.
 
 ```powershell
-Get-Date -UnixTime 1577836800
+Get-Date -UnixTimeSeconds 1577836800
 ```
 
 ```Output

--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 05/21/2020
+ms.date: 07/13/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Date

--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -233,7 +233,7 @@ directory is created.
 
 ### Example 9: Convert a Unix timestamp
 
-This example is a Unix time (it is represented by the number of seconds since 1970-01-01 0:00:00) to DateTime.
+This example converts a Unix time (represented by the number of seconds since 1970-01-01 0:00:00) to DateTime.
 
 ```powershell
 Get-Date -UnixTimeSeconds 1577836800

--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -16,20 +16,36 @@ Gets the current date and time.
 
 ## SYNTAX
 
-### net (Default)
+### Date (Default)
 
 ```
 Get-Date [[-Date] <DateTime>] [-Year <Int32>] [-Month <Int32>] [-Day <Int32>] [-Hour <Int32>]
  [-Minute <Int32>] [-Second <Int32>] [-Millisecond <Int32>] [-DisplayHint <DisplayHintType>]
- [-Format <String>] [-AsUTC] [-FromUnixTime] [<CommonParameters>]
+ [-Format <String>] [-AsUTC] [<CommonParameters>]
 ```
 
-### UFormat
+### DateUFormat
 
 ```
 Get-Date [[-Date] <DateTime>] [-Year <Int32>] [-Month <Int32>] [-Day <Int32>] [-Hour <Int32>]
  [-Minute <Int32>] [-Second <Int32>] [-Millisecond <Int32>] [-DisplayHint <DisplayHintType>]
- [-UFormat <String>] [-FromUnixTime] [<CommonParameters>]
+ -UFormat <String> [<CommonParameters>]
+```
+
+### UnixTimeSeconds
+
+```
+Get-Date -UnixTimeSeconds <Int64> [-Year <Int32>] [-Month <Int32>] [-Day <Int32>] [-Hour <Int32>]
+ [-Minute <Int32>] [-Second <Int32>] [-Millisecond <Int32>] [-DisplayHint <DisplayHintType>]
+ [-Format <String>] [-AsUTC] [<CommonParameters>]
+```
+
+### UnixTimeSecondsUFormat
+
+```
+Get-Date -UnixTimeSeconds <Int64> [-Year <Int32>] [-Month <Int32>] [-Day <Int32>] [-Hour <Int32>]
+ [-Minute <Int32>] [-Second <Int32>] [-Millisecond <Int32>] [-DisplayHint <DisplayHintType>]
+ -UFormat <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -217,10 +233,10 @@ directory is created.
 
 ### Example 9: Convert a Unix timestamp
 
-This example converts the **Date** value represented as a Unix timestamp.
+This example is a Unix time (it is represented by the number of seconds since 1970-01-01 0:00:00) to DateTime.
 
 ```powershell
-Get-Date -Date 1577836800 -FromUnixTime
+Get-Date -UnixTime 1577836800
 ```
 
 ```Output
@@ -260,6 +276,24 @@ Wednesday, January 1, 2020 8:00:00 AM
 
 ## PARAMETERS
 
+### -AsUTC
+
+Converts the date value to the equivalent time in UTC.
+
+This parameter was added in PowerShell 7.1.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Date
 
 Specifies a date and time. Time is optional and if not specified, returns 00:00:00.
@@ -272,7 +306,7 @@ For example, in US English:
 
 ```yaml
 Type: System.DateTime
-Parameter Sets: (All)
+Parameter Sets: Date, DateUFormat
 Aliases: LastWriteTime
 
 Required: False
@@ -360,7 +394,7 @@ Starting in PowerShell 5.0, you can use the following additional formats as valu
 
 ```yaml
 Type: System.String
-Parameter Sets: net
+Parameter Sets: Date, UnixTimeSeconds
 Aliases:
 
 Required: False
@@ -465,10 +499,28 @@ objects might not be available.
 
 ```yaml
 Type: System.String
-Parameter Sets: UFormat
+Parameter Sets: DateUFormat, UnixTimeSecondsUFormat
 Aliases:
 
 Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UnixTimeSeconds
+
+Date and time represented in seconds since January 1, 1970, 0:00:00.
+
+This parameter was introduced in PowerShell 7.1.
+
+```yaml
+Type: System.Int64
+Parameter Sets: UnixTimeSeconds, UnixTimeSecondsUFormat
+Aliases: UnixTime
+
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -487,42 +539,6 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -AsUTC
-
-Converts the date value to the equivalent time in UTC.
-
-This parameter was added in PowerShell 7.1.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-Parameter Sets: net
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -FromUnixTime
-
-When this parameter is used, the value of the **Date** parameter is treated as a Unix timestamp. A
-Unix timestamp is a numeric value that is the of seconds elapsed since
-**1970-01-01​T00:00:00.000Z**.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -280,7 +280,7 @@ Wednesday, January 1, 2020 8:00:00 AM
 
 Converts the date value to the equivalent time in UTC.
 
-This parameter was added in PowerShell 7.1.
+This parameter was introduced in PowerShell 7.1.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 07/13/2020
+ms.date: 08/13/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Date
@@ -306,7 +306,7 @@ For example, in US English:
 
 ```yaml
 Type: System.DateTime
-Parameter Sets: Date, DateUFormat
+Parameter Sets: DateAndFormat, DateAndUFormat
 Aliases: LastWriteTime
 
 Required: False
@@ -394,7 +394,7 @@ Starting in PowerShell 5.0, you can use the following additional formats as valu
 
 ```yaml
 Type: System.String
-Parameter Sets: Date, UnixTimeSeconds
+Parameter Sets: DateAndFormat, UnixTimeSecondsAndFormat
 Aliases:
 
 Required: False
@@ -499,7 +499,7 @@ objects might not be available.
 
 ```yaml
 Type: System.String
-Parameter Sets: DateUFormat, UnixTimeSecondsUFormat
+Parameter Sets: DateAndUFormat, UnixTimeSecondsAndUFormat
 Aliases:
 
 Required: False
@@ -517,7 +517,7 @@ This parameter was introduced in PowerShell 7.1.
 
 ```yaml
 Type: System.Int64
-Parameter Sets: UnixTimeSeconds, UnixTimeSecondsUFormat
+Parameter Sets: UnixTimeSecondsAndFormat, UnixTimeSecondsAndUFormat
 Aliases: UnixTime
 
 Required: True


### PR DESCRIPTION
https://github.com/PowerShell/PowerShell/pull/13084

# PR Summary
Make the following changes to the reference of the `Get-Date` command.
- Add `-UnixTimeSeconds` parameter
- Remove `-FromUnixTime` parameter
- Change parameter sets

Close #6263

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
