### PR TITLE
Update PSReadLine about doc for predictive intellisense and dynamic help

### DIFF
--- a/reference/7.2/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.2/PSReadLine/About/about_PSReadLine.md
@@ -984,26 +984,6 @@ Display the list of possible completions.
 - Vi insert mode: `<Ctrl+Spacebar>`
 - Vi command mode: `<Ctrl+Spacebar>`
 
-### ShowParameterHelp
-
-Provides dynamic help for parameters by showing it below the current command
-line like `MenuComplete`.
-
-- Cmd: `<Alt+h>`
-- Emacs: `<Alt+h>`
-- Vi insert mode: `<Alt+h>`
-- Vi command mode: `<Alt+h>`
-
-### ShowCommandHelp
-
-Provides a view of full cmdlet help on alternate screen buffer using a Pager
-from **Microsoft.PowerShell.Pager**.
-
-- Cmd: `<F1>`
-- Emacs: `<F1>`
-- Vi insert mode: `<F1>`
-- Vi command mode: `<F1>`
-
 ### TabCompleteNext
 
 Attempt to complete the text surrounding the cursor with the next available
@@ -1032,19 +1012,39 @@ Ends the current edit group, if needed, and invokes TabCompletePrevious.
 
 - Vi insert mode: `<Shift+Tab>`
 
-## Miscellaneous functions
+## Prediction functions
 
 ### AcceptNextSuggestionWord
 
-Accept the next word of the inline or selected suggestion.
+When using `InlineView` as the view style for prediction, accept the next word of the inline suggestion.
 
 - Function is unbound.
 
 ### AcceptSuggestion
 
-Accept the current inline or selected suggestion.
+When using `InlineView` as the view style for prediction, accept the current inline suggestion.
 
 - Function is unbound.
+
+### NextSuggestion
+
+When using `ListView` as the view style for prediction, navigate to the next suggestion in the list.
+
+- Function is unbound.
+
+### PreviousSuggestion
+
+When using `ListView` as the view style for prediction, navigate to the previous suggestion in the list.
+
+- Function is unbound.
+
+### SwitchPredictionView
+
+Switch the view style for prediction between `InlineView` and `ListView`.
+
+- Cmd: `<F2>`
+
+## Miscellaneous functions
 
 ### CaptureScreen
 
@@ -1127,6 +1127,16 @@ Insert the key.
 
 - Function is unbound.
 
+### ShowCommandHelp
+
+Provides a view of full cmdlet help on alternate screen buffer using a Pager
+from **Microsoft.PowerShell.Pager**.
+
+- Cmd: `<F1>`
+- Emacs: `<F1>`
+- Vi insert mode: `<F1>`
+- Vi command mode: `<F1>`
+
 ### ShowKeyBindings
 
 Show all bound keys.
@@ -1134,6 +1144,16 @@ Show all bound keys.
 - Cmd: `<Ctrl+Alt+?>`
 - Emacs: `<Ctrl+Alt+?>`
 - Vi insert mode: `<Ctrl+Alt+?>`
+
+### ShowParameterHelp
+
+Provides dynamic help for parameters by showing it below the current command
+line like `MenuComplete`.
+
+- Cmd: `<Alt+h>`
+- Emacs: `<Alt+h>`
+- Vi insert mode: `<Alt+h>`
+- Vi command mode: `<Alt+h>`
 
 ### ViCommandMode
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Update PSReadLine about doc for predictive intellisense and dynamic help.
The dynamic help content is moved to the `Miscellaneous functions` section because they belong to that group.
Prediction functions were added but not added to the about-* doc.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
