### PR TITLE
Fixes #7175 - Updates Start-Transcript

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -3,14 +3,14 @@ external help file: Microsoft.PowerShell.ConsoleHost.dll-help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Host
-ms.date: 04/22/2020
+ms.date: 01/26/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.host/start-transcript?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Transcript
 ---
 # Start-Transcript
 
-## SYNOPSIS
+## SYNOPSIS7175
 Creates a record of all or part of a PowerShell session to a text file.
 
 ## SYNTAX
@@ -48,6 +48,9 @@ Files that are created by the `Start-Transcript` cmdlet include random character
 prevent potential overwrites or duplication when two or more transcripts are started simultaneously.
 This also prevents unauthorized discovery of transcripts that are stored in a centralized file
 share.
+
+If the target file doesn't have a Byte Order Mark (BOM), `Start-Transcript` defaults to `ASCII`
+encoding in the target file.
 
 ## EXAMPLES
 

--- a/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -49,8 +49,8 @@ prevent potential overwrites or duplication when two or more transcripts are sta
 This also prevents unauthorized discovery of transcripts that are stored in a centralized file
 share.
 
-If the target file doesn't have a Byte Order Mark (BOM), `Start-Transcript` defaults to `ASCII`
-encoding in the target file.
+If the target file doesn't have a Byte Order Mark (BOM), when using the **Append** parameter,
+`Start-Transcript` defaults to `ASCII` encoding in the target file.
 
 ## Examples
 

--- a/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -10,10 +10,10 @@ title: Start-Transcript
 ---
 # Start-Transcript
 
-## SYNOPSIS7175
+## Synopsis
 Creates a record of all or part of a PowerShell session to a text file.
 
-## SYNTAX
+## Syntax
 
 ### ByPath (Default)
 
