### PR TITLE
Use inline code blocks for if statement

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/About.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/About.md
@@ -324,7 +324,7 @@ Describes how to use splatting to pass parameters to commands in PowerShell.
 Explains how to use the Split operator to split one or more strings into substrings.
 
 ### [about_Switch](about_Switch.md)
-Explains how to use a switch to handle multiple If statements.
+Explains how to use a switch to handle multiple `If` statements.
 
 ### [about_Throw](about_Throw.md)
 Describes the Throw keyword, which generates a terminating error.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_If.md
@@ -14,7 +14,7 @@ Describes a language command you can use to run statement lists based on
 the results of one or more conditional tests.
 
 ## LONG DESCRIPTION
-You can use the If statement to run code blocks if a specified conditional
+You can use the `If` statement to run code blocks if a specified conditional
 test evaluates to true. You can also specify one or more additional
 conditional tests to run if all the prior tests evaluate to false. Finally,
 you can specify an additional code block that is run if no other prior
@@ -22,7 +22,7 @@ conditional test evaluates to true.
 
 ### Syntax
 
-The following example shows the If statement syntax:
+The following example shows the `If` statement syntax:
 
 ```powershell
 if (<test1>)
@@ -33,27 +33,27 @@ if (<test1>)
     {<statement list 3>}]
 ```
 
-When you run an If statement, PowerShell evaluates the `<test1>`
+When you run an `If` statement, PowerShell evaluates the `<test1>`
 conditional expression as true or false. If `<test1>` is true,
-`<statement list 1>` runs, and PowerShell exits the If statement. If
+`<statement list 1>` runs, and PowerShell exits the `If` statement. If
 `<test1>` is false, PowerShell evaluates the condition specified by the
 `<test2>` conditional statement.
 
 If `<test2>` is true, `<statement list 2>` runs, and PowerShell exits the
-If statement. If both `<test1>` and `<test2>` evaluate to false, the
+`If` statement. If both `<test1>` and `<test2>` evaluate to false, the
 `<statement list 3`> code block runs, and PowerShell exits the If
 statement.
 
 You can use multiple Elseif statements to chain a series of conditional
 tests. So, that each test is run only if all the previous tests are false.
-If you need to create an If statement that contains many Elseif statements,
+If you need to create an `If` statement that contains many Elseif statements,
 consider using a Switch statement instead.
 
 Examples:
 
-The simplest If statement contains a single command and does not contain
+The simplest `If` statement contains a single command and does not contain
 any Elseif statements or any Else statements. The following example shows
-the simplest form of the If statement:
+the simplest form of the `If` statement:
 
 ```powershell
 if ($a -gt 2) {
@@ -63,7 +63,7 @@ if ($a -gt 2) {
 
 In this example, if the $a variable is greater than 2, the condition
 evaluates to true, and the statement list runs. However, if $a is less than
-or equal to 2 or is not an existing variable, the If statement does not
+or equal to 2 or is not an existing variable, the `If` statement does not
 display a message.
 
 By adding an Else statement, a message is displayed when $a is less than or

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -484,7 +484,7 @@ See `Class` for usage examples.
 ### Switch
 
 To check multiple conditions, use a `Switch` statement. The `Switch` statement is
-equivalent to a series of If statements, but it is simpler.
+equivalent to a series of `If` statements, but it is simpler.
 
 The `Switch` statement lists each condition and an optional action. If a
 condition obtains, the action is performed.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
@@ -65,7 +65,7 @@ determine the truth value of the statement. If the left operand in a statement
 that contains the and operator is FALSE, the right operand is not evaluated.
 If the left operand in a statement that contains the or statement is TRUE, the
 right operand is not evaluated. As a result, you can use these statements in
-the same way that you would use the If statement.
+the same way that you would use the `If` statement.
 
 ## SEE ALSO
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -130,7 +130,7 @@ if (!(Test-Path -Path $PROFILE)) {
 }
 ```
 
-In this command, the If statement prevents you from overwriting an existing
+In this command, the `If` statement prevents you from overwriting an existing
 profile. Replace the value of the \<profile-path\> placeholder with the path
 to the profile file that you want to create.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
