### PR TITLE
Fixes #7393 - clarify max-strings behavior

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
@@ -109,7 +109,7 @@ Address
 Specifies the maximum number of substrings returned by the split operation. The
 default is all substrings split by the delimiter. If there are more
 substrings, they are concatenated to the final substring. If there are fewer
-substrings, all the substrings are returned. A value of 0 returns all the
+substrings, all substrings are returned. A value of 0 returns all the
 substrings.
 
 Example:
@@ -145,7 +145,7 @@ c
 `<Max-substrings>` does not specify the maximum number of objects that are
 returned. In the following example, `<Max-substrings>` is set to 3.
 This results in three substring values, but a total of five strings
-in the resulting output. The delimiter is included after the splits, until the
+in the resulting output. The delimiter is included after the splits until the
 maximum of three substrings is reached. Additional delimiters in the final
 substring become part of the substring.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
@@ -107,7 +107,7 @@ Address
 ### `<Max-substrings>`
 
 Specifies the maximum number of substrings returned by the split operation. The
-default is all the substrings split by the delimiter. If there are more
+default is all substrings split by the delimiter. If there are more
 substrings, they are concatenated to the final substring. If there are fewer
 substrings, all the substrings are returned. A value of 0 returns all the
 substrings.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
@@ -143,7 +143,7 @@ c
 ```
 
 `<Max-substrings>` does not specify the maximum number of objects that are
-returned. If you use In the following example, `<Max-substrings>` is set to 3.
+returned. In the following example, `<Max-substrings>` is set to 3.
 This results in three substring values, but a total of five strings
 in the resulting output. The delimiter is included after the splits, until the
 maximum of three substrings is reached. Additional delimiters in the final
@@ -492,4 +492,3 @@ LastName, FirstName
 [about_Comparison_Operators](about_Comparison_Operators.md)
 
 [about_Join](about_Join.md)
-

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
@@ -1,17 +1,14 @@
 ---
-description:  Explains how to use the Split operator to split one or more strings into substrings. 
-keywords: powershell,cmdlet
+description: Explains how to use the Split operator to split one or more strings into substrings.
 Locale: en-US
-ms.date: 12/20/2017
+ms.date: 03/30/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_split?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Split
 ---
-
 # About Split
 
 ## SHORT DESCRIPTION
-
 Explains how to use the Split operator to split one or more strings into
 substrings.
 
@@ -22,7 +19,7 @@ change the following elements of the Split operation:
 
 - Delimiter. The default is whitespace, but you can specify characters,
   strings, patterns, or script blocks that specify the delimiter. The Split
-  operator in Windows PowerShell uses a regular expression in the delimiter,
+  operator in PowerShell uses a regular expression in the delimiter,
   rather than a simple character.
 - Maximum number of substrings. The default is to return all substrings. If
   you specify a number less than the number of substrings, the remaining
@@ -74,7 +71,7 @@ whitespace, including spaces and non-printable characters, such as newline
 (\`n) and tab (\`t). When the strings are split, the delimiter is omitted from
 all the substrings. Example:
 
-```
+```powershell
 "Lastname:FirstName:Address" -split ":"
 Lastname
 FirstName
@@ -83,7 +80,7 @@ Address
 
 By default, the delimiter is omitted from the results. To preserve all or part
 of the delimiter, enclose in parentheses the part that you want to preserve.
-If the \<Max-substrings\> parameter is added, this takes precedence when your
+If the `<Max-substrings>` parameter is added, this takes precedence when your
 command splits up the collection. If you opt to include a delimiter as part of
 the output, the command returns the delimiter as part of the output; however,
 splitting the string to return the delimiter as part of output does not count
@@ -91,7 +88,7 @@ as a split.
 
 Examples:
 
-```
+```powershell
 "Lastname:FirstName:Address" -split "(:)"
 Lastname
 :
@@ -107,36 +104,13 @@ FirstName
 Address
 ```
 
-In the following example, \<Max-substrings\> is set to 3. This results in
-three splits of the string values, but a total of five strings in the
-resulting output; the delimiter is included after the splits, until the
-maximum of three substrings is reached. Additional delimiters in the final
-substring become part of the substring.
+### `<Max-substrings>`
 
-```powershell
-'Chocolate-Vanilla-Strawberry-Blueberry' -split '(-)', 3
-```
-
-```output
-Chocolate
--
-Vanilla
--
-Strawberry-Blueberry
-```
-
-### \<Max-substrings\>
-
-Specifies the maximum number of times that a string is split. The default is
-all the substrings split by the delimiter. If there are more substrings, they
-are concatenated to the final substring. If there are fewer substrings, all
-the substrings are returned. A value of 0 and negative values return all the
+Specifies the maximum number of substrings returned by the split operation. The
+default is all the substrings split by the delimiter. If there are more
+substrings, they are concatenated to the final substring. If there are fewer
+substrings, all the substrings are returned. A value of 0 returns all the
 substrings.
-
-Max-substrings does not specify the maximum number of objects that are
-returned; its value equals the maximum number of times that a string is split.
-If you submit more than one string (an array of strings) to the Split operator
-, the Max-substrings limit is applied to each string separately.
 
 Example:
 
@@ -145,13 +119,50 @@ $c = "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune"
 $c -split ",", 5
 ```
 
-```output
+```Output
 Mercury
 Venus
 Earth
 Mars
 Jupiter,Saturn,Uranus,Neptune
 ```
+
+If you submit more than one string (an array of strings) to the `-split`
+operator, the `Max-substrings` limit is applied to each string separately.
+
+```powershell
+$c = 'a,b,c','1,2,3,4,5'
+$c -split ',', 3
+
+a
+b
+c
+1
+2
+3,4,5
+```
+
+`<Max-substrings>` does not specify the maximum number of objects that are
+returned. If you use In the following example, `<Max-substrings>` is set to 3.
+This results in three substring values, but a total of five strings
+in the resulting output. The delimiter is included after the splits, until the
+maximum of three substrings is reached. Additional delimiters in the final
+substring become part of the substring.
+
+```powershell
+'Chocolate-Vanilla-Strawberry-Blueberry' -split '(-)', 3
+```
+
+```Output
+Chocolate
+-
+Vanilla
+-
+Strawberry-Blueberry
+```
+
+Negative values are ignored.
+
 
 ### \<ScriptBlock\>
 
@@ -165,7 +176,7 @@ $c = "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune"
 $c -split {$_ -eq "e" -or $_ -eq "p"}
 ```
 
-```output
+```Output
 M
 rcury,V
 nus,
@@ -281,7 +292,7 @@ The following statement splits the string at whitespace.
 -split "Windows PowerShell 2.0`nWindows PowerShell with remoting"
 ```
 
-```output
+```Output
 
 Windows
 PowerShell
@@ -298,7 +309,7 @@ The following statement splits the string at any comma.
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -split ','
 ```
 
-```output
+```Output
 Mercury
 Venus
 Earth
@@ -315,7 +326,7 @@ The following statement splits the string at the pattern "er".
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -split 'er'
 ```
 
-```output
+```Output
 M
 cury,Venus,Earth,Mars,Jupit
 ,Saturn,Uranus,Neptune
@@ -327,7 +338,7 @@ The following statement performs a case-sensitive split at the letter "N".
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -cSplit 'N'
 ```
 
-```output
+```Output
 Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,
 eptune
 ```
@@ -338,7 +349,7 @@ The following statement splits the string at "e" and "t".
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -split '[et]'
 ```
 
-```output
+```Output
 M
 rcury,V
 nus,
@@ -358,7 +369,7 @@ resulting substrings to six substrings.
 "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -split '[er]', 6
 ```
 
-```output
+```Output
 M
 
 cu
@@ -373,7 +384,7 @@ The following statement splits a string into three substrings.
 "a,b,c,d,e,f,g,h" -split ",", 3
 ```
 
-```output
+```Output
 a
 b
 c,d,e,f,g,h
