### PR TITLE
Fixes #7383 - Updates about_Automatic_Variables

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description:  Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 03/15/2021
+ms.date: 03/29/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Automatic_Variables
@@ -210,7 +210,7 @@ Contains the exit code of the last Windows-based program that was run.
 
 ### $Matches
 
-The `Matches` variable works with the `-match` and `-notmatch` operators.
+The `$Matches` variable works with the `-match` and `-notmatch` operators.
 When you submit scalar input to the `-match` or `-notmatch` operator, and
 either one detects a match, they return a Boolean value and populate the
 `$Matches` automatic variable with a hash table of any string values that
@@ -220,6 +220,10 @@ when you use regular expressions with the `-match` operator.
 For more information about the `-match` operator, see
 [about_Comparison_Operators](about_comparison_operators.md). For more
 information on regular expressions, see [about_Regular_Expressions](about_Regular_Expressions.md).
+
+The `$Matches` variable also works in a `switch` statement with the `-Regex`
+parameter. It's populated the same way as the `-match` and `-notmatch` operators.
+For more information about the `switch` statement, see [about_Switch](about_Switch.md).
 
 ### $MyInvocation
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description:  Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 03/15/2021
+ms.date: 03/29/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Automatic_Variables
@@ -240,6 +240,10 @@ when you use regular expressions with the `-match` operator.
 For more information about the `-match` operator, see
 [about_Comparison_Operators](about_comparison_operators.md). For more
 information on regular expressions, see [about_Regular_Expressions](about_Regular_Expressions.md).
+
+The `$Matches` variable also works in a `switch` statement with the `-Regex`
+parameter. It's populated the same way as the `-match` and `-notmatch` operators.
+For more information about the `switch` statement, see [about_Switch](about_Switch.md).
 
 ### $MyInvocation
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description:  Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 03/15/2021
+ms.date: 03/29/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Automatic_Variables
@@ -240,6 +240,10 @@ when you use regular expressions with the `-match` operator.
 For more information about the `-match` operator, see
 [about_Comparison_Operators](about_comparison_operators.md). For more
 information on regular expressions, see [about_Regular_Expressions](about_Regular_Expressions.md).
+
+The `$Matches` variable also works in a `switch` statement with the `-Regex`
+parameter. It's populated the same way as the `-match` and `-notmatch` operators.
+For more information about the `switch` statement, see [about_Switch](about_Switch.md).
 
 ### $MyInvocation
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description:  Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 03/15/2021
+ms.date: 03/29/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Automatic_Variables
@@ -240,6 +240,10 @@ when you use regular expressions with the `-match` operator.
 For more information about the `-match` operator, see
 [about_Comparison_Operators](about_comparison_operators.md). For more
 information on regular expressions, see [about_Regular_Expressions](about_Regular_Expressions.md).
+
+The `$Matches` variable also works in a `switch` statement with the `-Regex`
+parameter. It's populated the same way as the `-match` and `-notmatch` operators.
+For more information about the `switch` statement, see [about_Switch](about_Switch.md).
 
 ### $MyInvocation
 


### PR DESCRIPTION
# PR Summary

Adds information about `` automatic variable being available in `switch` statement.

## PR Context

Fixes #7383
Fixes [AB#1830333](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1830333)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords