### PR TITLE
Fix Get-Location.md and Set-Location.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Location.md
@@ -147,7 +147,7 @@ To see the current prompt function, type the following command: `Get-Content Fun
 Specifies the current location in the specified PowerShell drive that this cmdlet gets in the
 operation.
 
-For instance, if you are in the `Certificate:` drive, you can use this parameter to find your
+For instance, if you are in the `Cert:` drive, you can use this parameter to find your
 current location in the `C:` drive.
 
 ```yaml
@@ -185,10 +185,11 @@ Accept wildcard characters: False
 
 ### -Stack
 
-Indicates that this cmdlet displays the locations in the current location stack.
+Indicates that this cmdlet displays the locations added to the current location stack. You can add
+locations to stacks by using the `Push-Location` cmdlet.
 
 To display the locations in a different location stack, use the **StackName** parameter. For
-information about location stacks, see the Notes.
+information about location stacks, see the [Notes](#notes).
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -207,7 +208,7 @@ Accept wildcard characters: False
 Specifies, as a string array, the named location stacks. Enter one or more location stack names.
 
 To display the locations in the current location stack, use the **Stack** parameter. To make a
-location stack the current location stack, use the `Set-Location` parameter.
+location stack the current location stack, use the `Set-Location` cmdlet.
 
 This cmdlet cannot display the locations in the unnamed default stack unless it is the current
 stack.
@@ -258,8 +259,8 @@ You cannot pipe input to this cmdlet.
 
 ### System.Management.Automation.PathInfo or System.Management.Automation.PathInfoStack
 
-If you use the **Stack** or **StackName** parameters, this cmdlet returns a **StackInfo** object.
-Otherwise, it returns a **PathInfo** object.
+If you use the **Stack** or **StackName** parameters, this cmdlet returns a **PathInfoStack**
+object. Otherwise, it returns a **PathInfo** object.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Location.md
@@ -153,7 +153,7 @@ Accept wildcard characters: True
 
 Specifies the location stack name that this cmdlet makes the current location stack. Enter a
 location stack name. To indicate the unnamed default location stack, type `$null` or an empty string
-("").
+(`""`).
 
 The `*-Location` cmdlets act on the current stack unless you use the **StackName** parameter to
 specify a different stack.

--- a/reference/6/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-Location.md
@@ -147,7 +147,7 @@ To see the current prompt function, type the following command: `Get-Content Fun
 Specifies the current location in the specified PowerShell drive that this cmdlet gets in the
 operation.
 
-For instance, if you are in the `Certificate:` drive, you can use this parameter to find your
+For instance, if you are in the `Cert:` drive, you can use this parameter to find your
 current location in the `C:` drive.
 
 ```yaml
@@ -185,10 +185,11 @@ Accept wildcard characters: False
 
 ### -Stack
 
-Indicates that this cmdlet displays the locations in the current location stack.
+Indicates that this cmdlet displays the locations added to the current location stack. You can add
+locations to stacks by using the `Push-Location` cmdlet.
 
 To display the locations in a different location stack, use the **StackName** parameter. For
-information about location stacks, see the Notes.
+information about location stacks, see the [Notes](#notes).
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -207,7 +208,7 @@ Accept wildcard characters: False
 Specifies, as a string array, the named location stacks. Enter one or more location stack names.
 
 To display the locations in the current location stack, use the **Stack** parameter. To make a
-location stack the current location stack, use the `Set-Location` parameter.
+location stack the current location stack, use the `Set-Location` cmdlet.
 
 This cmdlet cannot display the locations in the unnamed default stack unless it is the current
 stack.
@@ -241,8 +242,8 @@ You cannot pipe input to this cmdlet.
 
 ### System.Management.Automation.PathInfo or System.Management.Automation.PathInfoStack
 
-If you use the **Stack** or **StackName** parameters, this cmdlet returns a **StackInfo** object.
-Otherwise, it returns a **PathInfo** object.
+If you use the **Stack** or **StackName** parameters, this cmdlet returns a **PathInfoStack**
+object. Otherwise, it returns a **PathInfo** object.
 
 ## NOTES
 

--- a/reference/6/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Location.md
@@ -38,9 +38,9 @@ Set-Location [-PassThru] [-StackName <String>] [<CommonParameters>]
 The `Set-Location` cmdlet sets the working location to a specified location. That location could be
 a directory, a subdirectory, a registry location, or any provider path.
 
-PowerShell 6.2 added support for `-` and `+` with the **Path** parameter. PowerShell maintains a
-history of the last 20 locations that can be access with `-` and `+`. This list is independent from
-the location stack that is accessed using the **StackName** parameter.
+PowerShell 6.2 added support for `-` and `+` as a values for the **Path** parameter. PowerShell
+maintains a history of the last 20 locations that can be accessed with `-` and `+`. This list is
+independent from the location stack that is accessed using the **StackName** parameter.
 
 ## EXAMPLES
 
@@ -157,12 +157,12 @@ Specify the path of a new working location. If no path is provided, `Set-Locatio
 current user's home directory. When wildcards are used, the cmdlet chooses the first path that
 matches the wildcard pattern.
 
-PowerShell keeps a history of the last 20 locations you have set. If the path is the `-` character,
-then the new working location will be the previous working location in history (if it exists).
-Similarly, if the path is the `+` character, then the new working location will be the next working
-location in history (if it exists). This is similar to using `Pop-Location` and `Push-Location`
-except that the history is a list, not a stack, and is implicitly tracked, not manually controlled.
-Currently, there is no way to view the history list.
+PowerShell keeps a history of the last 20 locations you have set. If the **Path** parameter value
+is the `-` character, then the new working location will be the previous working location in history
+(if it exists). Similarly, if the value is the `+` character, then the new working location will be
+the next working location in history (if it exists). This is similar to using `Pop-Location` and
+`Push-Location` except that the history is a list, not a stack, and is implicitly tracked,
+not manually controlled. Currently, there is no way to view the history list.
 
 ```yaml
 Type: System.String
@@ -180,7 +180,7 @@ Accept wildcard characters: True
 
 Specifies the location stack name that this cmdlet makes the current location stack. Enter a
 location stack name. To indicate the unnamed default location stack, type `$null` or an empty string
-("").
+(`""`).
 
 The `*-Location` cmdlets act on the current stack unless you use the **StackName** parameter to
 specify a different stack. For more information about location stacks, see the [Notes](#notes).

--- a/reference/7.0/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Get-Location.md
@@ -147,7 +147,7 @@ To see the current prompt function, type the following command: `Get-Content Fun
 Specifies the current location in the specified PowerShell drive that this cmdlet gets in the
 operation.
 
-For instance, if you are in the `Certificate:` drive, you can use this parameter to find your
+For instance, if you are in the `Cert:` drive, you can use this parameter to find your
 current location in the `C:` drive.
 
 ```yaml
@@ -185,10 +185,11 @@ Accept wildcard characters: False
 
 ### -Stack
 
-Indicates that this cmdlet displays the locations in the current location stack.
+Indicates that this cmdlet displays the locations added to the current location stack. You can add
+locations to stacks by using the `Push-Location` cmdlet.
 
 To display the locations in a different location stack, use the **StackName** parameter. For
-information about location stacks, see the Notes.
+information about location stacks, see the [Notes](#notes).
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -207,7 +208,7 @@ Accept wildcard characters: False
 Specifies, as a string array, the named location stacks. Enter one or more location stack names.
 
 To display the locations in the current location stack, use the **Stack** parameter. To make a
-location stack the current location stack, use the `Set-Location` parameter.
+location stack the current location stack, use the `Set-Location` cmdlet.
 
 This cmdlet cannot display the locations in the unnamed default stack unless it is the current
 stack.
@@ -241,8 +242,8 @@ You cannot pipe input to this cmdlet.
 
 ### System.Management.Automation.PathInfo or System.Management.Automation.PathInfoStack
 
-If you use the **Stack** or **StackName** parameters, this cmdlet returns a **StackInfo** object.
-Otherwise, it returns a **PathInfo** object.
+If you use the **Stack** or **StackName** parameters, this cmdlet returns a **PathInfoStack**
+object. Otherwise, it returns a **PathInfo** object.
 
 ## NOTES
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Set-Location.md
@@ -38,9 +38,9 @@ Set-Location [-PassThru] [-StackName <String>] [<CommonParameters>]
 The `Set-Location` cmdlet sets the working location to a specified location. That location could be
 a directory, a subdirectory, a registry location, or any provider path.
 
-PowerShell 6.2 added support for `-` and `+` with the **Path** parameter. PowerShell maintains a
-history of the last 20 locations that can be access with `-` and `+`. This list is independent from
-the location stack that is accessed using the **StackName** parameter.
+PowerShell 6.2 added support for `-` and `+` as a values for the **Path** parameter. PowerShell
+maintains a history of the last 20 locations that can be accessed with `-` and `+`. This list is
+independent from the location stack that is accessed using the **StackName** parameter.
 
 ## EXAMPLES
 
@@ -157,12 +157,12 @@ Specify the path of a new working location. If no path is provided, `Set-Locatio
 current user's home directory. When wildcards are used, the cmdlet chooses the first path that
 matches the wildcard pattern.
 
-PowerShell keeps a history of the last 20 locations you have set. If the path is the `-` character,
-then the new working location will be the previous working location in history (if it exists).
-Similarly, if the path is the `+` character, then the new working location will be the next working
-location in history (if it exists). This is similar to using `Pop-Location` and `Push-Location`
-except that the history is a list, not a stack, and is implicitly tracked, not manually controlled.
-Currently, there is no way to view the history list.
+PowerShell keeps a history of the last 20 locations you have set. If the **Path** parameter value
+is the `-` character, then the new working location will be the previous working location in history
+(if it exists). Similarly, if the value is the `+` character, then the new working location will be
+the next working location in history (if it exists). This is similar to using `Pop-Location` and
+`Push-Location` except that the history is a list, not a stack, and is implicitly tracked,
+not manually controlled. Currently, there is no way to view the history list.
 
 ```yaml
 Type: System.String
@@ -180,7 +180,7 @@ Accept wildcard characters: True
 
 Specifies the location stack name that this cmdlet makes the current location stack. Enter a
 location stack name. To indicate the unnamed default location stack, type `$null` or an empty string
-("").
+(`""`).
 
 The `*-Location` cmdlets act on the current stack unless you use the **StackName** parameter to
 specify a different stack. For more information about location stacks, see the [Notes](#notes).

--- a/reference/7.1/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Get-Location.md
@@ -147,7 +147,7 @@ To see the current prompt function, type the following command: `Get-Content Fun
 Specifies the current location in the specified PowerShell drive that this cmdlet gets in the
 operation.
 
-For instance, if you are in the `Certificate:` drive, you can use this parameter to find your
+For instance, if you are in the `Cert:` drive, you can use this parameter to find your
 current location in the `C:` drive.
 
 ```yaml
@@ -185,10 +185,11 @@ Accept wildcard characters: False
 
 ### -Stack
 
-Indicates that this cmdlet displays the locations in the current location stack.
+Indicates that this cmdlet displays the locations added to the current location stack. You can add
+locations to stacks by using the `Push-Location` cmdlet.
 
 To display the locations in a different location stack, use the **StackName** parameter. For
-information about location stacks, see the Notes.
+information about location stacks, see the [Notes](#notes).
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -207,7 +208,7 @@ Accept wildcard characters: False
 Specifies, as a string array, the named location stacks. Enter one or more location stack names.
 
 To display the locations in the current location stack, use the **Stack** parameter. To make a
-location stack the current location stack, use the `Set-Location` parameter.
+location stack the current location stack, use the `Set-Location` cmdlet.
 
 This cmdlet cannot display the locations in the unnamed default stack unless it is the current
 stack.
@@ -241,8 +242,8 @@ You cannot pipe input to this cmdlet.
 
 ### System.Management.Automation.PathInfo or System.Management.Automation.PathInfoStack
 
-If you use the **Stack** or **StackName** parameters, this cmdlet returns a **StackInfo** object.
-Otherwise, it returns a **PathInfo** object.
+If you use the **Stack** or **StackName** parameters, this cmdlet returns a **PathInfoStack**
+object. Otherwise, it returns a **PathInfo** object.
 
 ## NOTES
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Set-Location.md
@@ -38,9 +38,9 @@ Set-Location [-PassThru] [-StackName <String>] [<CommonParameters>]
 The `Set-Location` cmdlet sets the working location to a specified location. That location could be
 a directory, a subdirectory, a registry location, or any provider path.
 
-PowerShell 6.2 added support for `-` and `+` with the **Path** parameter. PowerShell maintains a
-history of the last 20 locations that can be access with `-` and `+`. This list is independent from
-the location stack that is accessed using the **StackName** parameter.
+PowerShell 6.2 added support for `-` and `+` as a values for the **Path** parameter. PowerShell
+maintains a history of the last 20 locations that can be accessed with `-` and `+`. This list is
+independent from the location stack that is accessed using the **StackName** parameter.
 
 ## EXAMPLES
 
@@ -157,12 +157,12 @@ Specify the path of a new working location. If no path is provided, `Set-Locatio
 current user's home directory. When wildcards are used, the cmdlet chooses the first path that
 matches the wildcard pattern.
 
-PowerShell keeps a history of the last 20 locations you have set. If the path is the `-` character,
-then the new working location will be the previous working location in history (if it exists).
-Similarly, if the path is the `+` character, then the new working location will be the next working
-location in history (if it exists). This is similar to using `Pop-Location` and `Push-Location`
-except that the history is a list, not a stack, and is implicitly tracked, not manually controlled.
-Currently, there is no way to view the history list.
+PowerShell keeps a history of the last 20 locations you have set. If the **Path** parameter value
+is the `-` character, then the new working location will be the previous working location in history
+(if it exists). Similarly, if the value is the `+` character, then the new working location will be
+the next working location in history (if it exists). This is similar to using `Pop-Location` and
+`Push-Location` except that the history is a list, not a stack, and is implicitly tracked,
+not manually controlled. Currently, there is no way to view the history list.
 
 ```yaml
 Type: System.String
@@ -180,7 +180,7 @@ Accept wildcard characters: True
 
 Specifies the location stack name that this cmdlet makes the current location stack. Enter a
 location stack name. To indicate the unnamed default location stack, type `$null` or an empty string
-("").
+(`""`).
 
 The `*-Location` cmdlets act on the current stack unless you use the **StackName** parameter to
 specify a different stack. For more information about location stacks, see the [Notes](#notes).


### PR DESCRIPTION
# PR Summary

`Get-Location`:
  - Change `Certificate:` to `Cert:`, because there is no `Certificate:` drive, it is a provider.
  - Amend `-Stack` parameter description
  - Change *`Set-Location` parameter* to *`Set-Location` cmdlet*
  - Fix `Get-Location` return type

`Set-Location`:
  - Amend `+` and `-` **Path** parameter values description
  - Enclose empty string (`""`) in backticks

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
