### PR TITLE
about_Environment_Variables: Fix erroneous recommendation

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -310,16 +310,18 @@ PS Env:\> Get-ChildItem ComputerName
 
 ### Saving changes to environment variables
 
-To make a persistent change to an environment variable on Windows, use the
-System Control Panel. Select **Advanced System Settings**. On the **Advanced**
-tab, click **Environment Variable...**. You can add or edit existing
-environment variables in the **User** and **System** (Machine) scopes. Windows
-writes these values to the Registry so that they persist across sessions and
-system restarts.
+To make a persistent change to an environment variable on Windows, use either of
+the following:
+
+1. The [setx.exe](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx)
+   command-line utility.
+1. The Advanced tab of the System applet in Control Panel. Issuing the
+   `SystemPropertiesAdvanced.exe` command at the PowerShell prompt is a
+   straightforward way of accessing it.
 
 Alternately, you can add or change environment variables in your PowerShell
 profile. This method works for any version of PowerShell on any supported
-platform.
+platform, but restricts the changes to PowerShell and its child processes.
 
 ### Using System.Environment methods
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -313,7 +313,7 @@ PS Env:\> Get-ChildItem ComputerName
 To make a persistent change to an environment variable on Windows, use either of
 the following:
 
-1. The [setx.exe](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx)
+1. The [setx.exe](https://docs.microsoft.com/windows-server/administration/windows-commands/setx)
    command-line utility.
 1. The Advanced tab of the System applet in Control Panel. Issuing the
    `SystemPropertiesAdvanced.exe` command at the PowerShell prompt is a


### PR DESCRIPTION
# PR Summary
1. Fix erroneous recommendation. There isn't any such place as **Advanced System Settings** in the System applet of the Control Panel. But **Advanced System Settings** is a hyperlink in the Windows 10's Setting app, About page.
2. Add a way of saving the environment variables via a Windows command-line utility.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [X] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
