### PR TITLE
Fixes #7652 - Updates everything-about-null

### DIFF
--- a/reference/docs-conceptual/learn/deep-dives/everything-about-null.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-null.md
@@ -333,6 +333,10 @@ an empty result inside an array then it's not counted as an item. The count is `
 
 If you treat the empty `$null` like a collection, then it's empty.
 
+If you pass in an empty value to a function parameter that isn't strongly typed, PowerShell coerces
+the nothing value into a `$null` value by default. This means inside the function, the value will be
+treated as `$null` instead of the **System.Management.Automation.Internal.AutomationNull** type.
+
 ### Pipeline
 
 The primary place you see the difference is when using the pipeline. You can pipe a `$null`


### PR DESCRIPTION
# PR Summary

Updates null article to highligh "empty $null" behavior when passed to a function parameter.

## PR Context

Fixes #7652
Fixes [AB#1847849](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1847849)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [x] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords