### PR TITLE
[FIXES #6298] Adds Missing Verb to approved verbs list

### DIFF
--- a/reference/docs-conceptual/developer/cmdlet/approved-verbs-for-windows-powershell-commands.md
+++ b/reference/docs-conceptual/developer/cmdlet/approved-verbs-for-windows-powershell-commands.md
@@ -22,8 +22,8 @@ that the cmdlet performs. The noun part of the name identifies the entity on whi
 performed.
 
 > [!NOTE]
-> PowerShell uses the term *verb* to describe a word that implies an action even if that word is not
-> a standard verb in the English language. For example, the term *New* is a valid PowerShell verb
+> PowerShell uses the term _verb_ to describe a word that implies an action even if that word is not
+> a standard verb in the English language. For example, the term _New_ is a valid PowerShell verb
 > name because it implies an action even though it is not a verb in the English language.
 
 ## Verb Naming Rules
@@ -116,6 +116,7 @@ lists most of the defined verbs.
 |[Remove](/dotnet/api/System.Management.Automation.VerbsCommon.Remove) (r)|Deletes a resource from a container. For example, the `Remove-Variable` cmdlet deletes a variable and its value. This verb is paired with `Add`.|For this action, do not use verbs such as Clear, Cut, Dispose, Discard, or Erase.|
 |[Rename](/dotnet/api/System.Management.Automation.VerbsCommon.Rename) (rn)|Changes the name of a resource. For example, the `Rename-Item` cmdlet, which is used to access stored data, changes the name of an item in the data store.|For this action, do not use a verb such as Change.|
 |[Reset](/dotnet/api/System.Management.Automation.VerbsCommon.Reset) (rs)|Sets a resource back to its original state.||
+|[Resize](/dotnet/api/System.Management.Automation.VerbsCommon.Resize)(rz)|Changes the size of a resource.||
 |[Search](/dotnet/api/System.Management.Automation.VerbsCommon.Search) (sr)|Creates a reference to a resource in a container.|For this action, do not use verbs such as Find or Locate.|
 |[Select](/dotnet/api/System.Management.Automation.VerbsCommon.Select) (sc)|Locates a resource in a container. For example, the `Select-String` cmdlet finds text in strings and files.|For this action, do not use verbs such as Find or Locate.|
 |[Set](/dotnet/api/System.Management.Automation.VerbsCommon.Set) (s)|Replaces data on an existing resource or creates a resource that contains some data. For example, the `Set-Date` cmdlet changes the system time on the local computer. (The `New` verb can also be used to create a resource.) This verb is paired with `Get`.|For this action, do not use verbs such as Write, Reset, Assign, or Configure.|


### PR DESCRIPTION
# PR Summary

Customer noticed, there was a missing verb and this PR fixes that

## PR Context

Fixes #6298
Fixes [AB#1750311](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1750311)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [x] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
