### PR TITLE
Fixes #7854 - Updates Sort-Object

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/10/2020
+ms.date: 07/28/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/sort-object?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Sort-Object
@@ -11,10 +11,10 @@ title: Sort-Object
 
 # Sort-Object
 
-## SYNOPSIS
+## Synopsis
 Sorts objects by property values.
 
-## SYNTAX
+## Syntax
 
 ### Default (Default)
 
@@ -23,10 +23,10 @@ Sort-Object [[-Property] <Object[]>] [-Descending] [-Unique] [-InputObject <psob
  [-Culture <string>] [-CaseSensitive] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Sort-Object` cmdlet sorts objects in ascending or descending order based on object property
-values. If sort properties are not included in a command, PowerShell uses default sort properties 
+values. If sort properties are not included in a command, PowerShell uses default sort properties
 of the first input object. If the type of the input object has no default sort properties,
 PowerShell attempts to compare the objects themselves. For more information, see the [Notes](#notes)
 section.
@@ -36,15 +36,17 @@ tables to sort in ascending order, descending order, or a combination of sort or
 sorted as case-sensitive or case-insensitive. Use the **Unique** parameter to eliminate duplicates
 from the output.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Sort the current directory by name
 
-This command sorts the files and subdirectories in a directory.
+This example sorts the files and subdirectories in a directory.
 
+```powershell
+Get-ChildItem -Path C:\Test | Sort-Object
 ```
-PS> Get-ChildItem -Path C:\Test | Sort-Object
 
+```Output
     Directory: C:\Test
 
 Mode                LastWriteTime         Length Name
@@ -60,7 +62,7 @@ d-----        2/25/2019     18:24                Logs
 ```
 
 The `Get-ChildItem` cmdlet gets the files and subdirectories from the directory specified by the
-**Path** parameter, **C:\Test**. The objects are sent down the pipeline to the `Sort-Object` cmdlet.
+**Path** parameter, `C:\Test`. The objects are sent down the pipeline to the `Sort-Object` cmdlet.
 `Sort-Object` does not specify a property so the output is sorted by the default sort property,
 **Name**.
 
@@ -68,9 +70,11 @@ The `Get-ChildItem` cmdlet gets the files and subdirectories from the directory 
 
 This command displays the files in the current directory by length in ascending order.
 
+```powershell
+Get-ChildItem -Path C:\Test -File | Sort-Object -Property Length
 ```
-PS> Get-ChildItem -Path C:\Test -File | Sort-Object -Property Length
 
+```Output
     Directory: C:\Test
 
 Mode                LastWriteTime         Length Name
@@ -92,9 +96,11 @@ the files by length in ascending order.
 
 This example displays processes with the highest memory usage based on their working set (WS) size.
 
+```powershell
+Get-Process | Sort-Object -Property WS | Select-Object -Last 5
 ```
-PS> Get-Process | Sort-Object -Property WS | Select-Object -Last 5
 
+```Output
  NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
  ------    -----      -----     ------      --  -- -----------
     136   193.92     217.11     889.16   87492   8 OUTLOOK
@@ -115,9 +121,11 @@ with the highest **WS** usage.
 This command sorts the PowerShell session's **HistoryInfo** objects using the **Id** property. Each
 PowerShell session has its own command history.
 
+```powershell
+Get-History | Sort-Object -Property Id -Descending
 ```
-PS> Get-History | Sort-Object -Property Id -Descending
 
+```Output
   Id CommandLine
   -- -----------
   10 Get-Command Sort-Object -Syntax
@@ -139,7 +147,7 @@ newest to oldest.
 
 ### Example 5: Use a hash table to sort properties in ascending and descending order
 
-This command uses two properties to sort the objects, **Status** and **DisplayName**. **Status** is
+This example uses two properties to sort the objects, **Status** and **DisplayName**. **Status** is
 sorted in descending order and **DisplayName** is sorted in ascending order.
 
 A hash table is used to specify the **Property** parameter's value. The hash table uses an
@@ -149,9 +157,13 @@ see [about_Hash_Tables](../Microsoft.PowerShell.Core/About/about_Hash_Tables.md)
 The **Status** property used in the hash table is an enumerated property.
 For more information, see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrollerstatus).
 
+```powershell
+Get-Service |
+    Sort-Object -Property @{Expression = "Status"; Descending = $true},
+                          @{Expression = "DisplayName"; Descending = $false}
 ```
-PS C:\> Get-Service | Sort-Object -Property @{Expression = "Status"; Descending = $True}, @{Expression = "DisplayName"; Descending = $False}
 
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Running  Appinfo            Application Information
@@ -189,9 +201,13 @@ the display names in alphabetical order.
 This command sorts text files in descending order by the time span between **CreationTime** and
 **LastWriteTime**.
 
+```powershell
+Get-ChildItem -Path C:\Test\*.txt |
+    Sort-Object -Property {$_.CreationTime - $_.LastWriteTime} |
+    Format-Table CreationTime, LastWriteTime, FullName
 ```
-PS> Get-ChildItem -Path C:\Test\*.txt | Sort-Object -Property @{Expression = {$_.CreationTime - $_.LastWriteTime}; Descending = $False} | Format-Table CreationTime, LastWriteTime, FullName
 
+```Output
 CreationTime          LastWriteTime        FullName
 ------------          -------------        --------
 11/21/2018 12:39:01   2/26/2019 08:59:36   C:\Test\test2.txt
@@ -203,14 +219,12 @@ CreationTime          LastWriteTime        FullName
 2/25/2019 18:25:11    2/26/2019 12:08:47   C:\Test\Zsystemlog.txt
 2/25/2019 18:25:11    2/26/2019 08:55:33   C:\Test\Bfile.txt
 2/26/2019 08:46:59    2/26/2019 12:12:19   C:\Test\LogFile3.txt
-
 ```
 
-The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory **C:\Test** and all
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory `C:\Test` and all
 of the `*.txt` files. The objects are sent down the pipeline to the `Sort-Object` cmdlet.
-`Sort-Object` uses the **Property** parameter with a hash table to determine each files time span
-between **CreationTime** and **LastWriteTime**. The **Descending** parameter is set to `$False` to
-sort in the order of longest to shortest time span.
+`Sort-Object` uses the **Property** parameter with a scriptblock to determine each files time span
+between **CreationTime** and **LastWriteTime**.
 
 ### Example 7: Sort names in a text file
 
@@ -218,8 +232,12 @@ This example shows how to sort a list from a text file. The original file is dis
 unsorted list. `Sort-Object` sorts the contents and then sorts the contents with the **Unique**
 parameter that removes duplicates.
 
+```powershell
+# All items unsorted
+Get-Content -Path C:\Test\ServerNames.txt
 ```
-PS> Get-Content -Path C:\Test\ServerNames.txt
+
+```Output
 localhost
 server01
 server25
@@ -227,8 +245,11 @@ LOCALHOST
 Server19
 server3
 localhost
+```
 
-PS> Get-Content -Path C:\Test\ServerNames.txt | Sort-Object
+```powershell
+# All items sorted
+Get-Content -Path C:\Test\ServerNames.txt | Sort-Object
 localhost
 LOCALHOST
 localhost
@@ -236,8 +257,14 @@ server01
 Server19
 server25
 server3
+```
 
-PS> Get-Content -Path C:\Test\ServerNames.txt | Sort-Object -Unique
+```powershell
+# Unique filtered items sorted
+Get-Content -Path C:\Test\ServerNames.txt | Sort-Object -Unique
+```
+
+```Output
 localhost
 server01
 Server19
@@ -246,14 +273,14 @@ server3
 ```
 
 The `Get-Content` cmdlet uses the **Path** parameter to specify the directory and file name. The
-file **ServerNames.txt** contains an unsorted list of computer names.
+file `ServerNames.txt` contains an unsorted list of computer names.
 
 The `Get-Content` cmdlet uses the **Path** parameter to specify the directory and file name. The
-file **ServerNames.txt** contains an unsorted list of computer names. The objects are sent down the
+file `ServerNames.txt` contains an unsorted list of computer names. The objects are sent down the
 pipeline to the `Sort-Object` cmdlet. `Sort-Object` sorts the list in the default order, ascending.
 
 The `Get-Content` cmdlet uses the **Path** parameter to specify the directory and file name. The
-file **ServerNames.txt** contains an unsorted list of computer names. The objects are sent down the
+file `ServerNames.txt` contains an unsorted list of computer names. The objects are sent down the
 pipeline to the `Sort-Object` cmdlet. `Sort-Object` uses the **Unique** parameter to remove
 duplicate computer names. The list is sorted in the default order, ascending.
 
@@ -266,8 +293,12 @@ integers. For these examples, the `ProductId.txt` file contains an unsorted list
 In the first example, `Get-Content` gets the contents of the file and pipes lines to the
 `Sort-Object` cmdlet. `Sort-Object` sorts the string objects in ascending order.
 
+```powershell
+# String sorted
+Get-Content -Path C:\Test\ProductId.txt | Sort-Object
 ```
-PS> Get-Content -Path C:\Test\ProductId.txt | Sort-Object
+
+```Output
 0
 1
 12345
@@ -281,8 +312,14 @@ PS> Get-Content -Path C:\Test\ProductId.txt | Sort-Object
 77
 88
 99999
+```
 
-PS> Get-Content -Path C:\Test\ProductId.txt | Sort-Object {[int]$_}
+```powershell
+# Integer sorted
+Get-Content -Path C:\Test\ProductId.txt | Sort-Object {[int]$_}
+```
+
+```Output
 0
 1
 2
@@ -304,13 +341,7 @@ sample code, `[int]` converts the string to an integer and `$_` represents each 
 down the pipeline. The integer objects are sent down the pipeline to the `Sort-Object` cmdlet.
 `Sort-Object` sorts the integer objects in numeric order.
 
-The `Get-Content` cmdlet uses the **Path** parameter to specify the directory and file name. The
-file **ProductId.txt** contains an unsorted list of product numbers. The string objects are sent
-down the pipeline to the `ForEach-Object` cmdlet. `ForEach-Object` uses a script block to convert
-the strings to integers. In the sample code, `[int]` converts the string to an integer and `$_`
-represents each string as it comes down the pipeline. The integer objects are sent down the pipeline
-to the `Sort-Object` cmdlet. `Sort-Object` sorts the integer objects in numeric order.
-## PARAMETERS
+## Parameters
 
 ### -CaseSensitive
 
@@ -396,7 +427,7 @@ property. This process continues until there are no more specified properties or
 objects.
 
 The **Property** parameter's value can be a calculated property. To create a calculated property,
-use a hash table.
+use a scriptblock or a hashtable.
 
 Valid keys for a hash table are as follows:
 
@@ -444,19 +475,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.PSObject
 
 You can pipe the objects to be sorted to `Sort-Object`.
 
-## OUTPUTS
+## Outputs
 
 ### System.Management.Automation.PSObject
 
 `Sort-Object` returns the sorted objects.
 
-## NOTES
+## Notes
 
 The `Sort-Object` cmdlet sorts objects based on properties specified in the command or the default
 sort properties for the object type. Default sort properties are defined using the `PropertySet`
@@ -477,7 +508,7 @@ values. For Windows services, **Stopped** has a value of **1** and **Running** h
 **Stopped** is sorted before **Running** because of the enumerated values. For more information,
 see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrollerstatus).
 
-## RELATED LINKS
+## Related links
 
 [about_Calculated_Properties](../Microsoft.PowerShell.Core/About/about_Calculated_Properties.md)
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/10/2020
+ms.date: 07/28/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/sort-object?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Sort-Object
@@ -11,10 +11,10 @@ title: Sort-Object
 
 # Sort-Object
 
-## SYNOPSIS
+## Synopsis
 Sorts objects by property values.
 
-## SYNTAX
+## Syntax
 
 ### Default (Default)
 
@@ -37,7 +37,7 @@ Sort-Object [-Descending] [-Unique] -Bottom <Int32> [-InputObject <PSObject>] [[
  [-Culture <String>] [-CaseSensitive] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Sort-Object` cmdlet sorts objects in ascending or descending order based on object property
 values. If sort properties are not included in a command, PowerShell uses default sort properties
@@ -50,15 +50,17 @@ tables to sort in ascending order, descending order, or a combination of sort or
 sorted as case-sensitive or case-insensitive. Use the **Unique** parameter to eliminate duplicates
 from the output.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Sort the current directory by name
 
 This example sorts the files and subdirectories in a directory.
 
+```powershell
+Get-ChildItem -Path C:\Test | Sort-Object
 ```
-PS> Get-ChildItem -Path C:\Test | Sort-Object
 
+```Output
     Directory: C:\Test
 
 Mode                LastWriteTime         Length Name
@@ -74,7 +76,7 @@ d-----        2/25/2019     18:24                Logs
 ```
 
 The `Get-ChildItem` cmdlet gets the files and subdirectories from the directory specified by the
-**Path** parameter, **C:\Test**. The objects are sent down the pipeline to the `Sort-Object` cmdlet.
+**Path** parameter, `C:\Test`. The objects are sent down the pipeline to the `Sort-Object` cmdlet.
 `Sort-Object` does not specify a property so the output is sorted by the default sort property,
 **Name**.
 
@@ -82,9 +84,11 @@ The `Get-ChildItem` cmdlet gets the files and subdirectories from the directory 
 
 This command displays the files in the current directory by length in ascending order.
 
+```powershell
+Get-ChildItem -Path C:\Test -File | Sort-Object -Property Length
 ```
-PS> Get-ChildItem -Path C:\Test -File | Sort-Object -Property Length
 
+```Output
     Directory: C:\Test
 
 Mode                LastWriteTime         Length Name
@@ -106,9 +110,11 @@ the files by length in ascending order.
 
 This example displays processes with the highest memory usage based on their working set (WS) size.
 
+```powershell
+Get-Process | Sort-Object -Property WS | Select-Object -Last 5
 ```
-PS> Get-Process | Sort-Object -Property WS | Select-Object -Last 5
 
+```Output
  NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
  ------    -----      -----     ------      --  -- -----------
     136   193.92     217.11     889.16   87492   8 OUTLOOK
@@ -132,9 +138,11 @@ example, `Get-Process | Sort-Object -Property WS -Bottom 5`.
 This command sorts the PowerShell session's **HistoryInfo** objects using the **Id** property. Each
 PowerShell session has its own command history.
 
+```powershell
+Get-History | Sort-Object -Property Id -Descending
 ```
-PS> Get-History | Sort-Object -Property Id -Descending
 
+```Output
   Id CommandLine
   -- -----------
   10 Get-Command Sort-Object -Syntax
@@ -166,9 +174,13 @@ see [about_Hash_Tables](../Microsoft.PowerShell.Core/About/about_Hash_Tables.md)
 The **Status** property used in the hash table is an enumerated property.
 For more information, see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrollerstatus).
 
+```powershell
+Get-Service |
+    Sort-Object -Property @{Expression = "Status"; Descending = $true},
+                          @{Expression = "DisplayName"; Descending = $false}
 ```
-PS C:\> Get-Service | Sort-Object -Property @{Expression = "Status"; Descending = $True}, @{Expression = "DisplayName"; Descending = $False}
 
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Running  Appinfo            Application Information
@@ -206,9 +218,13 @@ the display names in alphabetical order.
 This command sorts text files in descending order by the time span between **CreationTime** and
 **LastWriteTime**.
 
+```powershell
+Get-ChildItem -Path C:\Test\*.txt |
+    Sort-Object -Property {$_.CreationTime - $_.LastWriteTime} |
+    Format-Table CreationTime, LastWriteTime, FullName
 ```
-PS> Get-ChildItem -Path C:\Test\*.txt | Sort-Object -Property @{Expression = {$_.CreationTime - $_.LastWriteTime}; Descending = $False} | Format-Table CreationTime, LastWriteTime, FullName
 
+```Output
 CreationTime          LastWriteTime        FullName
 ------------          -------------        --------
 11/21/2018 12:39:01   2/26/2019 08:59:36   C:\Test\test2.txt
@@ -222,11 +238,10 @@ CreationTime          LastWriteTime        FullName
 2/26/2019 08:46:59    2/26/2019 12:12:19   C:\Test\LogFile3.txt
 ```
 
-The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory **C:\Test** and all
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory `C:\Test` and all
 of the `*.txt` files. The objects are sent down the pipeline to the `Sort-Object` cmdlet.
-`Sort-Object` uses the **Property** parameter with a hash table to determine each files time span
-between **CreationTime** and **LastWriteTime**. The **Descending** parameter is set to `$False` to
-sort in the order of longest to shortest time span.
+`Sort-Object` uses the **Property** parameter with a scriptblock to determine each files time span
+between **CreationTime** and **LastWriteTime**.
 
 ### Example 7: Sort names in a text file
 
@@ -234,8 +249,12 @@ This example shows how to sort a list from a text file. The original file is dis
 unsorted list. `Sort-Object` sorts the contents and then sorts the contents with the **Unique**
 parameter that removes duplicates.
 
+```powershell
+# All items unsorted
+Get-Content -Path C:\Test\ServerNames.txt
 ```
-PS> Get-Content -Path C:\Test\ServerNames.txt
+
+```Output
 localhost
 server01
 server25
@@ -243,8 +262,11 @@ LOCALHOST
 Server19
 server3
 localhost
+```
 
-PS> Get-Content -Path C:\Test\ServerNames.txt | Sort-Object
+```powershell
+# All items sorted
+Get-Content -Path C:\Test\ServerNames.txt | Sort-Object
 localhost
 LOCALHOST
 localhost
@@ -252,8 +274,14 @@ server01
 Server19
 server25
 server3
+```
 
-PS> Get-Content -Path C:\Test\ServerNames.txt | Sort-Object -Unique
+```powershell
+# Unique filtered items sorted
+Get-Content -Path C:\Test\ServerNames.txt | Sort-Object -Unique
+```
+
+```Output
 localhost
 server01
 Server19
@@ -262,14 +290,14 @@ server3
 ```
 
 The `Get-Content` cmdlet uses the **Path** parameter to specify the directory and file name. The
-file **ServerNames.txt** contains an unsorted list of computer names.
+file `ServerNames.txt` contains an unsorted list of computer names.
 
 The `Get-Content` cmdlet uses the **Path** parameter to specify the directory and file name. The
-file **ServerNames.txt** contains an unsorted list of computer names. The objects are sent down the
+file `ServerNames.txt` contains an unsorted list of computer names. The objects are sent down the
 pipeline to the `Sort-Object` cmdlet. `Sort-Object` sorts the list in the default order, ascending.
 
 The `Get-Content` cmdlet uses the **Path** parameter to specify the directory and file name. The
-file **ServerNames.txt** contains an unsorted list of computer names. The objects are sent down the
+file `ServerNames.txt` contains an unsorted list of computer names. The objects are sent down the
 pipeline to the `Sort-Object` cmdlet. `Sort-Object` uses the **Unique** parameter to remove
 duplicate computer names. The list is sorted in the default order, ascending.
 
@@ -282,8 +310,12 @@ integers. For these examples, the `ProductId.txt` file contains an unsorted list
 In the first example, `Get-Content` gets the contents of the file and pipes lines to the
 `Sort-Object` cmdlet. `Sort-Object` sorts the string objects in ascending order.
 
+```powershell
+# String sorted
+Get-Content -Path C:\Test\ProductId.txt | Sort-Object
 ```
-PS> Get-Content -Path C:\Test\ProductId.txt | Sort-Object
+
+```Output
 0
 1
 12345
@@ -297,8 +329,14 @@ PS> Get-Content -Path C:\Test\ProductId.txt | Sort-Object
 77
 88
 99999
+```
 
-PS> Get-Content -Path C:\Test\ProductId.txt | Sort-Object {[int]$_}
+```powershell
+# Integer sorted
+Get-Content -Path C:\Test\ProductId.txt | Sort-Object {[int]$_}
+```
+
+```Output
 0
 1
 2
@@ -328,7 +366,10 @@ are sorting the numbers one through 20 by the their value 'modulo 3'. The modulo
 zero to two.
 
 ```powershell
-PS> 1..20 |Sort-Object {$_ % 3}
+1..20 |Sort-Object {$_ % 3}
+```
+
+```Output
 18
 3
 15
@@ -349,8 +390,13 @@ PS> 1..20 |Sort-Object {$_ % 3}
 17
 2
 20
+```
 
-PS> 1..20 |Sort-Object {$_ % 3} -Stable
+```powershell
+1..20 |Sort-Object {$_ % 3} -Stable
+```
+
+```Output
 3
 6
 9
@@ -377,7 +423,7 @@ The output from the first sort is correctly grouped by the modulus value but the
 are not sorted within the modulus range. The second sort uses the **Stable** option to return a
 stable sort.
 
-## PARAMETERS
+## Parameters
 
 ### -Bottom
 
@@ -482,7 +528,7 @@ property. This process continues until there are no more specified properties or
 objects.
 
 The **Property** parameter's value can be a calculated property. To create a calculated property,
-use a hash table.
+use a scriptblock or a hashtable.
 
 Valid keys for a hash table are as follows:
 
@@ -567,19 +613,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.PSObject
 
 You can pipe the objects to be sorted to `Sort-Object`.
 
-## OUTPUTS
+## Outputs
 
 ### System.Management.Automation.PSObject
 
 `Sort-Object` returns the sorted objects.
 
-## NOTES
+## Notes
 
 The `Sort-Object` cmdlet sorts objects based on properties specified in the command or the default
 sort properties for the object type. Default sort properties are defined using the `PropertySet`
@@ -602,7 +648,7 @@ see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrolle
 
 The performance of the sorting algorithm is slower when doing a stable sort.
 
-## RELATED LINKS
+## Related links
 
 [about_Calculated_Properties](../Microsoft.PowerShell.Core/About/about_Calculated_Properties.md)
 

--- a/reference/7.1/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/10/2020
+ms.date: 07/28/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/sort-object?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Sort-Object
@@ -11,10 +11,10 @@ title: Sort-Object
 
 # Sort-Object
 
-## SYNOPSIS
+## Synopsis
 Sorts objects by property values.
 
-## SYNTAX
+## Syntax
 
 ### Default (Default)
 
@@ -37,7 +37,7 @@ Sort-Object [-Descending] [-Unique] -Bottom <Int32> [-InputObject <PSObject>] [[
  [-Culture <String>] [-CaseSensitive] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Sort-Object` cmdlet sorts objects in ascending or descending order based on object property
 values. If sort properties are not included in a command, PowerShell uses default sort properties
@@ -50,15 +50,17 @@ tables to sort in ascending order, descending order, or a combination of sort or
 sorted as case-sensitive or case-insensitive. Use the **Unique** parameter to eliminate duplicates
 from the output.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Sort the current directory by name
 
 This example sorts the files and subdirectories in a directory.
 
+```powershell
+Get-ChildItem -Path C:\Test | Sort-Object
 ```
-PS> Get-ChildItem -Path C:\Test | Sort-Object
 
+```Output
     Directory: C:\Test
 
 Mode                LastWriteTime         Length Name
@@ -74,7 +76,7 @@ d-----        2/25/2019     18:24                Logs
 ```
 
 The `Get-ChildItem` cmdlet gets the files and subdirectories from the directory specified by the
-**Path** parameter, **C:\Test**. The objects are sent down the pipeline to the `Sort-Object` cmdlet.
+**Path** parameter, `C:\Test`. The objects are sent down the pipeline to the `Sort-Object` cmdlet.
 `Sort-Object` does not specify a property so the output is sorted by the default sort property,
 **Name**.
 
@@ -82,9 +84,11 @@ The `Get-ChildItem` cmdlet gets the files and subdirectories from the directory 
 
 This command displays the files in the current directory by length in ascending order.
 
+```powershell
+Get-ChildItem -Path C:\Test -File | Sort-Object -Property Length
 ```
-PS> Get-ChildItem -Path C:\Test -File | Sort-Object -Property Length
 
+```Output
     Directory: C:\Test
 
 Mode                LastWriteTime         Length Name
@@ -106,9 +110,11 @@ the files by length in ascending order.
 
 This example displays processes with the highest memory usage based on their working set (WS) size.
 
+```powershell
+Get-Process | Sort-Object -Property WS | Select-Object -Last 5
 ```
-PS> Get-Process | Sort-Object -Property WS | Select-Object -Last 5
 
+```Output
  NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
  ------    -----      -----     ------      --  -- -----------
     136   193.92     217.11     889.16   87492   8 OUTLOOK
@@ -132,9 +138,11 @@ example, `Get-Process | Sort-Object -Property WS -Bottom 5`.
 This command sorts the PowerShell session's **HistoryInfo** objects using the **Id** property. Each
 PowerShell session has its own command history.
 
+```powershell
+Get-History | Sort-Object -Property Id -Descending
 ```
-PS> Get-History | Sort-Object -Property Id -Descending
 
+```Output
   Id CommandLine
   -- -----------
   10 Get-Command Sort-Object -Syntax
@@ -166,9 +174,13 @@ see [about_Hash_Tables](../Microsoft.PowerShell.Core/About/about_Hash_Tables.md)
 The **Status** property used in the hash table is an enumerated property.
 For more information, see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrollerstatus).
 
+```powershell
+Get-Service |
+    Sort-Object -Property @{Expression = "Status"; Descending = $true},
+                          @{Expression = "DisplayName"; Descending = $false}
 ```
-PS C:\> Get-Service | Sort-Object -Property @{Expression = "Status"; Descending = $True}, @{Expression = "DisplayName"; Descending = $False}
 
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Running  Appinfo            Application Information
@@ -206,9 +218,13 @@ the display names in alphabetical order.
 This command sorts text files in descending order by the time span between **CreationTime** and
 **LastWriteTime**.
 
+```powershell
+Get-ChildItem -Path C:\Test\*.txt |
+    Sort-Object -Property {$_.CreationTime - $_.LastWriteTime} |
+    Format-Table CreationTime, LastWriteTime, FullName
 ```
-PS> Get-ChildItem -Path C:\Test\*.txt | Sort-Object -Property @{Expression = {$_.CreationTime - $_.LastWriteTime}; Descending = $False} | Format-Table CreationTime, LastWriteTime, FullName
 
+```Output
 CreationTime          LastWriteTime        FullName
 ------------          -------------        --------
 11/21/2018 12:39:01   2/26/2019 08:59:36   C:\Test\test2.txt
@@ -222,11 +238,10 @@ CreationTime          LastWriteTime        FullName
 2/26/2019 08:46:59    2/26/2019 12:12:19   C:\Test\LogFile3.txt
 ```
 
-The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory **C:\Test** and all
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory `C:\Test` and all
 of the `*.txt` files. The objects are sent down the pipeline to the `Sort-Object` cmdlet.
-`Sort-Object` uses the **Property** parameter with a hash table to determine each files time span
-between **CreationTime** and **LastWriteTime**. The **Descending** parameter is set to `$False` to
-sort in the order of longest to shortest time span.
+`Sort-Object` uses the **Property** parameter with a scriptblock to determine each files time span
+between **CreationTime** and **LastWriteTime**.
 
 ### Example 7: Sort names in a text file
 
@@ -234,8 +249,12 @@ This example shows how to sort a list from a text file. The original file is dis
 unsorted list. `Sort-Object` sorts the contents and then sorts the contents with the **Unique**
 parameter that removes duplicates.
 
+```powershell
+# All items unsorted
+Get-Content -Path C:\Test\ServerNames.txt
 ```
-PS> Get-Content -Path C:\Test\ServerNames.txt
+
+```Output
 localhost
 server01
 server25
@@ -243,8 +262,11 @@ LOCALHOST
 Server19
 server3
 localhost
+```
 
-PS> Get-Content -Path C:\Test\ServerNames.txt | Sort-Object
+```powershell
+# All items sorted
+Get-Content -Path C:\Test\ServerNames.txt | Sort-Object
 localhost
 LOCALHOST
 localhost
@@ -252,8 +274,14 @@ server01
 Server19
 server25
 server3
+```
 
-PS> Get-Content -Path C:\Test\ServerNames.txt | Sort-Object -Unique
+```powershell
+# Unique filtered items sorted
+Get-Content -Path C:\Test\ServerNames.txt | Sort-Object -Unique
+```
+
+```Output
 localhost
 server01
 Server19
@@ -262,14 +290,14 @@ server3
 ```
 
 The `Get-Content` cmdlet uses the **Path** parameter to specify the directory and file name. The
-file **ServerNames.txt** contains an unsorted list of computer names.
+file `ServerNames.txt` contains an unsorted list of computer names.
 
 The `Get-Content` cmdlet uses the **Path** parameter to specify the directory and file name. The
-file **ServerNames.txt** contains an unsorted list of computer names. The objects are sent down the
+file `ServerNames.txt` contains an unsorted list of computer names. The objects are sent down the
 pipeline to the `Sort-Object` cmdlet. `Sort-Object` sorts the list in the default order, ascending.
 
 The `Get-Content` cmdlet uses the **Path** parameter to specify the directory and file name. The
-file **ServerNames.txt** contains an unsorted list of computer names. The objects are sent down the
+file `ServerNames.txt` contains an unsorted list of computer names. The objects are sent down the
 pipeline to the `Sort-Object` cmdlet. `Sort-Object` uses the **Unique** parameter to remove
 duplicate computer names. The list is sorted in the default order, ascending.
 
@@ -282,8 +310,12 @@ integers. For these examples, the `ProductId.txt` file contains an unsorted list
 In the first example, `Get-Content` gets the contents of the file and pipes lines to the
 `Sort-Object` cmdlet. `Sort-Object` sorts the string objects in ascending order.
 
+```powershell
+# String sorted
+Get-Content -Path C:\Test\ProductId.txt | Sort-Object
 ```
-PS> Get-Content -Path C:\Test\ProductId.txt | Sort-Object
+
+```Output
 0
 1
 12345
@@ -297,8 +329,14 @@ PS> Get-Content -Path C:\Test\ProductId.txt | Sort-Object
 77
 88
 99999
+```
 
-PS> Get-Content -Path C:\Test\ProductId.txt | Sort-Object {[int]$_}
+```powershell
+# Integer sorted
+Get-Content -Path C:\Test\ProductId.txt | Sort-Object {[int]$_}
+```
+
+```Output
 0
 1
 2
@@ -328,7 +366,10 @@ are sorting the numbers one through 20 by the their value 'modulo 3'. The modulo
 zero to two.
 
 ```powershell
-PS> 1..20 |Sort-Object {$_ % 3}
+1..20 |Sort-Object {$_ % 3}
+```
+
+```Output
 18
 3
 15
@@ -349,8 +390,13 @@ PS> 1..20 |Sort-Object {$_ % 3}
 17
 2
 20
+```
 
-PS> 1..20 |Sort-Object {$_ % 3} -Stable
+```powershell
+1..20 |Sort-Object {$_ % 3} -Stable
+```
+
+```Output
 3
 6
 9
@@ -377,7 +423,7 @@ The output from the first sort is correctly grouped by the modulus value but the
 are not sorted within the modulus range. The second sort uses the **Stable** option to return a
 stable sort.
 
-## PARAMETERS
+## Parameters
 
 ### -Bottom
 
@@ -482,7 +528,7 @@ property. This process continues until there are no more specified properties or
 objects.
 
 The **Property** parameter's value can be a calculated property. To create a calculated property,
-use a hash table.
+use a scriptblock or a hashtable.
 
 Valid keys for a hash table are as follows:
 
@@ -567,19 +613,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.PSObject
 
 You can pipe the objects to be sorted to `Sort-Object`.
 
-## OUTPUTS
+## Outputs
 
 ### System.Management.Automation.PSObject
 
 `Sort-Object` returns the sorted objects.
 
-## NOTES
+## Notes
 
 The `Sort-Object` cmdlet sorts objects based on properties specified in the command or the default
 sort properties for the object type. Default sort properties are defined using the `PropertySet`
@@ -602,7 +648,7 @@ see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrolle
 
 The performance of the sorting algorithm is slower when doing a stable sort.
 
-## RELATED LINKS
+## Related links
 
 [about_Calculated_Properties](../Microsoft.PowerShell.Core/About/about_Calculated_Properties.md)
 

--- a/reference/7.2/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/10/2020
+ms.date: 07/28/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/sort-object?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Sort-Object
@@ -10,10 +10,10 @@ title: Sort-Object
 
 # Sort-Object
 
-## SYNOPSIS
+## Synopsis
 Sorts objects by property values.
 
-## SYNTAX
+## Syntax
 
 ### Default (Default)
 
@@ -36,7 +36,7 @@ Sort-Object [-Descending] [-Unique] -Bottom <Int32> [-InputObject <PSObject>] [[
  [-Culture <String>] [-CaseSensitive] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Sort-Object` cmdlet sorts objects in ascending or descending order based on object property
 values. If sort properties are not included in a command, PowerShell uses default sort properties
@@ -49,15 +49,17 @@ tables to sort in ascending order, descending order, or a combination of sort or
 sorted as case-sensitive or case-insensitive. Use the **Unique** parameter to eliminate duplicates
 from the output.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Sort the current directory by name
 
 This example sorts the files and subdirectories in a directory.
 
+```powershell
+Get-ChildItem -Path C:\Test | Sort-Object
 ```
-PS> Get-ChildItem -Path C:\Test | Sort-Object
 
+```Output
     Directory: C:\Test
 
 Mode                LastWriteTime         Length Name
@@ -73,7 +75,7 @@ d-----        2/25/2019     18:24                Logs
 ```
 
 The `Get-ChildItem` cmdlet gets the files and subdirectories from the directory specified by the
-**Path** parameter, **C:\Test**. The objects are sent down the pipeline to the `Sort-Object` cmdlet.
+**Path** parameter, `C:\Test`. The objects are sent down the pipeline to the `Sort-Object` cmdlet.
 `Sort-Object` does not specify a property so the output is sorted by the default sort property,
 **Name**.
 
@@ -81,9 +83,11 @@ The `Get-ChildItem` cmdlet gets the files and subdirectories from the directory 
 
 This command displays the files in the current directory by length in ascending order.
 
+```powershell
+Get-ChildItem -Path C:\Test -File | Sort-Object -Property Length
 ```
-PS> Get-ChildItem -Path C:\Test -File | Sort-Object -Property Length
 
+```Output
     Directory: C:\Test
 
 Mode                LastWriteTime         Length Name
@@ -105,9 +109,11 @@ the files by length in ascending order.
 
 This example displays processes with the highest memory usage based on their working set (WS) size.
 
+```powershell
+Get-Process | Sort-Object -Property WS | Select-Object -Last 5
 ```
-PS> Get-Process | Sort-Object -Property WS | Select-Object -Last 5
 
+```Output
  NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
  ------    -----      -----     ------      --  -- -----------
     136   193.92     217.11     889.16   87492   8 OUTLOOK
@@ -131,9 +137,11 @@ example, `Get-Process | Sort-Object -Property WS -Bottom 5`.
 This command sorts the PowerShell session's **HistoryInfo** objects using the **Id** property. Each
 PowerShell session has its own command history.
 
+```powershell
+Get-History | Sort-Object -Property Id -Descending
 ```
-PS> Get-History | Sort-Object -Property Id -Descending
 
+```Output
   Id CommandLine
   -- -----------
   10 Get-Command Sort-Object -Syntax
@@ -165,9 +173,13 @@ see [about_Hash_Tables](../Microsoft.PowerShell.Core/About/about_Hash_Tables.md)
 The **Status** property used in the hash table is an enumerated property.
 For more information, see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrollerstatus).
 
+```powershell
+Get-Service |
+    Sort-Object -Property @{Expression = "Status"; Descending = $true},
+                          @{Expression = "DisplayName"; Descending = $false}
 ```
-PS C:\> Get-Service | Sort-Object -Property @{Expression = "Status"; Descending = $True}, @{Expression = "DisplayName"; Descending = $False}
 
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Running  Appinfo            Application Information
@@ -205,9 +217,13 @@ the display names in alphabetical order.
 This command sorts text files in descending order by the time span between **CreationTime** and
 **LastWriteTime**.
 
+```powershell
+Get-ChildItem -Path C:\Test\*.txt |
+    Sort-Object -Property {$_.CreationTime - $_.LastWriteTime} |
+    Format-Table CreationTime, LastWriteTime, FullName
 ```
-PS> Get-ChildItem -Path C:\Test\*.txt | Sort-Object -Property @{Expression = {$_.CreationTime - $_.LastWriteTime}; Descending = $False} | Format-Table CreationTime, LastWriteTime, FullName
 
+```Output
 CreationTime          LastWriteTime        FullName
 ------------          -------------        --------
 11/21/2018 12:39:01   2/26/2019 08:59:36   C:\Test\test2.txt
@@ -221,11 +237,10 @@ CreationTime          LastWriteTime        FullName
 2/26/2019 08:46:59    2/26/2019 12:12:19   C:\Test\LogFile3.txt
 ```
 
-The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory **C:\Test** and all
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory `C:\Test` and all
 of the `*.txt` files. The objects are sent down the pipeline to the `Sort-Object` cmdlet.
-`Sort-Object` uses the **Property** parameter with a hash table to determine each files time span
-between **CreationTime** and **LastWriteTime**. The **Descending** parameter is set to `$False` to
-sort in the order of longest to shortest time span.
+`Sort-Object` uses the **Property** parameter with a scriptblock to determine each files time span
+between **CreationTime** and **LastWriteTime**.
 
 ### Example 7: Sort names in a text file
 
@@ -233,8 +248,12 @@ This example shows how to sort a list from a text file. The original file is dis
 unsorted list. `Sort-Object` sorts the contents and then sorts the contents with the **Unique**
 parameter that removes duplicates.
 
+```powershell
+# All items unsorted
+Get-Content -Path C:\Test\ServerNames.txt
 ```
-PS> Get-Content -Path C:\Test\ServerNames.txt
+
+```Output
 localhost
 server01
 server25
@@ -242,8 +261,11 @@ LOCALHOST
 Server19
 server3
 localhost
+```
 
-PS> Get-Content -Path C:\Test\ServerNames.txt | Sort-Object
+```powershell
+# All items sorted
+Get-Content -Path C:\Test\ServerNames.txt | Sort-Object
 localhost
 LOCALHOST
 localhost
@@ -251,8 +273,14 @@ server01
 Server19
 server25
 server3
+```
 
-PS> Get-Content -Path C:\Test\ServerNames.txt | Sort-Object -Unique
+```powershell
+# Unique filtered items sorted
+Get-Content -Path C:\Test\ServerNames.txt | Sort-Object -Unique
+```
+
+```Output
 localhost
 server01
 Server19
@@ -261,14 +289,14 @@ server3
 ```
 
 The `Get-Content` cmdlet uses the **Path** parameter to specify the directory and file name. The
-file **ServerNames.txt** contains an unsorted list of computer names.
+file `ServerNames.txt` contains an unsorted list of computer names.
 
 The `Get-Content` cmdlet uses the **Path** parameter to specify the directory and file name. The
-file **ServerNames.txt** contains an unsorted list of computer names. The objects are sent down the
+file `ServerNames.txt` contains an unsorted list of computer names. The objects are sent down the
 pipeline to the `Sort-Object` cmdlet. `Sort-Object` sorts the list in the default order, ascending.
 
 The `Get-Content` cmdlet uses the **Path** parameter to specify the directory and file name. The
-file **ServerNames.txt** contains an unsorted list of computer names. The objects are sent down the
+file `ServerNames.txt` contains an unsorted list of computer names. The objects are sent down the
 pipeline to the `Sort-Object` cmdlet. `Sort-Object` uses the **Unique** parameter to remove
 duplicate computer names. The list is sorted in the default order, ascending.
 
@@ -281,8 +309,12 @@ integers. For these examples, the `ProductId.txt` file contains an unsorted list
 In the first example, `Get-Content` gets the contents of the file and pipes lines to the
 `Sort-Object` cmdlet. `Sort-Object` sorts the string objects in ascending order.
 
+```powershell
+# String sorted
+Get-Content -Path C:\Test\ProductId.txt | Sort-Object
 ```
-PS> Get-Content -Path C:\Test\ProductId.txt | Sort-Object
+
+```Output
 0
 1
 12345
@@ -296,8 +328,14 @@ PS> Get-Content -Path C:\Test\ProductId.txt | Sort-Object
 77
 88
 99999
+```
 
-PS> Get-Content -Path C:\Test\ProductId.txt | Sort-Object {[int]$_}
+```powershell
+# Integer sorted
+Get-Content -Path C:\Test\ProductId.txt | Sort-Object {[int]$_}
+```
+
+```Output
 0
 1
 2
@@ -327,7 +365,10 @@ are sorting the numbers one through 20 by the their value 'modulo 3'. The modulo
 zero to two.
 
 ```powershell
-PS> 1..20 |Sort-Object {$_ % 3}
+1..20 |Sort-Object {$_ % 3}
+```
+
+```Output
 18
 3
 15
@@ -348,8 +389,13 @@ PS> 1..20 |Sort-Object {$_ % 3}
 17
 2
 20
+```
 
-PS> 1..20 |Sort-Object {$_ % 3} -Stable
+```powershell
+1..20 |Sort-Object {$_ % 3} -Stable
+```
+
+```Output
 3
 6
 9
@@ -376,7 +422,7 @@ The output from the first sort is correctly grouped by the modulus value but the
 are not sorted within the modulus range. The second sort uses the **Stable** option to return a
 stable sort.
 
-## PARAMETERS
+## Parameters
 
 ### -Bottom
 
@@ -481,7 +527,7 @@ property. This process continues until there are no more specified properties or
 objects.
 
 The **Property** parameter's value can be a calculated property. To create a calculated property,
-use a hash table.
+use a scriptblock or a hashtable.
 
 Valid keys for a hash table are as follows:
 
@@ -566,19 +612,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.PSObject
 
 You can pipe the objects to be sorted to `Sort-Object`.
 
-## OUTPUTS
+## Outputs
 
 ### System.Management.Automation.PSObject
 
 `Sort-Object` returns the sorted objects.
 
-## NOTES
+## Notes
 
 The `Sort-Object` cmdlet sorts objects based on properties specified in the command or the default
 sort properties for the object type. Default sort properties are defined using the `PropertySet`
@@ -601,7 +647,7 @@ see [ServiceControllerStatus](/dotnet/api/system.serviceprocess.servicecontrolle
 
 The performance of the sorting algorithm is slower when doing a stable sort.
 
-## RELATED LINKS
+## Related links
 
 [about_Calculated_Properties](../Microsoft.PowerShell.Core/About/about_Calculated_Properties.md)
 


### PR DESCRIPTION
# PR Summary

Updates Sort-Object to clarify hashtable and scriptblock in ``-Property`` parameter. Updates for formatting

## PR Context

Fixes #7854
Fixes [AB#1862205](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1862205)

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords