### PR TITLE
Fixes #6630 - fix typo in new() method

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -2,7 +2,7 @@
 description: Describes how you can use classes to create your own custom types.
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 04/12/2020
+ms.date: 09/16/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_classes?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Classes
@@ -60,7 +60,7 @@ Classes are instantiated using either of the following syntaxes:
 ```
 
 > [!NOTE]
-> When using the `[<class-name>]::new(` syntax, brackets around the class name
+> When using the `[<class-name>]::new()` syntax, brackets around the class name
 > are mandatory. The brackets signal a type definition for PowerShell.
 
 ### Example syntax and usage
@@ -845,7 +845,8 @@ Using the `[ref]` type-cast with a class member silently fails. APIs that use
 designed to support COM objects. COM objects have cases where you need to pass
 a value in by reference.
 
-For more information, see [PSReference Class](/dotnet/api/system.management.automation.psreference).
+For more information about the `[ref]` type, see
+[PSReference Class](/dotnet/api/system.management.automation.psreference).
 
 ## See also
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -2,7 +2,7 @@
 description: Describes how you can use classes to create your own custom types.
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 04/12/2020
+ms.date: 09/16/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_classes?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Classes
@@ -60,7 +60,7 @@ Classes are instantiated using either of the following syntaxes:
 ```
 
 > [!NOTE]
-> When using the `[<class-name>]::new(` syntax, brackets around the class name
+> When using the `[<class-name>]::new()` syntax, brackets around the class name
 > are mandatory. The brackets signal a type definition for PowerShell.
 
 ### Example syntax and usage
@@ -845,7 +845,8 @@ Using the `[ref]` type-cast with a class member silently fails. APIs that use
 designed to support COM objects. COM objects have cases where you need to pass
 a value in by reference.
 
-For more information, see [PSReference Class](/dotnet/api/system.management.automation.psreference).
+For more information about the `[ref]` type, see
+[PSReference Class](/dotnet/api/system.management.automation.psreference).
 
 ## See also
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -2,7 +2,7 @@
 description: Describes how you can use classes to create your own custom types.
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 04/12/2020
+ms.date: 09/16/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_classes?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Classes
@@ -60,7 +60,7 @@ Classes are instantiated using either of the following syntaxes:
 ```
 
 > [!NOTE]
-> When using the `[<class-name>]::new(` syntax, brackets around the class name
+> When using the `[<class-name>]::new()` syntax, brackets around the class name
 > are mandatory. The brackets signal a type definition for PowerShell.
 
 ### Example syntax and usage

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -2,7 +2,7 @@
 description: Describes how you can use classes to create your own custom types.
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 04/12/2020
+ms.date: 09/16/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_classes?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Classes
@@ -60,7 +60,7 @@ Classes are instantiated using either of the following syntaxes:
 ```
 
 > [!NOTE]
-> When using the `[<class-name>]::new(` syntax, brackets around the class name
+> When using the `[<class-name>]::new()` syntax, brackets around the class name
 > are mandatory. The brackets signal a type definition for PowerShell.
 
 ### Example syntax and usage
@@ -845,7 +845,8 @@ Using the `[ref]` type-cast with a class member silently fails. APIs that use
 designed to support COM objects. COM objects have cases where you need to pass
 a value in by reference.
 
-For more information, see [PSReference Class](/dotnet/api/system.management.automation.psreference).
+For more information about the `[ref]` type, see
+[PSReference Class](/dotnet/api/system.management.automation.psreference).
 
 ## See also
 
@@ -854,4 +855,3 @@ For more information, see [PSReference Class](/dotnet/api/system.management.auto
 - [about_Language_Keywords](about_language_keywords.md)
 - [about_Methods](about_methods.md)
 - [about_Using](about_using.md)
-


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Fixes [AB#1772245](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1772245) - Fixes #6630 - fix typo in new() method

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
