### PR TITLE
Correct code example for calling PowerShell in C#

### DIFF
--- a/reference/docs-conceptual/developer/hosting/adding-and-invoking-commands.md
+++ b/reference/docs-conceptual/developer/hosting/adding-and-invoking-commands.md
@@ -84,7 +84,7 @@ IDictionary parameters = new Dictionary<String, String>();
 parameters.Add("Name", "Get-VM");
 
 parameters.Add("Module", "Hyper-V");
-PowerShell.Create().AddCommand("Get-Process")
+PowerShell.Create().AddCommand("Get-Command")
    .AddParameters(parameters)
       .Invoke()
 

--- a/reference/docs-conceptual/developer/hosting/adding-and-invoking-commands.md
+++ b/reference/docs-conceptual/developer/hosting/adding-and-invoking-commands.md
@@ -69,9 +69,9 @@ You can add additional parameters by calling
 repeatedly.
 
 ```csharp
-PowerShell.Create().AddCommand("Get-Process")
-                   .AddParameter("Name", "PowerShell")
-                   .AddParameter("Id", "12768")
+PowerShell.Create().AddCommand("Get-Command")
+                   .AddParameter("Name", "Get-VM")
+                   .AddParameter("Module", "Hyper-V")
                    .Invoke();
 ```
 
@@ -81,9 +81,9 @@ method.
 
 ```csharp
 IDictionary parameters = new Dictionary<String, String>();
-parameters.Add("Name", "PowerShell");
+parameters.Add("Name", "Get-VM");
 
-parameters.Add("Id", "12768");
+parameters.Add("Module", "Hyper-V");
 PowerShell.Create().AddCommand("Get-Process")
    .AddParameters(parameters)
       .Invoke()


### PR DESCRIPTION
# PR Summary
Correct code example for calling PowerShell in C#

## PR Context
Example uses `Get-Process` cmdlet with `Name` and `Id` parameters together which is not possible as they both are Mandatory parameter from two different parameter sets.

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [x] Sample scripts
- [ ] Gallery articles
- [x] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
