### PR TITLE
Fixes #7715 - example 4 gets last line

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Content.md
@@ -107,8 +107,8 @@ last index in the returned array of 25 retrieved lines.
 
 ### Example 4: Get the last line of a text file
 
-This command gets the first line and last line of content from a file. This example uses the
-`LineNumbers.txt` file that was created in Example 1.
+This command gets the last line of content from a file. This example uses the `LineNumbers.txt` file
+that was created in Example 1.
 
 ```powershell
 Get-Item -Path .\LineNumbers.txt | Get-Content -Tail 1

--- a/reference/7.0/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Get-Content.md
@@ -106,8 +106,8 @@ last index in the returned array of 25 retrieved lines.
 
 ### Example 4: Get the last line of a text file
 
-This command gets the first line and last line of content from a file. This example uses the
-`LineNumbers.txt` file that was created in Example 1.
+This command gets the last line of content from a file. This example uses the `LineNumbers.txt` file
+that was created in Example 1.
 
 ```powershell
 Get-Item -Path .\LineNumbers.txt | Get-Content -Tail 1

--- a/reference/7.1/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Get-Content.md
@@ -106,8 +106,8 @@ last index in the returned array of 25 retrieved lines.
 
 ### Example 4: Get the last line of a text file
 
-This command gets the first line and last line of content from a file. This example uses the
-`LineNumbers.txt` file that was created in Example 1.
+This command gets the last line of content from a file. This example uses the `LineNumbers.txt` file
+that was created in Example 1.
 
 ```powershell
 Get-Item -Path .\LineNumbers.txt | Get-Content -Tail 1

--- a/reference/7.2/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Get-Content.md
@@ -106,8 +106,8 @@ last index in the returned array of 25 retrieved lines.
 
 ### Example 4: Get the last line of a text file
 
-This command gets the first line and last line of content from a file. This example uses the
-`LineNumbers.txt` file that was created in Example 1.
+This command gets the last line of content from a file. This example uses the `LineNumbers.txt` file
+that was created in Example 1.
 
 ```powershell
 Get-Item -Path .\LineNumbers.txt | Get-Content -Tail 1


### PR DESCRIPTION
# PR Summary
Fixes #7715 - Example 4 gets last line instead of first and last.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
