### PR TITLE
Fixes #6639 - add social image url metadata

### DIFF
--- a/reference/docfx.json
+++ b/reference/docfx.json
@@ -70,6 +70,10 @@
             }
         },
         "fileMetadata": {
+            "social_image_url": {
+                "**/**.md": "https://docs.microsoft.com/media/logos/logo-powershell-social.png",
+                "**/**.yml": "https://docs.microsoft.com/media/logos/logo-powershell-social.png"
+            },
             "ms.prod": {
                 "**/**.md": "powershell",
                 "**/**.yml": "powershell"


### PR DESCRIPTION
This PR is dependent on https://github.com/MicrosoftDocs/DocsMedia/pull/284

Do not merge until the dependent PR is merged.