### PR TITLE
Remove extra *the* in about_Redirection.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -130,7 +130,7 @@ This example suppresses all information stream data. To read more about
 ### Example 6: Show the affect of Action Preferences
 
 Action Preference variables and parameters can change what gets written to a
-particular stream. The script in this example shows the how the value of
+particular stream. The script in this example shows how the value of
 `$ErrorActionPreference` affects what gets written to the **Error** stream.
 
 ```powershell

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -130,7 +130,7 @@ This example suppresses all information stream data. To read more about
 ### Example 6: Show the affect of Action Preferences
 
 Action Preference variables and parameters can change what gets written to a
-particular stream. The script in this example shows the how the value of
+particular stream. The script in this example shows how the value of
 `$ErrorActionPreference` affects what gets written to the **Error** stream.
 
 ```powershell

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -130,7 +130,7 @@ This example suppresses all information stream data. To read more about
 ### Example 6: Show the affect of Action Preferences
 
 Action Preference variables and parameters can change what gets written to a
-particular stream. The script in this example shows the how the value of
+particular stream. The script in this example shows how the value of
 `$ErrorActionPreference` affects what gets written to the **Error** stream.
 
 ```powershell

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -130,7 +130,7 @@ This example suppresses all information stream data. To read more about
 ### Example 6: Show the affect of Action Preferences
 
 Action Preference variables and parameters can change what gets written to a
-particular stream. The script in this example shows the how the value of
+particular stream. The script in this example shows how the value of
 `$ErrorActionPreference` affects what gets written to the **Error** stream.
 
 ```powershell


### PR DESCRIPTION
# PR Summary
Remove extra *the* in about_Redirection.md

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
