### PR TITLE
Update, to reflect changes in PowerShell 7

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Throw.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Throw.md
@@ -8,10 +8,10 @@ title: about_Throw
 ---
 # About Throw
 
-## SHORT DESCRIPTION
+## Short description
 Describes the Throw keyword, which generates a terminating error.
 
-## LONG DESCRIPTION
+## Long description
 
 The Throw keyword causes a terminating error. You can use the Throw keyword to
 stop the processing of a command, function, or script.
@@ -24,7 +24,7 @@ declaration to make a function parameter mandatory.
 The Throw keyword can throw any object, such as a user message string or the
 object that caused the error.
 
-## SYNTAX
+## Syntax
 
 The syntax of the Throw keyword is as follows:
 
@@ -46,7 +46,7 @@ If the Throw keyword is used in a Catch block without an expression, it throws
 the current RuntimeException again. For more information, see
 about_Try_Catch_Finally.
 
-## THROWING A STRING
+## Throwing a string
 
 The optional expression in a Throw statement can be a string, as shown in the
 following example:
@@ -57,7 +57,7 @@ C:\PS> throw "This is an error."
 Exception: This is an error.
 ```
 
-## THROWING OTHER OBJECTS
+## Throwing other objects
 
 The expression can also be an object that throws the object that represents
 the PowerShell process, as shown in the following example:
@@ -81,7 +81,7 @@ C:\PS> $error[0].targetobject
      63    43.32      77.65       1.48    9092   2 pwsh
 ```
 
-You can also throw an ErrorRecord object or a Microsoft .NET Framework
+You can also throw an ErrorRecord object or a .NET
 exception. The following example uses the Throw keyword to throw a
 System.FormatException object.
 
@@ -93,7 +93,7 @@ C:\PS> throw $formatError
 OperationStopped: One of the identified items was in an invalid format.
 ```
 
-## RESULTING ERROR
+## The resulting error
 
 The Throw keyword can generate an ErrorRecord object. The Exception property
 of the ErrorRecord object contains a RuntimeException object. The remainder of
@@ -103,18 +103,14 @@ that the Throw keyword throws.
 The RunTimeException object is wrapped in an ErrorRecord object, and the
 ErrorRecord object is automatically saved in the $Error automatic variable.
 
-## USING THROW TO CREATE A MANDATORY PARAMETER
+## Using Throw to create a mandatory parameter
 
 Unlike past versions of PowerShell, do not use the Throw keyword for parameter validation. See [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md) for the correct way.
 
-## SEE ALSO
+## See also
 
-[about_Break](about_Break.md)
-
-[about_Continue](about_Continue.md)
-
-[about_Scopes](about_Scopes.md)
-
-[about_Trap](about_Trap.md)
-
-[about_Try_Catch_Finally](about_Try_Catch_Finally.md)
+- [about_Break](about_Break.md)
+- [about_Continue](about_Continue.md)
+- [about_Scopes](about_Scopes.md)
+- [about_Trap](about_Trap.md)
+- [about_Try_Catch_Finally](about_Try_Catch_Finally.md)

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Throw.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Throw.md
@@ -39,11 +39,7 @@ generates a ScriptHalted error.
 ```powershell
 C:\PS> throw
 
-ScriptHalted
-At line:1 char:6
-+ throw <<<<
-+ CategoryInfo          : OperationStopped: (:) [], RuntimeException
-+ FullyQualifiedErrorId : ScriptHalted
+Exception: ScriptHalted
 ```
 
 If the Throw keyword is used in a Catch block without an expression, it throws
@@ -58,12 +54,7 @@ following example:
 ```powershell
 C:\PS> throw "This is an error."
 
-This is an error.
-At line:1 char:6
-+ throw <<<<  "This is an error."
-+ CategoryInfo          : OperationStopped: (This is an error.:String) [], R
-untimeException
-+ FullyQualifiedErrorId : This is an error.
+Exception: This is an error.
 ```
 
 ## THROWING OTHER OBJECTS
@@ -72,15 +63,9 @@ The expression can also be an object that throws the object that represents
 the PowerShell process, as shown in the following example:
 
 ```powershell
-C:\PS> throw (get-process PowerShell)
+C:\PS> throw (get-process Pwsh)
 
-System.Diagnostics.Process (PowerShell)
-At line:1 char:6
-+ throw <<<<  (get-process PowerShell)
-+ CategoryInfo          : OperationStopped: (System.Diagnostics.Process (Pow
-erShell):Process) [],
-RuntimeException
-+ FullyQualifiedErrorId : System.Diagnostics.Process (PowerShell)
+Exception: System.Diagnostics.Process (pwsh) System.Diagnostics.Process (pwsh) System.Diagnostics.Process (pwsh)
 ```
 
 You can use the TargetObject property of the ErrorRecord object in the
@@ -89,9 +74,11 @@ $error automatic variable to examine the error.
 ```powershell
 C:\PS> $error[0].targetobject
 
-Handles  NPM(K)    PM(K)      WS(K) VM(M)   CPU(s)     Id ProcessName
--------  ------    -----      ----- -----   ------     -- -----------
-319      26    61016      70864   568     3.28   5548 PowerShell
+ NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
+ ------    -----      -----     ------      --  -- -----------
+    125   174.44     229.57      23.61    1548   2 pwsh
+     63    44.07      81.95       1.75    1732   2 pwsh
+     63    43.32      77.65       1.48    9092   2 pwsh
 ```
 
 You can also throw an ErrorRecord object or a Microsoft .NET Framework
@@ -103,12 +90,7 @@ C:\PS> $formatError = new-object system.formatexception
 
 C:\PS> throw $formatError
 
-One of the identified items was in an invalid format.
-At line:1 char:6
-+ throw <<<<  $formatError
-+ CategoryInfo          : OperationStopped: (:) [], FormatException
-+ FullyQualifiedErrorId : One of the identified items was in an invalid
-format.
+OperationStopped: One of the identified items was in an invalid format.
 ```
 
 ## RESULTING ERROR
@@ -123,30 +105,7 @@ ErrorRecord object is automatically saved in the $Error automatic variable.
 
 ## USING THROW TO CREATE A MANDATORY PARAMETER
 
-You can use the Throw keyword to make a function parameter mandatory.
-
-This is an alternative to using the Mandatory parameter of the Parameter
-keyword. When you use the Mandatory parameter, the system prompts the user
-for the required parameter value. When you use the Throw keyword, the
-command stops and displays the error record.
-
-For example, the Throw keyword in the parameter subexpression makes the
-Path parameter a required parameter in the function.
-
-In this case, the Throw keyword throws a message string, but it is the
-presence of the Throw keyword that generates the terminating error if the
-Path parameter is not specified. The expression that follows Throw is
-optional.
-
-```powershell
-function Get-XMLFiles
-{
-  param ($path = $(throw "The Path parameter is required."))
-  dir -path $path\*.xml -recurse |
-    sort lastwritetime |
-      ft lastwritetime, attributes, name  -auto
-}
-```
+Unlike past versions of PowerShell, do not use the Throw keyword for parameter validation. See [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md) for the correct way.
 
 ## SEE ALSO
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Throw.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Throw.md
@@ -2,16 +2,16 @@
 keywords: powershell,cmdlet
 Locale: en-US
 ms.date: 12/01/2017
-online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_throw?view=powershell-7.1&WT.mc_id=ps-gethelp
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_throw?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Throw
 ---
 # About Throw
 
-## SHORT DESCRIPTION
+## Short description
 Describes the Throw keyword, which generates a terminating error.
 
-## LONG DESCRIPTION
+## Long description
 
 The Throw keyword causes a terminating error. You can use the Throw keyword to
 stop the processing of a command, function, or script.
@@ -24,7 +24,7 @@ declaration to make a function parameter mandatory.
 The Throw keyword can throw any object, such as a user message string or the
 object that caused the error.
 
-## SYNTAX
+## Syntax
 
 The syntax of the Throw keyword is as follows:
 
@@ -39,18 +39,14 @@ generates a ScriptHalted error.
 ```powershell
 C:\PS> throw
 
-ScriptHalted
-At line:1 char:6
-+ throw <<<<
-+ CategoryInfo          : OperationStopped: (:) [], RuntimeException
-+ FullyQualifiedErrorId : ScriptHalted
+Exception: ScriptHalted
 ```
 
 If the Throw keyword is used in a Catch block without an expression, it throws
 the current RuntimeException again. For more information, see
 about_Try_Catch_Finally.
 
-## THROWING A STRING
+## Throwing a string
 
 The optional expression in a Throw statement can be a string, as shown in the
 following example:
@@ -58,29 +54,18 @@ following example:
 ```powershell
 C:\PS> throw "This is an error."
 
-This is an error.
-At line:1 char:6
-+ throw <<<<  "This is an error."
-+ CategoryInfo          : OperationStopped: (This is an error.:String) [], R
-untimeException
-+ FullyQualifiedErrorId : This is an error.
+Exception: This is an error.
 ```
 
