### PR TITLE
about_Enum Usage Example typo: oga -> ogg

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -112,7 +112,7 @@ m4v
 
 **Note**: GetEnumNames() and GetEnumValues() seem to return the same results.
 However, internally, PowerShell is changing values into labels. Read the list
-carefully and you'll notice that `oga` and `mogg` are mentioned under the 'Get
+carefully and you'll notice that `ogg` and `mogg` are mentioned under the 'Get
 Names' results, but not under the 'Get Values' similar output for `jpg`,
 `jpeg`, and `mpg`, `mpeg`.
 


### PR DESCRIPTION
# PR Summary
When explaining the difference between `GetEnumNames()` and `GetEnumValues()` the **about_Enum** help file accidentally refers to to wrong enum name, using `oga` instead of the correct `ogg`.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [x] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
