### PR TITLE
[FIXES #6259] Updates Experimental Features Article

### DIFF
--- a/reference/docs-conceptual/learn/experimental-features.md
+++ b/reference/docs-conceptual/learn/experimental-features.md
@@ -37,13 +37,38 @@ This article describes the experimental features that are available and how to u
 | PSUnixFileStat (non-Windows only)                          |         | &check; |    &check;    |
 | PSNativePSPathResolution                                   |         |         |    &check;    |
 | PSCultureInvariantReplaceOperator                          |         |         |    &check;    |
-| **Runspace** parameter in `*-Breakpoint` cmdlets           |         |         |    &check;    |
 
 ## Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace
 
-Enables the **BreakAll** parameter on the `Debug-Runspace` and `Debug-Job` cmdlets to allow users to
+In PowerShell 7.0, the experiment enables the **BreakAll** parameter on the `Debug-Runspace` and `Debug-Job` cmdlets to allow users to
 decide if they want PowerShell to break immediately in the current location when they attach a
 debugger.
+
+In PowerShell 7.1, this experiment adds the **Runspace** parameter to the ` *-PSBreakpoint` cmdlets.
+
+- `Disable-PSBreakpoint`
+- `Enable-PSBreakpoint`
+- `Get-PSBreakpoint`
+- `Remove-PSBreakpoint`
+- `Set-PSBreakpoint`
+
+The **Runspace** parameter specifies a **Runspace** object to interact with breakpoints in the
+specified runspace.
+
+```powershell
+Start-Job -ScriptBlock {
+    Set-PSBreakpoint -Command Start-Sleep
+    Start-Sleep -Seconds 10
+}
+
+$runspace = Get-Runspace -Id 1
+
+$breakpoint = Get-PSBreakPoint -Runspace $runspace
+```
+
+In this example, a job is started and a breakpoint is set to break when the `Set-PSBreakPoint` is
+run. The runspace is stored in a variable and passed to the `Get-PSBreakPoint` command with the
+**Runspace** parameter. You can then inspect the breakpoint in the `$breakpoint` variable.
 
 ## PSCommandNotFoundSuggestion
 
@@ -219,23 +244,3 @@ script.
 > [!NOTE]
 > This feature has moved out of the experimental phase and is a mainstream feature in PowerShell 7
 > and higher.
-
-## Runspace parameter in *-Breakpoint cmdlets
-
-Specifies a **Runspace** object to interact with Breakpoints in the specified runspace. This feature
-requires the `Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace` feature to be enabled.
-
-```powershell
-Start-Job -ScriptBlock {
-    Set-PSBreakpoint -Command Start-Sleep
-    Start-Sleep -Seconds 10
-}
-
-$runspace = Get-Runspace -Id 1
-
-$breakpoint = Get-PSBreakPoint -Runspace $runspace
-```
-
-In this example, a job is started and a breakpoint is set to break when the `Set-PSBreakPoint` is
-run. The runspace is stored in a variable and passed to the `Get-PSBreakPoint` command with the
-**Runspace** parameter. You can then inspect the breakpoint in the `$breakpoint` variable.

--- a/reference/docs-conceptual/learn/experimental-features.md
+++ b/reference/docs-conceptual/learn/experimental-features.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 04/28/2020
+ms.date: 07/23/2020
 title: Using Experimental Features in PowerShell
 description: Lists the currently available experimental features and how to use them.
 ---
@@ -37,6 +37,7 @@ This article describes the experimental features that are available and how to u
 | PSUnixFileStat (non-Windows only)                          |         | &check; |    &check;    |
 | PSNativePSPathResolution                                   |         |         |    &check;    |
 | PSCultureInvariantReplaceOperator                          |         |         |    &check;    |
+| **Runspace** parameter in `*-Breakpoint` cmdlets           |         |         |    &check;    |
 
 ## Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace
 
@@ -190,7 +191,7 @@ the underlying Unix type system.
 The output from `Get-ChildItem` should look something like this:
 
 ```powershell
-PS> dir | select -first 4 -skip 5
+dir | select -first 4 -skip 5
 
 
     Directory: /Users/jimtru/src/github/forks/JamesWTruher/PowerShell-1
@@ -218,3 +219,23 @@ script.
 > [!NOTE]
 > This feature has moved out of the experimental phase and is a mainstream feature in PowerShell 7
 > and higher.
+
+## Runspace parameter in *-Breakpoint cmdlets
+
+Specifies a **Runspace** object to interact with Breakpoints in the specified runspace. This feature
+requires the `Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace` feature to be enabled.
+
+```powershell
+Start-Job -ScriptBlock {
+    Set-PSBreakpoint -Command Start-Sleep
+    Start-Sleep -Seconds 10
+}
+
+$runspace = Get-Runspace -Id 1
+
+$breakpoint = Get-PSBreakPoint -Runspace $runspace
+```
+
+In this example, a job is started and a breakpoint is set to break when the `Set-PSBreakPoint` is
+run. The runspace is stored in a variable and passed to the `Get-PSBreakPoint` command with the
+**Runspace** parameter. You can then inspect the breakpoint in the `$breakpoint` variable.

--- a/reference/docs-conceptual/learn/experimental-features.md
+++ b/reference/docs-conceptual/learn/experimental-features.md
@@ -40,11 +40,12 @@ This article describes the experimental features that are available and how to u
 
 ## Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace
 
-In PowerShell 7.0, the experiment enables the **BreakAll** parameter on the `Debug-Runspace` and `Debug-Job` cmdlets to allow users to
-decide if they want PowerShell to break immediately in the current location when they attach a
-debugger.
+In PowerShell 7.0, the experiment enables the **BreakAll** parameter on the `Debug-Runspace` and
+`Debug-Job` cmdlets to allow users to decide if they want PowerShell to break immediately in the
+current location when they attach a debugger.
 
-In PowerShell 7.1, this experiment adds the **Runspace** parameter to the ` *-PSBreakpoint` cmdlets.
+In PowerShell 7.1, this experiment also adds the **Runspace** parameter to the `*-PSBreakpoint`
+cmdlets.
 
 - `Disable-PSBreakpoint`
 - `Enable-PSBreakpoint`


### PR DESCRIPTION
# PR Summary

Adds information about new **Runspace** parameter in `*-PSBreakpoint` cmdlets to experimental features article.

## PR Context

Fixes #6259 
Fixes [AB#1752475](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1752475)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [x] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
