### PR TITLE
Fixes #6667 - Updates about_Operators

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 07/21/2020
+ms.date: 09/23/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Operators
@@ -293,6 +293,17 @@ right side of the operator.
 
 ```output
 1 hello      3.14
+```
+
+If you need to keep the curly braces (`{}`) in the formatted string, you can
+escape them by doubling the curly braces.
+
+```powershell
+"{0} vs. {{0}}" -f 'foo'
+```
+
+```Output
+foo vs. {0}
 ```
 
 For more information, see the [String.Format](/dotnet/api/system.string.format)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 07/21/2020
+ms.date: 09/23/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Operators
@@ -370,6 +370,17 @@ right side of the operator.
 
 ```output
 1 hello      3.14
+```
+
+If you need to keep the curly braces (`{}`) in the formatted string, you can
+escape them by doubling the curly braces.
+
+```powershell
+"{0} vs. {{0}}" -f 'foo'
+```
+
+```Output
+foo vs. {0}
 ```
 
 For more information, see the [String.Format](/dotnet/api/system.string.format)

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 07/21/2020
+ms.date: 09/23/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Operators
@@ -360,6 +360,17 @@ right side of the operator.
 
 ```output
 1 hello      3.14
+```
+
+If you need to keep the curly braces (`{}`) in the formatted string, you can
+escape them by doubling the curly braces.
+
+```powershell
+"{0} vs. {{0}}" -f 'foo'
+```
+
+```Output
+foo vs. {0}
 ```
 
 For more information, see the [String.Format](/dotnet/api/system.string.format)

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 07/21/2020
+ms.date: 09/23/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Operators
@@ -360,6 +360,17 @@ right side of the operator.
 
 ```output
 1 hello      3.14
+```
+
+If you need to keep the curly braces (`{}`) in the formatted string, you can
+escape them by doubling the curly braces.
+
+```powershell
+"{0} vs. {{0}}" -f 'foo'
+```
+
+```Output
+foo vs. {0}
 ```
 
 For more information, see the [String.Format](/dotnet/api/system.string.format)


### PR DESCRIPTION
# PR Summary

Adds information about escaping curly braces when using formatting operators

## PR Context

Fixes #6667 
Fixes [AB#1775143](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1775143)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [x] Version 6 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
