### PR TITLE
Fixes #7882 - Clarify NoEnumerate behavior

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Output.md
@@ -42,7 +42,7 @@ be used to pass collections down the pipeline as a single object with the **NoEn
 ### Example 1: Get objects and write them to the console
 
 In this example, the results of the `Get-Process` cmdlet are stored in the `$P` variable. The
-`Write-Output` displays the process objects in `$P` in the console.
+`Write-Output` cmdlet displays the process objects in `$P` to the console.
 
 ```powershell
 $P = Get-Process

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Output.md
@@ -1,9 +1,8 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/14/2020
+ms.date: 08/10/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/write-output?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Output
@@ -11,8 +10,8 @@ title: Write-Output
 # Write-Output
 
 ## SYNOPSIS
-Sends the specified objects to the next command in the pipeline. If the command is the last command
-in the pipeline, the objects are displayed in the console.
+Writes the specified objects to the pipeline. If `Write-Output` is the last command in the pipeline,
+the objects are displayed in the console.
 
 ## SYNTAX
 
@@ -22,46 +21,47 @@ Write-Output [-InputObject] <PSObject[]> [-NoEnumerate] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The `Write-Output` cmdlet sends the specified object down the pipeline to the next command.
-If the command is the last command in the pipeline, the object is displayed in the console.
+Writes the specified objects to the pipeline. If `Write-Output` is the last command in the pipeline,
+the objects are displayed in the console.
 
-`Write-Output` sends objects down the primary pipeline, also known as the "output stream" or the
-"success pipeline." To send error objects down the error pipeline, use Write-Error.
+`Write-Output` sends objects to the primary pipeline, also known as the "output stream" or the
+"success pipeline." To send error objects to the error pipeline, use `Write-Error`.
 
 This cmdlet is typically used in scripts to display strings and other objects on the console. One of
-the built-in aliases for `Write-Output` is `echo` and similar to other shells that use `echo`, the
+the built-in aliases for `Write-Output` is `echo` and similar to other shells that use `echo`. The
 default behavior is to display the output at the end of a pipeline. In PowerShell, it is generally
 not necessary to use the cmdlet in instances where the output is displayed by default. For example,
 `Get-Process | Write-Output` is equivalent to `Get-Process`. Or, `echo "Home directory: $HOME"` can
 be written, `"Home directory: $HOME"`.
 
-By default, `Write-Output` enumerates through collections provided to the cmdlet. However,
-`Write-Output` can also be used to pass collections down the pipeline as a single object with the
-**NoEnumerate** parameter.
+By default, `Write-Output` enumerates through collection objects. However, `Write-Output` can also
+be used to pass collections down the pipeline as a single object with the **NoEnumerate** parameter.
 
 ## EXAMPLES
 
 ### Example 1: Get objects and write them to the console
+
+In this example, the results of the `Get-Process` cmdlet are stored in the `$P` variable. The
+`Write-Output` displays the process objects in `$P` in the console.
 
 ```powershell
 $P = Get-Process
 Write-Output $P
 ```
 
-The first command gets processes running on the computer and stores them in the `$P` variable.
-
-The second and third commands display the process objects in `$P` on the console.
-
 ### Example 2: Pass output to another cmdlet
+
+This command pipes the "test output" string to the `Get-Member` cmdlet, which displays the members
+of the **System.String** class, demonstrating that the string was passed along the pipeline.
 
 ```powershell
 Write-Output "test output" | Get-Member
 ```
 
-This command pipes the "test output" string to the `Get-Member` cmdlet, which displays the members
-of the **System.String** class, demonstrating that the string was passed along the pipeline.
-
 ### Example 3: Suppress enumeration in output
+
+This command adds the **NoEnumerate** parameter to treat a collection or array as a single object
+through the pipeline.
 
 ```powershell
 Write-Output 1,2,3 | Measure-Object
