### PR TITLE
Fixes #6497 - Document new PSRL method DeleteRelativeLines.

### DIFF
--- a/reference/7.1/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.1/PSReadLine/About/about_PSReadLine.md
@@ -187,6 +187,19 @@ Deletes the previous requested logical lines and the current logical line in a m
 
 - Vi command mode: `<d,k>`
 
+### DeleteRelativeLines
+
+Deletes from the beginning of the buffer to the current logical line in a multiline buffer.
+
+As most Vi commands, the `<d,g,g>` command can be prepended with a numeric argument that specifies an absolute line number,
+which, together with the current line number, make up a range of lines to be deleted.
+If not specified, the numeric argument defaults to 1, which refers to the first logical line in a multiline buffer.
+
+The actual number of lines to be deleted from the multiline is computed as the difference between the current logical line number
+and the specified numeric argument, which can thus be negative. Hence the _relative_ part of method name.
+
+- Vi command mode: `<d,g,g>`
+
 ### DeleteNextLines
 
 Deletes the current logical line and the next requested logical lines in a multiline buffer.


### PR DESCRIPTION
# PR Summary

Fixes #6497.

Supports a new `DeleteRelativeLines` method for PSReadLine to implement the <kbd>d</kbd>, <kbd>g</kbd>,<kbd>g</kbd>Vi command.

## PR Context

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - [ ] WMF, ISE, release notes, etc.
  - [x] PSReadLine
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
