### PR TITLE
[Fixes #6488] Updates about_Automatic_Variables

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -188,9 +188,13 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
+Since `$input` is an enumerator, you can only access a value in `input` once.
+After that, it is no longer available.
+
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
 [Using Enumerators](#using-enumerators).
+
 
 ### $LastExitCode
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -188,9 +188,9 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
-Since `$input` is an enumerator, accessing any of it's properties causes $input
-to no longer be available. You can store `$input` in another variable to reuse
-any of the `$input` properties more than once.
+Since `$input` is an enumerator, accessing any of it's properties causes
+`$input` to no longer be available. You can store `$input` in another variable to
+reuse the `$input` properties.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 04/10/2020
+ms.date: 08/14/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Automatic_Variables
@@ -188,8 +188,8 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
-Since `$input` is an enumerator, you can only access a value in `input` once.
-After that, it is no longer available.
+Since `$input` is an enumerator, once you enumerate a value, it is no longer
+accessible in `$input`.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -188,8 +188,9 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
-Since `$input` is an enumerator, once you enumerate a value, it is no longer
-accessible in `$input`.
+Since `$input` is an enumerator, accessing any of it's properties causes $input
+to no longer be available. You can store `$input` in another variable to reuse
+any of the `$input` properties more than once.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -188,6 +188,9 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
+Since `$input` is an enumerator, you can only access a value in `input` once.
+After that, it is no longer available.
+
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
 [Using Enumerators](#using-enumerators).

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -188,9 +188,9 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
-Since `$input` is an enumerator, accessing any of it's properties causes $input
-to no longer be available. You can store `$input` in another variable to reuse
-any of the `$input` properties more than once.
+Since `$input` is an enumerator, accessing any of it's properties causes
+`$input` to no longer be available. You can store `$input` in another variable to
+reuse the `$input` properties.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 04/10/2020
+ms.date: 08/14/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Automatic_Variables
@@ -188,8 +188,8 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
-Since `$input` is an enumerator, you can only access a value in `input` once.
-After that, it is no longer available.
+Since `$input` is an enumerator, once you enumerate a value, it is no longer
+accessible in `$input`.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -188,8 +188,9 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
-Since `$input` is an enumerator, once you enumerate a value, it is no longer
-accessible in `$input`.
+Since `$input` is an enumerator, accessing any of it's properties causes $input
+to no longer be available. You can store `$input` in another variable to reuse
+any of the `$input` properties more than once.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -188,6 +188,9 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
+Since `$input` is an enumerator, you can only access a value in `input` once.
+After that, it is no longer available.
+
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
 [Using Enumerators](#using-enumerators).

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -188,9 +188,9 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
-Since `$input` is an enumerator, accessing any of it's properties causes $input
-to no longer be available. You can store `$input` in another variable to reuse
-any of the `$input` properties more than once.
+Since `$input` is an enumerator, accessing any of it's properties causes
+`$input` to no longer be available. You can store `$input` in another variable to
+reuse the `$input` properties.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 04/10/2020
+ms.date: 08/14/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Automatic_Variables
@@ -188,8 +188,8 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
-Since `$input` is an enumerator, you can only access a value in `input` once.
-After that, it is no longer available.
+Since `$input` is an enumerator, once you enumerate a value, it is no longer
+accessible in `$input`.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -188,8 +188,9 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
-Since `$input` is an enumerator, once you enumerate a value, it is no longer
-accessible in `$input`.
+Since `$input` is an enumerator, accessing any of it's properties causes $input
+to no longer be available. You can store `$input` in another variable to reuse
+any of the `$input` properties more than once.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -188,6 +188,9 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
+Since `$input` is an enumerator, you can only access a value in `input` once.
+After that, it is no longer available.
+
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see
 [Using Enumerators](#using-enumerators).

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 04/10/2020
+ms.date: 08/14/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Automatic_Variables
@@ -188,8 +188,8 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
-Since `$input` is an enumerator, you can only access a value in `input` once.
-After that, it is no longer available.
+Since `$input` is an enumerator, once you enumerate a value, it is no longer
+accessible in `$input`.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -188,9 +188,9 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
-Since `$input` is an enumerator, accessing any of it's properties causes $input
-to no longer be available. You can store `$input` in another variable to reuse
-any of the `$input` properties more than once.
+Since `$input` is an enumerator, accessing any of it's properties causes
+`$input` to no longer be available. You can store `$input` in another variable to
+reuse the `$input` properties.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -188,8 +188,9 @@ blocks (which are unnamed functions).
   > You cannot use the `$input` variable inside both the Process block and the
   > End block in the same function or script block.
 
-Since `$input` is an enumerator, once you enumerate a value, it is no longer
-accessible in `$input`.
+Since `$input` is an enumerator, accessing any of it's properties causes $input
+to no longer be available. You can store `$input` in another variable to reuse
+any of the `$input` properties more than once.
 
 Enumerators contain properties and methods you can use to retrieve loop values
 and change the current loop iteration. For more information, see


### PR DESCRIPTION
# PR Summary

Clarifies behavior about value behavior in `$input` automatice variable. 

## PR Context

Fixes #6488 
Fixes [AB#1760778](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1760778)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