@@ -80,9 +80,6 @@ Write-Output 1,2,3 -NoEnumerate | Measure-Object
 Count    : 1
 ...
 ```
-
-This command adds the **NoEnumerate** parameter to treat a collection or array as a single object
-through the pipeline.
 
 ## PARAMETERS
 
@@ -109,6 +106,12 @@ By default, the `Write-Output` cmdlet always enumerates its output. The **NoEnum
 suppresses the default behavior, and prevents `Write-Output` from enumerating output. The
 **NoEnumerate** parameter has no effect if the command is wrapped in parentheses, because the
 parentheses force enumeration. For example, `(Write-Output 1,2,3)` still enumerates the array.
+
+The **NoEnumerate** parameter is only useful within a pipeline. Trying to see the effects of
+**NoEnumerate** in the console is problematic because PowerShell adds `Out-Default` to the end of
+every command line, which results in enumeration. But if you pipe `Write-Output -NoEnumerate` to
+another cmdlet, the downstream cmdlet receives the collection object, not the enumerated items of
+the collection.
 
 > [!IMPORTANT]
 > There is an issue with this switch in Windows PowerShell that is fixed in PowerShell 6.2 and

--- a/reference/7.0/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Write-Output.md
@@ -42,7 +42,7 @@ be used to pass collections down the pipeline as a single object with the **NoEn
 ### Example 1: Get objects and write them to the console
 
 In this example, the results of the `Get-Process` cmdlet are stored in the `$P` variable. The
-`Write-Output` displays the process objects in `$P` in the console.
+`Write-Output` cmdlet displays the process objects in `$P` to the console.
 
 ```powershell
 $P = Get-Process

--- a/reference/7.0/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Write-Output.md
@@ -1,9 +1,8 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/14/2020
+ms.date: 08/10/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/write-output?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Output
@@ -11,8 +10,8 @@ title: Write-Output
 # Write-Output
 
 ## SYNOPSIS
-Sends the specified objects to the next command in the pipeline. If the command is the last command
-in the pipeline, the objects are displayed in the console.
+Writes the specified objects to the pipeline. If `Write-Output` is the last command in the pipeline,
+the objects are displayed in the console.
 
 ## SYNTAX
 
@@ -22,46 +21,47 @@ Write-Output [-InputObject] <PSObject[]> [-NoEnumerate] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The `Write-Output` cmdlet sends the specified object down the pipeline to the next command.
-If the command is the last command in the pipeline, the object is displayed in the console.
+Writes the specified objects to the pipeline. If `Write-Output` is the last command in the pipeline,
+the objects are displayed in the console.
 
-`Write-Output` sends objects down the primary pipeline, also known as the "output stream" or the
-"success pipeline." To send error objects down the error pipeline, use Write-Error.
+`Write-Output` sends objects to the primary pipeline, also known as the "output stream" or the
+"success pipeline." To send error objects to the error pipeline, use `Write-Error`.
 
 This cmdlet is typically used in scripts to display strings and other objects on the console. One of
-the built-in aliases for `Write-Output` is `echo` and similar to other shells that use `echo`, the
+the built-in aliases for `Write-Output` is `echo` and similar to other shells that use `echo`. The
 default behavior is to display the output at the end of a pipeline. In PowerShell, it is generally
 not necessary to use the cmdlet in instances where the output is displayed by default. For example,
 `Get-Process | Write-Output` is equivalent to `Get-Process`. Or, `echo "Home directory: $HOME"` can
 be written, `"Home directory: $HOME"`.
 
-By default, `Write-Output` enumerates through collections provided to the cmdlet. However,
-`Write-Output` can also be used to pass collections down the pipeline as a single object with the
-**NoEnumerate** parameter.
+By default, `Write-Output` enumerates through collection objects. However, `Write-Output` can also
+be used to pass collections down the pipeline as a single object with the **NoEnumerate** parameter.
 
 ## EXAMPLES
 
 ### Example 1: Get objects and write them to the console
+
+In this example, the results of the `Get-Process` cmdlet are stored in the `$P` variable. The
+`Write-Output` displays the process objects in `$P` in the console.
 
 ```powershell
 $P = Get-Process
 Write-Output $P
 ```
 
-The first command gets processes running on the computer and stores them in the `$P` variable.
-
-The second and third commands display the process objects in `$P` on the console.
-
 ### Example 2: Pass output to another cmdlet
+
+This command pipes the "test output" string to the `Get-Member` cmdlet, which displays the members
+of the **System.String** class, demonstrating that the string was passed along the pipeline.
 
 ```powershell
 Write-Output "test output" | Get-Member
 ```
 
-This command pipes the "test output" string to the `Get-Member` cmdlet, which displays the members
-of the **System.String** class, demonstrating that the string was passed along the pipeline.
-
 ### Example 3: Suppress enumeration in output
+
+This command adds the **NoEnumerate** parameter to treat a collection or array as a single object
+through the pipeline.
 
 ```powershell
 Write-Output 1,2,3 | Measure-Object
@@ -80,9 +80,6 @@ Write-Output 1,2,3 -NoEnumerate | Measure-Object
 Count    : 1
 ...
 ```
-
-This command adds the **NoEnumerate** parameter to treat a collection or array as a single object
-through the pipeline.
 
 ## PARAMETERS
 
@@ -110,9 +107,11 @@ suppresses the default behavior, and prevents `Write-Output` from enumerating ou
 **NoEnumerate** parameter has no effect if the command is wrapped in parentheses, because the
 parentheses force enumeration. For example, `(Write-Output 1,2,3)` still enumerates the array.
 
-> [!NOTE]
-> This switch only works correctly with PowerShell Core 6.2 and newer. On older versions of
-> PowerShell Core, the collection is still enumerated even with use of this switch.
+The **NoEnumerate** parameter is only useful within a pipeline. Trying to see the effects of
+**NoEnumerate** in the console is problematic because PowerShell adds `Out-Default` to the end of
+every command line, which results in enumeration. But if you pipe `Write-Output -NoEnumerate` to
+another cmdlet, the downstream cmdlet receives the collection object, not the enumerated items of
+the collection.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.1/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Write-Output.md
@@ -1,9 +1,8 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/14/2020
+ms.date: 08/10/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/write-output?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Output
@@ -11,8 +10,8 @@ title: Write-Output
 # Write-Output
 
 ## SYNOPSIS
-Sends the specified objects to the next command in the pipeline. If the command is the last command
-in the pipeline, the objects are displayed in the console.
+Writes the specified objects to the pipeline. If `Write-Output` is the last command in the pipeline,
+the objects are displayed in the console.
 
 ## SYNTAX
 
@@ -22,46 +21,47 @@ Write-Output [-InputObject] <PSObject[]> [-NoEnumerate] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The `Write-Output` cmdlet sends the specified object down the pipeline to the next command.
-If the command is the last command in the pipeline, the object is displayed in the console.
+Writes the specified objects to the pipeline. If `Write-Output` is the last command in the pipeline,
+the objects are displayed in the console.
 
-`Write-Output` sends objects down the primary pipeline, also known as the "output stream" or the
-"success pipeline." To send error objects down the error pipeline, use Write-Error.
+`Write-Output` sends objects to the primary pipeline, also known as the "output stream" or the
+"success pipeline." To send error objects to the error pipeline, use `Write-Error`.
 
 This cmdlet is typically used in scripts to display strings and other objects on the console. One of
-the built-in aliases for `Write-Output` is `echo` and similar to other shells that use `echo`, the
+the built-in aliases for `Write-Output` is `echo` and similar to other shells that use `echo`. The
 default behavior is to display the output at the end of a pipeline. In PowerShell, it is generally
 not necessary to use the cmdlet in instances where the output is displayed by default. For example,
 `Get-Process | Write-Output` is equivalent to `Get-Process`. Or, `echo "Home directory: $HOME"` can
 be written, `"Home directory: $HOME"`.
 
-By default, `Write-Output` enumerates through collections provided to the cmdlet. However,
-`Write-Output` can also be used to pass collections down the pipeline as a single object with the
-**NoEnumerate** parameter.
+By default, `Write-Output` enumerates through collection objects. However, `Write-Output` can also
+be used to pass collections down the pipeline as a single object with the **NoEnumerate** parameter.
 
 ## EXAMPLES
 
 ### Example 1: Get objects and write them to the console
+
+In this example, the results of the `Get-Process` cmdlet are stored in the `$P` variable. The
+`Write-Output` displays the process objects in `$P` in the console.
 
 ```powershell
 $P = Get-Process
 Write-Output $P
 ```
 
-The first command gets processes running on the computer and stores them in the `$P` variable.
-
-The second and third commands display the process objects in `$P` on the console.
-
 ### Example 2: Pass output to another cmdlet
+
+This command pipes the "test output" string to the `Get-Member` cmdlet, which displays the members
+of the **System.String** class, demonstrating that the string was passed along the pipeline.
 
 ```powershell
 Write-Output "test output" | Get-Member
 ```
 
-This command pipes the "test output" string to the `Get-Member` cmdlet, which displays the members
-of the **System.String** class, demonstrating that the string was passed along the pipeline.
-
 ### Example 3: Suppress enumeration in output
+
+This command adds the **NoEnumerate** parameter to treat a collection or array as a single object
+through the pipeline.
 
 ```powershell
 Write-Output 1,2,3 | Measure-Object
@@ -80,9 +80,6 @@ Write-Output 1,2,3 -NoEnumerate | Measure-Object
 Count    : 1
 ...
 ```
-
-This command adds the **NoEnumerate** parameter to treat a collection or array as a single object
-through the pipeline.
 
 ## PARAMETERS
 
@@ -110,9 +107,11 @@ suppresses the default behavior, and prevents `Write-Output` from enumerating ou
 **NoEnumerate** parameter has no effect if the command is wrapped in parentheses, because the
 parentheses force enumeration. For example, `(Write-Output 1,2,3)` still enumerates the array.
 
-> [!NOTE]
-> This switch only works correctly with PowerShell Core 6.2 and newer. On older versions of
-> PowerShell Core, the collection is still enumerated even with use of this switch.
+The **NoEnumerate** parameter is only useful within a pipeline. Trying to see the effects of
+**NoEnumerate** in the console is problematic because PowerShell adds `Out-Default` to the end of
+every command line, which results in enumeration. But if you pipe `Write-Output -NoEnumerate` to
+another cmdlet, the downstream cmdlet receives the collection object, not the enumerated items of
+the collection.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.1/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Write-Output.md
@@ -42,7 +42,7 @@ be used to pass collections down the pipeline as a single object with the **NoEn
 ### Example 1: Get objects and write them to the console
 
 In this example, the results of the `Get-Process` cmdlet are stored in the `$P` variable. The
-`Write-Output` displays the process objects in `$P` in the console.
+`Write-Output` cmdlet displays the process objects in `$P` to the console.
 
 ```powershell
 $P = Get-Process

--- a/reference/7.2/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Write-Output.md
@@ -42,7 +42,7 @@ be used to pass collections down the pipeline as a single object with the **NoEn
 ### Example 1: Get objects and write them to the console
 
 In this example, the results of the `Get-Process` cmdlet are stored in the `$P` variable. The
-`Write-Output` displays the process objects in `$P` in the console.
+`Write-Output` cmdlet displays the process objects in `$P` to the console.
 
 ```powershell
 $P = Get-Process

--- a/reference/7.2/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Write-Output.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/14/2020
+ms.date: 08/10/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/write-output?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Output
@@ -10,8 +10,8 @@ title: Write-Output
 # Write-Output
 
 ## SYNOPSIS
-Sends the specified objects to the next command in the pipeline. If the command is the last command
-in the pipeline, the objects are displayed in the console.
+Writes the specified objects to the pipeline. If `Write-Output` is the last command in the pipeline,
+the objects are displayed in the console.
 
 ## SYNTAX
 
@@ -21,46 +21,47 @@ Write-Output [-InputObject] <PSObject[]> [-NoEnumerate] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The `Write-Output` cmdlet sends the specified object down the pipeline to the next command.
-If the command is the last command in the pipeline, the object is displayed in the console.
+Writes the specified objects to the pipeline. If `Write-Output` is the last command in the pipeline,
+the objects are displayed in the console.
 
-`Write-Output` sends objects down the primary pipeline, also known as the "output stream" or the
-"success pipeline." To send error objects down the error pipeline, use Write-Error.
+`Write-Output` sends objects to the primary pipeline, also known as the "output stream" or the
+"success pipeline." To send error objects to the error pipeline, use `Write-Error`.
 
 This cmdlet is typically used in scripts to display strings and other objects on the console. One of
-the built-in aliases for `Write-Output` is `echo` and similar to other shells that use `echo`, the
+the built-in aliases for `Write-Output` is `echo` and similar to other shells that use `echo`. The
 default behavior is to display the output at the end of a pipeline. In PowerShell, it is generally
 not necessary to use the cmdlet in instances where the output is displayed by default. For example,
 `Get-Process | Write-Output` is equivalent to `Get-Process`. Or, `echo "Home directory: $HOME"` can
 be written, `"Home directory: $HOME"`.
 
-By default, `Write-Output` enumerates through collections provided to the cmdlet. However,
-`Write-Output` can also be used to pass collections down the pipeline as a single object with the
-**NoEnumerate** parameter.
+By default, `Write-Output` enumerates through collection objects. However, `Write-Output` can also
+be used to pass collections down the pipeline as a single object with the **NoEnumerate** parameter.
 
 ## EXAMPLES
 
 ### Example 1: Get objects and write them to the console
+
+In this example, the results of the `Get-Process` cmdlet are stored in the `$P` variable. The
+`Write-Output` displays the process objects in `$P` in the console.
 
 ```powershell
 $P = Get-Process
 Write-Output $P
 ```
 
-The first command gets processes running on the computer and stores them in the `$P` variable.
-
-The second and third commands display the process objects in `$P` on the console.
-
 ### Example 2: Pass output to another cmdlet
+
+This command pipes the "test output" string to the `Get-Member` cmdlet, which displays the members
+of the **System.String** class, demonstrating that the string was passed along the pipeline.
 
 ```powershell
 Write-Output "test output" | Get-Member
 ```
 
-This command pipes the "test output" string to the `Get-Member` cmdlet, which displays the members
-of the **System.String** class, demonstrating that the string was passed along the pipeline.
-
 ### Example 3: Suppress enumeration in output
+
+This command adds the **NoEnumerate** parameter to treat a collection or array as a single object
+through the pipeline.
 
 ```powershell
 Write-Output 1,2,3 | Measure-Object
@@ -79,9 +80,6 @@ Write-Output 1,2,3 -NoEnumerate | Measure-Object
 Count    : 1
 ...
 ```
-
-This command adds the **NoEnumerate** parameter to treat a collection or array as a single object
-through the pipeline.
 
 ## PARAMETERS
 
@@ -109,9 +107,11 @@ suppresses the default behavior, and prevents `Write-Output` from enumerating ou
 **NoEnumerate** parameter has no effect if the command is wrapped in parentheses, because the
 parentheses force enumeration. For example, `(Write-Output 1,2,3)` still enumerates the array.
 
-> [!NOTE]
-> This switch only works correctly with PowerShell Core 6.2 and newer. On older versions of
-> PowerShell Core, the collection is still enumerated even with use of this switch.
+The **NoEnumerate** parameter is only useful within a pipeline. Trying to see the effects of
+**NoEnumerate** in the console is problematic because PowerShell adds `Out-Default` to the end of
+every command line, which results in enumeration. But if you pipe `Write-Output -NoEnumerate` to
+another cmdlet, the downstream cmdlet receives the collection object, not the enumerated items of
+the collection.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Fixes [AB#1866922](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1866922) - Fixes #7882 - Clarify NoEnumerate behavior

<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords