### PR TITLE
Added documentation for new user-facing PSReadLine’s DeleteEndOfBuffer function

### DIFF
--- a/reference/7.1/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.1/PSReadLine/About/about_PSReadLine.md
@@ -163,6 +163,12 @@ process.
 
 - Emacs: `<Ctrl+d>`
 
+### DeleteEndOfBuffer
+
+Deletes to the end of the multiline buffer.
+
+- Vi command mode: `<d,G>`
+
 ### DeleteEndOfWord
 
 Delete to the end of the word.


### PR DESCRIPTION
# PR Summary

Related to https://github.com/PowerShell/PSReadLine/pull/1692.
Fixes #6357.

When using PSReadLine in VI-Mode, using <kbd>d</kbd><kbd>G</kbd> deletes lines up to the end of the multiline buffer. This PR includes the documentation for the new `DeleteEndOfBuffer` command that was introduced to support the [changes made](https://github.com/PowerShell/PSReadLine/issues/1689) to the PSReadLine repo.

## PR Context

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - [ ] WMF, ISE, release notes, etc.
  - [x] PSReadLine
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
