### PR TITLE
Fixes AB#1770917 - PSNullConditionalOperators

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 05/06/2020
+ms.date: 09/14/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operator_precedence?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Operator_Precedence
@@ -38,9 +38,9 @@ type `get-help <topic-name>`.
 |         OPERATOR         |           REFERENCE            |
 | ------------------------ | ------------------------------ |
 | `$() @() ()`             | [about_Operators][]            |
-| `.` (member access)      | [about_Operators][]            |
+| `. ?.` (member access)   | [about_Operators][]            |
 | `::` (static)            | [about_Operators][]            |
-| `[0]` (index operator)   | [about_Operators][]            |
+| `[0] ?[0]` (index operator) | [about_Operators][]         |
 | `[int]` (cast operators) | [about_Operators][]            |
 | `-split` (unary)         | [about_Split][]                |
 | `-join` (unary)          | [about_Join][]                 |
@@ -85,6 +85,7 @@ that happens.
 | `.` (dot-source)                        | [about_Operators][]            |
 | `&` (call)                              | [about_Operators][]            |
 | `? <if-true> : <if-false>` (Ternary operator) | [about_Operators][]      |
+| `??` (null-coalese operator)            | [about_Operators][]            |
 | <code>&#124;</code> (pipeline operator) | [about_Operators][]            |
 | `> >> 2> 2>> 2>&1`                      | [about_Redirection][]          |
 | <code>&& &#124;&#124;</code> (pipeline chain operators) | [about_Operators][] |

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 05/06/2020
+ms.date: 09/14/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operator_precedence?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Operator_Precedence
@@ -38,9 +38,9 @@ type `get-help <topic-name>`.
 |         OPERATOR         |           REFERENCE            |
 | ------------------------ | ------------------------------ |
 | `$() @() ()`             | [about_Operators][]            |
-| `.` (member access)      | [about_Operators][]            |
+| `. ?.` (member access)   | [about_Operators][]            |
 | `::` (static)            | [about_Operators][]            |
-| `[0]` (index operator)   | [about_Operators][]            |
+| `[0] ?[0]` (index operator) | [about_Operators][]         |
 | `[int]` (cast operators) | [about_Operators][]            |
 | `-split` (unary)         | [about_Split][]                |
 | `-join` (unary)          | [about_Join][]                 |
@@ -85,6 +85,7 @@ that happens.
 | `.` (dot-source)                        | [about_Operators][]            |
 | `&` (call)                              | [about_Operators][]            |
 | `? <if-true> : <if-false>` (Ternary operator) | [about_Operators][]      |
+| `??` (null-coalese operator)            | [about_Operators][]            |
 | <code>&#124;</code> (pipeline operator) | [about_Operators][]            |
 | `> >> 2> 2>> 2>&1`                      | [about_Redirection][]          |
 | <code>&& &#124;&#124;</code> (pipeline chain operators) | [about_Operators][] |
@@ -205,4 +206,3 @@ are reading and maintaining your scripts.
 [about_Scopes]: about_Scopes.md
 [about_Split]: about_Split.md
 [about_Type_Operators]: about_Type_Operators.md
-

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -477,7 +477,8 @@ A
 
 #### Member access operator `.`
 
-Accesses the properties and methods of an object.  The member name may be an expression.
+Accesses the properties and methods of an object. The member name may be an
+expression.
 
 ```powershell
 $myProcess.peakWorkingSet
@@ -505,9 +506,10 @@ For more information, see [about_If](about_If.md).
 
 #### Null-coalescing operator `??`
 
-The null-coalescing operator `??` returns the value of its left-hand operand if it isn't null.
-Otherwise, it evaluates the right-hand operand and returns its result. The `??` operator doesn't
-evaluate its right-hand operand if the left-hand operand evaluates to non-null.
+The null-coalescing operator `??` returns the value of its left-hand operand if
+it isn't null. Otherwise, it evaluates the right-hand operand and returns its
+result. The `??` operator doesn't evaluate its right-hand operand if the
+left-hand operand evaluates to non-null.
 
 ```powershell
 $x = $null
@@ -531,9 +533,10 @@ $todaysDate ?? (Get-Date).ToShortDateString()
 
 #### Null-coalescing assignment operator `??=`
 
