### PR TITLE
Restore v6 release notes

### DIFF
--- a/reference/docs-conceptual/toc.yml
+++ b/reference/docs-conceptual/toc.yml
@@ -126,6 +126,18 @@
       href: whats-new/what-s-new-in-powershell-71.md
     - name: What's new in PowerShell 7.0
       href: whats-new/what-s-new-in-powershell-70.md
+  - name: PowerShell Core 6.x Release Notes
+    items:
+    - name: What's new in PowerShell Core 6.2
+      href: whats-new/what-s-new-in-powershell-core-62.md
+    - name: What's new in PowerShell Core 6.1
+      href: whats-new/what-s-new-in-powershell-core-61.md
+    - name: What's new in PowerShell Core 6.0
+      href: whats-new/what-s-new-in-powershell-core-60.md
+    - name: Breaking changes in PowerShell Core 6.0
+      href: whats-new/breaking-changes-ps6.md
+    - name: Known issues in PowerShell Core 6.0
+      href: whats-new/known-issues-ps6.md
   - name: Module and cmdlet release history
     href: whats-new/cmdlet-versions.md
   - name: Module compatibility list

--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
@@ -1,0 +1,494 @@
+---
+title: What's New in PowerShell Core 6.0
+description: New features and changes released in PowerShell Core 6.0
+ms.date: 08/06/2018
+---
+
+# What's New in PowerShell Core 6.0
+
+[PowerShell Core 6.0][github] is a new edition of PowerShell that is cross-platform (Windows, macOS,
+and Linux), open-source, and built for heterogeneous environments and the hybrid cloud.
+
+## Moved from .NET Framework to .NET Core
+
+PowerShell Core uses [.NET Core 2.0][] as its runtime. .NET Core 2.0 enables PowerShell Core to work
+on multiple platforms (Windows, macOS, and Linux). PowerShell Core also exposes the API set offered
+by .NET Core 2.0 to be used in PowerShell cmdlets and scripts.
+
+Windows PowerShell used the .NET Framework runtime to host the PowerShell engine. This means that
+Windows PowerShell exposes the API set offered by .NET Framework.
+
+The APIs shared between .NET Core and .NET Framework are defined as part of [.NET Standard][].
+
+For more information on how this affects module/script compatibility between PowerShell Core and
+Windows PowerShell, see
+[Backwards compatibility with Windows PowerShell](#backwards-compatibility-with-windows-powershell).
+
+## Support for macOS and Linux
+
+PowerShell now officially supports macOS and Linux, including:
+
+- Windows 7, 8.1, and 10
+- Windows Server 2008 R2, 2012 R2, 2016
+- [Windows Server Semi-Annual Channel][semi-annual]
+- Ubuntu 14.04, 16.04, and 17.04
+- Debian 8.7+, and 9
+- CentOS 7
+- Red Hat Enterprise Linux 7
+- OpenSUSE 42.2
+- Fedora 25, 26
+- macOS 10.12+
+
+Our community has also contributed packages for the following platforms,
+but they are not officially supported:
+
+- Arch Linux
+- Kali Linux
+- AppImage (works on multiple Linux platforms)
+
+We also have experimental (unsupported) releases for the following platforms:
+
+- Windows on ARM32/ARM64
+- Raspbian (Stretch)
+
+A number of changes were made to in PowerShell Core 6.0 to make it work better on non-Windows
+systems. Some of these are breaking changes, which also affect Windows. Others are only present or
+applicable in non-Windows installations of PowerShell Core.
+
+- Added support for native command globbing on Unix platforms.
+- The `more` functionality respects the Linux `$PAGER` and defaults to `less`. This means you can
+  now use wildcards with native binaries/commands (for example, `ls *.txt`). (#3463)
+- Trailing backslash is automatically escaped when dealing with native command arguments. (#4965)
+- Ignore the `-ExecutionPolicy` switch when running PowerShell on non-Windows platforms because
+  script signing is not currently supported. (#3481)
+- Fixed ConsoleHost to honor `NoEcho` on Unix platforms. (#3801)
+- Fixed `Get-Help` to support case insensitive pattern matching on Unix platforms. (#3852)
+- `powershell` man-page added to package
+
+### Logging
+
+On macOS, PowerShell uses the native `os_log` APIs to log to Apple's
+[unified logging system][os_log]. On Linux, PowerShell uses [Syslog][], a ubiquitous logging
+solution.
+
+### Filesystem
+
+A number of changes have been made on macOS and Linux to support filename characters not
+traditionally supported on Windows:
+
+- Paths given to cmdlets are now slash-agnostic (both / and \ work as directory separator)
+- XDG Base Directory Specification is now respected and used by default:
+  - The Linux/macOS profile path is located at `~/.config/powershell/profile.ps1`
+  - The history save path is located at `~/.local/share/powershell/PSReadline/ConsoleHost_history.txt`
+  - The user module path is located at `~/.local/share/powershell/Modules`
+- Support for file and folder names containing the colon character on Unix. (#4959)
+- Support for script names or full paths that have commas. (#4136) (Thanks to
+  [@TimCurwick](https://github.com/TimCurwick)!)
+- Detect when `-LiteralPath` is used to suppress wildcard expansion for navigation cmdlets. (#5038)
+- Updated `Get-ChildItem` to work more like the *nix `ls -R` and the Windows `DIR /S` native
+  commands. `Get-ChildItem` now returns the symbolic links encountered during a recursive search and
+  does not search the directories that those links target. (#3780)
+
+### Case sensitivity
+
+Linux and macOS tend to be case-sensitive while Windows is case-insensitive while preserving case.
+In general, PowerShell is case insensitive.
+
+For example, environment variables are case-sensitive on macOS and Linux, so the casing of the
+`PSModulePath` environment variable has been standardized. (#3255) `Import-Module` is case
+insensitive when it's using a file path to determine the module's name. (#5097)
+
+## Support for side-by-side installations
+
+PowerShell Core is installed, configured, and executed separately from Windows PowerShell.
+PowerShell Core has a "portable" ZIP package. Using the ZIP package, you can install any number of
+versions anywhere on disk, including local to an application that takes PowerShell as a dependency.
+Side-by-side installation makes it easier to test new versions of PowerShell and migrating existing
+scripts over time. Side-by-side also enables backwards compatibility as scripts can be pinned to
+specific versions that they require.
+
+> [!NOTE]
+> By default, the MSI-based installer on Windows does an in-place update install.
+
+## Renamed `powershell(.exe)` to `pwsh(.exe)`
+
+The binary name for PowerShell Core has been changed from `powershell(.exe)` to `pwsh(.exe)`. This
+change provides a deterministic way for users to run PowerShell Core on machines to support
+side-by-side Windows PowerShell and PowerShell Core installations. `pwsh` is also much shorter and
+easier to type.
+
+Additional changes to `pwsh(.exe)` from `powershell.exe`:
+
+- Changed the first positional parameter from `-Command` to `-File`. This change fixes the usage of
+  `#!` (aka as a shebang) in PowerShell scripts that are being executed from non-PowerShell shells
+  on non-Windows platforms. It also means that you can run commands like `pwsh foo.ps1` or
+  `pwsh fooScript` without specifying `-File`. However, this change requires that you explicitly
+  specify `-c` or `-Command` when trying to run commands like `pwsh.exe -Command Get-Command`.
+  (#4019)
+- PowerShell Core accepts the `-i` (or `-Interactive`) switch to indicate an interactive shell.
+  (#3558) This allows PowerShell to be used as a default shell on Unix platforms.
+- Removed parameters `-importsystemmodules` and `-psconsoleFile` from `pwsh.exe`. (#4995)
+- Changed `pwsh -version` and built-in help for `pwsh.exe` to align with other native tools. (#4958
+  & #4931) (Thanks [@iSazonov](https://github.com/iSazonov))
+- Invalid argument error messages for `-File` and `-Command` and exit codes consistent with Unix
+  standards (#4573)
+- Added `-WindowStyle` parameter on Windows. (#4573) Similarly, package-based installations updates
+  on non-Windows platforms are in-place updates.
+
+## Backwards compatibility with Windows PowerShell
+
+The goal of PowerShell Core is to remain as compatible as possible with Windows PowerShell.
+PowerShell Core uses [.NET Standard][] 2.0 to provide binary compatibility with existing .NET
+assemblies. Many PowerShell modules depend on these assemblies (often times DLLs), so .NET Standard
+allows them to continue working with .NET Core. PowerShell Core also includes a heuristic to look in
+well-known folders--like where the Global Assembly Cache typically resides on disk--to find .NET
+Framework DLL dependencies.
+
+You can learn more about .NET Standard on the [.NET Blog][], in this [YouTube][] video, and via this
+[FAQ][] on GitHub.
+
+Best efforts have been made to ensure that the PowerShell language and "built-in" modules (like
+`Microsoft.PowerShell.Management`, `Microsoft.PowerShell.Utility`, etc.) work the same as they do in
+Windows PowerShell. In many cases, with the help of the community, we've added new capabilities and
+bug fixes to those cmdlets. In some cases, due to a missing dependency in underlying .NET layers,
+functionality was removed or is unavailable.
+
+Most of the modules that ship as part of Windows (for example, `DnsClient`, `Hyper-V`, `NetTCPIP`,
+`Storage`, etc.) and other Microsoft products including Azure and Office have not been *explicitly*
+ported to .NET Core yet. The PowerShell team is working with these product groups and teams to
+validate and port their existing modules to PowerShell Core. With .NET Standard and [CDXML][], many
+of these traditional Windows PowerShell modules do seem to work in PowerShell Core, but they have
+not been formally validated, and they are not formally supported.
+
+By installing the [`WindowsPSModulePath`][windowspsmodulepath] module, you can use Windows
+PowerShell modules by appending the Windows PowerShell `PSModulePath` to your PowerShell Core
+`PSModulePath`.
+
+First, install the `WindowsPSModulePath` module from the PowerShell Gallery:
+
+```powershell
+# Add `-Scope CurrentUser` if you're installing as non-admin
+Install-Module WindowsPSModulePath -Force
+```
+
+After installing this module,
+run the `Add-WindowsPSModulePath` cmdlet to add the Windows PowerShell `PSModulePath` to PowerShell Core:
+
+```powershell
+# Add this line to your profile if you always want Windows PowerShell PSModulePath
+Add-WindowsPSModulePath
+```
+
+## Docker support
+
+PowerShell Core adds support for Docker containers for all the major platforms we support (including
+multiple Linux distros, Windows Server Core, and Nano Server).
+
+For a complete list, check out the tags on [`microsoft/powershell` on Docker Hub][docker-hub]. For
+more information on Docker and PowerShell Core, see [Docker][] on GitHub.
+
+## SSH-based PowerShell Remoting
+
+The PowerShell Remoting Protocol (PSRP) now works with the Secure Shell (SSH) protocol in addition
+to the traditional WinRM-based PSRP.
+
+This means that you can use cmdlets like `Enter-PSSession` and `New-PSSession` and authenticate
+using SSH. All you have to do is register PowerShell as a subsystem with an OpenSSH-based SSH
+server, and you can use your existing SSH-based authenticate mechanisms (like passwords or private
+keys) with the traditional `PSSession` semantics.
+
+For more information on configuring and using SSH-based remoting,
+see [PowerShell Remoting over SSH][ssh-remoting].
+
+## Default encoding is UTF-8 without a BOM except for New-ModuleManifest
+
+In the past, Windows PowerShell cmdlets like `Get-Content`, `Set-Content` used different encodings,
+such as ASCII and UTF-16. The variance in encoding defaults created problems when mixing cmdlets
+without specifying an encoding.
+
+Non-Windows platforms traditionally use UTF-8 without a Byte Order Mark (BOM) as the default
+encoding for text files. More Windows applications and tools are moving away from UTF-16 and towards
+BOM-less UTF-8 encoding. PowerShell Core changes the default encoding to conform with the broader
+ecosystems.
+
+This means that all built-in cmdlets that use the `-Encoding` parameter use the `UTF8NoBOM` value by
+default. The following cmdlets are affected by this change:
+
+- Add-Content
+- Export-Clixml
+- Export-Csv
+- Export-PSSession
+- Format-Hex
+- Get-Content
+- Import-Csv
+- Out-File
+- Select-String
+- Send-MailMessage
+- Set-Content
+
+These cmdlets have also been updated so that the `-Encoding` parameter universally accepts
+`System.Text.Encoding`.
+
+The default value of `$OutputEncoding` has also been changed to UTF-8.
+
+As a best practice, you should explicitly set encodings in scripts using the `-Encoding` parameter
+to produce deterministic behavior across platforms.
+
+`New-ModuleManifest` cmdlet does not have **Encoding** parameter. The encoding of the module
+manifest (.psd1) file created with `New-ModuleManifest` cmdlet depends on environment: if it is
+PowerShell Core running on Linux then encoding is UTF-8 (no BOM); otherwise encoding is UTF-16 (with
+BOM). (#3940)
+
+## Support backgrounding of pipelines with ampersand (`&`) (#3360)
+
+Putting `&` at the end of a pipeline causes the pipeline to be run as a PowerShell job. When a
+pipeline is backgrounded, a job object is returned. Once the pipeline is running as a job, all of
+the standard `*-Job` cmdlets can be used to manage the job. Variables (ignoring process-specific
+variables) used in the pipeline are automatically copied to the job so `Copy-Item $foo $bar &` just
+works. The job is also run in the current directory instead of the user's home directory. For more
+information about PowerShell jobs, see
+[about_Jobs](/powershell/module/microsoft.powershell.core/about/about_jobs).
+
+## Semantic versioning
+
+- Made `SemanticVersion` compatible with `SemVer 2.0`. (#5037) (Thanks
+  [@iSazonov](https://github.com/iSazonov)!)
+- Changed default `ModuleVersion` in `New-ModuleManifest` to `0.0.1` to align with SemVer. (#4842)
+  (Thanks [@LDSpits](https://github.com/LDSpits))
+- Added `semver` as a type accelerator for `System.Management.Automation.SemanticVersion`. (#4142)
+  (Thanks to [@oising](https://github.com/oising)!)
+- Enabled comparison between a `SemanticVersion` instance and a `Version` instance that is
+  constructed only with `Major` and `Minor` version values.
+
+## Language updates
+
+- Implement Unicode escape parsing so that users can use Unicode characters as arguments, strings,
+  or variable names. (#3958) (Thanks to [@rkeithhill](https://github.com/rkeithhill)!)
+- Added new escape character for ESC: `` `e``
+- Added support for converting enums to string (#4318) (Thanks [@KirkMunro](https://github.com/KirkMunro))
+- Fixed casting single element array to a generic collection. (#3170)
+- Added character range overload to the `..` operator, so `'a'..'z'` returns characters from 'a' to
+  'z'. (#5026) (Thanks [@IISResetMe](https://github.com/IISResetMe)!)
+- Fixed variable assignment to not overwrite read-only variables
+- Push locals of automatic variables to 'DottedScopes' when dotting script cmdlets (#4709)
+- Enable use of 'Singleline, Multiline' option in split operator (#4721) (Thanks
+  [@iSazonov](https://github.com/iSazonov))
+
+## Engine updates
+
+- `$PSVersionTable` has four new properties:
+  - `PSEdition`: This is set to `Core` on PowerShell Core and `Desktop` on Windows PowerShell
+  - `GitCommitId`: This is the Git commit ID of the Git branch or tag where PowerShell was built.
+    On released builds, it will likely be the same as `PSVersion`.
+  - `OS`: This is an OS version string returned by
+    `[System.Runtime.InteropServices.RuntimeInformation]::OSDescription`
+  - `Platform`: This is returned by `[System.Environment]::OSVersion.Platform`
+    It is set to `Win32NT` on Windows, `Unix` on macOS, and `Unix` on Linux.
+- Removed the `BuildVersion` property from `$PSVersionTable`. This property was strongly tied to the
+  Windows build version. Instead, we recommend that you use `GitCommitId` to retrieve the exact
+  build version of PowerShell Core. (#3877) (Thanks to [@iSazonov](https://github.com/iSazonov)!)
+- Remove `ClrVersion` property from `$PSVersionTable`. This property is irrelevant for .NET Core,
+  and was only preserved in .NET Core for specific legacy purposes that are inapplicable to
+  PowerShell.
+- Added three new automatic variables to determine whether PowerShell is running in a given OS:
+  `$IsWindows`, `$IsMacOs`, and `$IsLinux`.
+- Add `GitCommitId` to PowerShell Core banner. Now you don't have to run `$PSVersionTable` as soon
+  as you start PowerShell to get the version! (#3916) (Thanks to
+  [@iSazonov](https://github.com/iSazonov)!)
+- Add a JSON config file called `powershell.config.json` in `$PSHome` to store some settings
+  required before startup time (e.g. `ExecutionPolicy`).
+- Don't block pipeline when running Windows EXE's
+- Enabled enumeration of COM collections. (#4553)
+
+## Cmdlet updates
+
+### New cmdlets
+
+- Add `Get-Uptime` to `Microsoft.PowerShell.Utility`.
+- Add `Remove-Alias` Command. (#5143) (Thanks [@PowershellNinja](https://github.com/PowershellNinja)!)
+- Add `Remove-Service` to Management module. (#4858) (Thanks [@joandrsn](https://github.com/joandrsn)!)
+
+### Web cmdlets
+
+- Add certificate authentication support for web cmdlets. (#4646) (Thanks
+  [@markekraus](https://github.com/markekraus))
+- Add support for content headers to web cmdlets. (#4494 & #4640) (Thanks
+  [@markekraus](https://github.com/markekraus))
+- Add multiple link header support to Web Cmdlets. (#5265) (Thanks
+  [@markekraus](https://github.com/markekraus)!)
+- Support Link header pagination in web cmdlets (#3828)
+  - For `Invoke-WebRequest`, when the response includes a Link header we create a RelationLink
+    property as a Dictionary representing the URLs and `rel` attributes and ensure the URLs are
+    absolute to make it easier for the developer to use.
+  - For `Invoke-RestMethod`, when the response includes a Link header we expose a `-FollowRelLink`
+    switch to automatically follow `next` `rel` links until they no longer exist or once we hit the
+    optional `-MaximumFollowRelLink` parameter value.
+- Add `-CustomMethod` parameter to web cmdlets to allow for non-standard method verbs. (#3142)
+  (Thanks to @Lee303!)
+- Add `SslProtocol` support to Web Cmdlets. (#5329) (Thanks
+  [@markekraus](https://github.com/markekraus)!)
+- Add Multipart support to web cmdlets. (#4782) (Thanks [@markekraus](https://github.com/markekraus))
+- Add `-NoProxy` to web cmdlets so that they ignore the system-wide proxy setting. (#3447) (Thanks
+  to [@TheFlyingCorpse](https://github.com/TheFlyingCorpse)!)
+- User Agent of Web Cmdlets now reports the OS platform (#4937) (Thanks
+  [@LDSpits](https://github.com/LDSpits))
+- Add `-SkipHeaderValidation` switch to web cmdlets to support adding headers without validating the
+  header value. (#4085)
+- Enable web cmdlets to not validate the HTTPS certificate of the server if required.
+- Add authentication parameters to web cmdlets. (#5052) (Thanks
+  [@markekraus](https://github.com/markekraus))
+  - Add `-Authentication` that provides three options: Basic, OAuth, and Bearer.
+  - Add `-Token` to get the bearer token for OAuth and Bearer options.
+  - Add `-AllowUnencryptedAuthentication` to bypass authentication that is provided for any
+    transport scheme other than HTTPS.
+- Add `-ResponseHeadersVariable` to `Invoke-RestMethod` to enable the capture of response headers.
+  (#4888) (Thanks [@markekraus](https://github.com/markekraus))
+- Fix web cmdlets to include the HTTP response in the exception when the response status code is not
+  success. (#3201)
+- Change web cmdlets `UserAgent` from `WindowsPowerShell` to `PowerShell`. (#4914) (Thanks
+  [@markekraus](https://github.com/markekraus))
+- Add explicit `ContentType` detection to `Invoke-RestMethod` (#4692)
+- Fix web cmdlets `-SkipHeaderValidation` to work with non-standard User-Agent headers. (#4479 &
+  #4512) (Thanks [@markekraus](https://github.com/markekraus))
+
+### JSON cmdlets
+
+- Add `-AsHashtable` to `ConvertFrom-Json` to return a `Hashtable` instead. (#5043) (Thanks
+  [@bergmeister](https://github.com/bergmeister)!)
+- Use prettier formatter with `ConvertTo-Json` output. (#2787) (Thanks to @kittholland!)
+- Add `Jobject` serialization support to `ConvertTo-Json`. (#5141)
+- Fix `ConvertFrom-Json` to deserialize an array of strings from the pipeline that together
+  construct a complete JSON string. This fixes some cases where newlines would break JSON parsing.
+  (#3823)
+- Remove the `AliasProperty "Count"` defined for `System.Array`. This removes the extraneous `Count`
+  property on some `ConvertFrom-Json` output. (#3231) (Thanks to
+  [@PetSerAl](https://github.com/PetSerAl)!)
+
+### CSV cmdlets
+
+- `Import-Csv` now supports the W3C Extended Log File Format (#2482) (Thanks
+  [@iSazonov](https://github.com/iSazonov)!)
+- Add `PSTypeName` Support for `Import-Csv` and `ConvertFrom-Csv`. (#5389) (Thanks
+  [@markekraus](https://github.com/markekraus)!)
+- Make `Import-Csv` support `CR`, `LF`, and `CRLF` as line delimiters. (#5363) (Thanks
+  [@iSazonov](https://github.com/iSazonov)!)
+- Make `-NoTypeInformation` the default on `Export-Csv` and `ConvertTo-Csv`. (#5164) (Thanks
+  [@markekraus](https://github.com/markekraus)!)
+
+### Service cmdlets
+
+- Add properties `UserName`, `Description`, `DelayedAutoStart`, `BinaryPathName`, and `StartupType`
+  to the `ServiceController` objects returned by `Get-Service`. (#4907) (Thanks
+  [@joandrsn](https://github.com/joandrsn))
+- Add functionality to set credentials on `Set-Service` command. (#4844) (Thanks
+  [@joandrsn](https://github.com/joandrsn))
+
+### Other cmdlets
+
+- Add a parameter to `Get-ChildItem` called `-FollowSymlink` that traverses symlinks on demand, with
+  checks for link loops. (#4020)
+- Update `Add-Type` to support `CSharpVersion7`. (#3933) (Thanks to
+  [@iSazonov](https://github.com/iSazonov))
+- Remove the `Microsoft.PowerShell.LocalAccounts` module due to the use of unsupported APIs until a
+  better solution is found. (#4302)
+- Remove the `*-Counter` cmdlets in `Microsoft.PowerShell.Diagnostics` due to the use of unsupported
+  APIs until a better solution is found. (#4303)
+- Add support for `Invoke-Item -Path <folder>`. (#4262)
+- Add `-Extension` and `-LeafBase` switches to `Split-Path` so that you can split paths between the
+  filename extension and the rest of the filename. (#2721) (Thanks to
+  [@powercode](https://github.com/powercode)!)
+- Add parameters `-Top` and `-Bottom` to `Sort-Object` for Top/Bottom N sort
+- Expose a process' parent process by adding the `CodeProperty "Parent"` to
+  `System.Diagnostics.Process`. (#2850) (Thanks to [@powercode](https://github.com/powercode)!)
+- Use MB instead of KB for memory columns of `Get-Process`
+- Add `-NoNewLine` switch for `Out-String`. (#5056) (Thanks
+  [@raghav710](https://github.com/raghav710))
+- `Move-Item` cmdlet honors `-Include`, `-Exclude`, and `-Filter` parameters. (#3878)
+- Allow `*` to be used in registry path for `Remove-Item`. (#4866)
+- Add `-Title` to `Get-Credential` and unify the prompt experience across platforms.
+- Add the `-TimeOut` parameter to `Test-Connection`. (#2492)
+- `Get-AuthenticodeSignature` cmdlets can now get file signature timestamp. (#4061)
+- Remove unsupported `-ShowWindow` switch from `Get-Help`. (#4903)
+- Fix `Get-Content -Delimiter` to not include the delimiter in the array elements returned (#3706)
+  (Thanks [@mklement0](https://github.com/mklement0))
+- Add `Meta`, `Charset`, and `Transitional` parameters to `ConvertTo-HTML` (#4184) (Thanks [@ergo3114](https://github.com/ergo3114))
+- Add `WindowsUBR` and `WindowsVersion` properties to `Get-ComputerInfo` result
+- Add `-Group` parameter to `Get-Verb`
+- Add `ShouldProcess` support to `New-FileCatalog` and `Test-FileCatalog` (fixes `-WhatIf` and
+  `-Confirm`). (#3074) (Thanks to [@iSazonov](https://github.com/iSazonov)!)
+- Add `-WhatIf` switch to `Start-Process` cmdlet (#4735) (Thanks
+  [@sarithsutha](https://github.com/sarithsutha))
+- Add `ValidateNotNullOrEmpty` too many existing parameters.
+
+## Tab completion
+
+- Enhanced the type inference in tab completion based on runtime variable values. (#2744) (Thanks to
+  [@powercode](https://github.com/powercode)!) This enables tab completion in situations like:
+
+  ```powershell
+  $p = Get-Process
+  $p | Foreach-Object Prio<tab>
+  ```
+
+- Add Hashtable tab completion for `-Property` of `Select-Object`. (#3625) (Thanks to
+  [@powercode](https://github.com/powercode))
+- Enable argument auto-completion for `-ExcludeProperty` and `-ExpandProperty` of `Select-Object`.
+  (#3443) (Thanks to [@iSazonov](https://github.com/iSazonov)!)
+- Fix a bug in tab completion to make `native.exe --<tab>` call into native completer. (#3633)
+  (Thanks to [@powercode](https://github.com/powercode)!)
+
+## Breaking changes
+
+We've introduced a number of breaking changes in PowerShell Core 6.0.
+To read more about them in detail, see [Breaking Changes in PowerShell Core 6.0][breaking-changes].
+
+## Debugging
+
+- Support for remote step-in debugging for `Invoke-Command -ComputerName`. (#3015)
+- Enable binder debug logging in PowerShell Core
+
+## Filesystem updates
+
+- Enable usage of the Filesystem provider from a UNC path. ($4998)
+- `Split-Path` now works with UNC roots
+- `cd` with no arguments now behaves as `cd ~`
+- Fixed PowerShell Core to allow use of paths that are more than 260 characters long. (#3960)
+
+## Bug fixes and performance improvements
+
+We've made *many* improvements to performance across PowerShell, including in startup time, various
+built-in cmdlets, and interaction with native binaries.
+
+We've also fixed a number of bugs within PowerShell Core. For a complete list of fixes and changes,
+check out our [changelog][] on GitHub.
+
+## Telemetry
+
+- PowerShell Core 6.0 added telemetry to the console host to report two values (#3620):
+  - the OS platform (`$PSVersionTable.OSDescription`)
+  - the exact version of PowerShell (`$PSVersionTable.GitCommitId`)
+
+If you want to opt-out of this telemetry, simply create `POWERSHELL_TELEMETRY_OPTOUT` environment
+variable with one of the following values: `true`, `1` or `yes`. Creating the variable bypasses all
+telemetry even before the first run of PowerShell. We also plan on exposing this telemetry data and
+the insights we glean from the telemetry in the [community dashboard][community-dashboard]. You can
+find out more about how we use this data in this [blog post][telemetry-blog].
+
+[.NET Blog]: https://devblogs.microsoft.com/dotnet/introducing-net-standard/
+[.NET Core 2.0]: /dotnet/core/
+[.NET Standard]: /dotnet/standard/net-standard
+[breaking-changes]: breaking-changes-ps6.md
+[CDXML]: /previous-versions/windows/desktop/wmi_v2/getting-started-with-cdxml
+[changelog]: https://github.com/PowerShell/PowerShell/tree/master/CHANGELOG.md
+[community-dashboard]: https://aka.ms/PSGitHubBI
+[docker-hub]: https://hub.docker.com/r/microsoft/powershell/
+[docker]: https://github.com/PowerShell/PowerShell/tree/master/docker
+[FAQ]: https://github.com/dotnet/standard/blob/master/docs/faq.md
+[github]: https://github.com/PowerShell/PowerShell
+[os_log]: https://developer.apple.com/documentation/os/logging
+[semi-annual]: /windows-server/get-started/semi-annual-channel-overview
+[ssh-remoting]: /powershell/scripting/learn/remoting/SSH-Remoting-in-PowerShell-Core
+[Syslog]: https://en.wikipedia.org/wiki/Syslog
+[telemetry-blog]: https://devblogs.microsoft.com/powershell/powershell-open-source-community-dashboard/
+[windowspsmodulepath]: https://www.powershellgallery.com/packages/WindowsPSModulePath/
+[YouTube]: https://www.youtube.com/watch?v=YI4MurjfMn8&list=PLRAdsfhKI4OWx321A_pr-7HhRNk7wOLLY

--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-61.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-61.md
@@ -1,0 +1,588 @@
+---
+title: What's New in PowerShell Core 6.1
+description: New features and changes released in PowerShell Core 6.1
+ms.date: 09/13/2018
+---
+
+# What's New in PowerShell Core 6.1
+
+Below is a selection of some of the major new features and changes that have been introduced in
+PowerShell Core 6.1.
+
+There's also **tons** of "boring stuff" that make PowerShell faster and more stable (plus lots and
+lots of bug fixes)! For a full list of changes, check out our
+[changelog on GitHub](https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG.md).
+
+And while we call out some names below, thank you to
+[all of the community contributors](https://github.com/PowerShell/PowerShell/graphs/contributors)
+that made this release possible.
+
+## .NET Core 2.1
+
+PowerShell Core 6.1 moved to .NET Core 2.1 after it was
+[released in May](https://devblogs.microsoft.com/dotnet/announcing-net-core-2-1/), resulting in a
+number of improvements to PowerShell, including:
+
+- performance improvements (see [below](#performance-improvements))
+- Alpine Linux support (preview)
+- [.NET global tool support](/dotnet/core/tools/global-tools) - coming soon to PowerShell
+- [`Span<T>`](/dotnet/api/system.span-1)
+
+## Windows Compatibility Pack for .NET Core
+
+On Windows, the .NET team shipped the
+[Windows Compatibility Pack for .NET Core](https://devblogs.microsoft.com/dotnet/announcing-the-windows-compatibility-pack-for-net-core/),
+a set of assemblies that add a number of removed APIs back to .NET Core on Windows.
+
+We've added the Windows Compatibility Pack to PowerShell Core 6.1 release so that any modules or
+scripts that use these APIs can rely on them being available.
+
+The Windows Compatibility Pack enables PowerShell Core to use **more than 1900 cmdlets that ship
+with Windows 10 October 2018 Update and Windows Server 2019**.
+
+## Support for Application allow lists
+
+PowerShell Core 6.1 has parity with Windows PowerShell 5.1 supporting
+[AppLocker](/windows/security/threat-protection/windows-defender-application-control/applocker/applocker-overview)
+and
+[Device Guard](/windows/security/threat-protection/device-guard/introduction-to-device-guard-virtualization-based-security-and-windows-defender-application-control)
+application allow lists. Application allow lists allow granular control of what binaries are
+allowed to be executed used with PowerShell
+[Constrained Language mode](https://devblogs.microsoft.com/powershell/powershell-constrained-language-mode/).
+
+## Performance improvements
+
+PowerShell Core 6.0 made some significant performance improvements. PowerShell Core 6.1 continues to
+improve the speed of certain operations.
+
+For example, `Group-Object` has been sped up by 66%:
+
+```powershell
+Measure-Command { 1..100000 | % {Get-Random -Minimum 1 -Maximum 10000} | Group-Object }
+```
+
+|    Metric    | Windows PowerShell 5.1 | PowerShell Core 6.0 | PowerShell Core 6.1 |
+| ------------ | ---------------------- | ------------------- | ------------------- |
+| Time (sec)   | 25.178                 | 19.653              | 6.641               |
+| Speed-up (%) | N/A                    | 21.9%               | 66.2%               |
+
+Similarly, sorting scenarios like this one have improved by more than 15%:
+
+```powershell
+Measure-Command { 1..100000 | % {Get-Random -Minimum 1 -Maximum 10000} | Sort-Object }
+```
+
+|    Metric    | Windows PowerShell 5.1 | PowerShell Core 6.0 | PowerShell Core 6.1 |
+| ------------ | ---------------------- | ------------------- | ------------------- |
+| Time (sec)   | 12.170                 | 8.493               | 7.08                |
+| Speed-up (%) | N/A                    | 30.2%               | 16.6%               |
+
+`Import-Csv` has also been sped up significantly after a regression from Windows PowerShell.
+The following example uses a test CSV with 26,616 rows and six columns:
+
+```powershell
+Measure-Command {$a = Import-Csv foo.csv}
+```
+
+|    Metric    | Windows PowerShell 5.1 | PowerShell Core 6.0 |  PowerShell Core 6.1   |
+| ------------ | ---------------------- | ------------------- | ---------------------- |
+| Time (sec)   | 0.441                  | 1.069               | 0.268                  |
+| Speed-up (%) | N/A                    | -142.4%             | 74.9% (39.2% from WPS) |
+
+Lastly, conversion from JSON into `PSObject` has been sped up by more than 50%
+since Windows PowerShell.
+The following example uses a ~2MB test JSON file:
+
+```powershell
+Measure-Command {Get-Content .\foo.json | ConvertFrom-Json}
+```
+
+|    Metric    | Windows PowerShell 5.1 | PowerShell Core 6.0 |  PowerShell Core 6.1   |
+| ------------ | ---------------------- | ------------------- | ---------------------- |
+| Time (sec)   | 0.259                  | 0.577               | 0.125                  |
+| Speed-up (%) | N/A                    | -122.8%             | 78.3% (51.7% from WPS) |
+
+## Check `system32` for compatible built-in modules on Windows
+
+In the Windows 10 1809 update and Windows Server 2019, we updated a number of built-in PowerShell
+modules to mark them as compatible with PowerShell Core.
+
+When PowerShell Core 6.1 starts up, it will automatically include `$windir\System32` as part of the
+`PSModulePath` environment variable. However, it only exposes modules to `Get-Module` and
+`Import-Module` if its `CompatiblePSEdition` is marked as compatible with `Core`.
+
+```powershell
+Get-Module -ListAvailable
+```
+
+> [!NOTE]
+> You may see different available modules depending on what roles and features are installed.
+
+```Output
+...
+    Directory: C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules
+
+ModuleType Version    Name                                PSEdition ExportedCommands
+---------- -------    ----                                --------- ----------------
+Manifest   2.0.1.0    Appx                                Core,Desk {Add-AppxPackage, Get-AppxPackage, Get-AppxPacka...
+Manifest   1.0.0.0    BitLocker                           Core,Desk {Unlock-BitLocker, Suspend-BitLocker, Resume-Bit...
+Manifest   1.0.0.0    DnsClient                           Core,Desk {Resolve-DnsName, Clear-DnsClientCache, Get-DnsC...
+Manifest   1.0.0.0    HgsDiagnostics                      Core,Desk {New-HgsTraceTarget, Get-HgsTrace, Get-HgsTraceF...
+Binary     2.0.0.0    Hyper-V                             Core,Desk {Add-VMAssignableDevice, Add-VMDvdDrive, Add-VMF...
+Binary     1.1        Hyper-V                             Core,Desk {Add-VMDvdDrive, Add-VMFibreChannelHba, Add-VMHa...
+Manifest   2.0.0.0    NetAdapter                          Core,Desk {Disable-NetAdapter, Disable-NetAdapterBinding, ...
+Manifest   1.0.0.0    NetEventPacketCapture               Core,Desk {New-NetEventSession, Remove-NetEventSession, Ge...
+Manifest   2.0.0.0    NetLbfo                             Core,Desk {Add-NetLbfoTeamMember, Add-NetLbfoTeamNic, Get-...
+Manifest   1.0.0.0    NetNat                              Core,Desk {Get-NetNat, Get-NetNatExternalAddress, Get-NetN...
+Manifest   2.0.0.0    NetQos                              Core,Desk {Get-NetQosPolicy, Set-NetQosPolicy, Remove-NetQ...
+Manifest   2.0.0.0    NetSecurity                         Core,Desk {Get-DAPolicyChange, New-NetIPsecAuthProposal, N...
+Manifest   1.0.0.0    NetSwitchTeam                       Core,Desk {New-NetSwitchTeam, Remove-NetSwitchTeam, Get-Ne...
+Manifest   1.0.0.0    NetWNV                              Core,Desk {Get-NetVirtualizationProviderAddress, Get-NetVi...
+Manifest   2.0.0.0    TrustedPlatformModule               Core,Desk {Get-Tpm, Initialize-Tpm, Clear-Tpm, Unblock-Tpm...
+...
+```
+
+You can override this behavior to show all modules using the `-SkipEditionCheck` switch parameter.
+We've also added a `PSEdition` property to the table output.
+
+```powershell
+Get-Module Net* -ListAvailable -SkipEditionCheck
+```
+
+```Output
+    Directory: C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules
+
+ModuleType Version    Name                        PSEdition ExportedCommands
+---------- -------    ----                        --------- ----------------
+Manifest   2.0.0.0    NetAdapter                  Core,Desk {Disable-NetAdapter, Disable-NetAdapterBinding, ...
+Manifest   1.0.0.0    NetConnection               Core,Desk {Get-NetConnectionProfile, Set-NetConnectionProf...
+Manifest   1.0.0.0    NetDiagnostics              Desk      Get-NetView
+Manifest   1.0.0.0    NetEventPacketCapture       Core,Desk {New-NetEventSession, Remove-NetEventSession, Ge...
+Manifest   2.0.0.0    NetLbfo                     Core,Desk {Add-NetLbfoTeamMember, Add-NetLbfoTeamNic, Get-...
+Manifest   1.0.0.0    NetNat                      Core,Desk {Get-NetNat, Get-NetNatExternalAddress, Get-NetN...
+Manifest   2.0.0.0    NetQos                      Core,Desk {Get-NetQosPolicy, Set-NetQosPolicy, Remove-NetQ...
+Manifest   2.0.0.0    NetSecurity                 Core,Desk {Get-DAPolicyChange, New-NetIPsecAuthProposal, N...
+Manifest   1.0.0.0    NetSwitchTeam               Core,Desk {New-NetSwitchTeam, Remove-NetSwitchTeam, Get-Ne...
+Manifest   1.0.0.0    NetTCPIP                    Core,Desk {Get-NetIPAddress, Get-NetIPInterface, Get-NetIP...
+Manifest   1.0.0.0    NetWNV                      Core,Desk {Get-NetVirtualizationProviderAddress, Get-NetVi...
+Manifest   1.0.0.0    NetworkConnectivityStatus   Core,Desk {Get-DAConnectionStatus, Get-NCSIPolicyConfigura...
+Manifest   1.0.0.0    NetworkSwitchManager        Core,Desk {Disable-NetworkSwitchEthernetPort, Enable-Netwo...
+Manifest   1.0.0.0    NetworkTransition           Core,Desk {Add-NetIPHttpsCertBinding, Disable-NetDnsTransi...
+```
+
+For more information about this behavior, check out
+[PowerShell RFC0025](https://github.com/PowerShell/PowerShell-RFC/blob/master/5-Final/RFC0025-PSCore6-and-Windows-Modules.md).
+
+## Markdown cmdlets and rendering
+
+Markdown is a standard for creating readable plaintext documents with basic formatting that can be
+rendered into HTML.
+
+We've added some cmdlets in 6.1 that allow you to convert and render Markdown documents in the
+console, including:
+
+- `ConvertFrom-Markdown`
+- `Get-MarkdownOption`
+- `Set-MarkdownOption`
+- `Show-Markdown`
+
+For example, `Show-Markdown` renders a Markdown file in the console:
+
+![Show-Markdown example](media/What-s-New-in-PowerShell-Core-61/markdown_example.png)
+
+For more information about how these cmdlets work, check out
+[this RFC](https://github.com/PowerShell/PowerShell-RFC/blob/master/5-Final/RFC0025-Native-Markdown-Rendering.md).
+
+## Experimental feature flags
+
+We enabled support for [Experimental Features][]. This allows PowerShell developers to deliver new
+features and get feedback before the design is complete. This way we avoid making breaking changes
+as the design evolves.
+
+Use `Get-ExperimentalFeature` to get a list of available experimental features. You can enable or
+disable these features with `Enable-ExperimentalFeature` and `Disable-ExperimentalFeature`.
+
+You can learn more about this feature in
+[PowerShell RFC0029](https://github.com/PowerShell/PowerShell-RFC/blob/master/5-Final/RFC0029-Support-Experimental-Features.md).
+
+## Web cmdlet improvements
+
+Thanks to [@markekraus](https://github.com/markekraus), a whole slew of improvements have been made to our web cmdlets:
+[`Invoke-WebRequest`](/powershell/module/microsoft.powershell.utility/invoke-webrequest)
+and [`Invoke-RestMethod`](/powershell/module/microsoft.powershell.utility/invoke-restmethod).
+
+- [PR #6109](https://github.com/PowerShell/PowerShell/pull/6109) - default encoding set to UTF-8 for
+  `application-json` responses
+- [PR #6018](https://github.com/PowerShell/PowerShell/pull/6018) - `-SkipHeaderValidation` parameter
+  to allow `Content-Type` headers that aren't standards-compliant
+- [PR #5972](https://github.com/PowerShell/PowerShell/pull/5972) - `Form` parameter to support
+  simplified `multipart/form-data` support
+- [PR #6338](https://github.com/PowerShell/PowerShell/pull/6338) - Compliant, case-insensitive
+  handling of relation keys
+- [PR #6447](https://github.com/PowerShell/PowerShell/pull/6447) - Add `-Resume` parameter for web
+  cmdlets
+
+## Remoting improvements
+
+### PowerShell Direct for Containers tries to use PowerShell Core first
+
+[PowerShell Direct](/virtualization/hyper-v-on-windows/user-guide/powershell-direct) is a feature of
+PowerShell and Hyper-V that allows you to connect to a Hyper-V VM or Container without network
+connectivity or other remote management services.
+
+In the past, PowerShell Direct connected using the built-in Windows PowerShell instance on the
+Container. Now, PowerShell Direct first attempts to connect using any available `pwsh.exe` on the
+`PATH` environment variable. If `pwsh.exe` isn't available, PowerShell Direct falls back to use
+`powershell.exe`.
+
+### `Enable-PSRemoting` now creates separate remoting endpoints for preview versions
+
+`Enable-PSRemoting` now creates two remoting session configurations:
+
+- One for the major version of PowerShell. For example, `PowerShell.6`. This endpoint that can be
+  relied upon across minor version updates as the "system-wide" PowerShell 6 session configuration
+- One version-specific session configuration, for example: `PowerShell.6.1.0`
+
+This behavior is useful if you want to have multiple PowerShell 6 versions installed and accessible
+on the same machine.
+
+Additionally, preview versions of PowerShell now get their own
+remoting session configurations after running the `Enable-PSRemoting` cmdlet:
+
+```powershell
+C:\WINDOWS\system32> Enable-PSRemoting
+```
+
+Your output may be different if you haven't set up WinRM before.
+
+```Output
+WinRM is already set up to receive requests on this computer.
+WinRM is already set up for remote management on this computer.
+```
+
+Then you can see separate PowerShell session configurations for the preview and stable builds of
+PowerShell 6, and for each specific version.
+
+```powershell
+Get-PSSessionConfiguration
+```
+
+```Output
+Name          : PowerShell.6.2-preview.1
+PSVersion     : 6.2
+StartupScript :
+RunAsUser     :
+Permission    : NT AUTHORITY\INTERACTIVE AccessAllowed, BUILTIN\Administrators AccessAllowed, BUILTIN\Remote Management Users AccessAllowed
+
+Name          : PowerShell.6-preview
+PSVersion     : 6.2
+StartupScript :
+RunAsUser     :
+Permission    : NT AUTHORITY\INTERACTIVE AccessAllowed, BUILTIN\Administrators AccessAllowed, BUILTIN\Remote Management Users AccessAllowed
+
+Name          : powershell.6
+PSVersion     : 6.1
+StartupScript :
+RunAsUser     :
+Permission    : NT AUTHORITY\INTERACTIVE AccessAllowed, BUILTIN\Administrators AccessAllowed, BUILTIN\Remote Management Users AccessAllowed
+
+Name          : powershell.6.1.0
+PSVersion     : 6.1
+StartupScript :
+RunAsUser     :
+Permission    : NT AUTHORITY\INTERACTIVE AccessAllowed, BUILTIN\Administrators AccessAllowed, BUILTIN\Remote Management Users AccessAllowed
+```
+
+### `user@host:port` syntax supported for SSH
+
+SSH clients typically support a connection string in the format `user@host:port`. With the addition
+of SSH as a protocol for PowerShell Remoting, we've added support for this format of connection
+string:
+
+`Enter-PSSession -HostName fooUser@ssh.contoso.com:2222`
+
+## MSI option to add explorer shell context menu on Windows
+
+Thanks to [@bergmeister](https://github.com/bergmeister), now you can enable a context menu on
+Windows. Now you can open your system-wide installation of PowerShell 6.1 from any folder in the
+Windows Explorer:
+
+![Shell context menu for PowerShell 6](media/What-s-New-in-PowerShell-Core-61/shell_context_menu.png)
+
+## Goodies
+
+### "Run as Administrator" in the Windows shortcut jump list
+
+Thanks to [@bergmeister](https://github.com/bergmeister), the PowerShell Core shortcut's jump list
+now includes "Run as Administrator":
+
+![Run as administrator in the PowerShell 6 jump list](media/What-s-New-in-PowerShell-Core-61/jumplist.png)
+
+### `cd -` returns to previous directory
+
+```powershell
+C:\Windows\System32> cd C:\
+C:\> cd -
+C:\Windows\System32>
+```
+
+Or on Linux:
+
+```ShellSession
+PS /etc> cd /usr/bin
+PS /usr/bin> cd -
+PS /etc>
+```
+
+Also, `cd` and `cd --` change to `$HOME`.
+
+### `Test-Connection`
+
+Thanks to [@iSazonov](https://github.com/iSazonov), the
+[`Test-Connection`](/powershell/module/microsoft.powershell.management/test-connection) cmdlet has
+been ported to PowerShell Core.
+
+### `Update-Help` as non-admin
+
+By popular demand, `Update-Help` no longer needs to be run as an administrator. `Update-Help` now
+defaults to saving help to a user-scoped folder.
+
+### New methods/properties on `PSCustomObject`
+
+Thanks to [@iSazonov](https://github.com/iSazonov), we've added new methods and properties to
+`PSCustomObject`. `PSCustomObject` now includes a `Count`/`Length` property like other objects.
+
+```powershell
+$PSCustomObject = [pscustomobject]@{foo = 1}
+
+$PSCustomObject.Length
+```
+
+```Output
+1
+```
+
+```powershell
+$PSCustomObject.Count
+```
+
+```Output
+1
+```
+
+This work also includes `ForEach` and `Where` methods that allow you to operate and filter on
+`PSCustomObject` items:
+
+```powershell
+$PSCustomObject.ForEach({$_.foo + 1})
+```
+
+```Output
+2
+```
+
+```powershell
+$PSCustomObject.Where({$_.foo -gt 0})
+```
+
+```Output
+foo
+---
+  1
+```
+
+### `Where-Object -Not`
+
+Thanks to @SimonWahlin, we've added the `-Not` parameter to `Where-Object`. Now you can filter an
+object at the pipeline for the non-existence of a property, or a null/empty property value.
+
+For example, this command returns all services that don't have any dependent services defined:
+
+```powershell
+Get-Service | Where-Object -Not DependentServices
+```
+
+### `New-ModuleManifest` creates a BOM-less UTF-8 document
+
+Given our move to BOM-less UTF-8 in PowerShell 6.0, we've updated the `New-ModuleManifest` cmdlet to
+create a BOM-less UTF-8 document instead of a UTF-16 one.
+
+### Conversions from PSMethod to Delegate
+
+Thanks to [@powercode](https://github.com/powercode), we now support the conversion of a `PSMethod`
+into a delegate. This allows you to do things like passing `PSMethod` `[M]::DoubleStrLen` as a
+delegate value into `[M]::AggregateString`:
+
+```powershell
+class M {
+    static [int] DoubleStrLen([string] $value) { return 2 * $value.Length }
+
+    static [long] AggregateString([string[]] $values, [func[string, int]] $selector) {
+        [long] $res = 0
+        foreach($s in $values){
+            $res += $selector.Invoke($s)
+        }
+        return $res
+    }
+}
+
+[M]::AggregateString((gci).Name, [M]::DoubleStrLen)
+```
+
+For more info on this change, check out [PR #5287](https://github.com/PowerShell/PowerShell/pull/5287).
+
+### Standard deviation in `Measure-Object`
+
+Thanks to [@CloudyDino](https://github.com/CloudyDino), we've added a `StandardDeviation` property
+to `Measure-Object`:
+
+```powershell
+Get-Process | Measure-Object -Property CPU -AllStats
+```
+
+```Output
+Count             : 308
+Average           : 31.3720576298701
+Sum               : 9662.59375
+Maximum           : 4416.046875
+Minimum           :
+StandardDeviation : 264.389544720926
+Property          : CPU
+```
+
+### `GetPfxCertificate -Password`
+
+Thanks to [@maybe-hello-world](https://github.com/maybe-hello-world), `Get-PfxCertificate` now has
+the `Password` parameter, which takes a `SecureString`. This allows you to use it non-interactively:
+
+```powershell
+$certFile = '\\server\share\pwd-protected.pfx'
+$certPass = Read-Host -AsSecureString -Prompt 'Enter the password for certificate: '
+
+$certThumbPrint = (Get-PfxCertificate -FilePath $certFile -Password $certPass ).ThumbPrint
+```
+
+### Removal of the `more` function
+
+In the past, PowerShell shipped a function on Windows called `more` that wrapped `more.com`. That
+function has now been removed.
+
+Also, the `help` function changed to use `more.com` on Windows, or the system's default pager
+specified by `$env:PAGER` on non-Windows platforms.
+
+### `cd DriveName:` now returns users to the current working directory in that drive
+
+Previously, using `Set-Location` or `cd` to return to a PSDrive sent users
+to the default location for that drive.
+
+Thanks to [@mcbobke](https://github.com/mcbobke), users are now sent to the last known current
+working directory for that session.
+
+### Windows PowerShell type accelerators
+
+In Windows PowerShell, we included the following type accelerators to make it easier to work with
+their respective types:
+
+- `[adsi]`: `System.DirectoryServices.DirectoryEntry`
+- `[adsisearcher]`: `System.DirectoryServices.DirectorySearcher`
+- `[wmi]`: `System.Management.ManagementObject`
+- `[wmiclass]`: `System.Management.ManagementClass`
+- `[wmisearcher]`: `System.Management.ManagementObjectSearcher`
+
+These type accelerators were not included in PowerShell 6, but have been added to PowerShell 6.1
+running on Windows.
+
+These types are useful in easily constructing AD and WMI objects.
+
+For example, you can query using LDAP:
+
+```powershell
+[adsi]'LDAP://CN=FooUse,OU=People,DC=contoso,DC=com'
+```
+
+Following example creates a Win32_OperatingSystem CIM object:
+
+```powershell
+[wmi]"Win32_OperatingSystem=@"
+```
+
+```Output
+SystemDirectory : C:\WINDOWS\system32
+Organization    : Contoso IT
+BuildNumber     : 18234
+RegisteredUser  : Contoso Corp.
+SerialNumber    : 12345-67890-ABCDE-F0123
+Version         : 10.0.18234
+```
+
+This example returns a ManagementClass object for Win32_OperatingSystem class.
+
+```powershell
+[wmiclass]"Win32_OperatingSystem"
+```
+
+```Output
+   NameSpace: ROOT\cimv2
+
+Name                                Methods              Properties
+----                                -------              ----------
+Win32_OperatingSystem               {Reboot, Shutdown... {BootDevice, BuildNumber, BuildType, Caption...}
+```
+
+### `-lp` alias for all `-LiteralPath` parameters
+
+Thanks to [@kvprasoon](https://github.com/kvprasoon), we now have a parameter alias `-lp` for all
+the built-in PowerShell cmdlets that have a `-LiteralPath` parameter.
+
+## Breaking Changes
+
+### MSI-based installation paths on Windows
+
+On Windows, the MSI package now installs to the following path:
+
+- `$env:ProgramFiles\PowerShell\6\` for the stable installation of 6.x
+- `$env:ProgramFiles\PowerShell\6-preview\` for the preview installation of 6.x
+
+This change ensures that PowerShell Core can be updated/serviced by Microsoft Update.
+
+For more information, check out
+[PowerShell RFC0026](https://github.com/PowerShell/PowerShell-RFC/blob/master/5-Final/RFC0026-MSI-Installation-Path.md).
+
+### Telemetry can only be disabled with an environment variable
+
+PowerShell Core sends basic telemetry data to Microsoft when it is launched. The data includes the
+OS name, OS version, and PowerShell version. This data allows us to better understand the
+environments where PowerShell is used and enables us to prioritize new features and fixes.
+
+To opt-out of this telemetry, set the environment variable `POWERSHELL_TELEMETRY_OPTOUT` to `true`,
+`yes`, or `1`. We no longer support deletion of the file
+`DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY` to disable telemetry.
+
+### Disallowed Basic Auth over HTTP in PowerShell Remoting on Unix platforms
+
+To prevent the use of unencrypted traffic, PowerShell Remoting on Unix platforms now requires usage
+of NTLM/Negotiate or HTTPS.
+
+For more information on these changes, check out [Issue #6779](https://github.com/PowerShell/PowerShell/issues/6779).
+
+### Removed `VisualBasic` as a supported language in Add-Type
+
+In the past, you could compile Visual Basic code using the `Add-Type` cmdlet. Visual Basic was
+rarely used with `Add-Type`. We removed this feature to reduce the size of PowerShell.
+
+### Cleaned up uses of `CommandTypes.Workflow` and `WorkflowInfoCleaned`
+
+For more information on these changes, check out
+[PR #6708](https://github.com/PowerShell/PowerShell/pull/6708).
+
+### Group-Object now sorts the groups
+
+As part of the performance improvement, `Group-Object` now returns a sorted listing of the groups.
+Although you should not rely on the order, you could be broken by this change if you wanted the
+first group. We decided that this performance improvement was worth the change since the impact of
+being dependent on previous behavior is low.
+
+For more information on this change, see [Issue #7409](https://github.com/PowerShell/PowerShell/issues/7409).
+
+<!-- URL references -->
+[Experimental Features]: /powershell/module/Microsoft.PowerShell.Core/About/about_Experimental_Features

--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-62.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-62.md
@@ -1,0 +1,233 @@
+---
+title: What's New in PowerShell Core 6.2
+description: New features and changes released in PowerShell Core 6.2
+ms.date: 03/28/2019
+---
+
+# What's New in PowerShell Core 6.2
+
+The PowerShell Core 6.2 release focused on performance improvements, bug fixes, and smaller cmdlet
+and language enhancements that improve the quality. To see a full list of improvements, check out
+our detailed [changelogs](https://github.com/PowerShell/PowerShell/releases) on GitHub.
+
+## Experimental Features
+
+Previously, we enabled support for [Experimental Features][]. In the 6.2 release, we have four
+experimental features to try out. Please provide feedback so we can make improvements and to decide
+whether the feature is worth promoting to mainstream status.
+
+Use `Get-ExperimentalFeature` to get a list of available experimental features. You can enable or
+disable these features with `Enable-ExperimentalFeature` and `Disable-ExperimentalFeature`.
+
+### Command Not Found Suggestions
+
+This feature uses fuzzy matching to find suggestions for commands or cmdlets you may have mistyped.
+
+```powershell
+Enable-ExperimentalFeature -Name PSCommandNotFoundSuggestion
+```
+
+#### Example
+
+In this example, the misspelled cmdlet name is fuzzy matched to several suggestions from most likely
+to least likely.
+
+```powershell
+Get-Commnd
+```
+
+```Output
+Get-Commnd : The term 'Get-Commnd' is not recognized as the name of a cmdlet, function, script file, or operable program.
+Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
+At line:1 char:1
++ Get-Commnd
++ ~~~~~~~~~~
++ CategoryInfo          : ObjectNotFound: (Get-Commnd:String) [], CommandNotFoundException
++ FullyQualifiedErrorId : CommandNotFoundException
+
+
+Suggestion [4,General]: The most similar commands are: Get-Command, Get-Content, Get-Job, Get-Module, Get-Event, Get-Host, Get-Member, Get-Item, Set-Content.
+```
+
+### Implicit Remoting Batching
+
+When using [implicit remoting](https://devblogs.microsoft.com/scripting/remoting-the-implicit-way/)
+in a pipeline, PowerShell treats each command in the pipeline independently. Objects are repeatedly
+serialized and `de-serialized` between the client and remote system over the execution of the
+pipeline.
+
+With this feature, PowerShell analyzes the pipeline to determine if the command is safe to run and
+it exists on the target system. When true, PowerShell executes the entire pipeline remotely and only
+serializes and `de-serializes` the results back to the client.
+
+```powershell
+Enable-ExperimentalFeature -Name PSImplicitRemotingBatching
+```
+
+A real-world test of `Get-Process | Sort-Object` over localhost decreases from 10-15 seconds to
+20-30 **milliseconds**. The feature only needs to be enabled on the client. No changes are required
+on the server.
+
+### Temp Drive
+
+```powershell
+Enable-ExperimentalFeature -Name PSTempDrive
+```
+
+If you're using PowerShell Core on different operating systems, you'll discover that the environment
+variable for finding the temporary directory is different on Windows, macOS, and Linux! With this
+feature, you get a [PSDrive][] called `Temp:` that is automatically mapped to the temporary folder
+for the operating system you are using.
+
+#### Example
+
+```powershell
+PS> "Hello World!" > Temp:/hello.txt
+PS> Get-Content Temp:/hello.txt
+Hello World!
+```
+
+Be aware that native file commands (like `ls` on Linux) are not aware of PSDrives and won't see this
+`Temp:` drive.
+
+### Abbreviation Expansion
+
+PowerShell cmdlets are expected to have descriptive nouns. This results in long names that are more
+difficult to type. This feature allows you to just type the uppercase characters of the cmdlet and
+use tab-completion to find a match.
+
+```powershell
+Enable-ExperimentalFeature -Name PSUseAbbreviationExpansion
+```
+
+#### Example
+
+```powershell
+PS> i-arsavsf
+```
+
+If you hit tab, and have the Azure PowerShell [Az](https://www.powershellgallery.com/packages/Az)
+module installed, it will autocomplete to:
+
+```Output
+PS> Import-AzRecoveryServicesAsrVaultSettingsFile
+```
+
+> [!NOTE]
+> This feature is intended to be used interactively. Abbreviated forms of cmdlets can't be executed.
+> This feature is not a replacement for aliases.
+
+## Breaking Changes
+
+- Fix `-NoEnumerate` behavior in `Write-Output` to be consistent with Windows PowerShell. (#9069)
+- Make `Join-String -InputObject 1,2,3` result equal to `1,2,3 | Join-String` result (#8611) (Thanks
+  @sethvs!)
+- Add `-Stable` to `Sort-Object` and related tests (#7862) (Thanks @KirkMunro!)
+- Improve `Start-Sleep` cmdlet to accept fractional seconds (#8537) (Thanks @Prototyyppi!)
+- Change hashtable to use OrdinalIgnoreCase to be `case-insensitive` in all Cultures (#8566)
+- Fix **LiteralPath** in `Import-Csv` to bind to `Get-ChildItem` output (#8277) (Thanks @iSazonov!)
+- No longer skips a column without name if double quote delimiter is used in `Import-Csv` (#7899)
+  (Thanks @Topping!)
+- `Get-ExperimentalFeature` no longer has `-ListAvailable` switch (#8318)
+- Debug parameter now sets `$DebugPreference` to **Continue** instead of **Inquire** (#8195) (Thanks
+  @KirkMunro!)
+- Honor `-OutputFormat` if specified in non-interactive, redirected, encoded command used with pwsh
+  (#8115)
+- Load assembly from module base path before trying to load from the GAC (#8073)
+- Remove tilde from Linux preview packages (#8244)
+- Move processing of `-WorkingDirectory` before processing of profiles (#8079)
+- Do not add `PATHEXT` environment variable on Unix (#7697) (Thanks @iSazonov!)
+
+## Known Issues
+
+- Remoting on Windows IOT ARM platforms has an issue loading modules. See (#8053)
+
+## General Updates and Fixes
+
+- Enable case-insensitive tab completion for files and folders on case-sensitive filesystem (#8128)
+- Make PSVersionInfo.PSVersion and PSVersionInfo.PSEdition public (#8054) (Thanks @KirkMunro!)
+- Add Type Inference for `$_` / `$PSItem` in `catch{ }` blocks (#8020) (Thanks @vexx32!)
+- Fix static method invocation type inference (#8018) (Thanks @SeeminglyScience!)
+- Create inferred types for `Select-Object`, `Group-Object`, **PSObject** and **Hashtable** (#7231)
+  (Thanks @powercode!)
+- Support calling method with `ByRef-like` type parameters (#7721)
+- Handle the case where the Windows PowerShell module path is already in the environment's
+  PSModulePath (#7727)
+- Enable `SecureString` cmdlets for non-Windows by storing the plain text (#9199)
+- Improve error message on non-Windows when importing clixml with securestring (#7997)
+- Adding parameter ReplyTo to `Send-MailMessage` (#8727) (Thanks @replicaJunction!)
+- Add Obsolete message to `Send-MailMessage` (#9178)
+- Fix `Restart-Computer` to work on `localhost` when WinRM is not present (#9160)
+- Make `Start-Job` throw terminating error when PowerShell is being hosted (#9128)
+- Add C# style type accelerators and suffixes for ushort, uint, ulong, and short literals (#7813)
+  (Thanks @vexx32!)
+- Added new suffixes for numeric literals - see [about_Numeric_Literals][] (#7901) (Thanks @vexx32!)
+- Correctly Report impact level when SupportsShouldProcess is not set to 'true' (#8209) (Thanks
+  @vexx32!)
+- Fix Request Charset Issues in Web Cmdlets (#8742) (Thanks @markekraus!)
+- Fix Expect `100-continue` issue with Web Cmdlets (#8679) (Thanks @markekraus!)
+- Fix file blocking issue with web cmdlets (#7676) (Thanks @Claustn!)
+- Fix code page parsing issue in `Invoke-RestMethod` (#8694) (Thanks @markekraus!)
+- Refactor `ConvertTo-Json` to expose JsonObject.ConvertToJson as a public API (#8682)
+- Add configurable maximum depth in `ConvertFrom-Json` with -Depth (#8199) (Thanks @louistio!)
+- Add EscapeHandling parameter in `ConvertTo-Json` cmdlet (#7775) (Thanks @iSazonov!)
+- Add `-CustomPipeName` to pwsh and `Enter-PSHostProcess` (#8889)
+- Enable creating relative symbolic links on Windows with `New-Item` (#8783)
+- Allow Windows users in developer mode to create symlinks without elevation (#8534)
+- Enable `Write-Information` to accept `$null` (#8774)
+- Fix `Get-Help` for advanced functions with MAML help content (#8353)
+- Fix `Get-Help` PSTypeName issue with -Parameter when only one parameter is declared (#8754)
+  (Thanks @pougetat!)
+- Token calculation fix for `Get-Help` executed on ScriptBlock for comment help. (#8238) (Thanks
+  @hubuk!)
+- Change `Get-Help` cmdlet -Parameter parameter so it accepts string arrays (#8454) (Thanks
+  @sethvs!)
+- Resolve PAGER if its path contains spaces (#8571) (Thanks @pougetat!)
+- Add prompt to the use of `less` in the function 'help' to instruct user how to quit (#7998)
+- Add support enum and char types in `Format-Hex` cmdlet (#8191) (Thanks @iSazonov!)
+- Remove ShouldProcess from `Format-Hex` (#8178)
+- Add new Offset and Count parameters to `Format-Hex` and refactor the cmdlet (#7877) (Thanks
+  @iSazonov!)
+- Allow 'name' as an alias key for 'label' in `ConvertTo-Html`, allow the 'width' entry to be an
+  integer (#8426) (Thanks @mklement0!)
+- Make scriptblock based calculated properties work again in `ConvertTo-Html` (#8427) (Thanks
+  @mklement0!)
+- Add cmdlet `Join-String` for creating text from pipeline input (#7660) (Thanks @powercode!)
+- Fix `Join-String` cmdlet FormatString parameter logic (#8449) (Thanks @sethvs!)
+- Change `Clear-Host` back to using `$RAWUI` and clear to work over remoting (#8609)
+- Change `Clear-Host` to simply called `[console]::clear` and remove clear alias from Unix (#8603)
+- Fix LiteralPath in `Import-Csv` to bind to `Get-ChildItem` output (#8277) (Thanks @iSazonov!)
+- help function shouldn't use pager for AliasHelpInfo (#8552)
+- Add `-UseMinimalHeader` to `Start-Transcript` to minimize transcript header (#8402) (Thanks
+  @lukexjeremy!)
+- Add `Enable-ExperimentalFeature` and `Disable-ExperimentalFeature` cmdlets (#8318)
+- Expose all cmdlets from **PSDiagnostics** if logman.exe is available (#8366)
+- Remove **Persist** parameter from `New-PSDrive` on `non-Windows` platform (#8291) (Thanks
+  @lukexjeremy!)
+- Add support for `cd +` (#7206) (Thanks @bergmeister!)
+- Enable `Set-Location -LiteralPath` to work with folders named - and + (#8089)
+- `Test-Path` returns `$false` when given an empty or `$null` path value (#8080) (Thanks @vexx32!)
+- Allow dynamic parameter to be returned even if path does not match any provider (#7957)
+- Support `Get-PSHostProcessInfo` and `Enter-PSHostProcess` on Unix platforms (#8232)
+- Reduce allocations in `Get-Content` cmdlet (#8103) (Thanks @iSazonov!)
+- Enable `Add-Content` to share read access with other tools while writing content (#8091)
+- `Get/Add-Content` throws improved error when targeting a container (#7823) (Thanks @kvprasoon!)
+- Add `-Name`, `-NoUserOverrides` and `-ListAvailable` parameters to `Get-Culture` cmdlet (#7702)
+  (Thanks @iSazonov!)
+- Add unified attribute for completion for **Encoding** parameter. (#7732) (Thanks @ThreeFive-O!)
+- Allow numeric Ids and name of registered code pages in **Encoding** parameters (#7636) (Thanks
+  @iSazonov!)
+- Fix `Rename-Item -Path` with wildcard char (#7398) (Thanks @kwkam!)
+- When using `Start-Transcript` and file exists, empty file rather than deleting (#8131) (Thanks
+  @paalbra!)
+- Make `Add-Type` open source files with **FileAccess.Read** and **FileShare.Read** explicitly
+  (#7915) (Thanks @IISResetMe!)
+- Fix `Enter-PSSession -ContainerId` for the latest Windows (#7883)
+- Ensure **NestedModules** property gets populated by `Test-ModuleManifest` (#7859)
+- Add `%F` case to `Get-Date` -UFormat (#7630) (Thanks @britishben!)
+- Fix `Set-Service -Status Stopped` to stop services with dependencies (#5525) (Thanks @zhenggu!)
+
+<!-- Link references -->
+[about_Numeric_Literals]: /powershell/module/Microsoft.PowerShell.Core/About/about_numeric_literals
+[Experimental Features]: /powershell/module/Microsoft.PowerShell.Core/About/about_Experimental_Features
+[PSDrive]: /powershell/module/microsoft.powershell.management/new-psdrive

--- a/reference/docs-conceptual/whats-new/breaking-changes-ps6.md
+++ b/reference/docs-conceptual/whats-new/breaking-changes-ps6.md
@@ -1,0 +1,462 @@
+---
+ms.date: 02/03/2020
+keywords:  powershell,core
+title:  Breaking Changes for PowerShell 6.0
+description: This article summarizes the differences between Windows PowerShell 5.1 and PowerShell 6.0.
+---
+
+# Breaking Changes for PowerShell 6.x
+
+## Features no longer available in PowerShell Core
+
+### Modules not shipped for PowerShell 6.x
+
+For various compatibility reasons, the following modules are not included in PowerShell 6.
+
+- ISE
+- Microsoft.PowerShell.LocalAccounts
+- Microsoft.PowerShell.ODataUtils
+- Microsoft.PowerShell.Operation.Validation
+- PSScheduledJob
+- PSWorkflow
+- PSWorkflowUtility
+
+### PowerShell Workflow
+
+[PowerShell Workflow][workflow] is a feature in Windows PowerShell that builds on top of
+[Windows Workflow Foundation (WF)][workflow-foundation] that enables the creation of robust runbooks
+for long-running or parallelized tasks.
+
+Due to the lack of support for Windows Workflow Foundation in .NET Core, we are not supporting
+PowerShell Workflow in PowerShell Core.
+
+In the future, we would like to enable native parallelism/concurrency in the PowerShell language
+without the need for PowerShell Workflow.
+
+If there is a need to use checkpoints to resume a script after the OS restarts, we recommend
+using Task Scheduler to run a script on OS startup, but the script would need to maintain
+its own state (like persisting it to a file).
+
+[workflow]: /previous-versions/powershell/scripting/components/workflows-guide
+[workflow-foundation]: /dotnet/framework/windows-workflow-foundation/
+
+### Custom snap-ins
+
+[PowerShell snap-ins][snapin] are a predecessor to PowerShell modules that do not have widespread
+adoption in the PowerShell community.
+
+Due to the complexity of supporting snap-ins and their lack of usage in the community, we no longer
+support custom snap-ins in PowerShell Core.
+
+Today, this breaks the `ActiveDirectory` and `DnsClient` modules in Windows and Windows Server.
+
+[snapin]: /powershell/module/microsoft.powershell.core/about/about_pssnapins
+
+### WMI v1 cmdlets
+
+Due to the complexity of supporting two sets of WMI-based modules, we removed the WMI v1 cmdlets
+from PowerShell Core:
+
+- `Register-WmiEvent`
+- `Set-WmiInstance`
+- `Invoke-WmiMethod`
+- `Get-WmiObject`
+- `Remove-WmiObject`
+
+Instead, we recommend that you the use the CIM (aka WMI v2) cmdlets which provide the same
+functionality with new functionality and a redesigned syntax:
+
+- `Get-CimAssociatedInstance`
+- `Get-CimClass`
+- `Get-CimInstance`
+- `Get-CimSession`
+- `Invoke-CimMethod`
+- `New-CimInstance`
+- `New-CimSession`
+- `New-CimSessionOption`
+- `Register-CimIndicationEvent`
+- `Remove-CimInstance`
+- `Remove-CimSession`
+- `Set-CimInstance`
+
+### Microsoft.PowerShell.LocalAccounts
+
+Due to the use of unsupported APIs, `Microsoft.PowerShell.LocalAccounts` has been removed from
+PowerShell Core until a better solution is found.
+
+### `New-WebServiceProxy` cmdlet removed
+
+.NET Core does not support the Windows Communication Framework, which provide services for using the
+SOAP protocol. This cmdlet was removed because it requires SOAP.
+
+### `*-Transaction` cmdlets removed
+
+These cmdlets had very limited usage. The decision was made to discontinue support for them.
+
+- `Complete-Transaction`
+- `Get-Transaction`
+- `Start-Transaction`
+- `Undo-Transaction`
+- `Use-Transaction`
+
+### Security cmdlets not available on non-Windows platforms
+
+- `Get-Acl`
+- `Set-Acl`
+- `Get-AuthenticodeSignature`
+- `Set-AuthenticodeSignature`
+- `Get-CmsMessage`
+- `Protect-CmsMessage`
+- `Unprotect-CmsMessage`
+- `New-FileCatalog`
+- `Test-FileCatalog`
+
+### `*-Computer`and other Windows-specific cmdlets
+
+Due to the use of unsupported APIs, the following cmdlets have been removed from PowerShell Core
+until a better solution is found.
+
+- `Get-Clipboard`
+- `Set-Clipboard`
+- `Add-Computer`
+- `Checkpoint-Computer`
+- `Remove-Computer`
+- `Restore-Computer`
+- `Reset-ComputerMachinePassword`
+- `Disable-ComputerRestore`
+- `Enable-ComputerRestore`
+- `Get-ComputerRestorePoint`
+- `Test-ComputerSecureChannel`
+- `Get-ControlPanelItem`
+- `Show-ControlPanelItem`
+- `Get-HotFix`
+- `Clear-RecycleBin`
+- `Update-List`
+- `Out-Printer`
+- `ConvertFrom-String`
+- `Convert-String`
+
+### `*-Counter` cmdlets
+
+Due to the use of unsupported APIs, the `*-Counter` has been removed from PowerShell Core until a
+better solution is found.
+
+### `*-EventLog` cmdlets
+
+Due to the use of unsupported APIs, the `*-EventLog` has been removed from PowerShell Core. until a
+better solution is found. `Get-WinEvent` and `New-WinEvent` are available to get and create
+events on Windows.
+
+### Cmdlets that use WPF removed
+
+The Windows Presentation Framework is not supported on CoreCLR. The following cmdlets are affected:
+
+- `Show-Command`
+- `Out-GridView`
+- The **showwindow** parameter of `Get-Help`
+
+### Some DSC cmdlets removed
+
+- `Get-DscConfiguration`
+- `Publish-DscConfiguration`
+- `Restore-DscConfiguration`
+- `Start-DscConfiguration`
+- `Stop-DscConfiguration`
+- `Test-DscConfiguration`
+- `Update-DscConfiguration`
+- `Remove-DscConfigurationDocument`
+- `Get-DscConfigurationStatus`
+- `Disable-DscDebug`
+- `Enable-DscDebug`
+- `Get-DscLocalConfigurationManager`
+- `Set-DscLocalConfigurationManager`
+- `Invoke-DscResource`
+
+## Engine/language changes
+
+### Rename `powershell.exe` to `pwsh.exe` [#5101](https://github.com/PowerShell/PowerShell/issues/5101)
+
+In order to give users a deterministic way to call PowerShell Core on Windows (as opposed to
+Windows PowerShell), the PowerShell Core binary was changed to `pwsh.exe` on Windows and `pwsh` on
+non-Windows platforms.
+
+The shortened name is also consistent with naming of shells on non-Windows platforms.
+
+### Don't insert line breaks to output (except for tables) [#5193](https://github.com/PowerShell/PowerShell/issues/5193)
+
+Previously, output was aligned to the width of the console and line breaks were added at the end
+width of the console, meaning the output didn't get reformatted as expected if the terminal was
+resized. This change was not applied to tables, as the line breaks are necessary to keep the columns
+aligned.
+
+### Skip null-element check for collections with a value-type element type [#5432](https://github.com/PowerShell/PowerShell/issues/5432)
+
+For the `Mandatory` parameter and `ValidateNotNull` and `ValidateNotNullOrEmpty` attributes, skip
+the null-element check if the collection's element type is value type.
+
+### Change `$OutputEncoding` to use `UTF-8 NoBOM` encoding rather than ASCII [#5369](https://github.com/PowerShell/PowerShell/issues/5369)
+
+The previous encoding, ASCII (7-bit), would result in incorrect alteration of the output in some
+cases. This change is to make `UTF-8 NoBOM` default, which preserves Unicode output with an encoding
+supported by most tools and operating systems.
+
+### Remove `AllScope` from most default aliases [#5268](https://github.com/PowerShell/PowerShell/issues/5268)
+
+To speed up scope creation, `AllScope` was removed from most default aliases. `AllScope` was left
+for a few frequently used aliases where the lookup was faster.
+
+### `-Verbose` and `-Debug` no longer overrides `$ErrorActionPreference` [#5113](https://github.com/PowerShell/PowerShell/issues/5113)
+
+Previously, if `-Verbose` or `-Debug` were specified, it overrode the behavior of
+`$ErrorActionPreference`. With this change, `-Verbose` and `-Debug` no longer affect the behavior
+of `$ErrorActionPreference`.
+
+## Cmdlet changes
+
+### Invoke-RestMethod doesn't return useful info when no data is returned. [#5320](https://github.com/PowerShell/PowerShell/issues/5320)
+
+When an API returns just `null`, Invoke-RestMethod was serializing this as the string `"null"`
+instead of `$null`. This change fixes the logic in `Invoke-RestMethod` to properly serialize a
+valid single value JSON `null` literal as `$null`.
+
+### Remove `-Protocol` from `*-Computer` cmdlets [#5277](https://github.com/PowerShell/PowerShell/issues/5277)
+
+Due to issues with RPC remoting in CoreFX (particularly on non-Windows platforms) and ensuring a
+consistent remoting experience in PowerShell, the `-Protocol` parameter was removed from the
+`\*-Computer` cmdlets. DCOM is no longer supported for remoting. The following cmdlets only support
+WSMAN remoting:
+
+- Rename-Computer
+- Restart-Computer
+- Stop-Computer
+
+### Remove `-ComputerName` from `*-Service` cmdlets [#5090](https://github.com/PowerShell/PowerShell/issues/5094)
+
+In order to encourage the consistent use of PSRP, the `-ComputerName` parameter was removed from
+`*-Service` cmdlets.
+
+### Fix `Get-Item -LiteralPath a*b` if `a*b` doesn't actually exist to return error [#5197](https://github.com/PowerShell/PowerShell/issues/5197)
+
+Previously, `-LiteralPath` given a wildcard would treat it the same as `-Path` and if the wildcard
+found no files, it would silently exit. Correct behavior should be that `-LiteralPath` is literal
+so if the file doesn't exist, it should error. Change is to treat wildcards used with `-Literal` as
+literal.
+
+### `Import-Csv` should apply `PSTypeNames` upon import when type information is present in the CSV [#5134](https://github.com/PowerShell/PowerShell/issues/5134)
+
+Previously, objects exported using `Export-CSV` with `TypeInformation` imported with
+`ConvertFrom-Csv` were not retaining the type information. This change adds the type information to
+`PSTypeNames` member if available from the CSV file.
+
+### `-NoTypeInformation` should be default on `Export-Csv` [#5131](https://github.com/PowerShell/PowerShell/issues/5131)
+
+This change was made to address customer feedback on the default behavior of `Export-CSV` to
+include type information.
+
+Previously, the cmdlet would output a comment as the first line containing the type name of the
+object. The change is to suppress this by default as it's not understood by most tools. Use
+`-IncludeTypeInformation` to retain the previous behavior.
+
+### Web Cmdlets should warn when `-Credential` is sent over unencrypted connections [#5112](https://github.com/PowerShell/PowerShell/issues/5112)
+
+When using HTTP, content including passwords are sent as clear-text. This change is to not allow
+this by default and return an error if credentials are being passed in an insecure manner. Users
+can bypass this by using the `-AllowUnencryptedAuthentication` switch.
+
+## API changes
+
+### Remove `AddTypeCommandBase` class [#5407](https://github.com/PowerShell/PowerShell/issues/5407)
+
+The `AddTypeCommandBase` class was removed from `Add-Type` to improve performance. This class is
+only used by the Add-Type cmdlet and should not impact users.
+
+### Unify cmdlets with parameter `-Encoding` to be of type `System.Text.Encoding` [#5080](https://github.com/PowerShell/PowerShell/issues/5080)
+
+The `-Encoding` value `Byte` has been removed from the filesystem provider cmdlets. A new
+parameter, `-AsByteStream`, is now used to specify that a byte stream is required as input or that
+the output is a stream of bytes.
+
+### Add better error message for empty and null `-UFormat` parameter [#5055](https://github.com/PowerShell/PowerShell/issues/5055)
+
+Previously, when passing an empty format string to `-UFormat`, an unhelpful error message would
+appear. A more descriptive error has been added.
+
+### Clean up console code [#4995](https://github.com/PowerShell/PowerShell/issues/4995)
+
+The following features were removed as they are not supported in PowerShell Core, and there are no
+plans to add support as they exist for legacy reasons for Windows PowerShell: `-psconsolefile`
+switch and code, `-importsystemmodules` switch and code, and font changing code.
+
+### Removed `RunspaceConfiguration` support [#4942](https://github.com/PowerShell/PowerShell/issues/4942)
+
+Previously, when creating a PowerShell runspace programmatically using the API you could use the
+legacy [`RunspaceConfiguration`][runspaceconfig] or the newer [`InitialSessionState`][iss]. This
+change removed support for `RunspaceConfiguration` and only supports `InitialSessionState`.
+
+[runspaceconfig]: /dotnet/api/system.management.automation.runspaces.runspaceconfiguration
+[iss]: /dotnet/api/system.management.automation.runspaces.initialsessionstate
+
+### `CommandInvocationIntrinsics.InvokeScript` bind arguments to `$input` instead of `$args` [#4923](https://github.com/PowerShell/PowerShell/issues/4923)
+
+An incorrect position of a parameter resulted in the args passed as input instead of as args.
+
+### Remove unsupported `-showwindow` switch from `Get-Help` [#4903](https://github.com/PowerShell/PowerShell/issues/4903)
+
+`-showwindow` relies on WPF, which is not supported on CoreCLR.
+
+### Allow * to be used in registry path for `Remove-Item` [#4866](https://github.com/PowerShell/PowerShell/issues/4866)
+
+Previously, `-LiteralPath` given a wildcard would treat it the same as `-Path` and if the wildcard
+found no files, it would silently exit. Correct behavior should be that `-LiteralPath` is literal
+so if the file doesn't exist, it should error. Change is to treat wildcards used with `-Literal` as
+literal.
+
+### Fix `Set-Service` failing test [#4802](https://github.com/PowerShell/PowerShell/issues/4802)
+
+Previously, if `New-Service -StartupType foo` was used, `foo` was ignored and the service was
+created with some default startup type. This change is to explicitly throw an error for an invalid
+startup type.
+
+### Rename `$IsOSX` to `$IsMacOS` [#4700](https://github.com/PowerShell/PowerShell/issues/4700)
+
+The naming in PowerShell should be consistent with our naming and conform to Apple's use of macOS
+instead of OSX. However, for readability and consistently we are staying with Pascal casing.
+
+### Make error message consistent when invalid script is passed to -File, better error when passed ambiguous argument [#4573](https://github.com/PowerShell/PowerShell/issues/4573)
+
+Change the exit codes of `pwsh.exe` to align with Unix conventions
+
+### Removal of `LocalAccount` and cmdlets from  `Diagnostics` modules. [#4302](https://github.com/PowerShell/PowerShell/issues/4302) [#4303](https://github.com/PowerShell/PowerShell/issues/4303)
+
+Due to unsupported APIs, the `LocalAccounts` module and the `Counter` cmdlets in the `Diagnostics`
+module were removed until a better solution is found.
+
+### Executing PowerShell script with bool parameter does not work [#4036](https://github.com/PowerShell/PowerShell/issues/4036)
+
+Previously, using **powershell.exe** (now **pwsh.exe**) to execute a PowerShell script using `-File`
+provided no way to pass `$true`/`$false` as parameter values. Support for `$true`/`$false` as parsed
+values to parameters was added. Switch values are also supported as currently documented syntax
+doesn't work.
+
+### Remove `ClrVersion` property from `$PSVersionTable` [#4027](https://github.com/PowerShell/PowerShell/issues/4027)
+
+The `ClrVersion` property of `$PSVersionTable` is not useful with CoreCLR, end users should not be
+using that value to determine compatibility.
+
+### Change positional parameter for `powershell.exe` from `-Command` to `-File` [#4019](https://github.com/PowerShell/PowerShell/issues/4019)
+
+Enable shebang use of PowerShell on non-Windows platforms. This means on Unix based systems, you can
+make a script executable that would invoke PowerShell automatically rather than explicitly invoking
+`pwsh`. This also means that you can now do things like `powershell foo.ps1` or
+`powershell fooScript` without specifying `-File`. However, this change now requires that you
+explicitly specify `-c` or `-Command` when trying to do things like `powershell.exe Get-Command`.
+
+### Implement Unicode escape parsing [#3958](https://github.com/PowerShell/PowerShell/issues/3958)
+
+`` `u####`` or `` `u{####}`` is converted to the corresponding Unicode character. To output a
+literal `` `u``, escape the backtick: ``` ``u```.
+
+### Change `New-ModuleManifest` encoding to `UTF8NoBOM` on non-Windows platforms [#3940](https://github.com/PowerShell/PowerShell/issues/3940)
+
+Previously, `New-ModuleManifest` creates psd1 manifests in UTF-16 with BOM, creating a problem for
+Linux tools. This breaking change changes the encoding of `New-ModuleManifest` to be UTF (no BOM) in
+non-Windows platforms.
+
+### Prevent `Get-ChildItem` from recursing into symlinks (#1875). [#3780](https://github.com/PowerShell/PowerShell/issues/3780)
+
+This change brings `Get-ChildItem` more in line with the Unix `ls -r` and the Windows `dir /s`
+native commands. Like the mentioned commands, the cmdlet displays symbolic links to directories
+found during recursion, but does not recurse into them.
+
+### Fix `Get-Content -Delimiter` to not include the delimiter in the returned lines [#3706](https://github.com/PowerShell/PowerShell/issues/3706)
+
+Previously, the output while using `Get-Content -Delimiter` was inconsistent and inconvenient as it
+required further processing of the data to remove the delimiter. This change removes the delimiter
+in returned lines.
+
+### Implement Format-Hex in C# [#3320](https://github.com/PowerShell/PowerShell/issues/3320)
+
+The `-Raw` parameter is now a "no-op" (in that it does nothing). Going forward all of the output
+will be displayed with a true representation of numbers that includes all of the bytes for its type
+(what the `-Raw` parameter was formally doing prior to this change).
+
+### PowerShell as a default shell doesn't work with script command [#3319](https://github.com/PowerShell/PowerShell/issues/3319)
+
+On Unix, it is a convention for shells to accept `-i` for an interactive shell and many tools
+expect this behavior (`script` for example, and when setting PowerShell as the default shell) and
+calls the shell with the `-i` switch. This change is breaking in that `-i` previously could be used
+as short hand to match `-inputformat`, which now needs to be `-in`.
+
+### Typo fix in Get-ComputerInfo property name [#3167](https://github.com/PowerShell/PowerShell/issues/3167)
+
+`BiosSerialNumber` was misspelled as `BiosSeralNumber` and has been changed to the correct spelling.
+
+### Add `Get-StringHash` and `Get-FileHash` cmdlets [#3024](https://github.com/PowerShell/PowerShell/issues/3024)
+
+This change is that some hash algorithms are not supported by CoreFX, therefore they are no longer
+available:
+
+- `MACTripleDES`
+- `RIPEMD160`
+
+### Add validation on `Get-*` cmdlets where passing $null returns all objects instead of error [#2672](https://github.com/PowerShell/PowerShell/issues/2672)
+
+Passing `$null` to any of the following now throws an error:
+
+- `Get-Credential -UserName`
+- `Get-Event -SourceIdentifier`
+- `Get-EventSubscriber -SourceIdentifier`
+- `Get-Help -Name`
+- `Get-PSBreakpoint -Script`
+- `Get-PSProvider -PSProvider`
+- `Get-PSSessionConfiguration -Name`
+- `Get-PSSnapin -Name`
+- `Get-Runspace -Name`
+- `Get-RunspaceDebug -RunspaceName`
+- `Get-Service -Name`
+- `Get-TraceSource -Name`
+- `Get-Variable -Name`
+- `Get-WmiObject -Class`
+- `Get-WmiObject -Property`
+
+### Add support W3C Extended Log File Format in `Import-Csv` [#2482](https://github.com/PowerShell/PowerShell/issues/2482)
+
+Previously, the `Import-Csv` cmdlet cannot be used to directly import the log files in W3C extended
+log format and additional action would be required. With this change, W3C extended log format is
+supported.
+
+### Parameter binding problem with `ValueFromRemainingArguments` in PS functions [#2035](https://github.com/PowerShell/PowerShell/issues/2035)
+
+`ValueFromRemainingArguments` now returns the values as an array instead of a single value which
+itself is an array.
+
+### `BuildVersion` is removed from `$PSVersionTable` [#1415](https://github.com/PowerShell/PowerShell/issues/1415)
+
+Remove the `BuildVersion` property from `$PSVersionTable`. This property was tied to the Windows
+build version. Instead, we recommend that you use `GitCommitId` to retrieve the exact build version
+of PowerShell Core.
+
+### Changes to Web Cmdlets
+
+The underlying .NET API of the Web Cmdlets has been changed to `System.Net.Http.HttpClient`. This
+change provides many benefits. However, this change along with a lack of interoperability with
+Internet Explorer have resulted in several breaking changes within `Invoke-WebRequest` and
+`Invoke-RestMethod`.
+
+- `Invoke-WebRequest` now supports basic HTML Parsing only. `Invoke-WebRequest` always returns a
+  `BasicHtmlWebResponseObject` object. The `ParsedHtml` and `Forms` properties have been removed.
+- `BasicHtmlWebResponseObject.Headers` values are now `String[]` instead of `String`.
+- `BasicHtmlWebResponseObject.BaseResponse` is now a `System.Net.Http.HttpResponseMessage` object.
+- The `Response` property on Web Cmdlet exceptions is now a `System.Net.Http.HttpResponseMessage`
+  object.
+- Strict RFC header parsing is now default for the `-Headers` and `-UserAgent` parameter. This can
+  be bypassed with `-SkipHeaderValidation`.
+- `file://` and `ftp://` URI schemes are no longer supported.
+- `System.Net.ServicePointManager` settings are no longer honored.
+- There is currently no certificate based authentication available on macOS.
+- Use of `-Credential` over an `http://` URI will result in an error. Use an `https://` URI or
+  supply the `-AllowUnencryptedAuthentication` parameter to suppress the error.
+- `-MaximumRedirection` now produces a terminating error when redirection attempts exceed the
+  provided limit instead of returning the results of the last redirection.
+- In PowerShell 6.2, a change was made to default to UTF-8 encoding for JSON responses. When a
+  charset is not supplied for a JSON response, the default encoding should be UTF-8 per RFC 8259.

--- a/reference/docs-conceptual/whats-new/known-issues-ps6.md
+++ b/reference/docs-conceptual/whats-new/known-issues-ps6.md
@@ -1,0 +1,167 @@
+---
+ms.date: 02/03/2020
+keywords:  powershell,core
+title:  Known Issues for PowerShell 6.0
+description: This is a summary of known issues or limitations in PowerShell 6
+---
+# Known Issues for PowerShell 6.0
+
+## Known Issues for PowerShell on Non-Windows Platforms
+
+Alpha releases of PowerShell on Linux and macOS are mostly functional but do have some significant
+limitations and usability issues. Beta releases of PowerShell on Linux and macOS are more
+functional and stable than alpha releases, but still may be lacking some set of features, and can
+contain bugs. In some cases, these issues are simply bugs that haven't been fixed yet. In other
+cases (as with the default aliases for ls, cp, etc.), we are looking for feedback from the
+community regarding the choices we make.
+
+Note: Due to the similarities of many underlying subsystems, PowerShell on Linux and macOS tend to
+share the same level of maturity in both features and bugs. Except as noted below, the issues in
+this section apply to both operating systems.
+
+### Case-sensitivity in PowerShell
+
+Historically, PowerShell has been uniformly case-insensitive, with few exceptions. On UNIX-like
+operating systems, the file system is predominantly case-sensitive and PowerShell adheres to the
+standard of the file system; this is exposed through a number of ways, obvious and non-obvious.
+
+#### Directly
+
+- When specifying a file in PowerShell, the correct case must be used.
+
+#### Indirectly
+
+- If a script tries to load a module and the module name is not cased correctly, then the module
+  load fails. This may cause a problem with existing scripts if the name by which the module is
+  referenced doesn't match the actual filename.
+- Tab-completion does not auto-complete if the filename case is wrong. The fragment to complete must
+  be cased properly. (Completion is case-insensitive for type name and type member completions.)
+
+### .PS1 File Extensions
+
+PowerShell scripts must end in `.ps1` for the interpreter to understand how to load and run them in
+the current process. Running scripts in the current process is the expected usual behavior for
+PowerShell. The `#!` magic number may be added to a script that doesn't have a `.ps1` extension, but
+this causes the script to be run in a new PowerShell instance preventing the script from working
+properly when interchanging objects. (Note: this may be the desirable behavior when executing a
+PowerShell script from `bash` or another shell.)
+
+### Missing command aliases
+
+On Linux/macOS, the "convenience aliases" for the basic commands `ls`, `cp`, `mv`, `rm`, `cat`,
+`man`, `mount`, `ps` have been removed. On Windows, PowerShell provides a set of aliases that map to
+Linux command names for user convenience. These aliases have been removed from the default
+PowerShell on Linux/macOS distributions, allowing the native executable to be run without specifying
+a path.
+
+There are pros and cons to doing this. Removing the aliases exposes the native command experience to
+the PowerShell user, but reduces functionality in the shell because the native commands return
+strings instead of objects.
+
+> [!NOTE]
+> This is an area where the PowerShell team is looking for feedback. What is the preferred solution?
+> Should we leave it as is or add the convenience aliases back? See
+> [Issue #929](https://github.com/PowerShell/PowerShell/issues/929).
+
+### Missing Wildcard (globbing) Support
+
+Currently, PowerShell only does wildcard expansion (globbing) for built-in cmdlets on Windows, and
+for external commands or binaries as well as cmdlets on Linux. This means that a command like `ls
+*.txt` fails because the asterisk is not expanded to match filenames. You can work around this by
+doing `ls (gci *.txt | % name)` or, more simply, `gci *.txt` using the PowerShell built-in
+equivalent to `ls`.
+
+See [#954](https://github.com/PowerShell/PowerShell/issues/954) to give us feedback on how to
+improve the globbing experience on Linux/macOS.
+
+### .NET Framework vs .NET Core Framework
+
+PowerShell on Linux/macOS uses .NET Core which is a subset of the full .NET Framework on Microsoft
+Windows. This is significant because PowerShell provides direct access to the underlying framework
+types, methods, etc. As a result, scripts that run on Windows may not run on non-Windows platforms
+because of the differences in the frameworks. For more information about .NET Core Framework, see
+[dotnetfoundation.org](https://dotnetfoundation.org/).
+
+With the advent of
+[.NET Standard 2.0](https://devblogs.microsoft.com/dotnet/introducing-net-standard/), .NET Core 2.0
+brings back many of the traditional types and methods present in the full .NET Framework. This means
+that PowerShell Core can load many traditional Windows PowerShell modules without modification. You
+can follow our .NET Standard 2.0 related work
+[here](https://github.com/PowerShell/PowerShell/projects/4).
+
+### Redirection Issues
+
+Input redirection is not supported in PowerShell on any platform.
+[Issue #1629](https://github.com/PowerShell/PowerShell/issues/1629)
+
+Use `Get-Content` to write the contents of a file into the pipeline.
+
+Redirected output contains the Unicode byte order mark (BOM) when the default UTF-8 encoding is
+used. The BOM causes problems when working with utilities that do not expect it or when appending to
+a file. Use `-Encoding Ascii` to write ASCII text, which does not have a BOM.
+
+> [!Note]
+> see [RFC0020](https://github.com/PowerShell/PowerShell-RFC/issues/71) to give
+> us feedback on improving the encoding experience for PowerShell Core across all platforms. We are
+> working to support UTF-8 without a BOM and potentially changing the encoding defaults for various
+> cmdlets across platforms.
+
+### Job Control
+
+There is no job-control support in PowerShell on Linux/macOS.
+The `fg` and `bg` commands are not available.
+
+For the time being, you can use [PowerShell jobs](/powershell/module/microsoft.powershell.core/about/about_jobs)
+which do work across all platforms.
+
+### Remoting Support
+
+Currently, PowerShell Core supports PowerShell Remoting (PSRP) over WSMan with Basic authentication
+on macOS and Linux, and with NTLM-based authentication on Linux. (Kerberos-based authentication is
+not supported.)
+
+The work for WSMan-based remoting is being done in the
+[psl-omi-provider](https://github.com/PowerShell/psl-omi-provider) repo.
+
+PowerShell Core also supports PowerShell Remoting (PSRP) over SSH on all platforms (Windows, macOS,
+and Linux). While this is not currently supported in production, you can learn more about setting
+this up [here](/powershell/scripting/learn/remoting/SSH-Remoting-in-PowerShell-Core).
+
+### Just-Enough-Administration (JEA) Support
+
+The ability to create constrained administration (JEA) remoting endpoints is not currently
+available in PowerShell on Linux/macOS. This feature is currently not in scope for 6.0 and
+something we will consider post 6.0 as it requires significant design work.
+
+### `sudo`, `exec`, and PowerShell
+
+Because PowerShell runs most commands in memory (like Python or Ruby), you can't use sudo directly
+with PowerShell built-ins. (You can, of course, run `pwsh` from sudo.) If it is necessary to
+run a PowerShell cmdlet from within PowerShell with sudo, for example, `sudo Set-Date 8/18/2016`,
+then you would do `sudo pwsh Set-Date 8/18/2016`. Likewise, you can't exec a PowerShell
+built-in directly. Instead you would have to do `exec pwsh item_to_exec`.
+
+This issue is being tracked as part of
+[#3232](https://github.com/PowerShell/PowerShell/issues/3232).
+
+### Missing Cmdlets
+
+A large number of the commands (cmdlets) normally available in PowerShell are not available on
+Linux/macOS. In many cases, these commands make no sense on these platforms (e.g. Windows-specific
+features like the registry). Other commands like the service control commands
+(Get/Start/Stop-Service) are present, but not functional. Future releases may correct these problems
+by fixing the broken cmdlets and adding new ones over time.
+
+### Command Availability
+
+The following table lists commands that are known not to work in PowerShell on Linux/macOS.
+
+|Commands|Operational State|Notes|
+|--------|-----------------|-----|
+|`Get-Service`, `New-Service`, `Restart-Service`, `Resume-Service`, `Set-Service`, `Start-Service`, `Stop-Service`, `Suspend-Service`|Not Available.|These commands are not recognized. This should be fixed in a future release.|
+|`Get-Acl`, `Get-AuthenticodeSignature`, `Get-CmsMessage`, `New-FileCatalog`, `Protect-CmsMessage`, `Set-Acl`, `Set-AuthenticodeSignature`, `Test-FileCatalog`, `Unprotect-CmsMessage`|Not available.|These commands are not recognized. This should be fixed in a future release.|
+|`Wait-Process`|Available, doesn't work properly. |For example `Start-Process gvim -PassThru | Wait-Process` doesn't work; it fails to wait for the process.|
+|`Connect-PSSession`, `Disable-PSRemoting`, `Disable-PSSessionConfiguration`, `Disconnect-PSSession`, `Enable-PSRemoting`, `Enable-PSSessionConfiguration`, `Get-PSSessionCapability`, `Get-PSSessionConfiguration`, `New-PSSessionConfigurationFile`, `Receive-PSSession`, `Register-PSSessionConfiguration`, `Set-PSSessionConfiguration`, `Test-PSSessionConfigurationFile`, `Unregister-PSSessionConfiguration`|Not Available.|These commands are not recognized. This should be fixed in a future release.|
+|`Get-Event`, `New-Event`, `Register-EngineEvent`, `Remove-Event`, `Unregister-Event`|Available but no event sources are available.|The PowerShell eventing commands are present but most of the event sources used with the commands (such as System.Timers.Timer) are not available on Linux making the commands useless in the Alpha release.|
+|`Set-ExecutionPolicy`|Available but doesn't work.|Returns a message saying not supported on this platform. Execution policy is a user-focused "safety belt" that helps prevent the user from making expensive mistakes. It is not a security boundary.|
+|`New-PSSessionOption`, `New-PSTransportOption`|Available but `New-PSSession` doesn't work.|`New-PSSessionOption` and `New-PSTransportOption` are not currently verified to work now that `New-PSSession` works.|


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Restore v6 release notes
- V6 release notes contain breaking changes from PS5.1 - need these notes for historical reference

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [x] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
