### PR TITLE
Fix links to cmdlets

### DIFF
--- a/reference/docs-conceptual/lang-spec/chapter-01.md
+++ b/reference/docs-conceptual/lang-spec/chapter-01.md
@@ -42,7 +42,7 @@ another.)
 
 PowerShell includes a very rich scripting language that supports constructs for looping, conditions,
 flow-control, and variable assignment. This language has syntax features and keywords similar to
-those used in the C# programming language ([§C.][] References).
+those used in the C# programming language ([§C.][]).
 
 There are four kinds of commands in PowerShell: scripts, functions and methods, cmdlets, and native
 commands.
@@ -71,4 +71,4 @@ Framework common language runtime (CLR) and the .NET Framework, and accepts and 
 Framework objects.
 
 <!-- reference links -->
-[§C.]: chapter-16.md#c-references
+[§C.]: chapter-16.md

--- a/reference/docs-conceptual/lang-spec/chapter-02.md
+++ b/reference/docs-conceptual/lang-spec/chapter-02.md
@@ -425,8 +425,8 @@ Any use of a variable name with an explicit `Variable:` namespace is equivalent 
 same variable name without that qualification. For example, `$v` and `$Variable:v` are
 interchangeable.
 
-As well as being defined in the language, variables can also be defined by the cmdlet `New-Variable`
-([§13.37][]).
+As well as being defined in the language, variables can also be defined by the cmdlet
+[New-Variable](xref:Microsoft.PowerShell.Utility.New-Variable).
 
 #### 2.3.2.1 User-defined variables
 

--- a/reference/docs-conceptual/lang-spec/chapter-03.md
+++ b/reference/docs-conceptual/lang-spec/chapter-03.md
@@ -34,8 +34,9 @@ Windows PowerShell:
 
 The following cmdlets deal with providers and drives:
 
-- `Get-PSProvider`: Gets information about one or more providers (see [§13.25][])
-- `Get-PSDrive`: Gets information about one or more drives (see [§13.24][])
+- [Get-PSProvider](xref:Microsoft.PowerShell.Management.Get-PSProvider): Gets information about one
+  or more providers
+- [Get-PSDrive](xref:Microsoft.PowerShell.Management.Get-PSDrive): Gets information about one or more drives
 
 The type of an object that represents a provider is described in [§4.5.1][]. The type of an object
 that represents a drive is described in [§4.5.2][].
@@ -52,15 +53,16 @@ command.
 The provider Alias is a flat namespace that contains only objects that represent the aliases. The
 variables have no child items.
 
-Some aliases are built in to PowerShell. (For those built-in cmdlets having aliases, those aliases
-follow their cmdlets name in the section heading of [§13.][])
+Some aliases are built in to PowerShell.
 
 The following cmdlets deal with aliases:
 
-- `New-Alias`: Creates an alias (see [§13.33][])
-- `Set-Alias`: Creates or changes one or more aliases (see [§13.46][])
-- `Get-Alias`: Gets information about one or more aliases (see [§13.13][])
-- `Export-Alias`: Exports one or more aliases to a file (see [§13.10][])
+- [New-Alias](xref:Microsoft.PowerShell.Utility.New-Alias): Creates an alias
+- [Set-Alias](xref:Microsoft.PowerShell.Utility.Set-Alias): Creates or changes one or more aliases
+- [Get-Alias](xref:Microsoft.PowerShell.Utility.Get-Alias): Gets information about one or more
+  aliases
+- [Export-Alias](xref:Microsoft.PowerShell.Utility.Export-Alias): Exports one or more aliases to a
+  file
 
 When an alias is created for a command using `New-Alias`, parameters to that command cannot be
 included in that alias. However, direct assignment to a variable in the Alias: namespace does permit
@@ -131,11 +133,15 @@ The variables have no child items.
 
 The following cmdlets also deal with variables:
 
-- `New-Variable`: Creates a variable (see [§13.37][])
-- `Set-Variable`: Creates or changes the characteristics of one or more variables (see [§13.50][])
-- `Get-Variable`: Gets information about one or more variables (see [§13.26][])
-- `Clear-Variable`: Deletes the value of one or more variables (see [§13.5][])
-- `Remove-Variable`: Deletes one or more variables (see [§13.42][])
+- [New-Variable](xref:Microsoft.PowerShell.Utility.New-Variable): Creates a variable
+- [Set-Variable](xref:Microsoft.PowerShell.Utility.Set-Variable): Creates or changes the
+  characteristics of one or more variables
+- [Get-Variable](xref:Microsoft.PowerShell.Utility.Get-Variable): Gets information about one or more
+  variables
+- [Clear-Variable](xref:Microsoft.PowerShell.Utility.Clear-Variable): Deletes the value of one or
+  more variables
+- [Remove-Variable](xref:Microsoft.PowerShell.Utility.Remove-Variable): Deletes one or more
+  variables
 
 As a variable is an item ([§3.3][]), it can be manipulated by most Item-related cmdlets.
 
@@ -162,13 +168,14 @@ working location stack.
 
 The following cmdlets deal with locations:
 
-- `Set-Location`: Establishes the current working location (see [§13.49][])
-- `Get-Location`: Determines the current working location for the specified drive(s), or the working
-  locations for the specified stack(s) (see [§13.21][])
-- `Push-Location`: Saves the current working location on the top of a specified stack of locations
-  (see [§13.39][])
-- `Pop-Location`: Restores the current working location from the top of a specified stack of
-  locations (see [§13.38][])
+- [Set-Location](xref:Microsoft.PowerShell.Management.Set-Location): Establishes the current working
+  location
+- [Get-Location](xref:Microsoft.PowerShell.Management.Get-Location): Determines the current working
+  location for the specified drive(s), or the working locations for the specified stack(s)
+- [Push-Location](xref:Microsoft.PowerShell.Management.Push-Location): Saves the current working
+  location on the top of a specified stack of locations
+- [Pop-Location](xref:Microsoft.PowerShell.Management.Pop-Location): Restores the current working
+  location from the top of a specified stack of locations
 
 The object types that represents a working location and a stack of working locations are described
 in [§4.5.5][].
@@ -180,24 +187,32 @@ variable ([§3.1.2][]), or a file or directory in a file system ([§3.1.3][]).
 
 The following cmdlets deal with items:
 
-- `New-Item`: Creates a new item (see [§13.34][])
-- `Set-Item`: Changes the value of one or more items (see [§13.48][])
-- `Get-Item`: Gets the items at the specified location (see [§13.17][])
-- `Get-ChildItem`: Gets the items and child items at the specified location (see [§13.14][])
-- `Copy-Item`: Copies one or more items from one location to another (see [§13.9][])
-- `Move-Item`: Moves one or more items from one location to another (see [§13.32][])
-- `Rename-Item`: Renames an item (see [§13.43][])
-- `Invoke-Item`: Performs the default action on one or more items (see [§13.29][])
-- `Clear-Item`: Deletes the contents of one or more items, but does not delete the items (see
-  [§13.4][])
-- `Remove-Item`: Deletes the specified items (see [§13.40][])
+- [New-Item](xref:Microsoft.PowerShell.Management.New-Item): Creates a new item
+- [Set-Item](xref:Microsoft.PowerShell.Management.Set-Item): Changes the value of one or more items
+- [Get-Item](xref:Microsoft.PowerShell.Management.Get-Item): Gets the items at the specified
+  location
+- [Get-ChildItem](xref:Microsoft.PowerShell.Management.Get-ChildItem): Gets the items and child
+  items at the specified location
+- [Copy-Item](xref:Microsoft.PowerShell.Management.Copy-Item): Copies one or more items from one
+  location to another
+- [Move-Item](xref:Microsoft.PowerShell.Management.Move-Item): Moves one or more items from one
+  location to another
+- [Rename-Item](xref:Microsoft.PowerShell.Management.Rename-Item): Renames an item
+- [Invoke-Item](xref:Microsoft.PowerShell.Management.Invoke-Item): Performs the default action on
+  one or more items
+- [Clear-Item](xref:Microsoft.PowerShell.Management.Clear-Item): Deletes the contents of one or more
+  items, but does not delete the items (see
+- [Remove-Item](xref:Microsoft.PowerShell.Management.Remove-Item): Deletes the specified items
 
 The following cmdlets deal with the content of items:
 
-- `Get-Content`: Gets the content of the item (see [§13.16][])
-- `Add-Content`: Adds content to the specified items (see [§13.1][])
-- `Set-Content`: Writes or replaces the content in an item (see [§13.47][])
-- `Clear-Content`: Deletes the contents of an item (see [§13.3][])
+- [Get-Content](xref:Microsoft.PowerShell.Management.Get-Content): Gets the content of the item
+- [Add-Content](xref:Microsoft.PowerShell.Management.Add-Content): Adds content to the specified
+  items
+- [Set-Content](xref:Microsoft.PowerShell.Management.Set-Content): Writes or replaces the content in
+  an item
+- [Clear-Content](xref:Microsoft.PowerShell.Management.Clear-Content): Deletes the contents of an
+  item
 
 The type of an object that represents a directory is described in [§4.5.17][]. The type of an object
 that represents a file is described in [§4.5.18][].
@@ -270,16 +285,20 @@ relative path name.
 
 The following cmdlets deal with paths:
 
-- `Convert-Path`: Converts a path from a PowerShell path to a PowerShell provider path (see
-  [§13.8][])
-- `Join-Path`: Combines a path and a child path into a single path (see [§13.30][])
-- `Resolve-Path`: Resolves the wildcard characters in a path (see [§13.44][])
-- `Split-Path`: Returns the specified part of a path (see [§13.52][])
-- `Test-Path`: Determines whether the elements of a path exist or if a path is well formed (see
-  [§13.54][])
+- [Convert-Path](xref:Microsoft.PowerShell.Management.Convert-Path): Converts a path from a
+  PowerShell path to a PowerShell provider path
+- [Join-Path](xref:Microsoft.PowerShell.Management.Join-Path): Combines a path and a child path into
+  a single path
+- [Resolve-Path](xref:Microsoft.PowerShell.Management.Resolve-Path): Resolves the wildcard
+  characters in a path
+- [Split-Path](xref:Microsoft.PowerShell.Management.Split-Path): Returns the specified part of a
+  path
+- [Test-Path](xref:Microsoft.PowerShell.Management.Test-Path): Determines whether the elements of a
+  path exist or if a path is well formed
 
-Some cmdlets (such as `Add-Content` ([§13.1][]) and `Copy-Item` ([§13.9][])) use file filters. A
-*file filter* is a mechanism for specifying the criteria for selecting from a set of paths.
+Some cmdlets (such as [Add-Content](xref:Microsoft.PowerShell.Management.Add-Content) and
+`Copy-Item` use file filters. A *file filter* is a mechanism for specifying the criteria for
+selecting from a set of paths.
 
 The object type that represents a resolved path is described in [§4.5.5][]. Paths are often
 manipulated as strings.
@@ -483,8 +502,9 @@ instead. For example,
 
 Just like a top-level script file is at the root of a hierarchical nested scope tree, so too is each
 module ([§3.14][]). However, by default, only those names exported by a module are available by name
-from within the importing context. The Global parameter of the cmdlet `Import-Module` ([§13.28][])
-allows exported names to have increased visibility.
+from within the importing context. The Global parameter of the cmdlet
+[Import-Module](xref:Microsoft.PowerShell.Core.Import-Module) allows exported names to have
+increased visibility.
 
 ## 3.6 ReadOnly and Constant Properties
 
@@ -786,7 +806,7 @@ records are discarded as new ones are added. The automatic variable `$MaximumErr
 the number of records that can be stored.
 
 `$Error` contains all of the errors from all commands mixed in together in one collection. To
-collect the errors from a specific command, use the common parameter ErrorVariable ([§13.56][]),
+collect the errors from a specific command, use the common parameter [ErrorVariable][],
 which allows a user-defined variable to be specified to hold the collection.
 
 ## 3.13 Pipelines
@@ -832,8 +852,8 @@ organized, and abstracted. A module can contain commands (such as cmdlets and fu
 
 Once a module has been created, it must be *imported* into a session before the commands and items
 within it can be used. Once imported, commands and items behave as if they were defined locally. A
-module is imported explicitly with the `Import-Module` ([§13.28][]) command. A module may also be
-imported automatically as determined in an implementation defined manner.
+module is imported explicitly with the `Import-Module` command. A module may also be imported
+automatically as determined in an implementation defined manner.
 
 The type of an object that represents a module is described in [§4.5.12][].
 
@@ -995,3 +1015,4 @@ Quantifiers available in Microsoft .NET Framework regular expressions are suppor
 [§7.12]: chapter-07.md#712-redirection-operators
 [§8.10.1]: chapter-08.md#8101-filter-functions
 [§8.10]: chapter-08.md#810-function-definitions
+[ErrorVariable]: /powershell/module/microsoft.powershell.core/about/about_commonparameters

--- a/reference/docs-conceptual/lang-spec/chapter-04.md
+++ b/reference/docs-conceptual/lang-spec/chapter-04.md
@@ -37,8 +37,9 @@ integer, and integers of other sizes).
 A *collection* is a group of one or more related items, which need not have the same type. Examples
 of collection types are arrays, stacks, queues, lists, and hash tables. A program can *enumerate*
 (or *iterate*) over the elements in a collection, getting access to each element one at a time.
-Common ways to do this are with the foreach statement ([§8.4.4][]) and the `ForEach-Object` cmdlet
-([§13.12][]). The type of an object that represents an enumerator is described in [§4.5.16][].
+Common ways to do this are with the foreach statement ([§8.4.4][]) and the
+[ForEach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object) cmdlet. The type of an object that
+represents an enumerator is described in [§4.5.16][].
 
 In this chapter, there are tables that list the accessible members for a given type. For methods,
 the **Type** is written with the following form: *returnType*/*argumentTypeList*. If the argument
@@ -729,15 +730,15 @@ In PowerShell, this type is `System.Management.Automation.PSDriveInfo`.
 
 This type encapsulates the state of a variable. It has the following accessible members:
 
-| **Member**  |        **Member Kind**         |               **Type**               |                                                                          **Purpose**                                                                           |
-| ----------- | ------------------------------ | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Attributes  | Instance property (read-only)  | Implementation defined               | A collection of attributes                                                                                                                                     |
-| Description | Instance property (read-write) | string                               | The description assigned to the variable via the New-Variable ([§13.37][]) or Set-Variable ([§13.50][]) cmdlets.                                               |
-| Module      | Instance property (read-only)  | Implementation defined ([§4.5.12][]) | The module from which this variable was exported                                                                                                               |
-| ModuleName  | Instance property (read-only)  | string                               | The module in which this variable was defined                                                                                                                  |
-| Name        | Instance property (read-only)  | string                               | The name assigned to the variable when it was created in the PowerShell language or via the New-Variable ([§13.37][]) and Set-Variable ([§13.50][]) cmdlets.   |
-| Options     | Instance property (read-write) | string                               | The options assigned to the variable via the New-Variable ([§13.37][]) or Set-Variable ([§13.50][]) cmdlets.                                                   |
-| Value       | Instance property (read-write) | object                               | The value assigned to the variable when it was assigned in the PowerShell language or via the New-Variable ([§13.37][]) and Set-Variable ([§13.50][]) cmdlets. |
+| **Member**  |        **Member Kind**         |               **Type**               |                                                                                        **Purpose**                                                                                         |
+| ----------- | ------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Attributes  | Instance property (read-only)  | Implementation defined               | A collection of attributes                                                                                                                                                                 |
+| Description | Instance property (read-write) | string                               | The description assigned to the variable via the [New-Variable](xref:Microsoft.PowerShell.Utility.New-Variable) or [Set-Variable](xref:Microsoft.PowerShell.Utility.Set-Variable) cmdlets. |
+| Module      | Instance property (read-only)  | Implementation defined ([§4.5.12][]) | The module from which this variable was exported                                                                                                                                           |
+| ModuleName  | Instance property (read-only)  | string                               | The module in which this variable was defined                                                                                                                                              |
+| Name        | Instance property (read-only)  | string                               | The name assigned to the variable when it was created in the PowerShell language or via the `New-Variable` and `Set-Variable` cmdlets.                                                     |
+| Options     | Instance property (read-write) | string                               | The options assigned to the variable via the `New-Variable` and `Set-Variable` cmdlets.                                                                                                    |
+| Value       | Instance property (read-write) | object                               | The value assigned to the variable when it was assigned in the PowerShell language or via the `New-Variable` and `Set-Variable` cmdlets.                                                   |
 
 In PowerShell, this type is `System.Management.Automation.PSVariable`.
 
@@ -748,20 +749,20 @@ System.Management.Automation.PSVariableAttributeCollection.
 
 This type encapsulates the state of an alias. It has the following accessible members:
 
-|    **Member**     |        **Member Kind**         |               **Type**               |                                                      **Purpose**                                                       |
-| ----------------- | ------------------------------ | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| CommandType       | Instance property (read-only)  | Implementation defined               | Should compare equal with "Alias".                                                                                     |
-| Definition        | Instance property (read-only)  | string                               | The command or alias to which the alias was assigned via the New-Alias ([§13.33][]) or Set-Alias ([§13.46][]) cmdlets. |
-| Description       | Instance property (read-write) | string                               | The description assigned to the alias via the New-Alias ([§13.33][]) or Set-Alias ([§13.46][]) cmdlets.                |
-| Module            | Instance property (read-only)  | Implementation defined ([§4.5.12][]) | The module from which this alias was exported                                                                          |
-| ModuleName        | Instance property (read-only)  | string                               | The module in which this alias was defined                                                                             |
-| Name              | Instance property (read-only)  | string                               | The name assigned to the alias when it was created via the New-Alias ([§13.33][]) or Set-Alias ([§13.46][]) cmdlets.   |
-| Options           | Instance property (read-write) | string                               | The options assigned to the alias via the New-Alias ([§13.33][]) or Set-Alias ([§13.46][]) cmdlets.                    |
-| OutputType        | Instance property (read-only)  | Implementation defined collection    | Specifies the types of the values output by the command to which the alias refers.                                     |
-| Parameters        | Instance property (read-only)  | Implementation defined collection    | The parameters of the command.                                                                                         |
-| ParameterSets     | Instance property (read-only)  | Implementation defined collection    | Information about the parameter sets associated with the command.                                                      |
-| ReferencedCommand | Instance property (read-only)  | Implementation defined               | Information about the command that is immediately referenced by this alias.                                            |
-| ResolvedCommand   | Instance property (read-only)  | Implementation defined               | Information about the command to which the alias eventually resolves.                                                  |
+|    **Member**     |        **Member Kind**         |               **Type**               |                                                                                        **Purpose**                                                                                         |
+| ----------------- | ------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| CommandType       | Instance property (read-only)  | Implementation defined               | Should compare equal with "Alias".                                                                                                                                                         |
+| Definition        | Instance property (read-only)  | string                               | The command or alias to which the alias was assigned via the [New-Alias](xref:Microsoft.PowerShell.Utility.New-Alias) or [Set-Alias](xref:Microsoft.PowerShell.Utility.Set-Alias) cmdlets. |
+| Description       | Instance property (read-write) | string                               | The description assigned to the alias via the `New-Alias` or `Set-Alias` cmdlets.                                                                                                          |
+| Module            | Instance property (read-only)  | Implementation defined ([§4.5.12][]) | The module from which this alias was exported                                                                                                                                              |
+| ModuleName        | Instance property (read-only)  | string                               | The module in which this alias was defined                                                                                                                                                 |
+| Name              | Instance property (read-only)  | string                               | The name assigned to the alias when it was created via the `New-Alias` or `Set-Alias` cmdlets.                                                                                             |
+| Options           | Instance property (read-write) | string                               | The options assigned to the alias via the New-Alias `New-Alias` or `Set-Alias` cmdlets.                                                                                                    |
+| OutputType        | Instance property (read-only)  | Implementation defined collection    | Specifies the types of the values output by the command to which the alias refers.                                                                                                         |
+| Parameters        | Instance property (read-only)  | Implementation defined collection    | The parameters of the command.                                                                                                                                                             |
+| ParameterSets     | Instance property (read-only)  | Implementation defined collection    | Information about the parameter sets associated with the command.                                                                                                                          |
+| ReferencedCommand | Instance property (read-only)  | Implementation defined               | Information about the command that is immediately referenced by this alias.                                                                                                                |
+| ResolvedCommand   | Instance property (read-only)  | Implementation defined               | Information about the command to which the alias eventually resolves.                                                                                                                      |
 
 In PowerShell, this type is `System.Management.Automation.AliasInfo`.
 
@@ -864,21 +865,21 @@ In PowerShell, this type is `System.Management.Automation.ExternalScriptInfo`.
 
 This type encapsulates the state of a function. It has the following accessible members:
 
-|     **Member**      |        **Member Kind**         |               **Type**               |                                                                                                                                                                          **Purpose**                                                                                                                                                                           |
-| ------------------- | ------------------------------ | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CmdletBinding       | Instance property (read-only)  | bool                                 | Indicates whether the function uses the same parameter binding that compiled cmdlets use (see [§12.3.5][]).                                                                                                                                                                                                                                                    |
-| CommandType         | Instance property (read-only)  | Implementation defined               | Can be compared for equality with "Function" or "Filter" to see which of those this object represents.                                                                                                                                                                                                                                                         |
-| DefaultParameterSet | Instance property (read-only)  | string                               | Specifies the parameter set to use if that cannot be determined from the arguments (see [§12.3.5][]).                                                                                                                                                                                                                                                          |
-| Definition          | Instance property (read-only)  | string                               | A string version of ScriptBlock                                                                                                                                                                                                                                                                                                                                |
-| Description         | Instance property (read-write) | string                               | The description of the function.                                                                                                                                                                                                                                                                                                                               |
-| Module              | Instance property (read-only)  | Implementation defined ([§4.5.12][]) | The module from which this function was exported                                                                                                                                                                                                                                                                                                               |
-| ModuleName          | Instance property (read-only)  | string                               | The module in which this function was defined                                                                                                                                                                                                                                                                                                                  |
-| Name                | Instance property (read-only)  | string                               | The name of the function                                                                                                                                                                                                                                                                                                                                       |
-| Options             | Instance property (read-write) | Implementation defined               | The scope options for the function ([§3.5.4][]).                                                                                                                                                                                                                                                                                                               |
-| OutputType          | Instance property (read-only)  | Implementation defined collection    | Specifies the types of the values output, in order (see [§12.3.6][]).                                                                                                                                                                                                                                                                                          |
-| Parameters          | Instance property (read-only)  | Implementation defined collection    | Specifies the parameter names, in order. If the function acts like a cmdlet (see CmdletBinding above) the common parameters ([§13.56][]) are included at the end of the collection.                                                                                                                                                                            |
-| ParameterSets       | Instance property (read-only)  | Implementation defined collection    | Information about the parameter sets associated with the command. For each parameter, the result shows the parameter name and type, and indicates if the parameter is mandatory, by position or a switch parameter. If the function acts like a cmdlet (see CmdletBinding above) the common parameters ([§13.56][]) are included at the end of the collection. |
-| ScriptBlock         | Instance property (read-only)  | scriptblock ([§4.3.6][])             | The body of the function                                                                                                                                                                                                                                                                                                                                       |
+|     **Member**      |        **Member Kind**         |               **Type**               |                                                                                                                                                                      **Purpose**                                                                                                                                                                      |
+| ------------------- | ------------------------------ | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CmdletBinding       | Instance property (read-only)  | bool                                 | Indicates whether the function uses the same parameter binding that compiled cmdlets use (see [§12.3.5][]).                                                                                                                                                                                                                                           |
+| CommandType         | Instance property (read-only)  | Implementation defined               | Can be compared for equality with "Function" or "Filter" to see which of those this object represents.                                                                                                                                                                                                                                                |
+| DefaultParameterSet | Instance property (read-only)  | string                               | Specifies the parameter set to use if that cannot be determined from the arguments (see [§12.3.5][]).                                                                                                                                                                                                                                                 |
+| Definition          | Instance property (read-only)  | string                               | A string version of ScriptBlock                                                                                                                                                                                                                                                                                                                       |
+| Description         | Instance property (read-write) | string                               | The description of the function.                                                                                                                                                                                                                                                                                                                      |
+| Module              | Instance property (read-only)  | Implementation defined ([§4.5.12][]) | The module from which this function was exported                                                                                                                                                                                                                                                                                                      |
+| ModuleName          | Instance property (read-only)  | string                               | The module in which this function was defined                                                                                                                                                                                                                                                                                                         |
+| Name                | Instance property (read-only)  | string                               | The name of the function                                                                                                                                                                                                                                                                                                                              |
+| Options             | Instance property (read-write) | Implementation defined               | The scope options for the function ([§3.5.4][]).                                                                                                                                                                                                                                                                                                      |
+| OutputType          | Instance property (read-only)  | Implementation defined collection    | Specifies the types of the values output, in order (see [§12.3.6][]).                                                                                                                                                                                                                                                                                 |
+| Parameters          | Instance property (read-only)  | Implementation defined collection    | Specifies the parameter names, in order. If the function acts like a cmdlet (see CmdletBinding above) the [common parameters][] are included at the end of the collection.                                                                                                                                                                            |
+| ParameterSets       | Instance property (read-only)  | Implementation defined collection    | Information about the parameter sets associated with the command. For each parameter, the result shows the parameter name and type, and indicates if the parameter is mandatory, by position or a switch parameter. If the function acts like a cmdlet (see CmdletBinding above) the [common parameters][] are included at the end of the collection. |
+| ScriptBlock         | Instance property (read-only)  | scriptblock ([§4.3.6][])             | The body of the function                                                                                                                                                                                                                                                                                                                              |
 
 In PowerShell, this type is `System.Management.Automation.FunctionInfo`.
 
@@ -1005,9 +1006,9 @@ collection, an exception of type `InvalidOperationException` is raised. For `$fo
 
 ### 4.5.17 Directory description type
 
-The cmdlet `New-Item` ([§13.34][]) can create items of various kinds including FileSystem directories.
-The type of a directory description object is implementation defined; it has the following
-accessible members:
+The cmdlet [New-Item](xref:Microsoft.PowerShell.Management.New-Item) can create items of various
+kinds including FileSystem directories. The type of a directory description object is implementation
+defined; it has the following accessible members:
 
 |  **Member**   |        **Member Kind**         |               **Type**                |                             **Purpose**                             |
 | ------------- | ------------------------------ | ------------------------------------- | ------------------------------------------------------------------- |
@@ -1023,9 +1024,8 @@ In PowerShell, this type is `System.IO.DirectoryInfo`. The type of the **Attribu
 
 ### 4.5.18 File description type
 
-The cmdlet `New-Item` ([§13.34][]) can create items of various kinds including FileSystem files. The
-type of a file description object is implementation defined; it has the following accessible
-members:
+The cmdlet `New-Item` can create items of various kinds including FileSystem files. The type of a
+file description object is implementation defined; it has the following accessible members:
 
 |  **Member**   |        **Member Kind**         |               **Type**                |                                            **Purpose**                                             |
 | ------------- | ------------------------------ | ------------------------------------- | -------------------------------------------------------------------------------------------------- |
@@ -1055,7 +1055,7 @@ accessible members:
 | Second     | Instance property (read-only) | int      | Gets the seconds component of the date represented by this instance. |
 | Year       | Instance property (read-only) | int      | Gets the year component of the date represented by this instance.    |
 
-An object of this type can be created by cmdlet `Get-Date` ([§13.18][]).
+An object of this type can be created by cmdlet [Get-Date](xref:Microsoft.PowerShell.Utility.Get-Date).
 
 In PowerShell, this type is `System.DateTime`.
 
@@ -1071,7 +1071,7 @@ accessible members:
 | Name   | Instance property (read-only) | string                            | Gets the name of the group.                   |
 | Values | Instance property (read-only) | Implementation-defined collection | Gets the values of the elements of the group. |
 
-An object of this type can be created by cmdlet `Group-Object` ([§13.27][]).
+An object of this type can be created by cmdlet [Group-Object](xref:Microsoft.PowerShell.Utility.Group-Object).
 
 In PowerShell, this type is `Microsoft.PowerShell.Commands.GroupInfo`.
 
@@ -1089,7 +1089,7 @@ following accessible members:
 | Property   | Instance property (read-only) | string   | Gets the property to be measured.                                   |
 | Sum        | Instance property (read-only) | double   | Gets the sum of the values of the specified properties.             |
 
-An object of this type can be created by cmdlet `Measure-Object` ([§13.31][]).
+An object of this type can be created by cmdlet [Measure-Object](xref:Microsoft.PowerShell.Utility.Measure-Object).
 
 In PowerShell, this type is `Microsoft.PowerShell.Commands.GenericMeasureInfo`.
 
@@ -1105,7 +1105,7 @@ accessible members:
 | Property   | Instance property (read-only) | string   | Gets the property to be measured.                   |
 | Words      | Instance property (read-only) | int      | Gets the number of words in the target object.      |
 
-An object of this type can be created by cmdlet `Measure-Object` ([§13.31][]).
+An object of this type can be created by cmdlet `Measure-Object`.
 
 In PowerShell, this type is `Microsoft.PowerShell.Commands.TextMeasureInfo`.
 
@@ -1119,7 +1119,7 @@ is implementation defined; it has the following accessible members:
 | Password | Instance property (read-only) | Implementation defined | Gets the password. |
 | UserName | Instance property (read-only) | string                 | Gets the username. |
 
-An object of this type can be created by cmdlet `Get-Credential` ([§13.17][]).
+An object of this type can be created by cmdlet [Get-Credential](xref:Microsoft.PowerShell.Security.Get-Credential).
 
 In PowerShell, this type is `System.Management.Automation.PSCredential`.
 
@@ -1165,14 +1165,14 @@ unaffected.
 The base member set of a type can be augmented by the addition of the following kinds of members:
 
 - *adapted members*, via the *Extended Type System* (ETS), most details of which are unspecified.
-- *extended members*, via the cmdlet Add-Member ([§13.2][]).
+- *extended members*, via the cmdlet [Add-Member](xref:Microsoft.PowerShell.Utility.Add-Member).
 
 In PowerShell, extended members can also be added via `types.ps1xml` files. Adapted and extended
 members are collectively called *synthetic* *members*.
 
 The ETS adds the following members to all PowerShell objects: **psbase**, **psadapted**,
 **psextended**, and **pstypenames**. See the **Force** and **View** parameters in the cmdlet
-`Get-Member` ([§13.22][]) for more information on these members.
+[Get-Member](xref:Microsoft.PowerShell.Utility.Get-Member) for more information on these members.
 
 An instance member may hide an extended and/or adapted member of the same name, and an extended
 member may hide an adapted member. In such cases, the member sets **psadapted** and **psextended**
@@ -1236,3 +1236,4 @@ There are three ways create a custom object having a new member M:
 [§8.10.5]: chapter-08.md#8105-the-switch-type-constraint
 [§8.4.4]: chapter-08.md#844-the-foreach-statement
 [§9.]: chapter-09.md#9-arrays
+[common parameters]: /powershell/module/microsoft.powershell.core/about/about_commonparameters

--- a/reference/docs-conceptual/lang-spec/chapter-05.md
+++ b/reference/docs-conceptual/lang-spec/chapter-05.md
@@ -26,7 +26,7 @@ $i = 2147483647   # $i holds a value of type int
 ```
 
 Any use of a variable that has not been created results in the value $null. To see if a variable has
-been defined, use the `Test-Path` cmdlet ([§13.54][]).
+been defined, use the [Test-Path](xref:Microsoft.PowerShell.Management.Test-Path) cmdlet.
 
 ## 5.1 Writable location
 
@@ -112,7 +112,7 @@ An instance data member can be a field or a property.
 
 An array can be created via a unary comma operator ([§7.2.1][]), *sub-expression* ([§7.1.6][]),
 *array-expression* ([§7.1.7][]), binary comma operator ([§7.3][]), range operator ([§7.4][]), or
-`New-Object` cmdlet ([§13.36][]).
+[New-Object](xref:Microsoft.PowerShell.Utility.New-Object) cmdlet.
 
 Memory for creating and deleting arrays is managed by the host environment and the garbage
 collection system.
@@ -121,8 +121,9 @@ Arrays and array elements are discussed in [§9.][]
 
 ### 5.2.4 Hashtable key/value pairs
 
-A Hashtable is created via a hash literal ([§2.3.5.6][]) or the `New-Object` cmdlet ([§13.36][]). A
-new key/value pair can be added via the `[]` operator ([§7.1.4.3][]).
+A Hashtable is created via a hash literal ([§2.3.5.6][]) or the
+[New-Object](xref:Microsoft.PowerShell.Utility.New-Object) cmdlet. A new key/value pair can be added
+via the `[]` operator ([§7.1.4.3][]).
 
 Memory for creating and deleting Hashtables is managed by the host environment and the garbage
 collection system.

--- a/reference/docs-conceptual/lang-spec/chapter-08.md
+++ b/reference/docs-conceptual/lang-spec/chapter-08.md
@@ -495,8 +495,8 @@ Every foreach statement has its own enumerator, `$foreach` ([§2.3.2.2][], [§4.
 only while that loop is executing.
 
 The objects produced by *pipeline* are collected before *statement-block* begins to execute.
-However, with the `ForEach-Object` cmdlet ([§13.12][]), *statement-block* is executed on each object
-as it is produced.
+However, with the [ForEach-Object](xref:Microsoft.PowerShell.Core.ForEach-Object) cmdlet,
+*statement-block* is executed on each object as it is produced.
 
 Examples:
 
@@ -1170,7 +1170,8 @@ only:
 - Pipelines
 - Statements separated by semicolons (`;`)
 - Literals
-- Calls to the `ConvertFrom-StringData` cmdlet ([§13.7][])
+- Calls to the [ConvertFrom-StringData](xref:Microsoft.PowerShell.Utility.ConvertFrom-StringData)
+  cmdlet
 - Any other cmdlets identified via the **supportedcommand** parameter
 
 If the `ConvertFrom-StringData` cmdlet is used, the key/value pairs can be expressed using any form
@@ -1446,10 +1447,10 @@ Dynamic parameters are parameters of a cmdlet, function, filter, or script that 
 certain conditions only. One such case is the **Encoding** parameter of the `Set-Item` cmdlet.
 
 In the *statement-block*, use an if statement to specify the conditions under which the parameter is
-available in the function. Use the `New-Object` cmdlet ([§13.35][]) to create an object of an
-implementation-defined type to represent the parameter, and specify its name. Also, use `New-Object`
-to create an object of a different implementation-defined type to represent the
-implementation-defined attributes of the parameter.
+available in the function. Use the [New-Object](xref:Microsoft.PowerShell.Utility.New-Object) cmdlet
+to create an object of an implementation-defined type to represent the parameter, and specify its
+name. Also, use `New-Object` to create an object of a different implementation-defined type to
+represent the implementation-defined attributes of the parameter.
 
 The following example shows a function with standard parameters called Name and Path, and an
 optional dynamic parameter named **DP1**. The **DP1** parameter is in the PSet1 parameter set and
@@ -1587,7 +1588,7 @@ parameter by name. This is done by using a *parameter with argument*, which is a
 the parameter's name with a leading dash (-), followed by the associated value for that argument.
 The parameter name used can have any case-insensitive spelling and can use any prefix that uniquely
 designates the corresponding parameter. When choosing parameter names, avoid using the names of the
-common parameters ([§13.56][]).
+[common parameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 Consider the following calls to function `Get-Power`:
 

--- a/reference/docs-conceptual/lang-spec/chapter-09.md
+++ b/reference/docs-conceptual/lang-spec/chapter-09.md
@@ -50,7 +50,7 @@ All array types are derived from the type Array ([§4.3.2][]).
 
 An array is created via an *array creation expression*, which has the following forms: unary comma
 operator ([§7.2.1][]) ,*array-expression* ([§7.1.7][]), binary comma operator ([§7.3][]), range
-operator ([§7.4][]), or New-Object cmdlet ([§13.36][]).
+operator ([§7.4][]), or [New-Object](xref:Microsoft.PowerShell.Utility.New-Object) cmdlet.
 
 Here are some examples of array creation and usage:
 
@@ -108,10 +108,9 @@ $a[1] = "abc"           # implementation-defined behavior
 $a += 1.23              # new array is unconstrained
 ```
 
-The syntax for creating a multidimensional array requires the specification of a type ([§13.36][]),
-and that type becomes the constraint type for that array. However, by specifying type `object[]`,
-there really is no constraint as a value of any type can be assigned to an element of an array of
-that type.
+The syntax for creating a multidimensional array requires the specification of a type, and that type
+becomes the constraint type for that array. However, by specifying type `object[]`, there really is
+no constraint as a value of any type can be assigned to an element of an array of that type.
 
 Concatenating two arrays ([§7.7.3][]) always results in a new array that is unconstrained even if
 both arrays are constrained by the same type. For example,

--- a/reference/docs-conceptual/lang-spec/chapter-10.md
+++ b/reference/docs-conceptual/lang-spec/chapter-10.md
@@ -65,8 +65,9 @@ returned by Keys and Values have type **ICollection**.
 
 ## 10.2 Hashtable creation
 
-A `Hashtable` is created via a hash literal ([§7.1.9][]) or the `New-Object` cmdlet ([§13.36][]). It
-can be created with zero or more elements. The Count property returns the current element count.
+A `Hashtable` is created via a hash literal ([§7.1.9][]) or the
+[New-Object](xref:Microsoft.PowerShell.Utility.New-Object) cmdlet. It can be created with zero or
+more elements. The Count property returns the current element count.
 
 ## 10.3 Adding and removing Hashtable elements
 

--- a/reference/docs-conceptual/lang-spec/chapter-11.md
+++ b/reference/docs-conceptual/lang-spec/chapter-11.md
@@ -32,11 +32,11 @@ variable **PSModulePath**.
 
 The following cmdlets deal with modules:
 
-- `Get-Module`: Identifies the modules that have been, or that can be, imported (see [§13.23][])
-- `Import-Module`: Adds one or more modules to the current session (see [§11.4][], [§13.28][])
-- `Export-ModuleMember`: Identifies the module members that are to be exported (see [§13.11][])
-- `Remove-Module`: Removes one or more modules from the current session (see [§11.5][], [§13.41][])
-- `New-Module`: Creates a dynamic module (see [§11.7][], [§13.35][])
+- [Get-Module](xref:Microsoft.PowerShell.Core.Get-Module): Identifies the modules that have been, or that can be, imported
+- [Import-Module](xref:Microsoft.PowerShell.Core.Import-Module): Adds one or more modules to the current session (see [§11.4][])
+- [Export-ModuleMember](xref:Microsoft.PowerShell.Core.Export-ModuleMember): Identifies the module members that are to be exported
+- [Remove-Module](xref:Microsoft.PowerShell.Core.Remove-Module): Removes one or more modules from the current session (see [§11.5][])
+- [New-Module](xref:Microsoft.PowerShell.Core.New-Module): Creates a dynamic module (see [§11.7][])
 
 ## 11.2 Writing a script module
 
@@ -75,13 +75,13 @@ can be provided; for example,
 
 Any additional paths added affect the current session only.
 
-Alternatively, a fully qualified path can be specified when a module is imported ([§13.28][]).
+Alternatively, a fully qualified path can be specified when a module is imported.
 
 ## 11.4 Importing a script module
 
 Before the resources in a module can be used, that module must be imported into the current session,
-using the cmdlet `Import-Module` ([§13.28][]). `Import-Module` can restrict the resources that it
-actually imports.
+using the cmdlet `Import-Module`. `Import-Module` can restrict the resources that it actually
+imports.
 
 When a module is imported, its script file is executed. That process can be configured by defining
 one or more parameters in the script file, and passing in corresponding arguments via the
@@ -115,7 +115,7 @@ See [§3.5.6][] for a discussion of scope as it relates to modules.
 
 ## 11.5 Removing a script module
 
-One or more modules can be removed from a session via the cmdlet `Remove-Module` ([§13.41][]).
+One or more modules can be removed from a session via the cmdlet `Remove-Module`.
 
 Removing a module does not uninstall the module.
 
@@ -166,8 +166,8 @@ GUID, call the method `[guid]::NewGuid()`.
 
 ## 11.7 Dynamic modules
 
-A *dynamic module* is a module that is created in memory at runtime by the cmdlet `New-Module`
-([§13.35][]); it is not loaded from disk. Consider the following example:
+A *dynamic module* is a module that is created in memory at runtime by the cmdlet `New-Module`; it
+is not loaded from disk. Consider the following example:
 
 ```powershell
 $sb = {

--- a/reference/docs-conceptual/lang-spec/chapter-12.md
+++ b/reference/docs-conceptual/lang-spec/chapter-12.md
@@ -423,13 +423,13 @@ used to define the characteristics of the parameter:
 <td>Help (named)</td>
 <td><p>Type: string</p>
 <p>This argument specifies a message that is intended to contain a short description of the default value of a parameter. This message is used in an implementation-defined manner.</p>
-<p>Windows PowerShell: The message is used as part of the description of the parameter for the help topic displayed by the Get-Help ([§13.19][]) cmdlet.</p></td>
+<p>Windows PowerShell: The message is used as part of the description of the parameter for the help topic displayed by the [Get-Help](xref:Microsoft.PowerShell.Core.Get-Help) cmdlet.</p></td>
 </tr>
 <tr class="even">
 <td>Value (named)</td>
 <td><p>Type: object</p>
 <p>This argument specifies a value that is intended to be the default value of a parameter. The value is used in an implementation-defined manner.</p>
-<p>Windows PowerShell: The value is used as part of the description of the parameter for the help topic displayed by the Get-Help ([§13.19][]) cmdlet when the Help property is not specified.</p></td>
+<p>Windows PowerShell: The value is used as part of the description of the parameter for the help topic displayed by the [Get-Help](xref:Microsoft.PowerShell.Core.Get-Help)cmdlet when the Help property is not specified.</p></td>
 </tr>
 </tbody>
 </table>
@@ -440,7 +440,7 @@ This attribute is used in a *script-parameter* to provide additional information
 parameter. The attribute is used in an implementation defined manner.
 
 This attribute is used as part of the description of the parameter for the help topic displayed by
-the `Get-Help` ([§13.19][]) cmdlet.
+the [Get-Help](xref:Microsoft.PowerShell.Core.Get-Help) cmdlet.
 
 ### 12.3.10 The ValidateCount attribute
 

--- a/reference/docs-conceptual/lang-spec/chapter-14.md
+++ b/reference/docs-conceptual/lang-spec/chapter-14.md
@@ -7,8 +7,8 @@ title: Comment-Based Help
 # A. Comment-Based Help
 
 PowerShell provides a mechanism for programmers to document their scripts using special comment
-directives. Comments using such syntax are called *help comments*. The cmdlet `Get-Help`
-([§13.19][]) generates documentation from these directives.
+directives. Comments using such syntax are called *help comments*. The cmdlet
+[Get-Help](xref:Microsoft.PowerShell.Core.Get-Help) generates documentation from these directives.
 
 ## A.1 Introduction
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Fix links to cmdlets

<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [x] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords