### PR TITLE
To resolve issue #7442

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Test-Path.md
@@ -184,16 +184,14 @@ At line:1 char:11
 
 ### Example 8: Test a path with whitespace as the value
 
-When a whitespace or empty string is provided for the the `-Path` parameter, it returns **False**.
-The following example show whitespace and empty string.
+When a whitespace is provided for the the `-Path` parameter, it returns **False**.
+The following example show whitespace.
 
 ```powershell
 Test-Path ' '
-Test-Path ''
 ```
 
 ```Output
-False
 False
 ```
 


### PR DESCRIPTION
Empty string with Test-Path will always throw NullPathNotPermitted error. Example 8 will throw error instead of False value in case of **Test-Path -Path ''**.  We need to re-construct our example with white space only.

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [x] Scripting and development

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
