### PR TITLE
Fix inconsistent case of fictive function Format-Xml

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -88,7 +88,7 @@ The value of `-SupportedCommand` is a comma-separated list of one or more
 cmdlet or function names.
 
 For example, the following data section includes a user-written cmdlet,
-`Format-XML`, that formats data in an XML file:
+`Format-Xml`, that formats data in an XML file:
 
 ```powershell
 DATA -supportedCommand Format-Xml

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -88,7 +88,7 @@ The value of `-SupportedCommand` is a comma-separated list of one or more
 cmdlet or function names.
 
 For example, the following data section includes a user-written cmdlet,
-`Format-XML`, that formats data in an XML file:
+`Format-Xml`, that formats data in an XML file:
 
 ```powershell
 DATA -supportedCommand Format-Xml

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -88,7 +88,7 @@ The value of `-SupportedCommand` is a comma-separated list of one or more
 cmdlet or function names.
 
 For example, the following data section includes a user-written cmdlet,
-`Format-XML`, that formats data in an XML file:
+`Format-Xml`, that formats data in an XML file:
 
 ```powershell
 DATA -supportedCommand Format-Xml

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -87,7 +87,7 @@ The value of `-SupportedCommand` is a comma-separated list of one or more
 cmdlet or function names.
 
 For example, the following data section includes a user-written cmdlet,
-`Format-XML`, that formats data in an XML file:
+`Format-Xml`, that formats data in an XML file:
 
 ```powershell
 DATA -supportedCommand Format-Xml


### PR DESCRIPTION
# PR Summary
Fix inconsistent case of fictive function Format-Xml. The function was spelled Format-XML in one place and Format-Xml in another.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
