### PR TITLE
Fixes #7722 - clarify enum method behavior

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -117,8 +117,8 @@ m4v
 
 > [!NOTE]
 > `GetEnumNames()` and `GetEnumValues()` seem to return the same results; a
-> list of named values. However, internally, `GetEnumValues()` enumerating the
-> values, then mapping values into names. Read the list carefully and you'll
+> list of named values. However, internally, `GetEnumValues()` enumerates the
+> values, then maps values into names. Read the list carefully and you'll
 > notice that `ogg`, `oga`, and `mogg` appear in the output of
 > `GetEnumNames()`, but the output of `GetEnumValues()` only shows `oga`. The
 > same thing happens for `jpg`, `jpeg`, and `mpg`, `mpeg`.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,17 +1,14 @@
 ---
-description:  The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list. 
-keywords: powershell,cmdlet
+description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 11/27/2017
+ms.date: 06/21/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
 ---
-
 # about_Enum
 
 ## SHORT DESCRIPTION
-
 The `enum` statement is used to declare an enumeration. An enumeration is a
 distinct type that consists of a set of named labels called the enumerator
 list.
@@ -72,6 +69,9 @@ The `GetEnumNames()` method returns the list of the labels for the enumeration.
 
 ```powershell
 [MediaTypes].GetEnumNames()
+```
+
+```Output
 unknown
 music
 mp3
@@ -94,6 +94,9 @@ The `GetEnumValues()` method returns the list of the values for the enumeration.
 
 ```powershell
 [MediaTypes].GetEnumValues()
+```
+
+```Output
 unknown
 music
 mp3
@@ -112,19 +115,32 @@ avi
 m4v
 ```
 
-**Note**: GetEnumNames() and GetEnumValues() seem to return the same results.
-However, internally, PowerShell is changing values into labels. Read the list
-carefully and you'll notice that `oga` and `mogg` are mentioned under the 'Get
-Names' results, but not under the 'Get Values' similar output for `jpg`,
-`jpeg`, and `mpg`, `mpeg`.
+> [!NOTE]
+> `GetEnumNames()` and `GetEnumValues()` seem to return the same results; a
+> list of named values. However, internally, `GetEnumValues()` enumerating the
+> values, then mapping values into names. Read the list carefully and you'll
+> notice that `ogg`, `oga`, and `mogg` appear in the output of
+> `GetEnumNames()`, but the output of `GetEnumValues()` only shows `oga`. The
+> same thing happens for `jpg`, `jpeg`, and `mpg`, `mpeg`.
+
+The `GetEnumName()` method can be used to get a name associated with a specific
+value. If there are multiple names associated with a value, the method returns
+the alphabetically-first name.
 
 ```powershell
 [MediaTypes].GetEnumName(15)
 oga
+```
 
+The following example shows how to map each name to its value.
+
+```powershell
 [MediaTypes].GetEnumNames() | ForEach-Object {
   "{0,-10} {1}" -f $_,[int]([MediaTypes]::$_)
 }
+```
+
+```Output
 unknown    0
 music      10
 mp3        11
@@ -187,7 +203,7 @@ In the following example the *FileAttributes* enumeration is created.
 "file2 attributes are: $file2"
 ```
 
-```output
+```Output
 file1 attributes are: Archive, Compressed, Device
 file2 attributes are: Device, Directory, Encrypted
 ```
@@ -196,7 +212,7 @@ To test that a specific is set, you can use the binary comparison operator
 `-band`. In this example, we test for the **Device** and the **Archive**
 attributes in the value of `$file2`.
 
-```
+```powershell
 PS > ($file2 -band [FileAttributes]::Device) -eq [FileAttributes]::Device
 True
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -117,8 +117,8 @@ m4v
 
 > [!NOTE]
 > `GetEnumNames()` and `GetEnumValues()` seem to return the same results; a
-> list of named values. However, internally, `GetEnumValues()` enumerating the
-> values, then mapping values into names. Read the list carefully and you'll
+> list of named values. However, internally, `GetEnumValues()` enumerates the
+> values, then maps values into names. Read the list carefully and you'll
 > notice that `ogg`, `oga`, and `mogg` appear in the output of
 > `GetEnumNames()`, but the output of `GetEnumValues()` only shows `oga`. The
 > same thing happens for `jpg`, `jpeg`, and `mpg`, `mpeg`.

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,8 +1,7 @@
 ---
-description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list. 
-keywords: powershell,cmdlet
+description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 11/27/2017
+ms.date: 06/21/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -70,6 +69,9 @@ The `GetEnumNames()` method returns the list of the labels for the enumeration.
 
 ```powershell
 [MediaTypes].GetEnumNames()
+```
+
+```Output
 unknown
 music
 mp3
@@ -92,6 +94,9 @@ The `GetEnumValues()` method returns the list of the values for the enumeration.
 
 ```powershell
 [MediaTypes].GetEnumValues()
+```
+
+```Output
 unknown
 music
 mp3
@@ -110,19 +115,32 @@ avi
 m4v
 ```
 
-**Note**: GetEnumNames() and GetEnumValues() seem to return the same results.
-However, internally, PowerShell is changing values into labels. Read the list
-carefully and you'll notice that `oga` and `mogg` are mentioned under the 'Get
-Names' results, but not under the 'Get Values' similar output for `jpg`,
-`jpeg`, and `mpg`, `mpeg`.
+> [!NOTE]
+> `GetEnumNames()` and `GetEnumValues()` seem to return the same results; a
+> list of named values. However, internally, `GetEnumValues()` enumerating the
+> values, then mapping values into names. Read the list carefully and you'll
+> notice that `ogg`, `oga`, and `mogg` appear in the output of
+> `GetEnumNames()`, but the output of `GetEnumValues()` only shows `oga`. The
+> same thing happens for `jpg`, `jpeg`, and `mpg`, `mpeg`.
+
+The `GetEnumName()` method can be used to get a name associated with a specific
+value. If there are multiple names associated with a value, the method returns
+the alphabetically-first name.
 
 ```powershell
 [MediaTypes].GetEnumName(15)
 oga
+```
 
+The following example shows how to map each name to its value.
+
+```powershell
 [MediaTypes].GetEnumNames() | ForEach-Object {
   "{0,-10} {1}" -f $_,[int]([MediaTypes]::$_)
 }
+```
+
+```Output
 unknown    0
 music      10
 mp3        11
@@ -185,7 +203,7 @@ In the following example the *FileAttributes* enumeration is created.
 "file2 attributes are: $file2"
 ```
 
-```output
+```Output
 file1 attributes are: Archive, Compressed, Device
 file2 attributes are: Device, Directory, Encrypted
 ```
@@ -194,7 +212,7 @@ To test that a specific is set, you can use the binary comparison operator
 `-band`. In this example, we test for the **Device** and the **Archive**
 attributes in the value of `$file2`.
 
-```
+```powershell
 PS > ($file2 -band [FileAttributes]::Device) -eq [FileAttributes]::Device
 True
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,8 +1,7 @@
 ---
-description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list. 
-keywords: powershell,cmdlet
+description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 11/27/2017
+ms.date: 06/21/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -70,6 +69,9 @@ The `GetEnumNames()` method returns the list of the labels for the enumeration.
 
 ```powershell
 [MediaTypes].GetEnumNames()
+```
+
+```Output
 unknown
 music
 mp3
@@ -92,6 +94,9 @@ The `GetEnumValues()` method returns the list of the values for the enumeration.
 
 ```powershell
 [MediaTypes].GetEnumValues()
+```
+
+```Output
 unknown
 music
 mp3
@@ -110,19 +115,32 @@ avi
 m4v
 ```
 
-**Note**: GetEnumNames() and GetEnumValues() seem to return the same results.
-However, internally, PowerShell is changing values into labels. Read the list
-carefully and you'll notice that `oga` and `mogg` are mentioned under the 'Get
-Names' results, but not under the 'Get Values' similar output for `jpg`,
-`jpeg`, and `mpg`, `mpeg`.
+> [!NOTE]
+> `GetEnumNames()` and `GetEnumValues()` seem to return the same results; a
+> list of named values. However, internally, `GetEnumValues()` enumerating the
+> values, then mapping values into names. Read the list carefully and you'll
+> notice that `ogg`, `oga`, and `mogg` appear in the output of
+> `GetEnumNames()`, but the output of `GetEnumValues()` only shows `oga`. The
+> same thing happens for `jpg`, `jpeg`, and `mpg`, `mpeg`.
+
+The `GetEnumName()` method can be used to get a name associated with a specific
+value. If there are multiple names associated with a value, the method returns
+the alphabetically-first name.
 
 ```powershell
 [MediaTypes].GetEnumName(15)
 oga
+```
 
+The following example shows how to map each name to its value.
+
+```powershell
 [MediaTypes].GetEnumNames() | ForEach-Object {
   "{0,-10} {1}" -f $_,[int]([MediaTypes]::$_)
 }
+```
+
+```Output
 unknown    0
 music      10
 mp3        11
@@ -185,7 +203,7 @@ In the following example the *FileAttributes* enumeration is created.
 "file2 attributes are: $file2"
 ```
 
-```output
+```Output
 file1 attributes are: Archive, Compressed, Device
 file2 attributes are: Device, Directory, Encrypted
 ```
@@ -194,11 +212,10 @@ To test that a specific is set, you can use the binary comparison operator
 `-band`. In this example, we test for the **Device** and the **Archive**
 attributes in the value of `$file2`.
 
-```
+```powershell
 PS > ($file2 -band [FileAttributes]::Device) -eq [FileAttributes]::Device
 True
 
 PS > ($file2 -band [FileAttributes]::Archive) -eq [FileAttributes]::Archive
 False
 ```
-

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -117,8 +117,8 @@ m4v
 
 > [!NOTE]
 > `GetEnumNames()` and `GetEnumValues()` seem to return the same results; a
-> list of named values. However, internally, `GetEnumValues()` enumerating the
-> values, then mapping values into names. Read the list carefully and you'll
+> list of named values. However, internally, `GetEnumValues()` enumerates the
+> values, then maps values into names. Read the list carefully and you'll
 > notice that `ogg`, `oga`, and `mogg` appear in the output of
 > `GetEnumNames()`, but the output of `GetEnumValues()` only shows `oga`. The
 > same thing happens for `jpg`, `jpeg`, and `mpg`, `mpeg`.

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -117,8 +117,8 @@ m4v
 
 > [!NOTE]
 > `GetEnumNames()` and `GetEnumValues()` seem to return the same results; a
-> list of named values. However, internally, `GetEnumValues()` enumerating the
-> values, then mapping values into names. Read the list carefully and you'll
+> list of named values. However, internally, `GetEnumValues()` enumerates the
+> values, then maps values into names. Read the list carefully and you'll
 > notice that `ogg`, `oga`, and `mogg` appear in the output of
 > `GetEnumNames()`, but the output of `GetEnumValues()` only shows `oga`. The
 > same thing happens for `jpg`, `jpeg`, and `mpg`, `mpeg`.

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,7 +1,7 @@
 ---
 description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 11/27/2017
+ms.date: 06/21/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -69,6 +69,9 @@ The `GetEnumNames()` method returns the list of the labels for the enumeration.
 
 ```powershell
 [MediaTypes].GetEnumNames()
+```
+
+```Output
 unknown
 music
 mp3
@@ -91,6 +94,9 @@ The `GetEnumValues()` method returns the list of the values for the enumeration.
 
 ```powershell
 [MediaTypes].GetEnumValues()
+```
+
+```Output
 unknown
 music
 mp3
@@ -109,19 +115,32 @@ avi
 m4v
 ```
 
-**Note**: GetEnumNames() and GetEnumValues() seem to return the same results.
-However, internally, PowerShell is changing values into labels. Read the list
-carefully and you'll notice that `oga` and `mogg` are mentioned under the 'Get
-Names' results, but not under the 'Get Values' similar output for `jpg`,
-`jpeg`, and `mpg`, `mpeg`.
+> [!NOTE]
+> `GetEnumNames()` and `GetEnumValues()` seem to return the same results; a
+> list of named values. However, internally, `GetEnumValues()` enumerating the
+> values, then mapping values into names. Read the list carefully and you'll
+> notice that `ogg`, `oga`, and `mogg` appear in the output of
+> `GetEnumNames()`, but the output of `GetEnumValues()` only shows `oga`. The
+> same thing happens for `jpg`, `jpeg`, and `mpg`, `mpeg`.
+
+The `GetEnumName()` method can be used to get a name associated with a specific
+value. If there are multiple names associated with a value, the method returns
+the alphabetically-first name.
 
 ```powershell
 [MediaTypes].GetEnumName(15)
 oga
+```
 
+The following example shows how to map each name to its value.
+
+```powershell
 [MediaTypes].GetEnumNames() | ForEach-Object {
   "{0,-10} {1}" -f $_,[int]([MediaTypes]::$_)
 }
+```
+
+```Output
 unknown    0
 music      10
 mp3        11
@@ -184,7 +203,7 @@ In the following example the *FileAttributes* enumeration is created.
 "file2 attributes are: $file2"
 ```
 
-```output
+```Output
 file1 attributes are: Archive, Compressed, Device
 file2 attributes are: Device, Directory, Encrypted
 ```
@@ -193,11 +212,10 @@ To test that a specific is set, you can use the binary comparison operator
 `-band`. In this example, we test for the **Device** and the **Archive**
 attributes in the value of `$file2`.
 
-```
+```powershell
 PS > ($file2 -band [FileAttributes]::Device) -eq [FileAttributes]::Device
 True
 
 PS > ($file2 -band [FileAttributes]::Archive) -eq [FileAttributes]::Archive
 False
 ```
-


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Fixes [AB#1853880](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1853880) - Fixes #7722 - clarify enum method behavior

<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords