### PR TITLE
Fix broken links from OPS report

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
@@ -22,7 +22,7 @@ jobs types provided by PowerShell to support concurrency.
   machine. For more information, see [about_Jobs](about_Jobs.md).
 - `PSTaskJob` or `ThreadJob` - Commands and scripts run in a separate thread
   within the same process on the local machine. For more information, see
-  [about_Thread_Jobs](/powershell/module/ThreadJob/about_Thread_Jobs).
+  [about_Thread_Jobs](/powershell/module/Microsoft.PowerShell.Core/About/about_Thread_Jobs).
 
 Running scripts remotely, on a separate machine or in a separate process,
 provide great isolation. Any errors that occur in the remote job do not affect

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
@@ -22,7 +22,7 @@ jobs types provided by PowerShell to support concurrency.
   machine. For more information, see [about_Jobs](about_Jobs.md).
 - `PSTaskJob` or `ThreadJob` - Commands and scripts run in a separate thread
   within the same process on the local machine. For more information, see
-  [about_Thread_Jobs](/powershell/module/ThreadJob/about_Thread_Jobs).
+  [about_Thread_Jobs](about_Thread_Jobs.md).
 
 Running scripts remotely, on a separate machine or in a separate process,
 provide great isolation. Any errors that occur in the remote job do not affect

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
@@ -21,7 +21,7 @@ jobs types provided by PowerShell to support concurrency.
   machine. For more information, see [about_Jobs](about_Jobs.md).
 - `PSTaskJob` or `ThreadJob` - Commands and scripts run in a separate thread
   within the same process on the local machine. For more information, see
-  [about_Thread_Jobs](/powershell/module/ThreadJob/about_Thread_Jobs).
+  [about_Thread_Jobs](about_Thread_Jobs.md).
 
 Running scripts remotely, on a separate machine or in a separate process,
 provide great isolation. Any errors that occur in the remote job do not affect

--- a/reference/docs-conceptual/community/contributing/managing-issues.md
+++ b/reference/docs-conceptual/community/contributing/managing-issues.md
@@ -71,7 +71,6 @@ meets weekly to discuss issues that need triage or remain unresolved.
   | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
   | dsc      | [https://windowsserver.uservoice.com/forums/301869-powershell](https://windowsserver.uservoice.com/forums/301869-powershell) |
   | gallery  | [https://github.com/powershell/powershellgallery/issues/new](https://github.com/powershell/powershellgallery/issues/new)     |
-  | jea      | [https://github.com/powershell/jea/issues/new](https://github.com/powershell/jea/issues/new)                                 |
   | wmf      | [https://windowsserver.uservoice.com/forums/301869-powershell](https://windowsserver.uservoice.com/forums/301869-powershell) |
 
 ### Support requests

--- a/reference/docs-conceptual/learn/deep-dives/everything-about-pscustomobject.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-pscustomobject.md
@@ -399,7 +399,7 @@ something and can find a way to work this into your scripts.
 [about_Functions_OutputTypeAttribute]: /powershell/module/microsoft.powershell.core/about/about_functions_outputtypeattribute
 [The many ways to read and write to files]: https://powershellexplained.com/2017-03-18-Powershell-reading-and-saving-data-to-files
 [post by /u/markekraus]: https://www.reddit.com/r/PowerShell/comments/590awc/is_it_possible_to_initialize_a_pscustoobject_with/
-[Adam Bertram]: http://www.adamtheautomator.com/building-custom-object-types-PowerShell-pstypename/
+[Adam Bertram]: http://www.adamtheautomator.com/
 [Mike Shepard]: https://powershellstation.com/2016/05/22/custom-objects-and-pstypename/
 [psunplugged]: https://www.youtube.com/watch?v=Ab46gHXNm8Q
 [Update-TypeData]: /powershell/module/microsoft.powershell.utility/update-typedata

--- a/reference/docs-conceptual/learn/experimental-features.md
+++ b/reference/docs-conceptual/learn/experimental-features.md
@@ -117,7 +117,7 @@ UnderlineOff     Property   string UnderlineOff {get;}
 The base members return strings of ANSI escape sequences mapped to their names. The values are
 settable to allow customization.
 
-For more information, see [about_Automatic_Variables](/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md)
+For more information, see [about_Automatic_Variables](/powershell/module/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md)
 
 > [!NOTE]
 > For C# developers, you can access `PSStyle` as a singleton. Usage will look like this:


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Fixes AB#1669513 - Fix broken links from OPS report

<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [x] Learning PowerShell
  - [ ] PowerShell 101
  - [x] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [x] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [ ] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords