### PR TITLE
Fix issues in Push-Location.md and Pop-Location.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Pop-Location.md
@@ -92,8 +92,8 @@ Specifies the location stack from which the location is popped. Enter a location
 
 Without this parameter, `Pop-Location` pops a location from the current location stack. By
 default, the current location stack is the unnamed default location stack that PowerShell
-creates. To make a location stack the current location stack, use the **StackName** parameter of
-`Set-Location`.
+creates. To make a location stack the current location stack, use the **StackName** parameter
+of the `Set-Location` cmdlet. For more information about location stacks, see the [Notes](#notes).
 
 `Pop-Location` cannot pop a location from the unnamed default stack unless it is the current
 location stack.
@@ -152,7 +152,7 @@ output.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 
 Even if the location cmdlets did set the process-wide current directory, you can't depend on it

--- a/reference/5.1/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Push-Location.md
@@ -214,7 +214,7 @@ cmdlet does not generate any output.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 
 Even if the location cmdlets did set the process-wide current directory, you can't depend on it
@@ -226,7 +226,7 @@ You add items to a stack in the order that you use them, and then retrieve them 
 reverse order. PowerShell lets you store provider locations in location stacks.
 
 PowerShell creates an unnamed default location stack and you can create multiple named location
-stacks. If you do not specify a stack name, Windows PowerShell uses the current location stack. By
+stacks. If you do not specify a stack name, PowerShell uses the current location stack. By
 default, the unnamed default location is the current location stack, but you can use the
 `Set-Location` cmdlet to change the current location stack.
 

--- a/reference/6/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Pop-Location.md
@@ -92,8 +92,8 @@ Specifies the location stack from which the location is popped. Enter a location
 
 Without this parameter, `Pop-Location` pops a location from the current location stack. By
 default, the current location stack is the unnamed default location stack that PowerShell
-creates. To make a location stack the current location stack, use the **StackName** parameter of
-`Set-Location`.
+creates. To make a location stack the current location stack, use the **StackName** parameter
+of the `Set-Location` cmdlet. For more information about location stacks, see the [Notes](#notes).
 
 `Pop-Location` cannot pop a location from the unnamed default stack unless it is the current
 location stack.
@@ -134,7 +134,7 @@ output.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 
 Even if the location cmdlets did set the process-wide current directory, you can't depend on it

--- a/reference/6/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Push-Location.md
@@ -196,7 +196,7 @@ cmdlet does not generate any output.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 
 Even if the location cmdlets did set the process-wide current directory, you can't depend on it
@@ -208,7 +208,7 @@ You add items to a stack in the order that you use them, and then retrieve them 
 reverse order. PowerShell lets you store provider locations in location stacks.
 
 PowerShell creates an unnamed default location stack and you can create multiple named location
-stacks. If you do not specify a stack name, Windows PowerShell uses the current location stack. By
+stacks. If you do not specify a stack name, PowerShell uses the current location stack. By
 default, the unnamed default location is the current location stack, but you can use the
 `Set-Location` cmdlet to change the current location stack.
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Pop-Location.md
@@ -92,8 +92,8 @@ Specifies the location stack from which the location is popped. Enter a location
 
 Without this parameter, `Pop-Location` pops a location from the current location stack. By
 default, the current location stack is the unnamed default location stack that PowerShell
-creates. To make a location stack the current location stack, use the **StackName** parameter of
-`Set-Location`.
+creates. To make a location stack the current location stack, use the **StackName** parameter
+of the `Set-Location` cmdlet. For more information about location stacks, see the [Notes](#notes).
 
 `Pop-Location` cannot pop a location from the unnamed default stack unless it is the current
 location stack.
@@ -134,7 +134,7 @@ output.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 
 Even if the location cmdlets did set the process-wide current directory, you can't depend on it

--- a/reference/7.0/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Push-Location.md
@@ -196,7 +196,7 @@ cmdlet does not generate any output.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 
 Even if the location cmdlets did set the process-wide current directory, you can't depend on it
@@ -208,7 +208,7 @@ You add items to a stack in the order that you use them, and then retrieve them 
 reverse order. PowerShell lets you store provider locations in location stacks.
 
 PowerShell creates an unnamed default location stack and you can create multiple named location
-stacks. If you do not specify a stack name, Windows PowerShell uses the current location stack. By
+stacks. If you do not specify a stack name, PowerShell uses the current location stack. By
 default, the unnamed default location is the current location stack, but you can use the
 `Set-Location` cmdlet to change the current location stack.
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Pop-Location.md
@@ -92,8 +92,8 @@ Specifies the location stack from which the location is popped. Enter a location
 
 Without this parameter, `Pop-Location` pops a location from the current location stack. By
 default, the current location stack is the unnamed default location stack that PowerShell
-creates. To make a location stack the current location stack, use the **StackName** parameter of
-`Set-Location`.
+creates. To make a location stack the current location stack, use the **StackName** parameter
+of the `Set-Location` cmdlet. For more information about location stacks, see the [Notes](#notes).
 
 `Pop-Location` cannot pop a location from the unnamed default stack unless it is the current
 location stack.
@@ -134,7 +134,7 @@ output.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 
 Even if the location cmdlets did set the process-wide current directory, you can't depend on it

--- a/reference/7.1/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Push-Location.md
@@ -196,7 +196,7 @@ cmdlet does not generate any output.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 
 Even if the location cmdlets did set the process-wide current directory, you can't depend on it
@@ -208,7 +208,7 @@ You add items to a stack in the order that you use them, and then retrieve them 
 reverse order. PowerShell lets you store provider locations in location stacks.
 
 PowerShell creates an unnamed default location stack and you can create multiple named location
-stacks. If you do not specify a stack name, Windows PowerShell uses the current location stack. By
+stacks. If you do not specify a stack name, PowerShell uses the current location stack. By
 default, the unnamed default location is the current location stack, but you can use the
 `Set-Location` cmdlet to change the current location stack.
 


### PR DESCRIPTION
# PR Summary

- Bring `Push-Location` and `Pop-Location` cmdlets **-StackName** parameter description to consistency
- Fix a typo
- Remove **Windows** from **Windows PowerShell**


## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
