### PR TITLE
Fixes #7135 - not all event logs require admin

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Write-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Write-EventLog.md
@@ -218,8 +218,8 @@ This cmdlet returns objects that represents the events in the logs.
 
 ## NOTES
 
-For csme of Windows event logs, writing events requires administrator rights. You must start
-PowerShell using the **Run as administrator** option.
+For some Windows event logs, writing events requires administrator rights. You must start
+PowerShell using the **Run as Administrator** option.
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Write-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Write-EventLog.md
@@ -22,6 +22,7 @@ Write-EventLog [-LogName] <String> [-Source] <String> [[-EntryType] <EventLogEnt
 ```
 
 ## DESCRIPTION
+
 The `Write-EventLog` cmdlet writes an event to an event log.
 
 To write an event to an event log, the event log must exist on the computer and the source must be
@@ -206,16 +207,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
 
 ## OUTPUTS
 
 ### System.Diagnostics.EventLogEntry
+
 This cmdlet returns objects that represents the events in the logs.
 
 ## NOTES
 
-To use `Write-EventLog`, start Windows PowerShell by using the Run as administrator option.
+For csme of Windows event logs, writing events requires administrator rights. You must start
+PowerShell using the **Run as administrator** option.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Fixes [AB#1809053](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1809053) - Fixes #7135 - not all event logs require admin

<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords