### PR TITLE
Fix Get-Location examples.

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Location.md
@@ -64,7 +64,7 @@ directory.
 
 This example demonstrates the use of `Get-Location` to display your current location in different
 PowerShell drives. `Set-Location` is used to change the location to several different paths on
-different **PSDrives**.
+different PSDrives.
 
 ```powershell
 PS C:\> Set-Location C:\Windows
@@ -76,22 +76,18 @@ Path
 ----
 C:\Windows
 
-PS C:\Windows> Get-Location -PSDrive HKLM
+PS HKCU:\Control Panel\Input Method> Get-Location -PSDrive HKLM
 
 Path
 ----
 HKLM:\Software\Microsoft
 
 PS HKCU:\Control Panel\Input Method> Set-Location C:
-PS C:\Windows> Get-Location -PSProvider registry
+PS C:\Windows> Get-Location -PSProvider Registry
 
 Path
 ----
 HKCU:\Control Panel\Input Method
-
-Path
-----
-HKLM:\Software\Microsoft
 ```
 
 ### Example 3: Get locations using stacks
@@ -128,8 +124,8 @@ This example shows how to customize the PowerShell prompt.
 
 ```powershell
 PS C:\>
-function prompt { 'PowerShell: ' + (get-location) + '> '}
-PowerShell: C:\WINDOWS>
+function prompt { 'PowerShell: ' + (Get-Location) + '> '}
+PowerShell: C:\>
 ```
 
 The function that defines the prompt includes a `Get-Location` command, which is run whenever the
@@ -138,7 +134,7 @@ prompt appears in the console.
 The format of the default PowerShell prompt is defined by a special function named `prompt`. You can
 change the prompt in your console by creating a new function named `prompt`.
 
-To see the current prompt function, type the following command: `Get-Content Function:prompt`
+To see the current prompt function, type the following command: `Get-Content Function:\prompt`
 
 ## PARAMETERS
 

--- a/reference/6/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-Location.md
@@ -64,7 +64,7 @@ directory.
 
 This example demonstrates the use of `Get-Location` to display your current location in different
 PowerShell drives. `Set-Location` is used to change the location to several different paths on
-different **PSDrives**.
+different PSDrives.
 
 ```powershell
 PS C:\> Set-Location C:\Windows
@@ -76,22 +76,18 @@ Path
 ----
 C:\Windows
 
-PS C:\Windows> Get-Location -PSDrive HKLM
+PS HKCU:\Control Panel\Input Method> Get-Location -PSDrive HKLM
 
 Path
 ----
 HKLM:\Software\Microsoft
 
 PS HKCU:\Control Panel\Input Method> Set-Location C:
-PS C:\Windows> Get-Location -PSProvider registry
+PS C:\Windows> Get-Location -PSProvider Registry
 
 Path
 ----
 HKCU:\Control Panel\Input Method
-
-Path
-----
-HKLM:\Software\Microsoft
 ```
 
 ### Example 3: Get locations using stacks
@@ -128,8 +124,8 @@ This example shows how to customize the PowerShell prompt.
 
 ```powershell
 PS C:\>
-function prompt { 'PowerShell: ' + (get-location) + '> '}
-PowerShell: C:\WINDOWS>
+function prompt { 'PowerShell: ' + (Get-Location) + '> '}
+PowerShell: C:\>
 ```
 
 The function that defines the prompt includes a `Get-Location` command, which is run whenever the
@@ -138,7 +134,7 @@ prompt appears in the console.
 The format of the default PowerShell prompt is defined by a special function named `prompt`. You can
 change the prompt in your console by creating a new function named `prompt`.
 
-To see the current prompt function, type the following command: `Get-Content Function:prompt`
+To see the current prompt function, type the following command: `Get-Content Function:\prompt`
 
 ## PARAMETERS
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Get-Location.md
@@ -64,7 +64,7 @@ directory.
 
 This example demonstrates the use of `Get-Location` to display your current location in different
 PowerShell drives. `Set-Location` is used to change the location to several different paths on
-different **PSDrives**.
+different PSDrives.
 
 ```powershell
 PS C:\> Set-Location C:\Windows
@@ -76,22 +76,18 @@ Path
 ----
 C:\Windows
 
-PS C:\Windows> Get-Location -PSDrive HKLM
+PS HKCU:\Control Panel\Input Method> Get-Location -PSDrive HKLM
 
 Path
 ----
 HKLM:\Software\Microsoft
 
 PS HKCU:\Control Panel\Input Method> Set-Location C:
-PS C:\Windows> Get-Location -PSProvider registry
+PS C:\Windows> Get-Location -PSProvider Registry
 
 Path
 ----
 HKCU:\Control Panel\Input Method
-
-Path
-----
-HKLM:\Software\Microsoft
 ```
 
 ### Example 3: Get locations using stacks
@@ -128,8 +124,8 @@ This example shows how to customize the PowerShell prompt.
 
 ```powershell
 PS C:\>
-function prompt { 'PowerShell: ' + (get-location) + '> '}
-PowerShell: C:\WINDOWS>
+function prompt { 'PowerShell: ' + (Get-Location) + '> '}
+PowerShell: C:\>
 ```
 
 The function that defines the prompt includes a `Get-Location` command, which is run whenever the
@@ -138,7 +134,7 @@ prompt appears in the console.
 The format of the default PowerShell prompt is defined by a special function named `prompt`. You can
 change the prompt in your console by creating a new function named `prompt`.
 
-To see the current prompt function, type the following command: `Get-Content Function:prompt`
+To see the current prompt function, type the following command: `Get-Content Function:\prompt`
 
 ## PARAMETERS
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Get-Location.md
@@ -64,7 +64,7 @@ directory.
 
 This example demonstrates the use of `Get-Location` to display your current location in different
 PowerShell drives. `Set-Location` is used to change the location to several different paths on
-different **PSDrives**.
+different PSDrives.
 
 ```powershell
 PS C:\> Set-Location C:\Windows
@@ -76,22 +76,18 @@ Path
 ----
 C:\Windows
 
-PS C:\Windows> Get-Location -PSDrive HKLM
+PS HKCU:\Control Panel\Input Method> Get-Location -PSDrive HKLM
 
 Path
 ----
 HKLM:\Software\Microsoft
 
 PS HKCU:\Control Panel\Input Method> Set-Location C:
-PS C:\Windows> Get-Location -PSProvider registry
+PS C:\Windows> Get-Location -PSProvider Registry
 
 Path
 ----
 HKCU:\Control Panel\Input Method
-
-Path
-----
-HKLM:\Software\Microsoft
 ```
 
 ### Example 3: Get locations using stacks
@@ -128,8 +124,8 @@ This example shows how to customize the PowerShell prompt.
 
 ```powershell
 PS C:\>
-function prompt { 'PowerShell: ' + (get-location) + '> '}
-PowerShell: C:\WINDOWS>
+function prompt { 'PowerShell: ' + (Get-Location) + '> '}
+PowerShell: C:\>
 ```
 
 The function that defines the prompt includes a `Get-Location` command, which is run whenever the
@@ -138,7 +134,7 @@ prompt appears in the console.
 The format of the default PowerShell prompt is defined by a special function named `prompt`. You can
 change the prompt in your console by creating a new function named `prompt`.
 
-To see the current prompt function, type the following command: `Get-Content Function:prompt`
+To see the current prompt function, type the following command: `Get-Content Function:\prompt`
 
 ## PARAMETERS
 


### PR DESCRIPTION
# PR Summary
Fix `Get-Location` examples.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
