### PR TITLE
FIxes #6546 - Updates Get-Date

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 6/27/2019
+ms.date: 08/25/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Date
@@ -511,7 +511,7 @@ The valid **UFormat specifiers** are displayed in the following table:
 | `%t` | Horizontal tab character                                                |                          |
 | `%T` | Time in 24-hour format                                                  | 17:45:52                 |
 | `%U` | Same as 'W'                                                             |                          |
-| `%u` | Day of the week - number                                                | Monday = 1               |
+| `%u` | Day of the week - number                                                | Sunday = 0               |
 | `%V` | Week of the year                                                        | 01-53                    |
 | `%w` | Same as 'u'                                                             |                          |
 | `%W` | Week of the year                                                        | 00-52                    |

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Date.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 6/27/2019
+ms.date: 08/25/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Date
@@ -512,7 +512,7 @@ The valid **UFormat specifiers** are displayed in the following table:
 | `%t` | Horizontal tab character                                                |                          |
 | `%T` | Time in 24-hour format                                                  | 17:45:52                 |
 | `%U` | Same as 'W'                                                             |                          |
-| `%u` | Day of the week - number                                                | Monday = 1               |
+| `%u` | Day of the week - number                                                | Sunday = 0               |
 | `%V` | Week of the year                                                        | 01-53                    |
 | `%w` | Same as 'u'                                                             |                          |
 | `%W` | Week of the year                                                        | 00-52                    |

--- a/reference/7.0/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Get-Date.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 6/27/2019
+ms.date: 08/25/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Date
@@ -512,7 +512,7 @@ The valid **UFormat specifiers** are displayed in the following table:
 | `%t` | Horizontal tab character                                                |                          |
 | `%T` | Time in 24-hour format                                                  | 17:45:52                 |
 | `%U` | Same as 'W'                                                             |                          |
-| `%u` | Day of the week - number                                                | Monday = 1               |
+| `%u` | Day of the week - number                                                | Sunday = 0               |
 | `%V` | Week of the year                                                        | 01-53                    |
 | `%w` | Same as 'u'                                                             |                          |
 | `%W` | Week of the year                                                        | 00-52                    |

--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/13/2020
+ms.date: 08/25/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Date
@@ -608,7 +608,7 @@ The valid **UFormat specifiers** are displayed in the following table:
 | `%t` | Horizontal tab character                                                |                          |
 | `%T` | Time in 24-hour format                                                  | 17:45:52                 |
 | `%U` | Same as 'W'                                                             |                          |
-| `%u` | Day of the week - number                                                | Monday = 1               |
+| `%u` | Day of the week - number                                                | Sunday = 0               |
 | `%V` | Week of the year                                                        | 01-53                    |
 | `%w` | Same as 'u'                                                             |                          |
 | `%W` | Week of the year                                                        | 00-52                    |


### PR DESCRIPTION
# PR Summary

Customer noted that the example for `Get-Date -UFormat %u` was confusing

The UFormat value `%u` shows the numbered day of the week and our current example is: `Monday = 1`. The current example could cause the assumption that if Monday = 1 then Sunday = 7, but in reality, Sunday = 0. 

This PR updates the example to show Sunday = 0 to clarify the count.

## PR Context

Fixes #6546 
Fixes AB#

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
