### PR TITLE
Add PowerShell 6.1 and 6.2, fix .NET Core version in Version History table

### DIFF
--- a/reference/docs-conceptual/PowerShell-Support-Lifecycle.md
+++ b/reference/docs-conceptual/PowerShell-Support-Lifecycle.md
@@ -172,11 +172,13 @@ for historical reference. It is not intended for use to determine the support li
 
 |         Version          | Release Date |                                                                     Note                                                                      |
 | ------------------------ | :----------: | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| PowerShell 7.1 (current) |   Nov-2020   | Built on .NET Core 5.0 (current)                                                                                                              |
-| PowerShell 7.0 (LTS)     |   Mar-2020   | Built on .NET Core 3.1 (LTS)                                                                                                                  |
-| PowerShell 6.0           |   Jan-2018   | First release, built on .NET Core 2.1. Installable on Windows, Linux, and macOS.                                                              |
-| PowerShell 5.1           |   Aug-2016   | Released in Windows 10 Anniversary Update and Windows Server 2016                                                                             |
-| PowerShell 5.0           |   Feb-2016   | Released in Windows Management Framework (WMF) 5.0                                                                                            |
+| PowerShell 7.1 (current) |   Nov-2020   | Built on .NET Core 5.0 (current).                                                                                                             |
+| PowerShell 7.0 (LTS)     |   Mar-2020   | Built on .NET Core 3.1 (LTS).                                                                                                                 |
+| PowerShell 6.2           |   Mar-2019   |                                                                                                                                               |
+| PowerShell 6.1           |   Sep-2018   | Built on .NET Core 2.1.                                                                                                                       |
+| PowerShell 6.0           |   Jan-2018   | First release, built on .NET Core 2.0. Installable on Windows, Linux, and macOS.                                                              |
+| PowerShell 5.1           |   Aug-2016   | Released in Windows 10 Anniversary Update and Windows Server 2016.                                                                            |
+| PowerShell 5.0           |   Feb-2016   | Released in Windows Management Framework (WMF) 5.0.                                                                                           |
 | PowerShell 4.0           |   Oct-2013   | Integrated in Windows 8.1 and with Windows Server 2012 R2. Installable on Windows 7 SP1, Windows Server 2008 R2 SP1, and Windows Server 2012. |
 | PowerShell 3.0           |   Oct-2012   | Integrated in Windows 8 and with Windows Server 2012. Installable on Windows 7 SP1, Windows Server 2008 SP1, and Windows Server 2008 R2 SP1.  |
 | PowerShell 2.0           |   Jul-2009   | Integrated in Windows 7 and Windows Server 2008 R2. Installable on Windows XP SP3, Windows Server 2003 SP2, and Windows Vista SP1.            |


### PR DESCRIPTION
# PR Summary
Add PowerShell 6.1 and 6.2 release dates to Release History. Fix incorrect .NET Core version for 6.0 release.

## PR Context

Change is to /docs-conceptual folder.


## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
