### PR TITLE
Updated doc for PSRL DeleteLineToFirstChar to better reflect changes

### DIFF
--- a/reference/7.2/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.2/PSReadLine/About/about_PSReadLine.md
@@ -255,7 +255,7 @@ Deletes the current logical line and the next requested logical lines in a multi
 
 ### DeleteLineToFirstChar
 
-Deletes text from the cursor to the first non-blank character of the line.
+Deletes from the first non-blank character of the current logical line in a multiline buffer.
 
 - Vi command mode: `<d,^>`
 


### PR DESCRIPTION
# PR Summary

Related to [PSReadLine#2001](https://github.com/PowerShell/PSReadLine/pull/2001).
Fixes #6958.

## PR Context

Using <kbd>d</kbd><kbd>^</kbd> currently deletes the entire selection from the first non blank character in the buffer up to the cursor position. However, when using multiline input, it should delete only from the first non blank character in the current logical line instead.

The PSReadLine’s `DeleteLineToFirstChar` is changed to better reflect the new behaviour. Accordingly, the text for the documention is updated.

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [x] PSReadLine
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [x] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated (Only version 7.1, due to PSReadLine having a HelpInfoUri that points to this specific version)
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
