### PR TITLE
Fix for #6469

### DIFF
--- a/reference/docs-conceptual/gallery/installing-psget.md
+++ b/reference/docs-conceptual/gallery/installing-psget.md
@@ -20,7 +20,6 @@ elevated PowerShell session, run the following command.
 
 ```powershell
 Install-PackageProvider -Name NuGet -Force
-Exit
 ```
 
 ### For systems with PowerShell 5.0 (or newer) you can install the latest PowerShellGet
@@ -31,7 +30,6 @@ session.
 
 ```powershell
 Install-Module -Name PowerShellGet -Force
-Exit
 ```
 
 Use `Update-Module` to get newer versions.
@@ -56,13 +54,32 @@ For more information, see
 
 > [!NOTE]
 > PowerShell 3.0 and PowerShell 4.0 only supported one version of a module. Starting in PowerShell
-> 5.0, modules are installed in `<modulename>\<version>`. This allowed you to install
+> 5.0, modules are installed in `<modulename>\<version>`. This allows you to install
 > multiple versions side-by-side. After downloading the module using `Save-Module` you must copy the
-> files from the `<modulename>\<version>` to the `<modulename>` folder on the destination machine.
+> files from the `<modulename>\<version>` to the `<modulename>` folder on the destination machine,
+> as shown in the instructions below.
+
+> [!NOTE]
+> The instructions below install the modules in directory `$env:ProgramFiles\WindowsPowerShell\Modules`.
+> In PowerShell 3.0, this directory isn't listed in `$env:PSModulePath` by default, so you'll need
+> to add it in order for the modules to be auto-loaded. Open an elevated PowerShell session and run
+> the following command (which will take effect in future sessions):
+
+```powershell
+[Environment]::SetEnvironmentVariable(
+  'PSModulePath',
+  ((([Environment]::GetEnvironmentVariable('PSModulePath', 'Machine') -split ';') + "$env:ProgramFiles\WindowsPowerShell\Modules") -join ';'),
+  'Machine'
+)
+```
 
 #### Computers with the PackageManagement Preview installed
 
-1. From a PowerShell session, use `Save-Module` to save the modules to a local directory.
+> [!NOTE] 
+> PackageManagement Preview was a downloadable component that made PowerShellGet available to PowerShell versions 3 and 4, but it is no longer available.
+> To test if it was installed on a given computer, run `Get-Module -ListAvailable PowerShellGet`.
+
+1. From a PowerShell session, use `Save-Module` to save the use `Save-Module` to download the current version of **PowerShellGet**. Two folders are downloaded: **PowerShellGet** and **PackageManagement**. Each folder contains a subfolder with a version number.
 
    ```powershell
    Save-Module -Name PowerShellGet -Path C:\LocalFolder -Repository PSGallery
@@ -70,18 +87,20 @@ For more information, see
 
 1. Ensure that the **PowerShellGet** and **PackageManagement** modules aren't loaded in any other
    processes.
-1. Delete the contents of the folders: `$env:ProgramFiles\WindowsPowerShell\Modules\PowerShellGet\`
-   and `$env:ProgramFiles\WindowsPowerShell\Modules\PackageManagement\`.
-1. Reopen the PowerShell console with elevated permissions and run the following commands.
+
+1. Reopen the PowerShell console with elevated permissions and run the following command.
 
    ```powershell
-   Copy-Item "C:\LocalFolder\PowerShellGet\<version>\*" "$env:ProgramFiles\WindowsPowerShell\Modules\PowerShellGet\" -Recurse -Force
-   Copy-Item "C:\LocalFolder\PackageManagement\<version>\*" "$env:ProgramFiles\WindowsPowerShell\Modules\PackageManagement\" -Recurse -Force
+   'PowerShellGet', 'PackageManagement' | % { 
+     $targetDir = "$env:ProgramFiles\WindowsPowerShell\Modules\$_"
+     Remove-Item $targetDir\* -Recurse -Force
+     Copy-Item C:\LocalFolder\$_\*\* $targetDir\ -Recurse -Force
+   }
    ```
 
 #### Computers without PowerShellGet
 
-For computer's without any version of **PowerShellGet** installed, a computer with **PowerShellGet**
+For computers without any version of **PowerShellGet** installed (test with `Get-Module -ListAvailable PowerShellGet`), a computer with **PowerShellGet**
 installed is needed to download the modules.
 
 1. From the computer that has **PowerShellGet** installed, use `Save-Module` to download the current
@@ -92,7 +111,17 @@ installed is needed to download the modules.
    Save-Module -Name PowerShellGet -Path C:\LocalFolder -Repository PSGallery
    ```
 
-1. Copy the **PowerShellGet** and **PackageManagement** folders to the computer that doesn't have
-   **PowerShellGet** installed.
+1. Copy the respective `<version>` subfolder in the **PowerShellGet** and **PackageManagement** folders to the computer that doesn't have
+   **PowerShellGet** installed, into folders `$env:ProgramFiles\WindowsPowerShell\Modules\PowerShellGet\` and `$env:ProgramFiles\WindowsPowerShell\Modules\PackageManagement\`, respectively which requires an elevated session.
+   
+1. For instance, if you can access the download folder on the other computer, say `ws1`, from the target computer via a UNC path, say `\\ws1\C$\LocalFolder`, open a PowerShell console with elevated permissions and run the following command:
 
-   The destination directory is: `$env:ProgramFiles\WindowsPowerShell\Modules`
+   ```powershell
+   'PowerShellGet', 'PackageManagement' | % {
+     $targetDir = "$env:ProgramFiles\WindowsPowerShell\Modules\$_"
+     $null = New-Item -Type Directory -Force $targetDir
+     $fromComputer = 'ws1'  # Specify the name of the other computer here.
+     Copy-Item \\$fromComputer\C$\LocalFolder\$_\*\* $targetDir -Recurse -Force
+     if (-not (Get-ChildItem $targetDir)) { Throw "Copying failed." }
+   }
+   ```

--- a/reference/docs-conceptual/gallery/installing-psget.md
+++ b/reference/docs-conceptual/gallery/installing-psget.md
@@ -59,11 +59,13 @@ For more information, see
 > files from the `<modulename>\<version>` to the `<modulename>` folder on the destination machine,
 > as shown in the instructions below.
 
-> [!NOTE]
-> The instructions below install the modules in directory `$env:ProgramFiles\WindowsPowerShell\Modules`.
-> In PowerShell 3.0, this directory isn't listed in `$env:PSModulePath` by default, so you'll need
-> to add it in order for the modules to be auto-loaded. Open an elevated PowerShell session and run
-> the following command (which will take effect in future sessions):
+#### Preparatory Step on computers running PowerShell 3.0
+
+The instructions in the sections below install the modules in directory `$env:ProgramFiles\WindowsPowerShell\Modules`.
+In PowerShell 3.0, this directory isn't listed in `$env:PSModulePath` by default, so you'll need
+to add it in order for the modules to be auto-loaded. 
+
+Open an elevated PowerShell session and run the following command (which will take effect in future sessions):
 
 ```powershell
 [Environment]::SetEnvironmentVariable(

--- a/reference/docs-conceptual/gallery/installing-psget.md
+++ b/reference/docs-conceptual/gallery/installing-psget.md
@@ -112,7 +112,7 @@ installed is needed to download the modules.
    ```
 
 1. Copy the respective `<version>` subfolder in the **PowerShellGet** and **PackageManagement** folders to the computer that doesn't have
-   **PowerShellGet** installed, into folders `$env:ProgramFiles\WindowsPowerShell\Modules\PowerShellGet\` and `$env:ProgramFiles\WindowsPowerShell\Modules\PackageManagement\`, respectively which requires an elevated session.
+   **PowerShellGet** installed, into folders `$env:ProgramFiles\WindowsPowerShell\Modules\PowerShellGet\` and `$env:ProgramFiles\WindowsPowerShell\Modules\PackageManagement\` respectively, which requires an elevated session.
    
 1. For instance, if you can access the download folder on the other computer, say `ws1`, from the target computer via a UNC path, say `\\ws1\C$\LocalFolder`, open a PowerShell console with elevated permissions and run the following command:
 

--- a/reference/docs-conceptual/gallery/installing-psget.md
+++ b/reference/docs-conceptual/gallery/installing-psget.md
@@ -79,7 +79,7 @@ For more information, see
 > PackageManagement Preview was a downloadable component that made PowerShellGet available to PowerShell versions 3 and 4, but it is no longer available.
 > To test if it was installed on a given computer, run `Get-Module -ListAvailable PowerShellGet`.
 
-1. From a PowerShell session, use `Save-Module` to save the use `Save-Module` to download the current version of **PowerShellGet**. Two folders are downloaded: **PowerShellGet** and **PackageManagement**. Each folder contains a subfolder with a version number.
+1. From a PowerShell session, use `Save-Module` to download the current version of **PowerShellGet**. Two folders are downloaded: **PowerShellGet** and **PackageManagement**. Each folder contains a subfolder with a version number.
 
    ```powershell
    Save-Module -Name PowerShellGet -Path C:\LocalFolder -Repository PSGallery


### PR DESCRIPTION
# PR Summary

Amends and corrects the instructions for installing / updating the PackageManagement and PowerShellGet modules on computers running Windows PowerShell v3 and v4.

* Clarifications re `Save-Module` use and what "PackageManagement Preview" refers to.
* Streamlining of the commands to provide a higher degree of automation.
* Added required command for v3 to ensure that the modules are auto-loaded.
* Minor copy-editing.

## PR Context

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [x] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated (N/A)
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
