### PR TITLE
Remove duplicate code example in about_For.md

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_For.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_For.md
@@ -82,13 +82,6 @@ The following syntaxes are supported for multiple assignment operations in the
 **Repeat** statement:
 
 ```powershell
-# Comma separated assignment expressions.
-for (($i = 0), ($j = 0); $i -lt 10; $i++)
-{
-    "`$i:$i"
-    "`$j:$j"
-}
-
 # Comma separated assignment expressions enclosed in parenthesis.
 for (($i = 0), ($j = 0); $i -lt 10; ($i++), ($j++))
 {


### PR DESCRIPTION
The "Support for multiple operations" section has two example paragraphs, one for `init` and one for `repeat`
The first example for-loop in the `repeat` part is the same example for-loop already demonstrated at the beginning of the `init` part.

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
