### PR TITLE
Fix `Rename-ItemProperty` `-Path` and `-LiteralPath` sections

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Rename-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Rename-ItemProperty.md
@@ -150,7 +150,7 @@ Accept wildcard characters: True
 
 ### -LiteralPath
 
-Specifies a path of the item property.
+Specifies a path to the item.
 Unlike the **Path** parameter, the value of **LiteralPath** is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
@@ -219,7 +219,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path of the item to rename.
+Specifies a path to the item.
 
 ```yaml
 Type: System.String

--- a/reference/7.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
@@ -149,7 +149,7 @@ Accept wildcard characters: True
 
 ### -LiteralPath
 
-Specifies a path to one or more locations. The value of **LiteralPath** is used exactly as it is
+Specifies a path to the item. The value of **LiteralPath** is used exactly as it is
 typed. No characters are interpreted as wildcards. If the path includes escape characters, enclose
 it in single quotation marks. Single quotation marks tell PowerShell not to interpret any characters
 as escape sequences.
@@ -219,7 +219,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path of the item to rename.
+Specifies a path to the item.
 Wildcard characters are permitted.
 
 ```yaml

--- a/reference/7.1/Microsoft.PowerShell.Management/Rename-ItemProperty.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Rename-ItemProperty.md
@@ -149,7 +149,7 @@ Accept wildcard characters: True
 
 ### -LiteralPath
 
-Specifies a path to one or more locations. The value of **LiteralPath** is used exactly as it is
+Specifies a path to the item. The value of **LiteralPath** is used exactly as it is
 typed. No characters are interpreted as wildcards. If the path includes escape characters, enclose
 it in single quotation marks. Single quotation marks tell PowerShell not to interpret any characters
 as escape sequences.
@@ -219,7 +219,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path of the item to rename.
+Specifies a path to the item.
 Wildcard characters are permitted.
 
 ```yaml

--- a/reference/7.2/Microsoft.PowerShell.Management/Rename-ItemProperty.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Rename-ItemProperty.md
@@ -148,7 +148,7 @@ Accept wildcard characters: True
 
 ### -LiteralPath
 
-Specifies a path to one or more locations. The value of **LiteralPath** is used exactly as it is
+Specifies a path to the item. The value of **LiteralPath** is used exactly as it is
 typed. No characters are interpreted as wildcards. If the path includes escape characters, enclose
 it in single quotation marks. Single quotation marks tell PowerShell not to interpret any characters
 as escape sequences.
@@ -218,7 +218,7 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path of the item to rename.
+Specifies a path to the item.
 Wildcard characters are permitted.
 
 ```yaml


### PR DESCRIPTION
# PR Summary

Fix two issues in `Rename-ItemProperty` existing documentation:

* Documentation states that the `Path` parameter specifies: _"the path of the item to rename"_. This is incorrect, as the cmdlet does not rename the item, but a property of the item.
* Documentation states that the `LiteralPath` parameter specifies _"a path to one or more locations"_. This is incorrect, only a single location may be specified.


## PR Context

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [NA] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
