### PR TITLE
Jobs gets killed with parent powershell

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Jobs.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Jobs.md
@@ -348,6 +348,18 @@ credentials to run the command. The value of the **Reason** property is:
 Connecting to remote server failed with the following error message: "Access is
 denied".
 
+## Notes
+
+- The jobs are tied to invoking powershell process. Stopping (job) invoking powershell
+  process will result in stopping all jobs.
+- If you are familiar with linux backgroud processes using `nohup`, where commands continue
+  executing even after parent shell is killed, take a look at
+  [Start-Process](xref:Microsoft.PowerShell.Core.Start-Process). [Start-Process](xref:Microsoft.PowerShell.Core.Start-Process)
+  by itself will not provide `nohup` like behaviour on non-Windows platforms.
+- On non-Windows platforms you need to explicitely execute `nohup`. Here is an
+  [example](https://stackoverflow.com/a/64708000/1686377).
+
+
 ## See also
 
 - [about_Remote_Jobs](about_Remote_Jobs.md)


### PR DESCRIPTION
Related conversation: 
1. https://github.com/PowerShell/PowerShell/issues/12090#issuecomment-680936907
2. https://stackoverflow.com/a/64708000/1686377
3. https://github.com/PowerShell/PowerShell/issues/13701#issuecomment-722769646

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Version 7.1 preview content
- [ ] Version 7.0 content
- [ ] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
