### PR TITLE
WIP: Correct the description of when $Matches is set for -not/match operators

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -379,28 +379,10 @@ Collection examples:
 
 `-match` and `-notmatch` support regex capture groups. Each time they run on
 scalar input, and the `-match` result is **True**, or the `-notmatch` result is
-**False**, they overwrite the `$Matches` automatic variable. Otherwise, the
-`$Matches` automatic variable is not overwritten, and it will contain the
-previously set value, or `$null` if the variable has not been set. Therefore,
-when referencing `$Matches` after invoking one of these operators, consider
-verifying that the variable has been set by the current operator invocation by
-using a condition statement.
-
-Examples:
-
-```powershell
-if ("<version>1.0.0</version>" -match '<version>(.*?)</version>') {
-    $Matches
-}
-
-if (-not ("RedHat 8" -notmatch '(ubuntu|redhat) (.*)')) {
-    $Matches
-}
-```
-
-`$Matches` is a **Hashtable** that always has a key named '0', which stores the
-entire match. If the regular expression contains capture groups, the `$Matches`
-contains additional keys for each group.
+**False**, they overwrite the `$Matches` automatic variable. `$Matches` is a
+**Hashtable** that always has a key named '0', which stores the entire match.
+If the regular expression contains capture groups, the `$Matches` contains
+additional keys for each group.
 
 Example:
 
@@ -431,6 +413,21 @@ CONTOSO
 
 User name:
 jsmith
+```
+
+When the `-match` result is **False**, or the `-notmatch` result is **True**,
+or when the input is a collection, the `$Matches` automatic variable is not
+overwritten. Consequently, it will contain the previously set value, or `$null`
+if the variable has not been set. When referencing `$Matches` after invoking
+one of these operators, consider verifying that the variable was set by the
+current operator invocation by using a condition statement.
+
+Example:
+
+```powershell
+if ("<version>1.0.0</version>" -match '<version>(.*?)</version>') {
+    $Matches
+}
 ```
 
 For details, see [about_Regular_Expressions](about_Regular_Expressions.md) and

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -378,13 +378,13 @@ Collection examples:
 ```
 
 `-match` and `-notmatch` support regex capture groups. Each time they run on
-scalar input, and the `-match` result is True, or the `-notmatch` result is False,
-they overwrite the `$Matches` automatic variable. Otherwise, the `$Matches`
-automatic variable is not overwritten, and it will contain the previously set
-value, or `$null` if the variable has not been set. Therefore, when referencing
-`$Matches` after invoking one of these operators, consider verifying that the
-variable has been set by the current operator invocation by using a condition
-statement.
+scalar input, and the `-match` result is **True**, or the `-notmatch` result is
+**False**, they overwrite the `$Matches` automatic variable. Otherwise, the
+`$Matches` automatic variable is not overwritten, and it will contain the
+previously set value, or `$null` if the variable has not been set. Therefore,
+when referencing `$Matches` after invoking one of these operators, consider
+verifying that the variable has been set by the current operator invocation by
+using a condition statement.
 
 Examples:
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -359,7 +359,7 @@ Scalar examples:
 ```
 
 If the input is a collection, the operators return the matching members of that
-collection and the `$Matches` automatic variable is `$null`.
+collection.
 
 Collection examples:
 
@@ -377,12 +377,30 @@ Collection examples:
 #Output: Bag, Beg
 ```
 
-`-match` and `-notmatch` support regex capture groups. Each time they run, they
-overwrite the `$Matches` automatic variable. When `<input>` is a collection the
-`$Matches` variable is `$null`. `$Matches` is a **Hashtable** that always has a
-key named '0', which stores the entire match. If the regular expression
-contains capture groups, the `$Matches` contains additional keys for each
-group.
+`-match` and `-notmatch` support regex capture groups. Each time they run on
+scalar input, and the `-match` result is True, or the `-notmatch` result is False,
+they overwrite the `$Matches` automatic variable. Otherwise, the `$Matches`
+automatic variable is not overwritten, and it will contain the previously set
+value, or `$null` if the variable has not been set. Therefore, when referencing
+`$Matches` after invoking one of these operators, consider verifying that the
+variable has been set by the current operator invocation by using a condition
+statement.
+
+Examples:
+
+```powershell
+if ("<version>1.0.0</version>" -match '<version>(.*?)</version>') {
+    $Matches
+}
+
+if (-not ("RedHat 8" -notmatch '(ubuntu|redhat) (.*)')) {
+    $Matches
+}
+```
+
+`$Matches` is a **Hashtable** that always has a key named '0', which stores the
+entire match. If the regular expression contains capture groups, the `$Matches`
+contains additional keys for each group.
 
 Example:
 


### PR DESCRIPTION
# PR Summary
Updates to about_Comparison_Operators to cover when $Matches is NOT set.

This is just for `Preview` until I get the wording correct.  Then I'll propagate it back to the previous versions.

## PR Context
Address issue #7776 

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
