### PR TITLE
Sort-Object: more about default properties

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -26,7 +26,10 @@ Sort-Object [[-Property] <Object[]>] [-Descending] [-Unique] [-InputObject <psob
 ## DESCRIPTION
 
 The `Sort-Object` cmdlet sorts objects in ascending or descending order based on object property
-values. If sort properties are not included in a command, PowerShell uses default sort properties.
+values. If sort properties are not included in a command, PowerShell uses default sort properties 
+of the first input object. If the type of the input object has no default sort properties,
+PowerShell attempts to compare the objects themselves. For more information, see the [Notes](#notes)
+section.
 
 You can sort objects by a single property or multiple properties. Multiple properties use hash
 tables to sort in ascending order, descending order, or a combination of sort orders. Properties are
@@ -384,7 +387,7 @@ Accept wildcard characters: False
 
 Specifies the property names that `Sort-Object` uses to sort the objects. Wildcards are permitted.
 Objects are sorted based on the property values. If you do not specify a property, `Sort-Object`
-sorts based on default properties for the object type.
+sorts based on default properties for the object type or the objects themselves.
 
 Multiple properties can be sorted in ascending order, descending order, or a combination of sort
 orders. When you specify multiple properties, the objects are sorted by the first property. If
@@ -454,21 +457,29 @@ You can pipe the objects to be sorted to `Sort-Object`.
 ## NOTES
 
 The `Sort-Object` cmdlet sorts objects based on properties specified in the command or the default
-sort properties for the object type. If an object does not have one of the specified properties, the
-property value for that object is interpreted by `Sort-Object` as **Null** and placed at the end of
-the sort order.
+sort properties for the object type. Default sort properties are defined using the `PropertySet`
+named `DefaultKeyPropertySet` in a `types.ps1xml` file. For more information, see
+[about_Types.ps1xml](/powershell/module/Microsoft.PowerShell.Core/About/about_Types.ps1xml).
 
+If an object does not have one of the specified properties, the property value for that object is
+interpreted by `Sort-Object` as **Null** and placed at the end of the sort order.
+
+When no sort properties are available, PowerShell attempts to compare the objects themselves.
 `Sort-Object` uses the **Compare** method for each property. If a property does not implement
 **IComparable**, the cmdlet converts the property value to a string and uses the **Compare** method
-for **System.String**. For more information, see [PSObject.CompareTo(Object) Method](/dotnet/api/system.management.automation.psobject.compareto).
+for **System.String**. For more information, see
+[PSObject.CompareTo(Object) Method](/dotnet/api/system.management.automation.psobject.compareto).
 
 If you sort on an enumerated property such as **Status**, `Sort-Object` sorts by the enumeration
-values. **Stopped** has a value of **1** and **Running** has a value of **4**. **Stopped** is sorted
-before **Running** because of the enumerated values. For more information, see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrollerstatus).
+values. For Windows services, **Stopped** has a value of **1** and **Running** has a value of **4**.
+**Stopped** is sorted before **Running** because of the enumerated values. For more information,
+see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrollerstatus).
 
 ## RELATED LINKS
 
 [about_Hash_Tables](../Microsoft.PowerShell.Core/About/about_Hash_Tables.md)
+
+[about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md)
 
 [Compare-Object](Compare-Object.md)
 

--- a/reference/6/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -40,7 +40,10 @@ Sort-Object [-Descending] [-Unique] -Bottom <Int32> [-InputObject <PSObject>] [[
 ## DESCRIPTION
 
 The `Sort-Object` cmdlet sorts objects in ascending or descending order based on object property
-values. If sort properties are not included in a command, PowerShell uses default sort properties.
+values. If sort properties are not included in a command, PowerShell uses default sort properties 
+of the first input object. If the type of the input object has no default sort properties,
+PowerShell attempts to compare the objects themselves. For more information, see the [Notes](#notes)
+section.
 
 You can sort objects by a single property or multiple properties. Multiple properties use hash
 tables to sort in ascending order, descending order, or a combination of sort orders. Properties are
@@ -470,7 +473,7 @@ Accept wildcard characters: False
 
 Specifies the property names that `Sort-Object` uses to sort the objects. Wildcards are permitted.
 Objects are sorted based on the property values. If you do not specify a property, `Sort-Object`
-sorts based on default properties for the object type.
+sorts based on default properties for the object type or the objects themselves.
 
 Multiple properties can be sorted in ascending order, descending order, or a combination of sort
 orders. When you specify multiple properties, the objects are sorted by the first property. If
@@ -577,23 +580,31 @@ You can pipe the objects to be sorted to `Sort-Object`.
 ## NOTES
 
 The `Sort-Object` cmdlet sorts objects based on properties specified in the command or the default
-sort properties for the object type. If an object does not have one of the specified properties, the
-property value for that object is interpreted by `Sort-Object` as **Null** and placed at the end of
-the sort order.
+sort properties for the object type. Default sort properties are defined using the `PropertySet`
+named `DefaultKeyPropertySet` in a `types.ps1xml` file. For more information, see
+[about_Types.ps1xml](/powershell/module/Microsoft.PowerShell.Core/About/about_Types.ps1xml).
 
+If an object does not have one of the specified properties, the property value for that object is
+interpreted by `Sort-Object` as **Null** and placed at the end of the sort order.
+
+When no sort properties are available, PowerShell attempts to compare the objects themselves.
 `Sort-Object` uses the **Compare** method for each property. If a property does not implement
 **IComparable**, the cmdlet converts the property value to a string and uses the **Compare** method
-for **System.String**. For more information, see [PSObject.CompareTo(Object) Method](/dotnet/api/system.management.automation.psobject.compareto).
+for **System.String**. For more information, see
+[PSObject.CompareTo(Object) Method](/dotnet/api/system.management.automation.psobject.compareto).
 
 If you sort on an enumerated property such as **Status**, `Sort-Object` sorts by the enumeration
-values. **Stopped** has a value of **1** and **Running** has a value of **4**. **Stopped** is sorted
-before **Running** because of the enumerated values. For more information, see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrollerstatus).
+values. For Windows services, **Stopped** has a value of **1** and **Running** has a value of **4**.
+**Stopped** is sorted before **Running** because of the enumerated values. For more information,
+see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrollerstatus).
 
 The performance of the sorting algorithm is slower when doing a stable sort.
 
 ## RELATED LINKS
 
 [about_Hash_Tables](../Microsoft.PowerShell.Core/About/about_Hash_Tables.md)
+
+[about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md)
 
 [Compare-Object](Compare-Object.md)
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -40,7 +40,10 @@ Sort-Object [-Descending] [-Unique] -Bottom <Int32> [-InputObject <PSObject>] [[
 ## DESCRIPTION
 
 The `Sort-Object` cmdlet sorts objects in ascending or descending order based on object property
-values. If sort properties are not included in a command, PowerShell uses default sort properties.
+values. If sort properties are not included in a command, PowerShell uses default sort properties 
+of the first input object. If the type of the input object has no default sort properties,
+PowerShell attempts to compare the objects themselves. For more information, see the [Notes](#notes)
+section.
 
 You can sort objects by a single property or multiple properties. Multiple properties use hash
 tables to sort in ascending order, descending order, or a combination of sort orders. Properties are
@@ -470,7 +473,7 @@ Accept wildcard characters: False
 
 Specifies the property names that `Sort-Object` uses to sort the objects. Wildcards are permitted.
 Objects are sorted based on the property values. If you do not specify a property, `Sort-Object`
-sorts based on default properties for the object type.
+sorts based on default properties for the object type or the objects themselves.
 
 Multiple properties can be sorted in ascending order, descending order, or a combination of sort
 orders. When you specify multiple properties, the objects are sorted by the first property. If
@@ -577,23 +580,31 @@ You can pipe the objects to be sorted to `Sort-Object`.
 ## NOTES
 
 The `Sort-Object` cmdlet sorts objects based on properties specified in the command or the default
-sort properties for the object type. If an object does not have one of the specified properties, the
-property value for that object is interpreted by `Sort-Object` as **Null** and placed at the end of
-the sort order.
+sort properties for the object type. Default sort properties are defined using the `PropertySet`
+named `DefaultKeyPropertySet` in a `types.ps1xml` file. For more information, see
+[about_Types.ps1xml](/powershell/module/Microsoft.PowerShell.Core/About/about_Types.ps1xml).
 
+If an object does not have one of the specified properties, the property value for that object is
+interpreted by `Sort-Object` as **Null** and placed at the end of the sort order.
+
+When no sort properties are available, PowerShell attempts to compare the objects themselves.
 `Sort-Object` uses the **Compare** method for each property. If a property does not implement
 **IComparable**, the cmdlet converts the property value to a string and uses the **Compare** method
-for **System.String**. For more information, see [PSObject.CompareTo(Object) Method](/dotnet/api/system.management.automation.psobject.compareto).
+for **System.String**. For more information, see
+[PSObject.CompareTo(Object) Method](/dotnet/api/system.management.automation.psobject.compareto).
 
 If you sort on an enumerated property such as **Status**, `Sort-Object` sorts by the enumeration
-values. **Stopped** has a value of **1** and **Running** has a value of **4**. **Stopped** is sorted
-before **Running** because of the enumerated values. For more information, see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrollerstatus).
+values. For Windows services, **Stopped** has a value of **1** and **Running** has a value of **4**.
+**Stopped** is sorted before **Running** because of the enumerated values. For more information,
+see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrollerstatus).
 
 The performance of the sorting algorithm is slower when doing a stable sort.
 
 ## RELATED LINKS
 
 [about_Hash_Tables](../Microsoft.PowerShell.Core/About/about_Hash_Tables.md)
+
+[about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md)
 
 [Compare-Object](Compare-Object.md)
 

--- a/reference/7.1/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -40,9 +40,10 @@ Sort-Object [-Descending] [-Unique] -Bottom <Int32> [-InputObject <PSObject>] [[
 ## DESCRIPTION
 
 The `Sort-Object` cmdlet sorts objects in ascending or descending order based on object property
-values. If sort properties are not included in a command, PowerShell uses default sort properties,
-defined as the `DefaultKeyPropertySet` of the type data of the first input object,
-or compares the objects themselves.
+values. If sort properties are not included in a command, PowerShell uses default sort properties 
+of the first input object. If the type of the input object has no default sort properties,
+PowerShell attempts to compare the objects themselves. For more information, see the [Notes](#notes)
+section.
 
 You can sort objects by a single property or multiple properties. Multiple properties use hash
 tables to sort in ascending order, descending order, or a combination of sort orders. Properties are
@@ -82,7 +83,8 @@ The `Get-ChildItem` cmdlet gets the files and subdirectories from the directory 
 This command displays the files in the current directory by length in ascending order.
 
 ```
-PS> Get-ChildItem -Path C:\Test -File | Sort-Object -Property Length
+PS> Get-ChildItem -Path C:\Test -File | Sort-Object 
+ty Length
 
     Directory: C:\Test
 
@@ -579,17 +581,23 @@ You can pipe the objects to be sorted to `Sort-Object`.
 ## NOTES
 
 The `Sort-Object` cmdlet sorts objects based on properties specified in the command or the default
-sort properties for the object type. If an object does not have one of the specified properties, the
-property value for that object is interpreted by `Sort-Object` as **Null** and placed at the end of
-the sort order.
+sort properties for the object type. Default sort properties are defined using the
+`DefaultKeyPropertySet` element in a `types.ps1xml` file. For more information, see
+[about_Types.ps1xml](/powershell/module/Microsoft.PowerShell.Core/About/about_Types.ps1xml).
 
+If an object does not have one of the specified properties, the property value for that object is
+interpreted by `Sort-Object` as **Null** and placed at the end of the sort order.
+
+When no sort properties are available, PowerShell attempts to compare the objects themselves.
 `Sort-Object` uses the **Compare** method for each property. If a property does not implement
 **IComparable**, the cmdlet converts the property value to a string and uses the **Compare** method
-for **System.String**. For more information, see [PSObject.CompareTo(Object) Method](/dotnet/api/system.management.automation.psobject.compareto).
+for **System.String**. For more information, see
+[PSObject.CompareTo(Object) Method](/dotnet/api/system.management.automation.psobject.compareto).
 
 If you sort on an enumerated property such as **Status**, `Sort-Object` sorts by the enumeration
-values. **Stopped** has a value of **1** and **Running** has a value of **4**. **Stopped** is sorted
-before **Running** because of the enumerated values. For more information, see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrollerstatus).
+values. For Windows services, **Stopped** has a value of **1** and **Running** has a value of **4**.
+**Stopped** is sorted before **Running** because of the enumerated values. For more information,
+see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrollerstatus).
 
 The performance of the sorting algorithm is slower when doing a stable sort.
 
@@ -612,4 +620,3 @@ The performance of the sorting algorithm is slower when doing a stable sort.
 [Select-Object](Select-Object.md)
 
 [Tee-Object](Tee-Object.md)
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -83,8 +83,7 @@ The `Get-ChildItem` cmdlet gets the files and subdirectories from the directory 
 This command displays the files in the current directory by length in ascending order.
 
 ```
-PS> Get-ChildItem -Path C:\Test -File | Sort-Object 
-ty Length
+PS> Get-ChildItem -Path C:\Test -File | Sort-Object -Property Length
 
     Directory: C:\Test
 
@@ -581,8 +580,8 @@ You can pipe the objects to be sorted to `Sort-Object`.
 ## NOTES
 
 The `Sort-Object` cmdlet sorts objects based on properties specified in the command or the default
-sort properties for the object type. Default sort properties are defined using the
-`DefaultKeyPropertySet` element in a `types.ps1xml` file. For more information, see
+sort properties for the object type. Default sort properties are defined using the `PropertySet`
+named `DefaultKeyPropertySet` in a `types.ps1xml` file. For more information, see
 [about_Types.ps1xml](/powershell/module/Microsoft.PowerShell.Core/About/about_Types.ps1xml).
 
 If an object does not have one of the specified properties, the property value for that object is

--- a/reference/7.1/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -40,7 +40,9 @@ Sort-Object [-Descending] [-Unique] -Bottom <Int32> [-InputObject <PSObject>] [[
 ## DESCRIPTION
 
 The `Sort-Object` cmdlet sorts objects in ascending or descending order based on object property
-values. If sort properties are not included in a command, PowerShell uses default sort properties.
+values. If sort properties are not included in a command, PowerShell uses default sort properties,
+defined as the `DefaultKeyPropertySet` of the type data of the first input object,
+or compares the objects themselves.
 
 You can sort objects by a single property or multiple properties. Multiple properties use hash
 tables to sort in ascending order, descending order, or a combination of sort orders. Properties are
@@ -470,7 +472,7 @@ Accept wildcard characters: False
 
 Specifies the property names that `Sort-Object` uses to sort the objects. Wildcards are permitted.
 Objects are sorted based on the property values. If you do not specify a property, `Sort-Object`
-sorts based on default properties for the object type.
+sorts based on default properties for the object type or the objects themselves.
 
 Multiple properties can be sorted in ascending order, descending order, or a combination of sort
 orders. When you specify multiple properties, the objects are sorted by the first property. If
@@ -594,6 +596,8 @@ The performance of the sorting algorithm is slower when doing a stable sort.
 ## RELATED LINKS
 
 [about_Hash_Tables](../Microsoft.PowerShell.Core/About/about_Hash_Tables.md)
+
+[about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md)
 
 [Compare-Object](Compare-Object.md)
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
I indicated where the default sorting properties come from and what happens if there are still none.  Fixes #6382.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [X] Version 7.1 preview content
- [X] Version 7.0 content
- [X] Version 6 content
- [X] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