-The null-coalescing assignment operator `??=` assigns the value of its right-hand operand to its
-left-hand operand only if the left-hand operand evaluates to null. The `??=` operator doesn't
-evaluate its right-hand operand if the left-hand operand evaluates to non-null.
+The null-coalescing assignment operator `??=` assigns the value of its
+right-hand operand to its left-hand operand only if the left-hand operand
+evaluates to null. The `??=` operator doesn't evaluate its right-hand operand
+if the left-hand operand evaluates to non-null.
 
 ```powershell
 $x = $null
@@ -559,15 +562,16 @@ $todaysDate ??= (Get-Date).ToShortDateString()
 #### Null-conditional operators `?.` and `?[]`
 
 > [!NOTE]
-> This is an experimental feature. For more information see
-> [about_Experimental_Features](about_Experimental_Features.md).
+> This feature was moved from experimental to mainstream in PowerShell 7.1.
 
-A null-conditional operator applies a member access, `?.`, or element access, `?[]`, operation to
-its operand only if that operand evaluates to non-null; otherwise, it returns null.
+A null-conditional operator applies a member access, `?.`, or element access,
+`?[]`, operation to its operand only if that operand evaluates to non-null;
+otherwise, it returns null.
 
-Since PowerShell allows `?` to be part of the variable name, formal specification of the variable
-name is required for using these operators. So it is required to use `{}` around the variable names
-like `${a}` or when `?` is part of the variable name `${a?}`.
+Since PowerShell allows `?` to be part of the variable name, formal
+specification of the variable name is required for using these operators. So it
+is required to use `{}` around the variable names like `${a}` or when `?` is
+part of the variable name `${a?}`.
 
 In the following example, the value of **PropName** is returned.
 
@@ -580,7 +584,8 @@ ${a}?.PropName
 100
 ```
 
-The following example will return null, without trying to access the member name **PropName**.
+The following example will return null, without trying to access the member
+name **PropName**.
 
 ```powershell
 $a = $null

--- a/reference/docs-conceptual/learn/experimental-features.md
+++ b/reference/docs-conceptual/learn/experimental-features.md
@@ -1,5 +1,5 @@
 ---
-ms.date: 08/31/2020
+ms.date: 09/14/2020
 title: Using Experimental Features in PowerShell
 description: Lists the currently available experimental features and how to use them.
 ---
@@ -25,19 +25,19 @@ For more information about enabling or disabling these features, see
 
 This article describes the experimental features that are available and how to use the feature.
 
-|                            Name                            |   6.2   |   7.0   | 7.1 (preview) |
-| ---------------------------------------------------------- | :-----: | :-----: | :-----------: |
-| PSTempDrive (mainstream in PS 7.0+)                        | &check; |         |               |
-| PSUseAbbreviationExpansion (mainstream in PS 7.0+)         | &check; |         |               |
-| PSCommandNotFoundSuggestion                                | &check; | &check; |    &check;    |
-| PSImplicitRemotingBatching                                 | &check; | &check; |    &check;    |
-| Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace |         | &check; |    &check;    |
-| PSDesiredStateConfiguration.InvokeDscResource              |         | &check; |    &check;    |
-| PSNullConditionalOperators                                 |         | &check; |    &check;    |
-| PSUnixFileStat (non-Windows only)                          |         | &check; |    &check;    |
-| PSNativePSPathResolution (mainstream in PS 7.1+)           |         |         |    &check;    |
-| PSCultureInvariantReplaceOperator                          |         |         |    &check;    |
-| PSNotApplyErrorActionToStderr                              |         |         |    &check;    |
+|                            Name                            |   6.2   |   7.0   |   7.1   |
+| ---------------------------------------------------------- | :-----: | :-----: | :-----: |
+| PSTempDrive (mainstream in PS 7.0+)                        | &check; |         |         |
+| PSUseAbbreviationExpansion (mainstream in PS 7.0+)         | &check; |         |         |
+| PSCommandNotFoundSuggestion                                | &check; | &check; | &check; |
+| PSImplicitRemotingBatching                                 | &check; | &check; | &check; |
+| Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace |         | &check; | &check; |
+| PSDesiredStateConfiguration.InvokeDscResource              |         | &check; | &check; |
+| PSNullConditionalOperators (mainstream in PS 7.1+)         |         | &check; |         |
+| PSUnixFileStat (non-Windows only)                          |         | &check; | &check; |
+| PSNativePSPathResolution (mainstream in PS 7.1+)           |         |         |         |
+| PSCultureInvariantReplaceOperator                          |         |         | &check; |
+| PSNotApplyErrorActionToStderr                              |         |         | &check; |
 
 ## Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace
 
@@ -184,8 +184,11 @@ using redirection operators (`2>&1`), are not written to the `$Error` variable a
 variable `$ErrorActionPreference` does not affect the redirected output.
 
 Many native commands write to `stderr` as an alternative stream for additional information. This
-behavior can cause confusion when looking through errors; or the additional output information can
+behavior can cause confusion when looking through errors or the additional output information can
 be lost to the user if `$ErrorActionPreference` is set to a state that mutes the output.
+
+When a native command has a non-zero exit code, `$?` is set to `$false`. If the exit code is zero,
+`$?` is set to `$true`.
 
 ## PSNullConditionalOperators
 
@@ -213,6 +216,10 @@ variable name and the operator.
 Since PowerShell allows `?` as part of the variable name, disambiguation is required when the
 operators are used without a space between the variable name and the operator. To disambiguate, the
 variables must use `{}` around the variable name like: `${x?}?.propertyName` or `${y}?[0]`.
+
+> [!NOTE]
+> This feature has moved out of the experimental phase and is a mainstream feature in PowerShell 7.1
+> and higher.
 
 ## PSTempDrive
 


### PR DESCRIPTION
Fixes [AB#1770917](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1770917) - PSNullConditionalOperators
Fixes [AB#1770916](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1770916) - update fir $?

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [x] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
