### PR TITLE
[WIP] Document PSRL DeleteNextLines function

### DIFF
--- a/reference/7.1/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.1/PSReadLine/About/about_PSReadLine.md
@@ -181,6 +181,12 @@ Deletes the current logical line of a multiline buffer, enabling undo.
 
 - Vi command mode: `<d,d>`, `<d,_>`
 
+### DeleteNextLines
+
+Deletes the current logical line and the next requested logical lines in a multiline buffer.
+
+- Vi command mode: `<d,j>`
+
 ### DeleteLineToFirstChar
 
 Deletes text from the cursor to the first non-blank character of the line.


### PR DESCRIPTION
# PR Summary

Fixes #6361.

In order to better handle multiline buffer in PSReadLine’s VI mode, I introduced a PR to handle command <kbd>d</kbd><kbd>j</kbd> to delete the current logical line and the next _n_ requested logical lines in a multiline buffer.

A new function `DeleteNextLines` supports this behaviour.

## PR Context

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - [ ] WMF, ISE, release notes, etc.
  - [x] PSReadLine
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