@@ -386,7 +397,7 @@ The following statement splits two strings into three substrings.
 "a,b,c,d", "e,f,g,h" -split ",", 3
 ```
 
-```output
+```Output
 a
 b
 c,d
@@ -433,7 +444,7 @@ newline.
 "This.is.a.test" -split "\."
 ```
 
-```output
+```Output
 This
 is
 a
@@ -451,7 +462,7 @@ specified.
 "This.is.a.test" -split ".", 0, "simplematch"
 ```
 
-```output
+```Output
 This
 is
 a
@@ -467,7 +478,7 @@ $c = "LastName, FirstName; Address, City, State, Zip"
 $c -split $(if ($i -lt 1) {","} else {";"})
 ```
 
-```output
+```Output
 LastName, FirstName
  Address, City, State, Zip
 ```
@@ -481,3 +492,4 @@ LastName, FirstName
 [about_Comparison_Operators](about_Comparison_Operators.md)
 
 [about_Join](about_Join.md)
+

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Split.md
@@ -107,9 +107,9 @@ Address
 ### `<Max-substrings>`
 
 Specifies the maximum number of substrings returned by the split operation. The
-default is all the substrings split by the delimiter. If there are more
+default is all substrings split by the delimiter. If there are more
 substrings, they are concatenated to the final substring. If there are fewer
-substrings, all the substrings are returned. A value of 0 returns all the
+substrings, all substrings are returned. A value of 0 returns all the
 substrings.
 
 Example:
@@ -143,9 +143,9 @@ c
 ```
 
 `<Max-substrings>` does not specify the maximum number of objects that are
-returned. If you use In the following example, `<Max-substrings>` is set to 3.
+returned. In the following example, `<Max-substrings>` is set to 3.
 This results in three substring values, but a total of five strings
-in the resulting output. The delimiter is included after the splits, until the
+in the resulting output. The delimiter is included after the splits until the
 maximum of three substrings is reached. Additional delimiters in the final
 substring become part of the substring.
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Split.md
@@ -1,8 +1,7 @@
 ---
-description: Explains how to use the Split operator to split one or more strings into substrings. 
-keywords: powershell,cmdlet
+description: Explains how to use the Split operator to split one or more strings into substrings.
 Locale: en-US
-ms.date: 03/24/2020
+ms.date: 03/30/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_split?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Split
@@ -72,7 +71,7 @@ whitespace, including spaces and non-printable characters, such as newline
 (\`n) and tab (\`t). When the strings are split, the delimiter is omitted from
 all the substrings. Example:
 
-```
+```powershell
 "Lastname:FirstName:Address" -split ":"
 Lastname
 FirstName
@@ -81,7 +80,7 @@ Address
 
 By default, the delimiter is omitted from the results. To preserve all or part
 of the delimiter, enclose in parentheses the part that you want to preserve.
-If the \<Max-substrings\> parameter is added, this takes precedence when your
+If the `<Max-substrings>` parameter is added, this takes precedence when your
 command splits up the collection. If you opt to include a delimiter as part of
 the output, the command returns the delimiter as part of the output; however,
 splitting the string to return the delimiter as part of output does not count
@@ -89,7 +88,7 @@ as a split.
 
 Examples:
 
-```
+```powershell
 "Lastname:FirstName:Address" -split "(:)"
 Lastname
 :
@@ -105,40 +104,13 @@ FirstName
 Address
 ```
 
-In the following example, \<Max-substrings\> is set to 3. This results in
-three splits of the string values, but a total of five strings in the
-resulting output; the delimiter is included after the splits, until the
-maximum of three substrings is reached. Additional delimiters in the final
-substring become part of the substring.
+### `<Max-substrings>`
 
-```powershell
-'Chocolate-Vanilla-Strawberry-Blueberry' -split '(-)', 3
-```
-
-```Output
-Chocolate
--
-Vanilla
--
-Strawberry-Blueberry
-```
-
-### \<Max-substrings\>
-
-Specifies the maximum number of times that a string is split. The default is
-all the substrings split by the delimiter. If there are more substrings, they
-are concatenated to the final substring. If there are fewer substrings, all
-the substrings are returned. A value of 0 returns all the substrings. Negative
-values return the amount of substrings requested starting from the end of the
-input string.
-
-> [!NOTE]
-> Support for negative values was added in PowerShell 7.
-
-**Max-substrings** does not specify the maximum number of objects that are
-returned. Its value equals the maximum number of times that a string is split.
-If you submit more than one string (an array of strings) to the `-split`
-operator, the **Max-substrings** limit is applied to each string separately.
+Specifies the maximum number of substrings returned by the split operation. The
+default is all the substrings split by the delimiter. If there are more
+substrings, they are concatenated to the final substring. If there are fewer
+substrings, all the substrings are returned. A value of 0 returns all the
+substrings.
 
 Example:
 
@@ -154,6 +126,46 @@ Earth
 Mars
 Jupiter,Saturn,Uranus,Neptune
 ```
+
+If you submit more than one string (an array of strings) to the `-split`
+operator, the `Max-substrings` limit is applied to each string separately.
+
+```powershell
+$c = 'a,b,c','1,2,3,4,5'
+$c -split ',', 3
+
+a
+b
+c
+1
+2
+3,4,5
+```
+
+`<Max-substrings>` does not specify the maximum number of objects that are
+returned. If you use In the following example, `<Max-substrings>` is set to 3.
+This results in three substring values, but a total of five strings
+in the resulting output. The delimiter is included after the splits, until the
+maximum of three substrings is reached. Additional delimiters in the final
+substring become part of the substring.
+
+```powershell
+'Chocolate-Vanilla-Strawberry-Blueberry' -split '(-)', 3
+```
+
+```Output
+Chocolate
+-
+Vanilla
+-
+Strawberry-Blueberry
+```
+
+Negative values return the amount of substrings requested starting
+from the end of the input string.
+
+> [!NOTE]
+> Support for negative values was added in PowerShell 7.
 
 ```powershell
 $c = "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune"

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Split.md
@@ -107,9 +107,9 @@ Address
 ### `<Max-substrings>`
 
 Specifies the maximum number of substrings returned by the split operation. The
-default is all the substrings split by the delimiter. If there are more
+default is all substrings split by the delimiter. If there are more
 substrings, they are concatenated to the final substring. If there are fewer
-substrings, all the substrings are returned. A value of 0 returns all the
+substrings, all substrings are returned. A value of 0 returns all the
 substrings.
 
 Example:
@@ -143,9 +143,9 @@ c
 ```
 
 `<Max-substrings>` does not specify the maximum number of objects that are
-returned. If you use In the following example, `<Max-substrings>` is set to 3.
+returned. In the following example, `<Max-substrings>` is set to 3.
 This results in three substring values, but a total of five strings
-in the resulting output. The delimiter is included after the splits, until the
+in the resulting output. The delimiter is included after the splits until the
 maximum of three substrings is reached. Additional delimiters in the final
 substring become part of the substring.
 
@@ -514,4 +514,3 @@ LastName, FirstName
 [about_Comparison_Operators](about_Comparison_Operators.md)
 
 [about_Join](about_Join.md)
-

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Split.md
@@ -1,8 +1,7 @@
 ---
-description: Explains how to use the Split operator to split one or more strings into substrings. 
-keywords: powershell,cmdlet
+description: Explains how to use the Split operator to split one or more strings into substrings.
 Locale: en-US
-ms.date: 03/24/2020
+ms.date: 03/30/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_split?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Split
@@ -72,7 +71,7 @@ whitespace, including spaces and non-printable characters, such as newline
 (\`n) and tab (\`t). When the strings are split, the delimiter is omitted from
 all the substrings. Example:
 
-```
+```powershell
 "Lastname:FirstName:Address" -split ":"
 Lastname
 FirstName
@@ -81,7 +80,7 @@ Address
 
 By default, the delimiter is omitted from the results. To preserve all or part
 of the delimiter, enclose in parentheses the part that you want to preserve.
-If the \<Max-substrings\> parameter is added, this takes precedence when your
+If the `<Max-substrings>` parameter is added, this takes precedence when your
 command splits up the collection. If you opt to include a delimiter as part of
 the output, the command returns the delimiter as part of the output; however,
 splitting the string to return the delimiter as part of output does not count
@@ -89,7 +88,7 @@ as a split.
 
 Examples:
 
-```
+```powershell
 "Lastname:FirstName:Address" -split "(:)"
 Lastname
 :
@@ -105,40 +104,13 @@ FirstName
 Address
 ```
 
-In the following example, \<Max-substrings\> is set to 3. This results in
-three splits of the string values, but a total of five strings in the
-resulting output; the delimiter is included after the splits, until the
-maximum of three substrings is reached. Additional delimiters in the final
-substring become part of the substring.
+### `<Max-substrings>`
 
-```powershell
-'Chocolate-Vanilla-Strawberry-Blueberry' -split '(-)', 3
-```
-
-```Output
-Chocolate
--
-Vanilla
--
-Strawberry-Blueberry
-```
-
-### \<Max-substrings\>
-
-Specifies the maximum number of times that a string is split. The default is
-all the substrings split by the delimiter. If there are more substrings, they
-are concatenated to the final substring. If there are fewer substrings, all
-the substrings are returned. A value of 0 returns all the substrings. Negative
-values return the amount of substrings requested starting from the end of the
-input string.
-
-> [!NOTE]
-> Support for negative values was added in PowerShell 7.
-
-**Max-substrings** does not specify the maximum number of objects that are
-returned. Its value equals the maximum number of times that a string is split.
-If you submit more than one string (an array of strings) to the `-split`
-operator, the **Max-substrings** limit is applied to each string separately.
+Specifies the maximum number of substrings returned by the split operation. The
+default is all the substrings split by the delimiter. If there are more
+substrings, they are concatenated to the final substring. If there are fewer
+substrings, all the substrings are returned. A value of 0 returns all the
+substrings.
 
 Example:
 
@@ -154,6 +126,46 @@ Earth
 Mars
 Jupiter,Saturn,Uranus,Neptune
 ```
+
+If you submit more than one string (an array of strings) to the `-split`
+operator, the `Max-substrings` limit is applied to each string separately.
+
+```powershell
+$c = 'a,b,c','1,2,3,4,5'
+$c -split ',', 3
+
+a
+b
+c
+1
+2
+3,4,5
+```
+
+`<Max-substrings>` does not specify the maximum number of objects that are
+returned. If you use In the following example, `<Max-substrings>` is set to 3.
+This results in three substring values, but a total of five strings
+in the resulting output. The delimiter is included after the splits, until the
+maximum of three substrings is reached. Additional delimiters in the final
+substring become part of the substring.
+
+```powershell
+'Chocolate-Vanilla-Strawberry-Blueberry' -split '(-)', 3
+```
+
+```Output
+Chocolate
+-
+Vanilla
+-
+Strawberry-Blueberry
+```
+
+Negative values return the amount of substrings requested starting
+from the end of the input string.
+
+> [!NOTE]
+> Support for negative values was added in PowerShell 7.
 
 ```powershell
 $c = "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune"

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Split.md
@@ -107,9 +107,9 @@ Address
 ### `<Max-substrings>`
 
 Specifies the maximum number of substrings returned by the split operation. The
-default is all the substrings split by the delimiter. If there are more
+default is all substrings split by the delimiter. If there are more
 substrings, they are concatenated to the final substring. If there are fewer
-substrings, all the substrings are returned. A value of 0 returns all the
+substrings, all substrings are returned. A value of 0 returns all the
 substrings.
 
 Example:
@@ -143,9 +143,9 @@ c
 ```
 
 `<Max-substrings>` does not specify the maximum number of objects that are
-returned. If you use In the following example, `<Max-substrings>` is set to 3.
+returned. In the following example, `<Max-substrings>` is set to 3.
 This results in three substring values, but a total of five strings
-in the resulting output. The delimiter is included after the splits, until the
+in the resulting output. The delimiter is included after the splits until the
 maximum of three substrings is reached. Additional delimiters in the final
 substring become part of the substring.
 
@@ -514,4 +514,3 @@ LastName, FirstName
 [about_Comparison_Operators](about_Comparison_Operators.md)
 
 [about_Join](about_Join.md)
-

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Split.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to use the Split operator to split one or more strings into substrings.
 Locale: en-US
-ms.date: 03/24/2020
+ms.date: 03/30/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_split?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Split
@@ -71,7 +71,7 @@ whitespace, including spaces and non-printable characters, such as newline
 (\`n) and tab (\`t). When the strings are split, the delimiter is omitted from
 all the substrings. Example:
 
-```
+```powershell
 "Lastname:FirstName:Address" -split ":"
 Lastname
 FirstName
@@ -80,7 +80,7 @@ Address
 
 By default, the delimiter is omitted from the results. To preserve all or part
 of the delimiter, enclose in parentheses the part that you want to preserve.
-If the \<Max-substrings\> parameter is added, this takes precedence when your
+If the `<Max-substrings>` parameter is added, this takes precedence when your
 command splits up the collection. If you opt to include a delimiter as part of
 the output, the command returns the delimiter as part of the output; however,
 splitting the string to return the delimiter as part of output does not count
@@ -88,7 +88,7 @@ as a split.
 
 Examples:
 
-```
+```powershell
 "Lastname:FirstName:Address" -split "(:)"
 Lastname
 :
@@ -104,40 +104,13 @@ FirstName
 Address
 ```
 
-In the following example, \<Max-substrings\> is set to 3. This results in
-three splits of the string values, but a total of five strings in the
-resulting output; the delimiter is included after the splits, until the
-maximum of three substrings is reached. Additional delimiters in the final
-substring become part of the substring.
+### `<Max-substrings>`
 
-```powershell
-'Chocolate-Vanilla-Strawberry-Blueberry' -split '(-)', 3
-```
-
-```Output
-Chocolate
--
-Vanilla
--
-Strawberry-Blueberry
-```
-
-### \<Max-substrings\>
-
-Specifies the maximum number of times that a string is split. The default is
-all the substrings split by the delimiter. If there are more substrings, they
-are concatenated to the final substring. If there are fewer substrings, all
-the substrings are returned. A value of 0 returns all the substrings. Negative
-values return the amount of substrings requested starting from the end of the
-input string.
-
-> [!NOTE]
-> Support for negative values was added in PowerShell 7.
-
-**Max-substrings** does not specify the maximum number of objects that are
-returned. Its value equals the maximum number of times that a string is split.
-If you submit more than one string (an array of strings) to the `-split`
-operator, the **Max-substrings** limit is applied to each string separately.
+Specifies the maximum number of substrings returned by the split operation. The
+default is all the substrings split by the delimiter. If there are more
+substrings, they are concatenated to the final substring. If there are fewer
+substrings, all the substrings are returned. A value of 0 returns all the
+substrings.
 
 Example:
 
@@ -153,6 +126,46 @@ Earth
 Mars
 Jupiter,Saturn,Uranus,Neptune
 ```
+
+If you submit more than one string (an array of strings) to the `-split`
+operator, the `Max-substrings` limit is applied to each string separately.
+
+```powershell
+$c = 'a,b,c','1,2,3,4,5'
+$c -split ',', 3
+
+a
+b
+c
+1
+2
+3,4,5
+```
+
+`<Max-substrings>` does not specify the maximum number of objects that are
+returned. If you use In the following example, `<Max-substrings>` is set to 3.
+This results in three substring values, but a total of five strings
+in the resulting output. The delimiter is included after the splits, until the
+maximum of three substrings is reached. Additional delimiters in the final
+substring become part of the substring.
+
+```powershell
+'Chocolate-Vanilla-Strawberry-Blueberry' -split '(-)', 3
+```
+
+```Output
+Chocolate
+-
+Vanilla
+-
+Strawberry-Blueberry
+```
+
+Negative values return the amount of substrings requested starting
+from the end of the input string.
+
+> [!NOTE]
+> Support for negative values was added in PowerShell 7.
 
 ```powershell
 $c = "Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune"


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Fixes [AB#1830928](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1830928) - Fixes #7393 - clarify max-strings behavior

<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords