### PR TITLE
Update Write-Progress.md

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -174,6 +174,8 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+> [!NOTE]
+> If backward compatibility to PowerShell version 2 is required, the `-Completed` parameter also requires the `-Status <String>` parameter.
 
 ### -CurrentOperation
 


### PR DESCRIPTION
With great disappointment some of us still have to write code that may be run on PowerShell v2.  I've bumped into this issue a lot since I've started using the write-progress cmdlet.

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
