### PR TITLE
Recommend New-WinEvent instead of Create-WinEvent

### DIFF
--- a/reference/docs-conceptual/whats-new/breaking-changes-ps6.md
+++ b/reference/docs-conceptual/whats-new/breaking-changes-ps6.md
@@ -144,7 +144,7 @@ better solution is found.
 ### `*-EventLog` cmdlets
 
 Due to the use of unsupported APIs, the `*-EventLog` has been removed from PowerShell Core. until a
-better solution is found. `Get-WinEvent` and `Create-WinEvent` are available to get and create
+better solution is found. `Get-WinEvent` and `New-WinEvent` are available to get and create
 events on Windows.
 
 ### Cmdlets that use WPF removed


### PR DESCRIPTION
The "Create-WinEvent" cmdlet does not exist. It seems the author intended to call out the New-WinEvent cmdlet instead.

# PR Summary
The PowerShell 6.x breaking changes doc recommends "Create-WinEvent" as an alternative to the EventLog cmdlets. That cmdlet doesn't exist and was most likely intended to be "New-WinEvent"

## PR Context


**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [x] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [x] Version 6 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