@@ -36,7 +36,7 @@ Start-Transcript [[-OutputDirectory] <String>] [-Append] [-Force] [-NoClobber] [
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Start-Transcript` cmdlet creates a record of all or part of a PowerShell session to a text
 file. The transcript includes all command that the user types and all output that appears on the
@@ -52,7 +52,7 @@ share.
 If the target file doesn't have a Byte Order Mark (BOM), `Start-Transcript` defaults to `ASCII`
 encoding in the target file.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Start a transcript file with default settings
 
@@ -72,7 +72,7 @@ This command starts a transcript in the `Transcript0.txt` file in `C:\transcript
 **NoClobber** parameter is used, the command prevents any existing files from being overwritten. If
 the `Transcript0.txt` file already exists, the command fails.
 
-## PARAMETERS
+## Parameters
 
 ### -Append
 
@@ -240,25 +240,25 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### None
 
 You cannot pipe objects to this cmdlet.
 
-## OUTPUTS
+## Outputs
 
 ### System.String
 
 This cmdlet returns a string that contains a confirmation message and the path to the output file.
 
-## NOTES
+## Notes
 
 To stop a transcript, use the `Stop-Transcript` cmdlet.
 
 To record an entire session, add the `Start-Transcript` command to your profile. For more
 information, see [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
 
-## RELATED LINKS
+## Related Links
 
 [Stop-Transcript](Stop-Transcript.md)

--- a/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -49,8 +49,9 @@ prevent potential overwrites or duplication when two or more transcripts are sta
 This also prevents unauthorized discovery of transcripts that are stored in a centralized file
 share.
 
-If the target file doesn't have a Byte Order Mark (BOM), when using the **Append** parameter,
-`Start-Transcript` defaults to `ASCII` encoding in the target file.
+When using the **Append** parameter, if the target file doesn't have a Byte Order Mark (BOM)
+`Start-Transcript` defaults to `ASCII` encoding in the target file. This behavior can result in
+improper encoding of mulitbyte characters in the transcript.
 
 ## Examples
 

--- a/reference/7.0/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/7.0/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -49,8 +49,8 @@ prevent potential overwrites or duplication when two or more transcripts are sta
 This also prevents unauthorized discovery of transcripts that are stored in a centralized file
 share.
 
-If the target file doesn't have a Byte Order Mark (BOM), `Start-Transcript` defaults to `ASCII`
-encoding in the target file.
+If the target file doesn't have a Byte Order Mark (BOM), when using the **Append** parameter,
+`Start-Transcript` defaults to `ASCII` encoding in the target file.
 
 ## Examples
 

--- a/reference/7.0/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/7.0/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -10,10 +10,10 @@ title: Start-Transcript
 ---
 # Start-Transcript
 
-## SYNOPSIS
+## Synopsis
 Creates a record of all or part of a PowerShell session to a text file.
 
-## SYNTAX
+## Syntax
 
 ### ByPath (Default)
 
@@ -36,7 +36,7 @@ Start-Transcript [[-OutputDirectory] <String>] [-Append] [-Force] [-NoClobber]
  [-IncludeInvocationHeader] [-UseMinimalHeader] [-WhatIf] [-Confirm]  [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Start-Transcript` cmdlet creates a record of all or part of a PowerShell session to a text
 file. The transcript includes all command that the user types and all output that appears on the
@@ -52,7 +52,7 @@ share.
 If the target file doesn't have a Byte Order Mark (BOM), `Start-Transcript` defaults to `ASCII`
 encoding in the target file.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Start a transcript file with default settings
 
@@ -72,7 +72,7 @@ This command starts a transcript in the `Transcript0.txt` file in `C:\transcript
 **NoClobber** parameter is used, the command prevents any existing files from being overwritten. If
 the `Transcript0.txt` file already exists, the command fails.
 
-## PARAMETERS
+## Parameters
 
 ### -Append
 
@@ -257,25 +257,25 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### None
 
 You cannot pipe objects to this cmdlet.
 
-## OUTPUTS
+## Outputs
 
 ### System.String
 
 This cmdlet returns a string that contains a confirmation message and the path to the output file.
 
-## NOTES
+## Notes
 
 To stop a transcript, use the `Stop-Transcript` cmdlet.
 
 To record an entire session, add the `Start-Transcript` command to your profile. For more
 information, see [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
 
-## RELATED LINKS
+## Related Links
 
 [Stop-Transcript](Stop-Transcript.md)

--- a/reference/7.0/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/7.0/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -49,8 +49,9 @@ prevent potential overwrites or duplication when two or more transcripts are sta
 This also prevents unauthorized discovery of transcripts that are stored in a centralized file
 share.
 
-If the target file doesn't have a Byte Order Mark (BOM), when using the **Append** parameter,
-`Start-Transcript` defaults to `ASCII` encoding in the target file.
+When using the **Append** parameter, if the target file doesn't have a Byte Order Mark (BOM)
+`Start-Transcript` defaults to `ASCII` encoding in the target file. This behavior can result in
+improper encoding of mulitbyte characters in the transcript.
 
 ## Examples
 

--- a/reference/7.0/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/7.0/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.ConsoleHost.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Host
-ms.date: 04/22/2020
+ms.date: 01/26/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.host/start-transcript?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Transcript
@@ -48,6 +48,9 @@ Files that are created by the `Start-Transcript` cmdlet include random character
 prevent potential overwrites or duplication when two or more transcripts are started simultaneously.
 This also prevents unauthorized discovery of transcripts that are stored in a centralized file
 share.
+
+If the target file doesn't have a Byte Order Mark (BOM), `Start-Transcript` defaults to `ASCII`
+encoding in the target file.
 
 ## EXAMPLES
 

--- a/reference/7.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/7.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -49,8 +49,9 @@ prevent potential overwrites or duplication when two or more transcripts are sta
 This also prevents unauthorized discovery of transcripts that are stored in a centralized file
 share.
 
-If the target file doesn't have a Byte Order Mark (BOM), when using the **Append** parameter,
-`Start-Transcript` defaults to `ASCII` encoding in the target file.
+When using the **Append** parameter, if the target file doesn't have a Byte Order Mark (BOM)
+`Start-Transcript` defaults to `ASCII` encoding in the target file. This behavior can result in
+improper encoding of mulitbyte characters in the transcript.
 
 ## Examples
 
@@ -279,4 +280,3 @@ information, see [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profi
 ## Related Links
 
 [Stop-Transcript](Stop-Transcript.md)
-

--- a/reference/7.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/7.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -49,8 +49,8 @@ prevent potential overwrites or duplication when two or more transcripts are sta
 This also prevents unauthorized discovery of transcripts that are stored in a centralized file
 share.
 
-If the target file doesn't have a Byte Order Mark (BOM), `Start-Transcript` defaults to `ASCII`
-encoding in the target file.
+If the target file doesn't have a Byte Order Mark (BOM), when using the **Append** parameter,
+`Start-Transcript` defaults to `ASCII` encoding in the target file.
 
 ## Examples
 

--- a/reference/7.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/7.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.ConsoleHost.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Host
-ms.date: 06/09/2017
+ms.date: 01/26/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.host/start-transcript?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Transcript
@@ -48,6 +48,9 @@ Files that are created by the `Start-Transcript` cmdlet include random character
 prevent potential overwrites or duplication when two or more transcripts are started simultaneously.
 This also prevents unauthorized discovery of transcripts that are stored in a centralized file
 share.
+
+If the target file doesn't have a Byte Order Mark (BOM), `Start-Transcript` defaults to `ASCII`
+encoding in the target file.
 
 ## EXAMPLES
 

--- a/reference/7.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/7.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -10,10 +10,10 @@ title: Start-Transcript
 ---
 # Start-Transcript
 
-## SYNOPSIS
+## Synopsis
 Creates a record of all or part of a PowerShell session to a text file.
 
-## SYNTAX
+## Syntax
 
 ### ByPath (Default)
 
@@ -36,7 +36,7 @@ Start-Transcript [[-OutputDirectory] <String>] [-Append] [-Force] [-NoClobber]
  [-IncludeInvocationHeader] [-UseMinimalHeader] [-WhatIf] [-Confirm]  [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Start-Transcript` cmdlet creates a record of all or part of a PowerShell session to a text
 file. The transcript includes all command that the user types and all output that appears on the
@@ -52,7 +52,7 @@ share.
 If the target file doesn't have a Byte Order Mark (BOM), `Start-Transcript` defaults to `ASCII`
 encoding in the target file.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Start a transcript file with default settings
 
@@ -72,7 +72,7 @@ This command starts a transcript in the `Transcript0.txt` file in `C:\transcript
 **NoClobber** parameter is used, the command prevents any existing files from being overwritten. If
 the `Transcript0.txt` file already exists, the command fails.
 
-## PARAMETERS
+## Parameters
 
 ### -Append
 
@@ -257,26 +257,26 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### None
 
 You cannot pipe objects to this cmdlet.
 
-## OUTPUTS
+## Outputs
 
 ### System.String
 
 This cmdlet returns a string that contains a confirmation message and the path to the output file.
 
-## NOTES
+## Notes
 
 To stop a transcript, use the `Stop-Transcript` cmdlet.
 
 To record an entire session, add the `Start-Transcript` command to your profile. For more
 information, see [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
 
-## RELATED LINKS
+## Related Links
 
 [Stop-Transcript](Stop-Transcript.md)
 

--- a/reference/7.2/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/7.2/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -9,10 +9,10 @@ title: Start-Transcript
 ---
 # Start-Transcript
 
-## SYNOPSIS
+## Synopsis
 Creates a record of all or part of a PowerShell session to a text file.
 
-## SYNTAX
+## Syntax
 
 ### ByPath (Default)
 
@@ -35,7 +35,7 @@ Start-Transcript [[-OutputDirectory] <String>] [-Append] [-Force] [-NoClobber]
  [-IncludeInvocationHeader] [-UseMinimalHeader] [-WhatIf] [-Confirm]  [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Start-Transcript` cmdlet creates a record of all or part of a PowerShell session to a text
 file. The transcript includes all command that the user types and all output that appears on the
@@ -51,7 +51,7 @@ share.
 If the target file doesn't have a Byte Order Mark (BOM), `Start-Transcript` defaults to `Utf8NoBom`
 encoding in the target file.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Start a transcript file with default settings
 
@@ -71,7 +71,7 @@ This command starts a transcript in the `Transcript0.txt` file in `C:\transcript
 **NoClobber** parameter is used, the command prevents any existing files from being overwritten. If
 the `Transcript0.txt` file already exists, the command fails.
 
-## PARAMETERS
+## Parameters
 
 ### -Append
 
@@ -256,26 +256,25 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### None
 
 You cannot pipe objects to this cmdlet.
 
-## OUTPUTS
+## Outputs
 
 ### System.String
 
 This cmdlet returns a string that contains a confirmation message and the path to the output file.
 
-## NOTES
+## Notes
 
 To stop a transcript, use the `Stop-Transcript` cmdlet.
 
 To record an entire session, add the `Start-Transcript` command to your profile. For more
 information, see [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
 
-## RELATED LINKS
+## Related Links
 
 [Stop-Transcript](Stop-Transcript.md)
-

--- a/reference/7.2/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/7.2/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ConsoleHost.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Host
-ms.date: 06/09/2017
+ms.date: 01/26/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.host/start-transcript?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Transcript
@@ -47,6 +47,9 @@ Files that are created by the `Start-Transcript` cmdlet include random character
 prevent potential overwrites or duplication when two or more transcripts are started simultaneously.
 This also prevents unauthorized discovery of transcripts that are stored in a centralized file
 share.
+
+If the target file doesn't have a Byte Order Mark (BOM), `Start-Transcript` defaults to `Utf8NoBom`
+encoding in the target file.
 
 ## EXAMPLES
 


### PR DESCRIPTION
# PR Summary

Adds information about default encoding behavior in ``Start-Transcript`` for different versions of PowerShell

## PR Context

Fixes #7175
Fixes [AB#1811023](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1811023)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords