### PR TITLE
Fix *-Location.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Location.md
@@ -264,7 +264,7 @@ Otherwise, it returns a **PathInfo** object.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 The `Get-Location` cmdlet returns the current directory of the current PowerShell runspace.
 
@@ -285,7 +285,7 @@ specify a stack name, PowerShell uses the current location stack. By default, th
 location is the current location stack, but you can use the `Set-Location` cmdlet to change the
 current location stack.
 
-To manage location stacks, use the PowerShellLocation cmdlets, as follows.
+To manage location stacks, use the PowerShell `*-Location` cmdlets, as follows.
 
 - To add a location to a location stack, use the `Push-Location` cmdlet.
 
@@ -302,10 +302,11 @@ To manage location stacks, use the PowerShellLocation cmdlets, as follows.
   `Set-Location` cmdlet.
 
 The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use the
-`Push-Location` or `Pop-Location` add or get items from the default stack or use this cmdlet command
-to display the locations in the unnamed stack. To make the unnamed stack the current stack, use the
-**StackName** parameter of the `Set-Location` cmdlet with a value of $null or an empty string ("").
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use this
+cmdlet to display the locations in the unnamed stack. To make the unnamed stack the current stack,
+use the **StackName** parameter of the `Set-Location` cmdlet with a value of `$null` or an empty
+string (`""`).
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Pop-Location.md
@@ -187,12 +187,12 @@ To manage location stacks, use the PowerShell `*-Location` cmdlets, as follows:
 - To make a location stack the current location stack, use the **StackName** parameter of the
   `Set-Location` cmdlet.
 
-The unnamed default location stack is fully available only when it is the current location stack.
-If you make a named location stack the current location stack, you can no longer use
-`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use a
-`Get-Location` command to display the locations in the unnamed stack. To make the unnamed stack
-the current stack, use the **StackName** parameter of `Set-Location` with a value of `$Null` or an
-empty string (`""`).
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
+`Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
+the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
+`$Null` or an empty string (`""`).
 
 You can also refer to `Pop-Location` by its built-in alias, `popd`. For more information, see
 [about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).

--- a/reference/5.1/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Push-Location.md
@@ -249,11 +249,11 @@ To manage location stacks, use the PowerShell Location cmdlets, as follows.
   `Set-Location` cmdlet.
 
 The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you can no longer use
