### PR TITLE
Fix list formatting issues in Get-Location.md and Set-Location.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Location.md
@@ -288,12 +288,16 @@ current location stack.
 To manage location stacks, use the PowerShellLocation cmdlets, as follows.
 
 - To add a location to a location stack, use the `Push-Location` cmdlet.
+
 - To get a location from a location stack, use the `Pop-Location` cmdlet.
+
 - To display the locations in the current location stack, use the **Stack** parameter of the
   `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
   parameter of the `Get-Location` cmdlet.
+
 - To create a new location stack, use the **StackName** parameter of the `Push-Location` cmdlet.
   If you specify a stack that does not exist, `Push-Location` creates the stack.
+
 - To make a location stack the current location stack, use the **StackName** parameter of the
   `Set-Location` cmdlet.
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Location.md
@@ -235,12 +235,16 @@ location stack.
 To manage location stacks, use the `*-Location` cmdlets, as follows:
 
 - To add a location to a location stack, use the `Push-Location` cmdlet.
+
 - To get a location from a location stack, use the `Pop-Location` cmdlet.
+
 - To display the locations in the current location stack, use the **Stack** parameter of the
   `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
   parameter of `Get-Location`.
+
 - To create a new location stack, use the **StackName** parameter of `Push-Location`. If you specify
   a stack that does not exist, `Push-Location` creates the stack.
+
 - To make a location stack the current location stack, use the **StackName** parameter of
   `Set-Location`.
 

--- a/reference/6/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-Location.md
@@ -271,12 +271,16 @@ current location stack.
 To manage location stacks, use the PowerShellLocation cmdlets, as follows.
 
 - To add a location to a location stack, use the `Push-Location` cmdlet.
+
 - To get a location from a location stack, use the `Pop-Location` cmdlet.
+
 - To display the locations in the current location stack, use the **Stack** parameter of the
   `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
   parameter of the `Get-Location` cmdlet.
+
 - To create a new location stack, use the **StackName** parameter of the `Push-Location` cmdlet.
   If you specify a stack that does not exist, `Push-Location` creates the stack.
+
 - To make a location stack the current location stack, use the **StackName** parameter of the
   `Set-Location` cmdlet.
 

--- a/reference/6/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Location.md
@@ -243,12 +243,16 @@ location stack.
 To manage location stacks, use the `*-Location` cmdlets, as follows:
 
 - To add a location to a location stack, use the `Push-Location` cmdlet.
+
 - To get a location from a location stack, use the `Pop-Location` cmdlet.
+
 - To display the locations in the current location stack, use the **Stack** parameter of the
   `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
   parameter of `Get-Location`.
+
 - To create a new location stack, use the **StackName** parameter of `Push-Location`. If you specify
   a stack that does not exist, `Push-Location` creates the stack.
+
 - To make a location stack the current location stack, use the **StackName** parameter of
   `Set-Location`.
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Get-Location.md
@@ -271,12 +271,16 @@ current location stack.
 To manage location stacks, use the PowerShellLocation cmdlets, as follows.
 
 - To add a location to a location stack, use the `Push-Location` cmdlet.
+
 - To get a location from a location stack, use the `Pop-Location` cmdlet.
+
 - To display the locations in the current location stack, use the **Stack** parameter of the
   `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
   parameter of the `Get-Location` cmdlet.
+
 - To create a new location stack, use the **StackName** parameter of the `Push-Location` cmdlet.
   If you specify a stack that does not exist, `Push-Location` creates the stack.
+
 - To make a location stack the current location stack, use the **StackName** parameter of the
   `Set-Location` cmdlet.
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Set-Location.md
@@ -243,12 +243,16 @@ location stack.
 To manage location stacks, use the `*-Location` cmdlets, as follows:
 
 - To add a location to a location stack, use the `Push-Location` cmdlet.
+
 - To get a location from a location stack, use the `Pop-Location` cmdlet.
+
 - To display the locations in the current location stack, use the **Stack** parameter of the
   `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
   parameter of `Get-Location`.
+
 - To create a new location stack, use the **StackName** parameter of `Push-Location`. If you specify
   a stack that does not exist, `Push-Location` creates the stack.
+
 - To make a location stack the current location stack, use the **StackName** parameter of
   `Set-Location`.
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Get-Location.md
@@ -271,12 +271,16 @@ current location stack.
 To manage location stacks, use the PowerShellLocation cmdlets, as follows.
 
 - To add a location to a location stack, use the `Push-Location` cmdlet.
+
 - To get a location from a location stack, use the `Pop-Location` cmdlet.
+
 - To display the locations in the current location stack, use the **Stack** parameter of the
   `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
   parameter of the `Get-Location` cmdlet.
+
 - To create a new location stack, use the **StackName** parameter of the `Push-Location` cmdlet.
   If you specify a stack that does not exist, `Push-Location` creates the stack.
+
 - To make a location stack the current location stack, use the **StackName** parameter of the
   `Set-Location` cmdlet.
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Set-Location.md
@@ -243,12 +243,16 @@ location stack.
 To manage location stacks, use the `*-Location` cmdlets, as follows:
 
 - To add a location to a location stack, use the `Push-Location` cmdlet.
+
 - To get a location from a location stack, use the `Pop-Location` cmdlet.
+
 - To display the locations in the current location stack, use the **Stack** parameter of the
   `Get-Location` cmdlet. To display the locations in a named location stack, use the **StackName**
   parameter of `Get-Location`.
+
 - To create a new location stack, use the **StackName** parameter of `Push-Location`. If you specify
   a stack that does not exist, `Push-Location` creates the stack.
+
 - To make a location stack the current location stack, use the **StackName** parameter of
   `Set-Location`.
 


### PR DESCRIPTION
# PR Summary

It seems that PlatyPS combines different list items that span several lines into one paragraph:

```
 To manage location stacks, use the PowerShellLocation cmdlets, as follows.

        - To add a location to a location stack, use the `Push-Location` cmdlet.

        - To get a location from a location stack, use the `Pop-Location` cmdlet.

        - To display the locations in the current location stack, use the Stack parameter of the   `Get-Location` cmdlet. To display the locations in a named location stack, use the StackName parameter of the `Get-Location` cmdlet. - To create a new location stack, use the StackName parameter of the `Push-Location` cmdlet.   If you specify a stack that does not exist, `Push-Location` creates the stack. - To make a location stack the current location stack, use the StackName parameter of the   `Set-Location` cmdlet.
```

Added empty lines between list items to fix the issue.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
