### PR TITLE
Fixes to '&' operators in about_Operators.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -188,7 +188,7 @@ cmdlet, function, script file, or operable program. Check the spelling of
 the name, or if a path was included, verify that the path is correct and
 try again.
 At line:1 char:2
-+ &$c
++ & $c
 +  ~~
     + CategoryInfo          : ObjectNotFound: (Get-Service -Name Spooler:String) [], CommandNotFoundException
     + FullyQualifiedErrorId : CommandNotFoundException
@@ -199,12 +199,12 @@ cmdlet can execute code that causes parsing errors when using the call
 operator.
 
 ```
-PS> &"1+1"
+PS> & "1+1"
 & : The term '1+1' is not recognized as the name of a cmdlet, function, script
 file, or operable program. Check the spelling of the name, or if a path was
 included, verify that the path is correct and try again.
 At line:1 char:2
-+ &"1+1"
++ & "1+1"
 +  ~~~~~
     + CategoryInfo          : ObjectNotFound: (1+1:String) [], CommandNotFoundException
     + FullyQualifiedErrorId : CommandNotFoundException
@@ -230,7 +230,7 @@ Mode                LastWriteTime         Length Name
 
 PS C:\Scripts> ".\script name with spaces.ps1"
 .\script name with spaces.ps1
-PS C:\Scripts> &".\script name with spaces.ps1"
+PS C:\Scripts> & ".\script name with spaces.ps1"
 Hello World!
 ```
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -188,7 +188,7 @@ cmdlet, function, script file, or operable program. Check the spelling of
 the name, or if a path was included, verify that the path is correct and
 try again.
 At line:1 char:2
-+ &$c
++ & $c
 +  ~~
     + CategoryInfo          : ObjectNotFound: (Get-Service -Name Spooler:String) [], CommandNotFoundException
     + FullyQualifiedErrorId : CommandNotFoundException
@@ -199,12 +199,12 @@ cmdlet can execute code that causes parsing errors when using the call
 operator.
 
 ```
-PS> &"1+1"
+PS> & "1+1"
 & : The term '1+1' is not recognized as the name of a cmdlet, function, script
 file, or operable program. Check the spelling of the name, or if a path was
 included, verify that the path is correct and try again.
 At line:1 char:2
-+ &"1+1"
++ & "1+1"
 +  ~~~~~
     + CategoryInfo          : ObjectNotFound: (1+1:String) [], CommandNotFoundException
     + FullyQualifiedErrorId : CommandNotFoundException
@@ -230,7 +230,7 @@ Mode                LastWriteTime         Length Name
 
 PS C:\Scripts> ".\script name with spaces.ps1"
 .\script name with spaces.ps1
-PS C:\Scripts> &".\script name with spaces.ps1"
+PS C:\Scripts> & ".\script name with spaces.ps1"
 Hello World!
 ```
 
@@ -275,7 +275,6 @@ Receive-Job $job -Wait
 ```
 
 ```powershell
-$job = Get-Process -Name pwsh &
 Remove-Job $job
 ```
 
@@ -307,6 +306,10 @@ Receive-Job $job -Wait
 
 If you want to run multiple commands, each in their own background process but
 all on one line, simply place `&` between and after each of the commands.
+
+```powershell
+Get-Process -Name pwsh & Get-Service -Name BITS & Get-CimInstance -ClassName Win32_ComputerSystem &
+```
 
 For more information on PowerShell jobs, see [about_Jobs](about_Jobs.md).
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -180,11 +180,6 @@ PS> & $c
 cmdlet, function, script file, or operable program. Check the spelling of
 the name, or if a path was included, verify that the path is correct and
 try again.
-At line:1 char:2
-+ &$c
-+  ~~
-    + CategoryInfo          : ObjectNotFound: (Get-Service -Name Spooler:String) [], CommandNotFoundException
-    + FullyQualifiedErrorId : CommandNotFoundException
 ```
 
 The [Invoke-Expression](xref:Microsoft.PowerShell.Utility.Invoke-Expression)