-## THROWING OTHER OBJECTS
+## Throwing other objects
 
 The expression can also be an object that throws the object that represents
 the PowerShell process, as shown in the following example:
 
 ```powershell
-C:\PS> throw (get-process PowerShell)
+C:\PS> throw (get-process Pwsh)
 
-System.Diagnostics.Process (PowerShell)
-At line:1 char:6
-+ throw <<<<  (get-process PowerShell)
-+ CategoryInfo          : OperationStopped: (System.Diagnostics.Process (Pow
-erShell):Process) [],
-RuntimeException
-+ FullyQualifiedErrorId : System.Diagnostics.Process (PowerShell)
+Exception: System.Diagnostics.Process (pwsh) System.Diagnostics.Process (pwsh) System.Diagnostics.Process (pwsh)
 ```
 
 You can use the TargetObject property of the ErrorRecord object in the
@@ -89,12 +74,14 @@ $error automatic variable to examine the error.
 ```powershell
 C:\PS> $error[0].targetobject
 
-Handles  NPM(K)    PM(K)      WS(K) VM(M)   CPU(s)     Id ProcessName
--------  ------    -----      ----- -----   ------     -- -----------
-319      26    61016      70864   568     3.28   5548 PowerShell
+ NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
+ ------    -----      -----     ------      --  -- -----------
+    125   174.44     229.57      23.61    1548   2 pwsh
+     63    44.07      81.95       1.75    1732   2 pwsh
+     63    43.32      77.65       1.48    9092   2 pwsh
 ```
 
-You can also throw an ErrorRecord object or a Microsoft .NET Framework
+You can also throw an ErrorRecord object or a .NET
 exception. The following example uses the Throw keyword to throw a
 System.FormatException object.
 
@@ -103,15 +90,10 @@ C:\PS> $formatError = new-object system.formatexception
 
 C:\PS> throw $formatError
 
-One of the identified items was in an invalid format.
-At line:1 char:6
-+ throw <<<<  $formatError
-+ CategoryInfo          : OperationStopped: (:) [], FormatException
-+ FullyQualifiedErrorId : One of the identified items was in an invalid
-format.
+OperationStopped: One of the identified items was in an invalid format.
 ```
 
-## RESULTING ERROR
+## The resulting error
 
 The Throw keyword can generate an ErrorRecord object. The Exception property
 of the ErrorRecord object contains a RuntimeException object. The remainder of
@@ -121,34 +103,11 @@ that the Throw keyword throws.
 The RunTimeException object is wrapped in an ErrorRecord object, and the
 ErrorRecord object is automatically saved in the $Error automatic variable.
 
-## USING THROW TO CREATE A MANDATORY PARAMETER
+## Using Throw to create a mandatory parameter
 
-You can use the Throw keyword to make a function parameter mandatory.
+Unlike past versions of PowerShell, do not use the Throw keyword for parameter validation. See [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md) for the correct way.
 
-This is an alternative to using the Mandatory parameter of the Parameter
-keyword. When you use the Mandatory parameter, the system prompts the user
-for the required parameter value. When you use the Throw keyword, the
-command stops and displays the error record.
-
-For example, the Throw keyword in the parameter subexpression makes the
-Path parameter a required parameter in the function.
-
-In this case, the Throw keyword throws a message string, but it is the
-presence of the Throw keyword that generates the terminating error if the
-Path parameter is not specified. The expression that follows Throw is
-optional.
-
-```powershell
-function Get-XMLFiles
-{
-  param ($path = $(throw "The Path parameter is required."))
-  dir -path $path\*.xml -recurse |
-    sort lastwritetime |
-      ft lastwritetime, attributes, name  -auto
-}
-```
-
-## SEE ALSO
+## See also
 
 [about_Break](about_Break.md)
 
@@ -159,4 +118,3 @@ function Get-XMLFiles
 [about_Trap](about_Trap.md)
 
 [about_Try_Catch_Finally](about_Try_Catch_Finally.md)
-

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Throw.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Throw.md
@@ -109,12 +109,8 @@ Unlike past versions of PowerShell, do not use the Throw keyword for parameter v
 
 ## See also
 
-[about_Break](about_Break.md)
-
-[about_Continue](about_Continue.md)
-
-[about_Scopes](about_Scopes.md)
-
-[about_Trap](about_Trap.md)
-
-[about_Try_Catch_Finally](about_Try_Catch_Finally.md)
+- [about_Break](about_Break.md)
+- [about_Continue](about_Continue.md)
+- [about_Scopes](about_Scopes.md)
+- [about_Trap](about_Trap.md)
+- [about_Try_Catch_Finally](about_Try_Catch_Finally.md)


### PR DESCRIPTION
# PR Summary
- Update to reflect changes in PowerShell 7 as to how errors are handled or displayed
- Update mention of ".NET Framework"; PowerShell 7.x is based on .NET Core 3.x, and if I am not mistaken, will soon adopt .NET 5.0.
- Apply proper list style to a list

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [X] Version 7.1 preview content
- [X] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
