### PR TITLE
New (fixed) Get-Date -UFormat %u behavior

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Get-Date.md
@@ -607,9 +607,9 @@ The valid **UFormat specifiers** are displayed in the following table:
 | `%t` | Horizontal tab character                                                |                          |
 | `%T` | Time in 24-hour format                                                  | 17:45:52                 |
 | `%U` | Same as 'W'                                                             |                          |
-| `%u` | Day of the week - number                                                | Sunday = 0               |
+| `%u` | Numeric day of the week (1-7)                                           | Monday = 1, Sunday = 7   |
 | `%V` | Week of the year                                                        | 01-53                    |
-| `%w` | Same as 'u'                                                             |                          |
+| `%w` | Numeric day of the week (0-6)                                           | Sunday = 0, Saturday = 6 |
 | `%W` | Week of the year                                                        | 00-52                    |
 | `%X` | Same as 'T'                                                             |                          |
 | `%x` | Date in standard format for locale                                      | 06/27/19 for English-US  |


### PR DESCRIPTION
# PR Summary
Update Get-Date -UFormat documentation to match the new (corrected) behavior in #7180 

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
