### PR TITLE
[FIXES #4992] Adds information Get-DscResource

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_DesiredStateConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_DesiredStateConfiguration.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 01/04/2018
+ms.date: 07/23/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_desiredstateconfiguration?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_DesiredStateConfiguration
@@ -152,12 +152,15 @@ You can use the following built-in resources in your configuration scripts:
 |WindowsProcess        |{Arguments, Path, Credential, DependsOn...}        |
 
 To get a list of available DSC resources on your system, run the
-Get-DscResource cmdlet.
+`Get-DscResource` cmdlet.
+
+> [!NOTE]
+> In PowerShell versions below 7.0, `Get-DscResource` does not find Class based DSC resources.
 
 The example in this topic demonstrates how to use the File and WindowsFeature
 resources. To see all properties that you can use with a resource, insert the
 cursor in the resource keyword (for example, File) within your configuration
-script in PowerShell ISE, hold down CTRL, and then press SPACEBAR.
+script in PowerShell ISE, hold down <kbd>CTRL</kbd>+<kbd>SPACEBAR</kbd>
 
 ## FIND MORE RESOURCES
 

--- a/reference/5.1/PSDesiredStateConfiguration/Get-DscResource.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Get-DscResource.md
@@ -158,6 +158,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
+- `Get-DscResource` does not find Class based DSC resources in PowerShell versions below 7.0.
+
 ## RELATED LINKS
 
 [PowerShell Desired State Configuration Overview](/powershell/scripting/dsc/overview/overview)

--- a/reference/5.1/PSDesiredStateConfiguration/Get-DscResource.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Get-DscResource.md
@@ -3,7 +3,7 @@ external help file: PSDesiredStateConfiguration-help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: PSDesiredStateConfiguration
-ms.date: 06/09/2017
+ms.date: 07/23/2020
 online version: https://docs.microsoft.com/powershell/module/psdesiredstateconfiguration/get-dscresource?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-DscResource

--- a/reference/6/PSDesiredStateConfiguration/Get-DscResource.md
+++ b/reference/6/PSDesiredStateConfiguration/Get-DscResource.md
@@ -3,7 +3,7 @@ external help file: PSDesiredStateConfiguration-help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: PSDesiredStateConfiguration
-ms.date: 06/09/2017
+ms.date: 07/23/2020
 online version: https://docs.microsoft.com/powershell/module/psdesiredstateconfiguration/get-dscresource?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-DscResource

--- a/reference/6/PSDesiredStateConfiguration/Get-DscResource.md
+++ b/reference/6/PSDesiredStateConfiguration/Get-DscResource.md
@@ -158,6 +158,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
+- `Get-DscResource` does not find Class based DSC resources in PowerShell versions below 7.0.
+
 ## RELATED LINKS
 
 [PowerShell Desired State Configuration Overview](/powershell/scripting/dsc/overview/overview)

--- a/reference/7.0/PSDesiredStateConfiguration/Get-DscResource.md
+++ b/reference/7.0/PSDesiredStateConfiguration/Get-DscResource.md
@@ -3,7 +3,7 @@ external help file: PSDesiredStateConfiguration-help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: PSDesiredStateConfiguration
-ms.date: 06/09/2017
+ms.date: 07/23/2020
 online version: https://docs.microsoft.com/powershell/module/psdesiredstateconfiguration/get-dscresource?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-DscResource

--- a/reference/7.1/PSDesiredStateConfiguration/Get-DscResource.md
+++ b/reference/7.1/PSDesiredStateConfiguration/Get-DscResource.md
@@ -3,7 +3,7 @@ external help file: PSDesiredStateConfiguration-help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: PSDesiredStateConfiguration
-ms.date: 06/09/2017
+ms.date: 07/23/2020
 online version: https://docs.microsoft.com/powershell/module/psdesiredstateconfiguration/get-dscresource?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-DscResource

--- a/reference/docs-conceptual/dsc/resources/resources.md
+++ b/reference/docs-conceptual/dsc/resources/resources.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 07/08/2020
+ms.date: 07/23/2020
 keywords:  dsc,powershell,configuration,setup
 title:  DSC Resources
 ---
@@ -61,6 +61,9 @@ Service [String] #ResourceName
     [State = [string]{ Running | Stopped }]
 }
 ```
+
+> [!NOTE]
+> In PowerShell versions below 7.0, `Get-DscResource` does not find Class based DSC resources.
 
 Inside a Configuration, a **Service** resource block might look like this to **Ensure** that the
 Spooler service is running.


### PR DESCRIPTION
# PR Summary

Adds information about `Get-DscResource` working/not working with Class based resources in different versions.

## PR Context

Fixes #4992 
Fixes [AB#1752340](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1752340)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [x] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
