### PR TITLE
Removed PSBoundParameters duplicate variable

### DIFF
--- a/reference/docs-conceptual/learn/deep-dives/everything-about-hashtable.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-hashtable.md
@@ -884,7 +884,7 @@ used with member access (`.`) notation. Or, you can use array index (`[]`) notat
 
 ### $PSBoundParameters
 
-[$PSBoundParameters][$PSBoundParameters] is an automatic variable that only exists inside the context of a function.
+`$PSBoundParameters` is an automatic variable that only exists inside the context of a function.
 It contains all the parameters that the function was called with. This isn't exactly a hashtable but
 close enough that you can treat it like one.
 

--- a/reference/docs-conceptual/learn/deep-dives/everything-about-hashtable.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-hashtable.md
@@ -884,7 +884,7 @@ used with member access (`.`) notation. Or, you can use array index (`[]`) notat
 
 ### $PSBoundParameters
 
-`$PSBoundParameters` is an automatic variable that only exists inside the context of a function.
+[$PSBoundParameters][PSBoundParameters] is an automatic variable that only exists inside the context of a function.
 It contains all the parameters that the function was called with. This isn't exactly a hashtable but
 close enough that you can treat it like one.
 


### PR DESCRIPTION
# PR Summary
Removed small typo in `PSBoundParameters` section.

## PR Context
Only text, cmdlets were not changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [X] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [X] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] This PR is ready to merge and is not **Work in Progress**