### PR TITLE
Fixes #7255 - Updates Set-PSReadLineKeyHandler

### DIFF
--- a/reference/5.1/PSReadLine/Set-PSReadLineKeyHandler.md
+++ b/reference/5.1/PSReadLine/Set-PSReadLineKeyHandler.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: PSReadline
-ms.date: 12/07/2018
+ms.date: 02/16/2021
 online version: https://docs.microsoft.com/powershell/module/psreadline/set-psreadlinekeyhandler?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineKeyHandler
@@ -85,6 +85,10 @@ specify a single binding. If the binding is a sequence of keys, separate the key
 the following example:
 
 `Ctrl+X,Ctrl+L`
+
+> [!NOTE]
+> As of PSReadLine 2.0.0, the **Chord** parameter is **case-sensitive**. Meaning, `Ctrl+X` and
+> `Ctrl+x` will create different bindings.
 
 This parameter accepts an array of strings. Each string is a separate binding, not a sequence of
 keys for a single binding.

--- a/reference/7.0/PSReadLine/Set-PSReadLineKeyHandler.md
+++ b/reference/7.0/PSReadLine/Set-PSReadLineKeyHandler.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/07/2018
+ms.date: 02/16/2021
 online version: https://docs.microsoft.com/powershell/module/psreadline/set-psreadlinekeyhandler?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineKeyHandler
@@ -85,6 +85,10 @@ specify a single binding. If the binding is a sequence of keys, separate the key
 the following example:
 
 `Ctrl+X,Ctrl+L`
+
+> [!NOTE]
+> As of PSReadLine 2.0.0, the **Chord** parameter is **case-sensitive**. Meaning, `Ctrl+X` and
+> `Ctrl+x` will create different bindings.
 
 This parameter accepts an array of strings. Each string is a separate binding, not a sequence of
 keys for a single binding.

--- a/reference/7.1/PSReadLine/Set-PSReadLineKeyHandler.md
+++ b/reference/7.1/PSReadLine/Set-PSReadLineKeyHandler.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/07/2018
+ms.date: 02/16/2021
 online version: https://docs.microsoft.com/powershell/module/psreadline/set-psreadlinekeyhandler?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineKeyHandler
@@ -85,6 +85,10 @@ specify a single binding. If the binding is a sequence of keys, separate the key
 the following example:
 
 `Ctrl+X,Ctrl+L`
+
+> [!NOTE]
+> As of PSReadLine 2.0.0, the **Chord** parameter is **case-sensitive**. Meaning, `Ctrl+X` and
+> `Ctrl+x` will create different bindings.
 
 This parameter accepts an array of strings. Each string is a separate binding, not a sequence of
 keys for a single binding.

--- a/reference/7.2/PSReadLine/Set-PSReadLineKeyHandler.md
+++ b/reference/7.2/PSReadLine/Set-PSReadLineKeyHandler.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/07/2018
+ms.date: 02/16/2021
 online version: https://docs.microsoft.com/powershell/module/psreadline/set-psreadlinekeyhandler?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineKeyHandler
@@ -84,6 +84,10 @@ specify a single binding. If the binding is a sequence of keys, separate the key
 the following example:
 
 `Ctrl+X,Ctrl+L`
+
+> [!NOTE]
+> As of PSReadLine 2.0.0, the **Chord** parameter is **case-sensitive**. Meaning, `Ctrl+X` and
+> `Ctrl+x` will create different bindings.
 
 This parameter accepts an array of strings. Each string is a separate binding, not a sequence of
 keys for a single binding.


### PR DESCRIPTION
# PR Summary

Adds info to **Chord** parameter in `Set-PSReadLineKeyHandler`.

## PR Context

Fixes #7255
Fixes [AB#1817823](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1817823)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords