### PR TITLE
update menubar titles and their description

### DIFF
--- a/reference/docs-conceptual/windows-powershell/ise/Exploring-the-Windows-PowerShell-ISE.md
+++ b/reference/docs-conceptual/windows-powershell/ise/Exploring-the-Windows-PowerShell-ISE.md
@@ -55,8 +55,8 @@ The following buttons are located on the toolbar.
 | **Show Script Pane Top**       | Moves the Script Pane to the top in the display.                                                                                                                                 |
 | **Show Script Pane Right**     | Moves the Script Pane to the right in the display.                                                                                                                               |
 | **Show Script Pane Maximized** | Maximizes the Script Pane.                                                                                                                                                       |
-| **Show Command Window** | Shows the Commands Pane for installed Modules, as a separate Window. 
-| **Show Command Add-on** | Shows the Commands Pane for installed Modules, as a sidebar Add-on. 
+| **Show Command Window** | Shows the Commands Pane for installed Modules, as a separate Window. |
+| **Show Command Add-on** | Shows the Commands Pane for installed Modules, as a sidebar Add-on. |
 
 
 ## Script Tab

--- a/reference/docs-conceptual/windows-powershell/ise/Exploring-the-Windows-PowerShell-ISE.md
+++ b/reference/docs-conceptual/windows-powershell/ise/Exploring-the-Windows-PowerShell-ISE.md
@@ -44,17 +44,20 @@ The following buttons are located on the toolbar.
 | **Cut**                        | Cuts the selected text and copies it to the clipboard.                                                                                                                           |
 | **Copy**                       | Copies the selected text to the clipboard.                                                                                                                                       |
 | **Paste**                      | Pastes the contents of the clipboard at the cursor location.                                                                                                                     |
-| **Clear Output Pane**          | Clears all content in the Output Pane.                                                                                                                                           |
+| **Clear Console Pane**          | Clears all content in the Console Pane.                                                                                                                                           |
 | **Undo**                       | Reverses the action that was just performed.                                                                                                                                     |
 | **Redo**                       | Performs the action that was just undone.                                                                                                                                        |
 | **Run Script**                 | Runs a script.                                                                                                                                                                   |
 | **Run Selection**              | Runs a selected portion of a script.                                                                                                                                             |
-| **Stop Execution**             | Stops a script that is running.                                                                                                                                                  |
+| **Stop Operation**             | Stops a script that is running.                                                                                                                                                  |
 | **New Remote PowerShell Tab**  | Creates a new PowerShell Tab that establishes a session on a remote computer. A dialog box appears and prompts you to enter details required to establish the remote connection. |
 | **Start PowerShell.exe**       | Opens a PowerShell Console.                                                                                                                                                      |
 | **Show Script Pane Top**       | Moves the Script Pane to the top in the display.                                                                                                                                 |
 | **Show Script Pane Right**     | Moves the Script Pane to the right in the display.                                                                                                                               |
 | **Show Script Pane Maximized** | Maximizes the Script Pane.                                                                                                                                                       |
+| **Show Command Window** | Shows the Commands Pane for installed Modules, as a separate Window. 
+| **Show Command Add-on** | Shows the Commands Pane for installed Modules, as a sidebar Add-on. 
+
 
 ## Script Tab
 


### PR DESCRIPTION
Tooltip title says "Clear Console Pane", not Output Pane (powershell v5.1.19041.x), so even though we understand what this is, just wanting to be as accurate as possible when having any type of documentation  reference real world software and what the user exactly sees.


**Conceptual content**
- [X] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [X] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.


