### PR TITLE
Update approved-verbs-for-windows-powershell-commands.md

### DIFF
--- a/reference/docs-conceptual/developer/cmdlet/approved-verbs-for-windows-powershell-commands.md
+++ b/reference/docs-conceptual/developer/cmdlet/approved-verbs-for-windows-powershell-commands.md
@@ -65,7 +65,7 @@ resource in a container.
 ### Get vs. Read
 
 Use the `Get` verb to obtain information about a resource (such as a file) or to obtain an object
-with which you can access the resource in future. Use the `Read` verb to open a resource and either
+with which you can access the resource in future. Use the `Read` verb to open a resource and
 extract information contained within.
 
 ### Invoke vs. Start


### PR DESCRIPTION
"either" is used to introduce two possibilities ... "either ... or ..." but there's no "or" here.

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
