### PR TITLE
Fix typo in final NOTE section

### DIFF
--- a/reference/docs-conceptual/install/Migrating-from-Windows-PowerShell-51-to-PowerShell-7.md
+++ b/reference/docs-conceptual/install/Migrating-from-Windows-PowerShell-51-to-PowerShell-7.md
@@ -311,7 +311,7 @@ For details about customizing the VSCode layout to ISE, see
 [How to Replicate the ISE Experience in Visual Studio Code](/powershell/scripting/components/vscode/how-to-replicate-the-ise-experience-in-vscode)
 
 > [!NOTE]
-> There no plans to update the ISE with new features. The ISE is now a user-uninstallable feature in
+> There are no plans to update the ISE with new features. The ISE is now a user-uninstallable feature in
 > the latest versions of Windows 10 and Windows Server. There are no plans to permanently remove the
 > ISE. The PowerShell Team and its partners are focused on improving the scripting experience in the
 > PowerShell extension for Visual Studio Code.


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fix small typo in final NOTE section of the file Migrating-from-Windows-PowerShell-51-to-PowerShell-7.md

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [x] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
