### PR TITLE
Add doc for 'SelectCommandArgument'

### DIFF
--- a/reference/7.2/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.2/PSReadLine/About/about_PSReadLine.md
@@ -1232,6 +1232,13 @@ Adjust the current selection to include the previous word.
 - Cmd: `<Shift+Ctrl+LeftArrow>`
 - Emacs: `<Alt+B>`
 
+### SelectCommandArgument
+
+Make visual selection of the command arguments.
+
+- Cmd: `<Alt+a>`
+- Emacs: `<Alt+a>`
+
 ### SelectForwardChar
 
 Adjust the current selection to include the next character.


### PR DESCRIPTION
# PR Summary

Fix #7259
The bind-able function `SelectCommandArgument` was added to PSReadLine, as well as the default key binding `Alt+a` to it for the `Windows` and `Emacs` edit modes. Update the `about` doc for 'SelectCommandArgument'.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
