### PR TITLE
Fix incorrect language hint for a code snippet

### DIFF
--- a/reference/docs-conceptual/developer/cmdlet/how-to-invoke-scripts-within-a-cmdlet.md
+++ b/reference/docs-conceptual/developer/cmdlet/how-to-invoke-scripts-within-a-cmdlet.md
@@ -28,7 +28,7 @@ This example shows how to invoke a script that is supplied to a cmdlet. The scri
 
 2. Then, the script iterates through the returned collection of [System.Management.Automation.PSObject](/dotnet/api/System.Management.Automation.PSObject) objects and perform the necessary operations.
 
-    ```c
+    ```csharp
     foreach (PSObject psObject in psObjects)
     {
       if (LanguagePrimitives.IsTrue(psObject))


### PR DESCRIPTION
# PR Summary
A very minor correction.

Please check the page https://docs.microsoft.com/en-us/powershell/scripting/developer/cmdlet/how-to-invoke-scripts-within-a-cmdlet?view=powershell-7.1. The second code snippet  hint's the language is `C` although it should be `C#`.
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [x] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [ x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ x] PR has a meaningful title
- [x ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
