### PR TITLE
About passing parameters to sourced scripts

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,8 +1,8 @@
 ---
-description: Describes the operators that are supported by PowerShell. 
+description: Describes the operators that are supported by PowerShell.
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 10/08/2020
+ms.date: 10/28/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Operators
@@ -32,7 +32,8 @@ operators on any .NET type that implements them, such as: `Int`, `String`,
 Bitwise operators (`-band`, `-bor`, `-bxor`, `-bnot`, `-shl`, `-shr`)
 manipulate the bit patterns in values.
 
-For more information, see [about_Arithmetic_Operators](about_Arithmetic_Operators.md).
+For more information, see
+[about_Arithmetic_Operators](about_Arithmetic_Operators.md).
 
 ### Assignment Operators
 
@@ -40,7 +41,8 @@ Use assignment operators (`=`, `+=`, `-=`, `*=`, `/=`, `%=`) to assign, change,
 or append values to variables. You can combine arithmetic operators with
 assignment to assign the result of the arithmetic operation to a variable.
 
-For more information, see [about_Assignment_Operators](about_Assignment_Operators.md).
+For more information, see
+[about_Assignment_Operators](about_Assignment_Operators.md).
 
 ### Comparison Operators
 
@@ -58,7 +60,8 @@ reference set (`-in`, `-notin`, `-contains`, `-notcontains`).
 Type comparison operators (`-is`, `-isnot`) determine whether an object is of a
 given type.
 
-For more information, see [about_Comparison_Operators](about_Comparison_Operators.md).
+For more information, see
+[about_Comparison_Operators](about_Comparison_Operators.md).
 
 ### Logical Operators
 
@@ -114,7 +117,8 @@ expressions. For example: `(1 + 2) / 3`
 
 However, in PowerShell, there are additional behaviors.
 
-- `(...)` allows you to let output from a _command_ participate in an expression. For example:
+- `(...)` allows you to let output from a _command_ participate in an
+  expression. For example:
 
   ```powershell
   PS> (Get-Item *.txt).Count -gt 10
@@ -249,38 +253,47 @@ converted, PowerShell generates an error.
 [Int] '1' + 0
 ```
 
-A cast can also be performed when a variable is assigned to using [cast notation](about_Variables.md).
+A cast can also be performed when a variable is assigned to using
+[cast notation](about_Variables.md).
 
 #### Comma operator `,`
 
-As a binary operator, the comma creates an array. As a unary operator, the
-comma creates an array with one member. Place the comma before the member.
+As a binary operator, the comma creates an array or appends to the array being
+created. In expression mode, as a unary operator, the comma creates an array
+with just one member. Place the comma before the member.
 
 ```powershell
 $myArray = 1,2,3
 $SingleArray = ,1
+Write-Output (,1)
 ```
+
+Since `Write-Object` expects an argument, you must put the expression in
+parentheses.
 
 #### Dot sourcing operator `.`
 
 Runs a script in the current scope so that any functions, aliases, and
-variables that the script creates are added to the current scope.
+variables that the script creates are added to the current scope, overriding
+existing ones. Parameters declared by the script become variables. Parameters
+for which no value has been given become variables with no value. However, the
+automatic variable `$args` is preserved.
 
 ```powershell
-. c:\scripts\sample.ps1
+. c:\scripts\sample.ps1 1 2 -Also:3
 ```
 
 > [!NOTE]
 > The dot sourcing operator is followed by a space. Use the space to
 > distinguish the dot from the dot (`.`) symbol that represents the current
 > directory.
-
-In the following example, the Sample.ps1 script in the current directory is run
-in the current scope.
-
-```powershell
-. .\sample.ps1
-```
+>
+> In the following example, the Sample.ps1 script in the current directory is
+> run in the current scope.
+>
+> ```powershell
+> . .\sample.ps1
+> ```
 
 #### Format operator `-f`
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,8 +1,8 @@
 ---
-description: Describes the operators that are supported by PowerShell. 
+description: Describes the operators that are supported by PowerShell.
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 10/08/2020
+ms.date: 10/28/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Operators
@@ -32,7 +32,8 @@ operators on any .NET type that implements them, such as: `Int`, `String`,
 Bitwise operators (`-band`, `-bor`, `-bxor`, `-bnot`, `-shl`, `-shr`)
 manipulate the bit patterns in values.
 
-For more information, see [about_Arithmetic_Operators](about_Arithmetic_Operators.md).
+For more information, see
+[about_Arithmetic_Operators](about_Arithmetic_Operators.md).
 
 ### Assignment Operators
 
@@ -40,7 +41,8 @@ Use assignment operators (`=`, `+=`, `-=`, `*=`, `/=`, `%=`) to assign, change,
 or append values to variables. You can combine arithmetic operators with
 assignment to assign the result of the arithmetic operation to a variable.
 
-For more information, see [about_Assignment_Operators](about_Assignment_Operators.md).
+For more information, see
+[about_Assignment_Operators](about_Assignment_Operators.md).
 
 ### Comparison Operators
 
@@ -58,7 +60,8 @@ reference set (`-in`, `-notin`, `-contains`, `-notcontains`).
 Type comparison operators (`-is`, `-isnot`) determine whether an object is of a
 given type.
 
-For more information, see [about_Comparison_Operators](about_Comparison_Operators.md).
+For more information, see
+[about_Comparison_Operators](about_Comparison_Operators.md).
 
 ### Logical Operators
 
@@ -114,7 +117,8 @@ expressions. For example: `(1 + 2) / 3`
 
 However, in PowerShell, there are additional behaviors.
 
-- `(...)` allows you to let output from a _command_ participate in an expression. For example:
+- `(...)` allows you to let output from a _command_ participate in an
+  expression. For example:
 
   ```powershell
   PS> (Get-Item *.txt).Count -gt 10
@@ -326,38 +330,47 @@ converted, PowerShell generates an error.
 [Int] '1' + 0
 ```
 
-A cast can also be performed when a variable is assigned to using [cast notation](about_Variables.md).
+A cast can also be performed when a variable is assigned to using
+[cast notation](about_Variables.md).
 
 #### Comma operator `,`
 
-As a binary operator, the comma creates an array. As a unary operator, the
-comma creates an array with one member. Place the comma before the member.
+As a binary operator, the comma creates an array or appends to the array being
+created. In expression mode, as a unary operator, the comma creates an array
+with just one member. Place the comma before the member.
 
 ```powershell
 $myArray = 1,2,3
 $SingleArray = ,1
+Write-Output (,1)
 ```
+
+Since `Write-Object` expects an argument, you must put the expression in
+parentheses.
 
 #### Dot sourcing operator `.`
 
 Runs a script in the current scope so that any functions, aliases, and
-variables that the script creates are added to the current scope.
+variables that the script creates are added to the current scope, overriding
+existing ones. Parameters declared by the script become variables. Parameters
+for which no value has been given become variables with no value. However, the
+automatic variable `$args` is preserved.
 
 ```powershell
-. c:\scripts\sample.ps1
+. c:\scripts\sample.ps1 1 2 -Also:3
 ```
 
 > [!NOTE]
 > The dot sourcing operator is followed by a space. Use the space to
 > distinguish the dot from the dot (`.`) symbol that represents the current
 > directory.
-
-In the following example, the Sample.ps1 script in the current directory is run
-in the current scope.
-
-```powershell
-. .\sample.ps1
-```
+>
+> In the following example, the Sample.ps1 script in the current directory is
+> run in the current scope.
+>
+> ```powershell
+> . .\sample.ps1
+> ```
 
 #### Format operator `-f`
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,8 +1,8 @@
 ---
-description: Describes the operators that are supported by PowerShell. 
+description: Describes the operators that are supported by PowerShell.
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 10/08/2020
+ms.date: 10/28/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Operators
@@ -32,7 +32,8 @@ operators on any .NET type that implements them, such as: `Int`, `String`,
 Bitwise operators (`-band`, `-bor`, `-bxor`, `-bnot`, `-shl`, `-shr`)
 manipulate the bit patterns in values.
 
-For more information, see [about_Arithmetic_Operators](about_Arithmetic_Operators.md).
+For more information, see
+[about_Arithmetic_Operators](about_Arithmetic_Operators.md).
 
 ### Assignment Operators
 
@@ -40,7 +41,8 @@ Use assignment operators (`=`, `+=`, `-=`, `*=`, `/=`, `%=`) to assign, change,
 or append values to variables. You can combine arithmetic operators with
 assignment to assign the result of the arithmetic operation to a variable.
 
-For more information, see [about_Assignment_Operators](about_Assignment_Operators.md).
+For more information, see
+[about_Assignment_Operators](about_Assignment_Operators.md).
 
 ### Comparison Operators
 
@@ -58,7 +60,8 @@ reference set (`-in`, `-notin`, `-contains`, `-notcontains`).
 Type comparison operators (`-is`, `-isnot`) determine whether an object is of a
 given type.
 
-For more information, see [about_Comparison_Operators](about_Comparison_Operators.md).
+For more information, see
+[about_Comparison_Operators](about_Comparison_Operators.md).
 
 ### Logical Operators
 
@@ -114,7 +117,8 @@ expressions. For example: `(1 + 2) / 3`
 
 However, in PowerShell, there are additional behaviors.
 
-- `(...)` allows you to let output from a _command_ participate in an expression. For example:
+- `(...)` allows you to let output from a _command_ participate in an
+  expression. For example:
 
   ```powershell
   PS> (Get-Item *.txt).Count -gt 10
@@ -316,38 +320,47 @@ converted, PowerShell generates an error.
 [Int] '1' + 0
 ```
 
-A cast can also be performed when a variable is assigned to using [cast notation](about_Variables.md).
+A cast can also be performed when a variable is assigned to using
+[cast notation](about_Variables.md).
 
 #### Comma operator `,`
 
-As a binary operator, the comma creates an array. As a unary operator, the
-comma creates an array with one member. Place the comma before the member.
+As a binary operator, the comma creates an array or appends to the array being
+created. In expression mode, as a unary operator, the comma creates an array
+with just one member. Place the comma before the member.
 
 ```powershell
 $myArray = 1,2,3
 $SingleArray = ,1
+Write-Output (,1)
 ```
+
+Since `Write-Object` expects an argument, you must put the expression in
+parentheses.
 
 #### Dot sourcing operator `.`
 
 Runs a script in the current scope so that any functions, aliases, and
-variables that the script creates are added to the current scope.
+variables that the script creates are added to the current scope, overriding
+existing ones. Parameters declared by the script become variables. Parameters
+for which no value has been given become variables with no value. However, the
+automatic variable `$args` is preserved.
 
 ```powershell
-. c:\scripts\sample.ps1
+. c:\scripts\sample.ps1 1 2 -Also:3
 ```
 
 > [!NOTE]
 > The dot sourcing operator is followed by a space. Use the space to
 > distinguish the dot from the dot (`.`) symbol that represents the current
 > directory.
-
-In the following example, the Sample.ps1 script in the current directory is run
-in the current scope.
-
-```powershell
-. .\sample.ps1
-```
+>
+> In the following example, the Sample.ps1 script in the current directory is
+> run in the current scope.
+>
+> ```powershell
+> . .\sample.ps1
+> ```
 
 #### Format operator `-f`
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -339,7 +339,7 @@ Runs a script in the current scope so that any functions, aliases, and
 variables that the script creates are added to the current scope, overriding
 existing ones. Parameters declared by the sourced script become variables too.
 Parameters for which no value has been given become variables with no value.
-However, the automatic variable `$Args` is preserved.
+However, the automatic variable `$args` is preserved.
 
 ```powershell
 . c:\scripts\sample.ps1 1 2 -Also:3

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -320,21 +320,29 @@ A cast can also be performed when a variable is assigned to using [cast notation
 
 #### Comma operator `,`
 
-As a binary operator, the comma creates an array. As a unary operator, the
-comma creates an array with one member. Place the comma before the member.
+As a binary operator, the comma creates an array or appends to the array being
+created. In expression mode, as a unary operator, the comma creates an array
+with just one member. Place the comma before the member.
 
 ```powershell
 $myArray = 1,2,3
 $SingleArray = ,1
+Write-Output (,1)
 ```
 
 #### Dot sourcing operator `.`
 
+<!--
+01234567890123456789012345678901234567890123456789012345678901234567890123456789
+-->
 Runs a script in the current scope so that any functions, aliases, and
-variables that the script creates are added to the current scope.
+variables that the script creates are added to the current scope, overriding
+existing ones. Parameters declared by the sourced script become variables too.
+Parameters for which no value has been given become variables with no value.
+However, the automatic variable `$Args` is preserved.
 
 ```powershell
-. c:\scripts\sample.ps1
+. c:\scripts\sample.ps1 1 2 -Also:3
 ```
 
 > [!NOTE]

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,8 +1,8 @@
 ---
-description: Describes the operators that are supported by PowerShell. 
+description: Describes the operators that are supported by PowerShell.
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 10/08/2020
+ms.date: 10/28/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Operators
@@ -32,7 +32,8 @@ operators on any .NET type that implements them, such as: `Int`, `String`,
 Bitwise operators (`-band`, `-bor`, `-bxor`, `-bnot`, `-shl`, `-shr`)
 manipulate the bit patterns in values.
 
-For more information, see [about_Arithmetic_Operators](about_Arithmetic_Operators.md).
+For more information, see
+[about_Arithmetic_Operators](about_Arithmetic_Operators.md).
 
 ### Assignment Operators
 
@@ -40,7 +41,8 @@ Use assignment operators (`=`, `+=`, `-=`, `*=`, `/=`, `%=`) to assign, change,
 or append values to variables. You can combine arithmetic operators with
 assignment to assign the result of the arithmetic operation to a variable.
 
-For more information, see [about_Assignment_Operators](about_Assignment_Operators.md).
+For more information, see
+[about_Assignment_Operators](about_Assignment_Operators.md).
 
 ### Comparison Operators
 
@@ -58,7 +60,8 @@ reference set (`-in`, `-notin`, `-contains`, `-notcontains`).
 Type comparison operators (`-is`, `-isnot`) determine whether an object is of a
 given type.
 
-For more information, see [about_Comparison_Operators](about_Comparison_Operators.md).
+For more information, see
+[about_Comparison_Operators](about_Comparison_Operators.md).
 
 ### Logical Operators
 
@@ -114,7 +117,8 @@ expressions. For example: `(1 + 2) / 3`
 
 However, in PowerShell, there are additional behaviors.
 
-- `(...)` allows you to let output from a _command_ participate in an expression. For example:
+- `(...)` allows you to let output from a _command_ participate in an
+  expression. For example:
 
   ```powershell
   PS> (Get-Item *.txt).Count -gt 10
@@ -316,7 +320,8 @@ converted, PowerShell generates an error.
 [Int] '1' + 0
 ```
 
-A cast can also be performed when a variable is assigned to using [cast notation](about_Variables.md).
+A cast can also be performed when a variable is assigned to using
+[cast notation](about_Variables.md).
 
 #### Comma operator `,`
 
@@ -330,16 +335,16 @@ $SingleArray = ,1
 Write-Output (,1)
 ```
 
+Since `Write-Object` expects an argument, you must put the expression in
+parentheses.
+
 #### Dot sourcing operator `.`
 
-<!--
-01234567890123456789012345678901234567890123456789012345678901234567890123456789
--->
 Runs a script in the current scope so that any functions, aliases, and
 variables that the script creates are added to the current scope, overriding
-existing ones. Parameters declared by the sourced script become variables too.
-Parameters for which no value has been given become variables with no value.
-However, the automatic variable `$args` is preserved.
+existing ones. Parameters declared by the script become variables. Parameters
+for which no value has been given become variables with no value. However, the
+automatic variable `$args` is preserved.
 
 ```powershell
 . c:\scripts\sample.ps1 1 2 -Also:3
@@ -349,13 +354,13 @@ However, the automatic variable `$args` is preserved.
 > The dot sourcing operator is followed by a space. Use the space to
 > distinguish the dot from the dot (`.`) symbol that represents the current
 > directory.
-
-In the following example, the Sample.ps1 script in the current directory is run
-in the current scope.
-
-```powershell
-. .\sample.ps1
-```
+>
+> In the following example, the Sample.ps1 script in the current directory is
+> run in the current scope.
+>
+> ```powershell
+> . .\sample.ps1
+> ```
 
 #### Format operator `-f`
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
1. Clarification about unary `,`.
2. Sourced scripts can take parameters too.


## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [X] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
