### PR TITLE
Fix casing issues and typos in about_Operators.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -122,7 +122,7 @@ However, in PowerShell, there are additional behaviors.
 
 - When used as the first segment of a pipeline, wrapping a command or
   expression in parentheses invariably causes _enumeration_ of the expression
-  result. if the parentheses wrap a _command_, it is run to completion with all
+  result. If the parentheses wrap a _command_, it is run to completion with all
   output _collected in memory_ before the results are sent through the
   pipeline.
 
@@ -162,7 +162,7 @@ item, the array has only one member.
 Runs a command, script, or script block. The call operator, also known as the
 "invocation operator", lets you run commands that are stored in variables and
 represented by strings or script blocks. The call operator executes in a child
-scope. For more about scopes, see [about_scopes](about_scopes.md).
+scope. For more about scopes, see [about_Scopes](about_Scopes.md).
 
 This example stores a command in a string and executes it using the call
 operator.
@@ -370,12 +370,12 @@ $myProcess.peakWorkingSet
 
 #### Static member operator `::`
 
-Calls the static properties operator and methods of a .NET Framework class. To
+Calls the static properties and methods of a .NET Framework class. To
 find the static properties and methods of an object, use the Static parameter
 of the `Get-Member` cmdlet.
 
 ```powershell
-[datetime]::now
+[datetime]::Now
 ```
 
 ## See also

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -122,7 +122,7 @@ However, in PowerShell, there are additional behaviors.
 
 - When used as the first segment of a pipeline, wrapping a command or
   expression in parentheses invariably causes _enumeration_ of the expression
-  result. if the parentheses wrap a _command_, it is run to completion with all
+  result. If the parentheses wrap a _command_, it is run to completion with all
   output _collected in memory_ before the results are sent through the
   pipeline.
 
@@ -162,7 +162,7 @@ item, the array has only one member.
 Runs a command, script, or script block. The call operator, also known as the
 "invocation operator", lets you run commands that are stored in variables and
 represented by strings or script blocks. The call operator executes in a child
-scope. For more about scopes, see [about_scopes](about_scopes.md).
+scope. For more about scopes, see [about_Scopes](about_Scopes.md).
 
 This example stores a command in a string and executes it using the call
 operator.
@@ -240,7 +240,7 @@ For more about script blocks, see [about_Script_Blocks](about_Script_Blocks.md).
 
 Runs the pipeline before it in the background, in a PowerShell job. This
 operator acts similarly to the UNIX control operator ampersand (`&`), which
-runs the command before it asynchronously in sub shell as a job.
+runs the command before it asynchronously in subshell as a job.
 
 This operator is functionally equivalent to `Start-Job`. The following example
 demonstrates basic usage of the background job operator.
@@ -472,12 +472,12 @@ $myProcess.peakWorkingSet
 
 #### Static member operator `::`
 
-Calls the static properties operator and methods of a .NET Framework class. To
+Calls the static properties and methods of a .NET Framework class. To
 find the static properties and methods of an object, use the Static parameter
 of the `Get-Member` cmdlet.
 
 ```powershell
-[datetime]::now
+[datetime]::Now
 ```
 
 ## See also

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -122,7 +122,7 @@ However, in PowerShell, there are additional behaviors.
 
 - When used as the first segment of a pipeline, wrapping a command or
   expression in parentheses invariably causes _enumeration_ of the expression
-  result. if the parentheses wrap a _command_, it is run to completion with all
+  result. If the parentheses wrap a _command_, it is run to completion with all
   output _collected in memory_ before the results are sent through the
   pipeline.
 
@@ -155,7 +155,7 @@ item, the array has only one member.
 Runs a command, script, or script block. The call operator, also known as the
 "invocation operator", lets you run commands that are stored in variables and
 represented by strings or script blocks. The call operator executes in a child
-scope. For more about scopes, see [about_scopes](about_scopes.md).
+scope. For more about scopes, see [about_Scopes](about_Scopes.md).
 
 This example stores a command in a string and executes it using the call
 operator.
@@ -233,7 +233,7 @@ For more about script blocks, see [about_Script_Blocks](about_Script_Blocks.md).
 
 Runs the pipeline before it in the background, in a PowerShell job. This
 operator acts similarly to the UNIX control operator ampersand (`&`), which
-runs the command before it asynchronously in sub shell as a job.
+runs the command before it asynchronously in subshell as a job.
 
 This operator is functionally equivalent to `Start-Job`. By default, the
 background operator starts the jobs in the current working directory of the
@@ -485,12 +485,12 @@ $myProcess.peakWorkingSet
 
 #### Static member operator `::`
 
-Calls the static properties operator and methods of a .NET Framework class. To
+Calls the static properties and methods of a .NET Framework class. To
 find the static properties and methods of an object, use the Static parameter
 of the `Get-Member` cmdlet.
 
 ```powershell
-[datetime]::now
+[datetime]::Now
 ```
 
 #### Ternary operator `? <if-true> : <if-false>`

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -122,7 +122,7 @@ However, in PowerShell, there are additional behaviors.
 
 - When used as the first segment of a pipeline, wrapping a command or
   expression in parentheses invariably causes _enumeration_ of the expression
-  result. if the parentheses wrap a _command_, it is run to completion with all
+  result. If the parentheses wrap a _command_, it is run to completion with all
   output _collected in memory_ before the results are sent through the
   pipeline.
 
@@ -155,7 +155,7 @@ item, the array has only one member.
 Runs a command, script, or script block. The call operator, also known as the
 "invocation operator", lets you run commands that are stored in variables and
 represented by strings or script blocks. The call operator executes in a child
-scope. For more about scopes, see [about_scopes](about_scopes.md).
+scope. For more about scopes, see [about_Scopes](about_Scopes.md).
 
 This example stores a command in a string and executes it using the call
 operator.
@@ -233,7 +233,7 @@ For more about script blocks, see [about_Script_Blocks](about_Script_Blocks.md).
 
 Runs the pipeline before it in the background, in a PowerShell job. This
 operator acts similarly to the UNIX control operator ampersand (`&`), which
-runs the command before it asynchronously in sub shell as a job.
+runs the command before it asynchronously in subshell as a job.
 
 This operator is functionally equivalent to `Start-Job`. By default, the
 background operator starts the jobs in the current working directory of the
@@ -485,12 +485,12 @@ $myProcess.peakWorkingSet
 
 #### Static member operator `::`
 
-Calls the static properties operator and methods of a .NET Framework class. To
+Calls the static properties and methods of a .NET Framework class. To
 find the static properties and methods of an object, use the Static parameter
 of the `Get-Member` cmdlet.
 
 ```powershell
-[datetime]::now
+[datetime]::Now
 ```
 
 #### Ternary operator `? <if-true> : <if-false>`


### PR DESCRIPTION
# PR Summary
Fix casing issues and typos in about_Operators.md

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
