### PR TITLE
Rename 'PredictionColor' to 'InlinePredictionColor'

### DIFF
--- a/reference/7.1/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.1/PSReadLine/Set-PSReadLineOption.md
@@ -247,7 +247,7 @@ The valid keys include:
 - **Type**: The type token color.
 - **Number**: The number token color.
 - **Member**: The member name token color.
-- **Prediction**: The color for the suggestion text that comes from the prediction API.
+- **InlinePrediction**: The color for the inline view of the predictive suggestion.
 
 ```yaml
 Type: System.Collections.Hashtable


### PR DESCRIPTION
# PR Summary

Rename `PredictionColor` to `InlinePredictionColor` to make the color setting unambiguous.
We will have a couple more color settings for the list view, so rename `PredictionColor` to make it more specific.

Make the PR a draft for now. Will move it out of draft after the corresponding PR https://github.com/PowerShell/PSReadLine/pull/1860 gets merged.


Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
