### PR TITLE
Migrate changes in PR 7783 back to previous versions

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -359,7 +359,7 @@ Scalar examples:
 ```
 
 If the input is a collection, the operators return the matching members of that
-collection and the `$Matches` automatic variable is `$null`.
+collection.
 
 Collection examples:
 
@@ -377,12 +377,12 @@ Collection examples:
 #Output: Bag, Beg
 ```
 
-`-match` and `-notmatch` support regex capture groups. Each time they run, they
-overwrite the `$Matches` automatic variable. When `<input>` is a collection the
-`$Matches` variable is `$null`. `$Matches` is a **Hashtable** that always has a
-key named '0', which stores the entire match. If the regular expression
-contains capture groups, the `$Matches` contains additional keys for each
-group.
+`-match` and `-notmatch` support regex capture groups. Each time they run on
+scalar input, and the `-match` result is **True**, or the `-notmatch` result is
+**False**, they overwrite the `$Matches` automatic variable. `$Matches` is a
+**Hashtable** that always has a key named '0', which stores the entire match.
+If the regular expression contains capture groups, the `$Matches` contains
+additional keys for each group.
 
 Example:
 
@@ -413,6 +413,21 @@ CONTOSO
 
 User name:
 jsmith
+```
+
+When the `-match` result is **False**, or the `-notmatch` result is **True**,
+or when the input is a collection, the `$Matches` automatic variable is not
+overwritten. Consequently, it will contain the previously set value, or `$null`
+if the variable has not been set. When referencing `$Matches` after invoking
+one of these operators, consider verifying that the variable was set by the
+current operator invocation by using a condition statement.
+
+Example:
+
+```powershell
+if ("<version>1.0.0</version>" -match '<version>(.*?)</version>') {
+    $Matches
+}
 ```
 
 For details, see [about_Regular_Expressions](about_Regular_Expressions.md) and

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -359,7 +359,7 @@ Scalar examples:
 ```
 
 If the input is a collection, the operators return the matching members of that
-collection and the `$Matches` automatic variable is `$null`.
+collection.
 
 Collection examples:
 
@@ -377,12 +377,12 @@ Collection examples:
 #Output: Bag, Beg
 ```
 
-`-match` and `-notmatch` support regex capture groups. Each time they run, they
-overwrite the `$Matches` automatic variable. When `<input>` is a collection the
-`$Matches` variable is `$null`. `$Matches` is a **Hashtable** that always has a
-key named '0', which stores the entire match. If the regular expression
-contains capture groups, the `$Matches` contains additional keys for each
-group.
+`-match` and `-notmatch` support regex capture groups. Each time they run on
+scalar input, and the `-match` result is **True**, or the `-notmatch` result is
+**False**, they overwrite the `$Matches` automatic variable. `$Matches` is a
+**Hashtable** that always has a key named '0', which stores the entire match.
+If the regular expression contains capture groups, the `$Matches` contains
+additional keys for each group.
 
 Example:
 
@@ -413,6 +413,21 @@ CONTOSO
 
 User name:
 jsmith
+```
+
+When the `-match` result is **False**, or the `-notmatch` result is **True**,
+or when the input is a collection, the `$Matches` automatic variable is not
+overwritten. Consequently, it will contain the previously set value, or `$null`
+if the variable has not been set. When referencing `$Matches` after invoking
+one of these operators, consider verifying that the variable was set by the
+current operator invocation by using a condition statement.
+
+Example:
+
+```powershell
+if ("<version>1.0.0</version>" -match '<version>(.*?)</version>') {
+    $Matches
+}
 ```
 
 For details, see [about_Regular_Expressions](about_Regular_Expressions.md) and

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -359,7 +359,7 @@ Scalar examples:
 ```
 
 If the input is a collection, the operators return the matching members of that
-collection and the `$Matches` automatic variable is `$null`.
+collection.
 
 Collection examples:
 
@@ -377,12 +377,12 @@ Collection examples:
 #Output: Bag, Beg
 ```
 
-`-match` and `-notmatch` support regex capture groups. Each time they run, they
-overwrite the `$Matches` automatic variable. When `<input>` is a collection the
-`$Matches` variable is `$null`. `$Matches` is a **Hashtable** that always has a
-key named '0', which stores the entire match. If the regular expression
-contains capture groups, the `$Matches` contains additional keys for each
-group.
+`-match` and `-notmatch` support regex capture groups. Each time they run on
+scalar input, and the `-match` result is **True**, or the `-notmatch` result is
+**False**, they overwrite the `$Matches` automatic variable. `$Matches` is a
+**Hashtable** that always has a key named '0', which stores the entire match.
+If the regular expression contains capture groups, the `$Matches` contains
+additional keys for each group.
 
 Example:
 
@@ -413,6 +413,21 @@ CONTOSO
 
 User name:
 jsmith
+```
+
+When the `-match` result is **False**, or the `-notmatch` result is **True**,
+or when the input is a collection, the `$Matches` automatic variable is not
+overwritten. Consequently, it will contain the previously set value, or `$null`
+if the variable has not been set. When referencing `$Matches` after invoking
+one of these operators, consider verifying that the variable was set by the
+current operator invocation by using a condition statement.
+
+Example:
+
+```powershell
+if ("<version>1.0.0</version>" -match '<version>(.*?)</version>') {
+    $Matches
+}
 ```
 
 For details, see [about_Regular_Expressions](about_Regular_Expressions.md) and


### PR DESCRIPTION
# PR Summary
Finishes work for #7776

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Applies the changes made to 7.2 in PR #7783 to 7.1, 7.0 and 5.1.

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