@@ -192,12 +187,12 @@ cmdlet can execute code that causes parsing errors when using the call
 operator.
 
 ```
-PS> &"1+1"
+PS> & "1+1"
 & : The term '1+1' is not recognized as the name of a cmdlet, function, script
 file, or operable program. Check the spelling of the name, or if a path was
 included, verify that the path is correct and try again.
 At line:1 char:2
-+ &"1+1"
++ & "1+1"
 +  ~~~~~
     + CategoryInfo          : ObjectNotFound: (1+1:String) [], CommandNotFoundException
     + FullyQualifiedErrorId : CommandNotFoundException
@@ -223,7 +218,7 @@ Mode                LastWriteTime         Length Name
 
 PS C:\Scripts> ".\script name with spaces.ps1"
 .\script name with spaces.ps1
-PS C:\Scripts> &".\script name with spaces.ps1"
+PS C:\Scripts> & ".\script name with spaces.ps1"
 Hello World!
 ```
 
@@ -270,7 +265,6 @@ Receive-Job $job -Wait
 ```
 
 ```powershell
-$job = Get-Process -Name pwsh &
 Remove-Job $job
 ```
 
@@ -302,6 +296,10 @@ Receive-Job $job -Wait
 
 If you want to run multiple commands, each in their own background process but
 all on one line, simply place `&` between and after each of the commands.
+
+```powershell
+Get-Process -Name pwsh & Get-Service -Name BITS & Get-CimInstance -ClassName Win32_ComputerSystem &
+```
 
 For more information on PowerShell jobs, see [about_Jobs](about_Jobs.md).
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -180,11 +180,6 @@ PS> & $c
 cmdlet, function, script file, or operable program. Check the spelling of
 the name, or if a path was included, verify that the path is correct and
 try again.
-At line:1 char:2
-+ &$c
-+  ~~
-    + CategoryInfo          : ObjectNotFound: (Get-Service -Name Spooler:String) [], CommandNotFoundException
-    + FullyQualifiedErrorId : CommandNotFoundException
 ```
 
 The [Invoke-Expression](xref:Microsoft.PowerShell.Utility.Invoke-Expression)
@@ -192,12 +187,12 @@ cmdlet can execute code that causes parsing errors when using the call
 operator.
 
 ```
-PS> &"1+1"
+PS> & "1+1"
 & : The term '1+1' is not recognized as the name of a cmdlet, function, script
 file, or operable program. Check the spelling of the name, or if a path was
 included, verify that the path is correct and try again.
 At line:1 char:2
-+ &"1+1"
++ & "1+1"
 +  ~~~~~
     + CategoryInfo          : ObjectNotFound: (1+1:String) [], CommandNotFoundException
     + FullyQualifiedErrorId : CommandNotFoundException
@@ -223,7 +218,7 @@ Mode                LastWriteTime         Length Name
 
 PS C:\Scripts> ".\script name with spaces.ps1"
 .\script name with spaces.ps1
-PS C:\Scripts> &".\script name with spaces.ps1"
+PS C:\Scripts> & ".\script name with spaces.ps1"
 Hello World!
 ```
 
@@ -270,7 +265,6 @@ Receive-Job $job -Wait
 ```
 
 ```powershell
-$job = Get-Process -Name pwsh &
 Remove-Job $job
 ```
 
@@ -302,6 +296,10 @@ Receive-Job $job -Wait
 
 If you want to run multiple commands, each in their own background process but
 all on one line, simply place `&` between and after each of the commands.
+
+```powershell
+Get-Process -Name pwsh & Get-Service -Name BITS & Get-CimInstance -ClassName Win32_ComputerSystem &
+```
 
 For more information on PowerShell jobs, see [about_Jobs](about_Jobs.md).
 


### PR DESCRIPTION
# PR Summary
Fixes to '&' operators in about_Operators.md

- Replace errors with a new default concise view in 7.0 and 7.1
- Add space between `&` and its argument for consistency 
- Remove second `$job = Get-Process -Name pwsh &` from examples. It is not needed as it is the continuation of the examples.
- Add example for multiple `&` operators in single line

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
