### PR TITLE
Fix Certificate Provider example for .NotAfter

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
@@ -182,10 +182,11 @@ the following attributes:
 The **NotAfter** property stores the certificate expiration date.
 
 ```powershell
+[DateTime] $ValidThrough = (Get-Date) + (New-TimeSpan -Days 30)
 Get-ChildItem -Path cert:\* -Recurse -DNSName "*fabrikam*" `
   -EKU "*Client Authentication*" | Where-Object {
                                      $_.SendAsTrustedIssuer -and `
-                                     $_.NotAfter -gt (get-date).AddDays.(30)
+                                     $_.NotAfter -gt $ValidThrough
                                    }
 ```
 

--- a/reference/6/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
+++ b/reference/6/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
@@ -182,10 +182,11 @@ the following attributes:
 The **NotAfter** property stores the certificate expiration date.
 
 ```powershell
+[DateTime] $ValidThrough = (Get-Date) + (New-TimeSpan -Days 30)
 Get-ChildItem -Path cert:\* -Recurse -DNSName "*fabrikam*" `
   -EKU "*Client Authentication*" | Where-Object {
                                      $_.SendAsTrustedIssuer -and `
-                                     $_.NotAfter -gt (get-date).AddDays.(30)
+                                     $_.NotAfter -gt $ValidThrough
                                    }
 ```
 

--- a/reference/7.0/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
+++ b/reference/7.0/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
@@ -182,10 +182,12 @@ the following attributes:
 The **NotAfter** property stores the certificate expiration date.
 
 ```powershell
+[DateTime] $ValidThrough = (Get-Date) + (New-TimeSpan -Days 30)
 Get-ChildItem -Path cert:\* -Recurse -DNSName "*fabrikam*" `
   -EKU "*Client Authentication*" | Where-Object {
                                      $_.SendAsTrustedIssuer -and `
                                      $_.NotAfter -gt (get-date).AddDays.(30)
+                                     $_.NotAfter -gt $ValidThrough
                                    }
 ```
 

--- a/reference/7.0/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
+++ b/reference/7.0/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
@@ -186,7 +186,6 @@ The **NotAfter** property stores the certificate expiration date.
 Get-ChildItem -Path cert:\* -Recurse -DNSName "*fabrikam*" `
   -EKU "*Client Authentication*" | Where-Object {
                                      $_.SendAsTrustedIssuer -and `
-                                     $_.NotAfter -gt (get-date).AddDays.(30)
                                      $_.NotAfter -gt $ValidThrough
                                    }
 ```

--- a/reference/7.1/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
+++ b/reference/7.1/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
@@ -182,10 +182,11 @@ the following attributes:
 The **NotAfter** property stores the certificate expiration date.
 
 ```powershell
+[DateTime] $ValidThrough = (Get-Date) + (New-TimeSpan -Days 30)
 Get-ChildItem -Path cert:\* -Recurse -DNSName "*fabrikam*" `
   -EKU "*Client Authentication*" | Where-Object {
                                      $_.SendAsTrustedIssuer -and `
-                                     $_.NotAfter -gt (get-date).AddDays.(30)
+                                     $_.NotAfter -gt $ValidThrough
                                    }
 ```
 


### PR DESCRIPTION

# PR Summary
<!-- Summarize your changes and list related issues here -->
The example did not work as intended.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [X] Version 7.1 preview content
- [X] Version 7.0 content
- [X] Version 6 content
- [X] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
