### PR TITLE
Fixes #7380 - Updates ForEach-Object

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 02/18/2021
+ms.date: 03/26/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -785,6 +785,9 @@ This cmdlet returns objects that are determined by the input.
   Using the **Parallel** parameter can cause scripts to run much slower than normal. Especially if
   the parallel scripts are trivial. Experiment with **Parallel** to discover where it can be
   beneficial.
+
+- [PipelineVariable](About/about_CommonParameters.md) common parameter variables are _not_ supported
+  in `Foreach-Object -Parallel` scenarios even with the `$using:` keyword.
 
   > [!IMPORTANT]
   > The `ForEach-Object -Parallel` parameter set runs script blocks in parallel on separate process

--- a/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 02/18/2021
+ms.date: 03/26/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -807,6 +807,9 @@ This cmdlet returns objects that are determined by the input.
   Using the **Parallel** parameter can cause scripts to run much slower than normal. Especially if
   the parallel scripts are trivial. Experiment with **Parallel** to discover where it can be
   beneficial.
+
+- [PipelineVariable](About/about_CommonParameters.md) common parameter variables are _not_ supported
+  in `Foreach-Object -Parallel` scenarios even with the `$using:` keyword.
 
   > [!IMPORTANT]
   > The `ForEach-Object -Parallel` parameter set runs script blocks in parallel on separate process

--- a/reference/7.2/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 09/08/2020
+ms.date: 03/26/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -448,6 +448,10 @@ Output: 5
 
 `Output: 3` is never written because the parallel scriptblock for that iteration was terminated.
 
+> [!NOTE]
+> [PipelineVariable](About/about_CommonParameters.md) common parameter variables are _not_
+> supported in `Foreach-Object -Parallel` scenarios even with the `$using:` keyword.
+
 ## Parameters
 
 ### -ArgumentList
@@ -767,6 +771,9 @@ This cmdlet returns objects that are determined by the input.
   Using the **Parallel** parameter can cause scripts to run much slower than normal. Especially if
   the parallel scripts are trivial. Experiment with **Parallel** to discover where it can be
   beneficial.
+
+- [PipelineVariable](About/about_CommonParameters.md) common parameter variables are _not_ supported
+  in `Foreach-Object -Parallel` scenarios even with the `$using:` keyword.
 
   > [!IMPORTANT]
   > The `ForEach-Object -Parallel` parameter set runs script blocks in parallel on separate process


### PR DESCRIPTION
# PR Summary

Adds note about `PipelineVariable` variables not being supported in `Foreach-Object -Parallel` scenarios.

## PR Context

Fixes #7380
Fixes [AB#1830264](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1830264)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords