### PR TITLE
line 101: typo in path name (disk name)

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -98,7 +98,7 @@ desired result.
    Write-Warning "hello"
    Write-Error "hello"
    Write-Output "hi"
-} 3>&1 2>&1 > P:\Temp\redirection.log
+} 3>&1 2>&1 > C:\Temp\redirection.log
 ```
 
 - `3>&1` redirects the **Warning** stream to the **Success** stream.


### PR DESCRIPTION
} 3>&1 2>&1 > P:\Temp\redirection.log
correct is
} 3>&1 2>&1 > C:\Temp\redirection.log