-`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use
-`Get-Location` command to display the locations in the unnamed stack. To make the unnamed stack the
-current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of `$null`
-or an empty string (`""`).
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
+`Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
+the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
+`$null` or an empty string (`""`).
 
 You can also refer to `Push-Location` by its built-in alias, `pushd`. For more information, see
 [about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Location.md
@@ -213,7 +213,7 @@ representing the new stack context.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 
 Even if the location cmdlets did set the process-wide current directory, you can't depend on it
@@ -248,12 +248,12 @@ To manage location stacks, use the `*-Location` cmdlets, as follows:
 - To make a location stack the current location stack, use the **StackName** parameter of
   `Set-Location`.
 
-  The unnamed default location stack is fully accessible only when it is the current location
-  stack. If you make a named location stack the current location stack, you cannot no longer use
-  `Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use
-  `Get-Location` to display the locations in the unnamed stack. To make the unnamed stack the
-  current stack, use the **StackName** parameter of `Set-Location` with a value of `$null` or an
-  empty string ("").
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
+`Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
+the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
+`$null` or an empty string (`""`).
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-Location.md
@@ -247,7 +247,7 @@ Otherwise, it returns a **PathInfo** object.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 The `Get-Location` cmdlet returns the current directory of the current PowerShell runspace.
 
@@ -268,7 +268,7 @@ specify a stack name, PowerShell uses the current location stack. By default, th
 location is the current location stack, but you can use the `Set-Location` cmdlet to change the
 current location stack.
 
-To manage location stacks, use the PowerShellLocation cmdlets, as follows.
+To manage location stacks, use the PowerShell `*-Location` cmdlets, as follows.
 
 - To add a location to a location stack, use the `Push-Location` cmdlet.
 
@@ -285,10 +285,11 @@ To manage location stacks, use the PowerShellLocation cmdlets, as follows.
   `Set-Location` cmdlet.
 
 The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use the
-`Push-Location` or `Pop-Location` add or get items from the default stack or use this cmdlet command
-to display the locations in the unnamed stack. To make the unnamed stack the current stack, use the
-**StackName** parameter of the `Set-Location` cmdlet with a value of $null or an empty string ("").
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use this
+cmdlet to display the locations in the unnamed stack. To make the unnamed stack the current stack,
+use the **StackName** parameter of the `Set-Location` cmdlet with a value of `$null` or an empty
+string (`""`).
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Pop-Location.md
@@ -169,12 +169,12 @@ To manage location stacks, use the PowerShell `*-Location` cmdlets, as follows:
 - To make a location stack the current location stack, use the **StackName** parameter of the
   `Set-Location` cmdlet.
 
-The unnamed default location stack is fully available only when it is the current location stack.
-If you make a named location stack the current location stack, you can no longer use
-`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use a
-`Get-Location` command to display the locations in the unnamed stack. To make the unnamed stack
-the current stack, use the **StackName** parameter of `Set-Location` with a value of `$Null` or an
-empty string (`""`).
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
+`Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
+the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
+`$Null` or an empty string (`""`).
 
 You can also refer to `Pop-Location` by its built-in alias, `popd`. For more information, see
 [about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).

--- a/reference/6/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Push-Location.md
@@ -231,11 +231,11 @@ To manage location stacks, use the PowerShell Location cmdlets, as follows.
   `Set-Location` cmdlet.
 
 The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you can no longer use
-`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use
-`Get-Location` command to display the locations in the unnamed stack. To make the unnamed stack the
-current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of `$null`
-or an empty string (`""`).
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
+`Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
+the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
+`$null` or an empty string (`""`).
 
 You can also refer to `Push-Location` by its built-in alias, `pushd`. For more information, see
 [about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).

--- a/reference/6/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Location.md
@@ -221,7 +221,7 @@ representing the new stack context.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 
 Even if the location cmdlets did set the process-wide current directory, you can't depend on it
@@ -256,12 +256,12 @@ To manage location stacks, use the `*-Location` cmdlets, as follows:
 - To make a location stack the current location stack, use the **StackName** parameter of
   `Set-Location`.
 
-  The unnamed default location stack is fully accessible only when it is the current location
-  stack. If you make a named location stack the current location stack, you cannot no longer use
-  `Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use
-  `Get-Location` to display the locations in the unnamed stack. To make the unnamed stack the
-  current stack, use the **StackName** parameter of `Set-Location` with a value of `$null` or an
-  empty string ("").
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
+`Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
+the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
+`$null` or an empty string (`""`).
 
 ## RELATED LINKS
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Get-Location.md
@@ -247,7 +247,7 @@ Otherwise, it returns a **PathInfo** object.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 The `Get-Location` cmdlet returns the current directory of the current PowerShell runspace.
 
@@ -268,7 +268,7 @@ specify a stack name, PowerShell uses the current location stack. By default, th
 location is the current location stack, but you can use the `Set-Location` cmdlet to change the
 current location stack.
 
-To manage location stacks, use the PowerShellLocation cmdlets, as follows.
+To manage location stacks, use the PowerShell `*-Location` cmdlets, as follows.
 
 - To add a location to a location stack, use the `Push-Location` cmdlet.
 
@@ -285,10 +285,11 @@ To manage location stacks, use the PowerShellLocation cmdlets, as follows.
   `Set-Location` cmdlet.
 
 The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use the
-`Push-Location` or `Pop-Location` add or get items from the default stack or use this cmdlet command
-to display the locations in the unnamed stack. To make the unnamed stack the current stack, use the
-**StackName** parameter of the `Set-Location` cmdlet with a value of $null or an empty string ("").
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use this
+cmdlet to display the locations in the unnamed stack. To make the unnamed stack the current stack,
+use the **StackName** parameter of the `Set-Location` cmdlet with a value of `$null` or an empty
+string (`""`).
 
 ## RELATED LINKS
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Pop-Location.md
@@ -169,12 +169,12 @@ To manage location stacks, use the PowerShell `*-Location` cmdlets, as follows:
 - To make a location stack the current location stack, use the **StackName** parameter of the
   `Set-Location` cmdlet.
 
-The unnamed default location stack is fully available only when it is the current location stack.
-If you make a named location stack the current location stack, you can no longer use
-`Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use a
-`Get-Location` command to display the locations in the unnamed stack. To make the unnamed stack
-the current stack, use the **StackName** parameter of `Set-Location` with a value of `$Null` or an
-empty string (`""`).
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
+`Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
+the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
+`$Null` or an empty string (`""`).
 
 You can also refer to `Pop-Location` by its built-in alias, `popd`. For more information, see
 [about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).

--- a/reference/7.0/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Push-Location.md
@@ -231,11 +231,11 @@ To manage location stacks, use the PowerShell Location cmdlets, as follows.
   `Set-Location` cmdlet.
 
 The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you can no longer use
-`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use
-`Get-Location` command to display the locations in the unnamed stack. To make the unnamed stack the
-current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of `$null`
-or an empty string (`""`).
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
+`Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
+the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
+`$null` or an empty string (`""`).
 
 You can also refer to `Push-Location` by its built-in alias, `pushd`. For more information, see
 [about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).

--- a/reference/7.0/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Set-Location.md
@@ -221,7 +221,7 @@ representing the new stack context.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 
 Even if the location cmdlets did set the process-wide current directory, you can't depend on it
@@ -256,12 +256,12 @@ To manage location stacks, use the `*-Location` cmdlets, as follows:
 - To make a location stack the current location stack, use the **StackName** parameter of
   `Set-Location`.
 
-  The unnamed default location stack is fully accessible only when it is the current location
-  stack. If you make a named location stack the current location stack, you cannot no longer use
-  `Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use
-  `Get-Location` to display the locations in the unnamed stack. To make the unnamed stack the
-  current stack, use the **StackName** parameter of `Set-Location` with a value of `$null` or an
-  empty string ("").
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
+`Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
+the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
+`$null` or an empty string (`""`).
 
 ## RELATED LINKS
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Get-Location.md
@@ -247,7 +247,7 @@ Otherwise, it returns a **PathInfo** object.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 The `Get-Location` cmdlet returns the current directory of the current PowerShell runspace.
 
@@ -268,7 +268,7 @@ specify a stack name, PowerShell uses the current location stack. By default, th
 location is the current location stack, but you can use the `Set-Location` cmdlet to change the
 current location stack.
 
-To manage location stacks, use the PowerShellLocation cmdlets, as follows.
+To manage location stacks, use the PowerShell `*-Location` cmdlets, as follows.
 
 - To add a location to a location stack, use the `Push-Location` cmdlet.
 
@@ -285,10 +285,11 @@ To manage location stacks, use the PowerShellLocation cmdlets, as follows.
   `Set-Location` cmdlet.
 
 The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use the
-`Push-Location` or `Pop-Location` add or get items from the default stack or use this cmdlet command
-to display the locations in the unnamed stack. To make the unnamed stack the current stack, use the
-**StackName** parameter of the `Set-Location` cmdlet with a value of $null or an empty string ("").
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use this
+cmdlet to display the locations in the unnamed stack. To make the unnamed stack the current stack,
+use the **StackName** parameter of the `Set-Location` cmdlet with a value of `$null` or an empty
+string (`""`).
 
 ## RELATED LINKS
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Pop-Location.md
@@ -169,12 +169,12 @@ To manage location stacks, use the PowerShell `*-Location` cmdlets, as follows:
 - To make a location stack the current location stack, use the **StackName** parameter of the
   `Set-Location` cmdlet.
 
-The unnamed default location stack is fully available only when it is the current location stack.
-If you make a named location stack the current location stack, you can no longer use
-`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use a
-`Get-Location` command to display the locations in the unnamed stack. To make the unnamed stack
-the current stack, use the **StackName** parameter of `Set-Location` with a value of `$Null` or an
-empty string (`""`).
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
+`Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
+the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
+`$Null` or an empty string (`""`).
 
 You can also refer to `Pop-Location` by its built-in alias, `popd`. For more information, see
 [about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).

--- a/reference/7.1/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Push-Location.md
@@ -231,11 +231,11 @@ To manage location stacks, use the PowerShell Location cmdlets, as follows.
   `Set-Location` cmdlet.
 
 The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you can no longer use
-`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use
-`Get-Location` command to display the locations in the unnamed stack. To make the unnamed stack the
-current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of `$null`
-or an empty string (`""`).
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
+`Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
+the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
+`$null` or an empty string (`""`).
 
 You can also refer to `Push-Location` by its built-in alias, `pushd`. For more information, see
 [about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).

--- a/reference/7.1/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Set-Location.md
@@ -221,7 +221,7 @@ representing the new stack context.
 ## NOTES
 
 PowerShell supports multiple runspaces per process. Each runspace has its own _current directory_.
-This is not that same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
+This is not the same as `[System.Environment]::CurrentDirectory`. This behavior can be an issue
 when calling .NET APIs or running native applications without providing explicit directory paths.
 
 Even if the location cmdlets did set the process-wide current directory, you can't depend on it
@@ -256,12 +256,12 @@ To manage location stacks, use the `*-Location` cmdlets, as follows:
 - To make a location stack the current location stack, use the **StackName** parameter of
   `Set-Location`.
 
-  The unnamed default location stack is fully accessible only when it is the current location
-  stack. If you make a named location stack the current location stack, you cannot no longer use
-  `Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use
-  `Get-Location` to display the locations in the unnamed stack. To make the unnamed stack the
-  current stack, use the **StackName** parameter of `Set-Location` with a value of `$null` or an
-  empty string ("").
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you can no longer use the
+`Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
+`Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
+the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
+`$null` or an empty string (`""`).
 
 ## RELATED LINKS
 


### PR DESCRIPTION
# PR Summary

- Fix a typo.
- Separate and highlight `*-Location`.
- Unify notes among `Get-`, `Set-`, `Push-` and `Pop-Location`.

*PS. I'm not sure why github marked Windows PowerShell 5.1 Set-Location.md and Pop-Location.md like this.*

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
