### PR TITLE
Fixed Typo

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -65,7 +65,7 @@ Within the script block, the available values for **Id** are retrieved using the
 cmdlet. The **Id** property for each Time Zone is piped to the `Where-Object` cmdlet. The
 `Where-Object` cmdlet filters out any ids that do not start with the value provided by
 `$wordToComplete`, which represents the text the user typed before they pressed <kbd>Tab</kbd>. The
-filtered ids are piped to the `For-EachObject` cmdlet which encloses each value in quotes, should
+filtered ids are piped to the `ForEach-Object` cmdlet which encloses each value in quotes, should
 the value contain spaces.
 
 The second command registers the argument completer by passing the scriptblock, the

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Random.md
@@ -205,7 +205,7 @@ $Sample = $Files | Get-Random -Count 50
 
 ### Example 11: Roll fair dice
 
-This example rolls a fair die 1200 times and counts the outcomes. The first command, `For-EachObject`
+This example rolls a fair dice 1200 times and counts the outcomes. The first command, `ForEach-Object`
 repeats the call to `Get-Random` from the piped in numbers (1-6). The results are grouped by their
 value with `Group-Object` and formatted as a table with `Select-Object`.
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Random.md
@@ -205,7 +205,7 @@ $Sample = $Files | Get-Random -Count 50
 
 ### Example 11: Roll fair dice
 
-This example rolls a fair dice 1200 times and counts the outcomes. The first command, `ForEach-Object`
+This example rolls a fair die 1200 times and counts the outcomes. The first command, `ForEach-Object`
 repeats the call to `Get-Random` from the piped in numbers (1-6). The results are grouped by their
 value with `Group-Object` and formatted as a table with `Select-Object`.
 

--- a/reference/7.0/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -65,7 +65,7 @@ Within the script block, the available values for **Id** are retrieved using the
 cmdlet. The **Id** property for each Time Zone is piped to the `Where-Object` cmdlet. The
 `Where-Object` cmdlet filters out any ids that do not start with the value provided by
 `$wordToComplete`, which represents the text the user typed before they pressed <kbd>Tab</kbd>. The
-filtered ids are piped to the `For-EachObject` cmdlet which encloses each value in quotes, should
+filtered ids are piped to the `ForEach-Object` cmdlet which encloses each value in quotes, should
 the value contain spaces.
 
 The second command registers the argument completer by passing the scriptblock, the

--- a/reference/7.0/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Get-Random.md
@@ -205,7 +205,7 @@ $Sample = $Files | Get-Random -Count 50
 
 ### Example 11: Roll fair dice
 
-This example rolls a fair die 1200 times and counts the outcomes. The first command, `For-EachObject`
+This example rolls a fair die 1200 times and counts the outcomes. The first command, `ForEach-Object`
 repeats the call to `Get-Random` from the piped in numbers (1-6). The results are grouped by their
 value with `Group-Object` and formatted as a table with `Select-Object`.
 

--- a/reference/7.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -65,7 +65,7 @@ Within the script block, the available values for **Id** are retrieved using the
 cmdlet. The **Id** property for each Time Zone is piped to the `Where-Object` cmdlet. The
 `Where-Object` cmdlet filters out any ids that do not start with the value provided by
 `$wordToComplete`, which represents the text the user typed before they pressed <kbd>Tab</kbd>. The
-filtered ids are piped to the `For-EachObject` cmdlet which encloses each value in quotes, should
+filtered ids are piped to the `ForEach-Object` cmdlet which encloses each value in quotes, should
 the value contain spaces.
 
 The second command registers the argument completer by passing the scriptblock, the

--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-Random.md
@@ -208,7 +208,7 @@ $Sample = $Files | Get-Random -Count 50
 
 ### Example 11: Roll fair dice
 
-This example rolls a fair die 1200 times and counts the outcomes. The first command, `For-EachObject`
+This example rolls a fair die 1200 times and counts the outcomes. The first command, `ForEach-Object`
 repeats the call to `Get-Random` from the piped in numbers (1-6). The results are grouped by their
 value with `Group-Object` and formatted as a table with `Select-Object`.
 

--- a/reference/7.2/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -64,7 +64,7 @@ Within the script block, the available values for **Id** are retrieved using the
 cmdlet. The **Id** property for each Time Zone is piped to the `Where-Object` cmdlet. The
 `Where-Object` cmdlet filters out any ids that do not start with the value provided by
 `$wordToComplete`, which represents the text the user typed before they pressed <kbd>Tab</kbd>. The
-filtered ids are piped to the `For-EachObject` cmdlet which encloses each value in quotes, should
+filtered ids are piped to the `ForEach-Object` cmdlet which encloses each value in quotes, should
 the value contain spaces.
 
 The second command registers the argument completer by passing the scriptblock, the

--- a/reference/7.2/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Get-Random.md
@@ -207,7 +207,7 @@ $Sample = $Files | Get-Random -Count 50
 
 ### Example 11: Roll fair dice
 
-This example rolls a fair die 1200 times and counts the outcomes. The first command, `For-EachObject`
+This example rolls a fair die 1200 times and counts the outcomes. The first command, `ForEach-Object`
 repeats the call to `Get-Random` from the piped in numbers (1-6). The results are grouped by their
 value with `Group-Object` and formatted as a table with `Select-Object`.
 


### PR DESCRIPTION
# PR Summary
Fixed typo, `ForEach-Object` instead of `For-EachObject`

## PR Context

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [x] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
