### PR TITLE
Adding note on 5.1 Support Lifecycle

### DIFF
--- a/reference/docs-conceptual/PowerShell-Support-Lifecycle.md
+++ b/reference/docs-conceptual/PowerShell-Support-Lifecycle.md
@@ -123,6 +123,10 @@ the dates when various releases will no longer be supported.
 |   6.1   | September 28, 2019 |
 |   6.0   | February 13, 2019  |
 
+> [!NOTE]
+> Windows PowerShell 5.1 supportability is completely independent from PowerShell 6+
+> As an integral part of Windows, it is supported as long as the [Operating System itself remains supported](https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet).
+
 ## Unsupported platforms
 
 When a platform version reaches end-of-life as defined by the platform owner, PowerShell Core will

--- a/reference/docs-conceptual/PowerShell-Support-Lifecycle.md
+++ b/reference/docs-conceptual/PowerShell-Support-Lifecycle.md
@@ -126,7 +126,7 @@ the dates when various releases will no longer be supported.
 > [!NOTE]
 > This document is about support for PowerShell Core 6 and PowerShell 7. Windows PowerShell (1.0 -
 > 5.1) is a component of the Windows OS. Components receive the same support as their parent product
-> or platform. For more information, see Product and [Services Lifecycle Information](https://docs.microsoft.com/en-us/lifecycle/products/)
+> or platform. For more information, see [Product and Services Lifecycle Information](https://docs.microsoft.com/en-us/lifecycle/products/)
 
 ## Unsupported platforms
 

--- a/reference/docs-conceptual/PowerShell-Support-Lifecycle.md
+++ b/reference/docs-conceptual/PowerShell-Support-Lifecycle.md
@@ -124,8 +124,9 @@ the dates when various releases will no longer be supported.
 |   6.0   | February 13, 2019  |
 
 > [!NOTE]
-> Windows PowerShell 5.1 supportability is completely independent from PowerShell 6+
-> As an integral part of Windows, it is supported as long as the [Operating System itself remains supported](https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet).
+> This document is about support for PowerShell Core 6 and PowerShell 7. Windows PowerShell (1.0 -
+> 5.1) is a component of the Windows OS. Components receive the same support as their parent product
+> or platform. For more information, see Product and [Services Lifecycle Information](https://docs.microsoft.com/en-us/lifecycle/products/)
 
 ## Unsupported platforms
 


### PR DESCRIPTION
# PR Summary

Fixes https://github.com/MicrosoftDocs/PowerShell-Docs/issues/6551.

Adding a note, clarifying that PS5.1 is supported effectively indefinitely

## PR Context
Frequent confusion about Windows PowerShell support cycle when higher numbers are going out of support.

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [x] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
