### PR TITLE
Fixes #6509 - Updates Encoding Param for Cmdlets in 7.1

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Add-Content.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 5/14/2019
+ms.date: 08/18/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/add-content?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Add-Content
@@ -232,6 +232,10 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+> [!NOTE]
+> **UTF-7*** is no longer recommended to use and in PowerShell 7.1, a warning will be written if you
+> specify `utf7` for the **Encoding** parameter.
 
 ```yaml
 Type: System.Text.Encoding

--- a/reference/7.1/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Get-Content.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 5/14/2019
+ms.date: 08/18/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/get-content?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Content
@@ -556,6 +556,10 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+> [!NOTE]
+> **UTF-7*** is no longer recommended to use and in PowerShell 7.1, a warning will be written if you
+> specify `utf7` for the **Encoding** parameter.
 
 ```yaml
 Type: System.Text.Encoding

--- a/reference/7.1/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Set-Content.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 5/14/2019
+ms.date: 08/18/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/set-content?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-Content
@@ -210,6 +210,10 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+> [!NOTE]
+> **UTF-7*** is no longer recommended to use and in PowerShell 7.1, a warning will be written if you
+> specify `utf7` for the **Encoding** parameter.
 
 ```yaml
 Type: System.Text.Encoding

--- a/reference/7.1/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -54,7 +54,7 @@ string **This is a test**.
 "This is a test" | Export-Clixml -Path .\sample.xml
 ```
 
-The string **This is a test** is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
+The string `This is a test` is sent down the pipeline. `Export-Clixml` uses the **Path** parameter
 to create an XML file named `sample.xml` in the current directory.
 
 ### Example 2: Export an object to an XML file

--- a/reference/7.1/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 05/21/2020
+ms.date: 08/18/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/export-clixml?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Export-Clixml
@@ -208,6 +208,10 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+> [!NOTE]
+> **UTF-7*** is no longer recommended to use and in PowerShell 7.1, a warning will be written if you
+> specify `utf7` for the **Encoding** parameter.
 
 ```yaml
 Type: System.Text.Encoding

--- a/reference/7.1/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 1/7/2019
+ms.date: 08/18/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/export-csv?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Export-Csv
@@ -438,6 +438,10 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+> [!NOTE]
+> **UTF-7*** is no longer recommended to use and in PowerShell 7.1, a warning will be written if you
+> specify `utf7` for the **Encoding** parameter.
 
 ```yaml
 Type: System.Text.Encoding

--- a/reference/7.1/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 01/17/2020
+ms.date: 08/18/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/format-hex?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Format-Hex
@@ -179,6 +179,10 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+> [!NOTE]
+> **UTF-7*** is no longer recommended to use and in PowerShell 7.1, a warning will be written if you
+> specify `utf7` for the **Encoding** parameter.
 
 ```yaml
 Type: System.Text.Encoding

--- a/reference/7.1/Microsoft.PowerShell.Utility/Import-Csv.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Import-Csv.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 1/8/2019
+ms.date: 08/18/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/import-csv?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Import-Csv
@@ -353,6 +353,10 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+> [!NOTE]
+> **UTF-7*** is no longer recommended to use and in PowerShell 7.1, a warning will be written if you
+> specify `utf7` for the **Encoding** parameter.
 
 ```yaml
 Type: System.Text.Encoding

--- a/reference/7.1/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Out-File.md
@@ -172,6 +172,10 @@ pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
 
+> [!NOTE]
+> **UTF-7*** is no longer recommended to use and in PowerShell 7.1, a warning will be written if you
+> specify `utf7` for the **Encoding** parameter.
+
 ```yaml
 Type: System.Text.Encoding
 Parameter Sets: (All)

--- a/reference/7.1/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Select-String.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/20/2019
+ms.date: 08/18/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/select-string?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Select-String
@@ -468,6 +468,10 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+> [!NOTE]
+> **UTF-7*** is no longer recommended to use and in PowerShell 7.1, a warning will be written if you
+> specify `utf7` for the **Encoding** parameter.
 
 ```yaml
 Type: System.Text.Encoding


### PR DESCRIPTION
# PR Summary

A warning is now written when UTF-7 is specified in the encoding parameter in PowerShell 7.1

## PR Context

Fixes #6509 
Fixes AB#1761967

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
