### PR TITLE
add IEquatable example in about_Comparison_Operators

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -74,9 +74,10 @@ There are a few exceptions:
 
 ### -eq and -ne
 
-When the left-hand side is scalar, `-eq` returns **True** if the right-hand side is
-an exact match, otherwise, `-eq` returns **False**. `-ne` does the opposite; it
-returns **False** when both sides match; otherwise, `-ne` returns True.
+When the left-hand side is scalar, `-eq` returns **True** if the right-hand
+side is an exact match, otherwise, `-eq` returns **False**. `-ne` does the
+opposite; it returns **False** when both sides match; otherwise, `-ne` returns
+True.
 
 Example:
 
@@ -131,12 +132,12 @@ False
 ```
 
 In this example, we created two objects with identical properties. Yet, the
-equality test result is **False** because they are different objects. If you intend
-to develop meaningfully comparable classes, you need to implement
-[System.IEquatable\<T>][2] in your class.The following example demonstrates the partial
-implementation of a MyFileInfoSet class that implements [System.IEquatable\<T>][2] and has two properties,
-File and Size. The Equals method returns True if the File and Size properties of two MyFileInfoSet
-objects are identical; otherwise, it returns False.
+equality test result is **False** because they are different objects. To create
+comparable classes, you need to implement [System.IEquatable\<T>][2] in your
+class. The following example demonstrates the partial implementation of a
+**MyFileInfoSet** class that implements [System.IEquatable\<T>][2] and has two
+properties, **File** and **Size**. The `Equals()` method returns True if the
+File and Size properties of two **MyFileInfoSet** objects are the same.
 
 ```powershell
 class MyFileInfoSet : System.IEquatable[Object] {
@@ -268,8 +269,7 @@ Members smaller than or equal to 7
 7
 ```
 
-These operators aren't restricted to numbers; they work with any class that
-implements [System.IComparable][1].
+These operators work with any class that implements [System.IComparable][1].
 
 Examples:
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 12/11/2020
+ms.date: 12/17/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
@@ -119,7 +119,7 @@ The following example demonstrates the issue.
 ```powershell
 class MyFileInfoSet {
     [String]$File
-    [String]$Size
+    [Int64]$Size
 }
 $a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
 $b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
@@ -133,7 +133,28 @@ False
 In this example, we created two objects with identical properties. Yet, the
 equality test result is **False** because they are different objects. If you intend
 to develop meaningfully comparable classes, you need to implement
-[System.IComparable][1] in your class.
+[System.IEquatable\<T>][2] in your class.The following example demonstrates the partial
+implementation of a MyFileInfoSet class that implements [System.IEquatable\<T>][2] and has two properties,
+File and Size. The Equals method returns True if the File and Size properties of two MyFileInfoSet
+objects are identical; otherwise, it returns False.
+
+```powershell
+class MyFileInfoSet : System.IEquatable[Object] {
+    [String]$File
+    [Int64]$Size
+
+    [bool] Equals([Object] $obj) {
+        return ($this.File -eq $obj.File) -and ($this.Size -eq $obj.Size)
+    }
+}
+$a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$a -eq $b
+```
+
+```Output
+True
+```
 
 A prominent example of comparing arbitrary objects is to find out if they are
 null. But if you need to determine whether a variable is `$null`, you must put
@@ -626,6 +647,7 @@ $a -isnot $b.GetType() # Output: True
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
 
 [1]: /dotnet/api/system.icomparable
-[2]: /dotnet/api/system.text.regularexpressions.match
-[3]: about_Redirection.md#potential-confusion-with-comparison-operators
-[4]: /dotnet/standard/base-types/substitutions-in-regular-expressions
+[2]: /dotnet/api/system.iequatable-1
+[3]: /dotnet/api/system.text.regularexpressions.match
+[4]: about_Redirection.md#potential-confusion-with-comparison-operators
+[5]: /dotnet/standard/base-types/substitutions-in-regular-expressions

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -74,9 +74,10 @@ There are a few exceptions:
 
 ### -eq and -ne
 
-When the left-hand side is scalar, `-eq` returns **True** if the right-hand side is
-an exact match, otherwise, `-eq` returns **False**. `-ne` does the opposite; it
-returns **False** when both sides match; otherwise, `-ne` returns True.
+When the left-hand side is scalar, `-eq` returns **True** if the right-hand
+side is an exact match, otherwise, `-eq` returns **False**. `-ne` does the
+opposite; it returns **False** when both sides match; otherwise, `-ne` returns
+True.
 
 Example:
 
@@ -131,12 +132,12 @@ False
 ```
 
 In this example, we created two objects with identical properties. Yet, the
-equality test result is **False** because they are different objects. If you intend
-to develop meaningfully comparable classes, you need to implement
-[System.IEquatable\<T>][2] in your class.The following example demonstrates the partial
-implementation of a MyFileInfoSet class that implements [System.IEquatable\<T>][2] and has two properties,
-File and Size. The Equals method returns True if the File and Size properties of two MyFileInfoSet
-objects are identical; otherwise, it returns False.
+equality test result is **False** because they are different objects. To create
+comparable classes, you need to implement [System.IEquatable\<T>][2] in your
+class. The following example demonstrates the partial implementation of a
+**MyFileInfoSet** class that implements [System.IEquatable\<T>][2] and has two
+properties, **File** and **Size**. The `Equals()` method returns True if the
+File and Size properties of two **MyFileInfoSet** objects are the same.
 
 ```powershell
 class MyFileInfoSet : System.IEquatable[Object] {
@@ -268,8 +269,7 @@ Members smaller than or equal to 7
 7
 ```
 
-These operators aren't restricted to numbers; they work with any class that
-implements [System.IComparable][1].
+These operators work with any class that implements [System.IComparable][1].
 
 Examples:
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 12/11/2020
+ms.date: 12/17/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
@@ -119,7 +119,7 @@ The following example demonstrates the issue.
 ```powershell
 class MyFileInfoSet {
     [String]$File
-    [String]$Size
+    [Int64]$Size
 }
 $a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
 $b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
@@ -133,7 +133,28 @@ False
 In this example, we created two objects with identical properties. Yet, the
 equality test result is **False** because they are different objects. If you intend
 to develop meaningfully comparable classes, you need to implement
-[System.IComparable][1] in your class.
+[System.IEquatable\<T>][2] in your class.The following example demonstrates the partial
+implementation of a MyFileInfoSet class that implements [System.IEquatable\<T>][2] and has two properties,
+File and Size. The Equals method returns True if the File and Size properties of two MyFileInfoSet
+objects are identical; otherwise, it returns False.
+
+```powershell
+class MyFileInfoSet : System.IEquatable[Object] {
+    [String]$File
+    [Int64]$Size
+
+    [bool] Equals([Object] $obj) {
+        return ($this.File -eq $obj.File) -and ($this.Size -eq $obj.Size)
+    }
+}
+$a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$a -eq $b
+```
+
+```Output
+True
+```
 
 A prominent example of comparing arbitrary objects is to find out if they are
 null. But if you need to determine whether a variable is `$null`, you must put
@@ -653,6 +674,7 @@ $a -isnot $b.GetType() # Output: True
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
 
 [1]: /dotnet/api/system.icomparable
-[2]: /dotnet/api/system.text.regularexpressions.match
-[3]: about_Redirection.md#potential-confusion-with-comparison-operators
-[4]: /dotnet/standard/base-types/substitutions-in-regular-expressions
+[2]: /dotnet/api/system.iequatable-1
+[3]: /dotnet/api/system.text.regularexpressions.match
+[4]: about_Redirection.md#potential-confusion-with-comparison-operators
+[5]: /dotnet/standard/base-types/substitutions-in-regular-expressions

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 12/11/2020
+ms.date: 12/17/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
@@ -119,7 +119,7 @@ The following example demonstrates the issue.
 ```powershell
 class MyFileInfoSet {
     [String]$File
-    [String]$Size
+    [Int64]$Size
 }
 $a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
 $b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
@@ -133,7 +133,28 @@ False
 In this example, we created two objects with identical properties. Yet, the
 equality test result is **False** because they are different objects. If you intend
 to develop meaningfully comparable classes, you need to implement
-[System.IComparable][1] in your class.
+[System.IEquatable\<T>][2] in your class.The following example demonstrates the partial
+implementation of a MyFileInfoSet class that implements [System.IEquatable\<T>][2] and has two properties,
+File and Size. The Equals method returns True if the File and Size properties of two MyFileInfoSet
+objects are identical; otherwise, it returns False.
+
+```powershell
+class MyFileInfoSet : System.IEquatable[Object] {
+    [String]$File
+    [Int64]$Size
+
+    [bool] Equals([Object] $obj) {
+        return ($this.File -eq $obj.File) -and ($this.Size -eq $obj.Size)
+    }
+}
+$a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$a -eq $b
+```
+
+```Output
+True
+```
 
 A prominent example of comparing arbitrary objects is to find out if they are
 null. But if you need to determine whether a variable is `$null`, you must put
@@ -653,6 +674,7 @@ $a -isnot $b.GetType() # Output: True
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
 
 [1]: /dotnet/api/system.icomparable
-[2]: /dotnet/api/system.text.regularexpressions.match
-[3]: about_Redirection.md#potential-confusion-with-comparison-operators
-[4]: /dotnet/standard/base-types/substitutions-in-regular-expressions
+[2]: /dotnet/api/system.iequatable-1
+[3]: /dotnet/api/system.text.regularexpressions.match
+[4]: about_Redirection.md#potential-confusion-with-comparison-operators
+[5]: /dotnet/standard/base-types/substitutions-in-regular-expressions

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -74,9 +74,10 @@ There are a few exceptions:
 
 ### -eq and -ne
 
-When the left-hand side is scalar, `-eq` returns **True** if the right-hand side is
-an exact match, otherwise, `-eq` returns **False**. `-ne` does the opposite; it
-returns **False** when both sides match; otherwise, `-ne` returns True.
+When the left-hand side is scalar, `-eq` returns **True** if the right-hand
+side is an exact match, otherwise, `-eq` returns **False**. `-ne` does the
+opposite; it returns **False** when both sides match; otherwise, `-ne` returns
+True.
 
 Example:
 
@@ -131,12 +132,12 @@ False
 ```
 
 In this example, we created two objects with identical properties. Yet, the
-equality test result is **False** because they are different objects. If you intend
-to develop meaningfully comparable classes, you need to implement
-[System.IEquatable\<T>][2] in your class.The following example demonstrates the partial
-implementation of a MyFileInfoSet class that implements [System.IEquatable\<T>][2] and has two properties,
-File and Size. The Equals method returns True if the File and Size properties of two MyFileInfoSet
-objects are identical; otherwise, it returns False.
+equality test result is **False** because they are different objects. To create
+comparable classes, you need to implement [System.IEquatable\<T>][2] in your
+class. The following example demonstrates the partial implementation of a
+**MyFileInfoSet** class that implements [System.IEquatable\<T>][2] and has two
+properties, **File** and **Size**. The `Equals()` method returns True if the
+File and Size properties of two **MyFileInfoSet** objects are the same.
 
 ```powershell
 class MyFileInfoSet : System.IEquatable[Object] {
@@ -268,8 +269,7 @@ Members smaller than or equal to 7
 7
 ```
 
-These operators aren't restricted to numbers; they work with any class that
-implements [System.IComparable][1].
+These operators work with any class that implements [System.IComparable][1].
 
 Examples:
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 12/11/2020
+ms.date: 12/17/2020
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
@@ -119,7 +119,7 @@ The following example demonstrates the issue.
 ```powershell
 class MyFileInfoSet {
     [String]$File
-    [String]$Size
+    [Int64]$Size
 }
 $a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
 $b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
@@ -133,7 +133,28 @@ False
 In this example, we created two objects with identical properties. Yet, the
 equality test result is **False** because they are different objects. If you intend
 to develop meaningfully comparable classes, you need to implement
-[System.IComparable][1] in your class.
+[System.IEquatable\<T>][2] in your class. The following example demonstrates the partial
+implementation of a MyFileInfoSet class that implements [System.IEquatable\<T>][2] and has two properties,
+File and Size. The Equals method returns True if the File and Size properties of two MyFileInfoSet
+objects are identical; otherwise, it returns False.
+
+```powershell
+class MyFileInfoSet : System.IEquatable[Object] {
+    [String]$File
+    [Int64]$Size
+
+    [bool] Equals([Object] $obj) {
+        return ($this.File -eq $obj.File) -and ($this.Size -eq $obj.Size)
+    }
+}
+$a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
+$a -eq $b
+```
+
+```Output
+True
+```
 
 A prominent example of comparing arbitrary objects is to find out if they are
 null. But if you need to determine whether a variable is `$null`, you must put
@@ -653,6 +674,7 @@ $a -isnot $b.GetType() # Output: True
 - [Where-Object](xref:Microsoft.PowerShell.Core.Where-Object)
 
 [1]: /dotnet/api/system.icomparable
-[2]: /dotnet/api/system.text.regularexpressions.match
-[3]: about_Redirection.md#potential-confusion-with-comparison-operators
-[4]: /dotnet/standard/base-types/substitutions-in-regular-expressions
+[2]: /dotnet/api/system.iequatable-1
+[3]: /dotnet/api/system.text.regularexpressions.match
+[4]: about_Redirection.md#potential-confusion-with-comparison-operators
+[5]: /dotnet/standard/base-types/substitutions-in-regular-expressions

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -74,9 +74,10 @@ There are a few exceptions:
 
 ### -eq and -ne
 
-When the left-hand side is scalar, `-eq` returns **True** if the right-hand side is
-an exact match, otherwise, `-eq` returns **False**. `-ne` does the opposite; it
-returns **False** when both sides match; otherwise, `-ne` returns True.
+When the left-hand side is scalar, `-eq` returns **True** if the right-hand
+side is an exact match, otherwise, `-eq` returns **False**. `-ne` does the
+opposite; it returns **False** when both sides match; otherwise, `-ne` returns
+True.
 
 Example:
 
@@ -131,12 +132,12 @@ False
 ```
 
 In this example, we created two objects with identical properties. Yet, the
-equality test result is **False** because they are different objects. If you intend
-to develop meaningfully comparable classes, you need to implement
-[System.IEquatable\<T>][2] in your class. The following example demonstrates the partial
-implementation of a MyFileInfoSet class that implements [System.IEquatable\<T>][2] and has two properties,
-File and Size. The Equals method returns True if the File and Size properties of two MyFileInfoSet
-objects are identical; otherwise, it returns False.
+equality test result is **False** because they are different objects. To create
+comparable classes, you need to implement [System.IEquatable\<T>][2] in your
+class. The following example demonstrates the partial implementation of a
+**MyFileInfoSet** class that implements [System.IEquatable\<T>][2] and has two
+properties, **File** and **Size**. The `Equals()` method returns True if the
+File and Size properties of two **MyFileInfoSet** objects are the same.
 
 ```powershell
 class MyFileInfoSet : System.IEquatable[Object] {
@@ -268,8 +269,7 @@ Members smaller than or equal to 7
 7
 ```
 
-These operators aren't restricted to numbers; they work with any class that
-implements [System.IComparable][1].
+These operators work with any class that implements [System.IComparable][1].
 
 Examples:
 


### PR DESCRIPTION
# PR Summary
- add IEquatable example
- fix incorrect interface name System.IComparable -> System.IEquatable\<T>

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
