### PR TITLE
fix redirection rules

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -2,7 +2,7 @@
     "redirections": [{
             "source_path": "reference/docs-conceptual/dsc/tutorials/dscCiCd.md",
             "redirect_url": "/azure/devops/pipelines/get-started/dsc-cicd",
-            "redirect_document_id": true
+            "redirect_document_id": false
         },
         {
             "source_path": "reference/docs-conceptual/index.md",
@@ -49,12 +49,12 @@
         {
             "source_path": "reference/docs-conceptual/dsc/getting-started/azuredscexthistory.md",
             "redirect_url": "/azure/automation/automation-dsc-extension-history",
-            "redirect_document_id": true
+            "redirect_document_id": false
         },
         {
             "source_path": "reference/docs-conceptual/dsc/getting-started/azuredsc.md",
             "redirect_url": "/azure/automation/automation-dsc-getting-started",
-            "redirect_document_id": true
+            "redirect_document_id": false
         },
 
 


### PR DESCRIPTION
# PR Summary
- [x] [AB#288460](https://dev.azure.com/ceapex/Engineering/_workitems/edit/288460): yml redirections not supported in v2

## PR Context
  - `.yml` redirections with document_id are not supported in v2, they are exactly the same as setting to `false` .
  - In order not to change the generated document_id during migration, they need to be turned to `false`. 
  - However, the redirect_document_id: true will be supported after migrated to `docfx-v3`.
