### PR TITLE
Fixes #7307 - Updates Read-Host

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Read-Host.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Read-Host.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 03/02/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/read-host?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Read-Host
@@ -24,6 +24,9 @@ Read-Host [[-Prompt] <Object>] [-AsSecureString] [<CommonParameters>]
 The `Read-Host` cmdlet reads a line of input from the console. You can use it to prompt a user for
 input. Because you can save the input as a secure string, you can use this cmdlet to prompt users
 for secure data, such as passwords, as well as shared data.
+
+> [!NOTE]
+> `Read-Host` has a limit of 8190 characters it can accept as input from a user.
 
 ## EXAMPLES
 
@@ -68,10 +71,8 @@ Accept wildcard characters: False
 
 ### -Prompt
 
-Specifies the text of the prompt.
-Type a string.
-If the string includes spaces, enclose it in quotation marks.
-PowerShell appends a colon (`:`) to the text that you enter.
+Specifies the text of the prompt. Type a string. If the string includes spaces, enclose it in
+quotation marks. PowerShell appends a colon (`:`) to the text that you enter.
 
 ```yaml
 Type: System.Object

--- a/reference/7.0/Microsoft.PowerShell.Utility/Read-Host.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Read-Host.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 03/02/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/read-host?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Read-Host
@@ -24,6 +24,9 @@ Read-Host [[-Prompt] <Object>] [-AsSecureString] [<CommonParameters>]
 The `Read-Host` cmdlet reads a line of input from the console. You can use it to prompt a user for
 input. Because you can save the input as a secure string, you can use this cmdlet to prompt users
 for secure data, such as passwords, as well as shared data.
+
+> [!NOTE]
+> `Read-Host` has a limit of 1022 characters it can accept as input from a user.
 
 ## EXAMPLES
 
@@ -68,10 +71,8 @@ Accept wildcard characters: False
 
 ### -Prompt
 
-Specifies the text of the prompt.
-Type a string.
-If the string includes spaces, enclose it in quotation marks.
-PowerShell appends a colon (`:`) to the text that you enter.
+Specifies the text of the prompt. Type a string. If the string includes spaces, enclose it in
+quotation marks. PowerShell appends a colon (`:`) to the text that you enter.
 
 ```yaml
 Type: System.Object

--- a/reference/7.1/Microsoft.PowerShell.Utility/Read-Host.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Read-Host.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/04/2020
+ms.date: 03/02/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/read-host?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Read-Host
@@ -32,6 +32,9 @@ Read-Host [[-Prompt] <Object>] [-AsSecureString] [<CommonParameters>]
 The `Read-Host` cmdlet reads a line of input from the console. You can use it to prompt a user for
 input. Because you can save the input as a secure string, you can use this cmdlet to prompt users
 for secure data, such as passwords, as well as shared data.
+
+> [!NOTE]
+> `Read-Host` has a limit of 1022 characters it can accept as input from a user.
 
 ## EXAMPLES
 
@@ -105,10 +108,8 @@ Accept wildcard characters: False
 
 ### -Prompt
 
-Specifies the text of the prompt.
-Type a string.
-If the string includes spaces, enclose it in quotation marks.
-PowerShell appends a colon (`:`) to the text that you enter.
+Specifies the text of the prompt. Type a string. If the string includes spaces, enclose it in
+quotation marks. PowerShell appends a colon (`:`) to the text that you enter.
 
 ```yaml
 Type: System.Object

--- a/reference/7.2/Microsoft.PowerShell.Utility/Read-Host.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Read-Host.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/04/2020
+ms.date: 03/02/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/read-host?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Read-Host
@@ -31,6 +31,9 @@ Read-Host [[-Prompt] <Object>] [-AsSecureString] [<CommonParameters>]
 The `Read-Host` cmdlet reads a line of input from the console. You can use it to prompt a user for
 input. Because you can save the input as a secure string, you can use this cmdlet to prompt users
 for secure data, such as passwords, as well as shared data.
+
+> [!NOTE]
+> `Read-Host` has a limit of 1022 characters it can accept as input from a user.
 
 ## EXAMPLES
 
@@ -104,10 +107,8 @@ Accept wildcard characters: False
 
 ### -Prompt
 
-Specifies the text of the prompt.
-Type a string.
-If the string includes spaces, enclose it in quotation marks.
-PowerShell appends a colon (`:`) to the text that you enter.
+Specifies the text of the prompt. Type a string. If the string includes spaces, enclose it in
+quotation marks. PowerShell appends a colon (`:`) to the text that you enter.
 
 ```yaml
 Type: System.Object


### PR DESCRIPTION
# PR Summary

Adds note about input limit in `Read-Host`

## PR Context

Fixes #7307
Fixes [AB#1822500](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1822500)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords