### PR TITLE
Fixes #7301 - Updates about_Preference_Variables

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Variables that customize the behavior of PowerShell.
 Locale: en-US
-ms.date: 04/22/2020
+ms.date: 04/12/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Preference_Variables
@@ -484,11 +484,12 @@ Determines the display format of error messages in PowerShell.
 The valid values are as follows:
 
 - **ConciseView**: (Default) Provides a concise error message and a refactored
-  view for advanced module builders. If the error is from command line it's a
-  single line error message. Otherwise, you receive a multiline error message
-  that contains the error and a pointer to the error showing where it occurs in
-  that line. If the terminal supports Virtual Terminal, then ANSI color codes
-  are used to provide color accent. The Accent color can be changed at
+  view for advanced module builders. As of PowerShell 7.2, if the error is from
+  the command line or a script module the output is a single line error
+  message. Otherwise, you receive a multiline error message that contains the
+  error and a pointer to the error showing where it occurs in that line. If the
+  terminal supports Virtual Terminal, then ANSI color codes are used to provide
+  color accent. The Accent color can be changed at
   `$Host.PrivateData.ErrorAccentColor`. Use `Get-Error` cmdlet for a
   comprehensive detailed view of the fully qualified error, including inner
   exceptions.


### PR DESCRIPTION
# PR Summary

Updates information about ``$ErrorView`` **ConciseView** option. In PowerShell 7.2, if an error is thrown from a script module, it is now a single line error. There is no more location data and if you want to see that you will use ``Get-Error``.

## PR Context

Fixes #7301
Fixes [AB#1834385](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1834385)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords