### PR TITLE
Fixes #7803 - Updates about_Comparison_Operators

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -40,13 +40,12 @@ specified patterns. PowerShell includes the following comparison operators:
 
 ## Common features
 
-By default, almost all comparison operators are case-insensitive.
-Case-sensitive operators only work for string comparisons and since `-is` and
-`-isnot` are used to compare types, there is no case-sensitive option. To make
-a comparison operator case-sensitive, add a `c` after the `-`. For example,
-`-ceq` is the case-sensitive version of `-eq`. To make the case-insensitivity
-explicit, add an `i` after `-`. For example, `-ieq` is the explicitly
-case-insensitive version of `-eq`.
+By default, string comparisons are case-insensitive. The equality operators have
+explicit case-sensitive and case-insensitive forms. To make a comparison
+operator case-sensitive, add a `c` after the `-`. For example, `-ceq` is the
+case-sensitive version of `-eq`. To make the case-insensitivity explicit, add
+an `i` after `-`. For example, `-ieq` is the explicitly case-insensitive
+version of `-eq`.
 
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 07/06/2021
+ms.date: 07/15/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -40,11 +40,13 @@ specified patterns. PowerShell includes the following comparison operators:
 
 ## Common features
 
-By default, all comparison operators are case-insensitive. To make a comparison
-operator case-sensitive, add a `c` after the `-`. For example, `-ceq` is the
-case-sensitive version of `-eq`. To make the case-insensitivity explicit,
-add an `i` after `-`. For example, `-ieq` is the explicitly case-insensitive
-version of `-eq`.
+By default, almost all comparison operators are case-insensitive.
+Case-sensitive operators only work for string comparisons and since `-is` and
+`-isnot` are used to compare types, there is no case-sensitive option. To make
+a comparison operator case-sensitive, add a `c` after the `-`. For example,
+`-ceq` is the case-sensitive version of `-eq`. To make the case-insensitivity
+explicit, add an `i` after `-`. For example, `-ieq` is the explicitly
+case-insensitive version of `-eq`.
 
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -40,13 +40,12 @@ specified patterns. PowerShell includes the following comparison operators:
 
 ## Common features
 
-By default, almost all comparison operators are case-insensitive.
-Case-sensitive operators only work for string comparisons and since `-is` and
-`-isnot` are used to compare types, there is no case-sensitive option. To make
-a comparison operator case-sensitive, add a `c` after the `-`. For example,
-`-ceq` is the case-sensitive version of `-eq`. To make the case-insensitivity
-explicit, add an `i` after `-`. For example, `-ieq` is the explicitly
-case-insensitive version of `-eq`.
+By default, string comparisons are case-insensitive. The equality operators have
+explicit case-sensitive and case-insensitive forms. To make a comparison
+operator case-sensitive, add a `c` after the `-`. For example, `-ceq` is the
+case-sensitive version of `-eq`. To make the case-insensitivity explicit, add
+an `i` after `-`. For example, `-ieq` is the explicitly case-insensitive
+version of `-eq`.
 
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 07/06/2021
+ms.date: 07/15/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -40,11 +40,13 @@ specified patterns. PowerShell includes the following comparison operators:
 
 ## Common features
 
-By default, all comparison operators are case-insensitive. To make a comparison
-operator case-sensitive, add a `c` after the `-`. For example, `-ceq` is the
-case-sensitive version of `-eq`. To make the case-insensitivity explicit,
-add an `i` after `-`. For example, `-ieq` is the explicitly case-insensitive
-version of `-eq`.
+By default, almost all comparison operators are case-insensitive.
+Case-sensitive operators only work for string comparisons and since `-is` and
+`-isnot` are used to compare types, there is no case-sensitive option. To make
+a comparison operator case-sensitive, add a `c` after the `-`. For example,
+`-ceq` is the case-sensitive version of `-eq`. To make the case-insensitivity
+explicit, add an `i` after `-`. For example, `-ieq` is the explicitly
+case-insensitive version of `-eq`.
 
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -40,13 +40,12 @@ specified patterns. PowerShell includes the following comparison operators:
 
 ## Common features
 
-By default, almost all comparison operators are case-insensitive.
-Case-sensitive operators only work for string comparisons and since `-is` and
-`-isnot` are used to compare types, there is no case-sensitive option. To make
-a comparison operator case-sensitive, add a `c` after the `-`. For example,
-`-ceq` is the case-sensitive version of `-eq`. To make the case-insensitivity
-explicit, add an `i` after `-`. For example, `-ieq` is the explicitly
-case-insensitive version of `-eq`.
+By default, string comparisons are case-insensitive. The equality operators have
+explicit case-sensitive and case-insensitive forms. To make a comparison
+operator case-sensitive, add a `c` after the `-`. For example, `-ceq` is the
+case-sensitive version of `-eq`. To make the case-insensitivity explicit, add
+an `i` after `-`. For example, `-ieq` is the explicitly case-insensitive
+version of `-eq`.
 
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,8 +1,8 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 07/06/2021
-online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.1&WT.mc_id=ps-gethelp
+ms.date: 07/15/2021
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
 ---
@@ -40,11 +40,13 @@ specified patterns. PowerShell includes the following comparison operators:
 
 ## Common features
 
-By default, all comparison operators are case-insensitive. To make a comparison
-operator case-sensitive, add a `c` after the `-`. For example, `-ceq` is the
-case-sensitive version of `-eq`. To make the case-insensitivity explicit,
-add an `i` after `-`. For example, `-ieq` is the explicitly case-insensitive
-version of `-eq`.
+By default, almost all comparison operators are case-insensitive.
+Case-sensitive operators only work for string comparisons and since `-is` and
+`-isnot` are used to compare types, there is no case-sensitive option. To make
+a comparison operator case-sensitive, add a `c` after the `-`. For example,
+`-ceq` is the case-sensitive version of `-eq`. To make the case-insensitivity
+explicit, add an `i` after `-`. For example, `-ieq` is the explicitly
+case-insensitive version of `-eq`.
 
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -40,13 +40,12 @@ specified patterns. PowerShell includes the following comparison operators:
 
 ## Common features
 
-By default, almost all comparison operators are case-insensitive.
-Case-sensitive operators only work for string comparisons and since `-is` and
-`-isnot` are used to compare types, there is no case-sensitive option. To make
-a comparison operator case-sensitive, add a `c` after the `-`. For example,
-`-ceq` is the case-sensitive version of `-eq`. To make the case-insensitivity
-explicit, add an `i` after `-`. For example, `-ieq` is the explicitly
-case-insensitive version of `-eq`.
+By default, string comparisons are case-insensitive. The equality operators have
+explicit case-sensitive and case-insensitive forms. To make a comparison
+operator case-sensitive, add a `c` after the `-`. For example, `-ceq` is the
+case-sensitive version of `-eq`. To make the case-insensitivity explicit, add
+an `i` after `-`. For example, `-ieq` is the explicitly case-insensitive
+version of `-eq`.
 
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 07/06/2021
+ms.date: 07/15/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -40,11 +40,13 @@ specified patterns. PowerShell includes the following comparison operators:
 
 ## Common features
 
-By default, all comparison operators are case-insensitive. To make a comparison
-operator case-sensitive, add a `c` after the `-`. For example, `-ceq` is the
-case-sensitive version of `-eq`. To make the case-insensitivity explicit,
-add an `i` after `-`. For example, `-ieq` is the explicitly case-insensitive
-version of `-eq`.
+By default, almost all comparison operators are case-insensitive.
+Case-sensitive operators only work for string comparisons and since `-is` and
+`-isnot` are used to compare types, there is no case-sensitive option. To make
+a comparison operator case-sensitive, add a `c` after the `-`. For example,
+`-ceq` is the case-sensitive version of `-eq`. To make the case-insensitivity
+explicit, add an `i` after `-`. For example, `-ieq` is the explicitly
+case-insensitive version of `-eq`.
 
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the


### PR DESCRIPTION
# PR Summary

Corrects language around case-sensitive comparison operators

## PR Context

Fixes #7803
Fixes [AB#1859239](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1859239)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords