### PR TITLE
Fixes #6519 - Updates Required macOS Version for PowerShell Core

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-macOS.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-macOS.md
@@ -1,12 +1,12 @@
 ---
 title: Installing PowerShell on macOS
 description: Information about installing PowerShell on macOS
-ms.date: 07/30/2020
+ms.date: 08/20/2020
 ---
 
 # Installing PowerShell on macOS
 
-PowerShell supports macOS 10.12 and higher. All packages are available on our GitHub [releases][]
+PowerShell supports macOS 10.13 and higher. All packages are available on our GitHub [releases][]
 page. After the package is installed, run `pwsh` from a terminal.
 
 > [!NOTE]
@@ -26,7 +26,7 @@ There are several ways to install PowerShell on macOS. Choose one of the followi
 After installing PowerShell, you should install [OpenSSL](#installing-dependencies). OpenSSL is
 needed for PowerShell remoting and CIM operations.
 
-## Installation of latest stable release via Homebrew on macOS 10.12 or higher
+## Installation of latest stable release via Homebrew on macOS 10.13 or higher
 
 If the `brew` command is not found, you need to install Homebrew following
 [their instructions][brew].
@@ -57,7 +57,7 @@ brew cask upgrade powershell
 
 [brew]: https://brew.sh/
 
-## Installation of latest preview release via Homebrew on macOS 10.12 or higher
+## Installation of latest preview release via Homebrew on macOS 10.13 or higher
 
 After you've installed Homebrew, you can install PowerShell. First, install the [Cask-Versions][cask-versions]
 package that lets you install alternative versions of cask packages:


### PR DESCRIPTION
# PR Summary

The latest release of .NET core now requires macOS 10.13 or higher. This affects PowerShell as well. 

## PR Context

Fixes #6519 
Fixes AB#1762940

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [x] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
