### PR TITLE
Fixes #7579 - Updates Get-ChildItem

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -454,14 +454,17 @@ Accept wildcard characters: False
 
 ### -Exclude
 
-Specifies, as a string array, a property or property that this cmdlet excludes from the operation.
-The value of this parameter qualifies the **Path** parameter. Enter a path element or pattern, such
-as `*.txt` or `A*`. Wildcard characters are accepted.
+Specifies an array of one or more string patterns to be matched as the cmdlet gets child items. Any
+matching item is excluded from the output. Enter a path element or pattern, such as `*.txt` or `A*`.
+Wildcard characters are accepted.
 
 A trailing asterisk (`*`) in the **Path** parameter is optional. For example, `-Path C:\Test\Logs`
 or `-Path C:\Test\Logs\*`. If a trailing asterisk (`*`) is included, the command recurses into the
 **Path** parameter's subdirectories. Without the asterisk (`*`), the contents of the **Path**
 parameter are displayed. More details are included in Example 5 and the Notes section.
+
+The **Include** and **Exclude** parameters can be used together. However, the exclusions are applied
+after the inclusions, which can affect the final output.
 
 ```yaml
 Type: System.String[]
@@ -550,11 +553,14 @@ Accept wildcard characters: False
 
 ### -Include
 
-Specifies, as a string array, an item or items that this cmdlet includes in the operation. The value
-of this parameter qualifies the **Path** parameter. Enter a path element or pattern, such as
-`"*.txt"`. Wildcard characters are permitted. The **Include** parameter is effective only when the
-command includes the contents of an item, such as `C:\Windows\*`, where the wildcard character
-specifies the contents of the `C:\Windows` directory.
+Specifies an array of one or more string patterns to be matched as the cmdlet gets child items. Any
+matching item is included in the output. Enter a path element or pattern, such as `"*.txt"`.
+Wildcard characters are permitted. The **Include** parameter is effective only when the command
+includes the contents of an item, such as `C:\Windows\*`, where the wildcard character specifies the
+contents of the `C:\Windows` directory.
+
+The **Include** and **Exclude** parameters can be used together. However, the exclusions are applied
+after the inclusions, which can affect the final output.
 
 ```yaml
 Type: System.String[]

--- a/reference/7.0/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -493,14 +493,17 @@ Accept wildcard characters: False
 
 ### -Exclude
 
-Specifies, as a string array, a property or property that this cmdlet excludes from the operation.
-The value of this parameter qualifies the **Path** parameter. Enter a path element or pattern, such
-as `*.txt` or `A*`. Wildcard characters are accepted.
+Specifies an array of one or more string patterns to be matched as the cmdlet gets child items. Any
+matching item is excluded from the output. Enter a path element or pattern, such as `*.txt` or `A*`.
+Wildcard characters are accepted.
 
 A trailing asterisk (`*`) in the **Path** parameter is optional. For example, `-Path C:\Test\Logs`
 or `-Path C:\Test\Logs\*`. If a trailing asterisk (`*`) is included, the command recurses into the
 **Path** parameter's subdirectories. Without the asterisk (`*`), the contents of the **Path**
 parameter are displayed. More details are included in Example 5 and the Notes section.
+
+The **Include** and **Exclude** parameters can be used together. However, the exclusions are applied
+after the inclusions, which can affect the final output.
 
 ```yaml
 Type: System.String[]
@@ -610,11 +613,14 @@ Accept wildcard characters: False
 
 ### -Include
 
-Specifies, as a string array, an item or items that this cmdlet includes in the operation. The value
-of this parameter qualifies the **Path** parameter. Enter a path element or pattern, such as
-`"*.txt"`. Wildcard characters are permitted. The **Include** parameter is effective only when the
-command includes the contents of an item, such as `C:\Windows\*`, where the wildcard character
-specifies the contents of the `C:\Windows` directory.
+Specifies an array of one or more string patterns to be matched as the cmdlet gets child items. Any
+matching item is included in the output. Enter a path element or pattern, such as `"*.txt"`.
+Wildcard characters are permitted. The **Include** parameter is effective only when the command
+includes the contents of an item, such as `C:\Windows\*`, where the wildcard character specifies the
+contents of the `C:\Windows` directory.
+
+The **Include** and **Exclude** parameters can be used together. However, the exclusions are applied
+after the inclusions, which can affect the final output.
 
 ```yaml
 Type: System.String[]

--- a/reference/7.1/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -496,14 +496,17 @@ Accept wildcard characters: False
 
 ### -Exclude
 
