### PR TITLE
Fix NOTE in Get/Set-Clipboard

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Management/Get-Clipboard.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Get-Clipboard.md
@@ -13,9 +13,6 @@ title: Get-Clipboard
 ## SYNOPSIS
 Gets the contents of the clipboard.
 
-[!NOTE]
-> On Linux, this cmdlet requires the `xclip` utility to be in the path.
-
 ## SYNTAX
 
 ```
@@ -26,6 +23,9 @@ Get-Clipboard [-Raw] [<CommonParameters>]
 
 The `Get-Clipboard` cmdlet gets the contents of the clipboard as text. Multiple lines of text are
 returned as an array of strings similar to `Get-Content`.
+
+> [!NOTE]
+> On Linux, this cmdlet requires the `xclip` utility to be in the path.
 
 ## EXAMPLES
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -23,7 +23,7 @@ Set-Clipboard [-Value] <string[]> [-Append] [-WhatIf] [-Confirm] [<CommonParamet
 
 The `Set-Clipboard` cmdlet sets the contents of the clipboard.
 
-[!NOTE]
+> [!NOTE]
 > On Linux, this cmdlet requires the `xclip` utility to be in the path.
 
 ## EXAMPLES

--- a/reference/7.1/Microsoft.PowerShell.Management/Get-Clipboard.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Get-Clipboard.md
@@ -13,9 +13,6 @@ title: Get-Clipboard
 ## SYNOPSIS
 Gets the contents of the clipboard.
 
-[!NOTE]
-> On Linux, this cmdlet requires the `xclip` utility to be in the path.
-
 ## SYNTAX
 
 ```
@@ -26,6 +23,9 @@ Get-Clipboard [-Raw] [<CommonParameters>]
 
 The `Get-Clipboard` cmdlet gets the contents of the clipboard as text. Multiple lines of text are
 returned as an array of strings similar to `Get-Content`.
+
+> [!NOTE]
+> On Linux, this cmdlet requires the `xclip` utility to be in the path.
 
 ## EXAMPLES
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -23,7 +23,7 @@ Set-Clipboard -Value <String[]> [-Append] [-WhatIf] [-Confirm] [<CommonParameter
 
 The `Set-Clipboard` cmdlet sets the contents of the clipboard.
 
-[!NOTE]
+> [!NOTE]
 > On Linux, this cmdlet requires the `xclip` utility to be in the path.
 
 ## EXAMPLES


### PR DESCRIPTION
# PR Summary
* Add missing "`>`"
* Move to Description (Get-Clipboard)

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Version 7.1 preview content
- [x] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
<del>- [ ] Includes content related to issues and PRs - see Closing issues using keywords.</del>
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
