### PR TITLE
fix: Fix minor typos & grammatical errors in `Out-String.md`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
@@ -12,7 +12,7 @@ title: Out-String
 # Out-String
 
 ## Synopsis
-Outputs input objects as a strings.
+Outputs input objects as a string.
 
 ## Syntax
 
@@ -26,7 +26,7 @@ Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParamete
 
 The `Out-String` cmdlet converts input objects into strings. By default, `Out-String`
 accumulates the strings and returns them as a single string, but you can use the **Stream**
-parameter to direct `Out-String` to return one line at a time or create and array of strings. This
+parameter to direct `Out-String` to return one line at a time or create an array of strings. This
 cmdlet lets you search and manipulate string output as you would in traditional shells when object
 manipulation is less convenient.
 
@@ -96,9 +96,9 @@ Alias           gcm -> Get-Command
 
 `Get-Alias` gets the **System.Management.Automation.AliasInfo** objects, one for each alias, and
 sends the objects down the pipeline. `Out-String` uses the **Stream** parameter to convert each
-object to a string rather concatenating all the objects into a single string. The **System.String**
-objects are sent down the pipeline and `Select-String` uses the **Pattern** parameter to find
-matches for the text **gcm**.
+object to a string rather than concatenating all the objects into a single string.
+The **System.String** objects are sent down the pipeline and `Select-String` uses the **Pattern**
+parameter to find matches for the text **gcm**.
 
 > [!NOTE]
 > If you omit the **Stream** parameter, the command displays all the aliases because `Select-String`

--- a/reference/7.0/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Out-String.md
@@ -12,7 +12,7 @@ title: Out-String
 # Out-String
 
 ## Synopsis
-Outputs input objects as a strings.
+Outputs input objects as a string.
 
 ## Syntax
 
@@ -32,7 +32,7 @@ Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParamete
 
 The `Out-String` cmdlet converts input objects into strings. By default, `Out-String`
 accumulates the strings and returns them as a single string, but you can use the **Stream**
-parameter to direct `Out-String` to return one line at a time or create and array of strings. This
+parameter to direct `Out-String` to return one line at a time or create an array of strings. This
 cmdlet lets you search and manipulate string output as you would in traditional shells when object
 manipulation is less convenient.
 
@@ -102,9 +102,9 @@ Alias           gcm -> Get-Command
 
 `Get-Alias` gets the **System.Management.Automation.AliasInfo** objects, one for each alias, and
 sends the objects down the pipeline. `Out-String` uses the **Stream** parameter to convert each
-object to a string rather concatenating all the objects into a single string. The **System.String**
-objects are sent down the pipeline and `Select-String` uses the **Pattern** parameter to find
-matches for the text **gcm**.
+object to a string rather than concatenating all the objects into a single string.
+The **System.String** objects are sent down the pipeline and `Select-String` uses the **Pattern**
+parameter to find matches for the text **gcm**.
 
 > [!NOTE]
 > If you omit the **Stream** parameter, the command displays all the aliases because `Select-String`

--- a/reference/7.1/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Out-String.md
@@ -12,7 +12,7 @@ title: Out-String
 # Out-String
 
 ## Synopsis
-Outputs input objects as a strings.
+Outputs input objects as a string.
 
 ## Syntax
 
@@ -32,7 +32,7 @@ Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParamete
 
 The `Out-String` cmdlet converts input objects into strings. By default, `Out-String`
 accumulates the strings and returns them as a single string, but you can use the **Stream**
-parameter to direct `Out-String` to return one line at a time or create and array of strings. This
+parameter to direct `Out-String` to return one line at a time or create an array of strings. This
 cmdlet lets you search and manipulate string output as you would in traditional shells when object
 manipulation is less convenient.
 
@@ -102,9 +102,9 @@ Alias           gcm -> Get-Command
 
 `Get-Alias` gets the **System.Management.Automation.AliasInfo** objects, one for each alias, and
 sends the objects down the pipeline. `Out-String` uses the **Stream** parameter to convert each
-object to a string rather concatenating all the objects into a single string. The **System.String**
-objects are sent down the pipeline and `Select-String` uses the **Pattern** parameter to find
-matches for the text **gcm**.
+object to a string rather than concatenating all the objects into a single string.
+The **System.String** objects are sent down the pipeline and `Select-String` uses the **Pattern**
+parameter to find matches for the text **gcm**.
 
 > [!NOTE]
 > If you omit the **Stream** parameter, the command displays all the aliases because `Select-String`

--- a/reference/7.2/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Out-String.md
@@ -11,7 +11,7 @@ title: Out-String
 # Out-String
 
 ## Synopsis
-Outputs input objects as a strings.
+Outputs input objects as a string.
 
 ## Syntax
 
@@ -31,7 +31,7 @@ Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParamete
 
 The `Out-String` cmdlet converts input objects into strings. By default, `Out-String`
 accumulates the strings and returns them as a single string, but you can use the **Stream**
-parameter to direct `Out-String` to return one line at a time or create and array of strings. This
+parameter to direct `Out-String` to return one line at a time or create an array of strings. This
 cmdlet lets you search and manipulate string output as you would in traditional shells when object
 manipulation is less convenient.
 
@@ -101,9 +101,9 @@ Alias           gcm -> Get-Command
 
 `Get-Alias` gets the **System.Management.Automation.AliasInfo** objects, one for each alias, and
 sends the objects down the pipeline. `Out-String` uses the **Stream** parameter to convert each
-object to a string rather concatenating all the objects into a single string. The **System.String**
-objects are sent down the pipeline and `Select-String` uses the **Pattern** parameter to find
-matches for the text **gcm**.
+object to a string rather than concatenating all the objects into a single string.
+The **System.String** objects are sent down the pipeline and `Select-String` uses the **Pattern**
+parameter to find matches for the text **gcm**.
 
 > [!NOTE]
 > If you omit the **Stream** parameter, the command displays all the aliases because `Select-String`


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

- Replace "strings" with "string" in **Synopsis**
- Replace "_and_ array of strings" with "_an_ array of strings" in **Description**
- Replace "rather concatenating" with "rather _than_ concatenating" in **Example 2**

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [x] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [x] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
