### PR TITLE
Rewrote the whole about_Comparison_Operators document from top to bottom

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -65,10 +65,10 @@ Object[]
 
 There are a few exceptions:
 
-- The containment and type operators. They always return a **Boolean** value.
-- The `-replace` operator returns the values resulting from the replacement.
+- The containment and type operators always return a **Boolean** value
+- The `-replace` operator returns the replacement result
 - The `-match` and `-notmatch` operators also populate the `$Matches` automatic
-  variable.
+  variable
 
 ## Equality operators
 
@@ -323,10 +323,9 @@ automatic variable.
 ### -match and -notmatch
 
 `-match` and `-notmatch` use regular expressions to search for pattern in the
-left-hand side values. Regular expressions can be used to match complex
-patterns like email addresses, UNC paths, or formatted phone numbers. The
-right-hand side string must adhere to the
-[regular expressions](about_Regular_Expressions.md) rules.
+left-hand side values. Regular expressions can match complex patterns like email
+addresses, UNC paths, or formatted phone numbers. The right-hand side string
+must adhere to the [regular expressions](about_Regular_Expressions.md) rules.
 
 Scalar examples:
 
@@ -402,9 +401,10 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with regular expressions
 
-The replacement , , is an extension of the `-match` operator. Like `-match`,
-`-replace` operator uses regular expressions to find the specified pattern. But
-unlike `-match`, it replaces the matches with another specified value.
+The replacement operator, `-replace`, is an extension of the `-match` operator.
+Like `-match`, the `-replace` operator uses regular expressions to find the
+specified pattern. But unlike `-match`, it replaces the matches with another
+specified value.
 
 Syntax:
 
@@ -436,6 +436,7 @@ Examples:
 Cook
 book
 ```
+
 ### Regular expressions substitutions
 
 It is also possible to use regular expressions to dynamically replace text
@@ -458,24 +459,34 @@ John.Doe@Contoso.local
 ```
 
 > [!WARNING]
-> Since the `$` character is used in string expansion, you will must use
-> literal strings or escape the `$` character.
+> The `$` has syntatic roles in both PowerShell and regular expressions: - In
+> PowerShell, between double quotation marks, it designates variables and acts
+> as a subexpression operator. - In Regex search strings, it denotes end of the
+> line - In Regex substitution strings, it denotes captured groups As such, be
+> sure to either put your regular expressions between single quotation marks or
+> insert a backtick (\`) character before them. For example:
 >
 > ```powershell
-> PS> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
-> Hello Universe
+> $1 = 'Goodbye'
+> 
+> 'Hello World' -replace '(\w+) \w+', "$1 Universe"
+> # Output: Goodbye Universe
+> 
+> 'Hello World' -replace '(\w+) \w+', '$1 Universe'
+> # Output: Hello Universe
 > ```
 >
-> Additionally, since the `$` character is used in substitution, you must
-> escape any instances in your string.
+> `$$` in Regex denotes a literal `$`. Be sure to understand its caveats. For
+> example:
 >
 > ```powershell
-> PS> '5.72' -replace '(.+)', '$$$1'
-> $5.72
+> '5.72' -replace '(.+)', '$ $1' # Output: $ 5.72
+> '5.72' -replace '(.+)', '$$$1' # Output: $5.72
+> '5.72' -replace '(.+)', '$$1'  # Output: $1
 > ```
 
-To learn more see [about_Regular_Expressions](about_Regular_Expressions.md) and
-[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
+To learn more, see [about_Regular_Expressions](about_Regular_Expressions.md) and
+[Substitutions in Regular Expressions][4]
 
 ### Substituting in a collection
 
@@ -614,3 +625,4 @@ $a -isnot $b.GetType() # Output: True
 [1]: /dotnet/api/system.icomparable
 [2]: /dotnet/api/system.text.regularexpressions.match
 [3]: about_Redirection.md#potential-confusion-with-comparison-operators
+[4]: /dotnet/standard/base-types/substitutions-in-regular-expressions

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -430,7 +430,8 @@ book
 It is also possible to use regular expressions to dynamically replace text
 using capturing groups, and substitutions.
 
-In the following example, the `-replace` operator accepts a username in the form of `DomainName\Username` and converts to the `Username@DomainName` format:
+In the following example, the `-replace` operator accepts a username in the form
+of `DomainName\Username` and converts to the `Username@DomainName` format:
 
 ```powershell
 $SearchExp = '^(?<Username>[\w-.]+)\\(?<DomainName>[\w-.]+)$'
@@ -447,7 +448,7 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with a script block
 
-In Powershell 6 and later, the `-replace` operator also accepts a script block
+In PowerShell 6 and later, the `-replace` operator also accepts a script block
 that performs the replacement. The script block runs once for every match.
 
 Syntax:
@@ -592,6 +593,6 @@ $a -isnot $b.GetType() # Output: True
 - [Foreach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object)
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
 
-[1]: https://docs.microsoft.com/dotnet/api/system.icomparable?view=netstandard-2.0
-[2]: https://docs.microsoft.com/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6
+[1]: https://docs.microsoft.com/dotnet/api/system.icomparable?view=netstandard-2.0&preserve-view=true
+[2]: https://docs.microsoft.com/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6&preserve-view=true
 [3]: about_Redirection.md#potential-confusion-with-comparison-operators

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -3,7 +3,7 @@ description: Describes the operators that compare values in PowerShell.
 keywords: powershell,cmdlet
 Locale: en-US
 ms.date: 12/11/2020
-online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7&WT.mc_id=ps-gethelp
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
 ---

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -188,7 +188,8 @@ In the following examples, all statements return True.
 8 -le 8  # Ouput: True
 ```
 
-> [!NOTE] The greater-than operator, in most programming languages, is `>`. In
+> [!NOTE]
+> The greater-than operator, in most programming languages, is `>`. In
 > PowerShell, however, this character is used for redirection. For details, see
 > [About_redirection][3].
 
@@ -591,6 +592,6 @@ $a -isnot $b.GetType() # Output: True
 - [Foreach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object)
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
 
-[1]: https://docs.microsoft.com/en-us/dotnet/api/system.icomparable?view=netstandard-2.0
-[2]: https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6
+[1]: https://docs.microsoft.com/dotnet/api/system.icomparable?view=netstandard-2.0
+[2]: https://docs.microsoft.com/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6
 [3]: about_Redirection.md#potential-confusion-with-comparison-operators

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -317,15 +317,13 @@ Example:
 "PowerShell", "Server" -notlike "*shell" # Output: Server
 ```
 
-Unlike `-match` and `-notmatch`, these operators don't affect the `$Matches`
-automatic variable.
-
 ### -match and -notmatch
 
 `-match` and `-notmatch` use regular expressions to search for pattern in the
-left-hand side values. Regular expressions can match complex patterns like email
-addresses, UNC paths, or formatted phone numbers. The right-hand side string
-must adhere to the [regular expressions](about_Regular_Expressions.md) rules.
+left-hand side values. Regular expressions can match complex patterns like
+email addresses, UNC paths, or formatted phone numbers. The right-hand side
+string must adhere to the [regular expressions](about_Regular_Expressions.md)
+rules.
 
 Scalar examples:
 
@@ -340,7 +338,7 @@ Scalar examples:
 ```
 
 If the input is a collection, the operators return the matching members of that
-collection. However, the `$Matches` variable isn't populated.
+collection.
 
 Collection examples:
 
@@ -359,10 +357,11 @@ Collection examples:
 ```
 
 `-match` and `-notmatch` support regex capture groups. Each time they run, they
-overwrite the `$Matches` automatic variable with their findings. `$Matches` is
-a **Hashtable** that always has a key named '0', which stores the entire match.
-If the regular expression contains capture groups, the `$Matches` contains
-additional keys for each group.
+overwrite the `$Matches` automatic variable. When `<input>` is a collection the
+`$Matches` variable is `$null`. `$Matches` is a **Hashtable** that always has a
+key named '0', which stores the entire match. If the regular expression
+contains capture groups, the `$Matches` contains additional keys for each
+group.
 
 Example:
 
@@ -401,7 +400,6 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with regular expressions
 
-The replacement operator, `-replace`, is an extension of the `-match` operator.
 Like `-match`, the `-replace` operator uses regular expressions to find the
 specified pattern. But unlike `-match`, it replaces the matches with another
 specified value.
@@ -459,34 +457,39 @@ John.Doe@Contoso.local
 ```
 
 > [!WARNING]
-> The `$` has syntatic roles in both PowerShell and regular expressions: - In
-> PowerShell, between double quotation marks, it designates variables and acts
-> as a subexpression operator. - In Regex search strings, it denotes end of the
-> line - In Regex substitution strings, it denotes captured groups As such, be
-> sure to either put your regular expressions between single quotation marks or
-> insert a backtick (\`) character before them. For example:
+> The `$` character has syntatic roles in both PowerShell and regular
+> expressions:
 >
-> ```powershell
-> $1 = 'Goodbye'
-> 
-> 'Hello World' -replace '(\w+) \w+', "$1 Universe"
-> # Output: Goodbye Universe
-> 
-> 'Hello World' -replace '(\w+) \w+', '$1 Universe'
-> # Output: Hello Universe
-> ```
->
-> `$$` in Regex denotes a literal `$`. Be sure to understand its caveats. For
-> example:
->
-> ```powershell
-> '5.72' -replace '(.+)', '$ $1' # Output: $ 5.72
-> '5.72' -replace '(.+)', '$$$1' # Output: $5.72
-> '5.72' -replace '(.+)', '$$1'  # Output: $1
-> ```
+> - In PowerShell, between double quotation marks, it designates variables and
+>   acts as a subexpression operator.
+> - In Regex search strings, it denotes end of the line
+> - In Regex substitution strings, it denotes captured groups As such, be sure
+>   to to either put your regular expressions between single quotation marks or
+>   insert a backtick (`` ` ``) character before them.
+
+For example:
+
+```powershell
+$1 = 'Goodbye'
+
+'Hello World' -replace '(\w+) \w+', "$1 Universe"
+# Output: Goodbye Universe
+
+'Hello World' -replace '(\w+) \w+', '$1 Universe'
+# Output: Hello Universe
+```
+
+`$$` in Regex denotes a literal `$`. This `$$` in the substitution string to
+include a a literal `$` in the resulting replacement. For example:
+
+```powershell
+'5.72' -replace '(.+)', '$ $1' # Output: $ 5.72
+'5.72' -replace '(.+)', '$$$1' # Output: $5.72
+'5.72' -replace '(.+)', '$$1'  # Output: $1
+```
 
 To learn more, see [about_Regular_Expressions](about_Regular_Expressions.md) and
-[Substitutions in Regular Expressions][4]
+[Substitutions in Regular Expressions][4].
 
 ### Substituting in a collection
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,6 +1,5 @@
 ---
 description: Describes the operators that compare values in PowerShell.
-keywords: powershell,cmdlet
 Locale: en-US
 ms.date: 12/11/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
@@ -9,37 +8,35 @@ title: about_Comparison_Operators
 ---
 # About Comparison Operators
 
-## Abstract
+## Short description
 
 The comparison operators in PowerShell can either compare two values or filter
-elements of a collection against an input value. These operators include:
-`-eq`,`-ne`,`-gt`,`-ge`,`-lt`,`-le`,`-like`,`-notlike`,`-match`,`-notmatch`,
-`-replace`,`-contains`,`-notcontains`,`-in`,`-notin`,`-is`,`-isnot`.
+elements of a collection against an input value.
 
-## The operators
+## Long description
 
 Comparison operators let you compare values or finding values that match
 specified patterns. PowerShell includes the following comparison operators:
 
-| Type        | Operator     | Comparison test
-| ----------- | ------------ | ------------------------------------------------
-| Equality    | -eq          | equals
-|             | -ne          | not equals
-|             | -gt          | greater than
-|             | -ge          | greater than or equal
-|             | -lt          | less than
-|             | -le          | less than or equal
-| Matching    | -like        | string matches wildcard pattern
-|             | -notlike     | string does not match wildcard pattern
-|             | -match       | string matches regex pattern
-|             | -notmatch    | string does not match regex pattern
-| Replacement | -replace     | string matches regex pattern; replaces the match
-| Containment | -contains    | collection contains a value
-|             | -notcontains | collection does not contain a value
-|             | -in          | value is in a collection
-|             | -notin       | value is not in a collection
-| Type        | -is          | both objectd are the same type
-|             | -isnot       | the objects are not the same type
+|    Type     |   Operator   |              Comparison test              |
+| ----------- | ------------ | ----------------------------------------- |
+| Equality    | -eq          | equals                                    |
+|             | -ne          | not equals                                |
+|             | -gt          | greater than                              |
+|             | -ge          | greater than or equal                     |
+|             | -lt          | less than                                 |
+|             | -le          | less than or equal                        |
+| Matching    | -like        | string matches wildcard pattern           |
+|             | -notlike     | string does not match wildcard pattern    |
+|             | -match       | string matches regex pattern              |
+|             | -notmatch    | string does not match regex pattern       |
+| Replacement | -replace     | replaces strings matching a regex pattern |
+| Containment | -contains    | collection contains a value               |
+|             | -notcontains | collection does not contain a value       |
+|             | -in          | value is in a collection                  |
+|             | -notin       | value is not in a collection              |
+| Type        | -is          | both objects are the same type            |
+|             | -isnot       | the objects are not the same type         |
 
 ## Common features
 
@@ -49,10 +46,11 @@ case-sensitive version of `-eq`. To make the case-insensitivity explicit,
 add an `i` before `-`. For example, `-ieq` is the explicitly case-insensitive
 version of `-eq`.
 
-When the input of an operator is a scalar value, the operator returns a Boolean
-value. When the input is a collection, the operator returns those collection
-elements that match the input. If there are no matches in the collection,
-comparison operators return an empty array. For example:
+When the input of an operator is a scalar value, the operator returns a
+**Boolean** value. When the input is a collection, the operator returns the
+elements of the collection that match the right-hand value of the expression.
+If there are no matches in the collection, comparison operators return an empty
+array. For example:
 
 ```powershell
 $a = (1, 2 -eq 3)
@@ -65,27 +63,31 @@ Object[]
 0
 ```
 
-The exceptions are the containment operators and the type operators; they always
-return a Boolean value.
+There are a few exceptions:
+
+- The containment and type operators. They always return a **Boolean** value.
+- The `-replace` operator returns the values resulting from the replacement.
+- The `-match` and `-notmatch` operators also populate the `$Matches` automatic
+  variable.
 
 ## Equality operators
 
 ### -eq and -ne
 
-When the left-hand side is scalar, `-eq` returns True if the right-hand side is
-an exact match; otherwise, `-eq` returns False. `-ne` does the opposite; it
-returns False when both sides match; otherwise, `-ne` returns True.
+When the left-hand side is scalar, `-eq` returns **True** if the right-hand side is
+an exact match, otherwise, `-eq` returns **False**. `-ne` does the opposite; it
+returns **False** when both sides match; otherwise, `-ne` returns True.
 
 Example:
 
 ```powershell
-2 -eq 2                 # Ouput: True
-2 -eq 3                 # Ouput: False
-"abc" -eq "abc"         # Ouput: True
-"abc" -eq "abc", "def"  # Ouput: False
-"abc" -ne "def"         # Ouput: True
-"abc" -ne "abc"         # Ouput: False
-"abc" -ne "abc", "def"  # Ouput: True
+2 -eq 2                 # Output: True
+2 -eq 3                 # Output: False
+"abc" -eq "abc"         # Output: True
+"abc" -eq "abc", "def"  # Output: False
+"abc" -ne "def"         # Output: True
+"abc" -ne "abc"         # Output: False
+"abc" -ne "abc", "def"  # Output: True
 ```
 
 When the left-hand side is a collection, `-eq` returns those members that match
@@ -94,9 +96,9 @@ the right-hand side, while `-ne` filters them out.
 Example:
 
 ```powershell
-1,2,3 -eq 2             # Ouput: 2
-"abc", "def" -eq "abc"  # Ouput: abc
-"abc", "def" -ne "abc"  # Ouput: def
+1,2,3 -eq 2             # Output: 2
+"abc", "def" -eq "abc"  # Output: abc
+"abc", "def" -ne "abc"  # Output: def
 ```
 
 These operators process all elements of the collection. Example:
@@ -110,7 +112,7 @@ zzz
 zzz
 ```
 
-The equality operators accept any two objects, not just scalar or collection.
+The equality operators accept any two objects, not just a scalar or collection.
 But the comparison result is not guaranteed to be meaningful for the end-user.
 The following example demonstrates the issue.
 
@@ -129,7 +131,7 @@ False
 ```
 
 In this example, we created two objects with identical properties. Yet, the
-equality test result is False, because they are different objects. If you intend
+equality test result is **False** because they are different objects. If you intend
 to develop meaningfully comparable classes, you need to implement
 [System.IComparable][1] in your class.
 
@@ -170,7 +172,7 @@ $a -ne $null # Output: 1, 2, 4, 6
 ### -gt, -ge, -lt, and -le
 
 `-gt`, `-ge`, `-lt`, and `-le` behave very similarly. When both sides are scalar
-they return True or False depending on how the two sides compare:
+they return **True** or **False** depending on how the two sides compare:
 
 | Operator | Returns True when...                   |
 | -------- | -------------------------------------- |
@@ -182,16 +184,16 @@ they return True or False depending on how the two sides compare:
 In the following examples, all statements return True.
 
 ```powershell
-8 -gt 6  # Ouput: True
-8 -ge 8  # Ouput: True
-6 -lt 8  # Ouput: True
-8 -le 8  # Ouput: True
+8 -gt 6  # Output: True
+8 -ge 8  # Output: True
+6 -lt 8  # Output: True
+8 -le 8  # Output: True
 ```
 
 > [!NOTE]
-> The greater-than operator, in most programming languages, is `>`. In
-> PowerShell, however, this character is used for redirection. For details, see
-> [About_redirection][3].
+> In most programming languages the greater-than operator is `>`. In
+> PowerShell, this character is used for redirection. For details, see
+> [about_Redirection][3].
 
 When the left-hand side is a collection, these operators compare each member of
 the collection with the right-hand side. Depending on their logic, they either
@@ -266,8 +268,8 @@ keyboard that gets sorted after 'a'. It feeds a set containing all such symbols
 to the `-gt` operator to compare them against 'a'. The output is an empty array.
 
 ```powershell
-$a=' ','`','~','!','@','#','$','%','^','&','*','(',')','_','+','-','=','{','}',
-   '[',']',':',';','"','''','\','|','/','?','.','>',',','<'
+$a=' ','`','~','!','@','#','$','%','^','&','*','(',')','_','+','-','=',
+   '{','}','[',']',':',';','"','''','\','|','/','?','.','>',',','<'
 $a -gt 'a'
 # Output: Nothing
 ```
@@ -284,14 +286,14 @@ and `-notlike` is a wildcard expression (containing `*`, `?`, and `[ ]`), while
 
 The syntax is:
 
-```powershell
+```
 <string[]> -like    <wildcard-expression>
 <string[]> -notlike <wildcard-expression>
 <string[]> -match    <regular-expression>
 <string[]> -notmatch <regular-expression>
 ```
 
-When the input of these operators is a scalar value, they return a Boolean
+When the input of these operators is a scalar value, they return a **Boolean**
 value. When the input is a collection of values, the operators return any
 matching members. If there are no matches in a collection, the operators return
 an empty array.
@@ -304,35 +306,42 @@ side could be a string containing [wildcards](about_Wildcards.md).
 Example:
 
 ```powershell
-"PowerShell" -like    "*shell"           # Ouput: True
-"PowerShell" -notlike "*shell"           # Ouput: False
-"PowerShell" -like    "Power?hell"       # Ouput: True
-"PowerShell" -notlike "Power?hell"       # Ouput: False
-"PowerShell" -like    "Power[p-w]hell"   # Ouput: True
-"PowerShell" -notlike "Power[p-w]hell"   # Ouput: False
+"PowerShell" -like    "*shell"           # Output: True
+"PowerShell" -notlike "*shell"           # Output: False
+"PowerShell" -like    "Power?hell"       # Output: True
+"PowerShell" -notlike "Power?hell"       # Output: False
+"PowerShell" -like    "Power[p-w]hell"   # Output: True
+"PowerShell" -notlike "Power[p-w]hell"   # Output: False
 
-"PowerShell", "Server" -like "*shell"    # Ouput: PowerShell
-"PowerShell", "Server" -notlike "*shell" # Ouput: Server
+"PowerShell", "Server" -like "*shell"    # Output: PowerShell
+"PowerShell", "Server" -notlike "*shell" # Output: Server
 ```
 
-## -match and -notmatch
+Unlike `-match` and `-notmatch`, these operators don't affect the `$Matches`
+automatic variable.
 
-`-match` and `-notmatch` use regular expressions to conduct their search. As
-such, they support very complex searches, e.g. they can find email addresses,
-UNC paths, or dash-formatted phone numbers. The right-hand side string must
-adhere to the [regular expressions](about_Regular_Expressions.md) rules.
+### -match and -notmatch
+
+`-match` and `-notmatch` use regular expressions to search for pattern in the
+left-hand side values. Regular expressions can be used to match complex
+patterns like email addresses, UNC paths, or formatted phone numbers. The
+right-hand side string must adhere to the
+[regular expressions](about_Regular_Expressions.md) rules.
 
 Scalar examples:
 
 ```powershell
 # Partial match test, showing how differently -match and -like behave
-"PowerShell" -match 'shell'        # Ouput: True
-"PowerShell" -like  'shell'        # Ouput: False
+"PowerShell" -match 'shell'        # Output: True
+"PowerShell" -like  'shell'        # Output: False
 
 # Regex syntax test
-"PowerShell" -match    '^Power\w+' # Ouput: True
-'bag'        -notmatch 'b[iou]g'   # Ouput: True
+"PowerShell" -match    '^Power\w+' # Output: True
+'bag'        -notmatch 'b[iou]g'   # Output: True
 ```
+
+If the input is a collection, the operators return the matching members of that
+collection. However, the `$Matches` variable isn't populated.
 
 Collection examples:
 
@@ -341,7 +350,7 @@ Collection examples:
 # Output: PowerShell
 
 "Rhell", "Chell", "Mel", "Smell", "Shell" -match "hell"
-# Ouput: Rhell, Chell, Shell
+# Output: Rhell, Chell, Shell
 
 "Bag", "Beg", "Big", "Bog", "Bug"  -match 'b[iou]g'
 #Output: Big, Bog, Bug
@@ -351,10 +360,10 @@ Collection examples:
 ```
 
 `-match` and `-notmatch` support regex capture groups. Each time they run, they
-overwrite the `$Matches` automatic variable with their findings. This variable
-is a **Hashtable** and always has a key named '0' that stores the entire match.
-If the regular expression contains capture groups, the Hashtable will contain
-additional corresponding keys.
+overwrite the `$Matches` automatic variable with their findings. `$Matches` is
+a **Hashtable** that always has a key named '0', which stores the entire match.
+If the regular expression contains capture groups, the `$Matches` contains
+additional keys for each group.
 
 Example:
 
@@ -393,19 +402,20 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with regular expressions
 
-The replacement operator, `-replace`, is an extension of the `-match` operator.
-Like `-match`, it finds the specified pattern, but unlike `-match`, it replaces
-them with another specified value.
+The replacement , , is an extension of the `-match` operator. Like `-match`,
+`-replace` operator uses regular expressions to find the specified pattern. But
+unlike `-match`, it replaces the matches with another specified value.
 
 Syntax:
 
-```powershell
-<String> -replace <regular-expression>, <substitute>
+```
+<input> -replace <regular-expression>, <substitute>
 ```
 
-You can use the `-replace` operator for many administrative tasks, such as
-renaming files. For example, the following command changes the file name
-extensions of all `.txt` files to `.log`:
+The operator replaces all or part of a value with the specified value using
+regular expressions. You can use the operator for many administrative tasks,
+such as renaming files. For example, the following command changes the file
+name extensions of all `.txt` files to `.log`:
 
 ```powershell
 Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
@@ -426,9 +436,12 @@ Examples:
 Cook
 book
 ```
+### Regular expressions substitutions
 
 It is also possible to use regular expressions to dynamically replace text
-using capturing groups, and substitutions.
+using capturing groups, and substitutions. Capture groups can be referenced in
+the `<substitute>` string using the dollar sign (`$`) character before the
+group identifier.
 
 In the following example, the `-replace` operator accepts a username in the form
 of `DomainName\Username` and converts to the `Username@DomainName` format:
@@ -444,39 +457,44 @@ $ReplaceExp = '${Username}@${DomainName}'
 John.Doe@Contoso.local
 ```
 
-For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
+> [!WARNING]
+> Since the `$` character is used in string expansion, you will must use
+> literal strings or escape the `$` character.
+>
+> ```powershell
+> PS> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
+> Hello Universe
+> ```
+>
+> Additionally, since the `$` character is used in substitution, you must
+> escape any instances in your string.
+>
+> ```powershell
+> PS> '5.72' -replace '(.+)', '$$$1'
+> $5.72
+> ```
 
-### Replacement with a script block
+To learn more see [about_Regular_Expressions](about_Regular_Expressions.md) and
+[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
 
-In PowerShell 6 and later, the `-replace` operator also accepts a script block
-that performs the replacement. The script block runs once for every match.
+### Substituting in a collection
 
-Syntax:
+When the `<input>` to the `-replace` operator is a collection, PowerShell
+applies the replacement to every value in the collection. For example:
 
 ```powershell
-<String> -replace <regular-expression>, {<Script-block>}
-```
-
-Within the script block, use the `$_` automatic variable to access the input
-text being replaced and other useful information. This variable's class type is
-[System.Text.RegularExpressions.Match][2].
-
-The following example replaces each sequence of three digits with the character
-equivalents. The script block runs for each set of three digits that needs to be
-replaced.
-
-```powershell
-"072101108108111" -replace "\d{3}", {return [char][int]$_.Value}
-```
-
-```output
-Hello
+"B1","B2","B3","B4","B5" -replace "B", 'a'
+a1
+a2
+a3
+a4
+a5
 ```
 
 ## Containment operators
 
 The containment operators (`-contains`, `-notcontains`, `-in`, and `-notin`) are
-similar to the equality operators, except that they always return a Boolean
+similar to the equality operators, except that they always return a **Boolean**
 value, even when the input is a collection. These operators stop comparing as
 soon as they detect the first match, whereas the equality operators evaluate all
 input members. In a very large collection, these operators return quicker than
@@ -484,7 +502,7 @@ the equality operators.
 
 Syntax:
 
-```powershell
+```
 <Collection> -contains <Test-object>
 <Collection> -notcontains <Test-object>
 <Test-object> -in <Collection>
@@ -529,10 +547,10 @@ $a, "ghi" -contains $a           # Output: True
 
 The `-in` and -`notin` operators were introduced in PowerShell 3 as the
 syntactic reverse of the of `contains` and `-notcontain` operators. `-in`
-returns True when the left-hand side (test object) matches one of the elements
-in the set. `-notin` returns False instead. When the test object is a set, these
-operators use reference equality, i.e. they check whether one of the set's
-elements is the same instance of the test object.
+returns **True** when the left-hand side `<test-object>` matches one of the
+elements in the set. `-notin` returns **False** instead. When the test object
+is a set, these operators use reference equality to check whether one of the
+set's elements is the same instance of the test object.
 
 The following examples do the same thing that the examples for `-contain`
 and `-notcontain` do, but they are written with `-in` and `-notin` instead.
@@ -593,6 +611,6 @@ $a -isnot $b.GetType() # Output: True
 - [Foreach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object)
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
 
-[1]: https://docs.microsoft.com/dotnet/api/system.icomparable?view=netstandard-2.0&preserve-view=true
-[2]: https://docs.microsoft.com/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6&preserve-view=true
+[1]: /dotnet/api/system.icomparable
+[2]: /dotnet/api/system.text.regularexpressions.match
 [3]: about_Redirection.md#potential-confusion-with-comparison-operators

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,652 +1,562 @@
 ---
 description: Describes the operators that compare values in PowerShell.
+keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 12/10/2020
-online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
+ms.date: 12/11/2020
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
 ---
 # About Comparison Operators
 
-## Short description
-Describes the operators that compare values in PowerShell.
+## Abstract
 
-## Long description
+The comparison operators in PowerShell can either compare two values or filter
+elements of a collection against an input value. These operators include:
+`-eq`,`-ne`,`-gt`,`-ge`,`-lt`,`-le`,`-like`,`-notlike`,`-match`,`-notmatch`,
+`-replace`,`-contains`,`-notcontains`,`-in`,`-notin`,`-is`,`-isnot`.
 
-Comparison operators let you specify conditions for comparing values and
-finding values that match specified patterns. To use a comparison operator,
-specify the values that you want to compare together with an operator that
-separates these values.
+## The operators
 
-PowerShell includes the following comparison operators:
+Comparison operators let you compare values or finding values that match
+specified patterns. PowerShell includes the following comparison operators:
 
-| Type        | Operators    | Description                                 |
-| ----------- | ------------ | --------------------------------------------|
-| Equality    | -eq          | equals                                      |
-|             | -ne          | not equals                                  |
-|             | -gt          | greater than                                |
-|             | -ge          | greater than or equal                       |
-|             | -lt          | less than                                   |
-|             | -le          | less than or equal                          |
-|             |              |                                             |
-| Matching    | -like        | Returns true when string matches wildcard   |
-|             |              | pattern                                     |
-|             | -notlike     | Returns true when string does not match     |
-|             |              | wildcard pattern                            |
-|             | -match       | Returns true when string matches regex      |
-|             |              | pattern; $matches contains matching strings |
-|             | -notmatch    | Returns true when string does not match     |
-|             |              | regex pattern; $matches contains matching   |
-|             |              | strings                                     |
-|             |              |                                             |
-| Containment | -contains    | Returns true when reference value contained |
-|             |              | in a collection                             |
-|             | -notcontains | Returns true when reference value not       |
-|             |              | contained in a collection                   |
-|             | -in          | Returns true when test value contained in a |
-|             |              | collection                                  |
-|             | -notin       | Returns true when test value not contained  |
-|             |              | in a collection                             |
-|             |              |                                             |
-| Replacement | -replace     | Replaces a string pattern                   |
-|             |              |                                             |
-| Type        | -is          | Returns true if both object are the same    |
-|             |              | type                                        |
-|             | -isnot       | Returns true if the objects are not the same|
-|             |              | type                                        |
+| Type        | Operator     | Comparison test
+| ----------- | ------------ | ------------------------------------------------
+| Equality    | -eq          | equals
+|             | -ne          | not equals
+|             | -gt          | greater than
+|             | -ge          | greater than or equal
+|             | -lt          | less than
+|             | -le          | less than or equal
+| Matching    | -like        | string matches wildcard pattern
+|             | -notlike     | string does not match wildcard pattern
+|             | -match       | string matches regex pattern
+|             | -notmatch    | string does not match regex pattern
+| Replacement | -replace     | string matches regex pattern; replaces the match
+| Containment | -contains    | collection contains a value
+|             | -notcontains | collection does not contain a value
+|             | -in          | value is in a collection
+|             | -notin       | value is not in a collection
+| Type        | -is          | both objectd are the same type
+|             | -isnot       | the objects are not the same type
+
+## Common features
 
 By default, all comparison operators are case-insensitive. To make a comparison
-operator case-sensitive, precede the operator name with a `c`. For example, the
-case-sensitive version of `-eq` is `-ceq`. To make the case-insensitivity
-explicit, precede the operator with an `i`. For example, the explicitly
-case-insensitive version of `-eq` is `-ieq`.
+operator case-sensitive, add a `c` after the `-`. For example, `-ceq` is the
+case-sensitive version of `-eq`. To make the case-insensitivity explicit,
+add an `i` before `-`. For example, `-ieq` is the explicitly case-insensitive
+version of `-eq`.
 
-When the input to an operator is a scalar value, comparison operators return a
-Boolean value. When the input is a collection of values, the comparison
-operators return any matching values. If there are no matches in a collection,
-comparison operators return an empty array.
+When the input of an operator is a scalar value, the operator returns a Boolean
+value. When the input is a collection, the operator returns those collection
+elements that match the input. If there are no matches in the collection,
+comparison operators return an empty array. For example:
 
 ```powershell
-PS> (1, 2 -eq 3).GetType().FullName
-System.Object[]
+$a = (1, 2 -eq 3)
+$a.GetType().Name
+$a.Count
 ```
 
-The exceptions are the containment operators, the In operators, and the type
-operators, which always return a **Boolean** value.
+```output
+Object[]
+0
+```
 
-> [!NOTE]
-> If you need to compare a value to `$null` you should put `$null` on the
-> left-hand side of the comparison. When you compare `$null` to an **Object[]**
-> the result is **False** because the comparison object is an array. When you
-> compare an array to `$null`, the comparison filters out any `$null` values
-> stored in the array. For example:
->
-> ```powershell
-> PS> $null -ne $null, "hello"
-> True
-> PS> $null, "hello" -ne $null
-> hello
-> ```
+The exceptions are the containment operators and the type operators; they always
+return a Boolean value.
 
 ## Equality operators
 
-The equality operators (`-eq`, `-ne`) return a value of TRUE or the matches
-when one or more of the input values is identical to the specified pattern. The
-entire pattern must match an entire value.
+### -eq and -ne
 
-Example:
-
-### -eq
-
-Description: Equal to. Includes an identical value.
+When the left-hand side is scalar, `-eq` returns True if the right-hand side is
+an exact match; otherwise, `-eq` returns False. `-ne` does the opposite; it
+returns False when both sides match; otherwise, `-ne` returns True.
 
 Example:
 
 ```powershell
-PS> 2 -eq 2
-True
+2 -eq 2                 # Ouput: True
+2 -eq 3                 # Ouput: False
+"abc" -eq "abc"         # Ouput: True
+"abc" -eq "abc", "def"  # Ouput: False
+"abc" -ne "def"         # Ouput: True
+"abc" -ne "abc"         # Ouput: False
+"abc" -ne "abc", "def"  # Ouput: True
+```
 
-PS> 2 -eq 3
+When the left-hand side is a collection, `-eq` returns those members that match
+the right-hand side, while `-ne` filters them out.
+
+Example:
+
+```powershell
+1,2,3 -eq 2             # Ouput: 2
+"abc", "def" -eq "abc"  # Ouput: abc
+"abc", "def" -ne "abc"  # Ouput: def
+```
+
+These operators process all elements of the collection. Example:
+
+```powershell
+"zzz", "def", "zzz" -eq "zzz"
+```
+
+```output
+zzz
+zzz
+```
+
+The equality operators accept any two objects, not just scalar or collection.
+But the comparison result is not guaranteed to be meaningful for the end-user.
+The following example demonstrates the issue.
+
+```powershell
+class MyFileInfoSet {
+    [String]$File
+    [String]$Size
+}
+$a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$a -eq $b
+```
+
+```Output
 False
+```
 
-PS> 1,2,3 -eq 2
+In this example, we created two objects with identical properties. Yet, the
+equality test result is False, because they are different objects. If you intend
+to develop meaningfully comparable classes, you need to implement
+[System.IComparable][1] in your class.
+
+A prominent example of comparing arbitrary objects is to find out if they are
+null. But if you need to determine whether a variable is `$null`, you must put
+`$null` on the left-hand side of the equality operator. Putting it on the
+right-hand side does not do what you expect.
+
+For example, let `$a` be an array containing null elements:
+
+```powershell
+$a = 1, 2, $null, 4, $null, 6
+```
+
+The following tests that `$a` is not null.
+
+```powershell
+$null -ne $a
+```
+
+```output
+False
+```
+
+The following, however, filers out all null elements from `$a`:
+
+```powershell
+$a -ne $null # Output: 1, 2, 4, 6
+```
+
+```output
+1
 2
-PS> "abc" -eq "abc"
-True
-
-PS> "abc" -eq "abc", "def"
-False
-
-PS> "abc", "def" -eq "abc"
-abc
+4
+6
 ```
 
-### -ne
+### -gt, -ge, -lt, and -le
 
-Description: Not equal to. Includes a different value.
+`-gt`, `-ge`, `-lt`, and `-le` behave very similarly. When both sides are scalar
+they return True or False depending on how the two sides compare:
+
+| Operator | Returns True when...                   |
+| -------- | -------------------------------------- |
+| -gt      | The left-hand side is greater          |
+| -ge      | The left-hand side is greater or equal |
+| -lt      | The left-hand side is smaller          |
+| -le      | The left-hand side is smaller or equal |
+
+In the following examples, all statements return True.
+
+```powershell
+8 -gt 6  # Ouput: True
+8 -ge 8  # Ouput: True
+6 -lt 8  # Ouput: True
+8 -le 8  # Ouput: True
+```
+
+> [!NOTE] The greater-than operator, in most programming languages, is `>`. In
+> PowerShell, however, this character is used for redirection. For details, see
+> [About_redirection][3].
+
+When the left-hand side is a collection, these operators compare each member of
+the collection with the right-hand side. Depending on their logic, they either
+keep or discard the member.
 
 Example:
 
 ```powershell
-PS> "abc" -ne "def"
-True
+$a=5, 6, 7, 8, 9
 
-PS> "abc" -ne "abc"
-False
+Write-Output "Test collection:"
+$a
 
-PS> "abc" -ne "abc", "def"
-True
+Write-Output "`nMembers greater than 7"
+$a -gt 7
 
-PS> "abc", "def" -ne "abc"
-def
+Write-Output "`nMembers greater than or equal to 7"
+$a -ge 7
+
+Write-Output "`nMembers smaller than 7"
+$a -lt 7
+
+Write-Output "`nMembers smaller than or equal to 7"
+$a -le 7
 ```
 
-### -gt
-
-Description: Greater-than.
-
-Example:
-
-```powershell
-PS> 8 -gt 6
-True
-
-PS> 7, 8, 9 -gt 8
-9
-```
-
-> [!NOTE]
-> This should not to be confused with `>`, the greater-than operator in many
-> other programming languages. In PowerShell, `>` is used for redirection. For
-> more information, see
-> [About_redirection](about_Redirection.md#potential-confusion-with-comparison-operators).
-
-### -ge
-
-Description: Greater-than or equal to.
-
-Example:
-
-```powershell
-PS> 8 -ge 8
-True
-
-PS> 7, 8, 9 -ge 8
+```output
+Test collection:
+5
+6
+7
 8
 9
-```
 
-### -lt
+Memebers greater than 7
+8
+9
 
-Description: Less-than.
+Memebers greater than or equal to 7
+7
+8
+9
 
-Example:
+Memebers smaller than 7
+5
+6
 
-```powershell
-
-PS> 8 -lt 6
-False
-
-PS> 7, 8, 9 -lt 8
+Memebers smaller than or equal to 7
+5
+6
 7
 ```
 
-### -le
+These operators aren't restricted to numbers; they work with any class that
+implements [System.IComparable][1].
 
-Description: Less-than or equal to.
-
-Example:
+Examples:
 
 ```powershell
-PS> 6 -le 8
-True
+# Date comparison
+[DateTime]'2001-11-12' -lt [DateTime]'2020-08-01' # True
 
-PS> 7, 8, 9 -le 8
-7
-8
+# Sorting order comparison
+'a' -lt 'z'           # True; 'a' comes before 'z'
+'macOS' -ilt 'MacOS'  # False
+'MacOS' -ilt 'macOS'  # False
+'macOS' -clt 'MacOS'  # True; 'm' comes before 'M'
 ```
+
+The following example demonstrates that there is no symbol on an American QWERTY
+keyboard that gets sorted after 'a'. It feeds a set containing all such symbols
+to the `-gt` operator to compare them against 'a'. The output is an empty array.
+
+```powershell
+$a=' ','`','~','!','@','#','$','%','^','&','*','(',')','_','+','-','=','{','}',
+   '[',']',':',';','"','''','\','|','/','?','.','>',',','<'
+$a -gt 'a'
+# Output: Nothing
+```
+
+If the two sides of the operators are not reasonably comparable, these operators
+raise a non-terminating error.
 
 ## Matching operators
 
-The like operators (`-like` and `-notlike`) find elements that match or do not
-match a specified pattern using wildcard expressions.
+The matching operators (`-like`, `-notlike`, `-match`, and `-notmatch`) find
+elements that match or do not match a specified pattern. The pattern for `-like`
+and `-notlike` is a wildcard expression (containing `*`, `?`, and `[ ]`), while
+`-match` and `-notmatch` accept a regular expression (Regex).
 
 The syntax is:
 
 ```powershell
-<string[]> -like <wildcard-expression>
+<string[]> -like    <wildcard-expression>
 <string[]> -notlike <wildcard-expression>
-```
-
-The match operators (`-match` and `-notmatch`) find elements that match or do
-not match a specified pattern using regular expressions.
-
-The match operators populate the `$Matches` automatic variable when the input
-(the left-side argument) to the operator is a single scalar object. When the
-input is scalar, the `-match` and `-notmatch` operators return a Boolean value
-and set the value of the `$Matches` automatic variable to the matched
-components of the argument.
-
-The syntax is:
-
-```powershell
-<string[]> -match <regular-expression>
+<string[]> -match    <regular-expression>
 <string[]> -notmatch <regular-expression>
 ```
 
-### -like
+When the input of these operators is a scalar value, they return a Boolean
+value. When the input is a collection of values, the operators return any
+matching members. If there are no matches in a collection, the operators return
+an empty array.
 
-Description: Match using the wildcard character (\*).
+### -like and -notlike
 
-Example:
-
-```powershell
-PS> "PowerShell" -like "*shell"
-True
-
-PS> "PowerShell", "Server" -like "*shell"
-PowerShell
-```
-
-### -notlike
-
-Description: Does not match using the wildcard character (\*).
+`-like` and `-notlike` behave similarly to `-eq` and `-ne`, but the right-hand
+side could be a string containing [wildcards](about_Wildcards.md).
 
 Example:
 
 ```powershell
-PS> "PowerShell" -notlike "*shell"
-False
+"PowerShell" -like    "*shell"           # Ouput: True
+"PowerShell" -notlike "*shell"           # Ouput: False
+"PowerShell" -like    "Power?hell"       # Ouput: True
+"PowerShell" -notlike "Power?hell"       # Ouput: False
+"PowerShell" -like    "Power[p-w]hell"   # Ouput: True
+"PowerShell" -notlike "Power[p-w]hell"   # Ouput: False
 
-PS> "PowerShell", "Server" -notlike "*shell"
-Server
+"PowerShell", "Server" -like "*shell"    # Ouput: PowerShell
+"PowerShell", "Server" -notlike "*shell" # Ouput: Server
 ```
 
-### -match
+## -match and -notmatch
 
-Description: Matches a string using regular expressions. When the input is
-scalar, it populates the `$Matches` automatic variable.
+`-match` and `-notmatch` use regular expressions to conduct their search. As
+such, they support very complex searches, e.g. they can find email addresses,
+UNC paths, or dash-formatted phone numbers. The right-hand side string must
+adhere to the [regular expressions](about_Regular_Expressions.md) rules.
 
-If the input is a collection, the `-match` and `-notmatch` operators return
-the matching members of that collection, but the operator does not populate
-the `$Matches` variable.
-
-For example, the following command submits a collection of strings to the
-`-match` operator. The `-match` operator returns the items in the collection
-that match. It does not populate the `$Matches` automatic variable.
+Scalar examples:
 
 ```powershell
-PS> "Sunday", "Monday", "Tuesday" -match "sun"
-Sunday
+# Partial match test, showing how differently -match and -like behave
+"PowerShell" -match 'shell'        # Ouput: True
+"PowerShell" -like  'shell'        # Ouput: False
 
-PS> $Matches
-PS>
+# Regex syntax test
+"PowerShell" -match    '^Power\w+' # Ouput: True
+'bag'        -notmatch 'b[iou]g'   # Ouput: True
 ```
 
-In contrast, the following command submits a single string to the `-match`
-operator. The `-match` operator returns a Boolean value and populates the
-`$Matches` automatic variable. The `$Matches` automatic variable is a
-**Hashtable**. If no grouping or capturing is used, only one key is populated.
-The `0` key represents all text that was matched. For more information about
-grouping and capturing using regular expressions, see
-[about_Regular_Expressions](about_Regular_Expressions.md).
+Collection examples:
 
 ```powershell
-PS> "Sunday" -match "sun"
-True
+"PowerShell", "Super PowerShell", "Power's hell" -match '^Power\w+'
+# Output: PowerShell
 
-PS> $Matches
+"Rhell", "Chell", "Mel", "Smell", "Shell" -match "hell"
+# Ouput: Rhell, Chell, Shell
 
-Name                           Value
-----                           -----
-0                              Sun
+"Bag", "Beg", "Big", "Bog", "Bug"  -match 'b[iou]g'
+#Output: Big, Bog, Bug
+
+"Bag", "Beg", "Big", "Bog", "Bug"  -notmatch 'b[iou]g'
+#Output: Bag, Beg
 ```
 
-It is important to note that the `$Matches` hashtable will only contain the
-first occurrence of any matching pattern.
-
-```powershell
-PS> "Banana" -match "na"
-True
-
-PS> $Matches
-
-Name                           Value
-----                           -----
-0                              na
-```
-
-> [!IMPORTANT]
-> The `0` key is an **Integer**. You can use any **Hashtable** method to access
-> the value stored.
->
-> ```powershell
-> PS> "Good Dog" -match "Dog"
-> True
->
-> PS> $Matches[0]
-> Dog
->
-> PS> $Matches.Item(0)
-> Dog
->
-> PS> $Matches.0
-> Dog
-> ```
-
-The `-notmatch` operator populates the `$Matches` automatic variable when the
-input is scalar and the result is False, that it, when it detects a match.
-
-```powershell
-PS> "Sunday" -notmatch "rain"
-True
-
-PS> $matches
-PS>
-
-PS> "Sunday" -notmatch "day"
-False
-
-PS> $matches
-
-Name                           Value
-----                           -----
-0                              day
-```
-
-### -notmatch
-
-Description: Does not match a string. Uses regular expressions. When the input
-is scalar, it populates the `$Matches` automatic variable.
+`-match` and `-notmatch` support regex capture groups. Each time they run, they
+overwrite the `$Matches` automatic variable with their findings. This variable
+is a **Hashtable** and always has a key named '0' that stores the entire match.
+If the regular expression contains capture groups, the Hashtable will contain
+additional corresponding keys.
 
 Example:
 
 ```powershell
-PS> "Sunday" -notmatch "sun"
-False
+$string = 'The last logged on user was CONTOSO\jsmith'
+$string -match 'was (?<domain>.+)\\(?<user>.+)'
 
-PS> $matches
-Name Value
----- -----
-0    sun
+$Matches
 
-PS> "Sunday", "Monday" -notmatch "sun"
-Monday
+Write-Output "`nDomain name:"
+$Matches.domain
+
+Write-Output "`nUser name:"
+$Matches.user
 ```
 
-## Containment operators
+```output
+True
 
-The containment operators (`-contains` and `-notcontains`) are similar to the
-equality operators. However, the containment operators always return a Boolean
-value, even when the input is a collection.
+Name                           Value
+----                           -----
+domain                         CONTOSO
+user                           jsmith
+0                              was CONTOSO\jsmith
 
-Also, unlike the equality operators, the containment operators return a value
-as soon as they detect the first match. The equality operators evaluate all
-input and then return all the matches in the collection.
+Domain name:
+CONTOSO
 
-### -contains
+User name:
+jsmith
+```
 
-Description: Containment operator. Tells whether a collection of reference
-values includes a single test value. Always returns a Boolean value. Returns
-TRUE only when the test value exactly matches at least one of the reference
-values.
+For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
-When the test value is a collection, the Contains operator uses reference
-equality. It returns TRUE only when one of the reference values is the same
-instance of the test value object.
+## Replacement operator
 
-In a very large collection, the `-contains` operator returns results quicker
-than the equal to operator.
+### Replacement with regular expressions
+
+The replacement operator, `-replace`, is an extension of the `-match` operator.
+Like `-match`, it finds the specified pattern, but unlike `-match`, it replaces
+them with another specified value.
 
 Syntax:
 
-`<Reference-values> -contains <Test-value>`
-
-Examples:
-
 ```powershell
-PS> "abc", "def" -contains "def"
-True
-
-PS> "Windows", "PowerShell" -contains "Shell"
-False  #Not an exact match
-
-# Does the list of computers in $DomainServers include $ThisComputer?
-PS> $DomainServers -contains $thisComputer
-True
-
-PS> "abc", "def", "ghi" -contains "abc", "def"
-False
-
-PS> $a = "abc", "def"
-PS> "abc", "def", "ghi" -contains $a
-False
-PS> $a, "ghi" -contains $a
-True
+<String> -replace <regular-expression>, <substitute>
 ```
 
-### -notcontains
-
-Description: Containment operator. Tells whether a collection of reference
-values includes a single test value. Always returns a Boolean value. Returns
-TRUE when the test value is not an exact matches for at least one of the
-reference values.
-
-When the test value is a collection, the NotContains operator uses reference
-equality.
-
-Syntax:
-
-`<Reference-values> -notcontains <Test-value>`
-
-Examples:
-
-```powershell
-PS> "Windows", "PowerShell" -notcontains "Shell"
-True  #Not an exact match
-
-# Get cmdlet parameters, but exclude common parameters
-function get-parms ($cmdlet)
-{
-    $Common = "Verbose", "Debug", "WarningAction", "WarningVariable",
-      "ErrorAction", "ErrorVariable", "OutVariable", "OutBuffer"
-
-    $allparms = (Get-Command $Cmdlet).parametersets |
-      foreach {$_.Parameters} |
-        foreach {$_.Name} | Sort-Object | Get-Unique
-
-    $allparms | where {$Common -notcontains $_ }
-}
-
-# Find unapproved verbs in the functions in my module
-PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS> $myVerbs = Get-Command -Module MyModule | foreach {$_.verb}
-PS> $myVerbs | where {$ApprovedVerbs -notcontains $_}
-ForEach
-Sort
-Tee
-Where
-```
-
-### -in
-
-Description: In operator. Tells whether a test value appears in a collection of
-reference values. Always return as Boolean value. Returns TRUE only when the
-test value exactly matches at least one of the reference values.
-
-When the test value is a collection, the In operator uses reference equality.
-It returns TRUE only when one of the reference values is the same instance of
-the test value object.
-
-The `-in` operator was introduced in PowerShell 3.0.
-
-Syntax:
-
-`<Test-value> -in <Reference-values>`
-
-Examples:
-
-```powershell
-PS> "def" -in "abc", "def"
-True
-
-PS> "Shell" -in "Windows", "PowerShell"
-False  #Not an exact match
-
-PS> "Windows" -in "Windows", "PowerShell"
-True  #An exact match
-
-PS> "Windows", "PowerShell" -in "Windows", "PowerShell", "ServerManager"
-False  #Using reference equality
-
-PS> $a = "Windows", "PowerShell"
-PS> $a -in $a, "ServerManager"
-True  #Using reference equality
-
-# Does the list of computers in $DomainServers include $ThisComputer?
-PS> $thisComputer -in  $domainServers
-True
-```
-
-### -notin
-
-Description: Tells whether a test value appears in a collection of reference
-values. Always returns a Boolean value. Returns TRUE when the test value is not
-an exact match for at least one of the reference values.
-
-When the test value is a collection, the In operator uses reference equality.
-It returns TRUE only when one of the reference values is the same instance of
-the test value object.
-
-The `-notin` operator was introduced in PowerShell 3.0.
-
-Syntax:
-
-`<Test-value> -notin <Reference-values>`
-
-Examples:
-
-```powershell
-PS> "def" -notin "abc", "def"
-False
-
-PS> "ghi" -notin "abc", "def"
-True
-
-PS> "Shell" -notin "Windows", "PowerShell"
-True  #Not an exact match
-
-PS> "Windows" -notin "Windows", "PowerShell"
-False  #An exact match
-
-# Find unapproved verbs in the functions in my module
-PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS> $MyVerbs = Get-Command -Module MyModule | foreach {$_.verb}
-
-PS> $MyVerbs | where {$_ -notin $ApprovedVerbs}
-ForEach
-Sort
-Tee
-Where
-```
-
-## Replacement Operator
-
-The `-replace` operator has the following syntax:
-
-`<input> -replace <original>, <substitute>`
-
-The `<original>` placeholder is a regular expression matching the characters to
-be replaced. The `<substitute>` placeholder is a literal string that replaces
-them.
-
-The operator replaces all or part of a value with the specified value using
-regular expressions. You can use the operator for many administrative tasks,
-such as renaming files. For example, the following command changes the file
-name extensions of all `.txt` files to `.log`:
+You can use the `-replace` operator for many administrative tasks, such as
+renaming files. For example, the following command changes the file name
+extensions of all `.txt` files to `.log`:
 
 ```powershell
 Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
 ```
 
-### Case-sensitive matches
-
 By default, the `-replace` operator is case-insensitive. To make it case
 sensitive, use `-creplace`. To make it explicitly case-insensitive, use
 `-ireplace`.
 
-Consider the following examples:
+Examples:
 
 ```powershell
-PS> "book" -replace "B", "C"
-Cook
+"book" -ireplace "B", "C" # Case insensitive
+"book" -creplace "B", "C" # Case-sensitive; hence, nothing to replace
 ```
 
-```powershell
-PS> "book" -ireplace "B", "C"
+```Output
 Cook
-```
-
-```powershell
-PS> "book" -creplace "B", "C"
 book
 ```
 
-### Substitutions in regular expressions
-
 It is also possible to use regular expressions to dynamically replace text
-using capturing groups, and substitutions. Capture groups can be referenced in
-the `<substitute>` string using the dollar sign (`$`) character before the
-group identifier.
+using capturing groups, and substitutions.
 
-Capture groups can be referenced by **Number** or **Name**
-
-- By **Number** - Capturing Groups are numbered from left to right.
-
-  ```powershell
-  PS> "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
-  John.D.Smith@contoso.com
-  ```
-
-- By **Name** - Capturing Groups can also be referenced by name.
-
-  ```powershell
-  PS> "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
-  FABRIKAM\Administrator
-  ```
-
-> [!WARNING]
-> Since the `$` character is used in string expansion, you must use
-> literal strings or escape the `$` character.
->
-> ```powershell
-> PS> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
-> Hello Universe
-> ```
->
-> Additionally, since the `$` character is used in substitution, you must
-> escape any instances in your string.
->
-> ```powershell
-> PS> '5.72' -replace '(.+)', '$$$1'
-> $5.72
-> ```
-
-To learn more see [about_Regular_Expressions](about_Regular_Expressions.md) and
-[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
-
-### Substituting in a collection
-
-When the `<input>` to the `-replace` operator is a collection, PowerShell
-applies the replacement to every value in the collection. For example:
+In the following example, the `-replace` operator accepts a username in the form of `DomainName\Username` and converts to the `Username@DomainName` format:
 
 ```powershell
-"B1","B2","B3","B4","B5" -replace "B", 'a'
-a1
-a2
-a3
-a4
-a5
+$SearchExp = '^(?<Username>[\w-.]+)\\(?<DomainName>[\w-.]+)$'
+$ReplaceExp = '${Username}@${DomainName}'
+
+'Contoso.local\John.Doe' -replace $SearchExp,$ReplaceExp
+```
+
+```output
+John.Doe@Contoso.local
+```
+
+For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
+
+### Replacement with a script block
+
+In Powershell 6 and later, the `-replace` operator also accepts a script block
+that performs the replacement. The script block runs once for every match.
+
+Syntax:
+
+```powershell
+<String> -replace <regular-expression>, {<Script-block>}
+```
+
+Within the script block, use the `$_` automatic variable to access the input
+text being replaced and other useful information. This variable's class type is
+[System.Text.RegularExpressions.Match][2].
+
+The following example replaces each sequence of three digits with the character
+equivalents. The script block runs for each set of three digits that needs to be
+replaced.
+
+```powershell
+"072101108108111" -replace "\d{3}", {return [char][int]$_.Value}
+```
+
+```output
+Hello
+```
+
+## Containment operators
+
+The containment operators (`-contains`, `-notcontains`, `-in`, and `-notin`) are
+similar to the equality operators, except that they always return a Boolean
+value, even when the input is a collection. These operators stop comparing as
+soon as they detect the first match, whereas the equality operators evaluate all
+input members. In a very large collection, these operators return quicker than
+the equality operators.
+
+Syntax:
+
+```powershell
+<Collection> -contains <Test-object>
+<Collection> -notcontains <Test-object>
+<Test-object> -in <Collection>
+<Test-object> -notin <Collection>
+```
+
+### -contains and -notcontains
+
+These operators tell whether a set includes a certain element. `-contains`
+returns True when the right-hand side (test object) matches one of the elements
+in the set. `-notcontains` returns False instead. When the test object is a
+collection, these operators use reference equality, i.e. they check whether one
+of the set's elements is the same instance of the test object.
+
+Examples:
+
+```powershell
+"abc", "def" -contains "def"                  # Output: True
+"abc", "def" -notcontains "def"               # Output: False
+"Windows", "PowerShell" -contains "Shell"     # Output: False
+"Windows", "PowerShell" -notcontains "Shell"  # Output: True
+"abc", "def", "ghi" -contains "abc", "def"    # Output: False
+"abc", "def", "ghi" -notcontains "abc", "def" # Output: True
+```
+
+More complex examples:
+
+```powershell
+$DomainServers = "ContosoDC1","ContosoDC2","ContosoFileServer","ContosoDNS",
+                 "ContosoDHCP","ContosoWSUS"
+$thisComputer  = "ContosoDC2"
+
+$DomainServers -contains $thisComputer
+# Output: True
+
+$a = "abc", "def"
+"abc", "def", "ghi" -contains $a # Output: False
+$a, "ghi" -contains $a           # Output: True
+```
+
+### -in and -notin
+
+The `-in` and -`notin` operators were introduced in PowerShell 3 as the
+syntactic reverse of the of `contains` and `-notcontain` operators. `-in`
+returns True when the left-hand side (test object) matches one of the elements
+in the set. `-notin` returns False instead. When the test object is a set, these
+operators use reference equality, i.e. they check whether one of the set's
+elements is the same instance of the test object.
+
+The following examples do the same thing that the examples for `-contain`
+and `-notcontain` do, but they are written with `-in` and `-notin` instead.
+
+```powershell
+"def" -in "abc", "def"                  # Output: True
+"def" -notin "abc", "def"               # Output: False
+"Shell" -in "Windows", "PowerShell"     # Output: False
+"Shell" -notin "Windows", "PowerShell"  # Output: True
+"abc", "def" -in "abc", "def", "ghi"    # Output: False
+"abc", "def" -notin "abc", "def", "ghi" # Output: True
+```
+
+More complex examples:
+
+```powershell
+$DomainServers = "ContosoDC1","ContosoDC2","ContosoFileServer","ContosoDNS",
+                 "ContosoDHCP","ContosoWSUS"
+$thisComputer  = "ContosoDC2"
+
+$thisComputer -in $DomainServers
+# Output: True
+
+$a = "abc", "def"
+$a -in "abc", "def", "ghi" # Output: False
+$a -in $a, "ghi"           # Output: True
 ```
 
 ## Type comparison
@@ -654,41 +564,25 @@ a5
 The type comparison operators (`-is` and `-isnot`) are used to determine if an
 object is a specific type.
 
-### -is
-
 Syntax:
 
-`<object> -is <type reference>`
+```powershell
+<object> -is <type-reference>
+<object> -isnot <type-reference>
+```
 
 Example:
 
 ```powershell
-PS> $a = 1
-PS> $b = "1"
-PS> $a -is [int]
-True
-PS> $a -is $b.GetType()
-False
+$a = 1
+$b = "1"
+$a -is [int]           # Output: True
+$a -is $b.GetType()    # Output: False
+$b -isnot [int]        # Output: False
+$a -isnot $b.GetType() # Output: True
 ```
 
-### -isnot
-
-Syntax:
-
-`<object> -isnot <type reference>`
-
-Example:
-
-```powershell
-PS> $a = 1
-PS> $b = "1"
-PS> $a -isnot $b.GetType()
-True
-PS> $b -isnot [int]
-True
-```
-
-## See also
+## SEE ALSO
 
 - [about_Operators](about_Operators.md)
 - [about_Regular_Expressions](about_Regular_Expressions.md)
@@ -696,3 +590,7 @@ True
 - [Compare-Object](xref:Microsoft.PowerShell.Utility.Compare-Object)
 - [Foreach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object)
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
+
+[1]: https://docs.microsoft.com/en-us/dotnet/api/system.icomparable?view=netstandard-2.0
+[2]: https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6
+[3]: about_Redirection.md#potential-confusion-with-comparison-operators

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -1,6 +1,5 @@
 ---
 description: Explains how to redirect output from PowerShell to text files.
-keywords: PowerShell,cmdlet
 Locale: en-US
 ms.date: 10/14/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_redirection?view=powershell-5.1&WT.mc_id=ps-gethelp
@@ -10,7 +9,6 @@ title: about_Redirection
 # About Redirection
 
 ## Short description
-
 Explains how to redirect output from PowerShell to text files.
 
 ## Long description
@@ -259,7 +257,8 @@ The '<' operator is reserved for future use.
 ```
 
 If numeric comparison is the required operation, `-lt` and `-gt` should be
-used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt--ge--lt-and--le)
+used. For more information, see the `-gt` operator in
+[about_Comparison_Operators](about_Comparison_Operators.md#-gt--ge--lt-and--le).
 
 ## See also
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -10,6 +10,7 @@ title: about_Redirection
 # About Redirection
 
 ## Short description
+
 Explains how to redirect output from PowerShell to text files.
 
 ## Long description
@@ -220,7 +221,7 @@ formatted correctly. To write to files with a different encoding, use the
 ### Potential confusion with comparison operators
 
 The `>` operator is not to be confused with the
-[Greater-than](about_Comparison_Operators.md##-gt--ge--lt-and--le) comparison operator (often
+[Greater-than](about_Comparison_Operators.md#-gt--ge--lt-and--le) comparison operator (often
 denoted as `>` in other programming languages).
 
 Depending on the objects being compared, the output using `>` can appear to be
@@ -253,12 +254,12 @@ At line:1 char:8
 + if (36 < 42) { "true" } else { "false" }
 +        ~
 The '<' operator is reserved for future use.
-+ CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
-+ FullyQualifiedErrorId : RedirectionNotSupported
+    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
+    + FullyQualifiedErrorId : RedirectionNotSupported
 ```
 
 If numeric comparison is the required operation, `-lt` and `-gt` should be
-used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt)
+used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt--ge--lt-and--le)
 
 ## See also
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -220,7 +220,7 @@ formatted correctly. To write to files with a different encoding, use the
 ### Potential confusion with comparison operators
 
 The `>` operator is not to be confused with the
-[Greater-than](about_Comparison_Operators.md#-gt) comparison operator (often
+[Greater-than](about_Comparison_Operators.md##-gt--ge--lt-and--le) comparison operator (often
 denoted as `>` in other programming languages).
 
 Depending on the objects being compared, the output using `>` can appear to be

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,6 +1,5 @@
 ---
 description: Describes the operators that compare values in PowerShell.
-keywords: powershell,cmdlet
 Locale: en-US
 ms.date: 12/11/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7&WT.mc_id=ps-gethelp
@@ -9,37 +8,35 @@ title: about_Comparison_Operators
 ---
 # About Comparison Operators
 
-## Abstract
+## Short description
 
 The comparison operators in PowerShell can either compare two values or filter
-elements of a collection against an input value. These operators include:
-`-eq`,`-ne`,`-gt`,`-ge`,`-lt`,`-le`,`-like`,`-notlike`,`-match`,`-notmatch`,
-`-replace`,`-contains`,`-notcontains`,`-in`,`-notin`,`-is`,`-isnot`.
+elements of a collection against an input value.
 
-## The operators
+## Long description
 
 Comparison operators let you compare values or finding values that match
 specified patterns. PowerShell includes the following comparison operators:
 
-| Type        | Operator     | Comparison test
-| ----------- | ------------ | ------------------------------------------------
-| Equality    | -eq          | equals
-|             | -ne          | not equals
-|             | -gt          | greater than
-|             | -ge          | greater than or equal
-|             | -lt          | less than
-|             | -le          | less than or equal
-| Matching    | -like        | string matches wildcard pattern
-|             | -notlike     | string does not match wildcard pattern
-|             | -match       | string matches regex pattern
-|             | -notmatch    | string does not match regex pattern
-| Replacement | -replace     | string matches regex pattern; replaces the match
-| Containment | -contains    | collection contains a value
-|             | -notcontains | collection does not contain a value
-|             | -in          | value is in a collection
-|             | -notin       | value is not in a collection
-| Type        | -is          | both objectd are the same type
-|             | -isnot       | the objects are not the same type
+|    Type     |   Operator   |              Comparison test              |
+| ----------- | ------------ | ----------------------------------------- |
+| Equality    | -eq          | equals                                    |
+|             | -ne          | not equals                                |
+|             | -gt          | greater than                              |
+|             | -ge          | greater than or equal                     |
+|             | -lt          | less than                                 |
+|             | -le          | less than or equal                        |
+| Matching    | -like        | string matches wildcard pattern           |
+|             | -notlike     | string does not match wildcard pattern    |
+|             | -match       | string matches regex pattern              |
+|             | -notmatch    | string does not match regex pattern       |
+| Replacement | -replace     | replaces strings matching a regex pattern |
+| Containment | -contains    | collection contains a value               |
+|             | -notcontains | collection does not contain a value       |
+|             | -in          | value is in a collection                  |
+|             | -notin       | value is not in a collection              |
+| Type        | -is          | both objects are the same type            |
+|             | -isnot       | the objects are not the same type         |
 
 ## Common features
 
@@ -49,10 +46,11 @@ case-sensitive version of `-eq`. To make the case-insensitivity explicit,
 add an `i` before `-`. For example, `-ieq` is the explicitly case-insensitive
 version of `-eq`.
 
-When the input of an operator is a scalar value, the operator returns a Boolean
-value. When the input is a collection, the operator returns those collection
-elements that match the input. If there are no matches in the collection,
-comparison operators return an empty array. For example:
+When the input of an operator is a scalar value, the operator returns a
+**Boolean** value. When the input is a collection, the operator returns the
+elements of the collection that match the right-hand value of the expression.
+If there are no matches in the collection, comparison operators return an empty
+array. For example:
 
 ```powershell
 $a = (1, 2 -eq 3)
@@ -65,27 +63,31 @@ Object[]
 0
 ```
 
-The exceptions are the containment operators and the type operators; they always
-return a Boolean value.
+There are a few exceptions:
+
+- The containment and type operators. They always return a **Boolean** value.
+- The `-replace` operator returns the values resulting from the replacement.
+- The `-match` and `-notmatch` operators also populate the `$Matches` automatic
+  variable.
 
 ## Equality operators
 
 ### -eq and -ne
 
-When the left-hand side is scalar, `-eq` returns True if the right-hand side is
-an exact match; otherwise, `-eq` returns False. `-ne` does the opposite; it
-returns False when both sides match; otherwise, `-ne` returns True.
+When the left-hand side is scalar, `-eq` returns **True** if the right-hand side is
+an exact match, otherwise, `-eq` returns **False**. `-ne` does the opposite; it
+returns **False** when both sides match; otherwise, `-ne` returns True.
 
 Example:
 
 ```powershell
-2 -eq 2                 # Ouput: True
-2 -eq 3                 # Ouput: False
-"abc" -eq "abc"         # Ouput: True
-"abc" -eq "abc", "def"  # Ouput: False
-"abc" -ne "def"         # Ouput: True
-"abc" -ne "abc"         # Ouput: False
-"abc" -ne "abc", "def"  # Ouput: True
+2 -eq 2                 # Output: True
+2 -eq 3                 # Output: False
+"abc" -eq "abc"         # Output: True
+"abc" -eq "abc", "def"  # Output: False
+"abc" -ne "def"         # Output: True
+"abc" -ne "abc"         # Output: False
+"abc" -ne "abc", "def"  # Output: True
 ```
 
 When the left-hand side is a collection, `-eq` returns those members that match
@@ -94,9 +96,9 @@ the right-hand side, while `-ne` filters them out.
 Example:
 
 ```powershell
-1,2,3 -eq 2             # Ouput: 2
-"abc", "def" -eq "abc"  # Ouput: abc
-"abc", "def" -ne "abc"  # Ouput: def
+1,2,3 -eq 2             # Output: 2
+"abc", "def" -eq "abc"  # Output: abc
+"abc", "def" -ne "abc"  # Output: def
 ```
 
 These operators process all elements of the collection. Example:
@@ -110,7 +112,7 @@ zzz
 zzz
 ```
 
-The equality operators accept any two objects, not just scalar or collection.
+The equality operators accept any two objects, not just a scalar or collection.
 But the comparison result is not guaranteed to be meaningful for the end-user.
 The following example demonstrates the issue.
 
@@ -129,7 +131,7 @@ False
 ```
 
 In this example, we created two objects with identical properties. Yet, the
-equality test result is False, because they are different objects. If you intend
+equality test result is **False** because they are different objects. If you intend
 to develop meaningfully comparable classes, you need to implement
 [System.IComparable][1] in your class.
 
@@ -170,7 +172,7 @@ $a -ne $null # Output: 1, 2, 4, 6
 ### -gt, -ge, -lt, and -le
 
 `-gt`, `-ge`, `-lt`, and `-le` behave very similarly. When both sides are scalar
-they return True or False depending on how the two sides compare:
+they return **True** or **False** depending on how the two sides compare:
 
 | Operator | Returns True when...                   |
 | -------- | -------------------------------------- |
@@ -182,16 +184,16 @@ they return True or False depending on how the two sides compare:
 In the following examples, all statements return True.
 
 ```powershell
-8 -gt 6  # Ouput: True
-8 -ge 8  # Ouput: True
-6 -lt 8  # Ouput: True
-8 -le 8  # Ouput: True
+8 -gt 6  # Output: True
+8 -ge 8  # Output: True
+6 -lt 8  # Output: True
+8 -le 8  # Output: True
 ```
 
 > [!NOTE]
-> The greater-than operator, in most programming languages, is `>`. In
-> PowerShell, however, this character is used for redirection. For details, see
-> [About_redirection][3].
+> In most programming languages the greater-than operator is `>`. In
+> PowerShell, this character is used for redirection. For details, see
+> [about_Redirection][3].
 
 When the left-hand side is a collection, these operators compare each member of
 the collection with the right-hand side. Depending on their logic, they either
@@ -266,8 +268,8 @@ keyboard that gets sorted after 'a'. It feeds a set containing all such symbols
 to the `-gt` operator to compare them against 'a'. The output is an empty array.
 
 ```powershell
-$a=' ','`','~','!','@','#','$','%','^','&','*','(',')','_','+','-','=','{','}',
-   '[',']',':',';','"','''','\','|','/','?','.','>',',','<'
+$a=' ','`','~','!','@','#','$','%','^','&','*','(',')','_','+','-','=',
+   '{','}','[',']',':',';','"','''','\','|','/','?','.','>',',','<'
 $a -gt 'a'
 # Output: Nothing
 ```
@@ -284,14 +286,14 @@ and `-notlike` is a wildcard expression (containing `*`, `?`, and `[ ]`), while
 
 The syntax is:
 
-```powershell
+```
 <string[]> -like    <wildcard-expression>
 <string[]> -notlike <wildcard-expression>
 <string[]> -match    <regular-expression>
 <string[]> -notmatch <regular-expression>
 ```
 
-When the input of these operators is a scalar value, they return a Boolean
+When the input of these operators is a scalar value, they return a **Boolean**
 value. When the input is a collection of values, the operators return any
 matching members. If there are no matches in a collection, the operators return
 an empty array.
@@ -304,35 +306,42 @@ side could be a string containing [wildcards](about_Wildcards.md).
 Example:
 
 ```powershell
-"PowerShell" -like    "*shell"           # Ouput: True
-"PowerShell" -notlike "*shell"           # Ouput: False
-"PowerShell" -like    "Power?hell"       # Ouput: True
-"PowerShell" -notlike "Power?hell"       # Ouput: False
-"PowerShell" -like    "Power[p-w]hell"   # Ouput: True
-"PowerShell" -notlike "Power[p-w]hell"   # Ouput: False
+"PowerShell" -like    "*shell"           # Output: True
+"PowerShell" -notlike "*shell"           # Output: False
+"PowerShell" -like    "Power?hell"       # Output: True
+"PowerShell" -notlike "Power?hell"       # Output: False
+"PowerShell" -like    "Power[p-w]hell"   # Output: True
+"PowerShell" -notlike "Power[p-w]hell"   # Output: False
 
-"PowerShell", "Server" -like "*shell"    # Ouput: PowerShell
-"PowerShell", "Server" -notlike "*shell" # Ouput: Server
+"PowerShell", "Server" -like "*shell"    # Output: PowerShell
+"PowerShell", "Server" -notlike "*shell" # Output: Server
 ```
 
-## -match and -notmatch
+Unlike `-match` and `-notmatch`, these operators don't affect the `$Matches`
+automatic variable.
 
-`-match` and `-notmatch` use regular expressions to conduct their search. As
-such, they support very complex searches, e.g. they can find email addresses,
-UNC paths, or dash-formatted phone numbers. The right-hand side string must
-adhere to the [regular expressions](about_Regular_Expressions.md) rules.
+### -match and -notmatch
+
+`-match` and `-notmatch` use regular expressions to search for pattern in the
+left-hand side values. Regular expressions can be used to match complex
+patterns like email addresses, UNC paths, or formatted phone numbers. The
+right-hand side string must adhere to the
+[regular expressions](about_Regular_Expressions.md) rules.
 
 Scalar examples:
 
 ```powershell
 # Partial match test, showing how differently -match and -like behave
-"PowerShell" -match 'shell'        # Ouput: True
-"PowerShell" -like  'shell'        # Ouput: False
+"PowerShell" -match 'shell'        # Output: True
+"PowerShell" -like  'shell'        # Output: False
 
 # Regex syntax test
-"PowerShell" -match    '^Power\w+' # Ouput: True
-'bag'        -notmatch 'b[iou]g'   # Ouput: True
+"PowerShell" -match    '^Power\w+' # Output: True
+'bag'        -notmatch 'b[iou]g'   # Output: True
 ```
+
+If the input is a collection, the operators return the matching members of that
+collection. However, the `$Matches` variable isn't populated.
 
 Collection examples:
 
@@ -341,7 +350,7 @@ Collection examples:
 # Output: PowerShell
 
 "Rhell", "Chell", "Mel", "Smell", "Shell" -match "hell"
-# Ouput: Rhell, Chell, Shell
+# Output: Rhell, Chell, Shell
 
 "Bag", "Beg", "Big", "Bog", "Bug"  -match 'b[iou]g'
 #Output: Big, Bog, Bug
@@ -351,10 +360,10 @@ Collection examples:
 ```
 
 `-match` and `-notmatch` support regex capture groups. Each time they run, they
-overwrite the `$Matches` automatic variable with their findings. This variable
-is a **Hashtable** and always has a key named '0' that stores the entire match.
-If the regular expression contains capture groups, the Hashtable will contain
-additional corresponding keys.
+overwrite the `$Matches` automatic variable with their findings. `$Matches` is
+a **Hashtable** that always has a key named '0', which stores the entire match.
+If the regular expression contains capture groups, the `$Matches` contains
+additional keys for each group.
 
 Example:
 
@@ -393,19 +402,20 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with regular expressions
 
-The replacement operator, `-replace`, is an extension of the `-match` operator.
-Like `-match`, it finds the specified pattern, but unlike `-match`, it replaces
-them with another specified value.
+The replacement , , is an extension of the `-match` operator. Like `-match`,
+`-replace` operator uses regular expressions to find the specified pattern. But
+unlike `-match`, it replaces the matches with another specified value.
 
 Syntax:
 
-```powershell
-<String> -replace <regular-expression>, <substitute>
+```
+<input> -replace <regular-expression>, <substitute>
 ```
 
-You can use the `-replace` operator for many administrative tasks, such as
-renaming files. For example, the following command changes the file name
-extensions of all `.txt` files to `.log`:
+The operator replaces all or part of a value with the specified value using
+regular expressions. You can use the operator for many administrative tasks,
+such as renaming files. For example, the following command changes the file
+name extensions of all `.txt` files to `.log`:
 
 ```powershell
 Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
@@ -426,9 +436,12 @@ Examples:
 Cook
 book
 ```
+### Regular expressions substitutions
 
 It is also possible to use regular expressions to dynamically replace text
-using capturing groups, and substitutions.
+using capturing groups, and substitutions. Capture groups can be referenced in
+the `<substitute>` string using the dollar sign (`$`) character before the
+group identifier.
 
 In the following example, the `-replace` operator accepts a username in the form
 of `DomainName\Username` and converts to the `Username@DomainName` format:
@@ -444,7 +457,39 @@ $ReplaceExp = '${Username}@${DomainName}'
 John.Doe@Contoso.local
 ```
 
-For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
+> [!WARNING]
+> Since the `$` character is used in string expansion, you will must use
+> literal strings or escape the `$` character.
+>
+> ```powershell
+> PS> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
+> Hello Universe
+> ```
+>
+> Additionally, since the `$` character is used in substitution, you must
+> escape any instances in your string.
+>
+> ```powershell
+> PS> '5.72' -replace '(.+)', '$$$1'
+> $5.72
+> ```
+
+To learn more see [about_Regular_Expressions](about_Regular_Expressions.md) and
+[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
+
+### Substituting in a collection
+
+When the `<input>` to the `-replace` operator is a collection, PowerShell
+applies the replacement to every value in the collection. For example:
+
+```powershell
+"B1","B2","B3","B4","B5" -replace "B", 'a'
+a1
+a2
+a3
+a4
+a5
+```
 
 ### Replacement with a script block
 
@@ -476,7 +521,7 @@ Hello
 ## Containment operators
 
 The containment operators (`-contains`, `-notcontains`, `-in`, and `-notin`) are
-similar to the equality operators, except that they always return a Boolean
+similar to the equality operators, except that they always return a **Boolean**
 value, even when the input is a collection. These operators stop comparing as
 soon as they detect the first match, whereas the equality operators evaluate all
 input members. In a very large collection, these operators return quicker than
@@ -484,7 +529,7 @@ the equality operators.
 
 Syntax:
 
-```powershell
+```
 <Collection> -contains <Test-object>
 <Collection> -notcontains <Test-object>
 <Test-object> -in <Collection>
@@ -529,10 +574,10 @@ $a, "ghi" -contains $a           # Output: True
 
 The `-in` and -`notin` operators were introduced in PowerShell 3 as the
 syntactic reverse of the of `contains` and `-notcontain` operators. `-in`
-returns True when the left-hand side (test object) matches one of the elements
-in the set. `-notin` returns False instead. When the test object is a set, these
-operators use reference equality, i.e. they check whether one of the set's
-elements is the same instance of the test object.
+returns **True** when the left-hand side `<test-object>` matches one of the
+elements in the set. `-notin` returns **False** instead. When the test object
+is a set, these operators use reference equality to check whether one of the
+set's elements is the same instance of the test object.
 
 The following examples do the same thing that the examples for `-contain`
 and `-notcontain` do, but they are written with `-in` and `-notin` instead.
@@ -593,6 +638,6 @@ $a -isnot $b.GetType() # Output: True
 - [Foreach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object)
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
 
-[1]: https://docs.microsoft.com/dotnet/api/system.icomparable?view=netstandard-2.0&preserve-view=true
-[2]: https://docs.microsoft.com/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6&preserve-view=true
+[1]: /dotnet/api/system.icomparable
+[2]: /dotnet/api/system.text.regularexpressions.match
 [3]: about_Redirection.md#potential-confusion-with-comparison-operators

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -430,7 +430,8 @@ book
 It is also possible to use regular expressions to dynamically replace text
 using capturing groups, and substitutions.
 
-In the following example, the `-replace` operator accepts a username in the form of `DomainName\Username` and converts to the `Username@DomainName` format:
+In the following example, the `-replace` operator accepts a username in the form
+of `DomainName\Username` and converts to the `Username@DomainName` format:
 
 ```powershell
 $SearchExp = '^(?<Username>[\w-.]+)\\(?<DomainName>[\w-.]+)$'
@@ -447,7 +448,7 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with a script block
 
-In Powershell 6 and later, the `-replace` operator also accepts a script block
+In PowerShell 6 and later, the `-replace` operator also accepts a script block
 that performs the replacement. The script block runs once for every match.
 
 Syntax:
@@ -592,6 +593,6 @@ $a -isnot $b.GetType() # Output: True
 - [Foreach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object)
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
 
-[1]: https://docs.microsoft.com/dotnet/api/system.icomparable?view=netstandard-2.0
-[2]: https://docs.microsoft.com/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6
+[1]: https://docs.microsoft.com/dotnet/api/system.icomparable?view=netstandard-2.0&preserve-view=true
+[2]: https://docs.microsoft.com/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6&preserve-view=true
 [3]: about_Redirection.md#potential-confusion-with-comparison-operators

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,672 +1,562 @@
 ---
 description: Describes the operators that compare values in PowerShell.
+keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 12/10/2020
+ms.date: 12/11/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
 ---
 # About Comparison Operators
 
-## Short description
-Describes the operators that compare values in PowerShell.
+## Abstract
 
-## Long description
+The comparison operators in PowerShell can either compare two values or filter
+elements of a collection against an input value. These operators include:
+`-eq`,`-ne`,`-gt`,`-ge`,`-lt`,`-le`,`-like`,`-notlike`,`-match`,`-notmatch`,
+`-replace`,`-contains`,`-notcontains`,`-in`,`-notin`,`-is`,`-isnot`.
 
-Comparison operators let you specify conditions for comparing values and
-finding values that match specified patterns. To use a comparison operator,
-specify the values that you want to compare together with an operator that
-separates these values.
+## The operators
 
-PowerShell includes the following comparison operators:
+Comparison operators let you compare values or finding values that match
+specified patterns. PowerShell includes the following comparison operators:
 
-| Type        | Operators    | Description                                 |
-| ----------- | ------------ | --------------------------------------------|
-| Equality    | -eq          | equals                                      |
-|             | -ne          | not equals                                  |
-|             | -gt          | greater than                                |
-|             | -ge          | greater than or equal                       |
-|             | -lt          | less than                                   |
-|             | -le          | less than or equal                          |
-|             |              |                                             |
-| Matching    | -like        | Returns true when string matches wildcard   |
-|             |              | pattern                                     |
-|             | -notlike     | Returns true when string does not match     |
-|             |              | wildcard pattern                            |
-|             | -match       | Returns true when string matches regex      |
-|             |              | pattern; $matches contains matching strings |
-|             | -notmatch    | Returns true when string does not match     |
-|             |              | regex pattern; $matches contains matching   |
-|             |              | strings                                     |
-|             |              |                                             |
-| Containment | -contains    | Returns true when reference value contained |
-|             |              | in a collection                             |
-|             | -notcontains | Returns true when reference value not       |
-|             |              | contained in a collection                   |
-|             | -in          | Returns true when test value contained in a |
-|             |              | collection                                  |
-|             | -notin       | Returns true when test value not contained  |
-|             |              | in a collection                             |
-|             |              |                                             |
-| Replacement | -replace     | Replaces a string pattern                   |
-|             |              |                                             |
-| Type        | -is          | Returns true if both object are the same    |
-|             |              | type                                        |
-|             | -isnot       | Returns true if the objects are not the same|
-|             |              | type                                        |
+| Type        | Operator     | Comparison test
+| ----------- | ------------ | ------------------------------------------------
+| Equality    | -eq          | equals
+|             | -ne          | not equals
+|             | -gt          | greater than
+|             | -ge          | greater than or equal
+|             | -lt          | less than
+|             | -le          | less than or equal
+| Matching    | -like        | string matches wildcard pattern
+|             | -notlike     | string does not match wildcard pattern
+|             | -match       | string matches regex pattern
+|             | -notmatch    | string does not match regex pattern
+| Replacement | -replace     | string matches regex pattern; replaces the match
+| Containment | -contains    | collection contains a value
+|             | -notcontains | collection does not contain a value
+|             | -in          | value is in a collection
+|             | -notin       | value is not in a collection
+| Type        | -is          | both objectd are the same type
+|             | -isnot       | the objects are not the same type
+
+## Common features
 
 By default, all comparison operators are case-insensitive. To make a comparison
-operator case-sensitive, precede the operator name with a `c`. For example, the
-case-sensitive version of `-eq` is `-ceq`. To make the case-insensitivity
-explicit, precede the operator with an `i`. For example, the explicitly
-case-insensitive version of `-eq` is `-ieq`.
+operator case-sensitive, add a `c` after the `-`. For example, `-ceq` is the
+case-sensitive version of `-eq`. To make the case-insensitivity explicit,
+add an `i` before `-`. For example, `-ieq` is the explicitly case-insensitive
+version of `-eq`.
 
-When the input to an operator is a scalar value, comparison operators return a
-Boolean value. When the input is a collection of values, the comparison
-operators return any matching values. If there are no matches in a collection,
-comparison operators return an empty array.
+When the input of an operator is a scalar value, the operator returns a Boolean
+value. When the input is a collection, the operator returns those collection
+elements that match the input. If there are no matches in the collection,
+comparison operators return an empty array. For example:
 
 ```powershell
-PS> (1, 2 -eq 3).GetType().FullName
-System.Object[]
+$a = (1, 2 -eq 3)
+$a.GetType().Name
+$a.Count
 ```
 
-The exceptions are the containment operators, the In operators, and the type
-operators, which always return a **Boolean** value.
+```output
+Object[]
+0
+```
 
-> [!NOTE]
-> If you need to compare a value to `$null` you should put `$null` on the
-> left-hand side of the comparison. When you compare `$null` to an **Object[]**
-> the result is **False** because the comparison object is an array. When you
-> compare an array to `$null`, the comparison filters out any `$null` values
-> stored in the array. For example:
->
-> ```powershell
-> PS> $null -ne $null, "hello"
-> True
-> PS> $null, "hello" -ne $null
-> hello
-> ```
+The exceptions are the containment operators and the type operators; they always
+return a Boolean value.
 
 ## Equality operators
 
-The equality operators (`-eq`, `-ne`) return a value of TRUE or the matches
-when one or more of the input values is identical to the specified pattern. The
-entire pattern must match an entire value.
+### -eq and -ne
 
-Example:
-
-### -eq
-
-Description: Equal to. Includes an identical value.
+When the left-hand side is scalar, `-eq` returns True if the right-hand side is
+an exact match; otherwise, `-eq` returns False. `-ne` does the opposite; it
+returns False when both sides match; otherwise, `-ne` returns True.
 
 Example:
 
 ```powershell
-PS> 2 -eq 2
-True
+2 -eq 2                 # Ouput: True
+2 -eq 3                 # Ouput: False
+"abc" -eq "abc"         # Ouput: True
+"abc" -eq "abc", "def"  # Ouput: False
+"abc" -ne "def"         # Ouput: True
+"abc" -ne "abc"         # Ouput: False
+"abc" -ne "abc", "def"  # Ouput: True
+```
 
-PS> 2 -eq 3
+When the left-hand side is a collection, `-eq` returns those members that match
+the right-hand side, while `-ne` filters them out.
+
+Example:
+
+```powershell
+1,2,3 -eq 2             # Ouput: 2
+"abc", "def" -eq "abc"  # Ouput: abc
+"abc", "def" -ne "abc"  # Ouput: def
+```
+
+These operators process all elements of the collection. Example:
+
+```powershell
+"zzz", "def", "zzz" -eq "zzz"
+```
+
+```output
+zzz
+zzz
+```
+
+The equality operators accept any two objects, not just scalar or collection.
+But the comparison result is not guaranteed to be meaningful for the end-user.
+The following example demonstrates the issue.
+
+```powershell
+class MyFileInfoSet {
+    [String]$File
+    [String]$Size
+}
+$a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$a -eq $b
+```
+
+```Output
 False
+```
 
-PS> 1,2,3 -eq 2
+In this example, we created two objects with identical properties. Yet, the
+equality test result is False, because they are different objects. If you intend
+to develop meaningfully comparable classes, you need to implement
+[System.IComparable][1] in your class.
+
+A prominent example of comparing arbitrary objects is to find out if they are
+null. But if you need to determine whether a variable is `$null`, you must put
+`$null` on the left-hand side of the equality operator. Putting it on the
+right-hand side does not do what you expect.
+
+For example, let `$a` be an array containing null elements:
+
+```powershell
+$a = 1, 2, $null, 4, $null, 6
+```
+
+The following tests that `$a` is not null.
+
+```powershell
+$null -ne $a
+```
+
+```output
+False
+```
+
+The following, however, filers out all null elements from `$a`:
+
+```powershell
+$a -ne $null # Output: 1, 2, 4, 6
+```
+
+```output
+1
 2
-PS> "abc" -eq "abc"
-True
-
-PS> "abc" -eq "abc", "def"
-False
-
-PS> "abc", "def" -eq "abc"
-abc
+4
+6
 ```
 
-### -ne
+### -gt, -ge, -lt, and -le
 
-Description: Not equal to. Includes a different value.
+`-gt`, `-ge`, `-lt`, and `-le` behave very similarly. When both sides are scalar
+they return True or False depending on how the two sides compare:
+
+| Operator | Returns True when...                   |
+| -------- | -------------------------------------- |
+| -gt      | The left-hand side is greater          |
+| -ge      | The left-hand side is greater or equal |
+| -lt      | The left-hand side is smaller          |
+| -le      | The left-hand side is smaller or equal |
+
+In the following examples, all statements return True.
+
+```powershell
+8 -gt 6  # Ouput: True
+8 -ge 8  # Ouput: True
+6 -lt 8  # Ouput: True
+8 -le 8  # Ouput: True
+```
+
+> [!NOTE] The greater-than operator, in most programming languages, is `>`. In
+> PowerShell, however, this character is used for redirection. For details, see
+> [About_redirection][3].
+
+When the left-hand side is a collection, these operators compare each member of
+the collection with the right-hand side. Depending on their logic, they either
+keep or discard the member.
 
 Example:
 
 ```powershell
-PS> "abc" -ne "def"
-True
+$a=5, 6, 7, 8, 9
 
-PS> "abc" -ne "abc"
-False
+Write-Output "Test collection:"
+$a
 
-PS> "abc" -ne "abc", "def"
-True
+Write-Output "`nMembers greater than 7"
+$a -gt 7
 
-PS> "abc", "def" -ne "abc"
-def
+Write-Output "`nMembers greater than or equal to 7"
+$a -ge 7
+
+Write-Output "`nMembers smaller than 7"
+$a -lt 7
+
+Write-Output "`nMembers smaller than or equal to 7"
+$a -le 7
 ```
 
-### -gt
-
-Description: Greater-than.
-
-Example:
-
-```powershell
-PS> 8 -gt 6
-True
-
-PS> 7, 8, 9 -gt 8
-9
-```
-
-> [!NOTE]
-> This should not to be confused with `>`, the greater-than operator in many
-> other programming languages. In PowerShell, `>` is used for redirection. For
-> more information, see
-> [About_redirection](about_Redirection.md#potential-confusion-with-comparison-operators).
-
-### -ge
-
-Description: Greater-than or equal to.
-
-Example:
-
-```powershell
-PS> 8 -ge 8
-True
-
-PS> 7, 8, 9 -ge 8
+```output
+Test collection:
+5
+6
+7
 8
 9
-```
 
-### -lt
+Memebers greater than 7
+8
+9
 
-Description: Less-than.
+Memebers greater than or equal to 7
+7
+8
+9
 
-Example:
+Memebers smaller than 7
+5
+6
 
-```powershell
-
-PS> 8 -lt 6
-False
-
-PS> 7, 8, 9 -lt 8
+Memebers smaller than or equal to 7
+5
+6
 7
 ```
 
-### -le
+These operators aren't restricted to numbers; they work with any class that
+implements [System.IComparable][1].
 
-Description: Less-than or equal to.
-
-Example:
+Examples:
 
 ```powershell
-PS> 6 -le 8
-True
+# Date comparison
+[DateTime]'2001-11-12' -lt [DateTime]'2020-08-01' # True
 
-PS> 7, 8, 9 -le 8
-7
-8
+# Sorting order comparison
+'a' -lt 'z'           # True; 'a' comes before 'z'
+'macOS' -ilt 'MacOS'  # False
+'MacOS' -ilt 'macOS'  # False
+'macOS' -clt 'MacOS'  # True; 'm' comes before 'M'
 ```
+
+The following example demonstrates that there is no symbol on an American QWERTY
+keyboard that gets sorted after 'a'. It feeds a set containing all such symbols
+to the `-gt` operator to compare them against 'a'. The output is an empty array.
+
+```powershell
+$a=' ','`','~','!','@','#','$','%','^','&','*','(',')','_','+','-','=','{','}',
+   '[',']',':',';','"','''','\','|','/','?','.','>',',','<'
+$a -gt 'a'
+# Output: Nothing
+```
+
+If the two sides of the operators are not reasonably comparable, these operators
+raise a non-terminating error.
 
 ## Matching operators
 
-The like operators (`-like` and `-notlike`) find elements that match or do not
-match a specified pattern using wildcard expressions.
+The matching operators (`-like`, `-notlike`, `-match`, and `-notmatch`) find
+elements that match or do not match a specified pattern. The pattern for `-like`
+and `-notlike` is a wildcard expression (containing `*`, `?`, and `[ ]`), while
+`-match` and `-notmatch` accept a regular expression (Regex).
 
 The syntax is:
 
 ```powershell