@@ -101,9 +101,9 @@ foreach ($file in Get-ChildItem)
 }
 ```
 
-You can refine the example by using an If statement to limit the results that
+You can refine the example by using an `If` statement to limit the results that
 are returned. In the following example, the Foreach statement performs the
-same looping operation as the previous example, but it adds an If statement to
+same looping operation as the previous example, but it adds an `If` statement to
 limit the results to files that are greater than 100 kilobytes (KB):
 
 ```powershell
@@ -161,7 +161,7 @@ else {
 
 In the preceding example, the \$i variable is set to 0 outside the loop, and
 the variable is incremented inside the loop for each file that is found that
-is larger than 100 KB. When the loop exits, an If statement evaluates the
+is larger than 100 KB. When the loop exits, an `If` statement evaluates the
 value of $i to display a count of all the files over 100 KB. Or, it displays a
 message stating that no files over 100 KB were found.
 
@@ -195,7 +195,7 @@ whose working set (memory usage) is greater than 20 megabytes (MB).
 The Get-Process command gets all of the processes on the computer. The Foreach
 alias performs the commands in the script block on each process in sequence.
 
-The IF statement selects processes with a working set (WS) greater than 20
+The `If` statement selects processes with a working set (WS) greater than 20
 megabytes. The Write-Host cmdlet writes the name of the process followed by a
 colon. It divides the working set value, which is stored in bytes by 1
 megabyte to get the working set value in megabytes. Then it converts the

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -9,7 +9,7 @@ title: about_Switch
 # About Switch
 
 ## Short description
-Explains how to use a switch to handle multiple If statements.
+Explains how to use a switch to handle multiple `If` statements.
 
 ## Long description
 
@@ -18,7 +18,7 @@ statement can check many types of conditions, including the value of variables
 and the properties of objects.
 
 To check multiple conditions, use a `Switch` statement. The `Switch` statement
-is equivalent to a series of If statements, but it is simpler. The `Switch`
+is equivalent to a series of `If` statements, but it is simpler. The `Switch`
 statement lists each condition and an optional action. If a condition obtains,
 the action is performed.
 

--- a/reference/6/Microsoft.PowerShell.Core/About/About.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/About.md
@@ -321,7 +321,7 @@ Describes how to use splatting to pass parameters to commands in PowerShell.
 Explains how to use the Split operator to split one or more strings into substrings.
 
 ### [about_Switch](about_Switch.md)
-Explains how to use a switch to handle multiple If statements.
+Explains how to use a switch to handle multiple `If` statements.
 
 ### [about_Throw](about_Throw.md)
 Describes the Throw keyword, which generates a terminating error.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_If.md
@@ -14,7 +14,7 @@ the results of one or more conditional tests.
 
 ## LONG DESCRIPTION
 
-You can use the If statement to run code blocks if a specified conditional
+You can use the `If` statement to run code blocks if a specified conditional
 test evaluates to true. You can also specify one or more additional
 conditional tests to run if all the prior tests evaluate to false. Finally,
 you can specify an additional code block that is run if no other prior
@@ -22,7 +22,7 @@ conditional test evaluates to true.
 
 ### Syntax
 
-The following example shows the If statement syntax:
+The following example shows the `If` statement syntax:
 
 ```powershell
 if (<test1>)
@@ -33,27 +33,27 @@ if (<test1>)
     {<statement list 3>}]
 ```
 
-When you run an If statement, PowerShell evaluates the `<test1>`
+When you run an `If` statement, PowerShell evaluates the `<test1>`
 conditional expression as true or false. If `<test1>` is true,
-`<statement list 1>` runs, and PowerShell exits the If statement. If
+`<statement list 1>` runs, and PowerShell exits the `If` statement. If
 `<test1>` is false, PowerShell evaluates the condition specified by the
 `<test2>` conditional statement.
 
 If `<test2>` is true, `<statement list 2>` runs, and PowerShell exits the
-If statement. If both `<test1>` and `<test2>` evaluate to false, the
+`If` statement. If both `<test1>` and `<test2>` evaluate to false, the
 `<statement list 3`> code block runs, and PowerShell exits the If
 statement.
 
 You can use multiple Elseif statements to chain a series of conditional
 tests. So, that each test is run only if all the previous tests are false.
-If you need to create an If statement that contains many Elseif statements,
+If you need to create an `If` statement that contains many Elseif statements,
 consider using a Switch statement instead.
 
 Examples:
 
-The simplest If statement contains a single command and does not contain
+The simplest `If` statement contains a single command and does not contain
 any Elseif statements or any Else statements. The following example shows
-the simplest form of the If statement:
+the simplest form of the `If` statement:
 
 ```powershell
 if ($a -gt 2) {
@@ -63,7 +63,7 @@ if ($a -gt 2) {
 
 In this example, if the $a variable is greater than 2, the condition
 evaluates to true, and the statement list runs. However, if $a is less than
-or equal to 2 or is not an existing variable, the If statement does not
+or equal to 2 or is not an existing variable, the `If` statement does not
 display a message.
 
 By adding an Else statement, a message is displayed when $a is less than or

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -481,7 +481,7 @@ See `Class` for usage examples.
 ### Switch
 
 To check multiple conditions, use a `Switch` statement. The `Switch` statement is
-equivalent to a series of If statements, but it is simpler.
+equivalent to a series of `If` statements, but it is simpler.
 
 The `Switch` statement lists each condition and an optional action. If a
 condition obtains, the action is performed.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
@@ -63,7 +63,7 @@ determine the truth value of the statement. If the left operand in a statement
 that contains the and operator is FALSE, the right operand is not evaluated.
 If the left operand in a statement that contains the or statement is TRUE, the
 right operand is not evaluated. As a result, you can use these statements in
-the same way that you would use the If statement.
+the same way that you would use the `If` statement.
 
 ## SEE ALSO
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -130,7 +130,7 @@ if (!(Test-Path -Path $PROFILE)) {
 }
 ```
 
-In this command, the If statement prevents you from overwriting an existing
+In this command, the `If` statement prevents you from overwriting an existing
 profile. Replace the value of the \<profile-path\> placeholder with the path
 to the profile file that you want to create.
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
@@ -99,9 +99,9 @@ foreach ($file in Get-ChildItem)
 }
 ```
 
-You can refine the example by using an If statement to limit the results that
+You can refine the example by using an `If` statement to limit the results that
 are returned. In the following example, the Foreach statement performs the
-same looping operation as the previous example, but it adds an If statement to
+same looping operation as the previous example, but it adds an `If` statement to
 limit the results to files that are greater than 100 kilobytes (KB):
 
 ```powershell
@@ -159,7 +159,7 @@ else {
 
 In the preceding example, the \$i variable is set to 0 outside the loop, and
 the variable is incremented inside the loop for each file that is found that
-is larger than 100 KB. When the loop exits, an If statement evaluates the
+is larger than 100 KB. When the loop exits, an `If` statement evaluates the
 value of $i to display a count of all the files over 100 KB. Or, it displays a
 message stating that no files over 100 KB were found.
 
@@ -193,7 +193,7 @@ whose working set (memory usage) is greater than 20 megabytes (MB).
 The Get-Process command gets all of the processes on the computer. The Foreach
 alias performs the commands in the script block on each process in sequence.
 
-The IF statement selects processes with a working set (WS) greater than 20
+The `If` statement selects processes with a working set (WS) greater than 20
 megabytes. The Write-Host cmdlet writes the name of the process followed by a
 colon. It divides the working set value, which is stored in bytes by 1
 megabyte to get the working set value in megabytes. Then it converts the

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -9,7 +9,7 @@ title: about_Switch
 # About Switch
 
 ## Short description
-Explains how to use a switch to handle multiple If statements.
+Explains how to use a switch to handle multiple `If` statements.
 
 ## Long description
 
@@ -18,7 +18,7 @@ statement can check many types of conditions, including the value of variables
 and the properties of objects.
 
 To check multiple conditions, use a `Switch` statement. The `Switch` statement
-is equivalent to a series of If statements, but it is simpler. The `Switch`
+is equivalent to a series of `If` statements, but it is simpler. The `Switch`
 statement lists each condition and an optional action. If a condition obtains,
 the action is performed.
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/About.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/About.md
@@ -321,7 +321,7 @@ Describes how to use splatting to pass parameters to commands in PowerShell.
 Explains how to use the Split operator to split one or more strings into substrings.
 
 ### [about_Switch](about_Switch.md)
-Explains how to use a switch to handle multiple If statements.
+Explains how to use a switch to handle multiple `If` statements.
 
 ### [about_Telemetry](about_Telemetry.md)
 Describes the telemetry collected in PowerShell.

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_If.md
@@ -14,7 +14,7 @@ the results of one or more conditional tests.
 
 ## LONG DESCRIPTION
 
-You can use the If statement to run code blocks if a specified conditional
+You can use the `If` statement to run code blocks if a specified conditional
 test evaluates to true. You can also specify one or more additional
 conditional tests to run if all the prior tests evaluate to false. Finally,
 you can specify an additional code block that is run if no other prior
@@ -22,7 +22,7 @@ conditional test evaluates to true.
 
 ### Syntax
 
-The following example shows the If statement syntax:
+The following example shows the `If` statement syntax:
 
 ```powershell
 if (<test1>)
@@ -33,27 +33,27 @@ if (<test1>)
     {<statement list 3>}]
 ```
 
-When you run an If statement, PowerShell evaluates the `<test1>`
+When you run an `If` statement, PowerShell evaluates the `<test1>`
 conditional expression as true or false. If `<test1>` is true,
-`<statement list 1>` runs, and PowerShell exits the If statement. If
+`<statement list 1>` runs, and PowerShell exits the `If` statement. If
 `<test1>` is false, PowerShell evaluates the condition specified by the
 `<test2>` conditional statement.
 
 If `<test2>` is true, `<statement list 2>` runs, and PowerShell exits the
-If statement. If both `<test1>` and `<test2>` evaluate to false, the
+`If` statement. If both `<test1>` and `<test2>` evaluate to false, the
 `<statement list 3`> code block runs, and PowerShell exits the If
 statement.
 
 You can use multiple Elseif statements to chain a series of conditional
 tests. So, that each test is run only if all the previous tests are false.
-If you need to create an If statement that contains many Elseif statements,
+If you need to create an `If` statement that contains many Elseif statements,
 consider using a Switch statement instead.
 
 Examples:
 
-The simplest If statement contains a single command and does not contain
+The simplest `If` statement contains a single command and does not contain
 any Elseif statements or any Else statements. The following example shows
-the simplest form of the If statement:
+the simplest form of the `If` statement:
 
 ```powershell
 if ($a -gt 2) {
@@ -63,7 +63,7 @@ if ($a -gt 2) {
 
 In this example, if the $a variable is greater than 2, the condition
 evaluates to true, and the statement list runs. However, if $a is less than
-or equal to 2 or is not an existing variable, the If statement does not
+or equal to 2 or is not an existing variable, the `If` statement does not
 display a message.
 
 By adding an Else statement, a message is displayed when $a is less than or

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -481,7 +481,7 @@ See `Class` for usage examples.
 ### Switch
 
 To check multiple conditions, use a `Switch` statement. The `Switch` statement is
-equivalent to a series of If statements, but it is simpler.
+equivalent to a series of `If` statements, but it is simpler.
 
 The `Switch` statement lists each condition and an optional action. If a
 condition obtains, the action is performed.

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
@@ -63,7 +63,7 @@ determine the truth value of the statement. If the left operand in a statement
 that contains the and operator is FALSE, the right operand is not evaluated.
 If the left operand in a statement that contains the or statement is TRUE, the
 right operand is not evaluated. As a result, you can use these statements in
-the same way that you would use the If statement.
+the same way that you would use the `If` statement.
 
 ## SEE ALSO
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -130,7 +130,7 @@ if (!(Test-Path -Path $PROFILE)) {
 }
 ```
 
-In this command, the If statement prevents you from overwriting an existing
+In this command, the `If` statement prevents you from overwriting an existing
 profile. Replace the value of the \<profile-path\> placeholder with the path
 to the profile file that you want to create.
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
@@ -99,9 +99,9 @@ foreach ($file in Get-ChildItem)
 }
 ```
 
-You can refine the example by using an If statement to limit the results that
+You can refine the example by using an `If` statement to limit the results that
 are returned. In the following example, the Foreach statement performs the
-same looping operation as the previous example, but it adds an If statement to
+same looping operation as the previous example, but it adds an `If` statement to
 limit the results to files that are greater than 100 kilobytes (KB):
 
 ```powershell
