### PR TITLE
Updated documentation for PSReadLine’s 'DeleteLine' command in light of better handling multiline buffers.

### DIFF
--- a/reference/7.1/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.1/PSReadLine/About/about_PSReadLine.md
@@ -171,9 +171,9 @@ Delete to the end of the word.
 
 ### DeleteLine
 
-Deletes the current line, enabling undo.
+Deletes the current logical line of a multiline buffer, enabling undo.
 
-- Vi command mode: `<d,d>`
+- Vi command mode: `<d,d>`, `<d,_>`
 
 ### DeleteLineToFirstChar
 


### PR DESCRIPTION
# PR Summary
Related to https://github.com/PowerShell/PSReadLine/pull/1658

When using PSReadLine in VI-Mode, using <kbd>d</kbd><kbd>d</kbd> currently deletes the entire buffer, which seems wrong when using multiline input. This PR updates the documentation for the `DeleteLine` command, in light of the changes made to address [the corresponding issue](https://github.com/PowerShell/PSReadLine/issues/1657) in the PSReadLine repo.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - [ ] WMF, ISE, release notes, etc.
  - [x] PSReadLine
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
