### PR TITLE
Update New-ScriptFileInfo.md

### DIFF
--- a/reference/5.1/PowershellGet/New-ScriptFileInfo.md
+++ b/reference/5.1/PowershellGet/New-ScriptFileInfo.md
@@ -23,7 +23,7 @@ New-ScriptFileInfo [[-Path] <String>] [-Version <String>] [-Author <String>] -De
  [-Guid <Guid>] [-CompanyName <String>] [-Copyright <String>] [-RequiredModules <Object[]>]
  [-ExternalModuleDependencies <String[]>] [-RequiredScripts <String[]>]
  [-ExternalScriptDependencies <String[]>] [-Tags <String[]>] [-ProjectUri <Uri>] [-LicenseUri <Uri>]
- [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PrivateData <String>] [-PassThru] [-Force]
+ [-IconUri <Uri>] [-ReleaseNotes <String[]>] [-PassThru] [-Force]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -80,8 +80,6 @@ Get-Content -Path C:\Test\Temp-Scriptfile.ps1
 .EXTERNALSCRIPTDEPENDENCIES
 
 .RELEASENOTES
-
-.PRIVATEDATA
 
 #>
 
@@ -196,8 +194,6 @@ Feature 3
 Feature 4
 Feature 5
 
-.PRIVATEDATA
-
 #>
 
 #Requires -Module 1
@@ -284,7 +280,7 @@ Accept wildcard characters: False
 
 ### -Description
 
-Specifies a description for the script.
+Specifies a description for the script. This parameter is ignored. As shown in the sample output above, no ".DESCRIPTION" attribute is generated.
 
 ```yaml
 Type: System.String
@@ -425,22 +421,6 @@ Required: False
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -PrivateData
-
-Specifies private data for the script.
-
-```yaml
-Type: System.String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
In PS v5.1, the -PrivateData parameter is invalid. And the -Description parameter is ignored.

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