@@ -159,7 +159,7 @@ else {
 
 In the preceding example, the \$i variable is set to 0 outside the loop, and
 the variable is incremented inside the loop for each file that is found that
-is larger than 100 KB. When the loop exits, an If statement evaluates the
+is larger than 100 KB. When the loop exits, an `If` statement evaluates the
 value of $i to display a count of all the files over 100 KB. Or, it displays a
 message stating that no files over 100 KB were found.
 
@@ -193,7 +193,7 @@ whose working set (memory usage) is greater than 20 megabytes (MB).
 The Get-Process command gets all of the processes on the computer. The Foreach
 alias performs the commands in the script block on each process in sequence.
 
-The IF statement selects processes with a working set (WS) greater than 20
+The `If` statement selects processes with a working set (WS) greater than 20
 megabytes. The Write-Host cmdlet writes the name of the process followed by a
 colon. It divides the working set value, which is stored in bytes by 1
 megabyte to get the working set value in megabytes. Then it converts the

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -9,7 +9,7 @@ title: about_Switch
 # About Switch
 
 ## Short description
-Explains how to use a switch to handle multiple If statements.
+Explains how to use a switch to handle multiple `If` statements.
 
 ## Long description
 
@@ -18,7 +18,7 @@ statement can check many types of conditions, including the value of variables
 and the properties of objects.
 
 To check multiple conditions, use a `Switch` statement. The `Switch` statement
-is equivalent to a series of If statements, but it is simpler. The `Switch`
+is equivalent to a series of `If` statements, but it is simpler. The `Switch`
 statement lists each condition and an optional action. If a condition obtains,
 the action is performed.
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/About.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/About.md
@@ -321,7 +321,7 @@ Describes how to use splatting to pass parameters to commands in PowerShell.
 Explains how to use the Split operator to split one or more strings into substrings.
 
 ### [about_Switch](about_Switch.md)
-Explains how to use a switch to handle multiple If statements.
+Explains how to use a switch to handle multiple `If` statements.
 
 ### [about_Telemetry](about_Telemetry.md)
 Describes the telemetry collected in PowerShell.

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_If.md
@@ -14,7 +14,7 @@ the results of one or more conditional tests.
 
 ## LONG DESCRIPTION
 
-You can use the If statement to run code blocks if a specified conditional
+You can use the `If` statement to run code blocks if a specified conditional
 test evaluates to true. You can also specify one or more additional
 conditional tests to run if all the prior tests evaluate to false. Finally,
 you can specify an additional code block that is run if no other prior
@@ -22,7 +22,7 @@ conditional test evaluates to true.
 
 ### Syntax
 
-The following example shows the If statement syntax:
+The following example shows the `If` statement syntax:
 
 ```powershell
 if (<test1>)
@@ -33,27 +33,27 @@ if (<test1>)
     {<statement list 3>}]
 ```
 
-When you run an If statement, PowerShell evaluates the `<test1>`
+When you run an `If` statement, PowerShell evaluates the `<test1>`
 conditional expression as true or false. If `<test1>` is true,
-`<statement list 1>` runs, and PowerShell exits the If statement. If
+`<statement list 1>` runs, and PowerShell exits the `If` statement. If
 `<test1>` is false, PowerShell evaluates the condition specified by the
 `<test2>` conditional statement.
 
 If `<test2>` is true, `<statement list 2>` runs, and PowerShell exits the
-If statement. If both `<test1>` and `<test2>` evaluate to false, the
+`If` statement. If both `<test1>` and `<test2>` evaluate to false, the
 `<statement list 3`> code block runs, and PowerShell exits the If
 statement.
 
 You can use multiple Elseif statements to chain a series of conditional
 tests. So, that each test is run only if all the previous tests are false.
-If you need to create an If statement that contains many Elseif statements,
+If you need to create an `If` statement that contains many Elseif statements,
 consider using a Switch statement instead.
 
 Examples:
 
-The simplest If statement contains a single command and does not contain
+The simplest `If` statement contains a single command and does not contain
 any Elseif statements or any Else statements. The following example shows
-the simplest form of the If statement:
+the simplest form of the `If` statement:
 
 ```powershell
 if ($a -gt 2) {
@@ -63,7 +63,7 @@ if ($a -gt 2) {
 
 In this example, if the $a variable is greater than 2, the condition
 evaluates to true, and the statement list runs. However, if $a is less than
-or equal to 2 or is not an existing variable, the If statement does not
+or equal to 2 or is not an existing variable, the `If` statement does not
 display a message.
 
 By adding an Else statement, a message is displayed when $a is less than or

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -481,7 +481,7 @@ See `Class` for usage examples.
 ### Switch
 
 To check multiple conditions, use a `Switch` statement. The `Switch` statement is
-equivalent to a series of If statements, but it is simpler.
+equivalent to a series of `If` statements, but it is simpler.
 
 The `Switch` statement lists each condition and an optional action. If a
 condition obtains, the action is performed.

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
@@ -63,7 +63,7 @@ determine the truth value of the statement. If the left operand in a statement
 that contains the and operator is FALSE, the right operand is not evaluated.
 If the left operand in a statement that contains the or statement is TRUE, the
 right operand is not evaluated. As a result, you can use these statements in
-the same way that you would use the If statement.
+the same way that you would use the `If` statement.
 
 ## SEE ALSO
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -130,7 +130,7 @@ if (!(Test-Path -Path $PROFILE)) {
 }
 ```
 
-In this command, the If statement prevents you from overwriting an existing
+In this command, the `If` statement prevents you from overwriting an existing
 profile. Replace the value of the \<profile-path\> placeholder with the path
 to the profile file that you want to create.
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
@@ -99,9 +99,9 @@ foreach ($file in Get-ChildItem)
 }
 ```
 
-You can refine the example by using an If statement to limit the results that
+You can refine the example by using an `If` statement to limit the results that
 are returned. In the following example, the Foreach statement performs the
-same looping operation as the previous example, but it adds an If statement to
+same looping operation as the previous example, but it adds an `If` statement to
 limit the results to files that are greater than 100 kilobytes (KB):
 
 ```powershell
@@ -159,7 +159,7 @@ else {
 
 In the preceding example, the \$i variable is set to 0 outside the loop, and
 the variable is incremented inside the loop for each file that is found that
-is larger than 100 KB. When the loop exits, an If statement evaluates the
+is larger than 100 KB. When the loop exits, an `If` statement evaluates the
 value of $i to display a count of all the files over 100 KB. Or, it displays a
 message stating that no files over 100 KB were found.
 
@@ -193,7 +193,7 @@ whose working set (memory usage) is greater than 20 megabytes (MB).
 The Get-Process command gets all of the processes on the computer. The Foreach
 alias performs the commands in the script block on each process in sequence.
 
-The IF statement selects processes with a working set (WS) greater than 20
+The `If` statement selects processes with a working set (WS) greater than 20
 megabytes. The Write-Host cmdlet writes the name of the process followed by a
 colon. It divides the working set value, which is stored in bytes by 1
 megabyte to get the working set value in megabytes. Then it converts the

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -9,7 +9,7 @@ title: about_Switch
 # About Switch
 
 ## Short description
-Explains how to use a switch to handle multiple If statements.
+Explains how to use a switch to handle multiple `If` statements.
 
 ## Long description
 
@@ -18,7 +18,7 @@ statement can check many types of conditions, including the value of variables
 and the properties of objects.
 
 To check multiple conditions, use a `Switch` statement. The `Switch` statement
-is equivalent to a series of If statements, but it is simpler. The `Switch`
+is equivalent to a series of `If` statements, but it is simpler. The `Switch`
 statement lists each condition and an optional action. If a condition obtains,
 the action is performed.
 

--- a/reference/docs-conceptual/learn/deep-dives/everything-about-if.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-if.md
@@ -1,13 +1,13 @@
 ---
-title: Everything you wanted to know about the IF statement
+title: Everything you wanted to know about the if statement
 description: Like many other languages, PowerShell has statements for conditionally executing code in your scripts.
 ms.date: 05/23/2020
 ms.custom: contributor-KevinMarquette
 ---
-# Everything you wanted to know about the IF statement
+# Everything you wanted to know about the `if` statement
 
 Like many other languages, PowerShell has statements for conditionally executing code in your
-scripts. One of those statements is the [if][] statement. Today we will take a deep dive into one of
+scripts. One of those statements is the [If][] statement. Today we will take a deep dive into one of
 the most fundamental commands in PowerShell.
 
 > [!NOTE]
@@ -22,7 +22,7 @@ This is what I mean by conditional execution. You have one statement or value to
 execute a different section of code based on that evaluation. This is exactly what the `if`
 statement does.
 
-## The if statement
+## The `if` statement
 
 Here is a basic example of the `if` statement:
 
@@ -607,7 +607,7 @@ else
 ```
 
 Each script block is placing the results the commands or the value into the pipeline. Then we assign
-the result of the if statement to the `$discount` variable. That example could have just as easily
+the result of the `if` statement to the `$discount` variable. That example could have just as easily
 assigned those values to the `$discount` variable directly in each scriptblock. I can't say that I
 use this with the `if` statement often, but I do have an example where I used this recently.
 
@@ -646,7 +646,7 @@ fall into the `$snowSqlParam` in the correct place. Same holds true for the `$Pa
 ## Simplify complex operations
 
 It's inevitable that you run into a situation that has way too many comparisons to check and your
-if statement scrolls way off the right side of the screen.
+`If` statement scrolls way off the right side of the screen.
 
 ```powershell
 $user = Get-ADUser -Identity $UserName
@@ -682,7 +682,7 @@ read any of the logic.
 
 ### Pre-calculating results
 
-We can take that statement out of the if statement and only check the result.
+We can take that statement out of the `if` statement and only check the result.
 
 ```powershell
 $needsSecureHomeDrive = $null -ne $user -and

--- a/reference/docs-conceptual/learn/deep-dives/everything-about-shouldprocess.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-shouldprocess.md
@@ -552,7 +552,7 @@ if ($PSCmdlet.ShouldProcess('TARGET')){
 If someone specifies both `-Force` and `-WhatIf`, then `-WhatIf` needs to take priority. This
 approach preserves `-WhatIf` processing because `ShouldProcess` always gets executed.
 
-Do not add a check for the `$Force` value inside the if statement with the `ShouldProcess`. That is
+Do not add a check for the `$Force` value inside the `if` statement with the `ShouldProcess`. That is
 an anti-pattern for this specific scenario even though that's what I show you in the next section
 for `ShouldContinue`.
 

--- a/reference/docs-conceptual/learn/deep-dives/everything-about-switch.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-switch.md
@@ -16,7 +16,7 @@ that aren't found in other languages. Today, we take a deep dive into working wi
 > PowerShell team thanks Kevin for sharing this content with us. Please check out his blog at
 > [PowerShellExplained.com][].
 
-## If statement
+## The `if` statement
 
 One of the first statements that you learn is the `if` statement. It lets you execute a script block
 if a statement is `$true`.


### PR DESCRIPTION
# PR Summary

Use consistent inline code blocks for PowerShell language statements.

First step to make changes for `if` statement, looking for feedback on this change.

## PR Context

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [x] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
