### PR TITLE
fixes typo in #6930, change .NET Core 5.0 to .NET 5

### DIFF
--- a/reference/docs-conceptual/install/PowerShell-Core-on-ARM.md
+++ b/reference/docs-conceptual/install/PowerShell-Core-on-ARM.md
@@ -8,7 +8,7 @@ ms.date: 11/11/2020
 
 Support of PowerShell on Arm is based on the **.NET Core Supported OS Lifecycle Policies**.
 
-PowerShell 7.1 is based on the [.NET Core 3.1 Supported OS Lifecycle Policy](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md) and supports the following platforms:
+PowerShell 7.0 is based on the [.NET Core 3.1 Supported OS Lifecycle Policy](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md) and supports the following platforms:
 
 |         OS          |          Version           | Architectures |          Lifecycle           |
 | ------------------- | -------------------------- | ------------- | ---------------------------- |
@@ -17,11 +17,11 @@ PowerShell 7.1 is based on the [.NET Core 3.1 Supported OS Lifecycle Policy](htt
 | Debian              | 9+                         | Arm32, Arm64  | [Debian][Debian-lifecycle]   |
 | Ubuntu              | 20.10, 20.04, 18.04, 16.04 | Arm32, Arm64  | [Ubuntu][Ubuntu-lifecycle]   |
 
-PowerShell 7.0 is based on the [.NET Core 5.0 Supported OS Lifecycle Policy](https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0-supported-os.md) and supports the following platforms:
+PowerShell 7.1 is based on the [.NET 5.0 Supported OS Lifecycle Policy](https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0-supported-os.md) and supports the following platforms:
 
 |        OS         |          Version           | Architectures |          Lifecycle           |
 | ----------------- | -------------------------- | ------------- | ---------------------------- |
-| Windows 10 Client | Version 1607+              | Arm64         | [Windows][Windows-lifecycle] |
+| Windows 10 Client | Version 1703+              | Arm64         | [Windows][Windows-lifecycle] |
 | Alpine Linux      | 3.11+                      | Arm64         | [Alpine][Alpine-lifecycle]   |
 | Debian            | 9+                         | Arm32, Arm64  | [Debian][Debian-lifecycle]   |
 | Ubuntu            | 20.10, 20.04, 18.04, 16.04 | Arm32, Arm64  | [Ubuntu][Ubuntu-lifecycle]   |

--- a/reference/docs-conceptual/install/PowerShell-Core-on-ARM.md
+++ b/reference/docs-conceptual/install/PowerShell-Core-on-ARM.md
@@ -21,7 +21,7 @@ PowerShell 7.1 is based on the [.NET 5.0 Supported OS Lifecycle Policy](https://
 
 |        OS         |          Version           | Architectures |          Lifecycle           |
 | ----------------- | -------------------------- | ------------- | ---------------------------- |
-| Windows 10 Client | Version 1703+              | Arm64         | [Windows][Windows-lifecycle] |
+| Windows 10 Client | Version 1709+              | Arm64         | [Windows][Windows-lifecycle] |
 | Alpine Linux      | 3.11+                      | Arm64         | [Alpine][Alpine-lifecycle]   |
 | Debian            | 9+                         | Arm32, Arm64  | [Debian][Debian-lifecycle]   |
 | Ubuntu            | 20.10, 20.04, 18.04, 16.04 | Arm32, Arm64  | [Ubuntu][Ubuntu-lifecycle]   |


### PR DESCRIPTION

# PR Summary
Updated to map PowerShell 7.0 to .NET Core 3.1 and PowerShell 7.1 to .NET 5
Updated Windows 10 Client to be 1703+ instead of 1607+
Update .NET Core 5.0 to .NET 5

## PR Context

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [X] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
