### PR TITLE
Incorrect variable name

### DIFF
--- a/reference/docs-conceptual/learn/deep-dives/everything-about-shouldprocess.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-shouldprocess.md
@@ -143,7 +143,7 @@ to other commands. I recommend that you do the same.
 function Test-ShouldProcess {
     [CmdletBinding(SupportsShouldProcess)]
     param()
-    Remove-Item .\myfile1.txt -WhatIf:$WhatIf
+    Remove-Item .\myfile1.txt -WhatIf:$WhatIfPreference
 }
 ```
 
@@ -258,7 +258,7 @@ I tend to use the one with two parameters.
 
 We have a fourth overload that's more advanced than the others. It allows you to get the reason
 `ShouldProcess` was executed. I'm only adding this here for completeness because we can just check
-if `$WhatIf` is `$true` instead.
+if `$WhatIfPreference` is `$true` instead.
 
 ```powershell
 $reason = ''


### PR DESCRIPTION
I'm not totally sure if this is correct. But as far as I can tell, $WhatIf doesn't exist, and it should be $WhatIfPreference. This was really confusing when reading this doc, so I'm submitting this as a typo PR, but hopefully someone can fact check this.

# PR Summary
The doc/article incorrectly uses `$WhatIf` when it should be `$WhatIfPreference`

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [X] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