-<string[]> -like <wildcard-expression>
+<string[]> -like    <wildcard-expression>
 <string[]> -notlike <wildcard-expression>
-```
-
-The match operators (`-match` and `-notmatch`) find elements that match or do
-not match a specified pattern using regular expressions.
-
-The match operators populate the `$Matches` automatic variable when the input
-(the left-side argument) to the operator is a single scalar object. When the
-input is scalar, the `-match` and `-notmatch` operators return a Boolean value
-and set the value of the `$Matches` automatic variable to the matched
-components of the argument.
-
-The syntax is:
-
-```powershell
-<string[]> -match <regular-expression>
+<string[]> -match    <regular-expression>
 <string[]> -notmatch <regular-expression>
 ```
 
-### -like
+When the input of these operators is a scalar value, they return a Boolean
+value. When the input is a collection of values, the operators return any
+matching members. If there are no matches in a collection, the operators return
+an empty array.
 
-Description: Match using the wildcard character (\*).
+### -like and -notlike
 
-Example:
-
-```powershell
-PS> "PowerShell" -like "*shell"
-True
-
-PS> "PowerShell", "Server" -like "*shell"
-PowerShell
-```
-
-### -notlike
-
-Description: Does not match using the wildcard character (\*).
+`-like` and `-notlike` behave similarly to `-eq` and `-ne`, but the right-hand
+side could be a string containing [wildcards](about_Wildcards.md).
 
 Example:
 
 ```powershell
-PS> "PowerShell" -notlike "*shell"
-False
+"PowerShell" -like    "*shell"           # Ouput: True
+"PowerShell" -notlike "*shell"           # Ouput: False
+"PowerShell" -like    "Power?hell"       # Ouput: True
+"PowerShell" -notlike "Power?hell"       # Ouput: False
+"PowerShell" -like    "Power[p-w]hell"   # Ouput: True
+"PowerShell" -notlike "Power[p-w]hell"   # Ouput: False
 
-PS> "PowerShell", "Server" -notlike "*shell"
-Server
+"PowerShell", "Server" -like "*shell"    # Ouput: PowerShell
+"PowerShell", "Server" -notlike "*shell" # Ouput: Server
 ```
 
-### -match
+## -match and -notmatch
 
-Description: Matches a string using regular expressions. When the input is
-scalar, it populates the `$Matches` automatic variable.
+`-match` and `-notmatch` use regular expressions to conduct their search. As
+such, they support very complex searches, e.g. they can find email addresses,
+UNC paths, or dash-formatted phone numbers. The right-hand side string must
+adhere to the [regular expressions](about_Regular_Expressions.md) rules.
 
-If the input is a collection, the `-match` and `-notmatch` operators return
-the matching members of that collection, but the operator does not populate
-the `$Matches` variable.
-
-For example, the following command submits a collection of strings to the
-`-match` operator. The `-match` operator returns the items in the collection
-that match. It does not populate the `$Matches` automatic variable.
+Scalar examples:
 
 ```powershell
-PS> "Sunday", "Monday", "Tuesday" -match "sun"
-Sunday
+# Partial match test, showing how differently -match and -like behave
+"PowerShell" -match 'shell'        # Ouput: True
+"PowerShell" -like  'shell'        # Ouput: False
 
-PS> $Matches
-PS>
+# Regex syntax test
+"PowerShell" -match    '^Power\w+' # Ouput: True
+'bag'        -notmatch 'b[iou]g'   # Ouput: True
 ```
 
-In contrast, the following command submits a single string to the `-match`
-operator. The `-match` operator returns a Boolean value and populates the
-`$Matches` automatic variable. The `$Matches` automatic variable is a
-**Hashtable**. If no grouping or capturing is used, only one key is populated.
-The `0` key represents all text that was matched. For more information about
-grouping and capturing using regular expressions, see
-[about_Regular_Expressions](about_Regular_Expressions.md).
+Collection examples:
 
 ```powershell
-PS> "Sunday" -match "sun"
-True
+"PowerShell", "Super PowerShell", "Power's hell" -match '^Power\w+'
+# Output: PowerShell
 
-PS> $Matches
+"Rhell", "Chell", "Mel", "Smell", "Shell" -match "hell"
+# Ouput: Rhell, Chell, Shell
 
-Name                           Value
-----                           -----
-0                              Sun
+"Bag", "Beg", "Big", "Bog", "Bug"  -match 'b[iou]g'
+#Output: Big, Bog, Bug
+
+"Bag", "Beg", "Big", "Bog", "Bug"  -notmatch 'b[iou]g'
+#Output: Bag, Beg
 ```
 
-It is important to note that the `$Matches` hashtable will only contain the
-first occurrence of any matching pattern.
-
-```powershell
-PS> "Banana" -match "na"
-True
-
-PS> $Matches
-
-Name                           Value
-----                           -----
-0                              na
-```
-
-> [!IMPORTANT]
-> The `0` key is an **Integer**. You can use any **Hashtable** method to access
-> the value stored.
->
-> ```powershell
-> PS> "Good Dog" -match "Dog"
-> True
->
-> PS> $Matches[0]
-> Dog
->
-> PS> $Matches.Item(0)
-> Dog
->
-> PS> $Matches.0
-> Dog
-> ```
-
-The `-notmatch` operator populates the `$Matches` automatic variable when the
-input is scalar and the result is False, that it, when it detects a match.
-
-```powershell
-PS> "Sunday" -notmatch "rain"
-True
-
-PS> $matches
-PS>
-
-PS> "Sunday" -notmatch "day"
-False
-
-PS> $matches
-
-Name                           Value
-----                           -----
-0                              day
-```
-
-### -notmatch
-
-Description: Does not match a string. Uses regular expressions. When the input
-is scalar, it populates the `$Matches` automatic variable.
+`-match` and `-notmatch` support regex capture groups. Each time they run, they
+overwrite the `$Matches` automatic variable with their findings. This variable
+is a **Hashtable** and always has a key named '0' that stores the entire match.
+If the regular expression contains capture groups, the Hashtable will contain
+additional corresponding keys.
 
 Example:
 
 ```powershell
-PS> "Sunday" -notmatch "sun"
-False
+$string = 'The last logged on user was CONTOSO\jsmith'
+$string -match 'was (?<domain>.+)\\(?<user>.+)'
 
-PS> $matches
-Name Value
----- -----
-0    sun
+$Matches
 
-PS> "Sunday", "Monday" -notmatch "sun"
-Monday
+Write-Output "`nDomain name:"
+$Matches.domain
+
+Write-Output "`nUser name:"
+$Matches.user
 ```
 
-## Containment operators
+```output
+True
 
-The containment operators (`-contains` and `-notcontains`) are similar to the
-equality operators. However, the containment operators always return a Boolean
-value, even when the input is a collection.
+Name                           Value
+----                           -----
+domain                         CONTOSO
+user                           jsmith
+0                              was CONTOSO\jsmith
 
-Also, unlike the equality operators, the containment operators return a value
-as soon as they detect the first match. The equality operators evaluate all
-input and then return all the matches in the collection.
+Domain name:
+CONTOSO
 
-### -contains
+User name:
+jsmith
+```
 
-Description: Containment operator. Tells whether a collection of reference
-values includes a single test value. Always returns a Boolean value. Returns
-TRUE only when the test value exactly matches at least one of the reference
-values.
+For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
-When the test value is a collection, the Contains operator uses reference
-equality. It returns TRUE only when one of the reference values is the same
-instance of the test value object.
+## Replacement operator
 
-In a very large collection, the `-contains` operator returns results quicker
-than the equal to operator.
+### Replacement with regular expressions
+
+The replacement operator, `-replace`, is an extension of the `-match` operator.
+Like `-match`, it finds the specified pattern, but unlike `-match`, it replaces
+them with another specified value.
 
 Syntax:
 
-`<Reference-values> -contains <Test-value>`
-
-Examples:
-
 ```powershell
-PS> "abc", "def" -contains "def"
-True
-
-PS> "Windows", "PowerShell" -contains "Shell"
-False  #Not an exact match
-
-# Does the list of computers in $DomainServers include $ThisComputer?
-PS> $DomainServers -contains $thisComputer
-True
-
-PS> "abc", "def", "ghi" -contains "abc", "def"
-False
-
-PS> $a = "abc", "def"
-PS> "abc", "def", "ghi" -contains $a
-False
-PS> $a, "ghi" -contains $a
-True
+<String> -replace <regular-expression>, <substitute>
 ```
 
-### -notcontains
-
-Description: Containment operator. Tells whether a collection of reference
-values includes a single test value. Always returns a Boolean value. Returns
-TRUE when the test value is not an exact matches for at least one of the
-reference values.
-
-When the test value is a collection, the NotContains operator uses reference
-equality.
-
-Syntax:
-
-`<Reference-values> -notcontains <Test-value>`
-
-Examples:
-
-```powershell
-PS> "Windows", "PowerShell" -notcontains "Shell"
-True  #Not an exact match
-
-# Get cmdlet parameters, but exclude common parameters
-function get-parms ($cmdlet)
-{
-    $Common = "Verbose", "Debug", "WarningAction", "WarningVariable",
-      "ErrorAction", "ErrorVariable", "OutVariable", "OutBuffer"
-
-    $allparms = (Get-Command $Cmdlet).parametersets |
-      foreach {$_.Parameters} |
-        foreach {$_.Name} | Sort-Object | Get-Unique
-
-    $allparms | where {$Common -notcontains $_ }
-}
-
-# Find unapproved verbs in the functions in my module
-PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS> $myVerbs = Get-Command -Module MyModule | foreach {$_.verb}
-PS> $myVerbs | where {$ApprovedVerbs -notcontains $_}
-ForEach
-Sort
-Tee
-Where
-```
-
-### -in
-
-Description: In operator. Tells whether a test value appears in a collection of
-reference values. Always return as Boolean value. Returns TRUE only when the
-test value exactly matches at least one of the reference values.
-
-When the test value is a collection, the In operator uses reference equality.
-It returns TRUE only when one of the reference values is the same instance of
-the test value object.
-
-The `-in` operator was introduced in PowerShell 3.0.
-
-Syntax:
-
-`<Test-value> -in <Reference-values>`
-
-Examples:
-
-```powershell
-PS> "def" -in "abc", "def"
-True
-
-PS> "Shell" -in "Windows", "PowerShell"
-False  #Not an exact match
-
-PS> "Windows" -in "Windows", "PowerShell"
-True  #An exact match
-
-PS> "Windows", "PowerShell" -in "Windows", "PowerShell", "ServerManager"
-False  #Using reference equality
-
-PS> $a = "Windows", "PowerShell"
-PS> $a -in $a, "ServerManager"
-True  #Using reference equality
-
-# Does the list of computers in $DomainServers include $ThisComputer?
-PS> $thisComputer -in  $domainServers
-True
-```
-
-### -notin
-
-Description: Tells whether a test value appears in a collection of reference
-values. Always returns a Boolean value. Returns TRUE when the test value is not
-an exact match for at least one of the reference values.
-
-When the test value is a collection, the In operator uses reference equality.
-It returns TRUE only when one of the reference values is the same instance of
-the test value object.
-
-The `-notin` operator was introduced in PowerShell 3.0.
-
-Syntax:
-
-`<Test-value> -notin <Reference-values>`
-
-Examples:
-
-```powershell
-PS> "def" -notin "abc", "def"
-False
-
-PS> "ghi" -notin "abc", "def"
-True
-
-PS> "Shell" -notin "Windows", "PowerShell"
-True  #Not an exact match
-
-PS> "Windows" -notin "Windows", "PowerShell"
-False  #An exact match
-
-# Find unapproved verbs in the functions in my module
-PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS> $MyVerbs = Get-Command -Module MyModule | foreach {$_.verb}
-
-PS> $MyVerbs | where {$_ -notin $ApprovedVerbs}
-ForEach
-Sort
-Tee
-Where
-```
-
-## Replacement Operator
-
-The `-replace` operator has the following syntax:
-
-`<input> -replace <original>, <substitute>`
-
-The `<original>` placeholder is a regular expression matching the characters to
-be replaced. The `<substitute>` placeholder is a literal string that replaces
-them.
-
-The operator replaces all or part of a value with the specified value using
-regular expressions. You can use the operator for many administrative tasks,
-such as renaming files. For example, the following command changes the file
-name extensions of all `.txt` files to `.log`:
+You can use the `-replace` operator for many administrative tasks, such as
+renaming files. For example, the following command changes the file name
+extensions of all `.txt` files to `.log`:
 
 ```powershell
 Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
 ```
 
-### Case-sensitive matches
-
 By default, the `-replace` operator is case-insensitive. To make it case
 sensitive, use `-creplace`. To make it explicitly case-insensitive, use
 `-ireplace`.
 
-Consider the following examples:
+Examples:
 
 ```powershell
-PS> "book" -replace "B", "C"
-Cook
+"book" -ireplace "B", "C" # Case insensitive
+"book" -creplace "B", "C" # Case-sensitive; hence, nothing to replace
 ```
 
-```powershell
-PS> "book" -ireplace "B", "C"
+```Output
 Cook
-```
-
-```powershell
-PS> "book" -creplace "B", "C"
 book
 ```
 
-### Substitutions in regular expressions
-
 It is also possible to use regular expressions to dynamically replace text
-using capturing groups, and substitutions. Capture groups can be referenced in
-the `<substitute>` string using the dollar sign (`$`) character before the
-group identifier.
+using capturing groups, and substitutions.
 
-Capture groups can be referenced by **Number** or **Name**
-
-- By **Number** - Capturing Groups are numbered from left to right.
-
-  ```powershell
-  PS> "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
-  John.D.Smith@contoso.com
-  ```
-
-- By **Name** - Capturing Groups can also be referenced by name.
-
-  ```powershell
-  PS> "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
-  FABRIKAM\Administrator
-  ```
-
-> [!WARNING]
-> Since the `$` character is used in string expansion, you will must use
-> literal strings or escape the `$` character.
->
-> ```powershell
-> PS> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
-> Hello Universe
-> ```
->
-> Additionally, since the `$` character is used in substitution, you must
-> escape any instances in your string.
->
-> ```powershell
-> PS> '5.72' -replace '(.+)', '$$$1'
-> $5.72
-> ```
-
-To learn more see [about_Regular_Expressions](about_Regular_Expressions.md) and
-[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
-
-### Substituting in a collection
-
-When the `<input>` to the `-replace` operator is a collection, PowerShell
-applies the replacement to every value in the collection. For example:
+In the following example, the `-replace` operator accepts a username in the form of `DomainName\Username` and converts to the `Username@DomainName` format:
 
 ```powershell
-"B1","B2","B3","B4","B5" -replace "B", 'a'
-a1
-a2
-a3
-a4
-a5
+$SearchExp = '^(?<Username>[\w-.]+)\\(?<DomainName>[\w-.]+)$'
+$ReplaceExp = '${Username}@${DomainName}'
+
+'Contoso.local\John.Doe' -replace $SearchExp,$ReplaceExp
 ```
 
-### ScriptBlock substitutions
+```output
+John.Doe@Contoso.local
+```
 
-Beginning in PowerShell 6, you can use a **ScriptBlock** argument for the
-_Substitution_ text. The **ScriptBlock** will execute for each match found in
-the _input_ string.
+For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
-Within the **ScriptBlock**, use the `$_` automatic variable to refer to the
-current **System.Text.RegularExpressions.Match** object. The **Match** object
-gives you access to the current input text being replaced, as well as other
-useful information.
+### Replacement with a script block
 
-This example replaces each sequence of three decimals with the character
-equivalent. The **ScriptBlock** is run for each set of three decimals that
-needs to be replaced.
+In Powershell 6 and later, the `-replace` operator also accepts a script block
+that performs the replacement. The script block runs once for every match.
+
+Syntax:
 
 ```powershell
-PS> "072101108108111" -replace "\d{3}", {[char][int]$_.Value}
+<String> -replace <regular-expression>, {<Script-block>}
+```
+
+Within the script block, use the `$_` automatic variable to access the input
+text being replaced and other useful information. This variable's class type is
+[System.Text.RegularExpressions.Match][2].
+
+The following example replaces each sequence of three digits with the character
+equivalents. The script block runs for each set of three digits that needs to be
+replaced.
+
+```powershell
+"072101108108111" -replace "\d{3}", {return [char][int]$_.Value}
+```
+
+```output
 Hello
+```
+
+## Containment operators
+
+The containment operators (`-contains`, `-notcontains`, `-in`, and `-notin`) are
+similar to the equality operators, except that they always return a Boolean
+value, even when the input is a collection. These operators stop comparing as
+soon as they detect the first match, whereas the equality operators evaluate all
+input members. In a very large collection, these operators return quicker than
+the equality operators.
+
+Syntax:
+
+```powershell
+<Collection> -contains <Test-object>
+<Collection> -notcontains <Test-object>
+<Test-object> -in <Collection>
+<Test-object> -notin <Collection>
+```
+
+### -contains and -notcontains
+
+These operators tell whether a set includes a certain element. `-contains`
+returns True when the right-hand side (test object) matches one of the elements
+in the set. `-notcontains` returns False instead. When the test object is a
+collection, these operators use reference equality, i.e. they check whether one
+of the set's elements is the same instance of the test object.
+
+Examples:
+
+```powershell
+"abc", "def" -contains "def"                  # Output: True
+"abc", "def" -notcontains "def"               # Output: False
+"Windows", "PowerShell" -contains "Shell"     # Output: False
+"Windows", "PowerShell" -notcontains "Shell"  # Output: True
+"abc", "def", "ghi" -contains "abc", "def"    # Output: False
+"abc", "def", "ghi" -notcontains "abc", "def" # Output: True
+```
+
+More complex examples:
+
+```powershell
+$DomainServers = "ContosoDC1","ContosoDC2","ContosoFileServer","ContosoDNS",
+                 "ContosoDHCP","ContosoWSUS"
+$thisComputer  = "ContosoDC2"
+
+$DomainServers -contains $thisComputer
+# Output: True
+
+$a = "abc", "def"
+"abc", "def", "ghi" -contains $a # Output: False
+$a, "ghi" -contains $a           # Output: True
+```
+
+### -in and -notin
+
+The `-in` and -`notin` operators were introduced in PowerShell 3 as the
+syntactic reverse of the of `contains` and `-notcontain` operators. `-in`
+returns True when the left-hand side (test object) matches one of the elements
+in the set. `-notin` returns False instead. When the test object is a set, these
+operators use reference equality, i.e. they check whether one of the set's
+elements is the same instance of the test object.
+
+The following examples do the same thing that the examples for `-contain`
+and `-notcontain` do, but they are written with `-in` and `-notin` instead.
+
+```powershell
+"def" -in "abc", "def"                  # Output: True
+"def" -notin "abc", "def"               # Output: False
+"Shell" -in "Windows", "PowerShell"     # Output: False
+"Shell" -notin "Windows", "PowerShell"  # Output: True
+"abc", "def" -in "abc", "def", "ghi"    # Output: False
+"abc", "def" -notin "abc", "def", "ghi" # Output: True
+```
+
+More complex examples:
+
+```powershell
+$DomainServers = "ContosoDC1","ContosoDC2","ContosoFileServer","ContosoDNS",
+                 "ContosoDHCP","ContosoWSUS"
+$thisComputer  = "ContosoDC2"
+
+$thisComputer -in $DomainServers
+# Output: True
+
+$a = "abc", "def"
+$a -in "abc", "def", "ghi" # Output: False
+$a -in $a, "ghi"           # Output: True
 ```
 
 ## Type comparison
@@ -674,41 +564,25 @@ Hello
 The type comparison operators (`-is` and `-isnot`) are used to determine if an
 object is a specific type.
 
-### -is
-
 Syntax:
 
-`<object> -is <type reference>`
+```powershell
+<object> -is <type-reference>
+<object> -isnot <type-reference>
+```
 
 Example:
 
 ```powershell
-PS> $a = 1
-PS> $b = "1"
-PS> $a -is [int]
-True
-PS> $a -is $b.GetType()
-False
+$a = 1
+$b = "1"
+$a -is [int]           # Output: True
+$a -is $b.GetType()    # Output: False
+$b -isnot [int]        # Output: False
+$a -isnot $b.GetType() # Output: True
 ```
 
-### -isnot
-
-Syntax:
-
-`<object> -isnot <type reference>`
-
-Example:
-
-```powershell
-PS> $a = 1
-PS> $b = "1"
-PS> $a -isnot $b.GetType()
-True
-PS> $b -isnot [int]
-True
-```
-
-## See also
+## SEE ALSO
 
 - [about_Operators](about_Operators.md)
 - [about_Regular_Expressions](about_Regular_Expressions.md)
@@ -716,3 +590,7 @@ True
 - [Compare-Object](xref:Microsoft.PowerShell.Utility.Compare-Object)
 - [Foreach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object)
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
+
+[1]: https://docs.microsoft.com/en-us/dotnet/api/system.icomparable?view=netstandard-2.0
+[2]: https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6
+[3]: about_Redirection.md#potential-confusion-with-comparison-operators

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -65,10 +65,10 @@ Object[]
 
 There are a few exceptions:
 
-- The containment and type operators. They always return a **Boolean** value.
-- The `-replace` operator returns the values resulting from the replacement.
+- The containment and type operators always return a **Boolean** value
+- The `-replace` operator returns the replacement result
 - The `-match` and `-notmatch` operators also populate the `$Matches` automatic
-  variable.
+  variable
 
 ## Equality operators
 
@@ -323,10 +323,9 @@ automatic variable.
 ### -match and -notmatch
 
 `-match` and `-notmatch` use regular expressions to search for pattern in the
-left-hand side values. Regular expressions can be used to match complex
-patterns like email addresses, UNC paths, or formatted phone numbers. The
-right-hand side string must adhere to the
-[regular expressions](about_Regular_Expressions.md) rules.
+left-hand side values. Regular expressions can match complex patterns like email
+addresses, UNC paths, or formatted phone numbers. The right-hand side string
+must adhere to the [regular expressions](about_Regular_Expressions.md) rules.
 
 Scalar examples:
 
@@ -402,9 +401,10 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with regular expressions
 
-The replacement , , is an extension of the `-match` operator. Like `-match`,
-`-replace` operator uses regular expressions to find the specified pattern. But
-unlike `-match`, it replaces the matches with another specified value.
+The replacement operator, `-replace`, is an extension of the `-match` operator.
+Like `-match`, the `-replace` operator uses regular expressions to find the
+specified pattern. But unlike `-match`, it replaces the matches with another
+specified value.
 
 Syntax:
 
@@ -436,6 +436,7 @@ Examples:
 Cook
 book
 ```
+
 ### Regular expressions substitutions
 
 It is also possible to use regular expressions to dynamically replace text
@@ -458,24 +459,34 @@ John.Doe@Contoso.local
 ```
 
 > [!WARNING]
-> Since the `$` character is used in string expansion, you will must use
-> literal strings or escape the `$` character.
+> The `$` has syntatic roles in both PowerShell and regular expressions: - In
+> PowerShell, between double quotation marks, it designates variables and acts
+> as a subexpression operator. - In Regex search strings, it denotes end of the
+> line - In Regex substitution strings, it denotes captured groups As such, be
+> sure to either put your regular expressions between single quotation marks or
+> insert a backtick (\`) character before them. For example:
 >
 > ```powershell
-> PS> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
-> Hello Universe
+> $1 = 'Goodbye'
+> 
+> 'Hello World' -replace '(\w+) \w+', "$1 Universe"
+> # Output: Goodbye Universe
+> 
+> 'Hello World' -replace '(\w+) \w+', '$1 Universe'
+> # Output: Hello Universe
 > ```
 >
-> Additionally, since the `$` character is used in substitution, you must
-> escape any instances in your string.
+> `$$` in Regex denotes a literal `$`. Be sure to understand its caveats. For
+> example:
 >
 > ```powershell
-> PS> '5.72' -replace '(.+)', '$$$1'
-> $5.72
+> '5.72' -replace '(.+)', '$ $1' # Output: $ 5.72
+> '5.72' -replace '(.+)', '$$$1' # Output: $5.72
+> '5.72' -replace '(.+)', '$$1'  # Output: $1
 > ```
 
-To learn more see [about_Regular_Expressions](about_Regular_Expressions.md) and
-[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
+To learn more, see [about_Regular_Expressions](about_Regular_Expressions.md) and
+[Substitutions in Regular Expressions][4]
 
 ### Substituting in a collection
 
@@ -641,3 +652,4 @@ $a -isnot $b.GetType() # Output: True
 [1]: /dotnet/api/system.icomparable
 [2]: /dotnet/api/system.text.regularexpressions.match
 [3]: about_Redirection.md#potential-confusion-with-comparison-operators
+[4]: /dotnet/standard/base-types/substitutions-in-regular-expressions

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -188,7 +188,8 @@ In the following examples, all statements return True.
 8 -le 8  # Ouput: True
 ```
 
-> [!NOTE] The greater-than operator, in most programming languages, is `>`. In
+> [!NOTE]
+> The greater-than operator, in most programming languages, is `>`. In
 > PowerShell, however, this character is used for redirection. For details, see
 > [About_redirection][3].
 
@@ -591,6 +592,6 @@ $a -isnot $b.GetType() # Output: True
 - [Foreach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object)
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
 
-[1]: https://docs.microsoft.com/en-us/dotnet/api/system.icomparable?view=netstandard-2.0
-[2]: https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6
+[1]: https://docs.microsoft.com/dotnet/api/system.icomparable?view=netstandard-2.0
+[2]: https://docs.microsoft.com/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6
 [3]: about_Redirection.md#potential-confusion-with-comparison-operators

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -317,15 +317,13 @@ Example:
 "PowerShell", "Server" -notlike "*shell" # Output: Server
 ```
 
-Unlike `-match` and `-notmatch`, these operators don't affect the `$Matches`
-automatic variable.
-
 ### -match and -notmatch
 
 `-match` and `-notmatch` use regular expressions to search for pattern in the
-left-hand side values. Regular expressions can match complex patterns like email
-addresses, UNC paths, or formatted phone numbers. The right-hand side string
-must adhere to the [regular expressions](about_Regular_Expressions.md) rules.
+left-hand side values. Regular expressions can match complex patterns like
+email addresses, UNC paths, or formatted phone numbers. The right-hand side
+string must adhere to the [regular expressions](about_Regular_Expressions.md)
+rules.
 
 Scalar examples:
 
@@ -340,7 +338,7 @@ Scalar examples:
 ```
 
 If the input is a collection, the operators return the matching members of that
-collection. However, the `$Matches` variable isn't populated.
+collection.
 
 Collection examples:
 
@@ -359,10 +357,11 @@ Collection examples:
 ```
 
 `-match` and `-notmatch` support regex capture groups. Each time they run, they
-overwrite the `$Matches` automatic variable with their findings. `$Matches` is
-a **Hashtable** that always has a key named '0', which stores the entire match.
-If the regular expression contains capture groups, the `$Matches` contains
-additional keys for each group.
+overwrite the `$Matches` automatic variable. When `<input>` is a collection the
+`$Matches` variable is `$null`. `$Matches` is a **Hashtable** that always has a
+key named '0', which stores the entire match. If the regular expression
+contains capture groups, the `$Matches` contains additional keys for each
+group.
 
 Example:
 
@@ -401,7 +400,6 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with regular expressions
 
-The replacement operator, `-replace`, is an extension of the `-match` operator.
 Like `-match`, the `-replace` operator uses regular expressions to find the
 specified pattern. But unlike `-match`, it replaces the matches with another
 specified value.
@@ -459,34 +457,39 @@ John.Doe@Contoso.local
 ```
 
 > [!WARNING]
-> The `$` has syntatic roles in both PowerShell and regular expressions: - In
-> PowerShell, between double quotation marks, it designates variables and acts
-> as a subexpression operator. - In Regex search strings, it denotes end of the
-> line - In Regex substitution strings, it denotes captured groups As such, be
-> sure to either put your regular expressions between single quotation marks or
-> insert a backtick (\`) character before them. For example:
+> The `$` character has syntatic roles in both PowerShell and regular
+> expressions:
 >
-> ```powershell
-> $1 = 'Goodbye'
-> 
-> 'Hello World' -replace '(\w+) \w+', "$1 Universe"
-> # Output: Goodbye Universe
-> 
-> 'Hello World' -replace '(\w+) \w+', '$1 Universe'
-> # Output: Hello Universe
-> ```
->
-> `$$` in Regex denotes a literal `$`. Be sure to understand its caveats. For
-> example:
->
-> ```powershell
-> '5.72' -replace '(.+)', '$ $1' # Output: $ 5.72
-> '5.72' -replace '(.+)', '$$$1' # Output: $5.72
-> '5.72' -replace '(.+)', '$$1'  # Output: $1
-> ```
+> - In PowerShell, between double quotation marks, it designates variables and
+>   acts as a subexpression operator.
+> - In Regex search strings, it denotes end of the line
+> - In Regex substitution strings, it denotes captured groups As such, be sure
+>   to to either put your regular expressions between single quotation marks or
+>   insert a backtick (`` ` ``) character before them.
+
+For example:
+
+```powershell
+$1 = 'Goodbye'
+
+'Hello World' -replace '(\w+) \w+', "$1 Universe"
+# Output: Goodbye Universe
+
+'Hello World' -replace '(\w+) \w+', '$1 Universe'
+# Output: Hello Universe
+```
+
+`$$` in Regex denotes a literal `$`. This `$$` in the substitution string to
+include a a literal `$` in the resulting replacement. For example:
+
+```powershell
+'5.72' -replace '(.+)', '$ $1' # Output: $ 5.72
+'5.72' -replace '(.+)', '$$$1' # Output: $5.72
+'5.72' -replace '(.+)', '$$1'  # Output: $1
+```
 
 To learn more, see [about_Regular_Expressions](about_Regular_Expressions.md) and
-[Substitutions in Regular Expressions][4]
+[Substitutions in Regular Expressions][4].
 
 ### Substituting in a collection
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -1,6 +1,5 @@
 ---
 description: Explains how to redirect output from PowerShell to text files.
-keywords: PowerShell,cmdlet
 Locale: en-US
 ms.date: 10/14/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_redirection?view=powershell-7&WT.mc_id=ps-gethelp
@@ -10,7 +9,6 @@ title: about_Redirection
 # About Redirection
 
 ## Short description
-
 Explains how to redirect output from PowerShell to text files.
 
 ## Long description
@@ -258,7 +256,8 @@ Line |
 ```
 
 If numeric comparison is the required operation, `-lt` and `-gt` should be
-used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt--ge--lt-and--le)
+used. For more information, see the `-gt` operator in
+[about_Comparison_Operators](about_Comparison_Operators.md#-gt--ge--lt-and--le).
 
 ## See also
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -10,6 +10,7 @@ title: about_Redirection
 # About Redirection
 
 ## Short description
+
 Explains how to redirect output from PowerShell to text files.
 
 ## Long description
@@ -220,7 +221,7 @@ formatted correctly. To write to files with a different encoding, use the
 ### Potential confusion with comparison operators
 
 The `>` operator is not to be confused with the
-[Greater-than](about_Comparison_Operators.md##-gt--ge--lt-and--le) comparison operator (often
+[Greater-than](about_Comparison_Operators.md#-gt--ge--lt-and--le) comparison operator (often
 denoted as `>` in other programming languages).
 
 Depending on the objects being compared, the output using `>` can appear to be
@@ -249,16 +250,15 @@ Attempting to use the reverse comparison `<` (less than), yields a system error:
 
 ```powershell
 PS> if (36 < 42) { "true" } else { "false" }
-At line:1 char:8
-+ if (36 < 42) { "true" } else { "false" }
-+        ~
-The '<' operator is reserved for future use.
-+ CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
-+ FullyQualifiedErrorId : RedirectionNotSupported
+ParserError:
+Line |
+   1 |  if (36 < 42) { "true" } else { "false" }
+     |         ~
+     | The '<' operator is reserved for future use.
 ```
 
 If numeric comparison is the required operation, `-lt` and `-gt` should be
-used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt)
+used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt--ge--lt-and--le)
 
 ## See also
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -220,7 +220,7 @@ formatted correctly. To write to files with a different encoding, use the
 ### Potential confusion with comparison operators
 
 The `>` operator is not to be confused with the
-[Greater-than](about_Comparison_Operators.md#-gt) comparison operator (often
+[Greater-than](about_Comparison_Operators.md##-gt--ge--lt-and--le) comparison operator (often
 denoted as `>` in other programming languages).
 
 Depending on the objects being compared, the output using `>` can appear to be

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,672 +1,562 @@
 ---
 description: Describes the operators that compare values in PowerShell.
+keywords: powershell,cmdlet
 Locale: en-US
-ms.date: 12/10/2020
-online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.1&WT.mc_id=ps-gethelp
+ms.date: 12/11/2020
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
 ---
 # About Comparison Operators
 
-## Short description
-Describes the operators that compare values in PowerShell.
+## Abstract
 
-## Long description
+The comparison operators in PowerShell can either compare two values or filter
+elements of a collection against an input value. These operators include:
+`-eq`,`-ne`,`-gt`,`-ge`,`-lt`,`-le`,`-like`,`-notlike`,`-match`,`-notmatch`,
+`-replace`,`-contains`,`-notcontains`,`-in`,`-notin`,`-is`,`-isnot`.
 
-Comparison operators let you specify conditions for comparing values and
-finding values that match specified patterns. To use a comparison operator,
-specify the values that you want to compare together with an operator that
-separates these values.
+## The operators
 
-PowerShell includes the following comparison operators:
+Comparison operators let you compare values or finding values that match
+specified patterns. PowerShell includes the following comparison operators:
 
-| Type        | Operators    | Description                                 |
-| ----------- | ------------ | --------------------------------------------|
-| Equality    | -eq          | equals                                      |
-|             | -ne          | not equals                                  |
-|             | -gt          | greater than                                |
-|             | -ge          | greater than or equal                       |
-|             | -lt          | less than                                   |
-|             | -le          | less than or equal                          |
-|             |              |                                             |
-| Matching    | -like        | Returns true when string matches wildcard   |
-|             |              | pattern                                     |
-|             | -notlike     | Returns true when string does not match     |
-|             |              | wildcard pattern                            |
-|             | -match       | Returns true when string matches regex      |
-|             |              | pattern; $matches contains matching strings |
-|             | -notmatch    | Returns true when string does not match     |
-|             |              | regex pattern; $matches contains matching   |
-|             |              | strings                                     |
-|             |              |                                             |
-| Containment | -contains    | Returns true when reference value contained |
-|             |              | in a collection                             |
-|             | -notcontains | Returns true when reference value not       |
-|             |              | contained in a collection                   |
-|             | -in          | Returns true when test value contained in a |
-|             |              | collection                                  |
-|             | -notin       | Returns true when test value not contained  |
-|             |              | in a collection                             |
-|             |              |                                             |
-| Replacement | -replace     | Replaces a string pattern                   |
-|             |              |                                             |
-| Type        | -is          | Returns true if both object are the same    |
-|             |              | type                                        |
-|             | -isnot       | Returns true if the objects are not the same|
-|             |              | type                                        |
+| Type        | Operator     | Comparison test
+| ----------- | ------------ | ------------------------------------------------
+| Equality    | -eq          | equals
+|             | -ne          | not equals
+|             | -gt          | greater than
+|             | -ge          | greater than or equal
+|             | -lt          | less than
+|             | -le          | less than or equal
+| Matching    | -like        | string matches wildcard pattern
+|             | -notlike     | string does not match wildcard pattern
+|             | -match       | string matches regex pattern
+|             | -notmatch    | string does not match regex pattern
+| Replacement | -replace     | string matches regex pattern; replaces the match
+| Containment | -contains    | collection contains a value
+|             | -notcontains | collection does not contain a value
+|             | -in          | value is in a collection
+|             | -notin       | value is not in a collection
+| Type        | -is          | both objectd are the same type
+|             | -isnot       | the objects are not the same type
+
+## Common features
 
 By default, all comparison operators are case-insensitive. To make a comparison
-operator case-sensitive, precede the operator name with a `c`. For example, the
-case-sensitive version of `-eq` is `-ceq`. To make the case-insensitivity
-explicit, precede the operator with an `i`. For example, the explicitly
-case-insensitive version of `-eq` is `-ieq`.
+operator case-sensitive, add a `c` after the `-`. For example, `-ceq` is the
+case-sensitive version of `-eq`. To make the case-insensitivity explicit,
+add an `i` before `-`. For example, `-ieq` is the explicitly case-insensitive
+version of `-eq`.
 
-When the input to an operator is a scalar value, comparison operators return a
-Boolean value. When the input is a collection of values, the comparison
-operators return any matching values. If there are no matches in a collection,
-comparison operators return an empty array.
+When the input of an operator is a scalar value, the operator returns a Boolean
+value. When the input is a collection, the operator returns those collection
+elements that match the input. If there are no matches in the collection,
+comparison operators return an empty array. For example:
 
 ```powershell
-PS> (1, 2 -eq 3).GetType().FullName
-System.Object[]
+$a = (1, 2 -eq 3)
+$a.GetType().Name
+$a.Count
 ```
 
-The exceptions are the containment operators, the In operators, and the type
-operators, which always return a **Boolean** value.
+```output
+Object[]
+0
+```
 
-> [!NOTE]
-> If you need to compare a value to `$null` you should put `$null` on the
-> left-hand side of the comparison. When you compare `$null` to an **Object[]**
-> the result is **False** because the comparison object is an array. When you
-> compare an array to `$null`, the comparison filters out any `$null` values
-> stored in the array. For example:
->
-> ```powershell
-> PS> $null -ne $null, "hello"
-> True
-> PS> $null, "hello" -ne $null
-> hello
-> ```
+The exceptions are the containment operators and the type operators; they always
+return a Boolean value.
 
 ## Equality operators
 
-The equality operators (`-eq`, `-ne`) return a value of TRUE or the matches
-when one or more of the input values is identical to the specified pattern. The
-entire pattern must match an entire value.
+### -eq and -ne
 
-Example:
-
-### -eq
-
-Description: Equal to. Includes an identical value.
+When the left-hand side is scalar, `-eq` returns True if the right-hand side is
+an exact match; otherwise, `-eq` returns False. `-ne` does the opposite; it
+returns False when both sides match; otherwise, `-ne` returns True.
 
 Example:
 
 ```powershell
-PS> 2 -eq 2
-True
+2 -eq 2                 # Ouput: True
+2 -eq 3                 # Ouput: False
+"abc" -eq "abc"         # Ouput: True
+"abc" -eq "abc", "def"  # Ouput: False
+"abc" -ne "def"         # Ouput: True
+"abc" -ne "abc"         # Ouput: False
+"abc" -ne "abc", "def"  # Ouput: True
+```
 
-PS> 2 -eq 3
+When the left-hand side is a collection, `-eq` returns those members that match
+the right-hand side, while `-ne` filters them out.
+
+Example:
+
+```powershell
+1,2,3 -eq 2             # Ouput: 2
+"abc", "def" -eq "abc"  # Ouput: abc
+"abc", "def" -ne "abc"  # Ouput: def
+```
+
+These operators process all elements of the collection. Example:
+
+```powershell
+"zzz", "def", "zzz" -eq "zzz"
+```
+
+```output
+zzz
+zzz
+```
+
+The equality operators accept any two objects, not just scalar or collection.
+But the comparison result is not guaranteed to be meaningful for the end-user.
+The following example demonstrates the issue.
+
+```powershell
+class MyFileInfoSet {
+    [String]$File
+    [String]$Size
+}
+$a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$a -eq $b
+```
+
+```Output
 False
+```
 
-PS> 1,2,3 -eq 2
+In this example, we created two objects with identical properties. Yet, the
+equality test result is False, because they are different objects. If you intend
+to develop meaningfully comparable classes, you need to implement
+[System.IComparable][1] in your class.
+
+A prominent example of comparing arbitrary objects is to find out if they are
+null. But if you need to determine whether a variable is `$null`, you must put
+`$null` on the left-hand side of the equality operator. Putting it on the
+right-hand side does not do what you expect.
+
+For example, let `$a` be an array containing null elements:
+
+```powershell
+$a = 1, 2, $null, 4, $null, 6
+```
+
+The following tests that `$a` is not null.
+
+```powershell
+$null -ne $a
+```
+
+```output
+False
+```
+
+The following, however, filers out all null elements from `$a`:
+
+```powershell
+$a -ne $null # Output: 1, 2, 4, 6
+```
+
+```output
+1
 2
-PS> "abc" -eq "abc"
-True
-
-PS> "abc" -eq "abc", "def"
-False
-
-PS> "abc", "def" -eq "abc"
-abc
+4
+6
 ```
 
-### -ne
+### -gt, -ge, -lt, and -le
 
-Description: Not equal to. Includes a different value.
+`-gt`, `-ge`, `-lt`, and `-le` behave very similarly. When both sides are scalar
+they return True or False depending on how the two sides compare:
+
+| Operator | Returns True when...                   |
+| -------- | -------------------------------------- |
+| -gt      | The left-hand side is greater          |
+| -ge      | The left-hand side is greater or equal |
+| -lt      | The left-hand side is smaller          |
+| -le      | The left-hand side is smaller or equal |
+
+In the following examples, all statements return True.
+
+```powershell
+8 -gt 6  # Ouput: True
+8 -ge 8  # Ouput: True
+6 -lt 8  # Ouput: True
+8 -le 8  # Ouput: True
+```
+
+> [!NOTE] The greater-than operator, in most programming languages, is `>`. In
+> PowerShell, however, this character is used for redirection. For details, see
+> [About_redirection][3].
+
+When the left-hand side is a collection, these operators compare each member of
+the collection with the right-hand side. Depending on their logic, they either
+keep or discard the member.
 
 Example:
 
 ```powershell
-PS> "abc" -ne "def"
-True
+$a=5, 6, 7, 8, 9
 
-PS> "abc" -ne "abc"
-False
+Write-Output "Test collection:"
+$a
 
-PS> "abc" -ne "abc", "def"
-True
+Write-Output "`nMembers greater than 7"
+$a -gt 7
 
-PS> "abc", "def" -ne "abc"
-def
+Write-Output "`nMembers greater than or equal to 7"
+$a -ge 7
+
+Write-Output "`nMembers smaller than 7"
+$a -lt 7
+
+Write-Output "`nMembers smaller than or equal to 7"
+$a -le 7
 ```
 
-### -gt
-
-Description: Greater-than.
-
-Example:
-
-```powershell
-PS> 8 -gt 6
-True
-
-PS> 7, 8, 9 -gt 8
-9
-```
-
-> [!NOTE]
-> This should not to be confused with `>`, the greater-than operator in many
-> other programming languages. In PowerShell, `>` is used for redirection. For
-> more information, see
-> [About_redirection](about_Redirection.md#potential-confusion-with-comparison-operators).
-
-### -ge
-
-Description: Greater-than or equal to.
-
-Example:
-
-```powershell
-PS> 8 -ge 8
-True
-
-PS> 7, 8, 9 -ge 8
+```output
+Test collection:
+5
+6
+7
 8
 9
-```
 
-### -lt
+Memebers greater than 7
+8
+9
 
-Description: Less-than.
+Memebers greater than or equal to 7
+7
+8
+9
 
-Example:
+Memebers smaller than 7
+5
+6
 
-```powershell
-
-PS> 8 -lt 6
-False
-
-PS> 7, 8, 9 -lt 8
+Memebers smaller than or equal to 7
+5
+6
 7
 ```
 
-### -le
+These operators aren't restricted to numbers; they work with any class that
+implements [System.IComparable][1].
 
-Description: Less-than or equal to.
-
-Example:
+Examples:
 
 ```powershell
-PS> 6 -le 8
-True
+# Date comparison
+[DateTime]'2001-11-12' -lt [DateTime]'2020-08-01' # True
 
-PS> 7, 8, 9 -le 8
-7
-8
+# Sorting order comparison
+'a' -lt 'z'           # True; 'a' comes before 'z'
+'macOS' -ilt 'MacOS'  # False
+'MacOS' -ilt 'macOS'  # False
+'macOS' -clt 'MacOS'  # True; 'm' comes before 'M'
 ```
+
+The following example demonstrates that there is no symbol on an American QWERTY
+keyboard that gets sorted after 'a'. It feeds a set containing all such symbols
+to the `-gt` operator to compare them against 'a'. The output is an empty array.
+
+```powershell
+$a=' ','`','~','!','@','#','$','%','^','&','*','(',')','_','+','-','=','{','}',
+   '[',']',':',';','"','''','\','|','/','?','.','>',',','<'
+$a -gt 'a'
+# Output: Nothing
+```
+
+If the two sides of the operators are not reasonably comparable, these operators
+raise a non-terminating error.
 
 ## Matching operators
 
-The like operators (`-like` and `-notlike`) find elements that match or do not
-match a specified pattern using wildcard expressions.
+The matching operators (`-like`, `-notlike`, `-match`, and `-notmatch`) find
+elements that match or do not match a specified pattern. The pattern for `-like`
+and `-notlike` is a wildcard expression (containing `*`, `?`, and `[ ]`), while
+`-match` and `-notmatch` accept a regular expression (Regex).
 
 The syntax is:
 
 ```powershell
-<string[]> -like <wildcard-expression>
+<string[]> -like    <wildcard-expression>
 <string[]> -notlike <wildcard-expression>
-```
-
-The match operators (`-match` and `-notmatch`) find elements that match or do
-not match a specified pattern using regular expressions.
-
-The match operators populate the `$Matches` automatic variable when the input
-(the left-side argument) to the operator is a single scalar object. When the
-input is scalar, the `-match` and `-notmatch` operators return a Boolean value
-and set the value of the `$Matches` automatic variable to the matched
-components of the argument.
-
-The syntax is:
-
-```powershell
-<string[]> -match <regular-expression>
+<string[]> -match    <regular-expression>
 <string[]> -notmatch <regular-expression>
 ```
 
-### -like
+When the input of these operators is a scalar value, they return a Boolean
+value. When the input is a collection of values, the operators return any
+matching members. If there are no matches in a collection, the operators return
+an empty array.
 
-Description: Match using the wildcard character (\*).
+### -like and -notlike
 
-Example:
-
-```powershell
-PS> "PowerShell" -like "*shell"
-True
-
-PS> "PowerShell", "Server" -like "*shell"
-PowerShell
-```
-
-### -notlike
-
-Description: Does not match using the wildcard character (\*).
+`-like` and `-notlike` behave similarly to `-eq` and `-ne`, but the right-hand
+side could be a string containing [wildcards](about_Wildcards.md).
 
 Example:
 
 ```powershell
-PS> "PowerShell" -notlike "*shell"
-False
+"PowerShell" -like    "*shell"           # Ouput: True
+"PowerShell" -notlike "*shell"           # Ouput: False
+"PowerShell" -like    "Power?hell"       # Ouput: True
+"PowerShell" -notlike "Power?hell"       # Ouput: False
+"PowerShell" -like    "Power[p-w]hell"   # Ouput: True
+"PowerShell" -notlike "Power[p-w]hell"   # Ouput: False
 
-PS> "PowerShell", "Server" -notlike "*shell"
-Server
+"PowerShell", "Server" -like "*shell"    # Ouput: PowerShell
+"PowerShell", "Server" -notlike "*shell" # Ouput: Server
 ```
 
-### -match
+## -match and -notmatch
 
-Description: Matches a string using regular expressions. When the input is
-scalar, it populates the `$Matches` automatic variable.
+`-match` and `-notmatch` use regular expressions to conduct their search. As
+such, they support very complex searches, e.g. they can find email addresses,
+UNC paths, or dash-formatted phone numbers. The right-hand side string must
+adhere to the [regular expressions](about_Regular_Expressions.md) rules.
 
-If the input is a collection, the `-match` and `-notmatch` operators return
-the matching members of that collection, but the operator does not populate
-the `$Matches` variable.
-
-For example, the following command submits a collection of strings to the
-`-match` operator. The `-match` operator returns the items in the collection
-that match. It does not populate the `$Matches` automatic variable.
+Scalar examples:
 
 ```powershell
-PS> "Sunday", "Monday", "Tuesday" -match "sun"
-Sunday
+# Partial match test, showing how differently -match and -like behave
+"PowerShell" -match 'shell'        # Ouput: True
+"PowerShell" -like  'shell'        # Ouput: False
 
-PS> $Matches
-PS>
+# Regex syntax test
+"PowerShell" -match    '^Power\w+' # Ouput: True
+'bag'        -notmatch 'b[iou]g'   # Ouput: True
 ```
 
-In contrast, the following command submits a single string to the `-match`
-operator. The `-match` operator returns a Boolean value and populates the
-`$Matches` automatic variable. The `$Matches` automatic variable is a
-**Hashtable**. If no grouping or capturing is used, only one key is populated.
-The `0` key represents all text that was matched. For more information about
-grouping and capturing using regular expressions, see
-[about_Regular_Expressions](about_Regular_Expressions.md).
+Collection examples:
 
 ```powershell
-PS> "Sunday" -match "sun"
-True
+"PowerShell", "Super PowerShell", "Power's hell" -match '^Power\w+'
+# Output: PowerShell
 
-PS> $Matches
+"Rhell", "Chell", "Mel", "Smell", "Shell" -match "hell"
+# Ouput: Rhell, Chell, Shell
 
-Name                           Value
-----                           -----
-0                              Sun
+"Bag", "Beg", "Big", "Bog", "Bug"  -match 'b[iou]g'
+#Output: Big, Bog, Bug
+
+"Bag", "Beg", "Big", "Bog", "Bug"  -notmatch 'b[iou]g'
+#Output: Bag, Beg
 ```
 
-It is important to note that the `$Matches` hashtable will only contain the
-first occurrence of any matching pattern.
-
-```powershell
-PS> "Banana" -match "na"
-True
-
-PS> $Matches
-
-Name                           Value
-----                           -----
-0                              na
-```
-
-> [!IMPORTANT]
-> The `0` key is an **Integer**. You can use any **Hashtable** method to access
-> the value stored.
->
-> ```powershell
-> PS> "Good Dog" -match "Dog"
-> True
->
-> PS> $Matches[0]
-> Dog
->
-> PS> $Matches.Item(0)
-> Dog
->
-> PS> $Matches.0
-> Dog
-> ```
-
-The `-notmatch` operator populates the `$Matches` automatic variable when the
-input is scalar and the result is False, that it, when it detects a match.
-
-```powershell
-PS> "Sunday" -notmatch "rain"
-True
-
-PS> $matches
-PS>
-
-PS> "Sunday" -notmatch "day"
-False
-
-PS> $matches
-
-Name                           Value
-----                           -----
-0                              day
-```
-
-### -notmatch
-
-Description: Does not match a string. Uses regular expressions. When the input
-is scalar, it populates the `$Matches` automatic variable.
+`-match` and `-notmatch` support regex capture groups. Each time they run, they
+overwrite the `$Matches` automatic variable with their findings. This variable
+is a **Hashtable** and always has a key named '0' that stores the entire match.
+If the regular expression contains capture groups, the Hashtable will contain
+additional corresponding keys.
 
 Example:
 
 ```powershell
-PS> "Sunday" -notmatch "sun"
-False
+$string = 'The last logged on user was CONTOSO\jsmith'
+$string -match 'was (?<domain>.+)\\(?<user>.+)'
 
-PS> $matches
-Name Value
----- -----
-0    sun
+$Matches
 
-PS> "Sunday", "Monday" -notmatch "sun"
-Monday
+Write-Output "`nDomain name:"
+$Matches.domain
+
+Write-Output "`nUser name:"
+$Matches.user
 ```
 
-## Containment operators
+```output
+True
 
-The containment operators (`-contains` and `-notcontains`) are similar to the
-equality operators. However, the containment operators always return a Boolean
-value, even when the input is a collection.
+Name                           Value
+----                           -----
+domain                         CONTOSO
+user                           jsmith
+0                              was CONTOSO\jsmith
 
-Also, unlike the equality operators, the containment operators return a value
-as soon as they detect the first match. The equality operators evaluate all
-input and then return all the matches in the collection.
+Domain name:
+CONTOSO
 
-### -contains
+User name:
+jsmith
+```
 
-Description: Containment operator. Tells whether a collection of reference
-values includes a single test value. Always returns a Boolean value. Returns
-TRUE only when the test value exactly matches at least one of the reference
-values.
+For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
-When the test value is a collection, the Contains operator uses reference
-equality. It returns TRUE only when one of the reference values is the same
-instance of the test value object.
+## Replacement operator
 
-In a very large collection, the `-contains` operator returns results quicker
-than the equal to operator.
+### Replacement with regular expressions
+
+The replacement operator, `-replace`, is an extension of the `-match` operator.
+Like `-match`, it finds the specified pattern, but unlike `-match`, it replaces
+them with another specified value.
 
 Syntax:
 
-`<Reference-values> -contains <Test-value>`
-
-Examples:
-
 ```powershell
-PS> "abc", "def" -contains "def"
-True
-
-PS> "Windows", "PowerShell" -contains "Shell"
-False  #Not an exact match
-
-# Does the list of computers in $DomainServers include $ThisComputer?
-PS> $DomainServers -contains $thisComputer
-True
-
-PS> "abc", "def", "ghi" -contains "abc", "def"
-False
-
-PS> $a = "abc", "def"
-PS> "abc", "def", "ghi" -contains $a
-False
-PS> $a, "ghi" -contains $a
-True
+<String> -replace <regular-expression>, <substitute>
 ```
 
-### -notcontains
-
-Description: Containment operator. Tells whether a collection of reference
-values includes a single test value. Always returns a Boolean value. Returns
-TRUE when the test value is not an exact matches for at least one of the
-reference values.
-
-When the test value is a collection, the NotContains operator uses reference
-equality.
-
-Syntax:
-
-`<Reference-values> -notcontains <Test-value>`
-
-Examples:
-
-```powershell
-PS> "Windows", "PowerShell" -notcontains "Shell"
-True  #Not an exact match
-
-# Get cmdlet parameters, but exclude common parameters
-function get-parms ($cmdlet)
-{
-    $Common = "Verbose", "Debug", "WarningAction", "WarningVariable",
-      "ErrorAction", "ErrorVariable", "OutVariable", "OutBuffer"
-
-    $allparms = (Get-Command $Cmdlet).parametersets |
-      foreach {$_.Parameters} |
-        foreach {$_.Name} | Sort-Object | Get-Unique
-
-    $allparms | where {$Common -notcontains $_ }
-}
-
-# Find unapproved verbs in the functions in my module
-PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS> $myVerbs = Get-Command -Module MyModule | foreach {$_.verb}
-PS> $myVerbs | where {$ApprovedVerbs -notcontains $_}
-ForEach
-Sort
-Tee
-Where
-```
-
-### -in
-
-Description: In operator. Tells whether a test value appears in a collection of
-reference values. Always return as Boolean value. Returns TRUE only when the
-test value exactly matches at least one of the reference values.
-
-When the test value is a collection, the In operator uses reference equality.
-It returns TRUE only when one of the reference values is the same instance of
-the test value object.
-
-The `-in` operator was introduced in PowerShell 3.0.
-
-Syntax:
-
-`<Test-value> -in <Reference-values>`
-
-Examples:
-
-```powershell
-PS> "def" -in "abc", "def"
-True
-
-PS> "Shell" -in "Windows", "PowerShell"
-False  #Not an exact match
-
-PS> "Windows" -in "Windows", "PowerShell"
-True  #An exact match
-
-PS> "Windows", "PowerShell" -in "Windows", "PowerShell", "ServerManager"
-False  #Using reference equality
-
-PS> $a = "Windows", "PowerShell"
-PS> $a -in $a, "ServerManager"
-True  #Using reference equality
-
-# Does the list of computers in $DomainServers include $ThisComputer?
-PS> $thisComputer -in  $domainServers
-True
-```
-
-### -notin
-
-Description: Tells whether a test value appears in a collection of reference
-values. Always returns a Boolean value. Returns TRUE when the test value is not
-an exact match for at least one of the reference values.
-
-When the test value is a collection, the In operator uses reference equality.
-It returns TRUE only when one of the reference values is the same instance of
-the test value object.
-
-The `-notin` operator was introduced in PowerShell 3.0.
-
-Syntax:
-
-`<Test-value> -notin <Reference-values>`
-
-Examples:
-
-```powershell
-PS> "def" -notin "abc", "def"
-False
-
-PS> "ghi" -notin "abc", "def"
-True
-
-PS> "Shell" -notin "Windows", "PowerShell"
-True  #Not an exact match
-
-PS> "Windows" -notin "Windows", "PowerShell"
-False  #An exact match
-
-# Find unapproved verbs in the functions in my module
-PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS> $MyVerbs = Get-Command -Module MyModule | foreach {$_.verb}
-
-PS> $MyVerbs | where {$_ -notin $ApprovedVerbs}
-ForEach
-Sort
-Tee
-Where
-```
-
-## Replacement Operator
-
-The `-replace` operator has the following syntax:
-
-`<input> -replace <original>, <substitute>`
-
-The `<original>` placeholder is a regular expression matching the characters to
-be replaced. The `<substitute>` placeholder is a literal string that replaces
-them.
-
-The operator replaces all or part of a value with the specified value using
-regular expressions. You can use the operator for many administrative tasks,
-such as renaming files. For example, the following command changes the file
-name extensions of all `.txt` files to `.log`:
+You can use the `-replace` operator for many administrative tasks, such as
+renaming files. For example, the following command changes the file name
+extensions of all `.txt` files to `.log`:
 
 ```powershell
 Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
 ```
 
-### Case-sensitive matches
-
 By default, the `-replace` operator is case-insensitive. To make it case
 sensitive, use `-creplace`. To make it explicitly case-insensitive, use
 `-ireplace`.
 
-Consider the following examples:
+Examples:
 
 ```powershell
-PS> "book" -replace "B", "C"
-Cook
+"book" -ireplace "B", "C" # Case insensitive
+"book" -creplace "B", "C" # Case-sensitive; hence, nothing to replace
 ```
 
-```powershell
-PS> "book" -ireplace "B", "C"
+```Output
 Cook
-```
-
-```powershell
-PS> "book" -creplace "B", "C"
 book
 ```
 
-### Substitutions in regular expressions
-
 It is also possible to use regular expressions to dynamically replace text
-using capturing groups, and substitutions. Capture groups can be referenced in
-the `<substitute>` string using the dollar sign (`$`) character before the
-group identifier.
+using capturing groups, and substitutions.
 
-Capture groups can be referenced by **Number** or **Name**
-
-- By **Number** - Capturing Groups are numbered from left to right.
-
-  ```powershell
-  PS> "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
-  John.D.Smith@contoso.com
-  ```
-
-- By **Name** - Capturing Groups can also be referenced by name.
-
-  ```powershell
-  PS> "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
-  FABRIKAM\Administrator
-  ```
-
-> [!WARNING]
-> Since the `$` character is used in string expansion, you will must use
-> literal strings or escape the `$` character.
->
-> ```powershell
-> PS> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
-> Hello Universe
-> ```
->
-> Additionally, since the `$` character is used in substitution, you must
-> escape any instances in your string.
->
-> ```powershell
-> PS> '5.72' -replace '(.+)', '$$$1'
-> $5.72
-> ```
-
-To learn more see [about_Regular_Expressions](about_Regular_Expressions.md) and
-[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
-
-### Substituting in a collection
-
-When the `<input>` to the `-replace` operator is a collection, PowerShell
-applies the replacement to every value in the collection. For example:
+In the following example, the `-replace` operator accepts a username in the form of `DomainName\Username` and converts to the `Username@DomainName` format:
 
 ```powershell
-"B1","B2","B3","B4","B5" -replace "B", 'a'
-a1
-a2
-a3
-a4
-a5
+$SearchExp = '^(?<Username>[\w-.]+)\\(?<DomainName>[\w-.]+)$'
+$ReplaceExp = '${Username}@${DomainName}'
+
+'Contoso.local\John.Doe' -replace $SearchExp,$ReplaceExp
 ```
 
-### ScriptBlock substitutions
+```output
+John.Doe@Contoso.local
+```
 
-Beginning in PowerShell 6, you can use a **ScriptBlock** argument for the
-_Substitution_ text. The **ScriptBlock** will execute for each match found in
-the _input_ string.
+For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
-Within the **ScriptBlock**, use the `$_` automatic variable to refer to the
-current **System.Text.RegularExpressions.Match** object. The **Match** object
-gives you access to the current input text being replaced, as well as other
-useful information.
+### Replacement with a script block
 
-This example replaces each sequence of three decimals with the character
-equivalent. The **ScriptBlock** is run for each set of three decimals that
-needs to be replaced.
+In Powershell 6 and later, the `-replace` operator also accepts a script block
+that performs the replacement. The script block runs once for every match.
+
+Syntax:
 
 ```powershell
-PS> "072101108108111" -replace "\d{3}", {[char][int]$_.Value}
+<String> -replace <regular-expression>, {<Script-block>}
+```
+
+Within the script block, use the `$_` automatic variable to access the input
+text being replaced and other useful information. This variable's class type is
+[System.Text.RegularExpressions.Match][2].
+
+The following example replaces each sequence of three digits with the character
+equivalents. The script block runs for each set of three digits that needs to be
+replaced.
+
+```powershell
+"072101108108111" -replace "\d{3}", {return [char][int]$_.Value}
+```
+
+```output
 Hello
+```
+
+## Containment operators
+
+The containment operators (`-contains`, `-notcontains`, `-in`, and `-notin`) are
+similar to the equality operators, except that they always return a Boolean
+value, even when the input is a collection. These operators stop comparing as
+soon as they detect the first match, whereas the equality operators evaluate all
+input members. In a very large collection, these operators return quicker than
+the equality operators.
+
+Syntax:
+
+```powershell
+<Collection> -contains <Test-object>
+<Collection> -notcontains <Test-object>
+<Test-object> -in <Collection>
+<Test-object> -notin <Collection>
+```
+
+### -contains and -notcontains
+
+These operators tell whether a set includes a certain element. `-contains`
+returns True when the right-hand side (test object) matches one of the elements
+in the set. `-notcontains` returns False instead. When the test object is a
+collection, these operators use reference equality, i.e. they check whether one
+of the set's elements is the same instance of the test object.
+
+Examples:
+
+```powershell
+"abc", "def" -contains "def"                  # Output: True
+"abc", "def" -notcontains "def"               # Output: False
+"Windows", "PowerShell" -contains "Shell"     # Output: False
+"Windows", "PowerShell" -notcontains "Shell"  # Output: True
+"abc", "def", "ghi" -contains "abc", "def"    # Output: False
+"abc", "def", "ghi" -notcontains "abc", "def" # Output: True
+```
+
+More complex examples:
+
+```powershell
+$DomainServers = "ContosoDC1","ContosoDC2","ContosoFileServer","ContosoDNS",
+                 "ContosoDHCP","ContosoWSUS"
+$thisComputer  = "ContosoDC2"
+
+$DomainServers -contains $thisComputer
+# Output: True
+
+$a = "abc", "def"
+"abc", "def", "ghi" -contains $a # Output: False
+$a, "ghi" -contains $a           # Output: True
+```
+
+### -in and -notin
+
+The `-in` and -`notin` operators were introduced in PowerShell 3 as the
+syntactic reverse of the of `contains` and `-notcontain` operators. `-in`
+returns True when the left-hand side (test object) matches one of the elements
+in the set. `-notin` returns False instead. When the test object is a set, these
+operators use reference equality, i.e. they check whether one of the set's
+elements is the same instance of the test object.
+
+The following examples do the same thing that the examples for `-contain`
+and `-notcontain` do, but they are written with `-in` and `-notin` instead.
+
+```powershell
+"def" -in "abc", "def"                  # Output: True
+"def" -notin "abc", "def"               # Output: False
+"Shell" -in "Windows", "PowerShell"     # Output: False
+"Shell" -notin "Windows", "PowerShell"  # Output: True
+"abc", "def" -in "abc", "def", "ghi"    # Output: False
+"abc", "def" -notin "abc", "def", "ghi" # Output: True
+```
+
+More complex examples:
+
+```powershell
+$DomainServers = "ContosoDC1","ContosoDC2","ContosoFileServer","ContosoDNS",
+                 "ContosoDHCP","ContosoWSUS"
+$thisComputer  = "ContosoDC2"
+
+$thisComputer -in $DomainServers
+# Output: True
+
+$a = "abc", "def"
+$a -in "abc", "def", "ghi" # Output: False
+$a -in $a, "ghi"           # Output: True
 ```
 
 ## Type comparison
@@ -674,41 +564,25 @@ Hello
 The type comparison operators (`-is` and `-isnot`) are used to determine if an
 object is a specific type.
 
-### -is
-
 Syntax:
 
-`<object> -is <type reference>`
+```powershell
+<object> -is <type-reference>
+<object> -isnot <type-reference>
+```
 
 Example:
 
 ```powershell
-PS> $a = 1
-PS> $b = "1"
-PS> $a -is [int]
-True
-PS> $a -is $b.GetType()
-False
+$a = 1
+$b = "1"
+$a -is [int]           # Output: True
+$a -is $b.GetType()    # Output: False
+$b -isnot [int]        # Output: False
+$a -isnot $b.GetType() # Output: True
 ```
 
-### -isnot
-
-Syntax:
-
-`<object> -isnot <type reference>`
-
-Example:
-
-```powershell
-PS> $a = 1
-PS> $b = "1"
-PS> $a -isnot $b.GetType()
-True
-PS> $b -isnot [int]
-True
-```
-
-## See also
+## SEE ALSO
 
 - [about_Operators](about_Operators.md)
 - [about_Regular_Expressions](about_Regular_Expressions.md)
@@ -716,3 +590,7 @@ True
 - [Compare-Object](xref:Microsoft.PowerShell.Utility.Compare-Object)
 - [Foreach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object)
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
+
+[1]: https://docs.microsoft.com/en-us/dotnet/api/system.icomparable?view=netstandard-2.0
+[2]: https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6
+[3]: about_Redirection.md#potential-confusion-with-comparison-operators

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -430,7 +430,8 @@ book
 It is also possible to use regular expressions to dynamically replace text
 using capturing groups, and substitutions.
 
-In the following example, the `-replace` operator accepts a username in the form of `DomainName\Username` and converts to the `Username@DomainName` format:
+In the following example, the `-replace` operator accepts a username in the form
+of `DomainName\Username` and converts to the `Username@DomainName` format:
 
 ```powershell
 $SearchExp = '^(?<Username>[\w-.]+)\\(?<DomainName>[\w-.]+)$'
@@ -447,7 +448,7 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with a script block
 
-In Powershell 6 and later, the `-replace` operator also accepts a script block
+In PowerShell 6 and later, the `-replace` operator also accepts a script block
 that performs the replacement. The script block runs once for every match.
 
 Syntax:
@@ -592,6 +593,6 @@ $a -isnot $b.GetType() # Output: True
 - [Foreach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object)
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
 
-[1]: https://docs.microsoft.com/dotnet/api/system.icomparable?view=netstandard-2.0
-[2]: https://docs.microsoft.com/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6
+[1]: https://docs.microsoft.com/dotnet/api/system.icomparable?view=netstandard-2.0&preserve-view=true
+[2]: https://docs.microsoft.com/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6&preserve-view=true
 [3]: about_Redirection.md#potential-confusion-with-comparison-operators

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,6 +1,5 @@
 ---
 description: Describes the operators that compare values in PowerShell.
-keywords: powershell,cmdlet
 Locale: en-US
 ms.date: 12/11/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.1&WT.mc_id=ps-gethelp
@@ -9,37 +8,35 @@ title: about_Comparison_Operators
 ---
 # About Comparison Operators
 
-## Abstract
+## Short description
 
 The comparison operators in PowerShell can either compare two values or filter
-elements of a collection against an input value. These operators include:
-`-eq`,`-ne`,`-gt`,`-ge`,`-lt`,`-le`,`-like`,`-notlike`,`-match`,`-notmatch`,
-`-replace`,`-contains`,`-notcontains`,`-in`,`-notin`,`-is`,`-isnot`.
+elements of a collection against an input value.
 
-## The operators
+## Long description
 
 Comparison operators let you compare values or finding values that match
 specified patterns. PowerShell includes the following comparison operators:
 
-| Type        | Operator     | Comparison test
-| ----------- | ------------ | ------------------------------------------------
-| Equality    | -eq          | equals
-|             | -ne          | not equals
-|             | -gt          | greater than
-|             | -ge          | greater than or equal
-|             | -lt          | less than
-|             | -le          | less than or equal
-| Matching    | -like        | string matches wildcard pattern
-|             | -notlike     | string does not match wildcard pattern
-|             | -match       | string matches regex pattern
-|             | -notmatch    | string does not match regex pattern
-| Replacement | -replace     | string matches regex pattern; replaces the match
-| Containment | -contains    | collection contains a value
-|             | -notcontains | collection does not contain a value
-|             | -in          | value is in a collection
-|             | -notin       | value is not in a collection
-| Type        | -is          | both objectd are the same type
-|             | -isnot       | the objects are not the same type
+|    Type     |   Operator   |              Comparison test              |
+| ----------- | ------------ | ----------------------------------------- |
+| Equality    | -eq          | equals                                    |
+|             | -ne          | not equals                                |
+|             | -gt          | greater than                              |
+|             | -ge          | greater than or equal                     |
+|             | -lt          | less than                                 |
+|             | -le          | less than or equal                        |
+| Matching    | -like        | string matches wildcard pattern           |
+|             | -notlike     | string does not match wildcard pattern    |
+|             | -match       | string matches regex pattern              |
+|             | -notmatch    | string does not match regex pattern       |
+| Replacement | -replace     | replaces strings matching a regex pattern |
+| Containment | -contains    | collection contains a value               |
+|             | -notcontains | collection does not contain a value       |
+|             | -in          | value is in a collection                  |
+|             | -notin       | value is not in a collection              |
+| Type        | -is          | both objects are the same type            |
+|             | -isnot       | the objects are not the same type         |
 
 ## Common features
 
@@ -49,10 +46,11 @@ case-sensitive version of `-eq`. To make the case-insensitivity explicit,
 add an `i` before `-`. For example, `-ieq` is the explicitly case-insensitive
 version of `-eq`.
 
-When the input of an operator is a scalar value, the operator returns a Boolean
-value. When the input is a collection, the operator returns those collection
-elements that match the input. If there are no matches in the collection,
-comparison operators return an empty array. For example:
+When the input of an operator is a scalar value, the operator returns a
+**Boolean** value. When the input is a collection, the operator returns the
+elements of the collection that match the right-hand value of the expression.
+If there are no matches in the collection, comparison operators return an empty
+array. For example:
 
 ```powershell
 $a = (1, 2 -eq 3)
@@ -65,27 +63,31 @@ Object[]
 0
 ```
 
-The exceptions are the containment operators and the type operators; they always
-return a Boolean value.
+There are a few exceptions:
+
+- The containment and type operators. They always return a **Boolean** value.
+- The `-replace` operator returns the values resulting from the replacement.
+- The `-match` and `-notmatch` operators also populate the `$Matches` automatic
+  variable.
 
 ## Equality operators
 
 ### -eq and -ne
 
-When the left-hand side is scalar, `-eq` returns True if the right-hand side is
-an exact match; otherwise, `-eq` returns False. `-ne` does the opposite; it
-returns False when both sides match; otherwise, `-ne` returns True.
+When the left-hand side is scalar, `-eq` returns **True** if the right-hand side is
+an exact match, otherwise, `-eq` returns **False**. `-ne` does the opposite; it
+returns **False** when both sides match; otherwise, `-ne` returns True.
 
 Example:
 
 ```powershell
-2 -eq 2                 # Ouput: True
-2 -eq 3                 # Ouput: False
-"abc" -eq "abc"         # Ouput: True
-"abc" -eq "abc", "def"  # Ouput: False
-"abc" -ne "def"         # Ouput: True
-"abc" -ne "abc"         # Ouput: False
-"abc" -ne "abc", "def"  # Ouput: True
+2 -eq 2                 # Output: True
+2 -eq 3                 # Output: False
+"abc" -eq "abc"         # Output: True
+"abc" -eq "abc", "def"  # Output: False
+"abc" -ne "def"         # Output: True
+"abc" -ne "abc"         # Output: False
+"abc" -ne "abc", "def"  # Output: True
 ```
 
 When the left-hand side is a collection, `-eq` returns those members that match
@@ -94,9 +96,9 @@ the right-hand side, while `-ne` filters them out.
 Example:
 
 ```powershell
-1,2,3 -eq 2             # Ouput: 2
-"abc", "def" -eq "abc"  # Ouput: abc
-"abc", "def" -ne "abc"  # Ouput: def
+1,2,3 -eq 2             # Output: 2
+"abc", "def" -eq "abc"  # Output: abc
+"abc", "def" -ne "abc"  # Output: def
 ```
 
 These operators process all elements of the collection. Example:
@@ -110,7 +112,7 @@ zzz
 zzz
 ```
 
-The equality operators accept any two objects, not just scalar or collection.
+The equality operators accept any two objects, not just a scalar or collection.
 But the comparison result is not guaranteed to be meaningful for the end-user.
 The following example demonstrates the issue.
 
@@ -129,7 +131,7 @@ False
 ```
 
 In this example, we created two objects with identical properties. Yet, the
-equality test result is False, because they are different objects. If you intend
+equality test result is **False** because they are different objects. If you intend
 to develop meaningfully comparable classes, you need to implement
 [System.IComparable][1] in your class.
 
@@ -170,7 +172,7 @@ $a -ne $null # Output: 1, 2, 4, 6
 ### -gt, -ge, -lt, and -le
 
 `-gt`, `-ge`, `-lt`, and `-le` behave very similarly. When both sides are scalar
-they return True or False depending on how the two sides compare:
+they return **True** or **False** depending on how the two sides compare:
 
 | Operator | Returns True when...                   |
 | -------- | -------------------------------------- |
@@ -182,16 +184,16 @@ they return True or False depending on how the two sides compare:
 In the following examples, all statements return True.
 
 ```powershell
-8 -gt 6  # Ouput: True
-8 -ge 8  # Ouput: True
-6 -lt 8  # Ouput: True
-8 -le 8  # Ouput: True
+8 -gt 6  # Output: True
+8 -ge 8  # Output: True
+6 -lt 8  # Output: True
+8 -le 8  # Output: True
 ```
 
 > [!NOTE]
-> The greater-than operator, in most programming languages, is `>`. In
-> PowerShell, however, this character is used for redirection. For details, see
-> [About_redirection][3].
+> In most programming languages the greater-than operator is `>`. In
+> PowerShell, this character is used for redirection. For details, see
+> [about_Redirection][3].
 
 When the left-hand side is a collection, these operators compare each member of
 the collection with the right-hand side. Depending on their logic, they either
@@ -266,8 +268,8 @@ keyboard that gets sorted after 'a'. It feeds a set containing all such symbols
 to the `-gt` operator to compare them against 'a'. The output is an empty array.
 
 ```powershell
-$a=' ','`','~','!','@','#','$','%','^','&','*','(',')','_','+','-','=','{','}',
-   '[',']',':',';','"','''','\','|','/','?','.','>',',','<'
+$a=' ','`','~','!','@','#','$','%','^','&','*','(',')','_','+','-','=',
+   '{','}','[',']',':',';','"','''','\','|','/','?','.','>',',','<'
 $a -gt 'a'
 # Output: Nothing
 ```
@@ -284,14 +286,14 @@ and `-notlike` is a wildcard expression (containing `*`, `?`, and `[ ]`), while
 
 The syntax is:
 
-```powershell
+```
 <string[]> -like    <wildcard-expression>
 <string[]> -notlike <wildcard-expression>
 <string[]> -match    <regular-expression>
 <string[]> -notmatch <regular-expression>
 ```
 
-When the input of these operators is a scalar value, they return a Boolean
+When the input of these operators is a scalar value, they return a **Boolean**
 value. When the input is a collection of values, the operators return any
 matching members. If there are no matches in a collection, the operators return
 an empty array.
@@ -304,35 +306,42 @@ side could be a string containing [wildcards](about_Wildcards.md).
 Example:
 
 ```powershell
-"PowerShell" -like    "*shell"           # Ouput: True
-"PowerShell" -notlike "*shell"           # Ouput: False
-"PowerShell" -like    "Power?hell"       # Ouput: True
-"PowerShell" -notlike "Power?hell"       # Ouput: False
-"PowerShell" -like    "Power[p-w]hell"   # Ouput: True
-"PowerShell" -notlike "Power[p-w]hell"   # Ouput: False
+"PowerShell" -like    "*shell"           # Output: True
+"PowerShell" -notlike "*shell"           # Output: False
+"PowerShell" -like    "Power?hell"       # Output: True
+"PowerShell" -notlike "Power?hell"       # Output: False
+"PowerShell" -like    "Power[p-w]hell"   # Output: True
+"PowerShell" -notlike "Power[p-w]hell"   # Output: False
 
-"PowerShell", "Server" -like "*shell"    # Ouput: PowerShell
-"PowerShell", "Server" -notlike "*shell" # Ouput: Server
+"PowerShell", "Server" -like "*shell"    # Output: PowerShell
+"PowerShell", "Server" -notlike "*shell" # Output: Server
 ```
 
-## -match and -notmatch
+Unlike `-match` and `-notmatch`, these operators don't affect the `$Matches`
+automatic variable.
 
-`-match` and `-notmatch` use regular expressions to conduct their search. As
-such, they support very complex searches, e.g. they can find email addresses,
-UNC paths, or dash-formatted phone numbers. The right-hand side string must
-adhere to the [regular expressions](about_Regular_Expressions.md) rules.
+### -match and -notmatch
+
+`-match` and `-notmatch` use regular expressions to search for pattern in the
+left-hand side values. Regular expressions can be used to match complex
+patterns like email addresses, UNC paths, or formatted phone numbers. The
+right-hand side string must adhere to the
+[regular expressions](about_Regular_Expressions.md) rules.
 
 Scalar examples:
 
 ```powershell
 # Partial match test, showing how differently -match and -like behave
-"PowerShell" -match 'shell'        # Ouput: True
-"PowerShell" -like  'shell'        # Ouput: False
+"PowerShell" -match 'shell'        # Output: True
+"PowerShell" -like  'shell'        # Output: False
 
 # Regex syntax test
-"PowerShell" -match    '^Power\w+' # Ouput: True
-'bag'        -notmatch 'b[iou]g'   # Ouput: True
+"PowerShell" -match    '^Power\w+' # Output: True
+'bag'        -notmatch 'b[iou]g'   # Output: True
 ```
+
+If the input is a collection, the operators return the matching members of that
+collection. However, the `$Matches` variable isn't populated.
 
 Collection examples:
 
@@ -341,7 +350,7 @@ Collection examples:
 # Output: PowerShell
 
 "Rhell", "Chell", "Mel", "Smell", "Shell" -match "hell"
-# Ouput: Rhell, Chell, Shell
+# Output: Rhell, Chell, Shell
 
 "Bag", "Beg", "Big", "Bog", "Bug"  -match 'b[iou]g'
 #Output: Big, Bog, Bug
@@ -351,10 +360,10 @@ Collection examples:
 ```
 
 `-match` and `-notmatch` support regex capture groups. Each time they run, they
-overwrite the `$Matches` automatic variable with their findings. This variable
-is a **Hashtable** and always has a key named '0' that stores the entire match.
-If the regular expression contains capture groups, the Hashtable will contain
-additional corresponding keys.
+overwrite the `$Matches` automatic variable with their findings. `$Matches` is
+a **Hashtable** that always has a key named '0', which stores the entire match.
+If the regular expression contains capture groups, the `$Matches` contains
+additional keys for each group.
 
 Example:
 
@@ -393,19 +402,20 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with regular expressions
 
-The replacement operator, `-replace`, is an extension of the `-match` operator.
-Like `-match`, it finds the specified pattern, but unlike `-match`, it replaces
-them with another specified value.
+The replacement , , is an extension of the `-match` operator. Like `-match`,
+`-replace` operator uses regular expressions to find the specified pattern. But
+unlike `-match`, it replaces the matches with another specified value.
 
 Syntax:
 
-```powershell
-<String> -replace <regular-expression>, <substitute>
+```
+<input> -replace <regular-expression>, <substitute>
 ```
 
-You can use the `-replace` operator for many administrative tasks, such as
-renaming files. For example, the following command changes the file name
-extensions of all `.txt` files to `.log`:
+The operator replaces all or part of a value with the specified value using
+regular expressions. You can use the operator for many administrative tasks,
+such as renaming files. For example, the following command changes the file
+name extensions of all `.txt` files to `.log`:
 
 ```powershell
 Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
@@ -426,9 +436,12 @@ Examples:
 Cook
 book
 ```
+### Regular expressions substitutions
 
 It is also possible to use regular expressions to dynamically replace text
-using capturing groups, and substitutions.
+using capturing groups, and substitutions. Capture groups can be referenced in
+the `<substitute>` string using the dollar sign (`$`) character before the
+group identifier.
 
 In the following example, the `-replace` operator accepts a username in the form
 of `DomainName\Username` and converts to the `Username@DomainName` format:
@@ -444,7 +457,39 @@ $ReplaceExp = '${Username}@${DomainName}'
 John.Doe@Contoso.local
 ```
 
-For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
+> [!WARNING]
+> Since the `$` character is used in string expansion, you will must use
+> literal strings or escape the `$` character.
+>
+> ```powershell
+> PS> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
+> Hello Universe
+> ```
+>
+> Additionally, since the `$` character is used in substitution, you must
+> escape any instances in your string.
+>
+> ```powershell
+> PS> '5.72' -replace '(.+)', '$$$1'
+> $5.72
+> ```
+
+To learn more see [about_Regular_Expressions](about_Regular_Expressions.md) and
+[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
+
+### Substituting in a collection
+
+When the `<input>` to the `-replace` operator is a collection, PowerShell
+applies the replacement to every value in the collection. For example:
+
+```powershell
+"B1","B2","B3","B4","B5" -replace "B", 'a'
+a1
+a2
+a3
+a4
+a5
+```
 
 ### Replacement with a script block
 
@@ -476,7 +521,7 @@ Hello
 ## Containment operators
 
 The containment operators (`-contains`, `-notcontains`, `-in`, and `-notin`) are
-similar to the equality operators, except that they always return a Boolean
+similar to the equality operators, except that they always return a **Boolean**
 value, even when the input is a collection. These operators stop comparing as
 soon as they detect the first match, whereas the equality operators evaluate all
 input members. In a very large collection, these operators return quicker than
@@ -484,7 +529,7 @@ the equality operators.
 
 Syntax:
 
-```powershell
+```
 <Collection> -contains <Test-object>
 <Collection> -notcontains <Test-object>
 <Test-object> -in <Collection>
@@ -529,10 +574,10 @@ $a, "ghi" -contains $a           # Output: True
 
 The `-in` and -`notin` operators were introduced in PowerShell 3 as the
 syntactic reverse of the of `contains` and `-notcontain` operators. `-in`
-returns True when the left-hand side (test object) matches one of the elements
-in the set. `-notin` returns False instead. When the test object is a set, these
-operators use reference equality, i.e. they check whether one of the set's
-elements is the same instance of the test object.
+returns **True** when the left-hand side `<test-object>` matches one of the
+elements in the set. `-notin` returns **False** instead. When the test object
+is a set, these operators use reference equality to check whether one of the
+set's elements is the same instance of the test object.
 
 The following examples do the same thing that the examples for `-contain`
 and `-notcontain` do, but they are written with `-in` and `-notin` instead.
@@ -593,6 +638,6 @@ $a -isnot $b.GetType() # Output: True
 - [Foreach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object)
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
 
-[1]: https://docs.microsoft.com/dotnet/api/system.icomparable?view=netstandard-2.0&preserve-view=true
-[2]: https://docs.microsoft.com/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6&preserve-view=true
+[1]: /dotnet/api/system.icomparable
+[2]: /dotnet/api/system.text.regularexpressions.match
 [3]: about_Redirection.md#potential-confusion-with-comparison-operators

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -65,10 +65,10 @@ Object[]
 
 There are a few exceptions:
 
-- The containment and type operators. They always return a **Boolean** value.
-- The `-replace` operator returns the values resulting from the replacement.
+- The containment and type operators always return a **Boolean** value
+- The `-replace` operator returns the replacement result
 - The `-match` and `-notmatch` operators also populate the `$Matches` automatic
-  variable.
+  variable
 
 ## Equality operators
 
@@ -323,10 +323,9 @@ automatic variable.
 ### -match and -notmatch
 
 `-match` and `-notmatch` use regular expressions to search for pattern in the
-left-hand side values. Regular expressions can be used to match complex
-patterns like email addresses, UNC paths, or formatted phone numbers. The
-right-hand side string must adhere to the
-[regular expressions](about_Regular_Expressions.md) rules.
+left-hand side values. Regular expressions can match complex patterns like email
+addresses, UNC paths, or formatted phone numbers. The right-hand side string
+must adhere to the [regular expressions](about_Regular_Expressions.md) rules.
 
 Scalar examples:
 
@@ -402,9 +401,10 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with regular expressions
 
-The replacement , , is an extension of the `-match` operator. Like `-match`,
-`-replace` operator uses regular expressions to find the specified pattern. But
-unlike `-match`, it replaces the matches with another specified value.
+The replacement operator, `-replace`, is an extension of the `-match` operator.
+Like `-match`, the `-replace` operator uses regular expressions to find the
+specified pattern. But unlike `-match`, it replaces the matches with another
+specified value.
 
 Syntax:
 
@@ -436,6 +436,7 @@ Examples:
 Cook
 book
 ```
+
 ### Regular expressions substitutions
 
 It is also possible to use regular expressions to dynamically replace text
@@ -458,24 +459,34 @@ John.Doe@Contoso.local
 ```
 
 > [!WARNING]
-> Since the `$` character is used in string expansion, you will must use
-> literal strings or escape the `$` character.
+> The `$` has syntatic roles in both PowerShell and regular expressions: - In
+> PowerShell, between double quotation marks, it designates variables and acts
+> as a subexpression operator. - In Regex search strings, it denotes end of the
+> line - In Regex substitution strings, it denotes captured groups As such, be
+> sure to either put your regular expressions between single quotation marks or
+> insert a backtick (\`) character before them. For example:
 >
 > ```powershell
-> PS> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
-> Hello Universe
+> $1 = 'Goodbye'
+> 
+> 'Hello World' -replace '(\w+) \w+', "$1 Universe"
+> # Output: Goodbye Universe
+> 
+> 'Hello World' -replace '(\w+) \w+', '$1 Universe'
+> # Output: Hello Universe
 > ```
 >
-> Additionally, since the `$` character is used in substitution, you must
-> escape any instances in your string.
+> `$$` in Regex denotes a literal `$`. Be sure to understand its caveats. For
+> example:
 >
 > ```powershell
-> PS> '5.72' -replace '(.+)', '$$$1'
-> $5.72
+> '5.72' -replace '(.+)', '$ $1' # Output: $ 5.72
+> '5.72' -replace '(.+)', '$$$1' # Output: $5.72
+> '5.72' -replace '(.+)', '$$1'  # Output: $1
 > ```
 
-To learn more see [about_Regular_Expressions](about_Regular_Expressions.md) and
-[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
+To learn more, see [about_Regular_Expressions](about_Regular_Expressions.md) and
+[Substitutions in Regular Expressions][4]
 
 ### Substituting in a collection
 
@@ -641,3 +652,4 @@ $a -isnot $b.GetType() # Output: True
 [1]: /dotnet/api/system.icomparable
 [2]: /dotnet/api/system.text.regularexpressions.match
 [3]: about_Redirection.md#potential-confusion-with-comparison-operators
+[4]: /dotnet/standard/base-types/substitutions-in-regular-expressions

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -3,7 +3,7 @@ description: Describes the operators that compare values in PowerShell.
 keywords: powershell,cmdlet
 Locale: en-US
 ms.date: 12/11/2020
-online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7&WT.mc_id=ps-gethelp
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
 ---

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -188,7 +188,8 @@ In the following examples, all statements return True.
 8 -le 8  # Ouput: True
 ```
 
-> [!NOTE] The greater-than operator, in most programming languages, is `>`. In
+> [!NOTE]
+> The greater-than operator, in most programming languages, is `>`. In
 > PowerShell, however, this character is used for redirection. For details, see
 > [About_redirection][3].
 
@@ -591,6 +592,6 @@ $a -isnot $b.GetType() # Output: True
 - [Foreach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object)
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
 
-[1]: https://docs.microsoft.com/en-us/dotnet/api/system.icomparable?view=netstandard-2.0
-[2]: https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6
+[1]: https://docs.microsoft.com/dotnet/api/system.icomparable?view=netstandard-2.0
+[2]: https://docs.microsoft.com/dotnet/api/system.text.regularexpressions.match?view=netstandard-1.6
 [3]: about_Redirection.md#potential-confusion-with-comparison-operators

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -317,15 +317,13 @@ Example:
 "PowerShell", "Server" -notlike "*shell" # Output: Server
 ```
 
-Unlike `-match` and `-notmatch`, these operators don't affect the `$Matches`
-automatic variable.
-
 ### -match and -notmatch
 
 `-match` and `-notmatch` use regular expressions to search for pattern in the
-left-hand side values. Regular expressions can match complex patterns like email
-addresses, UNC paths, or formatted phone numbers. The right-hand side string
-must adhere to the [regular expressions](about_Regular_Expressions.md) rules.
+left-hand side values. Regular expressions can match complex patterns like
+email addresses, UNC paths, or formatted phone numbers. The right-hand side
+string must adhere to the [regular expressions](about_Regular_Expressions.md)
+rules.
 
 Scalar examples:
 
@@ -340,7 +338,7 @@ Scalar examples:
 ```
 
 If the input is a collection, the operators return the matching members of that
-collection. However, the `$Matches` variable isn't populated.
+collection.
 
 Collection examples:
 
@@ -359,10 +357,11 @@ Collection examples:
 ```
 
 `-match` and `-notmatch` support regex capture groups. Each time they run, they
-overwrite the `$Matches` automatic variable with their findings. `$Matches` is
-a **Hashtable** that always has a key named '0', which stores the entire match.
-If the regular expression contains capture groups, the `$Matches` contains
-additional keys for each group.
+overwrite the `$Matches` automatic variable. When `<input>` is a collection the
+`$Matches` variable is `$null`. `$Matches` is a **Hashtable** that always has a
+key named '0', which stores the entire match. If the regular expression
+contains capture groups, the `$Matches` contains additional keys for each
+group.
 
 Example:
 
@@ -401,7 +400,6 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with regular expressions
 
-The replacement operator, `-replace`, is an extension of the `-match` operator.
 Like `-match`, the `-replace` operator uses regular expressions to find the
 specified pattern. But unlike `-match`, it replaces the matches with another
 specified value.
@@ -459,34 +457,39 @@ John.Doe@Contoso.local
 ```
 
 > [!WARNING]
-> The `$` has syntatic roles in both PowerShell and regular expressions: - In
-> PowerShell, between double quotation marks, it designates variables and acts
-> as a subexpression operator. - In Regex search strings, it denotes end of the
-> line - In Regex substitution strings, it denotes captured groups As such, be
-> sure to either put your regular expressions between single quotation marks or
-> insert a backtick (\`) character before them. For example:
+> The `$` character has syntatic roles in both PowerShell and regular
+> expressions:
 >
-> ```powershell
-> $1 = 'Goodbye'
-> 
-> 'Hello World' -replace '(\w+) \w+', "$1 Universe"
-> # Output: Goodbye Universe
-> 
-> 'Hello World' -replace '(\w+) \w+', '$1 Universe'
-> # Output: Hello Universe
-> ```
->
-> `$$` in Regex denotes a literal `$`. Be sure to understand its caveats. For
-> example:
->
-> ```powershell
-> '5.72' -replace '(.+)', '$ $1' # Output: $ 5.72
-> '5.72' -replace '(.+)', '$$$1' # Output: $5.72
-> '5.72' -replace '(.+)', '$$1'  # Output: $1
-> ```
+> - In PowerShell, between double quotation marks, it designates variables and
+>   acts as a subexpression operator.
+> - In Regex search strings, it denotes end of the line
+> - In Regex substitution strings, it denotes captured groups As such, be sure
+>   to to either put your regular expressions between single quotation marks or
+>   insert a backtick (`` ` ``) character before them.
+
+For example:
+
+```powershell
+$1 = 'Goodbye'
+
+'Hello World' -replace '(\w+) \w+', "$1 Universe"
+# Output: Goodbye Universe
+
+'Hello World' -replace '(\w+) \w+', '$1 Universe'
+# Output: Hello Universe
+```
+
+`$$` in Regex denotes a literal `$`. This `$$` in the substitution string to
+include a a literal `$` in the resulting replacement. For example:
+
+```powershell
+'5.72' -replace '(.+)', '$ $1' # Output: $ 5.72
+'5.72' -replace '(.+)', '$$$1' # Output: $5.72
+'5.72' -replace '(.+)', '$$1'  # Output: $1
+```
 
 To learn more, see [about_Regular_Expressions](about_Regular_Expressions.md) and
-[Substitutions in Regular Expressions][4]
+[Substitutions in Regular Expressions][4].
 
 ### Substituting in a collection
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -10,6 +10,7 @@ title: about_Redirection
 # About Redirection
 
 ## Short description
+
 Explains how to redirect output from PowerShell to text files.
 
 ## Long description
@@ -220,7 +221,7 @@ formatted correctly. To write to files with a different encoding, use the
 ### Potential confusion with comparison operators
 
 The `>` operator is not to be confused with the
-[Greater-than](about_Comparison_Operators.md##-gt--ge--lt-and--le) comparison operator (often
+[Greater-than](about_Comparison_Operators.md#-gt--ge--lt-and--le) comparison operator (often
 denoted as `>` in other programming languages).
 
 Depending on the objects being compared, the output using `>` can appear to be
@@ -249,16 +250,15 @@ Attempting to use the reverse comparison `<` (less than), yields a system error:
 
 ```powershell
 PS> if (36 < 42) { "true" } else { "false" }
-At line:1 char:8
-+ if (36 < 42) { "true" } else { "false" }
-+        ~
-The '<' operator is reserved for future use.
-+ CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
-+ FullyQualifiedErrorId : RedirectionNotSupported
+ParserError:
+Line |
+   1 |  if (36 < 42) { "true" } else { "false" }
+     |         ~
+     | The '<' operator is reserved for future use.
 ```
 
 If numeric comparison is the required operation, `-lt` and `-gt` should be
-used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt)
+used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt--ge--lt-and--le)
 
 ## See also
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -1,6 +1,5 @@
 ---
 description: Explains how to redirect output from PowerShell to text files.
-keywords: PowerShell,cmdlet
 Locale: en-US
 ms.date: 10/14/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_redirection?view=powershell-7.1&WT.mc_id=ps-gethelp
@@ -10,7 +9,6 @@ title: about_Redirection
 # About Redirection
 
 ## Short description
-
 Explains how to redirect output from PowerShell to text files.
 
 ## Long description
@@ -258,7 +256,8 @@ Line |
 ```
 
 If numeric comparison is the required operation, `-lt` and `-gt` should be
-used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt--ge--lt-and--le)
+used. For more information, see the `-gt` operator in
+[about_Comparison_Operators](about_Comparison_Operators.md#-gt--ge--lt-and--le).
 
 ## See also
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -220,7 +220,7 @@ formatted correctly. To write to files with a different encoding, use the
 ### Potential confusion with comparison operators
 
 The `>` operator is not to be confused with the
-[Greater-than](about_Comparison_Operators.md#-gt) comparison operator (often
+[Greater-than](about_Comparison_Operators.md##-gt--ge--lt-and--le) comparison operator (often
 denoted as `>` in other programming languages).
 
 Depending on the objects being compared, the output using `>` can appear to be

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 12/10/2020
+ms.date: 12/11/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
@@ -9,556 +9,408 @@ title: about_Comparison_Operators
 # About Comparison Operators
 
 ## Short description
-Describes the operators that compare values in PowerShell.
+
+The comparison operators in PowerShell can either compare two values or filter
+elements of a collection against an input value.
 
 ## Long description
 
-Comparison operators let you specify conditions for comparing values and
-finding values that match specified patterns. To use a comparison operator,
-specify the values that you want to compare together with an operator that
-separates these values.
+Comparison operators let you compare values or finding values that match
+specified patterns. PowerShell includes the following comparison operators:
 
-PowerShell includes the following comparison operators:
+|    Type     |   Operator   |              Comparison test              |
+| ----------- | ------------ | ----------------------------------------- |
+| Equality    | -eq          | equals                                    |
+|             | -ne          | not equals                                |
+|             | -gt          | greater than                              |
+|             | -ge          | greater than or equal                     |
+|             | -lt          | less than                                 |
+|             | -le          | less than or equal                        |
+| Matching    | -like        | string matches wildcard pattern           |
+|             | -notlike     | string does not match wildcard pattern    |
+|             | -match       | string matches regex pattern              |
+|             | -notmatch    | string does not match regex pattern       |
+| Replacement | -replace     | replaces strings matching a regex pattern |
+| Containment | -contains    | collection contains a value               |
+|             | -notcontains | collection does not contain a value       |
+|             | -in          | value is in a collection                  |
+|             | -notin       | value is not in a collection              |
+| Type        | -is          | both objects are the same type            |
+|             | -isnot       | the objects are not the same type         |
 
-| Type        | Operators    | Description                                 |
-| ----------- | ------------ | --------------------------------------------|
-| Equality    | -eq          | equals                                      |
-|             | -ne          | not equals                                  |
-|             | -gt          | greater than                                |
-|             | -ge          | greater than or equal                       |
-|             | -lt          | less than                                   |
-|             | -le          | less than or equal                          |
-|             |              |                                             |
-| Matching    | -like        | Returns true when string matches wildcard   |
-|             |              | pattern                                     |
-|             | -notlike     | Returns true when string does not match     |
-|             |              | wildcard pattern                            |
-|             | -match       | Returns true when string matches regex      |
-|             |              | pattern; $matches contains matching strings |
-|             | -notmatch    | Returns true when string does not match     |
-|             |              | regex pattern; $matches contains matching   |
-|             |              | strings                                     |
-|             |              |                                             |
-| Containment | -contains    | Returns true when reference value contained |
-|             |              | in a collection                             |
-|             | -notcontains | Returns true when reference value not       |
-|             |              | contained in a collection                   |
-|             | -in          | Returns true when test value contained in a |
-|             |              | collection                                  |
-|             | -notin       | Returns true when test value not contained  |
-|             |              | in a collection                             |
-|             |              |                                             |
-| Replacement | -replace     | Replaces a string pattern                   |
-|             |              |                                             |
-| Type        | -is          | Returns true if both object are the same    |
-|             |              | type                                        |
-|             | -isnot       | Returns true if the objects are not the same|
-|             |              | type                                        |
+## Common features
 
 By default, all comparison operators are case-insensitive. To make a comparison
-operator case-sensitive, precede the operator name with a `c`. For example, the
-case-sensitive version of `-eq` is `-ceq`. To make the case-insensitivity
-explicit, precede the operator with an `i`. For example, the explicitly
-case-insensitive version of `-eq` is `-ieq`.
+operator case-sensitive, add a `c` after the `-`. For example, `-ceq` is the
+case-sensitive version of `-eq`. To make the case-insensitivity explicit,
+add an `i` before `-`. For example, `-ieq` is the explicitly case-insensitive
+version of `-eq`.
 
-When the input to an operator is a scalar value, comparison operators return a
-Boolean value. When the input is a collection of values, the comparison
-operators return any matching values. If there are no matches in a collection,
-comparison operators return an empty array.
+When the input of an operator is a scalar value, the operator returns a
+**Boolean** value. When the input is a collection, the operator returns the
+elements of the collection that match the right-hand value of the expression.
+If there are no matches in the collection, comparison operators return an empty
+array. For example:
 
 ```powershell
-PS> (1, 2 -eq 3).GetType().FullName
-System.Object[]
+$a = (1, 2 -eq 3)
+$a.GetType().Name
+$a.Count
 ```
 
-The exceptions are the containment operators, the In operators, and the type
-operators, which always return a **Boolean** value.
+```output
+Object[]
+0
+```
 
-> [!NOTE]
-> If you need to compare a value to `$null` you should put `$null` on the
-> left-hand side of the comparison. When you compare `$null` to an **Object[]**
-> the result is **False** because the comparison object is an array. When you
-> compare an array to `$null`, the comparison filters out any `$null` values
-> stored in the array. For example:
->
-> ```powershell
-> PS> $null -ne $null, "hello"
-> True
-> PS> $null, "hello" -ne $null
-> hello
-> ```
+There are a few exceptions:
+
+- The containment and type operators. They always return a **Boolean** value.
+- The `-replace` operator returns the values resulting from the replacement.
+- The `-match` and `-notmatch` operators also populate the `$Matches` automatic
+  variable.
 
 ## Equality operators
 
-The equality operators (`-eq`, `-ne`) return a value of TRUE or the matches
-when one or more of the input values is identical to the specified pattern. The
-entire pattern must match an entire value.
+### -eq and -ne
 
-Example:
-
-### -eq
-
-Description: Equal to. Includes an identical value.
+When the left-hand side is scalar, `-eq` returns **True** if the right-hand side is
+an exact match, otherwise, `-eq` returns **False**. `-ne` does the opposite; it
+returns **False** when both sides match; otherwise, `-ne` returns True.
 
 Example:
 
 ```powershell
-PS> 2 -eq 2
-True
+2 -eq 2                 # Output: True
+2 -eq 3                 # Output: False
+"abc" -eq "abc"         # Output: True
+"abc" -eq "abc", "def"  # Output: False
+"abc" -ne "def"         # Output: True
+"abc" -ne "abc"         # Output: False
+"abc" -ne "abc", "def"  # Output: True
+```
 
-PS> 2 -eq 3
+When the left-hand side is a collection, `-eq` returns those members that match
+the right-hand side, while `-ne` filters them out.
+
+Example:
+
+```powershell
+1,2,3 -eq 2             # Output: 2
+"abc", "def" -eq "abc"  # Output: abc
+"abc", "def" -ne "abc"  # Output: def
+```
+
+These operators process all elements of the collection. Example:
+
+```powershell
+"zzz", "def", "zzz" -eq "zzz"
+```
+
+```output
+zzz
+zzz
+```
+
+The equality operators accept any two objects, not just a scalar or collection.
+But the comparison result is not guaranteed to be meaningful for the end-user.
+The following example demonstrates the issue.
+
+```powershell
+class MyFileInfoSet {
+    [String]$File
+    [String]$Size
+}
+$a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$a -eq $b
+```
+
+```Output
 False
+```
 
-PS> 1,2,3 -eq 2
+In this example, we created two objects with identical properties. Yet, the
+equality test result is **False** because they are different objects. If you intend
+to develop meaningfully comparable classes, you need to implement
+[System.IComparable][1] in your class.
+
+A prominent example of comparing arbitrary objects is to find out if they are
+null. But if you need to determine whether a variable is `$null`, you must put
+`$null` on the left-hand side of the equality operator. Putting it on the
+right-hand side does not do what you expect.
+
+For example, let `$a` be an array containing null elements:
+
+```powershell
+$a = 1, 2, $null, 4, $null, 6
+```
+
+The following tests that `$a` is not null.
+
+```powershell
+$null -ne $a
+```
+
+```output
+False
+```
+
+The following, however, filers out all null elements from `$a`:
+
+```powershell
+$a -ne $null # Output: 1, 2, 4, 6
+```
+
+```output
+1
 2
-PS> "abc" -eq "abc"
-True
-
-PS> "abc" -eq "abc", "def"
-False
-
-PS> "abc", "def" -eq "abc"
-abc
+4
+6
 ```
 
-### -ne
+### -gt, -ge, -lt, and -le
 
-Description: Not equal to. Includes a different value.
+`-gt`, `-ge`, `-lt`, and `-le` behave very similarly. When both sides are scalar
+they return **True** or **False** depending on how the two sides compare:
 
-Example:
+| Operator | Returns True when...                   |
+| -------- | -------------------------------------- |
+| -gt      | The left-hand side is greater          |
+| -ge      | The left-hand side is greater or equal |
+| -lt      | The left-hand side is smaller          |
+| -le      | The left-hand side is smaller or equal |
 
-```powershell
-PS> "abc" -ne "def"
-True
-
-PS> "abc" -ne "abc"
-False
-
-PS> "abc" -ne "abc", "def"
-True
-
-PS> "abc", "def" -ne "abc"
-def
-```
-
-### -gt
-
-Description: Greater-than.
-
-Example:
+In the following examples, all statements return True.
 
 ```powershell
-PS> 8 -gt 6
-True
-
-PS> 7, 8, 9 -gt 8
-9
+8 -gt 6  # Output: True
+8 -ge 8  # Output: True
+6 -lt 8  # Output: True
+8 -le 8  # Output: True
 ```
 
 > [!NOTE]
-> This should not to be confused with `>`, the greater-than operator in many
-> other programming languages. In PowerShell, `>` is used for redirection. For
-> more information, see
-> [About_redirection](about_Redirection.md#potential-confusion-with-comparison-operators).
+> In most programming languages the greater-than operator is `>`. In
+> PowerShell, this character is used for redirection. For details, see
+> [about_Redirection][3].
 
-### -ge
-
-Description: Greater-than or equal to.
+When the left-hand side is a collection, these operators compare each member of
+the collection with the right-hand side. Depending on their logic, they either
+keep or discard the member.
 
 Example:
 
 ```powershell
-PS> 8 -ge 8
-True
+$a=5, 6, 7, 8, 9
 
-PS> 7, 8, 9 -ge 8
+Write-Output "Test collection:"
+$a
+
+Write-Output "`nMembers greater than 7"
+$a -gt 7
+
+Write-Output "`nMembers greater than or equal to 7"
+$a -ge 7
+
+Write-Output "`nMembers smaller than 7"
+$a -lt 7
+
+Write-Output "`nMembers smaller than or equal to 7"
+$a -le 7
+```
+
+```output
+Test collection:
+5
+6
+7
 8
 9
-```
 
-### -lt
+Memebers greater than 7
+8
+9
 
-Description: Less-than.
-
-Example:
-
-```powershell
-
-PS> 8 -lt 6
-False
-
-PS> 7, 8, 9 -lt 8
-7
-```
-
-### -le
-
-Description: Less-than or equal to.
-
-Example:
-
-```powershell
-PS> 6 -le 8
-True
-
-PS> 7, 8, 9 -le 8
+Memebers greater than or equal to 7
 7
 8
+9
+
+Memebers smaller than 7
+5
+6
+
+Memebers smaller than or equal to 7
+5
+6
+7
 ```
+
+These operators aren't restricted to numbers; they work with any class that
+implements [System.IComparable][1].
+
+Examples:
+
+```powershell
+# Date comparison
+[DateTime]'2001-11-12' -lt [DateTime]'2020-08-01' # True
+
+# Sorting order comparison
+'a' -lt 'z'           # True; 'a' comes before 'z'
+'macOS' -ilt 'MacOS'  # False
+'MacOS' -ilt 'macOS'  # False
+'macOS' -clt 'MacOS'  # True; 'm' comes before 'M'
+```
+
+The following example demonstrates that there is no symbol on an American QWERTY
+keyboard that gets sorted after 'a'. It feeds a set containing all such symbols
+to the `-gt` operator to compare them against 'a'. The output is an empty array.
+
+```powershell
+$a=' ','`','~','!','@','#','$','%','^','&','*','(',')','_','+','-','=',
+   '{','}','[',']',':',';','"','''','\','|','/','?','.','>',',','<'
+$a -gt 'a'
+# Output: Nothing
+```
+
+If the two sides of the operators are not reasonably comparable, these operators
+raise a non-terminating error.
 
 ## Matching operators
 
-The like operators (`-like` and `-notlike`) find elements that match or do not
-match a specified pattern using wildcard expressions.
+The matching operators (`-like`, `-notlike`, `-match`, and `-notmatch`) find
+elements that match or do not match a specified pattern. The pattern for `-like`
+and `-notlike` is a wildcard expression (containing `*`, `?`, and `[ ]`), while
+`-match` and `-notmatch` accept a regular expression (Regex).
 
 The syntax is:
 
-```powershell
-<string[]> -like <wildcard-expression>
-<string[]> -notlike <wildcard-expression>
 ```
-
-The match operators (`-match` and `-notmatch`) find elements that match or do
-not match a specified pattern using regular expressions.
-
-The match operators populate the `$Matches` automatic variable when the input
-(the left-side argument) to the operator is a single scalar object. When the
-input is scalar, the `-match` and `-notmatch` operators return a Boolean value
-and set the value of the `$Matches` automatic variable to the matched
-components of the argument.
-
-The syntax is:
-
-```powershell
-<string[]> -match <regular-expression>
+<string[]> -like    <wildcard-expression>
+<string[]> -notlike <wildcard-expression>
+<string[]> -match    <regular-expression>
 <string[]> -notmatch <regular-expression>
 ```
 
-### -like
+When the input of these operators is a scalar value, they return a **Boolean**
+value. When the input is a collection of values, the operators return any
+matching members. If there are no matches in a collection, the operators return
+an empty array.
 
-Description: Match using the wildcard character (\*).
+### -like and -notlike
 
-Example:
-
-```powershell
-PS> "PowerShell" -like "*shell"
-True
-
-PS> "PowerShell", "Server" -like "*shell"
-PowerShell
-```
-
-### -notlike
-
-Description: Does not match using the wildcard character (\*).
+`-like` and `-notlike` behave similarly to `-eq` and `-ne`, but the right-hand
+side could be a string containing [wildcards](about_Wildcards.md).
 
 Example:
 
 ```powershell
-PS> "PowerShell" -notlike "*shell"
-False
+"PowerShell" -like    "*shell"           # Output: True
+"PowerShell" -notlike "*shell"           # Output: False
+"PowerShell" -like    "Power?hell"       # Output: True
+"PowerShell" -notlike "Power?hell"       # Output: False
+"PowerShell" -like    "Power[p-w]hell"   # Output: True
+"PowerShell" -notlike "Power[p-w]hell"   # Output: False
 
-PS> "PowerShell", "Server" -notlike "*shell"
-Server
+"PowerShell", "Server" -like "*shell"    # Output: PowerShell
+"PowerShell", "Server" -notlike "*shell" # Output: Server
 ```
 
-### -match
+Unlike `-match` and `-notmatch`, these operators don't affect the `$Matches`
+automatic variable.
 
-Description: Matches a string using regular expressions. When the input is
-scalar, it populates the `$Matches` automatic variable.
+### -match and -notmatch
 
-If the input is a collection, the `-match` and `-notmatch` operators return
-the matching members of that collection, but the operator does not populate
-the `$Matches` variable.
+`-match` and `-notmatch` use regular expressions to search for pattern in the
+left-hand side values. Regular expressions can be used to match complex
+patterns like email addresses, UNC paths, or formatted phone numbers. The
+right-hand side string must adhere to the
+[regular expressions](about_Regular_Expressions.md) rules.
 
-For example, the following command submits a collection of strings to the
-`-match` operator. The `-match` operator returns the items in the collection
-that match. It does not populate the `$Matches` automatic variable.
+Scalar examples:
 
 ```powershell
-PS> "Sunday", "Monday", "Tuesday" -match "sun"
-Sunday
+# Partial match test, showing how differently -match and -like behave
+"PowerShell" -match 'shell'        # Output: True
+"PowerShell" -like  'shell'        # Output: False
 
-PS> $Matches
-PS>
+# Regex syntax test
+"PowerShell" -match    '^Power\w+' # Output: True
+'bag'        -notmatch 'b[iou]g'   # Output: True
 ```
 
-In contrast, the following command submits a single string to the `-match`
-operator. The `-match` operator returns a Boolean value and populates the
-`$Matches` automatic variable. The `$Matches` automatic variable is a
-**Hashtable**. If no grouping or capturing is used, only one key is populated.
-The `0` key represents all text that was matched. For more information about
-grouping and capturing using regular expressions, see
-[about_Regular_Expressions](about_Regular_Expressions.md).
+If the input is a collection, the operators return the matching members of that
+collection. However, the `$Matches` variable isn't populated.
+
+Collection examples:
 
 ```powershell
-PS> "Sunday" -match "sun"
-True
+"PowerShell", "Super PowerShell", "Power's hell" -match '^Power\w+'
+# Output: PowerShell
 
-PS> $Matches
+"Rhell", "Chell", "Mel", "Smell", "Shell" -match "hell"
+# Output: Rhell, Chell, Shell
 
-Name                           Value
-----                           -----
-0                              Sun
+"Bag", "Beg", "Big", "Bog", "Bug"  -match 'b[iou]g'
+#Output: Big, Bog, Bug
+
+"Bag", "Beg", "Big", "Bog", "Bug"  -notmatch 'b[iou]g'
+#Output: Bag, Beg
 ```
 
-It is important to note that the `$Matches` hashtable will only contain the
-first occurrence of any matching pattern.
-
-```powershell
-PS> "Banana" -match "na"
-True
-
-PS> $Matches
-
-Name                           Value
-----                           -----
-0                              na
-```
-
-> [!IMPORTANT]
-> The `0` key is an **Integer**. You can use any **Hashtable** method to access
-> the value stored.
->
-> ```powershell
-> PS> "Good Dog" -match "Dog"
-> True
->
-> PS> $Matches[0]
-> Dog
->
-> PS> $Matches.Item(0)
-> Dog
->
-> PS> $Matches.0
-> Dog
-> ```
-
-The `-notmatch` operator populates the `$Matches` automatic variable when the
-input is scalar and the result is False, that it, when it detects a match.
-
-```powershell
-PS> "Sunday" -notmatch "rain"
-True
-
-PS> $matches
-PS>
-
-PS> "Sunday" -notmatch "day"
-False
-
-PS> $matches
-
-Name                           Value
-----                           -----
-0                              day
-```
-
-### -notmatch
-
-Description: Does not match a string. Uses regular expressions. When the input
-is scalar, it populates the `$Matches` automatic variable.
+`-match` and `-notmatch` support regex capture groups. Each time they run, they
+overwrite the `$Matches` automatic variable with their findings. `$Matches` is
+a **Hashtable** that always has a key named '0', which stores the entire match.
+If the regular expression contains capture groups, the `$Matches` contains
+additional keys for each group.
 
 Example:
 
 ```powershell
-PS> "Sunday" -notmatch "sun"
-False
+$string = 'The last logged on user was CONTOSO\jsmith'
+$string -match 'was (?<domain>.+)\\(?<user>.+)'
 
-PS> $matches
-Name Value
----- -----
-0    sun
+$Matches
 
-PS> "Sunday", "Monday" -notmatch "sun"
-Monday
+Write-Output "`nDomain name:"
+$Matches.domain
+
+Write-Output "`nUser name:"
+$Matches.user
 ```
 
-## Containment operators
+```output
+True
 
-The containment operators (`-contains` and `-notcontains`) are similar to the
-equality operators. However, the containment operators always return a Boolean
-value, even when the input is a collection.
+Name                           Value
+----                           -----
+domain                         CONTOSO
+user                           jsmith
+0                              was CONTOSO\jsmith
 
-Also, unlike the equality operators, the containment operators return a value
-as soon as they detect the first match. The equality operators evaluate all
-input and then return all the matches in the collection.
+Domain name:
+CONTOSO
 
-### -contains
+User name:
+jsmith
+```
 
-Description: Containment operator. Tells whether a collection of reference
-values includes a single test value. Always returns a Boolean value. Returns
-TRUE only when the test value exactly matches at least one of the reference
-values.
+For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
-When the test value is a collection, the Contains operator uses reference
-equality. It returns TRUE only when one of the reference values is the same
-instance of the test value object.
+## Replacement operator
 
-In a very large collection, the `-contains` operator returns results quicker
-than the equal to operator.
+### Replacement with regular expressions
+
+The replacement , , is an extension of the `-match` operator. Like `-match`,
+`-replace` operator uses regular expressions to find the specified pattern. But
+unlike `-match`, it replaces the matches with another specified value.
 
 Syntax:
 
-`<Reference-values> -contains <Test-value>`
-
-Examples:
-
-```powershell
-PS> "abc", "def" -contains "def"
-True
-
-PS> "Windows", "PowerShell" -contains "Shell"
-False  #Not an exact match
-
-# Does the list of computers in $DomainServers include $ThisComputer?
-PS> $DomainServers -contains $thisComputer
-True
-
-PS> "abc", "def", "ghi" -contains "abc", "def"
-False
-
-PS> $a = "abc", "def"
-PS> "abc", "def", "ghi" -contains $a
-False
-PS> $a, "ghi" -contains $a
-True
 ```
-
-### -notcontains
-
-Description: Containment operator. Tells whether a collection of reference
-values includes a single test value. Always returns a Boolean value. Returns
-TRUE when the test value is not an exact matches for at least one of the
-reference values.
-
-When the test value is a collection, the NotContains operator uses reference
-equality.
-
-Syntax:
-
-`<Reference-values> -notcontains <Test-value>`
-
-Examples:
-
-```powershell
-PS> "Windows", "PowerShell" -notcontains "Shell"
-True  #Not an exact match
-
-# Get cmdlet parameters, but exclude common parameters
-function get-parms ($cmdlet)
-{
-    $Common = "Verbose", "Debug", "WarningAction", "WarningVariable",
-      "ErrorAction", "ErrorVariable", "OutVariable", "OutBuffer"
-
-    $allparms = (Get-Command $Cmdlet).parametersets |
-      foreach {$_.Parameters} |
-        foreach {$_.Name} | Sort-Object | Get-Unique
-
-    $allparms | where {$Common -notcontains $_ }
-}
-
-# Find unapproved verbs in the functions in my module
-PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS> $myVerbs = Get-Command -Module MyModule | foreach {$_.verb}
-PS> $myVerbs | where {$ApprovedVerbs -notcontains $_}
-ForEach
-Sort
-Tee
-Where
+<input> -replace <regular-expression>, <substitute>
 ```
-
-### -in
-
-Description: In operator. Tells whether a test value appears in a collection of
-reference values. Always return as Boolean value. Returns TRUE only when the
-test value exactly matches at least one of the reference values.
-
-When the test value is a collection, the In operator uses reference equality.
-It returns TRUE only when one of the reference values is the same instance of
-the test value object.
-
-The `-in` operator was introduced in PowerShell 3.0.
-
-Syntax:
-
-`<Test-value> -in <Reference-values>`
-
-Examples:
-
-```powershell
-PS> "def" -in "abc", "def"
-True
-
-PS> "Shell" -in "Windows", "PowerShell"
-False  #Not an exact match
-
-PS> "Windows" -in "Windows", "PowerShell"
-True  #An exact match
-
-PS> "Windows", "PowerShell" -in "Windows", "PowerShell", "ServerManager"
-False  #Using reference equality
-
-PS> $a = "Windows", "PowerShell"
-PS> $a -in $a, "ServerManager"
-True  #Using reference equality
-
-# Does the list of computers in $DomainServers include $ThisComputer?
-PS> $thisComputer -in  $domainServers
-True
-```
-
-### -notin
-
-Description: Tells whether a test value appears in a collection of reference
-values. Always returns a Boolean value. Returns TRUE when the test value is not
-an exact match for at least one of the reference values.
-
-When the test value is a collection, the In operator uses reference equality.
-It returns TRUE only when one of the reference values is the same instance of
-the test value object.
-
-The `-notin` operator was introduced in PowerShell 3.0.
-
-Syntax:
-
-`<Test-value> -notin <Reference-values>`
-
-Examples:
-
-```powershell
-PS> "def" -notin "abc", "def"
-False
-
-PS> "ghi" -notin "abc", "def"
-True
-
-PS> "Shell" -notin "Windows", "PowerShell"
-True  #Not an exact match
-
-PS> "Windows" -notin "Windows", "PowerShell"
-False  #An exact match
-
-# Find unapproved verbs in the functions in my module
-PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS> $MyVerbs = Get-Command -Module MyModule | foreach {$_.verb}
-
-PS> $MyVerbs | where {$_ -notin $ApprovedVerbs}
-ForEach
-Sort
-Tee
-Where
-```
-
-## Replacement Operator
-
-The `-replace` operator has the following syntax:
-
-`<input> -replace <original>, <substitute>`
-
-The `<original>` placeholder is a regular expression matching the characters to
-be replaced. The `<substitute>` placeholder is a literal string that replaces
-them.
 
 The operator replaces all or part of a value with the specified value using
 regular expressions. You can use the operator for many administrative tasks,
@@ -569,54 +421,44 @@ name extensions of all `.txt` files to `.log`:
 Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
 ```
 
-### Case-sensitive matches
-
 By default, the `-replace` operator is case-insensitive. To make it case
 sensitive, use `-creplace`. To make it explicitly case-insensitive, use
 `-ireplace`.
 
-Consider the following examples:
+Examples:
 
 ```powershell
-PS> "book" -replace "B", "C"
-Cook
+"book" -ireplace "B", "C" # Case insensitive
+"book" -creplace "B", "C" # Case-sensitive; hence, nothing to replace
 ```
 
-```powershell
-PS> "book" -ireplace "B", "C"
+```Output
 Cook
-```
-
-```powershell
-PS> "book" -creplace "B", "C"
 book
 ```
-
-### Substitutions in regular expressions
+### Regular expressions substitutions
 
 It is also possible to use regular expressions to dynamically replace text
 using capturing groups, and substitutions. Capture groups can be referenced in
 the `<substitute>` string using the dollar sign (`$`) character before the
 group identifier.
 
-Capture groups can be referenced by **Number** or **Name**
+In the following example, the `-replace` operator accepts a username in the form
+of `DomainName\Username` and converts to the `Username@DomainName` format:
 
-- By **Number** - Capturing Groups are numbered from left to right.
+```powershell
+$SearchExp = '^(?<Username>[\w-.]+)\\(?<DomainName>[\w-.]+)$'
+$ReplaceExp = '${Username}@${DomainName}'
 
-  ```powershell
-  PS> "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
-  John.D.Smith@contoso.com
-  ```
+'Contoso.local\John.Doe' -replace $SearchExp,$ReplaceExp
+```
 
-- By **Name** - Capturing Groups can also be referenced by name.
-
-  ```powershell
-  PS> "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
-  FABRIKAM\Administrator
-  ```
+```output
+John.Doe@Contoso.local
+```
 
 > [!WARNING]
-> Since the `$` character is used in string expansion, you must use
+> Since the `$` character is used in string expansion, you will must use
 > literal strings or escape the `$` character.
 >
 > ```powershell
@@ -632,7 +474,7 @@ Capture groups can be referenced by **Number** or **Name**
 > $5.72
 > ```
 
-To learn more, see [about_Regular_Expressions](about_Regular_Expressions.md) and
+To learn more see [about_Regular_Expressions](about_Regular_Expressions.md) and
 [Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
 
 ### Substituting in a collection
@@ -649,24 +491,119 @@ a4
 a5
 ```
 
-### ScriptBlock substitutions
+### Replacement with a script block
 
-Beginning in PowerShell 6, you can use a **ScriptBlock** argument for the
-_Substitution_ text. The **ScriptBlock** will execute for each match found in
-the _input_ string.
+In PowerShell 6 and later, the `-replace` operator also accepts a script block
+that performs the replacement. The script block runs once for every match.
 
-Within the **ScriptBlock**, use the `$_` automatic variable to refer to the
-current **System.Text.RegularExpressions.Match** object. The **Match** object
-gives you access to the current input text being replaced, as well as other
-useful information.
-
-This example replaces each sequence of three decimals with the character
-equivalent. The **ScriptBlock** is run for each set of three decimals that
-needs to be replaced.
+Syntax:
 
 ```powershell
-PS> "072101108108111" -replace "\d{3}", {[char][int]$_.Value}
+<String> -replace <regular-expression>, {<Script-block>}
+```
+
+Within the script block, use the `$_` automatic variable to access the input
+text being replaced and other useful information. This variable's class type is
+[System.Text.RegularExpressions.Match][2].
+
+The following example replaces each sequence of three digits with the character
+equivalents. The script block runs for each set of three digits that needs to be
+replaced.
+
+```powershell
+"072101108108111" -replace "\d{3}", {return [char][int]$_.Value}
+```
+
+```output
 Hello
+```
+
+## Containment operators
+
+The containment operators (`-contains`, `-notcontains`, `-in`, and `-notin`) are
+similar to the equality operators, except that they always return a **Boolean**
+value, even when the input is a collection. These operators stop comparing as
+soon as they detect the first match, whereas the equality operators evaluate all
+input members. In a very large collection, these operators return quicker than
+the equality operators.
+
+Syntax:
+
+```
+<Collection> -contains <Test-object>
+<Collection> -notcontains <Test-object>
+<Test-object> -in <Collection>
+<Test-object> -notin <Collection>
+```
+
+### -contains and -notcontains
+
+These operators tell whether a set includes a certain element. `-contains`
+returns True when the right-hand side (test object) matches one of the elements
+in the set. `-notcontains` returns False instead. When the test object is a
+collection, these operators use reference equality, i.e. they check whether one
+of the set's elements is the same instance of the test object.
+
+Examples:
+
+```powershell
+"abc", "def" -contains "def"                  # Output: True
+"abc", "def" -notcontains "def"               # Output: False
+"Windows", "PowerShell" -contains "Shell"     # Output: False
+"Windows", "PowerShell" -notcontains "Shell"  # Output: True
+"abc", "def", "ghi" -contains "abc", "def"    # Output: False
+"abc", "def", "ghi" -notcontains "abc", "def" # Output: True
+```
+
+More complex examples:
+
+```powershell
+$DomainServers = "ContosoDC1","ContosoDC2","ContosoFileServer","ContosoDNS",
+                 "ContosoDHCP","ContosoWSUS"
+$thisComputer  = "ContosoDC2"
+
+$DomainServers -contains $thisComputer
+# Output: True
+
+$a = "abc", "def"
+"abc", "def", "ghi" -contains $a # Output: False
+$a, "ghi" -contains $a           # Output: True
+```
+
+### -in and -notin
+
+The `-in` and -`notin` operators were introduced in PowerShell 3 as the
+syntactic reverse of the of `contains` and `-notcontain` operators. `-in`
+returns **True** when the left-hand side `<test-object>` matches one of the
+elements in the set. `-notin` returns **False** instead. When the test object
+is a set, these operators use reference equality to check whether one of the
+set's elements is the same instance of the test object.
+
+The following examples do the same thing that the examples for `-contain`
+and `-notcontain` do, but they are written with `-in` and `-notin` instead.
+
+```powershell
+"def" -in "abc", "def"                  # Output: True
+"def" -notin "abc", "def"               # Output: False
+"Shell" -in "Windows", "PowerShell"     # Output: False
+"Shell" -notin "Windows", "PowerShell"  # Output: True
+"abc", "def" -in "abc", "def", "ghi"    # Output: False
+"abc", "def" -notin "abc", "def", "ghi" # Output: True
+```
+
+More complex examples:
+
+```powershell
+$DomainServers = "ContosoDC1","ContosoDC2","ContosoFileServer","ContosoDNS",
+                 "ContosoDHCP","ContosoWSUS"
+$thisComputer  = "ContosoDC2"
+
+$thisComputer -in $DomainServers
+# Output: True
+
+$a = "abc", "def"
+$a -in "abc", "def", "ghi" # Output: False
+$a -in $a, "ghi"           # Output: True
 ```
 
 ## Type comparison
@@ -674,41 +611,25 @@ Hello
 The type comparison operators (`-is` and `-isnot`) are used to determine if an
 object is a specific type.
 
-### -is
-
 Syntax:
 
-`<object> -is <type reference>`
+```powershell
+<object> -is <type-reference>
+<object> -isnot <type-reference>
+```
 
 Example:
 
 ```powershell
-PS> $a = 1
-PS> $b = "1"
-PS> $a -is [int]
-True
-PS> $a -is $b.GetType()
-False
+$a = 1
+$b = "1"
+$a -is [int]           # Output: True
+$a -is $b.GetType()    # Output: False
+$b -isnot [int]        # Output: False
+$a -isnot $b.GetType() # Output: True
 ```
 
-### -isnot
-
-Syntax:
-
-`<object> -isnot <type reference>`
-
-Example:
-
-```powershell
-PS> $a = 1
-PS> $b = "1"
-PS> $a -isnot $b.GetType()
-True
-PS> $b -isnot [int]
-True
-```
-
-## See also
+## SEE ALSO
 
 - [about_Operators](about_Operators.md)
 - [about_Regular_Expressions](about_Regular_Expressions.md)
@@ -716,3 +637,7 @@ True
 - [Compare-Object](xref:Microsoft.PowerShell.Utility.Compare-Object)
 - [Foreach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object)
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
+
+[1]: /dotnet/api/system.icomparable
+[2]: /dotnet/api/system.text.regularexpressions.match
+[3]: about_Redirection.md#potential-confusion-with-comparison-operators

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -65,10 +65,10 @@ Object[]
 
 There are a few exceptions:
 
-- The containment and type operators. They always return a **Boolean** value.
-- The `-replace` operator returns the values resulting from the replacement.
+- The containment and type operators always return a **Boolean** value
+- The `-replace` operator returns the replacement result
 - The `-match` and `-notmatch` operators also populate the `$Matches` automatic
-  variable.
+  variable
 
 ## Equality operators
 
@@ -323,10 +323,9 @@ automatic variable.
 ### -match and -notmatch
 
 `-match` and `-notmatch` use regular expressions to search for pattern in the
-left-hand side values. Regular expressions can be used to match complex
-patterns like email addresses, UNC paths, or formatted phone numbers. The
-right-hand side string must adhere to the
-[regular expressions](about_Regular_Expressions.md) rules.
+left-hand side values. Regular expressions can match complex patterns like email
+addresses, UNC paths, or formatted phone numbers. The right-hand side string
+must adhere to the [regular expressions](about_Regular_Expressions.md) rules.
 
 Scalar examples:
 
@@ -402,9 +401,10 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with regular expressions
 
-The replacement , , is an extension of the `-match` operator. Like `-match`,
-`-replace` operator uses regular expressions to find the specified pattern. But
-unlike `-match`, it replaces the matches with another specified value.
+The replacement operator, `-replace`, is an extension of the `-match` operator.
+Like `-match`, the `-replace` operator uses regular expressions to find the
+specified pattern. But unlike `-match`, it replaces the matches with another
+specified value.
 
 Syntax:
 
@@ -436,6 +436,7 @@ Examples:
 Cook
 book
 ```
+
 ### Regular expressions substitutions
 
 It is also possible to use regular expressions to dynamically replace text
@@ -458,24 +459,34 @@ John.Doe@Contoso.local
 ```
 
 > [!WARNING]
-> Since the `$` character is used in string expansion, you will must use
-> literal strings or escape the `$` character.
+> The `$` has syntatic roles in both PowerShell and regular expressions: - In
+> PowerShell, between double quotation marks, it designates variables and acts
+> as a subexpression operator. - In Regex search strings, it denotes end of the
+> line - In Regex substitution strings, it denotes captured groups As such, be
+> sure to either put your regular expressions between single quotation marks or
+> insert a backtick (\`) character before them. For example:
 >
 > ```powershell
-> PS> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
-> Hello Universe
+> $1 = 'Goodbye'
+> 
+> 'Hello World' -replace '(\w+) \w+', "$1 Universe"
+> # Output: Goodbye Universe
+> 
+> 'Hello World' -replace '(\w+) \w+', '$1 Universe'
+> # Output: Hello Universe
 > ```
 >
-> Additionally, since the `$` character is used in substitution, you must
-> escape any instances in your string.
+> `$$` in Regex denotes a literal `$`. Be sure to understand its caveats. For
+> example:
 >
 > ```powershell
-> PS> '5.72' -replace '(.+)', '$$$1'
-> $5.72
+> '5.72' -replace '(.+)', '$ $1' # Output: $ 5.72
+> '5.72' -replace '(.+)', '$$$1' # Output: $5.72
+> '5.72' -replace '(.+)', '$$1'  # Output: $1
 > ```
 
-To learn more see [about_Regular_Expressions](about_Regular_Expressions.md) and
-[Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
+To learn more, see [about_Regular_Expressions](about_Regular_Expressions.md) and
+[Substitutions in Regular Expressions][4]
 
 ### Substituting in a collection
 
@@ -641,3 +652,4 @@ $a -isnot $b.GetType() # Output: True
 [1]: /dotnet/api/system.icomparable
 [2]: /dotnet/api/system.text.regularexpressions.match
 [3]: about_Redirection.md#potential-confusion-with-comparison-operators
+[4]: /dotnet/standard/base-types/substitutions-in-regular-expressions

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -317,15 +317,13 @@ Example:
 "PowerShell", "Server" -notlike "*shell" # Output: Server
 ```
 
-Unlike `-match` and `-notmatch`, these operators don't affect the `$Matches`
-automatic variable.
-
 ### -match and -notmatch
 
 `-match` and `-notmatch` use regular expressions to search for pattern in the
-left-hand side values. Regular expressions can match complex patterns like email
-addresses, UNC paths, or formatted phone numbers. The right-hand side string
-must adhere to the [regular expressions](about_Regular_Expressions.md) rules.
+left-hand side values. Regular expressions can match complex patterns like
+email addresses, UNC paths, or formatted phone numbers. The right-hand side
+string must adhere to the [regular expressions](about_Regular_Expressions.md)
+rules.
 
 Scalar examples:
 
@@ -340,7 +338,7 @@ Scalar examples:
 ```
 
 If the input is a collection, the operators return the matching members of that
-collection. However, the `$Matches` variable isn't populated.
+collection.
 
 Collection examples:
 
@@ -359,10 +357,11 @@ Collection examples:
 ```
 
 `-match` and `-notmatch` support regex capture groups. Each time they run, they
-overwrite the `$Matches` automatic variable with their findings. `$Matches` is
-a **Hashtable** that always has a key named '0', which stores the entire match.
-If the regular expression contains capture groups, the `$Matches` contains
-additional keys for each group.
+overwrite the `$Matches` automatic variable. When `<input>` is a collection the
+`$Matches` variable is `$null`. `$Matches` is a **Hashtable** that always has a
+key named '0', which stores the entire match. If the regular expression
+contains capture groups, the `$Matches` contains additional keys for each
+group.
 
 Example:
 
@@ -401,7 +400,6 @@ For details, see [about_Regular_Expressions](about_Regular_Expressions.md).
 
 ### Replacement with regular expressions
 
-The replacement operator, `-replace`, is an extension of the `-match` operator.
 Like `-match`, the `-replace` operator uses regular expressions to find the
 specified pattern. But unlike `-match`, it replaces the matches with another
 specified value.
@@ -459,34 +457,39 @@ John.Doe@Contoso.local
 ```
 
 > [!WARNING]
-> The `$` has syntatic roles in both PowerShell and regular expressions: - In
-> PowerShell, between double quotation marks, it designates variables and acts
-> as a subexpression operator. - In Regex search strings, it denotes end of the
-> line - In Regex substitution strings, it denotes captured groups As such, be
-> sure to either put your regular expressions between single quotation marks or
-> insert a backtick (\`) character before them. For example:
+> The `$` character has syntatic roles in both PowerShell and regular
+> expressions:
 >
-> ```powershell
-> $1 = 'Goodbye'
-> 
-> 'Hello World' -replace '(\w+) \w+', "$1 Universe"
-> # Output: Goodbye Universe
-> 
-> 'Hello World' -replace '(\w+) \w+', '$1 Universe'
-> # Output: Hello Universe
-> ```
->
-> `$$` in Regex denotes a literal `$`. Be sure to understand its caveats. For
-> example:
->
-> ```powershell
-> '5.72' -replace '(.+)', '$ $1' # Output: $ 5.72
-> '5.72' -replace '(.+)', '$$$1' # Output: $5.72
-> '5.72' -replace '(.+)', '$$1'  # Output: $1
-> ```
+> - In PowerShell, between double quotation marks, it designates variables and
+>   acts as a subexpression operator.
+> - In Regex search strings, it denotes end of the line
+> - In Regex substitution strings, it denotes captured groups As such, be sure
+>   to to either put your regular expressions between single quotation marks or
+>   insert a backtick (`` ` ``) character before them.
+
+For example:
+
+```powershell
+$1 = 'Goodbye'
+
+'Hello World' -replace '(\w+) \w+', "$1 Universe"
+# Output: Goodbye Universe
+
+'Hello World' -replace '(\w+) \w+', '$1 Universe'
+# Output: Hello Universe
+```
+
+`$$` in Regex denotes a literal `$`. This `$$` in the substitution string to
+include a a literal `$` in the resulting replacement. For example:
+
+```powershell
+'5.72' -replace '(.+)', '$ $1' # Output: $ 5.72
+'5.72' -replace '(.+)', '$$$1' # Output: $5.72
+'5.72' -replace '(.+)', '$$1'  # Output: $1
+```
 
 To learn more, see [about_Regular_Expressions](about_Regular_Expressions.md) and
-[Substitutions in Regular Expressions][4]
+[Substitutions in Regular Expressions][4].
 
 ### Substituting in a collection
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -219,7 +219,7 @@ formatted correctly. To write to files with a different encoding, use the
 ### Potential confusion with comparison operators
 
 The `>` operator is not to be confused with the
-[Greater-than](about_Comparison_Operators.md#-gt) comparison operator (often
+[Greater-than](about_Comparison_Operators.md#-gt--ge--lt-and--le) comparison operator (often
 denoted as `>` in other programming languages).
 
 Depending on the objects being compared, the output using `>` can appear to be
@@ -252,12 +252,13 @@ At line:1 char:8
 + if (36 < 42) { "true" } else { "false" }
 +        ~
 The '<' operator is reserved for future use.
-+ CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
-+ FullyQualifiedErrorId : RedirectionNotSupported
+    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
+    + FullyQualifiedErrorId : RedirectionNotSupported
 ```
 
 If numeric comparison is the required operation, `-lt` and `-gt` should be
-used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt)
+used. For more information, see the `-gt` operator in
+[about_Comparison_Operators](about_Comparison_Operators.md#-gt--ge--lt-and--le).
 
 ## See also
 


### PR DESCRIPTION
# PR Summary

**I re-wrote the `about_Comparison_Operators` completely.** As such, it would be futile to look at the diff; this new version is 99% different.

The current `about_Comparison_Operators` page suffers from several problems, some of which you can see in the screenshots below. These problems include:

1. TOC not being practically useful.
1. The first table is too long because it contains orphaned rows and empty rows.
1. Examples that confuse and make no sense, e.g. an unused function called "get-parms" (sic.)
1. Outright incorrect sentences, e.g. "Returns true when _reference value_ contained in a collection" (must be "Returns true when _test value_ contained in a collection";)
1. Out of context information snippets that are unlikely to be seen when this page is used as a reference, e.g. the implications of not using $null on the left-hand side of a comparison.

![Layout problems](https://user-images.githubusercontent.com/17097175/101842307-fea22000-3b5c-11eb-8aef-daf9ce171476.png)
![Example problem](https://user-images.githubusercontent.com/17097175/101842317-019d1080-3b5d-11eb-86f4-54bb8ba47126.png)

## PR Context

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [X] Version 7.1 content
- [X] Version 7.0 content
- [X] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
