### PR TITLE
Fixes #5436 - Updates ForEach-Object

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 09/08/2020
+ms.date: 02/18/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -445,6 +445,46 @@ Output: 5
 ```
 
 `Output: 3` is never written because the parallel scriptblock for that iteration was terminated.
+
+### Example 16: Passing variables in nested parallel script ScriptBlockSet
+
+You can create a variable outside a `Foreach-Object -Parallel` scoped scriptblock and use
+it inside the scriptblock with the `$using` keyword.
+
+```powershell
+$test1 = 'TestA'
+1..2 | Foreach-Object -Parallel {
+    $using:test1
+}
+```
+
+```Output
+TestA
+TestA
+```
+
+You _cannot_ create a variable _inside_ a scoped scriptblock to be used in a nested foreach parallel
+scriptblock.
+
+```powershell
+$test1 = 'TestA'
+1..2 | Foreach-Object -Parallel {
+    $using:test1
+    $test2 = 'TestB'
+    1..2 | Foreach-Object -Parallel {
+        $using:test2
+    }
+}
+```
+
+```Output
+Line |
+   2 |  1..2 | Foreach-Object -Parallel {
+     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | The value of the using variable '$using:test2' cannot be retrieved because it has not been set in the local session.
+```
+
+The nested scriptblock can't access the `$test2` variable and an error is thrown.
 
 ## Parameters
 

--- a/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 09/08/2020
+ms.date: 02/18/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -448,6 +448,46 @@ Output: 5
 ```
 
 `Output: 3` is never written because the parallel scriptblock for that iteration was terminated.
+
+### Example 16: Passing variables in nested parallel script ScriptBlockSet
+
+You can create a variable outside a `Foreach-Object -Parallel` scoped scriptblock and use
+it inside the scriptblock with the `$using` keyword.
+
+```powershell
+$test1 = 'TestA'
+1..2 | Foreach-Object -Parallel {
+    $using:test1
+}
+```
+
+```Output
+TestA
+TestA
+```
+
+You _cannot_ create a variable _inside_ a scoped scriptblock to be used in a nested foreach parallel
+scriptblock.
+
+```powershell
+$test1 = 'TestA'
+1..2 | Foreach-Object -Parallel {
+    $using:test1
+    $test2 = 'TestB'
+    1..2 | Foreach-Object -Parallel {
+        $using:test2
+    }
+}
+```
+
+```Output
+Line |
+   2 |  1..2 | Foreach-Object -Parallel {
+     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | The value of the using variable '$using:test2' cannot be retrieved because it has not been set in the local session.
+```
+
+The nested scriptblock can't access the `$test2` variable and an error is thrown.
 
 ## Parameters
 


### PR DESCRIPTION
# PR Summary

Adds example to highlight variable behavior in 7.1 and 7

## PR Context

Fixes #5436
Fixes [AB#1818623](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1818623)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords