### PR TITLE
Fixes #7464 - Updates Enter-PSSession + 2 more

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -381,7 +381,7 @@ Accept wildcard characters: False
 ### -ConnectingTimeout
 
 Specifies the amount of time in milliseconds allowed for the initial SSH connection to complete. If
-the connection doesn't complete within the specified time, and error is returned.
+the connection doesn't complete within the specified time, an error is returned.
 
 This parameter was introduced in PowerShell 7.2
 

--- a/reference/7.2/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -9,10 +9,10 @@ title: Enter-PSSession
 ---
 # Enter-PSSession
 
-## SYNOPSIS
+## Synopsis
 Starts an interactive session with a remote computer.
 
-## SYNTAX
+## Syntax
 
 ### ComputerName (Default)
 
@@ -27,7 +27,7 @@ Enter-PSSession [-ComputerName] <String> [-EnableNetworkAccess] [[-Credential] <
 
 ```
 Enter-PSSession [-HostName] <String> [-Port <Int32>] [-UserName <String>] [-KeyFilePath <String>]
- [-SSHTransport] [<CommonParameters>]
+ [-SSHTransport] [-ConnectingTimeout <int>] [<CommonParameters>]
 ```
 
 ### Session
@@ -82,7 +82,7 @@ Enter-PSSession [-ContainerId] <String> [-ConfigurationName <String>] [-RunAsAdm
  [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Enter-PSSession` cmdlet starts an interactive session with a single remote computer.
 During the session, the commands that you type run on the remote computer, just as if you were
@@ -104,7 +104,7 @@ information about how to set up PowerShell SSH remoting, see
 To end the interactive session and disconnect from the remote computer, use the `Exit-PSSession`
 cmdlet, or type `exit`.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Start an interactive session
 
@@ -201,7 +201,7 @@ This example shows how to start an interactive session using SSH. It uses the **
 specify the port to use and the **KeyFilePath** parameter to specify an RSA key used to authenticate
 the user on the remote computer.
 
-## PARAMETERS
+## Parameters
 
 ### -AllowRedirection
 
@@ -375,6 +375,25 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ConnectingTimeout
+
+Specifies the amount of time in milliseconds allowed for the initial SSH connection to complete. If
+the connection doesn't complete within the specified time, and error is returned.
+
+This parameter was introduced in PowerShell 7.2
+
+```yaml
+Type: System.Int32
+Parameter Sets: SSHHost
+Aliases:
+
+Required: False
+Position: Named
+Default value: unlimited
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -853,19 +872,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -WarningAction, and -WarningVariable. For more information, see
 [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.String, System.Management.Automation.Runspaces.PSSession
 
 You can pipe a computer name, as a string, or a session object to this cmdlet.
 
-## OUTPUTS
+## Outputs
 
 ### None
 
 The cmdlet does not return any output.
 
-## NOTES
+## Notes
 
 To connect to a remote computer, you must be a member of the Administrators group on the remote
 computer. To start an interactive session on the local computer, you must start PowerShell with the
@@ -904,7 +923,7 @@ Prior to PowerShell 7.1, remoting over SSH did not support second-hop remote ses
 capability was limited to sessions using WinRM. PowerShell 7.1 allows `Enter-PSSession` and
 `Enter-PSHostProcess` to work from within any interactive remote session.
 
-## RELATED LINKS
+## Related Links
 
 [Exit-PSSession](Exit-PSSession.md)
 

--- a/reference/7.2/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -933,7 +933,7 @@ Accept wildcard characters: False
 ### -ConnectingTimeout
 
 Specifies the amount of time in milliseconds allowed for the initial SSH connection to complete. If
-the connection doesn't complete within the specified time, and error is returned.
+the connection doesn't complete within the specified time, an error is returned.
 
 This parameter was introduced in PowerShell 7.2
 
@@ -1685,4 +1685,3 @@ PowerShell SSH remoting, see
 [Remove-PSSession](Remove-PSSession.md)
 
 [WSMan Provider](../Microsoft.WsMan.Management/About/about_WSMan_Provider.md)
-

--- a/reference/7.2/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -10,10 +10,10 @@ title: Invoke-Command
 
 # Invoke-Command
 
-## SYNOPSIS
+## Synopsis
 Runs commands on local and remote computers.
 
-## SYNTAX
+## Syntax
 
 ### InProcess (Default)
 
@@ -120,7 +120,7 @@ Invoke-Command -Credential <PSCredential> [-ConfigurationName <String>] [-Thrott
 Invoke-Command [-Port <Int32>] [-AsJob] [-HideComputerName] [-JobName <String>]
  [-ScriptBlock] <ScriptBlock> -HostName <String[]> [-UserName <String>] [-KeyFilePath <String>]
  [-SSHTransport] [-RemoteDebug] [-InputObject <PSObject>] [-ArgumentList <Object[]>]
- [-Subsystem <String>] [<CommonParameters>]
+ [-Subsystem <String>] [-ConnectingTimeout <int>] [<CommonParameters>]
 ```
 
 ### ContainerId
@@ -162,7 +162,7 @@ Invoke-Command [-AsJob] [-HideComputerName] -FilePath <String> -SSHConnection <H
  [-RemoteDebug] [-InputObject <PSObject>] [-ArgumentList <Object[]>] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Invoke-Command` cmdlet runs commands on a local or remote computer and returns all output from
 the commands, including errors. Using a single `Invoke-Command` command, you can run commands on
@@ -190,7 +190,7 @@ connection information. For more information about how to set up PowerShell SSH 
 
 Some code samples use splatting to reduce the line length. For more information, see [about_Splatting](./About/about_Splatting.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Run a script on a server
 
@@ -690,7 +690,7 @@ $sshConnections =
 $results = Invoke-Command -FilePath c:\Scripts\CollectEvents.ps1 -SSHConnection $sshConnections
 ```
 
-## PARAMETERS
+## Parameters
 
 ### -AllowRedirection
 
@@ -927,6 +927,25 @@ Required: False
 Position: Named
 Default value: $PSSessionConfigurationName if set on the local computer, otherwise Microsoft.PowerShell
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ConnectingTimeout
+
+Specifies the amount of time in milliseconds allowed for the initial SSH connection to complete. If
+the connection doesn't complete within the specified time, and error is returned.
+
+This parameter was introduced in PowerShell 7.2
+
+```yaml
+Type: System.Int32
+Parameter Sets: SSHHost
+Aliases:
+
+Required: False
+Position: Named
+Default value: unlimited
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -1577,14 +1596,14 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.ScriptBlock
 
 You can pipe a command in a script block to `Invoke-Command`. Use the `$Input` automatic variable to
 represent the input objects in the command.
 
-## OUTPUTS
+## Outputs
 
 ### System.Management.Automation.PSRemotingJob, System.Management.Automation.Runspaces.PSSession, or the output of the invoked command
 
@@ -1592,7 +1611,7 @@ This cmdlet returns a job object, if you use the **AsJob** parameter. If you spe
 **InDisconnectedSession** parameter, `Invoke-Command` returns a **PSSession** object. Otherwise, it
 returns the output of the invoked command, which is the value of the **ScriptBlock** parameter.
 
-## NOTES
+## Notes
 
 On Windows Vista, and later versions of the Windows operating system, to use the **ComputerName**
 parameter of `Invoke-Command` to run a command on the local computer, you must run PowerShell using
@@ -1639,7 +1658,7 @@ disconnect/reconnect features are currently not supported. For more information 
 PowerShell SSH remoting, see
 [PowerShell Remoting Over SSH](/powershell/scripting/learn/remoting/ssh-remoting-in-powershell-core).
 
-## RELATED LINKS
+## Related Links
 
 [about_PSSessions](./About/about_PSSessions.md)
 

--- a/reference/7.2/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/New-PSSession.md
@@ -9,10 +9,10 @@ title: New-PSSession
 ---
 # New-PSSession
 
-## SYNOPSIS
+## Synopsis
 Creates a persistent connection to a local or remote computer.
 
-## SYNTAX
+## Syntax
 
 ### ComputerName (Default)
 
@@ -69,8 +69,8 @@ New-PSSession [-Name <String[]>] [-UseWindowsPowerShell] [<CommonParameters>]
 ### SSHHost
 
 ```
-New-PSSession [-Name <String[]>] [-Port <Int32>] [-HostName] <String[]> [-UserName <String>]
- [-KeyFilePath <String>] [-SSHTransport] [-Subsystem <String>] [<CommonParameters>]
+New-PSSession [-Name <String[]>] [-Port <Int32>] [-HostName] <String[]> [-UserName <String>] [-KeyFilePath <String>]
+[-SSHTransport] [-Subsystem <String>] [-ConnectingTimeout <int>] [<CommonParameters>]
 ```
 
 ### SSHHostHashParam
@@ -79,7 +79,7 @@ New-PSSession [-Name <String[]>] [-Port <Int32>] [-HostName] <String[]> [-UserNa
 New-PSSession [-Name <String[]>] -SSHConnection <Hashtable[]> [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `New-PSSession` cmdlet creates a PowerShell session (**PSSession**) on a local or remote
 computer. When you create a **PSSession**, PowerShell establishes a persistent connection to the
@@ -110,7 +110,7 @@ connection information. For more information about how to set up PowerShell SSH 
 > this if you are in an environment where you can be certain of the server certificate and the
 > network connection to the target system.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Create a session on the local computer
 
@@ -306,7 +306,7 @@ This example shows how to create multiple sessions using Secure Shell (SSH) and 
 contain connection information for each session. Note that this example requires that the target
 remote computers have SSH configured to support key based user authentication.
 
-## PARAMETERS
+## Parameters
 
 ### -AllowRedirection
 
@@ -478,6 +478,25 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ConnectingTimeout
+
+Specifies the amount of time in milliseconds allowed for the initial SSH connection to complete. If
+the connection doesn't complete within the specified time, and error is returned.
+
+This parameter was introduced in PowerShell 7.2
+
+```yaml
+Type: System.Int32
+Parameter Sets: SSHHost
+Aliases:
+
+Required: False
+Position: Named
+Default value: unlimited
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -969,17 +988,17 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -WarningAction, and -WarningVariable. For more information, see about_CommonParameters
 (https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.String, System.URI, System.Management.Automation.Runspaces.PSSession
 
 You can pipe a string, URI, or session object to this cmdlet.
 
-## OUTPUTS
+## Outputs
 
 ### System.Management.Automation.Runspaces.PSSession
 
-## NOTES
+## Notes
 
 - This cmdlet uses the PowerShell remoting infrastructure. To use this cmdlet, the local
   computer and any remote computers must be configured for PowerShell remoting. For more
@@ -998,7 +1017,7 @@ You can pipe a string, URI, or session object to this cmdlet.
   more information about how to set up PowerShell SSH remoting, see
   [PowerShell Remoting Over SSH](/powershell/scripting/learn/remoting/ssh-remoting-in-powershell-core).
 
-## RELATED LINKS
+## Related Links
 
 [Connect-PSSession](Connect-PSSession.md)
 

--- a/reference/7.2/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/New-PSSession.md
@@ -484,7 +484,7 @@ Accept wildcard characters: False
 ### -ConnectingTimeout
 
 Specifies the amount of time in milliseconds allowed for the initial SSH connection to complete. If
-the connection doesn't complete within the specified time, and error is returned.
+the connection doesn't complete within the specified time, an error is returned.
 
 This parameter was introduced in PowerShell 7.2
 
@@ -1034,4 +1034,3 @@ You can pipe a string, URI, or session object to this cmdlet.
 [Receive-PSSession](Receive-PSSession.md)
 
 [Remove-PSSession](Remove-PSSession.md)
-


### PR DESCRIPTION
# PR Summary

Adds ``-ConnectingTimeout`` parameter information in PowerShell 7.2 docs.

## PR Context

Fixes #7464
Fixes [AB#1836019](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1836019)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords