### PR TITLE
Member operator: member names may be expressions

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -367,21 +367,23 @@ You can also create ranges in reverse order.
 
 #### Member access operator `.`
 
-Accesses the properties and methods of an object.
+Accesses the properties and methods of an object.  The member name may be an expression.
 
 ```powershell
 $myProcess.peakWorkingSet
 (Get-Process PowerShell).kill()
+'OS', 'Platform' | Foreach-Object { $PSVersionTable. $_ }
 ```
 
 #### Static member operator `::`
 
 Calls the static properties and methods of a .NET Framework class. To
 find the static properties and methods of an object, use the Static parameter
-of the `Get-Member` cmdlet.
+of the `Get-Member` cmdlet.  The member name may be an expression.
 
 ```powershell
 [datetime]::Now
+'MinValue', 'MaxValue' | Foreach-Object { [int]:: $_ }
 ```
 
 ## See also

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -469,21 +469,23 @@ A
 
 #### Member access operator `.`
 
-Accesses the properties and methods of an object.
+Accesses the properties and methods of an object.  The member name may be an expression.
 
 ```powershell
 $myProcess.peakWorkingSet
 (Get-Process PowerShell).kill()
+'OS', 'Platform' | Foreach-Object { $PSVersionTable. $_ }
 ```
 
 #### Static member operator `::`
 
 Calls the static properties and methods of a .NET Framework class. To
 find the static properties and methods of an object, use the Static parameter
-of the `Get-Member` cmdlet.
+of the `Get-Member` cmdlet.  The member name may be an expression.
 
 ```powershell
 [datetime]::Now
+'MinValue', 'MaxValue' | Foreach-Object { [int]:: $_ }
 ```
 
 ## See also

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -477,21 +477,23 @@ A
 
 #### Member access operator `.`
 
-Accesses the properties and methods of an object.
+Accesses the properties and methods of an object.  The member name may be an expression.
 
 ```powershell
 $myProcess.peakWorkingSet
 (Get-Process PowerShell).kill()
+'OS', 'Platform' | Foreach-Object { $PSVersionTable. $_ }
 ```
 
 #### Static member operator `::`
 
 Calls the static properties and methods of a .NET Framework class. To
 find the static properties and methods of an object, use the Static parameter
-of the `Get-Member` cmdlet.
+of the `Get-Member` cmdlet.  The member name may be an expression.
 
 ```powershell
 [datetime]::Now
+'MinValue', 'MaxValue' | Foreach-Object { [int]:: $_ }
 ```
 
 #### Ternary operator `? <if-true> : <if-false>`

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -477,21 +477,23 @@ A
 
 #### Member access operator `.`
 
-Accesses the properties and methods of an object.
+Accesses the properties and methods of an object.  The member name may be an expression.
 
 ```powershell
 $myProcess.peakWorkingSet
 (Get-Process PowerShell).kill()
+'OS', 'Platform' | Foreach-Object { $PSVersionTable. $_ }
 ```
 
 #### Static member operator `::`
 
 Calls the static properties and methods of a .NET Framework class. To
 find the static properties and methods of an object, use the Static parameter
-of the `Get-Member` cmdlet.
+of the `Get-Member` cmdlet.  The member name may be an expression.
 
 ```powershell
 [datetime]::Now
+'MinValue', 'MaxValue' | Foreach-Object { [int]:: $_ }
 ```
 
 #### Ternary operator `? <if-true> : <if-false>`


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Member operator: member names may be expressions,  I think it should be explicitly said because it is quite uncommon, as far as scripting languages are concerned.
## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [X] Version 7.1 preview content
- [X] Version 7.0 content
- [X] Version 6 content
- [X] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
