### PR TITLE
Replace references to powershell.exe with pwsh.exe

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -270,7 +270,7 @@ C:\scripts\test>type test.ps1
 
 exit 4
 
-C:\scripts\test>powershell -file ./test.ps1
+C:\scripts\test>pwsh -file ./test.ps1
 1
 
 2
@@ -281,7 +281,7 @@ C:\scripts\test>echo %ERRORLEVEL%
 4
 ```
 
-When you run `powershell.exe -File <path to a script>`, the exit statement
+When you run `pwsh.exe -File <path to a script>`, the exit statement
 sets the `%ERRORLEVEL%` variable to a value other than zero. If you have an
 unhandled exception in your script, `%ERRORLEVEL%` is set to the value of 1.
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
The executable is named `pwsh.exe` now.
## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [X] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
