### PR TITLE
FIXES #6476 - Updates to Invoke-DscResource

### DIFF
--- a/reference/7.0/PSDesiredStateConfiguration/Invoke-DscResource.md
+++ b/reference/7.0/PSDesiredStateConfiguration/Invoke-DscResource.md
@@ -154,7 +154,7 @@ context using the key **PsDscRunAsCredential**. In PowerShell 7.0, Resources run
 context, and **PsDscRunAsCredential** is no longer supported. Previous configurations using this key
 will throw an exception.
 
-- As of PowerShell 7, `Invoke-DscResource` no longer supports invoking WMI DSC Resources. This
+- As of PowerShell 7, `Invoke-DscResource` no longer supports invoking WMI DSC resources. This
   includes the **File** and **Log** resources in **PSDesiredStateConfiguration**.
 
 ## RELATED LINKS

--- a/reference/7.0/PSDesiredStateConfiguration/Invoke-DscResource.md
+++ b/reference/7.0/PSDesiredStateConfiguration/Invoke-DscResource.md
@@ -3,7 +3,7 @@ external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: PSDesiredStateConfiguration
-ms.date: 04/01/2020
+ms.date: 08/11/2020
 online version: https://docs.microsoft.com/powershell/module/psdesiredstateconfiguration/invoke-dscresource?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-DscResource
@@ -40,12 +40,13 @@ cmdlet also enables debugging of resources when the DSC engine is running with d
 
 ### Example 1: Invoke the Set method of a resource by specifying its mandatory properties
 
-This example invokes the **Set** method of a resource named Log and specifies a **Message** property
-for it.
+This example invokes the **Set** method of a resource named **WindowsProcess** and provides the
+mandatory **Path** and **Arguments** properties to start the specified Windows process.
 
 ```powershell
-Invoke-DscResource -Name Log -Method Set -ModuleName PSDesiredStateConfiguration -Property @{
-  Message = 'Hello World'
+Invoke-DscResource -Name WindowsProcess -Method Set -ModuleName PSDesiredStateConfiguration -Property @{
+  Path = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe'
+  Arguments = ''
 }
 ```
 
@@ -148,10 +149,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Previously, Windows PowerShell 5.1 resources ran under System context unless specified with user
+- Previously, Windows PowerShell 5.1 resources ran under System context unless specified with user
 context using the key **PsDscRunAsCredential**. In PowerShell 7.0, Resources run in the user's
 context, and **PsDscRunAsCredential** is no longer supported. Previous configurations using this key
 will throw an exception.
+
+- As of PowerShell 7, `Invoke-DscResource` no longer supports invoking WMI DSC Resources. This
+  includes the **File** and **Log** resources in **PSDesiredStateConfiguration**.
 
 ## RELATED LINKS
 

--- a/reference/7.1/PSDesiredStateConfiguration/Invoke-DscResource.md
+++ b/reference/7.1/PSDesiredStateConfiguration/Invoke-DscResource.md
@@ -158,7 +158,7 @@ context using the key **PsDscRunAsCredential**. In PowerShell 7.0, Resources run
 context, and **PsDscRunAsCredential** is no longer supported. Previous configurations using this key
 will throw an exception.
 
-- As of PowerShell 7, `Invoke-DscResource` no longer supports invoking WMI DSC Resources. This
+- As of PowerShell 7, `Invoke-DscResource` no longer supports invoking WMI DSC resources. This
   includes the **File** and **Log** resources in **PSDesiredStateConfiguration**.
 
 ## RELATED LINKS

--- a/reference/7.1/PSDesiredStateConfiguration/Invoke-DscResource.md
+++ b/reference/7.1/PSDesiredStateConfiguration/Invoke-DscResource.md
@@ -3,7 +3,7 @@ external help file: PSDesiredStateConfiguration-help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: PSDesiredStateConfiguration
-ms.date: 04/01/2020
+ms.date: 08/11/2020
 online version: https://docs.microsoft.com/powershell/module/psdesiredstateconfiguration/invoke-dscresource?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-DscResource
@@ -40,12 +40,13 @@ cmdlet also enables debugging of resources when the DSC engine is running with d
 
 ### Example 1: Invoke the Set method of a resource by specifying its mandatory properties
 
-This example invokes the **Set** method of a resource named Log and specifies a **Message** property
-for it.
+This example invokes the **Set** method of a resource named **WindowsProcess** and provides the
+mandatory **Path** and **Arguments** properties to start the specified Windows process.
 
 ```powershell
-Invoke-DscResource -Name Log -Method Set -ModuleName PSDesiredStateConfiguration -Property @{
-  Message = 'Hello World'
+Invoke-DscResource -Name WindowsProcess -Method Set -ModuleName PSDesiredStateConfiguration -Property @{
+  Path = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe'
+  Arguments = ''
 }
 ```
 
@@ -152,10 +153,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Previously, Windows PowerShell 5.1 resources ran under System context unless specified with user
+- Previously, Windows PowerShell 5.1 resources ran under System context unless specified with user
 context using the key **PsDscRunAsCredential**. In PowerShell 7.0, Resources run in the user's
 context, and **PsDscRunAsCredential** is no longer supported. Previous configurations using this key
 will throw an exception.
+
+- As of PowerShell 7, `Invoke-DscResource` no longer supports invoking WMI DSC Resources. This
+  includes the **File** and **Log** resources in **PSDesiredStateConfiguration**.
 
 ## RELATED LINKS
 

--- a/reference/docs-conceptual/dsc/managing-nodes/directCallResource.md
+++ b/reference/docs-conceptual/dsc/managing-nodes/directCallResource.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/12/2017
+ms.date: 08/11/2020
 keywords:  dsc,powershell,configuration,setup
 title:  Calling DSC resource methods directly
 ---
@@ -8,14 +8,22 @@ title:  Calling DSC resource methods directly
 
 >Applies To: Windows PowerShell 5.0
 
-You can use the [Invoke-DscResource](/powershell/module/PSDesiredStateConfiguration/Invoke-DscResource) cmdlet to directly call the functions or methods of a DSC resource (The **Get-TargetResource**,
-**Set-TargetResource**, and **Test-TargetResource** functions of a MOF-based resource, or the **Get**, **Set**, and **Test** methods of a class-based resource).
-This can be used by third-parties that want to use DSC resources, or as a helpful tool while developing resources.
+You can use the [Invoke-DscResource](/powershell/module/PSDesiredStateConfiguration/Invoke-DscResource)
+cmdlet to directly call the functions or methods of a DSC resource (The `Get-TargetResource`,
+`Set-TargetResource`, and `Test-TargetResource` functions of a MOF-based resource, or the
+**Get**, **Set**, and **Test** methods of a class-based resource). This can be used by third-parties
+that want to use DSC resources, or as a helpful tool while developing resources.
 
-This cmdlet is typically used in combination with a metaconfiguration property `refreshMode = 'Disabled'`, but it can be used no matter what **refreshMode** is set to.
+> [!NOTE]8
+> In PowerShell 7.0+, `Invoke-DscResource` no longer supports invoking WMI DSC resources. This
+> includes the **File** and **Log** resources in **PSDesiredStateConfiguration**.
 
-When calling the **Invoke-DscResource** cmdlet, you specify which method or function to call by using the **Method** parameter. You specify the properties of the resource by passing a
-hashtable as the value of the **Property** parameter.
+This cmdlet is typically used in combination with a metaconfiguration property
+`refreshMode = 'Disabled'`, but it can be used no matter what **refreshMode** is set to.
+
+When calling the `Invoke-DscResource` cmdlet, you specify which method or function to call by
+using the **Method** parameter. You specify the properties of the resource by passing a hashtable as
+the value of the **Property** parameter.
 
 The following are examples of directly calling resource methods:
 
@@ -46,7 +54,9 @@ $result = Invoke-DscResource -Name File -Method Get -Property @{
 $result.ItemValue | fl
 ```
 
->**Note:** Directly calling composite resource methods is not supported. Instead, call the methods of the underlying resources that make up the composite resource.
+>[!NOTE]
+> Directly calling composite resource methods is not supported. Instead, call the methods of the
+> underlying resources that make up the composite resource.
 
 ## See Also
 

--- a/reference/docs-conceptual/dsc/managing-nodes/directCallResource.md
+++ b/reference/docs-conceptual/dsc/managing-nodes/directCallResource.md
@@ -14,7 +14,7 @@ cmdlet to directly call the functions or methods of a DSC resource (The `Get-Tar
 **Get**, **Set**, and **Test** methods of a class-based resource). This can be used by third-parties
 that want to use DSC resources, or as a helpful tool while developing resources.
 
-> [!NOTE]8
+> [!NOTE]
 > In PowerShell 7.0+, `Invoke-DscResource` no longer supports invoking WMI DSC resources. This
 > includes the **File** and **Log** resources in **PSDesiredStateConfiguration**.
 

--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-70.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-70.md
@@ -329,7 +329,7 @@ that line. If the terminal doesn't support ANSI color escape sequences (VT100), 
 ![Error display from a script](./media/What-s-New-in-PowerShell-70/myscript-error.png)
 
 The default view in PowerShell 7 is **ConciseView**. The previous default view was **NormalView** and you can select thisby setting the preference variable `$ErrorView`.
- 
+
 ```powershell
 $ErrorView = 'NormalView' # Sets the error view to NormalView
 $ErrorView = 'ConciseView' # Sets the error view to ConciseView
@@ -407,8 +407,7 @@ For more information [About Update Notifications](/powershell/module/microsoft.p
 
 > [!NOTE]
 > This is an experimental feature named **PSDesiredStateConfiguration.InvokeDscResource**. Learn
-> more
-> [About Experimental Features](/powershell/module/microsoft.powershell.core/about/about_experimental_features?view=powershell-7).
+> more [About Experimental Features](/powershell/module/microsoft.powershell.core/about/about_experimental_features?view=powershell-7).
 
 The `Invoke-DscResource` cmdlet runs a method of a specified PowerShell Desired State Configuration
 (DSC) resource.
@@ -417,11 +416,13 @@ This cmdlet invokes a DSC resource directly, without creating a configuration do
 cmdlet, configuration management products can manage Windows or Linux by using DSC resources. This
 cmdlet also enables debugging of resources when the DSC engine is running with debugging enabled.
 
-This command invokes the **Set** method of a resource named Log and specifies a **Message** property.
+This command invokes the **Set** method of a resource named **WindowsProcess** and provides the
+mandatory **Path** and **Arguments** properties to start the specified Windows process.
 
 ```powershell
-Invoke-DscResource -Name Log -Method Set -ModuleName PSDesiredStateConfiguration -Property @{
-  Message = 'Hello World'
+Invoke-DscResource -Name WindowsProcess -Method Set -ModuleName PSDesiredStateConfiguration -Property @{
+  Path = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe'
+  Arguments = ''
 }
 ```
 


### PR DESCRIPTION
# PR Summary

Windows PowerShell 7 and up, `Invoke-DscResource` no longer supports WMI DSC resources. This is not apparent in the documentation. 

## PR Context

Fixes #6476 
Fixes [AB#1759435](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1759435)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [x] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [x] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