-Specifies, as a string array, a property or property that this cmdlet excludes from the operation.
-The value of this parameter qualifies the **Path** parameter. Enter a path element or pattern, such
-as `*.txt` or `A*`. Wildcard characters are accepted.
+Specifies an array of one or more string patterns to be matched as the cmdlet gets child items. Any
+matching item is excluded from the output. Enter a path element or pattern, such as `*.txt` or `A*`.
+Wildcard characters are accepted.
 
 A trailing asterisk (`*`) in the **Path** parameter is optional. For example, `-Path C:\Test\Logs`
 or `-Path C:\Test\Logs\*`. If a trailing asterisk (`*`) is included, the command recurses into the
 **Path** parameter's subdirectories. Without the asterisk (`*`), the contents of the **Path**
 parameter are displayed. More details are included in Example 5 and the Notes section.
+
+The **Include** and **Exclude** parameters can be used together. However, the exclusions are applied
+after the inclusions, which can affect the final output.
 
 ```yaml
 Type: System.String[]
@@ -613,11 +616,14 @@ Accept wildcard characters: False
 
 ### -Include
 
-Specifies, as a string array, an item or items that this cmdlet includes in the operation. The value
-of this parameter qualifies the **Path** parameter. Enter a path element or pattern, such as
-`"*.txt"`. Wildcard characters are permitted. The **Include** parameter is effective only when the
-command includes the contents of an item, such as `C:\Windows\*`, where the wildcard character
-specifies the contents of the `C:\Windows` directory.
+Specifies an array of one or more string patterns to be matched as the cmdlet gets child items. Any
+matching item is included in the output. Enter a path element or pattern, such as `"*.txt"`.
+Wildcard characters are permitted. The **Include** parameter is effective only when the command
+includes the contents of an item, such as `C:\Windows\*`, where the wildcard character specifies the
+contents of the `C:\Windows` directory.
+
+The **Include** and **Exclude** parameters can be used together. However, the exclusions are applied
+after the inclusions, which can affect the final output.
 
 ```yaml
 Type: System.String[]

--- a/reference/7.2/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -495,14 +495,17 @@ Accept wildcard characters: False
 
 ### -Exclude
 
-Specifies, as a string array, a property or property that this cmdlet excludes from the operation.
-The value of this parameter qualifies the **Path** parameter. Enter a path element or pattern, such
-as `*.txt` or `A*`. Wildcard characters are accepted.
+Specifies an array of one or more string patterns to be matched as the cmdlet gets child items. Any
+matching item is excluded from the output. Enter a path element or pattern, such as `*.txt` or `A*`.
+Wildcard characters are accepted.
 
 A trailing asterisk (`*`) in the **Path** parameter is optional. For example, `-Path C:\Test\Logs`
 or `-Path C:\Test\Logs\*`. If a trailing asterisk (`*`) is included, the command recurses into the
 **Path** parameter's subdirectories. Without the asterisk (`*`), the contents of the **Path**
 parameter are displayed. More details are included in Example 5 and the Notes section.
+
+The **Include** and **Exclude** parameters can be used together. However, the exclusions are applied
+after the inclusions, which can affect the final output.
 
 ```yaml
 Type: System.String[]
@@ -612,11 +615,14 @@ Accept wildcard characters: False
 
 ### -Include
 
-Specifies, as a string array, an item or items that this cmdlet includes in the operation. The value
-of this parameter qualifies the **Path** parameter. Enter a path element or pattern, such as
-`"*.txt"`. Wildcard characters are permitted. The **Include** parameter is effective only when the
-command includes the contents of an item, such as `C:\Windows\*`, where the wildcard character
-specifies the contents of the `C:\Windows` directory.
+Specifies an array of one or more string patterns to be matched as the cmdlet gets child items. Any
+matching item is included in the output. Enter a path element or pattern, such as `"*.txt"`.
+Wildcard characters are permitted. The **Include** parameter is effective only when the command
+includes the contents of an item, such as `C:\Windows\*`, where the wildcard character specifies the
+contents of the `C:\Windows` directory.
+
+The **Include** and **Exclude** parameters can be used together. However, the exclusions are applied
+after the inclusions, which can affect the final output.
 
 ```yaml
 Type: System.String[]


### PR DESCRIPTION
# PR Summary

Clarifies **Include** and **Exclude** parameter behavior in `Get-ChildItem`.

## PR Context

Fixes #7579
Fixes [AB#1843738](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1843738)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Sample scripts
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords