### PR TITLE
Fixes #6690 - Updates Set-Clipboard

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -9,10 +9,10 @@ title: Set-Clipboard
 ---
 # Set-Clipboard
 
-## SYNOPSIS
+## Synopsis
 Sets the current Windows clipboard entry.
 
-## SYNTAX
+## Syntax
 
 ### String (Default)
 
@@ -38,11 +38,11 @@ Set-Clipboard [-Append] -Path <String[]> [-AsHtml] [-WhatIf] [-Confirm] [<Common
 Set-Clipboard [-Append] -LiteralPath <String[]> [-AsHtml] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Set-Clipboard` cmdlet sets the current Windows clipboard entry.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Copy text to the clipboard
 
@@ -67,7 +67,7 @@ ssh key so that it can be pasted into another application, like GitHub.
 Get-Content C:\Users\user1\.ssh\id_ed25519.pub | Set-Clipboard
 ```
 
-## PARAMETERS
+## Parameters
 
 ### -Append
 
@@ -190,18 +190,18 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.String[]
 
-## OUTPUTS
+## Outputs
 
-## NOTES
+## Notes
 
 In rare cases when using `Set-Clipboard` with a high number of values in rapid succession, like in a
 loop, you might sporadically get a blank value from the clipboard. This can be fixed by using
 `Start-Sleep -Milliseconds 1` in the loop.
 
-## RELATED LINKS
+## Related links
 
 [Get-Clipboard](Get-Clipboard.md)

--- a/reference/7.0/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -9,23 +9,23 @@ title: Set-Clipboard
 ---
 # Set-Clipboard
 
-## SYNOPSIS
+## Synopsis
 Sets the contents of the clipboard.
 
-## SYNTAX
+## Syntax
 
 ```
 Set-Clipboard [-Value] <string[]> [-Append] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Set-Clipboard` cmdlet sets the contents of the clipboard.
 
 > [!NOTE]
 > On Linux, this cmdlet requires the `xclip` utility to be in the path.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Copy text to the clipboard
 
@@ -42,7 +42,7 @@ ssh key so that it can be pasted into another application, like GitHub.
 Get-Content C:\Users\user1\.ssh\id_ed25519.pub | Set-Clipboard
 ```
 
-## PARAMETERS
+## Parameters
 
 ### -Append
 
@@ -114,18 +114,18 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.String[]
 
-## OUTPUTS
+## Outputs
 
-## NOTES
+## Notes
 
 In rare cases when using `Set-Clipboard` with a high number of values in rapid succession, like in a
 loop, you might sporadically get a blank value from the clipboard. This can be fixed by using
 `Start-Sleep -Milliseconds 1` in the loop.
 
-## RELATED LINKS
+## Related links
 
 [Get-Clipboard](Get-Clipboard.md)

--- a/reference/7.1/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -10,23 +10,23 @@ title: Set-Clipboard
 ---
 # Set-Clipboard
 
-## SYNOPSIS
+## Synopsis
 Sets the contents of the clipboard.
 
-## SYNTAX
+## Syntax
 
 ```
 Set-Clipboard -Value <String[]> [-Append] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Set-Clipboard` cmdlet sets the contents of the clipboard.
 
 > [!NOTE]
 > On Linux, this cmdlet requires the `xclip` utility to be in the path.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Copy text to the clipboard
 
@@ -43,7 +43,7 @@ ssh key so that it can be pasted into another application, like GitHub.
 Get-Content C:\Users\user1\.ssh\id_ed25519.pub | Set-Clipboard
 ```
 
-## PARAMETERS
+## Parameters
 
 ### -Append
 
@@ -115,18 +115,18 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.String[]
 
-## OUTPUTS
+## Outputs
 
-## NOTES
+## Notes
 
 In rare cases when using `Set-Clipboard` with a high number of values in rapid succession, like in a
 loop, you might sporadically get a blank value from the clipboard. This can be fixed by using
 `Start-Sleep -Milliseconds 1` in the loop.
 
-## RELATED LINKS
+## Related links
 
 [Get-Clipboard](Get-Clipboard.md)

--- a/reference/7.2/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -2,30 +2,30 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/03/2020
+ms.date: 08/03/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/set-clipboard?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-Clipboard
 ---
 # Set-Clipboard
 
-## SYNOPSIS
+## Synopsis
 Sets the contents of the clipboard.
 
-## SYNTAX
+## Syntax
 
 ```
-Set-Clipboard -Value <String[]> [-Append] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-Clipboard -Value <String[]> [-Append] [-WhatIf] [-Confirm] [-PassThru] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Set-Clipboard` cmdlet sets the contents of the clipboard.
 
 > [!NOTE]
 > On Linux, this cmdlet requires the `xclip` utility to be in the path.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Copy text to the clipboard
 
@@ -42,7 +42,7 @@ ssh key so that it can be pasted into another application, like GitHub.
 Get-Content C:\Users\user1\.ssh\id_ed25519.pub | Set-Clipboard
 ```
 
-## PARAMETERS
+## Parameters
 
 ### -Append
 
@@ -68,6 +68,23 @@ Prompts you for confirmation before running the cmdlet.
 Type: System.Management.Automation.SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+
+Returns an object representing the item with which you're working. By default, this cmdlet does not
+generate any output.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named
@@ -114,18 +131,18 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.String[]
 
-## OUTPUTS
+## Outputs
 
-## NOTES
+## Notes
 
 In rare cases when using `Set-Clipboard` with a high number of values in rapid succession, like in a
 loop, you might sporadically get a blank value from the clipboard. This can be fixed by using
 `Start-Sleep -Milliseconds 1` in the loop.
 
-## RELATED LINKS
+## Related links
 
 [Get-Clipboard](Get-Clipboard.md)


### PR DESCRIPTION
# PR Summary

Adds ``-PassThru`` parameter to PowerShell 7.2 docs and formats headers for all versions

## PR Context

Fixes #6690
Fixes [AB#1777598](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1777598) 1864106

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords