### PR TITLE
Fixes #6560 - PSManageBreakpointsInRunspace no longer experimental

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Debug-Job.md
@@ -1,9 +1,8 @@
 ---
 external help file: System.Management.Automation.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/debug-job?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Debug-Job
@@ -11,7 +10,7 @@ title: Debug-Job
 
 # Debug-Job
 
-## SYNOPSIS
+## Synopsis
 Debugs a running background, remote, or Windows PowerShell Workflow job.
 
 ## SYNTAX
@@ -40,19 +39,25 @@ Debug-Job [-Id] <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
 Debug-Job [-InstanceId] <Guid> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
-The **Debug-Job** cmdlet lets you debug scripts that are running within jobs.
-The cmdlet is designed to debug Windows PowerShell Workflow jobs, background jobs, and jobs running in remote sessions.
-**Debug-Job** accepts a running job object, name, ID, or instance ID as input, and starts a debugging session on the script it is running.
-The debugger **quit** command stops the job and running script.
-Starting in Windows PowerShell 5.0, the **exit** command detaches the debugger, and allows the job to continue to run.
+## Description
 
-## EXAMPLES
+The `Debug-Job` cmdlet lets you debug scripts that are running within jobs. The cmdlet is designed
+to debug PowerShell Workflow jobs, background jobs, and jobs running in remote sessions. `Debug-Job`
+accepts a running job object, name, ID, or instance ID as input, and starts a debugging session on
+the script it is running. The debugger `quit` command stops the job and running script. The `exit`
+command detaches the debugger, and allows the job to continue to run.
+
+## Examples
 
 ### Example 1: Debug a job by job ID
 
+This command breaks into a running job with an ID of 3.
+
+```powershell
+Debug-Job -ID 3
 ```
-PS C:\> Debug-Job -ID 3
+
+```Output
 Id     Name            PSJobTypeName   State         HasMoreData     Location             Command
 --     ----            -------------   -----         -----------     --------             -------
 3      Job3            RemoteJob       Running       True            PowerShellIx         TestWFDemo1.ps1
@@ -83,13 +88,11 @@ Id     Name            PSJobTypeName   State         HasMoreData     Location   
              18:  SampleWorkflowTest -MyOutput "Hello"
 ```
 
-This command breaks into a running job with an ID of 3.
-
-## PARAMETERS
+## Parameters
 
 ### -Id
-Specifies the ID number of a running job.
-To get the ID number of a job, run the Get-Job cmdlet.
+
+Specifies the ID number of a running job. To get the ID number of a job, run the `Get-Job` cmdlet.
 
 ```yaml
 Type: System.Int32
@@ -104,10 +107,8 @@ Accept wildcard characters: False
 ```
 
 ### -InstanceId
-Specifies the instance ID GUID of a running job.
-To get the *InstanceId* of a job, run the **Get-Job** cmdlet, piping the results into a **Format-*** cmdlet, as shown in the following example:
 
-`Get-Job | Format-List -Property Id,Name,InstanceId,State`
+Specifies the instance ID GUID of a running job.
 
 ```yaml
 Type: System.Guid
@@ -122,8 +123,10 @@ Accept wildcard characters: False
 ```
 
 ### -Job
-Specifies a running job object.
-The simplest way to use this parameter is to save the results of a **Get-Job** command that returns the running job that you want to debug in a variable, and then specify the variable as the value of this parameter.
+
+Specifies a running job object. The simplest way to use this parameter is to save the results of a
+`Get-Job` command that returns the running job that you want to debug in a variable, and then
+specify the variable as the value of this parameter.
 
 ```yaml
 Type: System.Management.Automation.Job
@@ -138,8 +141,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies a job by the friendly name of the job.
-When you start a job, you can specify a job name by adding the *JobName* parameter, in cmdlets such as Invoke-Command and Start-Job.
+
+Specifies a job by the friendly name of the job. When you start a job, you can specify a job name by
+adding the **JobName** parameter, in cmdlets such as `Invoke-Command` and `Start-Job`.
 
 ```yaml
 Type: System.String
@@ -154,6 +158,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -169,8 +174,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -185,17 +190,21 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## Inputs
 
 ### System.Management.Automation.RemotingJob
 
-## OUTPUTS
+## Outputs
 
-## NOTES
+## Notes
 
-## RELATED LINKS
+## Related links
 
 [Get-Job](Get-Job.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Debug-Runspace.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Debug-Runspace.md
@@ -1,19 +1,18 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/debug-runspace?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Debug-Runspace
 ---
 # Debug-Runspace
 
-## SYNOPSIS
+## Synopsis
 Starts an interactive debugging session with a runspace.
 
-## SYNTAX
+## Syntax
 
 ### RunspaceParameterSet (Default)
 
@@ -39,7 +38,7 @@ Debug-Runspace [-Id] <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
 Debug-Runspace [-InstanceId] <Guid> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Debug-Runspace` cmdlet starts an interactive debugging session with a local or remote active
 runspace. You can find a runspace that you want to debug by first running `Get-Process` to find
@@ -56,11 +55,16 @@ running the process, or you are running the script that you want to debug. Also,
 the host process that is running the current PowerShell session. You can only enter a host process
 that is running a different PowerShell session.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Debug a remote runspace
 
-```
+In this example, you debug a runspace that is open on a remote computer, WS10TestServer. In the
+first line of the command, you run `Get-Process` on the remote computer, and filter for Windows
+PowerShell host processes. In this example, you want to debug process ID 1152, the Windows
+PowerShell ISE host process.
+
+```powershell
 PS C:\> Get-Process -ComputerName "WS10TestServer" -Name "*powershell*"
 
 Handles      WS(K)   VM(M)      CPU(s)    Id  ProcessName
@@ -77,7 +81,7 @@ Id Name            ComputerName    Type          State         Availability
  1 Runspace1       WS10TestServer  Remote        Opened        Available
  2 RemoteHost      WS10TestServer  Remote        Opened        Busy
 
-PS C:\> [WS10TestServer][Process:1152]: PS C:\Users\Test\Documents> Debug-Runspace -Id 2
+[WS10TestServer][Process:1152]: PS C:\Users\Test\Documents> Debug-Runspace -Id 2
 
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 At C:\TestWFVar1.ps1:83 char:1
@@ -85,11 +89,6 @@ At C:\TestWFVar1.ps1:83 char:1
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Process:1152]: [RSDBG: 2]: PS C:\> >
 ```
-
-In this example, you debug a runspace that is open on a remote computer, WS10TestServer. In the
-first line of the command, you run `Get-Process` on the remote computer, and filter for Windows
-PowerShell host processes. In this example, you want to debug process ID 1152, the Windows
-PowerShell ISE host process.
 
 In the second command, you run `Enter-PSSession` to open a remote session on WS10TestServer. In the
 third command, you attach to the Windows PowerShell ISE host process running on the remote server by
@@ -100,10 +99,10 @@ In the fourth command, you list available runspaces for process ID 1152 by runni
 You note the ID number of the Busy runspace; it is running a script that you want to debug.
 
 In the last command, you start debugging an opened runspace that is running a script,
-TestWFVar1.ps1, by running `Debug-Runspace`, and identifying the runspace by its ID, 2, by adding
+`TestWFVar1.ps1`, by running `Debug-Runspace`, and identifying the runspace by its ID, 2, by adding
 the **Id** parameter. Because there's a breakpoint in the script, the debugger opens.
 
-## PARAMETERS
+## Parameters
 
 ### -Id
 
@@ -206,17 +205,18 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.Runspaces.Runspace
 
 You can pipe the results of a `Get-Runspace` command to **Debug-Runspace.**
 
-## OUTPUTS
+## Outputs
 
-## NOTES
+## Notes
 
 `Debug-Runspace` works on runspaces that are in the Opened state. If a runspace state changes from
 Opened to another state, that runspace is automatically removed from the running list. A runspace is
@@ -227,7 +227,7 @@ added to the running list only if it meets the following criteria.
 - If it is coming from a PowerShell workflow, and its workflow job ID is the same as the current
   active debugger workflow job ID.
 
-## RELATED LINKS
+## Related links
 
 [about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
@@ -1,20 +1,18 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/disable-psbreakpoint?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Disable-PSBreakpoint
 ---
-
 # Disable-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Disables the breakpoints in the current console.
 
-## SYNTAX
+## Syntax
 
 ### Breakpoint (Default)
 
@@ -28,77 +26,79 @@ Disable-PSBreakpoint [-PassThru] [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confir
 Disable-PSBreakpoint [-PassThru] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
-The **Disable-PSBreakpoint** cmdlet disables breakpoints, which assures that they are not hit when the script runs.
-You can use it to disable all breakpoints, or you can specify breakpoints by submitting breakpoint objects or breakpoint IDs.
+## Description
+
+The `Disable-PSBreakpoint` cmdlet disables breakpoints, which assures that they are not hit when the
+script runs. You can use it to disable all breakpoints, or you can specify breakpoints by submitting
+breakpoint objects or breakpoint IDs.
 
 Technically, this cmdlet changes the value of the Enabled property of a breakpoint object to False.
-To re-enable a breakpoint, use the Enable-PSBreakpoint cmdlet.
-Breakpoints are enabled by default when you create them by using the Set-PSBreakpoint cmdlet.
+To re-enable a breakpoint, use the `Enable-PSBreakpoint` cmdlet. Breakpoints are enabled by default
+when you create them using the `Set-PSBreakpoint` cmdlet.
 
-A breakpoint is a point in a script where execution stops temporarily so that you can examine the instructions in the script.
-**Disable-PSBreakpoint** is one of several cmdlets designed for debugging Windows PowerShell scripts.
-For more information about the Windows PowerShell debugger, see about_Debuggers.
+A breakpoint is a point in a script where execution stops temporarily so that you can examine the
+instructions in the script. `Disable-PSBreakpoint` is one of several cmdlets designed for debugging
+PowerShell scripts. For more information about the PowerShell debugger, see
+[about_Debuggers](../microsoft.powershell.core/about/about_debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Set a breakpoint and disable it
 
-```
-PS C:\> $B = Set-PSBreakpoint -Script "sample.ps1" -Variable "name"
-PS C:\> $B | Disable-PSBreakpoint
-```
-
 These commands disable a newly-created breakpoint.
 
-The first command uses the Set-PSBreakpoint cmdlet to create a breakpoint on the *Name* variable in the Sample.ps1 script.
-Then, it saves the breakpoint object in the $B variable.
+```powershell
+$B = Set-PSBreakpoint -Script "sample.ps1" -Variable "name"
+$B | Disable-PSBreakpoint
+```
 
-The second command uses the **Disable-PSBreakpoint** cmdlet to disable the new breakpoint.
-It uses a pipeline operator (|) to send the breakpoint object in $B to the **Disable-PSBreakpoint** cmdlet.
+The `Set-PSBreakpoint` cmdlet creates a breakpoint on the `$Name` variable in the `Sample.ps1`
+script and saves the breakpoint object in the `$B` variable. The `Disable-PSBreakpoint` cmdlet
+disables the new breakpoint. It uses a pipeline operator (`|`) to send the breakpoint object in `$B`
+to the `Disable-PSBreakpoint` cmdlet.
 
-As a result of this command, the value of the Enabled property of the breakpoint object in $B is False.
+As a result of this command, the value of the **Enabled** property of the breakpoint object in `$B`
+is **False**.
 
 ### Example 2: Disable a breakpoint
 
-```
-PS C:\> Disable-PSBreakpoint -Id 0
-```
-
 This command disables the breakpoint with breakpoint ID 0.
+
+```powershell
+Disable-PSBreakpoint -Id 0
+```
 
 ### Example 3: Create a disabled breakpoint
 
-```
-PS C:\> Disable-PSBreakpoint -Breakpoint ($B = Set-PSBreakpoint -Script "sample.ps1" -Line 5)
-PS C:\> $B
-```
-
 This command creates a new breakpoint that is disabled until you enable it.
 
-It uses the **Disable-PSBreakpoint** cmdlet to disable the breakpoint.
-The value of the *Breakpoint* parameter is a Set-PSBreakpoint command that sets a new breakpoint, generates a breakpoint object, and saves the object in the $B variable.
+```powershell
+Disable-PSBreakpoint -Breakpoint ($B = Set-PSBreakpoint -Script "sample.ps1" -Line 5)
+```
 
-Cmdlet parameters that take objects as their values can accept a variable that contains the object or a command that gets or generates the object.
-In this case, because **Set-PSBreakpoint** generates a breakpoint object, it can be used as the value of the *Breakpoint* parameter.
+It uses the `Disable-PSBreakpoint` cmdlet to disable the breakpoint. The value of the **Breakpoint**
+parameter is a `Set-PSBreakpoint` command that sets a new breakpoint, generates a breakpoint object,
+and saves the object in the `$B` variable.
 
-The second command displays the breakpoint object in the value of the $B variable.
+Cmdlet parameters that take objects as their values can accept a variable that contains the object
+or a command that gets or generates the object. In this case, because `Set-PSBreakpoint` generates a
+breakpoint object, it can be used as the value of the **Breakpoint** parameter.
 
 ### Example 4: Disable all breakpoints in the current console
 
-```
-PS C:\> Get-PSBreakpoint | Disable-PSBreakpoint
-```
-
 This command disables all breakpoints in the current console.
-You can abbreviate this command as: "gbp | dbp".
 
-## PARAMETERS
+```powershell
+`Get-PSBreakpoint` | Disable-PSBreakpoint
+```
+
+## Parameters
 
 ### -Breakpoint
-Specifies the breakpoints to disable.
-Enter a variable that contains breakpoint objects or a command that gets breakpoint objects, such as a Get-PSBreakpoint command.
-You can also pipe breakpoint objects to the **Disable-PSBreakpoint** cmdlet.
+
+Specifies the breakpoints to disable. Enter a variable that contains breakpoint objects or a command
+that gets breakpoint objects, such as a `Get-PSBreakpoint` command. You can also pipe breakpoint
+objects to the `Disable-PSBreakpoint` cmdlet.
 
 ```yaml
 Type: System.Management.Automation.Breakpoint[]
@@ -113,9 +113,9 @@ Accept wildcard characters: False
 ```
 
 ### -Id
-Disables the breakpoints with the specified breakpoint IDs.
-Enter the IDs or a variable that contains the IDs.
-You cannot pipe IDs to **Disable-PSBreakpoint**.
+
+Disables the breakpoints with the specified breakpoint IDs. Enter the IDs or a variable that
+contains the IDs. You cannot pipe IDs to `Disable-PSBreakpoint`.
 
 ```yaml
 Type: System.Int32[]
@@ -130,8 +130,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Returns an object representing the enabled breakpoints.
-By default, this cmdlet does not generate any output.
+
+Returns an object representing the enabled breakpoints. By default, this cmdlet does not generate
+any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -146,6 +147,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -161,8 +163,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -177,22 +179,28 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## Inputs
 
 ### System.Management.Automation.Breakpoint
-You can pipe a breakpoint object to **Disable-PSBreakpoint**.
 
-## OUTPUTS
+You can pipe a breakpoint object to `Disable-PSBreakpoint`.
+
+## Outputs
 
 ### None or System.Management.Automation.Breakpoint
-When you use the *PassThru* parameter, **Disable-PSBreakpoint** returns an object that represents the disabled breakpoint.
-Otherwise, this cmdlet does not generate any output.
 
-## NOTES
+When you use the **PassThru** parameter, `Disable-PSBreakpoint` returns an object that represents
+the disabled breakpoint. Otherwise, this cmdlet does not generate any output.
 
-## RELATED LINKS
+## Notes
+
+## Related links
 
 [Enable-PSBreakpoint](Enable-PSBreakpoint.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
@@ -1,9 +1,8 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/09/2019
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/enable-psbreakpoint?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enable-PSBreakpoint
@@ -11,10 +10,10 @@ title: Enable-PSBreakpoint
 
 # Enable-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Enables the breakpoints in the current console.
 
-## SYNTAX
+## Syntax
 
 ### Id (Default)
 
@@ -29,7 +28,7 @@ Enable-PSBreakpoint [-PassThru] [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm
  [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Enable-PSBreakpoint` cmdlet re-enables disabled breakpoints. You can use it to enable all
 breakpoints, or specific breakpoints by providing breakpoint objects or IDs.
@@ -42,9 +41,10 @@ Technically, this cmdlet changes the value of the **Enabled** property of a brea
 **True**.
 
 `Enable-PSBreakpoint` is one of several cmdlets designed for debugging PowerShell scripts. For more
-information about the PowerShell debugger, see [about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
+information about the PowerShell debugger, see
+[about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Enable all breakpoints
 
@@ -114,7 +114,7 @@ Enable-PSBreakpoint -Breakpoint $B
 
 This example is equivalent to running `Enable-PSBreakpoint -Id 3, 5`.
 
-## PARAMETERS
+## Parameters
 
 ### -Breakpoint
 
@@ -205,21 +205,23 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.Breakpoint
 
 You can pipe a breakpoint object to `Enable-PSBreakpoint`.
 
-## OUTPUTS
+## Outputs
 
 ### None or System.Management.Automation.Breakpoint
 
-When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpoint object that represents that breakpoint that was enabled. Otherwise, this cmdlet doesn't generate any output.
+When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpoint object that
+represents that breakpoint that was enabled. Otherwise, this cmdlet doesn't generate any output.
 
-## NOTES
+## Notes
 
 - The `Enable-PSBreakpoint` cmdlet doesn't generate an error if you try to enable a breakpoint that
   is already enabled. As such, you can enable all breakpoints without error, even when only a few
@@ -228,7 +230,7 @@ When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpo
 - Breakpoints are enabled when you create them by using the `Set-PSBreakpoint` cmdlet. You don't
   need to enable newly created breakpoints.
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
@@ -1,19 +1,18 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 5/15/2019
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-psbreakpoint?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-PSBreakpoint
 ---
 # Get-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Gets the breakpoints that are set in the current session.
 
-## SYNTAX
+## Syntax
 
 ### Script (Default)
 
@@ -45,108 +44,109 @@ Get-PSBreakpoint [-Script <String[]>] [-Type] <BreakpointType[]> [<CommonParamet
 Get-PSBreakpoint [-Id] <Int32[]> [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
-The **Get-PSBreakPoint** cmdlet gets the breakpoints that are set in the current session.
-You can use the cmdlet parameters to get particular breakpoints.
+The `Get-PSBreakPoint` cmdlet gets the breakpoints that are set in the current session. You can use
+the cmdlet parameters to get particular breakpoints.
 
 A breakpoint is a point in a command or script where execution stops temporarily so that you can
-examine the instructions.
-**Get-PSBreakpoint** is one of several cmdlets designed for debugging Windows PowerShell scripts and
-commands. For more information about the Windows PowerShell debugger, see about_Debuggers.
+examine the instructions. `Get-PSBreakpoint` is one of several cmdlets designed for debugging
+PowerShell scripts and commands. For more information about the PowerShell debugger, see
+[about_Debuggers](../microsoft.powershell.core/about/about_debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Get all breakpoints for all scripts and functions
 
-```
-PS C:\> Get-PSBreakpoint
-```
-
 This command gets all breakpoints set on all scripts and functions in the current session.
+
+```powershell
+Get-PSBreakpoint
+```
 
 ### Example 2: Get breakpoints by ID
 
-```
-PS C:\> Get-PSBreakpoint -Id 2
-Function   :
-IncrementAction     :
-Enabled    :
-TrueHitCount   : 0
-Id         : 2
-Script     : C:\ps-test\sample.ps1
-ScriptName : C:\ps-test\sample.ps1
-```
-
 This command gets the breakpoint with breakpoint ID 2.
 
-### Example 3: Pipe an ID to Get-PSBreakpoint
-
-```
-PS C:\> $B = Set-PSBreakpoint -Script "sample.ps1" -Command "Increment"
-PS C:\> $B.Id | Get-PSBreakpoint
+```powershell
+Get-PSBreakpoint -Id 2
 ```
 
-These commands show how to get a breakpoint by piping a breakpoint ID to **Get-PSBreakpoint**.
+```Output
+Function         :
+IncrementAction  :
+Enabled          :
+TrueHitCount     : 0
+Id               : 2
+Script           : C:\ps-test\sample.ps1
+ScriptName       : C:\ps-test\sample.ps1
+```
 
-The first command uses the Set-PSBreakpoint cmdlet to create a breakpoint on the Increment function
-in the Sample.ps1 script. It saves the breakpoint object in the $B variable.
+### Example 3: Pipe an ID to `Get-PSBreakpoint`
 
-The second command uses the dot operator (.) to get the Id property of the breakpoint object in the
-$B variable. It uses a pipeline operator (|) to send the ID to the **Get-PSBreakpoint** cmdlet.
+These commands show how to get a breakpoint by piping a breakpoint ID to `Get-PSBreakpoint`.
 
-As a result, **Get-PSBreakpoint** gets the breakpoint with the specified ID.
+```powershell
+$B = `Set-PSBreakpoint` -Script "sample.ps1" -Command "Increment"
+$B.Id | Get-PSBreakpoint
+```
+
+The `Set-PSBreakpoint` cmdlet creates a breakpoint on the Increment function in the `Sample.ps1`
+script and saves the breakpoint object in the `$B` variable. The **Id** property of the breakpoint
+object in the `$B` variable is piped to the `Get-PSBreakpoint` cmdlet to display the breakpoint
+information.
 
 ### Example 4: Get breakpoints in specified script files
 
-```
-PS C:\> Get-PSBreakpoint -Script "Sample.ps1, SupportScript.ps1"
-```
+This command gets all of the breakpoints in the `Sample.ps1` and `SupportScript.ps1` files.
 
-This command gets all of the breakpoints in the Sample.ps1 and SupportScript.ps1 files.
+```powershell
+Get-PSBreakpoint -Script "Sample.ps1, SupportScript.ps1"
+```
 
 This command does not get other breakpoints that might be set in other scripts or on functions in
 the session.
 
 ### Example 5: Get breakpoints in specified cmdlets
 
-```
-PS C:\> Get-PSBreakpoint -Command "Read-Host, Write-Host" -Script "Sample.ps1"
-```
+This command gets all Command breakpoints that are set on `Read-Host` or `Write-Host` commands in
+the `Sample.ps1` file.
 
-This command gets all Command breakpoints that are set on Read-Host or Write-Host commands in the
-Sample.ps1 file.
+```powershell
+Get-PSBreakpoint -Command "Read-Host, Write-Host" -Script "Sample.ps1"
+```
 
 ### Example 6: Get Command breakpoints in a specified file
 
-```
-PS C:\> Get-PSBreakpoint -Type Command -Script "Sample.ps1"
+```powershell
+Get-PSBreakpoint -Type Command -Script "Sample.ps1"
 ```
 
 This command gets all Command breakpoints in the Sample.ps1 file.
 
 ### Example 7: Get breakpoints by variable
 
-```
-PS C:\> Get-PSBreakpoint -Variable "Index, Swap"
-```
+This command gets breakpoints that are set on the `$Index` and `$Swap` variables in the current
+session.
 
-This command gets breakpoints that are set on the $Index and $Swap variables in the current session.
+```powershell
+Get-PSBreakpoint -Variable "Index, Swap"
+```
 
 ### Example 8: Get all Line and Variable breakpoints in a file
 
-```
-PS C:\> Get-PSBreakpoint -Type Line, Variable -Script "Sample.ps1"
+This command gets all line and variable breakpoints in the `Sample.ps1` script.
+
+```powershell
+Get-PSBreakpoint -Type Line, Variable -Script "Sample.ps1"
 ```
 
-This command gets all line and variable breakpoints in the Sample.ps1 script.
-
-## PARAMETERS
+## Parameters
 
 ### -Command
 
-Specifies an array of command breakpoints that are set on the specified command names.
-Enter the command names, such as the name of a cmdlet or function.
+Specifies an array of command breakpoints that are set on the specified command names. Enter the
+command names, such as the name of a cmdlet or function.
 
 ```yaml
 Type: System.String[]
@@ -162,9 +162,8 @@ Accept wildcard characters: False
 
 ### -Id
 
-Specifies the breakpoint IDs that this cmdlet gets.
-Enter the IDs in a comma-separated list.
-You can also pipe breakpoint IDs to **Get-PSBreakpoint**.
+Specifies the breakpoint IDs that this cmdlet gets. Enter the IDs in a comma-separated list. You can
+also pipe breakpoint IDs to `Get-PSBreakpoint`.
 
 ```yaml
 Type: System.Int32[]
@@ -180,9 +179,8 @@ Accept wildcard characters: False
 
 ### -Script
 
-Specifies an array of scripts that contain the breakpoints.
-Enter the path (optional) and names of one or more script files.
-If you omit the path, the default location is the current directory.
+Specifies an array of scripts that contain the breakpoints. Enter the path (optional) and names of
+one or more script files. If you omit the path, the default location is the current directory.
 
 ```yaml
 Type: System.String[]
@@ -198,15 +196,14 @@ Accept wildcard characters: False
 
 ### -Type
 
-Specifies an array of breakpoint types that this cmdlet gets.
-Enter one or more types.
-The acceptable values for this parameter are:
+Specifies an array of breakpoint types that this cmdlet gets. Enter one or more types. The
+acceptable values for this parameter are:
 
 - Line
 - Command
 - Variable
 
-You can also pipe breakpoint types to **Get-PSBreakPoint**.
+You can also pipe breakpoint types to `Get-PSBreakPoint`.
 
 ```yaml
 Type: Microsoft.PowerShell.Commands.BreakpointType[]
@@ -223,8 +220,8 @@ Accept wildcard characters: False
 
 ### -Variable
 
-Specifies an array of variable breakpoints that are set on the specified variable names.
-Enter the variable names without dollar signs.
+Specifies an array of variable breakpoints that are set on the specified variable names. Enter the
+variable names without dollar signs.
 
 ```yaml
 Type: System.String[]
@@ -242,26 +239,34 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see about_CommonParameters
-(https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
-### System.Int32, Microsoft.PowerShell.Commands.BreakpointType
+### System.Int32
 
-You can pipe breakpoint IDs and breakpoint types to **Get-PSBreakPoint**.
+### Microsoft.PowerShell.Commands.BreakpointType
 
-## OUTPUTS
+You can pipe breakpoint IDs and breakpoint types to `Get-PSBreakPoint`.
+
+## Outputs
+
+### System.Management.Automation.CommandBreakpoint
+
+### System.Management.Automation.LineBreakpoint
+
+### System.Management.Automation.VariableBreakpoint
 
 ### System.Management.Automation.Breakpoint
 
-**Get-PSBreakPoint** returns objects that represent the breakpoints in the session.
+`Get-PSBreakPoint` returns objects that represent the breakpoints in the session.
 
-## NOTES
+## Notes
 
-* You can use **Get-PSBreakpoint** or its alias, "gbp".
+You can use `Get-PSBreakpoint` or its alias, "gbp".
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
@@ -1,9 +1,8 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/remove-psbreakpoint?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Remove-PSBreakpoint
@@ -11,10 +10,10 @@ title: Remove-PSBreakpoint
 
 # Remove-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Deletes breakpoints from the current console.
 
-## SYNTAX
+## Syntax
 
 ### Breakpoint (Default)
 
@@ -28,72 +27,71 @@ Remove-PSBreakpoint [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm] [<CommonPa
 Remove-PSBreakpoint [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
-The **Remove-PSBreakpoint** cmdlet deletes a breakpoint.
-Enter a breakpoint object or a breakpoint ID.
+## Description
 
-When you remove a breakpoint, the breakpoint object is no longer available or functional.
-If you have saved a breakpoint object in a variable, the reference still exists, but the breakpoint does not function.
+The `Remove-PSBreakpoint` cmdlet deletes a breakpoint. Enter a breakpoint object or a breakpoint ID.
 
-**Remove-PSBreakpoint** is one of several cmdlets designed for debugging Windows PowerShell scripts.
-For more information about the Windows PowerShell debugger, see about_Debuggers.
+When you remove a breakpoint, the breakpoint object is no longer available or functional. If you
+have saved a breakpoint object in a variable, the reference still exists, but the breakpoint does
+not function.
 
-## EXAMPLES
+`Remove-PSBreakpoint` is one of several cmdlets designed for debugging PowerShell scripts. For more
+information about the PowerShell debugger, see
+[about_Debuggers](../microsoft.powershell.core/about/about_debuggers.md).
+
+## Examples
 
 ### Example 1: Remove all breakpoints
 
-```
-PS C:\> Get-PSBreakpoint | Remove-PSBreakpoint
-```
-
 This command deletes all of the breakpoints in the current console.
+
+```powershell
+Get-PSBreakpoint | Remove-PSBreakpoint
+```
 
 ### Example 2: Remove a specified breakpoint
 
-```
-PS C:\> $B = Set-PSBreakpoint -Script "sample.ps1" -Variable "Name"
-PS C:\> $B | Remove-PSBreakpoint
-```
-
 This command deletes a breakpoint.
 
-The first command uses the Set-PSBreakpoint cmdlet to create a breakpoint on the Name variable in the Sample.ps1 script.
-Then, it saves the breakpoint object in the $B variable.
+```powershell
+$B = Set-PSBreakpoint -Script "sample.ps1" -Variable "Name"
+$B | Remove-PSBreakpoint
+```
 
-The second command uses the **Remove-PSBreakpoint** cmdlet to delete the new breakpoint.
-It uses a pipeline operator (|) to send the breakpoint object in the $B variable to the **Remove-PSBreakpoint** cmdlet.
+The `Set-PSBreakpoint` cmdlet creates a breakpoint on the `$Name` variable in the `Sample.ps1`
+script and saves the breakpoint object in the `$B` variable. The `Remove-PSBreakpoint` cmdlet
+deletes the new breakpoint. It uses a pipeline operator (`|`) to send the breakpoint object in the
+`$B` variable to the `Remove-PSBreakpoint` cmdlet.
 
-As a result of this command, if you run the script, it runs to completion without stopping.
-Also, the **Get-PSBreakpoint** cmdlet does not return this breakpoint.
+As a result of this command, if you run the script, it runs to completion without stopping. Also,
+the `Get-PSBreakpoint` cmdlet does not return this breakpoint.
 
 ### Example 3: Remove a breakpoint by ID
 
-```
-PS C:\> Remove-PSBreakpoint -Id 2
-```
-
 This command deletes the breakpoint with breakpoint ID 2.
+
+```powershell
+Remove-PSBreakpoint -Id 2
+```
 
 ### Example 4: Use a function to remove all breakpoints
 
-```
-PS C:\> function del-psb { get-psbreakpoint | remove-psbreakpoint }
-```
-
 This simple function deletes all of the breakpoints in the current console.
-It uses the Get-PSBreakpoint cmdlet to get the breakpoints.
-Then, it uses a pipeline operator (|) to send the breakpoints to the **Remove-PSBreakpoint** cmdlet, which deletes them.
 
-As a result, you can type `del-psb` instead of the longer command.
+```powershell
+function del-psb { Get-PSBreakpoint | Remove-PSBreakpoint }
+```
 
-To save the function, add it to your Windows PowerShell profile.
+It uses the `Get-PSBreakpoint` cmdlet to get the breakpoints. Then, it uses a pipeline operator
+(`|`) to send the breakpoints to the `Remove-PSBreakpoint` cmdlet, which deletes them.
 
-## PARAMETERS
+## Parameters
 
 ### -Breakpoint
-Specifies the breakpoints to delete.
-Enter a variable that contains breakpoint objects or a command that gets breakpoint objects, such as a **Get-PSBreakpoint** command.
-You can also pipe breakpoint objects to **Remove-PSBreakpoint**.
+
+Specifies the breakpoints to delete. Enter a variable that contains breakpoint objects or a command
+that gets breakpoint objects, such as a `Get-PSBreakpoint` command. You can also pipe breakpoint
+objects to `Remove-PSBreakpoint`.
 
 ```yaml
 Type: System.Management.Automation.Breakpoint[]
@@ -108,6 +106,7 @@ Accept wildcard characters: False
 ```
 
 ### -Id
+
 Specifies breakpoint IDs for which this cmdlet deletes breakpoints.
 
 ```yaml
@@ -154,21 +153,31 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-### System.Management.Automation.Breakpoint
-You can pipe breakpoint objects to **Remove-PSBreakpoint**.
+## Inputs
 
-## OUTPUTS
+### System.Management.Automation.Breakpoint[]
+
+You can pipe breakpoint objects to `Remove-PSBreakpoint`.
+
+### System.Int32[]
+
+### System.Management.Automation.Runspaces.Runspace
+
+## Outputs
 
 ### None
+
 The cmdlet does not generate any output.
 
-## NOTES
+## Notes
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -1,19 +1,18 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/24/2019
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/set-psbreakpoint?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSBreakpoint
 ---
 # Set-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Sets a breakpoint on a line, command, or variable.
 
-## SYNTAX
+## Syntax
 
 ### Line (Default)
 
@@ -35,7 +34,7 @@ Set-PSBreakpoint [-Action <ScriptBlock>] [[-Script] <String[]>] -Variable <Strin
  [-Mode <VariableAccessMode>] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Set-PSBreakpoint` cmdlet sets a breakpoint in a script or in any command run in the current
 session. You can use `Set-PSBreakpoint` to set a breakpoint before executing a script or running a
@@ -59,9 +58,10 @@ you can use the **Action** parameter to specify an alternate response, such as c
 breakpoint or instructions to perform additional tasks such as logging or diagnostics.
 
 The `Set-PSBreakpoint` cmdlet is one of several cmdlets designed for debugging PowerShell scripts.
-For more information about the PowerShell debugger, see [about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
+For more information about the PowerShell debugger, see
+[about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Set a breakpoint on a line
 
@@ -130,8 +130,8 @@ Set-PSBreakpoint -Script Sample.ps1 -Command "write*"
 
 ### Example 5: Set a breakpoint depending on the value of a variable
 
-This example stops execution at the `DiskTest` function in the Test.ps1 script only when the value of
-the `$Disk` variable is greater than 2.
+This example stops execution at the `DiskTest` function in the `Test.ps1` script only when the value
+of the `$Disk` variable is greater than 2.
 
 ```powershell
 Set-PSBreakpoint -Script "test.ps1" -Command "DiskTest" -Action { if ($Disk -gt 2) { break } }
@@ -208,7 +208,7 @@ Script     : C:\ps-test\sample.ps1
 ScriptName : C:\ps-test\sample.ps1
 ```
 
-## PARAMETERS
+## Parameters
 
 ### -Action
 
@@ -244,10 +244,10 @@ Accept wildcard characters: False
 Specifies the column number of the column in the script file on which execution stops. Enter only
 one column number. The default is column 1.
 
-The Column value is used with the value of the **Line** parameter to specify the breakpoint. If the **Line**
-parameter specifies multiple lines, the **Column** parameter sets a breakpoint at the specified column
-on each of the specified lines. PowerShell stops executing before the statement or expression that
-includes the character at the specified line and column position.
+The Column value is used with the value of the **Line** parameter to specify the breakpoint. If the
+**Line** parameter specifies multiple lines, the **Column** parameter sets a breakpoint at the
+specified column on each of the specified lines. PowerShell stops executing before the statement or
+expression that includes the character at the specified line and column position.
 
 Columns are counted from the top left margin beginning with column number 1 (not 0). If you specify
 a column that does not exist in the script, an error is not declared, but the breakpoint is never
@@ -377,20 +377,25 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### None
 You cannot pipe input to `Set-PSBreakpoint`.
 
 ## OUTPUTS
 
-### Breakpoint object (System.Management.Automation.LineBreakpoint, System.Management.Automation.VariableBreakpoint, System.Management.Automation.CommandBreakpoint)
+### System.Management.Automation.CommandBreakpoint
+
+### System.Management.Automation.LineBreakpoint
+
+### System.Management.Automation.VariableBreakpoint
 
 `Set-PSBreakpoint` returns an object that represents each breakpoint that it sets.
 
-## NOTES
+## Notes
 
 - `Set-PSBreakpoint` cannot set a breakpoint on a remote computer. To debug a script on a remote
   computer, copy the script to the local computer and then debug it locally.
@@ -399,7 +404,7 @@ You cannot pipe input to `Set-PSBreakpoint`.
 - When setting a breakpoint on a function or variable at the command prompt, you can set the
   breakpoint before or after you create the function or variable.
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 

--- a/reference/7.0/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Debug-Job.md
@@ -1,9 +1,8 @@
 ---
 external help file: System.Management.Automation.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/debug-job?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Debug-Job
@@ -11,48 +10,54 @@ title: Debug-Job
 
 # Debug-Job
 
-## SYNOPSIS
-Debugs a running background, remote, or PowerShell Workflow job.
+## Synopsis
+Debugs a running background or remote job.
 
-## SYNTAX
+## Syntax
 
 ### JobParameterSet (Default)
 
 ```
-Debug-Job [-Job] <Job> [-WhatIf] [-Confirm] [<CommonParameters>]
+Debug-Job [-Job] <Job> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### JobNameParameterSet
 
 ```
-Debug-Job [-Name] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Debug-Job [-Name] <String> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### JobIdParameterSet
 
 ```
-Debug-Job [-Id] <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+Debug-Job [-Id] <Int32> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### JobInstanceIdParameterSet
 
 ```
-Debug-Job [-InstanceId] <Guid> [-WhatIf] [-Confirm] [<CommonParameters>]
+Debug-Job [-InstanceId] <Guid> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
-The **Debug-Job** cmdlet lets you debug scripts that are running within jobs.
-The cmdlet is designed to debug PowerShell Workflow jobs, background jobs, and jobs running in remote sessions.
-**Debug-Job** accepts a running job object, name, ID, or instance ID as input, and starts a debugging session on the script it is running.
-The debugger **quit** command stops the job and running script.
-Starting in Windows PowerShell 5.0, the **exit** command detaches the debugger, and allows the job to continue to run.
+## Description
 
-## EXAMPLES
+The `Debug-Job` cmdlet lets you debug scripts that are running within jobs. The cmdlet is designed
+to debug PowerShell Workflow jobs, background jobs, and jobs running in remote sessions. `Debug-Job`
+accepts a running job object, name, ID, or instance ID as input, and starts a debugging session on
+the script it is running. The debugger `quit` command stops the job and running script. The `exit`
+command detaches the debugger, and allows the job to continue to run.
+
+## Examples
 
 ### Example 1: Debug a job by job ID
 
+This command breaks into a running job with an ID of 3.
+
+```powershell
+Debug-Job -ID 3
 ```
-PS C:\> Debug-Job -ID 3
+
+```Output
 Id     Name            PSJobTypeName   State         HasMoreData     Location             Command
 --     ----            -------------   -----         -----------     --------             -------
 3      Job3            RemoteJob       Running       True            PowerShellIx         TestWFDemo1.ps1
@@ -83,13 +88,30 @@ Id     Name            PSJobTypeName   State         HasMoreData     Location   
              18:  SampleWorkflowTest -MyOutput "Hello"
 ```
 
-This command breaks into a running job with an ID of 3.
+## Parameters
 
-## PARAMETERS
+### -BreakAll
+
+Allows you to break immediately in the current location when the debugger attaches.
+
+The parameter is only available as an experimental feature. For more information, see
+[Using experimental features](/powershell/scripting/learn/experimental-features#microsoftpowershellutilitypsmanagebreakpointsinrunspace).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Id
-Specifies the ID number of a running job.
-To get the ID number of a job, run the Get-Job cmdlet.
+
+Specifies the ID number of a running job. To get the ID number of a job, run the `Get-Job` cmdlet.
 
 ```yaml
 Type: System.Int32
@@ -104,10 +126,8 @@ Accept wildcard characters: False
 ```
 
 ### -InstanceId
-Specifies the instance ID GUID of a running job.
-To get the *InstanceId* of a job, run the **Get-Job** cmdlet, piping the results into a **Format-*** cmdlet, as shown in the following example:
 
-`Get-Job | Format-List -Property Id,Name,InstanceId,State`
+Specifies the instance ID GUID of a running job.
 
 ```yaml
 Type: System.Guid
@@ -122,8 +142,10 @@ Accept wildcard characters: False
 ```
 
 ### -Job
-Specifies a running job object.
-The simplest way to use this parameter is to save the results of a **Get-Job** command that returns the running job that you want to debug in a variable, and then specify the variable as the value of this parameter.
+
+Specifies a running job object. The simplest way to use this parameter is to save the results of a
+`Get-Job` command that returns the running job that you want to debug in a variable, and then
+specify the variable as the value of this parameter.
 
 ```yaml
 Type: System.Management.Automation.Job
@@ -138,8 +160,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies a job by the friendly name of the job.
-When you start a job, you can specify a job name by adding the *JobName* parameter, in cmdlets such as Invoke-Command and Start-Job.
+
+Specifies a job by the friendly name of the job. When you start a job, you can specify a job name by
+adding the **JobName** parameter, in cmdlets such as `Invoke-Command` and `Start-Job`.
 
 ```yaml
 Type: System.String
@@ -154,6 +177,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -169,8 +193,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -185,17 +209,21 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## Inputs
 
 ### System.Management.Automation.RemotingJob
 
-## OUTPUTS
+## Outputs
 
-## NOTES
+## Notes
 
-## RELATED LINKS
+## Related links
 
 [Get-Job](Get-Job.md)
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Debug-Runspace.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Debug-Runspace.md
@@ -1,45 +1,44 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/debug-runspace?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Debug-Runspace
 ---
 # Debug-Runspace
 
-## SYNOPSIS
+## Synopsis
 Starts an interactive debugging session with a runspace.
 
-## SYNTAX
+## Syntax
 
 ### RunspaceParameterSet (Default)
 
 ```
-Debug-Runspace [-Runspace] <Runspace> [-WhatIf] [-Confirm] [<CommonParameters>]
+Debug-Runspace [-Runspace] <Runspace> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### NameParameterSet
 
 ```
-Debug-Runspace [-Name] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Debug-Runspace [-Name] <String> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### IdParameterSet
 
 ```
-Debug-Runspace [-Id] <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+Debug-Runspace [-Id] <Int32> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InstanceIdParameterSet
 
 ```
-Debug-Runspace [-InstanceId] <Guid> [-WhatIf] [-Confirm] [<CommonParameters>]
+Debug-Runspace [-InstanceId] <Guid> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Debug-Runspace` cmdlet starts an interactive debugging session with a local or remote active
 runspace. You can find a runspace that you want to debug by first running `Get-Process` to find
@@ -56,11 +55,16 @@ running the process, or you are running the script that you want to debug. Also,
 the host process that is running the current PowerShell session. You can only enter a host process
 that is running a different PowerShell session.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Debug a remote runspace
 
-```
+In this example, you debug a runspace that is open on a remote computer, WS10TestServer. In the
+first line of the command, you run `Get-Process` on the remote computer, and filter for Windows
+PowerShell host processes. In this example, you want to debug process ID 1152, the Windows
+PowerShell ISE host process.
+
+```powershell
 PS C:\> Get-Process -ComputerName "WS10TestServer" -Name "*powershell*"
 
 Handles      WS(K)   VM(M)      CPU(s)    Id  ProcessName
@@ -77,7 +81,7 @@ Id Name            ComputerName    Type          State         Availability
  1 Runspace1       WS10TestServer  Remote        Opened        Available
  2 RemoteHost      WS10TestServer  Remote        Opened        Busy
 
-PS C:\> [WS10TestServer][Process:1152]: PS C:\Users\Test\Documents> Debug-Runspace -Id 2
+[WS10TestServer][Process:1152]: PS C:\Users\Test\Documents> Debug-Runspace -Id 2
 
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 At C:\TestWFVar1.ps1:83 char:1
@@ -85,11 +89,6 @@ At C:\TestWFVar1.ps1:83 char:1
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Process:1152]: [RSDBG: 2]: PS C:\> >
 ```
-
-In this example, you debug a runspace that is open on a remote computer, WS10TestServer. In the
-first line of the command, you run `Get-Process` on the remote computer, and filter for Windows
-PowerShell host processes. In this example, you want to debug process ID 1152, the Windows
-PowerShell ISE host process.
 
 In the second command, you run `Enter-PSSession` to open a remote session on WS10TestServer. In the
 third command, you attach to the Windows PowerShell ISE host process running on the remote server by
@@ -100,10 +99,29 @@ In the fourth command, you list available runspaces for process ID 1152 by runni
 You note the ID number of the Busy runspace; it is running a script that you want to debug.
 
 In the last command, you start debugging an opened runspace that is running a script,
-TestWFVar1.ps1, by running `Debug-Runspace`, and identifying the runspace by its ID, 2, by adding
+`TestWFVar1.ps1`, by running `Debug-Runspace`, and identifying the runspace by its ID, 2, by adding
 the **Id** parameter. Because there's a breakpoint in the script, the debugger opens.
 
-## PARAMETERS
+## Parameters
+
+### -BreakAll
+
+Allows you to break immediately in the current location when the debugger attaches.
+
+The parameter is only available as an experimental feature. For more information, see
+[Using experimental features](/powershell/scripting/learn/experimental-features#microsoftpowershellutilitypsmanagebreakpointsinrunspace).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Id
 
@@ -206,17 +224,18 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.Runspaces.Runspace
 
 You can pipe the results of a `Get-Runspace` command to **Debug-Runspace.**
 
-## OUTPUTS
+## Outputs
 
-## NOTES
+## Notes
 
 `Debug-Runspace` works on runspaces that are in the Opened state. If a runspace state changes from
 Opened to another state, that runspace is automatically removed from the running list. A runspace is
@@ -227,7 +246,7 @@ added to the running list only if it meets the following criteria.
 - If it is coming from a PowerShell workflow, and its workflow job ID is the same as the current
   active debugger workflow job ID.
 
-## RELATED LINKS
+## Related links
 
 [about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md)
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
@@ -1,24 +1,24 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/disable-psbreakpoint?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Disable-PSBreakpoint
 ---
 # Disable-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Disables the breakpoints in the current console.
 
-## SYNTAX
+## Syntax
 
 ### Breakpoint (Default)
 
 ```
-Disable-PSBreakpoint [-PassThru] [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+Disable-PSBreakpoint [-PassThru] [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### Id
@@ -27,79 +27,79 @@ Disable-PSBreakpoint [-PassThru] [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confir
 Disable-PSBreakpoint [-PassThru] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
-The **Disable-PSBreakpoint** cmdlet disables breakpoints, which assures that they are not hit when the script runs.
-You can use it to disable all breakpoints, or you can specify breakpoints by submitting breakpoint objects or breakpoint IDs.
+The `Disable-PSBreakpoint` cmdlet disables breakpoints, which assures that they are not hit when the
+script runs. You can use it to disable all breakpoints, or you can specify breakpoints by submitting
+breakpoint objects or breakpoint IDs.
 
 Technically, this cmdlet changes the value of the Enabled property of a breakpoint object to False.
-To re-enable a breakpoint, use the Enable-PSBreakpoint cmdlet.
-Breakpoints are enabled by default when you create them by using the Set-PSBreakpoint cmdlet.
+To re-enable a breakpoint, use the `Enable-PSBreakpoint` cmdlet. Breakpoints are enabled by default
+when you create them using the `Set-PSBreakpoint` cmdlet.
 
-A breakpoint is a point in a script where execution stops temporarily so that you can examine the instructions in the script.
-**Disable-PSBreakpoint** is one of several cmdlets designed for debugging PowerShell scripts.
-For more information about the PowerShell debugger, see about_Debuggers.
+A breakpoint is a point in a script where execution stops temporarily so that you can examine the
+instructions in the script. `Disable-PSBreakpoint` is one of several cmdlets designed for debugging
+PowerShell scripts. For more information about the PowerShell debugger, see
+[about_Debuggers](../microsoft.powershell.core/about/about_debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Set a breakpoint and disable it
 
-```
-PS C:\> $B = Set-PSBreakpoint -Script "sample.ps1" -Variable "name"
-PS C:\> $B | Disable-PSBreakpoint
-```
-
 These commands disable a newly-created breakpoint.
 
-The first command uses the Set-PSBreakpoint cmdlet to create a breakpoint on the *Name* variable in the Sample.ps1 script.
-Then, it saves the breakpoint object in the $B variable.
+```powershell
+$B = Set-PSBreakpoint -Script "sample.ps1" -Variable "name"
+$B | Disable-PSBreakpoint
+```
 
-The second command uses the **Disable-PSBreakpoint** cmdlet to disable the new breakpoint.
-It uses a pipeline operator (|) to send the breakpoint object in $B to the **Disable-PSBreakpoint** cmdlet.
+The `Set-PSBreakpoint` cmdlet creates a breakpoint on the `$Name` variable in the `Sample.ps1`
+script and saves the breakpoint object in the `$B` variable. The `Disable-PSBreakpoint` cmdlet
+disables the new breakpoint. It uses a pipeline operator (`|`) to send the breakpoint object in `$B`
+to the `Disable-PSBreakpoint` cmdlet.
 
-As a result of this command, the value of the Enabled property of the breakpoint object in $B is False.
+As a result of this command, the value of the **Enabled** property of the breakpoint object in `$B`
+is **False**.
 
 ### Example 2: Disable a breakpoint
 
-```
-PS C:\> Disable-PSBreakpoint -Id 0
-```
-
 This command disables the breakpoint with breakpoint ID 0.
+
+```powershell
+Disable-PSBreakpoint -Id 0
+```
 
 ### Example 3: Create a disabled breakpoint
 
-```
-PS C:\> Disable-PSBreakpoint -Breakpoint ($B = Set-PSBreakpoint -Script "sample.ps1" -Line 5)
-PS C:\> $B
-```
-
 This command creates a new breakpoint that is disabled until you enable it.
 
-It uses the **Disable-PSBreakpoint** cmdlet to disable the breakpoint.
-The value of the *Breakpoint* parameter is a Set-PSBreakpoint command that sets a new breakpoint, generates a breakpoint object, and saves the object in the $B variable.
+```powershell
+Disable-PSBreakpoint -Breakpoint ($B = Set-PSBreakpoint -Script "sample.ps1" -Line 5)
+```
 
-Cmdlet parameters that take objects as their values can accept a variable that contains the object or a command that gets or generates the object.
-In this case, because **Set-PSBreakpoint** generates a breakpoint object, it can be used as the value of the *Breakpoint* parameter.
+It uses the `Disable-PSBreakpoint` cmdlet to disable the breakpoint. The value of the **Breakpoint**
+parameter is a `Set-PSBreakpoint` command that sets a new breakpoint, generates a breakpoint object,
+and saves the object in the `$B` variable.
 
-The second command displays the breakpoint object in the value of the $B variable.
+Cmdlet parameters that take objects as their values can accept a variable that contains the object
+or a command that gets or generates the object. In this case, because `Set-PSBreakpoint` generates a
+breakpoint object, it can be used as the value of the **Breakpoint** parameter.
 
 ### Example 4: Disable all breakpoints in the current console
 
-```
-PS C:\> Get-PSBreakpoint | Disable-PSBreakpoint
-```
-
 This command disables all breakpoints in the current console.
-You can abbreviate this command as: "gbp | dbp".
 
-## PARAMETERS
+```powershell
+`Get-PSBreakpoint` | Disable-PSBreakpoint
+```
+
+## Parameters
 
 ### -Breakpoint
 
-Specifies the breakpoints to disable.
-Enter a variable that contains breakpoint objects or a command that gets breakpoint objects, such as a Get-PSBreakpoint command.
-You can also pipe breakpoint objects to the **Disable-PSBreakpoint** cmdlet.
+Specifies the breakpoints to disable. Enter a variable that contains breakpoint objects or a command
+that gets breakpoint objects, such as a `Get-PSBreakpoint` command. You can also pipe breakpoint
+objects to the `Disable-PSBreakpoint` cmdlet.
 
 ```yaml
 Type: System.Management.Automation.Breakpoint[]
@@ -115,9 +115,8 @@ Accept wildcard characters: False
 
 ### -Id
 
-Disables the breakpoints with the specified breakpoint IDs.
-Enter the IDs or a variable that contains the IDs.
-You cannot pipe IDs to **Disable-PSBreakpoint**.
+Disables the breakpoints with the specified breakpoint IDs. Enter the IDs or a variable that
+contains the IDs. You cannot pipe IDs to `Disable-PSBreakpoint`.
 
 ```yaml
 Type: System.Int32[]
@@ -133,8 +132,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the enabled breakpoints.
-By default, this cmdlet does not generate any output.
+Returns an object representing the enabled breakpoints. By default, this cmdlet does not generate
+any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -166,8 +165,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -183,24 +181,27 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.Breakpoint
 
-You can pipe a breakpoint object to **Disable-PSBreakpoint**.
+You can pipe a breakpoint object to `Disable-PSBreakpoint`.
 
-## OUTPUTS
+## Outputs
 
 ### None or System.Management.Automation.Breakpoint
 
-When you use the *PassThru* parameter, **Disable-PSBreakpoint** returns an object that represents the disabled breakpoint.
-Otherwise, this cmdlet does not generate any output.
+When you use the **PassThru** parameter, `Disable-PSBreakpoint` returns an object that represents
+the disabled breakpoint. Otherwise, this cmdlet does not generate any output.
 
-## NOTES
+## Notes
 
-## RELATED LINKS
+## Related links
 
 [Enable-PSBreakpoint](Enable-PSBreakpoint.md)
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
@@ -1,9 +1,8 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/09/2019
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/enable-psbreakpoint?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enable-PSBreakpoint
@@ -11,10 +10,10 @@ title: Enable-PSBreakpoint
 
 # Enable-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Enables the breakpoints in the current console.
 
-## SYNTAX
+## Syntax
 
 ### Id (Default)
 
@@ -29,7 +28,7 @@ Enable-PSBreakpoint [-PassThru] [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm
  [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Enable-PSBreakpoint` cmdlet re-enables disabled breakpoints. You can use it to enable all
 breakpoints, or specific breakpoints by providing breakpoint objects or IDs.
@@ -42,9 +41,10 @@ Technically, this cmdlet changes the value of the **Enabled** property of a brea
 **True**.
 
 `Enable-PSBreakpoint` is one of several cmdlets designed for debugging PowerShell scripts. For more
-information about the PowerShell debugger, see [about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
+information about the PowerShell debugger, see
+[about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Enable all breakpoints
 
@@ -114,7 +114,7 @@ Enable-PSBreakpoint -Breakpoint $B
 
 This example is equivalent to running `Enable-PSBreakpoint -Id 3, 5`.
 
-## PARAMETERS
+## Parameters
 
 ### -Breakpoint
 
@@ -205,21 +205,23 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.Breakpoint
 
 You can pipe a breakpoint object to `Enable-PSBreakpoint`.
 
-## OUTPUTS
+## Outputs
 
 ### None or System.Management.Automation.Breakpoint
 
-When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpoint object that represents that breakpoint that was enabled. Otherwise, this cmdlet doesn't generate any output.
+When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpoint object that
+represents that breakpoint that was enabled. Otherwise, this cmdlet doesn't generate any output.
 
-## NOTES
+## Notes
 
 - The `Enable-PSBreakpoint` cmdlet doesn't generate an error if you try to enable a breakpoint that
   is already enabled. As such, you can enable all breakpoints without error, even when only a few
@@ -228,7 +230,7 @@ When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpo
 - Breakpoints are enabled when you create them by using the `Set-PSBreakpoint` cmdlet. You don't
   need to enable newly created breakpoints.
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
@@ -1,19 +1,18 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 5/15/2019
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-psbreakpoint?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-PSBreakpoint
 ---
 # Get-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Gets the breakpoints that are set in the current session.
 
-## SYNTAX
+## Syntax
 
 ### Script (Default)
 
@@ -45,108 +44,109 @@ Get-PSBreakpoint [-Script <String[]>] [-Type] <BreakpointType[]> [<CommonParamet
 Get-PSBreakpoint [-Id] <Int32[]> [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
-The **Get-PSBreakPoint** cmdlet gets the breakpoints that are set in the current session.
-You can use the cmdlet parameters to get particular breakpoints.
+The `Get-PSBreakPoint` cmdlet gets the breakpoints that are set in the current session. You can use
+the cmdlet parameters to get particular breakpoints.
 
 A breakpoint is a point in a command or script where execution stops temporarily so that you can
-examine the instructions.
-**Get-PSBreakpoint** is one of several cmdlets designed for debugging PowerShell scripts and
-commands. For more information about the PowerShell debugger, see about_Debuggers.
+examine the instructions. `Get-PSBreakpoint` is one of several cmdlets designed for debugging
+PowerShell scripts and commands. For more information about the PowerShell debugger, see
+[about_Debuggers](../microsoft.powershell.core/about/about_debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Get all breakpoints for all scripts and functions
 
-```
-PS C:\> Get-PSBreakpoint
-```
-
 This command gets all breakpoints set on all scripts and functions in the current session.
+
+```powershell
+Get-PSBreakpoint
+```
 
 ### Example 2: Get breakpoints by ID
 
-```
-PS C:\> Get-PSBreakpoint -Id 2
-Function   :
-IncrementAction     :
-Enabled    :
-TrueHitCount   : 0
-Id         : 2
-Script     : C:\ps-test\sample.ps1
-ScriptName : C:\ps-test\sample.ps1
-```
-
 This command gets the breakpoint with breakpoint ID 2.
 
-### Example 3: Pipe an ID to Get-PSBreakpoint
-
-```
-PS C:\> $B = Set-PSBreakpoint -Script "sample.ps1" -Command "Increment"
-PS C:\> $B.Id | Get-PSBreakpoint
+```powershell
+Get-PSBreakpoint -Id 2
 ```
 
-These commands show how to get a breakpoint by piping a breakpoint ID to **Get-PSBreakpoint**.
+```Output
+Function         :
+IncrementAction  :
+Enabled          :
+TrueHitCount     : 0
+Id               : 2
+Script           : C:\ps-test\sample.ps1
+ScriptName       : C:\ps-test\sample.ps1
+```
 
-The first command uses the Set-PSBreakpoint cmdlet to create a breakpoint on the Increment function
-in the Sample.ps1 script. It saves the breakpoint object in the $B variable.
+### Example 3: Pipe an ID to `Get-PSBreakpoint`
 
-The second command uses the dot operator (.) to get the Id property of the breakpoint object in the
-$B variable. It uses a pipeline operator (|) to send the ID to the **Get-PSBreakpoint** cmdlet.
+These commands show how to get a breakpoint by piping a breakpoint ID to `Get-PSBreakpoint`.
 
-As a result, **Get-PSBreakpoint** gets the breakpoint with the specified ID.
+```powershell
+$B = `Set-PSBreakpoint` -Script "sample.ps1" -Command "Increment"
+$B.Id | Get-PSBreakpoint
+```
+
+The `Set-PSBreakpoint` cmdlet creates a breakpoint on the Increment function in the `Sample.ps1`
+script and saves the breakpoint object in the `$B` variable. The **Id** property of the breakpoint
+object in the `$B` variable is piped to the `Get-PSBreakpoint` cmdlet to display the breakpoint
+information.
 
 ### Example 4: Get breakpoints in specified script files
 
-```
-PS C:\> Get-PSBreakpoint -Script "Sample.ps1, SupportScript.ps1"
-```
+This command gets all of the breakpoints in the `Sample.ps1` and `SupportScript.ps1` files.
 
-This command gets all of the breakpoints in the Sample.ps1 and SupportScript.ps1 files.
+```powershell
+Get-PSBreakpoint -Script "Sample.ps1, SupportScript.ps1"
+```
 
 This command does not get other breakpoints that might be set in other scripts or on functions in
 the session.
 
 ### Example 5: Get breakpoints in specified cmdlets
 
-```
-PS C:\> Get-PSBreakpoint -Command "Read-Host, Write-Host" -Script "Sample.ps1"
-```
+This command gets all Command breakpoints that are set on `Read-Host` or `Write-Host` commands in
+the `Sample.ps1` file.
 
-This command gets all Command breakpoints that are set on Read-Host or Write-Host commands in the
-Sample.ps1 file.
+```powershell
+Get-PSBreakpoint -Command "Read-Host, Write-Host" -Script "Sample.ps1"
+```
 
 ### Example 6: Get Command breakpoints in a specified file
 
-```
-PS C:\> Get-PSBreakpoint -Type Command -Script "Sample.ps1"
+```powershell
+Get-PSBreakpoint -Type Command -Script "Sample.ps1"
 ```
 
 This command gets all Command breakpoints in the Sample.ps1 file.
 
 ### Example 7: Get breakpoints by variable
 
-```
-PS C:\> Get-PSBreakpoint -Variable "Index, Swap"
-```
+This command gets breakpoints that are set on the `$Index` and `$Swap` variables in the current
+session.
 
-This command gets breakpoints that are set on the $Index and $Swap variables in the current session.
+```powershell
+Get-PSBreakpoint -Variable "Index, Swap"
+```
 
 ### Example 8: Get all Line and Variable breakpoints in a file
 
-```
-PS C:\> Get-PSBreakpoint -Type Line, Variable -Script "Sample.ps1"
+This command gets all line and variable breakpoints in the `Sample.ps1` script.
+
+```powershell
+Get-PSBreakpoint -Type Line, Variable -Script "Sample.ps1"
 ```
 
-This command gets all line and variable breakpoints in the Sample.ps1 script.
-
-## PARAMETERS
+## Parameters
 
 ### -Command
 
-Specifies an array of command breakpoints that are set on the specified command names.
-Enter the command names, such as the name of a cmdlet or function.
+Specifies an array of command breakpoints that are set on the specified command names. Enter the
+command names, such as the name of a cmdlet or function.
 
 ```yaml
 Type: System.String[]
@@ -162,9 +162,8 @@ Accept wildcard characters: False
 
 ### -Id
 
-Specifies the breakpoint IDs that this cmdlet gets.
-Enter the IDs in a comma-separated list.
-You can also pipe breakpoint IDs to **Get-PSBreakpoint**.
+Specifies the breakpoint IDs that this cmdlet gets. Enter the IDs in a comma-separated list. You can
+also pipe breakpoint IDs to `Get-PSBreakpoint`.
 
 ```yaml
 Type: System.Int32[]
@@ -180,9 +179,8 @@ Accept wildcard characters: False
 
 ### -Script
 
-Specifies an array of scripts that contain the breakpoints.
-Enter the path (optional) and names of one or more script files.
-If you omit the path, the default location is the current directory.
+Specifies an array of scripts that contain the breakpoints. Enter the path (optional) and names of
+one or more script files. If you omit the path, the default location is the current directory.
 
 ```yaml
 Type: System.String[]
@@ -198,15 +196,14 @@ Accept wildcard characters: False
 
 ### -Type
 
-Specifies an array of breakpoint types that this cmdlet gets.
-Enter one or more types.
-The acceptable values for this parameter are:
+Specifies an array of breakpoint types that this cmdlet gets. Enter one or more types. The
+acceptable values for this parameter are:
 
 - Line
 - Command
 - Variable
 
-You can also pipe breakpoint types to **Get-PSBreakPoint**.
+You can also pipe breakpoint types to `Get-PSBreakPoint`.
 
 ```yaml
 Type: Microsoft.PowerShell.Commands.BreakpointType[]
@@ -223,8 +220,8 @@ Accept wildcard characters: False
 
 ### -Variable
 
-Specifies an array of variable breakpoints that are set on the specified variable names.
-Enter the variable names without dollar signs.
+Specifies an array of variable breakpoints that are set on the specified variable names. Enter the
+variable names without dollar signs.
 
 ```yaml
 Type: System.String[]
@@ -242,26 +239,34 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see about_CommonParameters
-(https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
-### System.Int32, Microsoft.PowerShell.Commands.BreakpointType
+### System.Int32
 
-You can pipe breakpoint IDs and breakpoint types to **Get-PSBreakPoint**.
+### Microsoft.PowerShell.Commands.BreakpointType
 
-## OUTPUTS
+You can pipe breakpoint IDs and breakpoint types to `Get-PSBreakPoint`.
+
+## Outputs
+
+### System.Management.Automation.CommandBreakpoint
+
+### System.Management.Automation.LineBreakpoint
+
+### System.Management.Automation.VariableBreakpoint
 
 ### System.Management.Automation.Breakpoint
 
-**Get-PSBreakPoint** returns objects that represent the breakpoints in the session.
+`Get-PSBreakPoint` returns objects that represent the breakpoints in the session.
 
-## NOTES
+## Notes
 
-* You can use **Get-PSBreakpoint** or its alias, "gbp".
+You can use `Get-PSBreakpoint` or its alias, "gbp".
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
@@ -1,9 +1,8 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/remove-psbreakpoint?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Remove-PSBreakpoint
@@ -11,10 +10,10 @@ title: Remove-PSBreakpoint
 
 # Remove-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Deletes breakpoints from the current console.
 
-## SYNTAX
+## Syntax
 
 ### Breakpoint (Default)
 
@@ -28,72 +27,71 @@ Remove-PSBreakpoint [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm] [<CommonPa
 Remove-PSBreakpoint [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
-The **Remove-PSBreakpoint** cmdlet deletes a breakpoint.
-Enter a breakpoint object or a breakpoint ID.
+## Description
 
-When you remove a breakpoint, the breakpoint object is no longer available or functional.
-If you have saved a breakpoint object in a variable, the reference still exists, but the breakpoint does not function.
+The `Remove-PSBreakpoint` cmdlet deletes a breakpoint. Enter a breakpoint object or a breakpoint ID.
 
-**Remove-PSBreakpoint** is one of several cmdlets designed for debugging PowerShell scripts.
-For more information about the PowerShell debugger, see about_Debuggers.
+When you remove a breakpoint, the breakpoint object is no longer available or functional. If you
+have saved a breakpoint object in a variable, the reference still exists, but the breakpoint does
+not function.
 
-## EXAMPLES
+`Remove-PSBreakpoint` is one of several cmdlets designed for debugging PowerShell scripts. For more
+information about the PowerShell debugger, see
+[about_Debuggers](../microsoft.powershell.core/about/about_debuggers.md).
+
+## Examples
 
 ### Example 1: Remove all breakpoints
 
-```
-PS C:\> Get-PSBreakpoint | Remove-PSBreakpoint
-```
-
 This command deletes all of the breakpoints in the current console.
+
+```powershell
+Get-PSBreakpoint | Remove-PSBreakpoint
+```
 
 ### Example 2: Remove a specified breakpoint
 
-```
-PS C:\> $B = Set-PSBreakpoint -Script "sample.ps1" -Variable "Name"
-PS C:\> $B | Remove-PSBreakpoint
-```
-
 This command deletes a breakpoint.
 
-The first command uses the Set-PSBreakpoint cmdlet to create a breakpoint on the Name variable in the Sample.ps1 script.
-Then, it saves the breakpoint object in the $B variable.
+```powershell
+$B = Set-PSBreakpoint -Script "sample.ps1" -Variable "Name"
+$B | Remove-PSBreakpoint
+```
 
-The second command uses the **Remove-PSBreakpoint** cmdlet to delete the new breakpoint.
-It uses a pipeline operator (|) to send the breakpoint object in the $B variable to the **Remove-PSBreakpoint** cmdlet.
+The `Set-PSBreakpoint` cmdlet creates a breakpoint on the `$Name` variable in the `Sample.ps1`
+script and saves the breakpoint object in the `$B` variable. The `Remove-PSBreakpoint` cmdlet
+deletes the new breakpoint. It uses a pipeline operator (`|`) to send the breakpoint object in the
+`$B` variable to the `Remove-PSBreakpoint` cmdlet.
 
-As a result of this command, if you run the script, it runs to completion without stopping.
-Also, the **Get-PSBreakpoint** cmdlet does not return this breakpoint.
+As a result of this command, if you run the script, it runs to completion without stopping. Also,
+the `Get-PSBreakpoint` cmdlet does not return this breakpoint.
 
 ### Example 3: Remove a breakpoint by ID
 
-```
-PS C:\> Remove-PSBreakpoint -Id 2
-```
-
 This command deletes the breakpoint with breakpoint ID 2.
+
+```powershell
+Remove-PSBreakpoint -Id 2
+```
 
 ### Example 4: Use a function to remove all breakpoints
 
-```
-PS C:\> function del-psb { get-psbreakpoint | remove-psbreakpoint }
-```
-
 This simple function deletes all of the breakpoints in the current console.
-It uses the Get-PSBreakpoint cmdlet to get the breakpoints.
-Then, it uses a pipeline operator (|) to send the breakpoints to the **Remove-PSBreakpoint** cmdlet, which deletes them.
 
-As a result, you can type `del-psb` instead of the longer command.
+```powershell
+function del-psb { Get-PSBreakpoint | Remove-PSBreakpoint }
+```
 
-To save the function, add it to your PowerShell profile.
+It uses the `Get-PSBreakpoint` cmdlet to get the breakpoints. Then, it uses a pipeline operator
+(`|`) to send the breakpoints to the `Remove-PSBreakpoint` cmdlet, which deletes them.
 
-## PARAMETERS
+## Parameters
 
 ### -Breakpoint
-Specifies the breakpoints to delete.
-Enter a variable that contains breakpoint objects or a command that gets breakpoint objects, such as a **Get-PSBreakpoint** command.
-You can also pipe breakpoint objects to **Remove-PSBreakpoint**.
+
+Specifies the breakpoints to delete. Enter a variable that contains breakpoint objects or a command
+that gets breakpoint objects, such as a `Get-PSBreakpoint` command. You can also pipe breakpoint
+objects to `Remove-PSBreakpoint`.
 
 ```yaml
 Type: System.Management.Automation.Breakpoint[]
@@ -108,6 +106,7 @@ Accept wildcard characters: False
 ```
 
 ### -Id
+
 Specifies breakpoint IDs for which this cmdlet deletes breakpoints.
 
 ```yaml
@@ -154,21 +153,31 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-### System.Management.Automation.Breakpoint
-You can pipe breakpoint objects to **Remove-PSBreakpoint**.
+## Inputs
 
-## OUTPUTS
+### System.Management.Automation.Breakpoint[]
+
+You can pipe breakpoint objects to `Remove-PSBreakpoint`.
+
+### System.Int32[]
+
+### System.Management.Automation.Runspaces.Runspace
+
+## Outputs
 
 ### None
+
 The cmdlet does not generate any output.
 
-## NOTES
+## Notes
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -1,19 +1,18 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/24/2019
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/set-psbreakpoint?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSBreakpoint
 ---
 # Set-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Sets a breakpoint on a line, command, or variable.
 
-## SYNTAX
+## Syntax
 
 ### Line (Default)
 
@@ -35,7 +34,7 @@ Set-PSBreakpoint [-Action <ScriptBlock>] [[-Script] <String[]>] -Variable <Strin
  [-Mode <VariableAccessMode>] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Set-PSBreakpoint` cmdlet sets a breakpoint in a script or in any command run in the current
 session. You can use `Set-PSBreakpoint` to set a breakpoint before executing a script or running a
@@ -59,9 +58,10 @@ you can use the **Action** parameter to specify an alternate response, such as c
 breakpoint or instructions to perform additional tasks such as logging or diagnostics.
 
 The `Set-PSBreakpoint` cmdlet is one of several cmdlets designed for debugging PowerShell scripts.
-For more information about the PowerShell debugger, see [about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
+For more information about the PowerShell debugger, see
+[about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Set a breakpoint on a line
 
@@ -130,8 +130,8 @@ Set-PSBreakpoint -Script Sample.ps1 -Command "write*"
 
 ### Example 5: Set a breakpoint depending on the value of a variable
 
-This example stops execution at the `DiskTest` function in the Test.ps1 script only when the value of
-the `$Disk` variable is greater than 2.
+This example stops execution at the `DiskTest` function in the `Test.ps1` script only when the value
+of the `$Disk` variable is greater than 2.
 
 ```powershell
 Set-PSBreakpoint -Script "test.ps1" -Command "DiskTest" -Action { if ($Disk -gt 2) { break } }
@@ -208,7 +208,7 @@ Script     : C:\ps-test\sample.ps1
 ScriptName : C:\ps-test\sample.ps1
 ```
 
-## PARAMETERS
+## Parameters
 
 ### -Action
 
@@ -244,10 +244,10 @@ Accept wildcard characters: False
 Specifies the column number of the column in the script file on which execution stops. Enter only
 one column number. The default is column 1.
 
-The Column value is used with the value of the **Line** parameter to specify the breakpoint. If the **Line**
-parameter specifies multiple lines, the **Column** parameter sets a breakpoint at the specified column
-on each of the specified lines. PowerShell stops executing before the statement or expression that
-includes the character at the specified line and column position.
+The Column value is used with the value of the **Line** parameter to specify the breakpoint. If the
+**Line** parameter specifies multiple lines, the **Column** parameter sets a breakpoint at the
+specified column on each of the specified lines. PowerShell stops executing before the statement or
+expression that includes the character at the specified line and column position.
 
 Columns are counted from the top left margin beginning with column number 1 (not 0). If you specify
 a column that does not exist in the script, an error is not declared, but the breakpoint is never
@@ -377,20 +377,25 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### None
 You cannot pipe input to `Set-PSBreakpoint`.
 
 ## OUTPUTS
 
-### Breakpoint object (System.Management.Automation.LineBreakpoint, System.Management.Automation.VariableBreakpoint, System.Management.Automation.CommandBreakpoint)
+### System.Management.Automation.CommandBreakpoint
+
+### System.Management.Automation.LineBreakpoint
+
+### System.Management.Automation.VariableBreakpoint
 
 `Set-PSBreakpoint` returns an object that represents each breakpoint that it sets.
 
-## NOTES
+## Notes
 
 - `Set-PSBreakpoint` cannot set a breakpoint on a remote computer. To debug a script on a remote
   computer, copy the script to the local computer and then debug it locally.
@@ -399,7 +404,7 @@ You cannot pipe input to `Set-PSBreakpoint`.
 - When setting a breakpoint on a function or variable at the command prompt, you can set the
   breakpoint before or after you create the function or variable.
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 

--- a/reference/7.1/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Debug-Job.md
@@ -1,9 +1,8 @@
 ---
 external help file: System.Management.Automation.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/debug-job?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Debug-Job
@@ -11,10 +10,10 @@ title: Debug-Job
 
 # Debug-Job
 
-## SYNOPSIS
-Debugs a running background, remote, or PowerShell Workflow job.
+## Synopsis
+Debugs a running background or remote job.
 
-## SYNTAX
+## Syntax
 
 ### JobParameterSet (Default)
 
@@ -40,19 +39,25 @@ Debug-Job [-Id] <Int32> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 Debug-Job [-InstanceId] <Guid> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
-The **Debug-Job** cmdlet lets you debug scripts that are running within jobs.
-The cmdlet is designed to debug PowerShell Workflow jobs, background jobs, and jobs running in remote sessions.
-**Debug-Job** accepts a running job object, name, ID, or instance ID as input, and starts a debugging session on the script it is running.
-The debugger **quit** command stops the job and running script.
-Starting in Windows PowerShell 5.0, the **exit** command detaches the debugger, and allows the job to continue to run.
+## Description
 
-## EXAMPLES
+The `Debug-Job` cmdlet lets you debug scripts that are running within jobs. The cmdlet is designed
+to debug PowerShell Workflow jobs, background jobs, and jobs running in remote sessions. `Debug-Job`
+accepts a running job object, name, ID, or instance ID as input, and starts a debugging session on
+the script it is running. The debugger `quit` command stops the job and running script. The `exit`
+command detaches the debugger, and allows the job to continue to run.
+
+## Examples
 
 ### Example 1: Debug a job by job ID
 
+This command breaks into a running job with an ID of 3.
+
+```powershell
+Debug-Job -ID 3
 ```
-PS C:\> Debug-Job -ID 3
+
+```Output
 Id     Name            PSJobTypeName   State         HasMoreData     Location             Command
 --     ----            -------------   -----         -----------     --------             -------
 3      Job3            RemoteJob       Running       True            PowerShellIx         TestWFDemo1.ps1
@@ -83,13 +88,30 @@ Id     Name            PSJobTypeName   State         HasMoreData     Location   
              18:  SampleWorkflowTest -MyOutput "Hello"
 ```
 
-This command breaks into a running job with an ID of 3.
+## Parameters
 
-## PARAMETERS
+### -BreakAll
+
+Allows you to break immediately in the current location when the debugger attaches.
+
+The parameter is only available as an experimental feature. For more information, see
+[Using experimental features](/powershell/scripting/learn/experimental-features#microsoftpowershellutilitypsmanagebreakpointsinrunspace).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Id
-Specifies the ID number of a running job.
-To get the ID number of a job, run the Get-Job cmdlet.
+
+Specifies the ID number of a running job. To get the ID number of a job, run the `Get-Job` cmdlet.
 
 ```yaml
 Type: System.Int32
@@ -104,10 +126,8 @@ Accept wildcard characters: False
 ```
 
 ### -InstanceId
-Specifies the instance ID GUID of a running job.
-To get the *InstanceId* of a job, run the **Get-Job** cmdlet, piping the results into a **Format-*** cmdlet, as shown in the following example:
 
-`Get-Job | Format-List -Property Id,Name,InstanceId,State`
+Specifies the instance ID GUID of a running job.
 
 ```yaml
 Type: System.Guid
@@ -122,8 +142,10 @@ Accept wildcard characters: False
 ```
 
 ### -Job
-Specifies a running job object.
-The simplest way to use this parameter is to save the results of a **Get-Job** command that returns the running job that you want to debug in a variable, and then specify the variable as the value of this parameter.
+
+Specifies a running job object. The simplest way to use this parameter is to save the results of a
+`Get-Job` command that returns the running job that you want to debug in a variable, and then
+specify the variable as the value of this parameter.
 
 ```yaml
 Type: System.Management.Automation.Job
@@ -138,8 +160,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies a job by the friendly name of the job.
-When you start a job, you can specify a job name by adding the *JobName* parameter, in cmdlets such as Invoke-Command and Start-Job.
+
+Specifies a job by the friendly name of the job. When you start a job, you can specify a job name by
+adding the **JobName** parameter, in cmdlets such as `Invoke-Command` and `Start-Job`.
 
 ```yaml
 Type: System.String
@@ -154,6 +177,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -169,8 +193,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -184,34 +208,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -BreakAll
-
-{{ Fill BreakAll Description }}
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## Inputs
 
 ### System.Management.Automation.RemotingJob
 
-## OUTPUTS
+## Outputs
 
-## NOTES
+## Notes
 
-## RELATED LINKS
+## Related links
 
 [Get-Job](Get-Job.md)
 
@@ -224,4 +236,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Stop-Job](Stop-Job.md)
 
 [Wait-Job](Wait-Job.md)
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/Debug-Runspace.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Debug-Runspace.md
@@ -1,19 +1,18 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/debug-runspace?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Debug-Runspace
 ---
 # Debug-Runspace
 
-## SYNOPSIS
+## Synopsis
 Starts an interactive debugging session with a runspace.
 
-## SYNTAX
+## Syntax
 
 ### RunspaceParameterSet (Default)
 
@@ -39,7 +38,7 @@ Debug-Runspace [-Id] <Int32> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters
 Debug-Runspace [-InstanceId] <Guid> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Debug-Runspace` cmdlet starts an interactive debugging session with a local or remote active
 runspace. You can find a runspace that you want to debug by first running `Get-Process` to find
@@ -56,11 +55,16 @@ running the process, or you are running the script that you want to debug. Also,
 the host process that is running the current PowerShell session. You can only enter a host process
 that is running a different PowerShell session.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Debug a remote runspace
 
-```
+In this example, you debug a runspace that is open on a remote computer, WS10TestServer. In the
+first line of the command, you run `Get-Process` on the remote computer, and filter for Windows
+PowerShell host processes. In this example, you want to debug process ID 1152, the Windows
+PowerShell ISE host process.
+
+```powershell
 PS C:\> Get-Process -ComputerName "WS10TestServer" -Name "*powershell*"
 
 Handles      WS(K)   VM(M)      CPU(s)    Id  ProcessName
@@ -77,7 +81,7 @@ Id Name            ComputerName    Type          State         Availability
  1 Runspace1       WS10TestServer  Remote        Opened        Available
  2 RemoteHost      WS10TestServer  Remote        Opened        Busy
 
-PS C:\> [WS10TestServer][Process:1152]: PS C:\Users\Test\Documents> Debug-Runspace -Id 2
+[WS10TestServer][Process:1152]: PS C:\Users\Test\Documents> Debug-Runspace -Id 2
 
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 At C:\TestWFVar1.ps1:83 char:1
@@ -85,11 +89,6 @@ At C:\TestWFVar1.ps1:83 char:1
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Process:1152]: [RSDBG: 2]: PS C:\> >
 ```
-
-In this example, you debug a runspace that is open on a remote computer, WS10TestServer. In the
-first line of the command, you run `Get-Process` on the remote computer, and filter for Windows
-PowerShell host processes. In this example, you want to debug process ID 1152, the Windows
-PowerShell ISE host process.
 
 In the second command, you run `Enter-PSSession` to open a remote session on WS10TestServer. In the
 third command, you attach to the Windows PowerShell ISE host process running on the remote server by
@@ -100,10 +99,29 @@ In the fourth command, you list available runspaces for process ID 1152 by runni
 You note the ID number of the Busy runspace; it is running a script that you want to debug.
 
 In the last command, you start debugging an opened runspace that is running a script,
-TestWFVar1.ps1, by running `Debug-Runspace`, and identifying the runspace by its ID, 2, by adding
+`TestWFVar1.ps1`, by running `Debug-Runspace`, and identifying the runspace by its ID, 2, by adding
 the **Id** parameter. Because there's a breakpoint in the script, the debugger opens.
 
-## PARAMETERS
+## Parameters
+
+### -BreakAll
+
+Allows you to break immediately in the current location when the debugger attaches.
+
+The parameter is only available as an experimental feature. For more information, see
+[Using experimental features](/powershell/scripting/learn/experimental-features#microsoftpowershellutilitypsmanagebreakpointsinrunspace).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Id
 
@@ -202,37 +220,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -BreakAll
-
-{{ Fill BreakAll Description }}
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.Runspaces.Runspace
 
 You can pipe the results of a `Get-Runspace` command to **Debug-Runspace.**
 
-## OUTPUTS
+## Outputs
 
-## NOTES
+## Notes
 
 `Debug-Runspace` works on runspaces that are in the Opened state. If a runspace state changes from
 Opened to another state, that runspace is automatically removed from the running list. A runspace is
@@ -243,7 +246,7 @@ added to the running list only if it meets the following criteria.
 - If it is coming from a PowerShell workflow, and its workflow job ID is the same as the current
   active debugger workflow job ID.
 
-## RELATED LINKS
+## Related links
 
 [about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md)
 
@@ -256,4 +259,3 @@ added to the running list only if it meets the following criteria.
 [Enter-PSHostProcess](../Microsoft.PowerShell.Core/Enter-PSHostProcess.md)
 
 [Enter-PSSession](../Microsoft.PowerShell.Core/Enter-PSSession.md)
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
@@ -1,24 +1,24 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/disable-psbreakpoint?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Disable-PSBreakpoint
 ---
 # Disable-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Disables the breakpoints in the current console.
 
-## SYNTAX
+## Syntax
 
 ### Breakpoint (Default)
 
 ```
-Disable-PSBreakpoint [-PassThru] [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+Disable-PSBreakpoint [-PassThru] [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### Id
@@ -27,79 +27,79 @@ Disable-PSBreakpoint [-PassThru] [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confir
 Disable-PSBreakpoint [-PassThru] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
-The **Disable-PSBreakpoint** cmdlet disables breakpoints, which assures that they are not hit when the script runs.
-You can use it to disable all breakpoints, or you can specify breakpoints by submitting breakpoint objects or breakpoint IDs.
+The `Disable-PSBreakpoint` cmdlet disables breakpoints, which assures that they are not hit when the
+script runs. You can use it to disable all breakpoints, or you can specify breakpoints by submitting
+breakpoint objects or breakpoint IDs.
 
 Technically, this cmdlet changes the value of the Enabled property of a breakpoint object to False.
-To re-enable a breakpoint, use the Enable-PSBreakpoint cmdlet.
-Breakpoints are enabled by default when you create them by using the Set-PSBreakpoint cmdlet.
+To re-enable a breakpoint, use the `Enable-PSBreakpoint` cmdlet. Breakpoints are enabled by default
+when you create them using the `Set-PSBreakpoint` cmdlet.
 
-A breakpoint is a point in a script where execution stops temporarily so that you can examine the instructions in the script.
-**Disable-PSBreakpoint** is one of several cmdlets designed for debugging PowerShell scripts.
-For more information about the PowerShell debugger, see about_Debuggers.
+A breakpoint is a point in a script where execution stops temporarily so that you can examine the
+instructions in the script. `Disable-PSBreakpoint` is one of several cmdlets designed for debugging
+PowerShell scripts. For more information about the PowerShell debugger, see
+[about_Debuggers](../microsoft.powershell.core/about/about_debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Set a breakpoint and disable it
 
-```
-PS C:\> $B = Set-PSBreakpoint -Script "sample.ps1" -Variable "name"
-PS C:\> $B | Disable-PSBreakpoint
-```
-
 These commands disable a newly-created breakpoint.
 
-The first command uses the Set-PSBreakpoint cmdlet to create a breakpoint on the *Name* variable in the Sample.ps1 script.
-Then, it saves the breakpoint object in the $B variable.
+```powershell
+$B = Set-PSBreakpoint -Script "sample.ps1" -Variable "name"
+$B | Disable-PSBreakpoint
+```
 
-The second command uses the **Disable-PSBreakpoint** cmdlet to disable the new breakpoint.
-It uses a pipeline operator (|) to send the breakpoint object in $B to the **Disable-PSBreakpoint** cmdlet.
+The `Set-PSBreakpoint` cmdlet creates a breakpoint on the `$Name` variable in the `Sample.ps1`
+script and saves the breakpoint object in the `$B` variable. The `Disable-PSBreakpoint` cmdlet
+disables the new breakpoint. It uses a pipeline operator (`|`) to send the breakpoint object in `$B`
+to the `Disable-PSBreakpoint` cmdlet.
 
-As a result of this command, the value of the Enabled property of the breakpoint object in $B is False.
+As a result of this command, the value of the **Enabled** property of the breakpoint object in `$B`
+is **False**.
 
 ### Example 2: Disable a breakpoint
 
-```
-PS C:\> Disable-PSBreakpoint -Id 0
-```
-
 This command disables the breakpoint with breakpoint ID 0.
+
+```powershell
+Disable-PSBreakpoint -Id 0
+```
 
 ### Example 3: Create a disabled breakpoint
 
-```
-PS C:\> Disable-PSBreakpoint -Breakpoint ($B = Set-PSBreakpoint -Script "sample.ps1" -Line 5)
-PS C:\> $B
-```
-
 This command creates a new breakpoint that is disabled until you enable it.
 
-It uses the **Disable-PSBreakpoint** cmdlet to disable the breakpoint.
-The value of the *Breakpoint* parameter is a Set-PSBreakpoint command that sets a new breakpoint, generates a breakpoint object, and saves the object in the $B variable.
+```powershell
+Disable-PSBreakpoint -Breakpoint ($B = Set-PSBreakpoint -Script "sample.ps1" -Line 5)
+```
 
-Cmdlet parameters that take objects as their values can accept a variable that contains the object or a command that gets or generates the object.
-In this case, because **Set-PSBreakpoint** generates a breakpoint object, it can be used as the value of the *Breakpoint* parameter.
+It uses the `Disable-PSBreakpoint` cmdlet to disable the breakpoint. The value of the **Breakpoint**
+parameter is a `Set-PSBreakpoint` command that sets a new breakpoint, generates a breakpoint object,
+and saves the object in the `$B` variable.
 
-The second command displays the breakpoint object in the value of the $B variable.
+Cmdlet parameters that take objects as their values can accept a variable that contains the object
+or a command that gets or generates the object. In this case, because `Set-PSBreakpoint` generates a
+breakpoint object, it can be used as the value of the **Breakpoint** parameter.
 
 ### Example 4: Disable all breakpoints in the current console
 
-```
-PS C:\> Get-PSBreakpoint | Disable-PSBreakpoint
-```
-
 This command disables all breakpoints in the current console.
-You can abbreviate this command as: "gbp | dbp".
 
-## PARAMETERS
+```powershell
+`Get-PSBreakpoint` | Disable-PSBreakpoint
+```
+
+## Parameters
 
 ### -Breakpoint
 
-Specifies the breakpoints to disable.
-Enter a variable that contains breakpoint objects or a command that gets breakpoint objects, such as a Get-PSBreakpoint command.
-You can also pipe breakpoint objects to the **Disable-PSBreakpoint** cmdlet.
+Specifies the breakpoints to disable. Enter a variable that contains breakpoint objects or a command
+that gets breakpoint objects, such as a `Get-PSBreakpoint` command. You can also pipe breakpoint
+objects to the `Disable-PSBreakpoint` cmdlet.
 
 ```yaml
 Type: System.Management.Automation.Breakpoint[]
@@ -115,9 +115,8 @@ Accept wildcard characters: False
 
 ### -Id
 
-Disables the breakpoints with the specified breakpoint IDs.
-Enter the IDs or a variable that contains the IDs.
-You cannot pipe IDs to **Disable-PSBreakpoint**.
+Disables the breakpoints with the specified breakpoint IDs. Enter the IDs or a variable that
+contains the IDs. You cannot pipe IDs to `Disable-PSBreakpoint`.
 
 ```yaml
 Type: System.Int32[]
@@ -133,8 +132,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the enabled breakpoints.
-By default, this cmdlet does not generate any output.
+Returns an object representing the enabled breakpoints. By default, this cmdlet does not generate
+any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -166,8 +165,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -183,24 +181,27 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.Breakpoint
 
-You can pipe a breakpoint object to **Disable-PSBreakpoint**.
+You can pipe a breakpoint object to `Disable-PSBreakpoint`.
 
-## OUTPUTS
+## Outputs
 
 ### None or System.Management.Automation.Breakpoint
 
-When you use the *PassThru* parameter, **Disable-PSBreakpoint** returns an object that represents the disabled breakpoint.
-Otherwise, this cmdlet does not generate any output.
+When you use the **PassThru** parameter, `Disable-PSBreakpoint` returns an object that represents
+the disabled breakpoint. Otherwise, this cmdlet does not generate any output.
 
-## NOTES
+## Notes
 
-## RELATED LINKS
+## Related links
 
 [Enable-PSBreakpoint](Enable-PSBreakpoint.md)
 
@@ -211,4 +212,3 @@ Otherwise, this cmdlet does not generate any output.
 [Remove-PSBreakpoint](Remove-PSBreakpoint.md)
 
 [Set-PSBreakpoint](Set-PSBreakpoint.md)
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
@@ -1,9 +1,8 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/09/2019
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/enable-psbreakpoint?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enable-PSBreakpoint
@@ -11,25 +10,25 @@ title: Enable-PSBreakpoint
 
 # Enable-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Enables the breakpoints in the current console.
 
-## SYNTAX
+## Syntax
 
-### Id (Default)
-
-```
-Enable-PSBreakpoint [-PassThru] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
-### Breakpoint
+### Breakpoint (Default)
 
 ```
 Enable-PSBreakpoint [-PassThru] [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
-## DESCRIPTION
+### Id
+
+```
+Enable-PSBreakpoint [-PassThru] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## Description
 
 The `Enable-PSBreakpoint` cmdlet re-enables disabled breakpoints. You can use it to enable all
 breakpoints, or specific breakpoints by providing breakpoint objects or IDs.
@@ -42,9 +41,10 @@ Technically, this cmdlet changes the value of the **Enabled** property of a brea
 **True**.
 
 `Enable-PSBreakpoint` is one of several cmdlets designed for debugging PowerShell scripts. For more
-information about the PowerShell debugger, see [about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
+information about the PowerShell debugger, see
+[about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Enable all breakpoints
 
@@ -114,7 +114,7 @@ Enable-PSBreakpoint -Breakpoint $B
 
 This example is equivalent to running `Enable-PSBreakpoint -Id 3, 5`.
 
-## PARAMETERS
+## Parameters
 
 ### -Breakpoint
 
@@ -205,21 +205,23 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.Breakpoint
 
 You can pipe a breakpoint object to `Enable-PSBreakpoint`.
 
-## OUTPUTS
+## Outputs
 
 ### None or System.Management.Automation.Breakpoint
 
-When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpoint object that represents that breakpoint that was enabled. Otherwise, this cmdlet doesn't generate any output.
+When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpoint object that
+represents that breakpoint that was enabled. Otherwise, this cmdlet doesn't generate any output.
 
-## NOTES
+## Notes
 
 - The `Enable-PSBreakpoint` cmdlet doesn't generate an error if you try to enable a breakpoint that
   is already enabled. As such, you can enable all breakpoints without error, even when only a few
@@ -228,7 +230,7 @@ When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpo
 - Breakpoints are enabled when you create them by using the `Set-PSBreakpoint` cmdlet. You don't
   need to enable newly created breakpoints.
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 
@@ -239,4 +241,3 @@ When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpo
 [Remove-PSBreakpoint](Remove-PSBreakpoint.md)
 
 [Set-PSBreakpoint](Set-PSBreakpoint.md)
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
@@ -15,138 +15,139 @@ Gets the breakpoints that are set in the current session.
 
 ## SYNTAX
 
-### Script (Default)
+### Line (Default)
 
 ```
-Get-PSBreakpoint [-Script <String[]>] [<CommonParameters>]
-```
-
-### Variable
-
-```
-Get-PSBreakpoint [-Script <String[]>] -Variable <String[]> [<CommonParameters>]
+Get-PSBreakpoint [[-Script] <string[]>] [<CommonParameters>]
 ```
 
 ### Command
 
 ```
-Get-PSBreakpoint [-Script <String[]>] -Command <String[]> [<CommonParameters>]
+Get-PSBreakpoint -Command <string[]> [-Script <string[]>] [<CommonParameters>]
+```
+
+### Variable
+
+```
+Get-PSBreakpoint -Variable <string[]> [-Script <string[]>] [<CommonParameters>]
 ```
 
 ### Type
 
 ```
-Get-PSBreakpoint [-Script <String[]>] [-Type] <BreakpointType[]> [<CommonParameters>]
+Get-PSBreakpoint [-Type] <BreakpointType[]> [-Script <string[]>] [<CommonParameters>]
 ```
 
 ### Id
 
 ```
-Get-PSBreakpoint [-Id] <Int32[]> [<CommonParameters>]
+Get-PSBreakpoint [-Id] <int[]> [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
-The **Get-PSBreakPoint** cmdlet gets the breakpoints that are set in the current session.
-You can use the cmdlet parameters to get particular breakpoints.
+The `Get-PSBreakPoint` cmdlet gets the breakpoints that are set in the current session. You can use
+the cmdlet parameters to get particular breakpoints.
 
 A breakpoint is a point in a command or script where execution stops temporarily so that you can
-examine the instructions.
-**Get-PSBreakpoint** is one of several cmdlets designed for debugging PowerShell scripts and
-commands. For more information about the PowerShell debugger, see about_Debuggers.
+examine the instructions. `Get-PSBreakpoint` is one of several cmdlets designed for debugging
+PowerShell scripts and commands. For more information about the PowerShell debugger, see
+[about_Debuggers](../microsoft.powershell.core/about/about_debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Get all breakpoints for all scripts and functions
 
-```
-PS C:\> Get-PSBreakpoint
-```
-
 This command gets all breakpoints set on all scripts and functions in the current session.
+
+```powershell
+Get-PSBreakpoint
+```
 
 ### Example 2: Get breakpoints by ID
 
-```
-PS C:\> Get-PSBreakpoint -Id 2
-Function   :
-IncrementAction     :
-Enabled    :
-TrueHitCount   : 0
-Id         : 2
-Script     : C:\ps-test\sample.ps1
-ScriptName : C:\ps-test\sample.ps1
-```
-
 This command gets the breakpoint with breakpoint ID 2.
 
-### Example 3: Pipe an ID to Get-PSBreakpoint
-
-```
-PS C:\> $B = Set-PSBreakpoint -Script "sample.ps1" -Command "Increment"
-PS C:\> $B.Id | Get-PSBreakpoint
+```powershell
+Get-PSBreakpoint -Id 2
 ```
 
-These commands show how to get a breakpoint by piping a breakpoint ID to **Get-PSBreakpoint**.
+```Output
+Function         :
+IncrementAction  :
+Enabled          :
+TrueHitCount     : 0
+Id               : 2
+Script           : C:\ps-test\sample.ps1
+ScriptName       : C:\ps-test\sample.ps1
+```
 
-The first command uses the Set-PSBreakpoint cmdlet to create a breakpoint on the Increment function
-in the Sample.ps1 script. It saves the breakpoint object in the $B variable.
+### Example 3: Pipe an ID to `Get-PSBreakpoint`
 
-The second command uses the dot operator (.) to get the Id property of the breakpoint object in the
-$B variable. It uses a pipeline operator (|) to send the ID to the **Get-PSBreakpoint** cmdlet.
+These commands show how to get a breakpoint by piping a breakpoint ID to `Get-PSBreakpoint`.
 
-As a result, **Get-PSBreakpoint** gets the breakpoint with the specified ID.
+```powershell
+$B = `Set-PSBreakpoint` -Script "sample.ps1" -Command "Increment"
+$B.Id | Get-PSBreakpoint
+```
+
+The `Set-PSBreakpoint` cmdlet creates a breakpoint on the Increment function in the `Sample.ps1`
+script and saves the breakpoint object in the `$B` variable. The **Id** property of the breakpoint
+object in the `$B` variable is piped to the `Get-PSBreakpoint` cmdlet to display the breakpoint
+information.
 
 ### Example 4: Get breakpoints in specified script files
 
-```
-PS C:\> Get-PSBreakpoint -Script "Sample.ps1, SupportScript.ps1"
-```
+This command gets all of the breakpoints in the `Sample.ps1` and `SupportScript.ps1` files.
 
-This command gets all of the breakpoints in the Sample.ps1 and SupportScript.ps1 files.
+```powershell
+Get-PSBreakpoint -Script "Sample.ps1, SupportScript.ps1"
+```
 
 This command does not get other breakpoints that might be set in other scripts or on functions in
 the session.
 
 ### Example 5: Get breakpoints in specified cmdlets
 
-```
-PS C:\> Get-PSBreakpoint -Command "Read-Host, Write-Host" -Script "Sample.ps1"
-```
+This command gets all Command breakpoints that are set on `Read-Host` or `Write-Host` commands in
+the `Sample.ps1` file.
 
-This command gets all Command breakpoints that are set on Read-Host or Write-Host commands in the
-Sample.ps1 file.
+```powershell
+Get-PSBreakpoint -Command "Read-Host, Write-Host" -Script "Sample.ps1"
+```
 
 ### Example 6: Get Command breakpoints in a specified file
 
-```
-PS C:\> Get-PSBreakpoint -Type Command -Script "Sample.ps1"
+```powershell
+Get-PSBreakpoint -Type Command -Script "Sample.ps1"
 ```
 
 This command gets all Command breakpoints in the Sample.ps1 file.
 
 ### Example 7: Get breakpoints by variable
 
-```
-PS C:\> Get-PSBreakpoint -Variable "Index, Swap"
-```
+This command gets breakpoints that are set on the `$Index` and `$Swap` variables in the current
+session.
 
-This command gets breakpoints that are set on the $Index and $Swap variables in the current session.
+```powershell
+Get-PSBreakpoint -Variable "Index, Swap"
+```
 
 ### Example 8: Get all Line and Variable breakpoints in a file
 
-```
-PS C:\> Get-PSBreakpoint -Type Line, Variable -Script "Sample.ps1"
+This command gets all line and variable breakpoints in the `Sample.ps1` script.
+
+```powershell
+Get-PSBreakpoint -Type Line, Variable -Script "Sample.ps1"
 ```
 
-This command gets all line and variable breakpoints in the Sample.ps1 script.
-
-## PARAMETERS
+## Parameters
 
 ### -Command
 
-Specifies an array of command breakpoints that are set on the specified command names.
-Enter the command names, such as the name of a cmdlet or function.
+Specifies an array of command breakpoints that are set on the specified command names. Enter the
+command names, such as the name of a cmdlet or function.
 
 ```yaml
 Type: System.String[]
@@ -162,9 +163,8 @@ Accept wildcard characters: False
 
 ### -Id
 
-Specifies the breakpoint IDs that this cmdlet gets.
-Enter the IDs in a comma-separated list.
-You can also pipe breakpoint IDs to **Get-PSBreakpoint**.
+Specifies the breakpoint IDs that this cmdlet gets. Enter the IDs in a comma-separated list. You can
+also pipe breakpoint IDs to `Get-PSBreakpoint`.
 
 ```yaml
 Type: System.Int32[]
@@ -180,9 +180,8 @@ Accept wildcard characters: False
 
 ### -Script
 
-Specifies an array of scripts that contain the breakpoints.
-Enter the path (optional) and names of one or more script files.
-If you omit the path, the default location is the current directory.
+Specifies an array of scripts that contain the breakpoints. Enter the path (optional) and names of
+one or more script files. If you omit the path, the default location is the current directory.
 
 ```yaml
 Type: System.String[]
@@ -198,15 +197,14 @@ Accept wildcard characters: False
 
 ### -Type
 
-Specifies an array of breakpoint types that this cmdlet gets.
-Enter one or more types.
-The acceptable values for this parameter are:
+Specifies an array of breakpoint types that this cmdlet gets. Enter one or more types. The
+acceptable values for this parameter are:
 
 - Line
 - Command
 - Variable
 
-You can also pipe breakpoint types to **Get-PSBreakPoint**.
+You can also pipe breakpoint types to `Get-PSBreakPoint`.
 
 ```yaml
 Type: Microsoft.PowerShell.Commands.BreakpointType[]
@@ -223,8 +221,8 @@ Accept wildcard characters: False
 
 ### -Variable
 
-Specifies an array of variable breakpoints that are set on the specified variable names.
-Enter the variable names without dollar signs.
+Specifies an array of variable breakpoints that are set on the specified variable names. Enter the
+variable names without dollar signs.
 
 ```yaml
 Type: System.String[]
@@ -242,26 +240,34 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see about_CommonParameters
-(https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
-### System.Int32, Microsoft.PowerShell.Commands.BreakpointType
+### System.Int32
 
-You can pipe breakpoint IDs and breakpoint types to **Get-PSBreakPoint**.
+### Microsoft.PowerShell.Commands.BreakpointType
 
-## OUTPUTS
+You can pipe breakpoint IDs and breakpoint types to `Get-PSBreakPoint`.
+
+## Outputs
+
+### System.Management.Automation.CommandBreakpoint
+
+### System.Management.Automation.LineBreakpoint
+
+### System.Management.Automation.VariableBreakpoint
 
 ### System.Management.Automation.Breakpoint
 
-**Get-PSBreakPoint** returns objects that represent the breakpoints in the session.
+`Get-PSBreakPoint` returns objects that represent the breakpoints in the session.
 
-## NOTES
+## Notes
 
-* You can use **Get-PSBreakpoint** or its alias, "gbp".
+You can use `Get-PSBreakpoint` or its alias, "gbp".
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 
@@ -272,4 +278,3 @@ You can pipe breakpoint IDs and breakpoint types to **Get-PSBreakPoint**.
 [Remove-PSBreakpoint](Remove-PSBreakpoint.md)
 
 [Set-PSBreakpoint](Set-PSBreakpoint.md)
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
@@ -1,9 +1,8 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/remove-psbreakpoint?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Remove-PSBreakpoint
@@ -11,10 +10,10 @@ title: Remove-PSBreakpoint
 
 # Remove-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Deletes breakpoints from the current console.
 
-## SYNTAX
+## Syntax
 
 ### Breakpoint (Default)
 
@@ -28,72 +27,71 @@ Remove-PSBreakpoint [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm] [<CommonPa
 Remove-PSBreakpoint [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
-The **Remove-PSBreakpoint** cmdlet deletes a breakpoint.
-Enter a breakpoint object or a breakpoint ID.
+## Description
 
-When you remove a breakpoint, the breakpoint object is no longer available or functional.
-If you have saved a breakpoint object in a variable, the reference still exists, but the breakpoint does not function.
+The `Remove-PSBreakpoint` cmdlet deletes a breakpoint. Enter a breakpoint object or a breakpoint ID.
 
-**Remove-PSBreakpoint** is one of several cmdlets designed for debugging PowerShell scripts.
-For more information about the PowerShell debugger, see about_Debuggers.
+When you remove a breakpoint, the breakpoint object is no longer available or functional. If you
+have saved a breakpoint object in a variable, the reference still exists, but the breakpoint does
+not function.
 
-## EXAMPLES
+`Remove-PSBreakpoint` is one of several cmdlets designed for debugging PowerShell scripts. For more
+information about the PowerShell debugger, see
+[about_Debuggers](../microsoft.powershell.core/about/about_debuggers.md).
+
+## Examples
 
 ### Example 1: Remove all breakpoints
 
-```
-PS C:\> Get-PSBreakpoint | Remove-PSBreakpoint
-```
-
 This command deletes all of the breakpoints in the current console.
+
+```powershell
+Get-PSBreakpoint | Remove-PSBreakpoint
+```
 
 ### Example 2: Remove a specified breakpoint
 
-```
-PS C:\> $B = Set-PSBreakpoint -Script "sample.ps1" -Variable "Name"
-PS C:\> $B | Remove-PSBreakpoint
-```
-
 This command deletes a breakpoint.
 
-The first command uses the Set-PSBreakpoint cmdlet to create a breakpoint on the Name variable in the Sample.ps1 script.
-Then, it saves the breakpoint object in the $B variable.
+```powershell
+$B = Set-PSBreakpoint -Script "sample.ps1" -Variable "Name"
+$B | Remove-PSBreakpoint
+```
 
-The second command uses the **Remove-PSBreakpoint** cmdlet to delete the new breakpoint.
-It uses a pipeline operator (|) to send the breakpoint object in the $B variable to the **Remove-PSBreakpoint** cmdlet.
+The `Set-PSBreakpoint` cmdlet creates a breakpoint on the `$Name` variable in the `Sample.ps1`
+script and saves the breakpoint object in the `$B` variable. The `Remove-PSBreakpoint` cmdlet
+deletes the new breakpoint. It uses a pipeline operator (`|`) to send the breakpoint object in the
+`$B` variable to the `Remove-PSBreakpoint` cmdlet.
 
-As a result of this command, if you run the script, it runs to completion without stopping.
-Also, the **Get-PSBreakpoint** cmdlet does not return this breakpoint.
+As a result of this command, if you run the script, it runs to completion without stopping. Also,
+the `Get-PSBreakpoint` cmdlet does not return this breakpoint.
 
 ### Example 3: Remove a breakpoint by ID
 
-```
-PS C:\> Remove-PSBreakpoint -Id 2
-```
-
 This command deletes the breakpoint with breakpoint ID 2.
+
+```powershell
+Remove-PSBreakpoint -Id 2
+```
 
 ### Example 4: Use a function to remove all breakpoints
 
-```
-PS C:\> function del-psb { get-psbreakpoint | remove-psbreakpoint }
-```
-
 This simple function deletes all of the breakpoints in the current console.
-It uses the Get-PSBreakpoint cmdlet to get the breakpoints.
-Then, it uses a pipeline operator (|) to send the breakpoints to the **Remove-PSBreakpoint** cmdlet, which deletes them.
 
-As a result, you can type `del-psb` instead of the longer command.
+```powershell
+function del-psb { Get-PSBreakpoint | Remove-PSBreakpoint }
+```
 
-To save the function, add it to your PowerShell profile.
+It uses the `Get-PSBreakpoint` cmdlet to get the breakpoints. Then, it uses a pipeline operator
+(`|`) to send the breakpoints to the `Remove-PSBreakpoint` cmdlet, which deletes them.
 
-## PARAMETERS
+## Parameters
 
 ### -Breakpoint
-Specifies the breakpoints to delete.
-Enter a variable that contains breakpoint objects or a command that gets breakpoint objects, such as a **Get-PSBreakpoint** command.
-You can also pipe breakpoint objects to **Remove-PSBreakpoint**.
+
+Specifies the breakpoints to delete. Enter a variable that contains breakpoint objects or a command
+that gets breakpoint objects, such as a `Get-PSBreakpoint` command. You can also pipe breakpoint
+objects to `Remove-PSBreakpoint`.
 
 ```yaml
 Type: System.Management.Automation.Breakpoint[]
@@ -108,6 +106,7 @@ Accept wildcard characters: False
 ```
 
 ### -Id
+
 Specifies breakpoint IDs for which this cmdlet deletes breakpoints.
 
 ```yaml
@@ -154,21 +153,31 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-### System.Management.Automation.Breakpoint
-You can pipe breakpoint objects to **Remove-PSBreakpoint**.
+## Inputs
 
-## OUTPUTS
+### System.Management.Automation.Breakpoint[]
+
+You can pipe breakpoint objects to `Remove-PSBreakpoint`.
+
+### System.Int32[]
+
+### System.Management.Automation.Runspaces.Runspace
+
+## Outputs
 
 ### None
+
 The cmdlet does not generate any output.
 
-## NOTES
+## Notes
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 
@@ -179,4 +188,3 @@ The cmdlet does not generate any output.
 [Get-PSCallStack](Get-PSCallStack.md)
 
 [Set-PSBreakpoint](Set-PSBreakpoint.md)
-

--- a/reference/7.1/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -1,19 +1,18 @@
 ---
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-keywords: powershell,cmdlet
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/24/2019
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/set-psbreakpoint?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSBreakpoint
 ---
 # Set-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Sets a breakpoint on a line, command, or variable.
 
-## SYNTAX
+## Syntax
 
 ### Line (Default)
 
@@ -35,7 +34,7 @@ Set-PSBreakpoint [-Action <ScriptBlock>] [[-Script] <String[]>] -Variable <Strin
  [-Mode <VariableAccessMode>] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Set-PSBreakpoint` cmdlet sets a breakpoint in a script or in any command run in the current
 session. You can use `Set-PSBreakpoint` to set a breakpoint before executing a script or running a
@@ -59,9 +58,10 @@ you can use the **Action** parameter to specify an alternate response, such as c
 breakpoint or instructions to perform additional tasks such as logging or diagnostics.
 
 The `Set-PSBreakpoint` cmdlet is one of several cmdlets designed for debugging PowerShell scripts.
-For more information about the PowerShell debugger, see [about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
+For more information about the PowerShell debugger, see
+[about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Set a breakpoint on a line
 
@@ -130,8 +130,8 @@ Set-PSBreakpoint -Script Sample.ps1 -Command "write*"
 
 ### Example 5: Set a breakpoint depending on the value of a variable
 
-This example stops execution at the `DiskTest` function in the Test.ps1 script only when the value of
-the `$Disk` variable is greater than 2.
+This example stops execution at the `DiskTest` function in the `Test.ps1` script only when the value
+of the `$Disk` variable is greater than 2.
 
 ```powershell
 Set-PSBreakpoint -Script "test.ps1" -Command "DiskTest" -Action { if ($Disk -gt 2) { break } }
@@ -208,7 +208,7 @@ Script     : C:\ps-test\sample.ps1
 ScriptName : C:\ps-test\sample.ps1
 ```
 
-## PARAMETERS
+## Parameters
 
 ### -Action
 
@@ -244,10 +244,10 @@ Accept wildcard characters: False
 Specifies the column number of the column in the script file on which execution stops. Enter only
 one column number. The default is column 1.
 
-The Column value is used with the value of the **Line** parameter to specify the breakpoint. If the **Line**
-parameter specifies multiple lines, the **Column** parameter sets a breakpoint at the specified column
-on each of the specified lines. PowerShell stops executing before the statement or expression that
-includes the character at the specified line and column position.
+The Column value is used with the value of the **Line** parameter to specify the breakpoint. If the
+**Line** parameter specifies multiple lines, the **Column** parameter sets a breakpoint at the
+specified column on each of the specified lines. PowerShell stops executing before the statement or
+expression that includes the character at the specified line and column position.
 
 Columns are counted from the top left margin beginning with column number 1 (not 0). If you specify
 a column that does not exist in the script, an error is not declared, but the breakpoint is never
@@ -377,20 +377,25 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### None
 You cannot pipe input to `Set-PSBreakpoint`.
 
 ## OUTPUTS
 
-### Breakpoint object (System.Management.Automation.LineBreakpoint, System.Management.Automation.VariableBreakpoint, System.Management.Automation.CommandBreakpoint)
+### System.Management.Automation.CommandBreakpoint
+
+### System.Management.Automation.LineBreakpoint
+
+### System.Management.Automation.VariableBreakpoint
 
 `Set-PSBreakpoint` returns an object that represents each breakpoint that it sets.
 
-## NOTES
+## Notes
 
 - `Set-PSBreakpoint` cannot set a breakpoint on a remote computer. To debug a script on a remote
   computer, copy the script to the local computer and then debug it locally.
@@ -399,7 +404,7 @@ You cannot pipe input to `Set-PSBreakpoint`.
 - When setting a breakpoint on a function or variable at the command prompt, you can set the
   breakpoint before or after you create the function or variable.
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 

--- a/reference/7.2/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Debug-Job.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/debug-job?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Debug-Job
@@ -10,10 +10,10 @@ title: Debug-Job
 
 # Debug-Job
 
-## SYNOPSIS
-Debugs a running background, remote, or PowerShell Workflow job.
+## Synopsis
+Debugs a running background or remote job.
 
-## SYNTAX
+## Syntax
 
 ### JobParameterSet (Default)
 
@@ -39,19 +39,25 @@ Debug-Job [-Id] <Int32> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 Debug-Job [-InstanceId] <Guid> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
-The **Debug-Job** cmdlet lets you debug scripts that are running within jobs.
-The cmdlet is designed to debug PowerShell Workflow jobs, background jobs, and jobs running in remote sessions.
-**Debug-Job** accepts a running job object, name, ID, or instance ID as input, and starts a debugging session on the script it is running.
-The debugger **quit** command stops the job and running script.
-Starting in Windows PowerShell 5.0, the **exit** command detaches the debugger, and allows the job to continue to run.
+## Description
 
-## EXAMPLES
+The `Debug-Job` cmdlet lets you debug scripts that are running within jobs. The cmdlet is designed
+to debug PowerShell Workflow jobs, background jobs, and jobs running in remote sessions. `Debug-Job`
+accepts a running job object, name, ID, or instance ID as input, and starts a debugging session on
+the script it is running. The debugger `quit` command stops the job and running script. The `exit`
+command detaches the debugger, and allows the job to continue to run.
+
+## Examples
 
 ### Example 1: Debug a job by job ID
 
+This command breaks into a running job with an ID of 3.
+
+```powershell
+Debug-Job -ID 3
 ```
-PS C:\> Debug-Job -ID 3
+
+```Output
 Id     Name            PSJobTypeName   State         HasMoreData     Location             Command
 --     ----            -------------   -----         -----------     --------             -------
 3      Job3            RemoteJob       Running       True            PowerShellIx         TestWFDemo1.ps1
@@ -82,13 +88,27 @@ Id     Name            PSJobTypeName   State         HasMoreData     Location   
              18:  SampleWorkflowTest -MyOutput "Hello"
 ```
 
-This command breaks into a running job with an ID of 3.
+## Parameters
 
-## PARAMETERS
+### -BreakAll
+
+Allows you to break immediately in the current location when the debugger attaches.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Id
-Specifies the ID number of a running job.
-To get the ID number of a job, run the Get-Job cmdlet.
+
+Specifies the ID number of a running job. To get the ID number of a job, run the `Get-Job` cmdlet.
 
 ```yaml
 Type: System.Int32
@@ -103,10 +123,8 @@ Accept wildcard characters: False
 ```
 
 ### -InstanceId
-Specifies the instance ID GUID of a running job.
-To get the *InstanceId* of a job, run the **Get-Job** cmdlet, piping the results into a **Format-*** cmdlet, as shown in the following example:
 
-`Get-Job | Format-List -Property Id,Name,InstanceId,State`
+Specifies the instance ID GUID of a running job.
 
 ```yaml
 Type: System.Guid
@@ -121,8 +139,10 @@ Accept wildcard characters: False
 ```
 
 ### -Job
-Specifies a running job object.
-The simplest way to use this parameter is to save the results of a **Get-Job** command that returns the running job that you want to debug in a variable, and then specify the variable as the value of this parameter.
+
+Specifies a running job object. The simplest way to use this parameter is to save the results of a
+`Get-Job` command that returns the running job that you want to debug in a variable, and then
+specify the variable as the value of this parameter.
 
 ```yaml
 Type: System.Management.Automation.Job
@@ -137,8 +157,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies a job by the friendly name of the job.
-When you start a job, you can specify a job name by adding the *JobName* parameter, in cmdlets such as Invoke-Command and Start-Job.
+
+Specifies a job by the friendly name of the job. When you start a job, you can specify a job name by
+adding the **JobName** parameter, in cmdlets such as `Invoke-Command` and `Start-Job`.
 
 ```yaml
 Type: System.String
@@ -153,6 +174,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -168,8 +190,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -183,34 +205,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -BreakAll
-
-{{ Fill BreakAll Description }}
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## Inputs
 
 ### System.Management.Automation.RemotingJob
 
-## OUTPUTS
+## Outputs
 
-## NOTES
+## Notes
 
-## RELATED LINKS
+## Related links
 
 [Get-Job](Get-Job.md)
 
@@ -223,4 +233,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Stop-Job](Stop-Job.md)
 
 [Wait-Job](Wait-Job.md)
-

--- a/reference/7.2/Microsoft.PowerShell.Utility/Debug-Runspace.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Debug-Runspace.md
@@ -2,17 +2,17 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/debug-runspace?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Debug-Runspace
 ---
 # Debug-Runspace
 
-## SYNOPSIS
+## Synopsis
 Starts an interactive debugging session with a runspace.
 
-## SYNTAX
+## Syntax
 
 ### RunspaceParameterSet (Default)
 
@@ -38,7 +38,7 @@ Debug-Runspace [-Id] <Int32> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters
 Debug-Runspace [-InstanceId] <Guid> [-BreakAll] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Debug-Runspace` cmdlet starts an interactive debugging session with a local or remote active
 runspace. You can find a runspace that you want to debug by first running `Get-Process` to find
@@ -55,11 +55,16 @@ running the process, or you are running the script that you want to debug. Also,
 the host process that is running the current PowerShell session. You can only enter a host process
 that is running a different PowerShell session.
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Debug a remote runspace
 
-```
+In this example, you debug a runspace that is open on a remote computer, WS10TestServer. In the
+first line of the command, you run `Get-Process` on the remote computer, and filter for Windows
+PowerShell host processes. In this example, you want to debug process ID 1152, the Windows
+PowerShell ISE host process.
+
+```powershell
 PS C:\> Get-Process -ComputerName "WS10TestServer" -Name "*powershell*"
 
 Handles      WS(K)   VM(M)      CPU(s)    Id  ProcessName
@@ -76,7 +81,7 @@ Id Name            ComputerName    Type          State         Availability
  1 Runspace1       WS10TestServer  Remote        Opened        Available
  2 RemoteHost      WS10TestServer  Remote        Opened        Busy
 
-PS C:\> [WS10TestServer][Process:1152]: PS C:\Users\Test\Documents> Debug-Runspace -Id 2
+[WS10TestServer][Process:1152]: PS C:\Users\Test\Documents> Debug-Runspace -Id 2
 
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 At C:\TestWFVar1.ps1:83 char:1
@@ -84,11 +89,6 @@ At C:\TestWFVar1.ps1:83 char:1
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Process:1152]: [RSDBG: 2]: PS C:\> >
 ```
-
-In this example, you debug a runspace that is open on a remote computer, WS10TestServer. In the
-first line of the command, you run `Get-Process` on the remote computer, and filter for Windows
-PowerShell host processes. In this example, you want to debug process ID 1152, the Windows
-PowerShell ISE host process.
 
 In the second command, you run `Enter-PSSession` to open a remote session on WS10TestServer. In the
 third command, you attach to the Windows PowerShell ISE host process running on the remote server by
@@ -99,10 +99,26 @@ In the fourth command, you list available runspaces for process ID 1152 by runni
 You note the ID number of the Busy runspace; it is running a script that you want to debug.
 
 In the last command, you start debugging an opened runspace that is running a script,
-TestWFVar1.ps1, by running `Debug-Runspace`, and identifying the runspace by its ID, 2, by adding
+`TestWFVar1.ps1`, by running `Debug-Runspace`, and identifying the runspace by its ID, 2, by adding
 the **Id** parameter. Because there's a breakpoint in the script, the debugger opens.
 
-## PARAMETERS
+## Parameters
+
+### -BreakAll
+
+Allows you to break immediately in the current location when the debugger attaches.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Id
 
@@ -201,37 +217,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -BreakAll
-
-{{ Fill BreakAll Description }}
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.Runspaces.Runspace
 
 You can pipe the results of a `Get-Runspace` command to **Debug-Runspace.**
 
-## OUTPUTS
+## Outputs
 
-## NOTES
+## Notes
 
 `Debug-Runspace` works on runspaces that are in the Opened state. If a runspace state changes from
 Opened to another state, that runspace is automatically removed from the running list. A runspace is
@@ -242,7 +243,7 @@ added to the running list only if it meets the following criteria.
 - If it is coming from a PowerShell workflow, and its workflow job ID is the same as the current
   active debugger workflow job ID.
 
-## RELATED LINKS
+## Related links
 
 [about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md)
 
@@ -255,4 +256,3 @@ added to the running list only if it meets the following criteria.
 [Enter-PSHostProcess](../Microsoft.PowerShell.Core/Enter-PSHostProcess.md)
 
 [Enter-PSSession](../Microsoft.PowerShell.Core/Enter-PSSession.md)
-

--- a/reference/7.2/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
@@ -2,103 +2,105 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/disable-psbreakpoint?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Disable-PSBreakpoint
 ---
 # Disable-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Disables the breakpoints in the current console.
 
-## SYNTAX
+## Syntax
 
 ### Breakpoint (Default)
 
 ```
-Disable-PSBreakpoint [-PassThru] [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+Disable-PSBreakpoint [-PassThru] [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### Id
 
 ```
-Disable-PSBreakpoint [-PassThru] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+Disable-PSBreakpoint [-PassThru] [-Id] <Int32[]> [-Runspace <Runspace>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
-The **Disable-PSBreakpoint** cmdlet disables breakpoints, which assures that they are not hit when the script runs.
-You can use it to disable all breakpoints, or you can specify breakpoints by submitting breakpoint objects or breakpoint IDs.
+The `Disable-PSBreakpoint` cmdlet disables breakpoints, which assures that they are not hit when the
+script runs. You can use it to disable all breakpoints, or you can specify breakpoints by submitting
+breakpoint objects or breakpoint IDs.
 
 Technically, this cmdlet changes the value of the Enabled property of a breakpoint object to False.
-To re-enable a breakpoint, use the Enable-PSBreakpoint cmdlet.
-Breakpoints are enabled by default when you create them by using the Set-PSBreakpoint cmdlet.
+To re-enable a breakpoint, use the `Enable-PSBreakpoint` cmdlet. Breakpoints are enabled by default
+when you create them using the `Set-PSBreakpoint` cmdlet.
 
-A breakpoint is a point in a script where execution stops temporarily so that you can examine the instructions in the script.
-**Disable-PSBreakpoint** is one of several cmdlets designed for debugging PowerShell scripts.
-For more information about the PowerShell debugger, see about_Debuggers.
+A breakpoint is a point in a script where execution stops temporarily so that you can examine the
+instructions in the script. `Disable-PSBreakpoint` is one of several cmdlets designed for debugging
+PowerShell scripts. For more information about the PowerShell debugger, see
+[about_Debuggers](../microsoft.powershell.core/about/about_debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Set a breakpoint and disable it
 
-```
-PS C:\> $B = Set-PSBreakpoint -Script "sample.ps1" -Variable "name"
-PS C:\> $B | Disable-PSBreakpoint
-```
-
 These commands disable a newly-created breakpoint.
 
-The first command uses the Set-PSBreakpoint cmdlet to create a breakpoint on the *Name* variable in the Sample.ps1 script.
-Then, it saves the breakpoint object in the $B variable.
+```powershell
+$B = Set-PSBreakpoint -Script "sample.ps1" -Variable "name"
+$B | Disable-PSBreakpoint
+```
 
-The second command uses the **Disable-PSBreakpoint** cmdlet to disable the new breakpoint.
-It uses a pipeline operator (|) to send the breakpoint object in $B to the **Disable-PSBreakpoint** cmdlet.
+The `Set-PSBreakpoint` cmdlet creates a breakpoint on the `$Name` variable in the `Sample.ps1`
+script and saves the breakpoint object in the `$B` variable. The `Disable-PSBreakpoint` cmdlet
+disables the new breakpoint. It uses a pipeline operator (`|`) to send the breakpoint object in `$B`
+to the `Disable-PSBreakpoint` cmdlet.
 
-As a result of this command, the value of the Enabled property of the breakpoint object in $B is False.
+As a result of this command, the value of the **Enabled** property of the breakpoint object in `$B`
+is **False**.
 
 ### Example 2: Disable a breakpoint
 
-```
-PS C:\> Disable-PSBreakpoint -Id 0
-```
-
 This command disables the breakpoint with breakpoint ID 0.
+
+```powershell
+Disable-PSBreakpoint -Id 0
+```
 
 ### Example 3: Create a disabled breakpoint
 
-```
-PS C:\> Disable-PSBreakpoint -Breakpoint ($B = Set-PSBreakpoint -Script "sample.ps1" -Line 5)
-PS C:\> $B
-```
-
 This command creates a new breakpoint that is disabled until you enable it.
 
-It uses the **Disable-PSBreakpoint** cmdlet to disable the breakpoint.
-The value of the *Breakpoint* parameter is a Set-PSBreakpoint command that sets a new breakpoint, generates a breakpoint object, and saves the object in the $B variable.
+```powershell
+Disable-PSBreakpoint -Breakpoint ($B = Set-PSBreakpoint -Script "sample.ps1" -Line 5)
+```
 
-Cmdlet parameters that take objects as their values can accept a variable that contains the object or a command that gets or generates the object.
-In this case, because **Set-PSBreakpoint** generates a breakpoint object, it can be used as the value of the *Breakpoint* parameter.
+It uses the `Disable-PSBreakpoint` cmdlet to disable the breakpoint. The value of the **Breakpoint**
+parameter is a `Set-PSBreakpoint` command that sets a new breakpoint, generates a breakpoint object,
+and saves the object in the `$B` variable.
 
-The second command displays the breakpoint object in the value of the $B variable.
+Cmdlet parameters that take objects as their values can accept a variable that contains the object
+or a command that gets or generates the object. In this case, because `Set-PSBreakpoint` generates a
+breakpoint object, it can be used as the value of the **Breakpoint** parameter.
 
 ### Example 4: Disable all breakpoints in the current console
 
-```
-PS C:\> Get-PSBreakpoint | Disable-PSBreakpoint
-```
-
 This command disables all breakpoints in the current console.
-You can abbreviate this command as: "gbp | dbp".
 
-## PARAMETERS
+```powershell
+`Get-PSBreakpoint` | Disable-PSBreakpoint
+```
+
+## Parameters
 
 ### -Breakpoint
 
-Specifies the breakpoints to disable.
-Enter a variable that contains breakpoint objects or a command that gets breakpoint objects, such as a Get-PSBreakpoint command.
-You can also pipe breakpoint objects to the **Disable-PSBreakpoint** cmdlet.
+Specifies the breakpoints to disable. Enter a variable that contains breakpoint objects or a command
+that gets breakpoint objects, such as a `Get-PSBreakpoint` command. You can also pipe breakpoint
+objects to the `Disable-PSBreakpoint` cmdlet.
 
 ```yaml
 Type: System.Management.Automation.Breakpoint[]
@@ -114,9 +116,8 @@ Accept wildcard characters: False
 
 ### -Id
 
-Disables the breakpoints with the specified breakpoint IDs.
-Enter the IDs or a variable that contains the IDs.
-You cannot pipe IDs to **Disable-PSBreakpoint**.
+Disables the breakpoints with the specified breakpoint IDs. Enter the IDs or a variable that
+contains the IDs. You cannot pipe IDs to `Disable-PSBreakpoint`.
 
 ```yaml
 Type: System.Int32[]
@@ -132,8 +133,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the enabled breakpoints.
-By default, this cmdlet does not generate any output.
+Returns an object representing the enabled breakpoints. By default, this cmdlet does not generate
+any output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -144,6 +145,23 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Runspace
+
+Specifies the Id of a **Runspace** object so you can interact with breakpoints in the specified
+runspace.
+
+```yaml
+Type: Runspace
+Parameter Sets: Id
+Aliases: RunspaceId
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -165,8 +183,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -182,24 +199,27 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.Breakpoint
 
-You can pipe a breakpoint object to **Disable-PSBreakpoint**.
+You can pipe a breakpoint object to `Disable-PSBreakpoint`.
 
-## OUTPUTS
+## Outputs
 
 ### None or System.Management.Automation.Breakpoint
 
-When you use the *PassThru* parameter, **Disable-PSBreakpoint** returns an object that represents the disabled breakpoint.
-Otherwise, this cmdlet does not generate any output.
+When you use the **PassThru** parameter, `Disable-PSBreakpoint` returns an object that represents
+the disabled breakpoint. Otherwise, this cmdlet does not generate any output.
 
-## NOTES
+## Notes
 
-## RELATED LINKS
+## Related links
 
 [Enable-PSBreakpoint](Enable-PSBreakpoint.md)
 
@@ -210,4 +230,3 @@ Otherwise, this cmdlet does not generate any output.
 [Remove-PSBreakpoint](Remove-PSBreakpoint.md)
 
 [Set-PSBreakpoint](Set-PSBreakpoint.md)
-

--- a/reference/7.2/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/09/2019
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/enable-psbreakpoint?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enable-PSBreakpoint
@@ -10,25 +10,26 @@ title: Enable-PSBreakpoint
 
 # Enable-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Enables the breakpoints in the current console.
 
-## SYNTAX
+## Syntax
 
-### Id (Default)
-
-```
-Enable-PSBreakpoint [-PassThru] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
-### Breakpoint
+### Breakpoint (Default)
 
 ```
 Enable-PSBreakpoint [-PassThru] [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
-## DESCRIPTION
+### Id
+
+```
+Enable-PSBreakpoint [-PassThru] [-Id] <Int32[]> [-Runspace <Runspace>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## Description
 
 The `Enable-PSBreakpoint` cmdlet re-enables disabled breakpoints. You can use it to enable all
 breakpoints, or specific breakpoints by providing breakpoint objects or IDs.
@@ -41,9 +42,10 @@ Technically, this cmdlet changes the value of the **Enabled** property of a brea
 **True**.
 
 `Enable-PSBreakpoint` is one of several cmdlets designed for debugging PowerShell scripts. For more
-information about the PowerShell debugger, see [about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
+information about the PowerShell debugger, see
+[about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Enable all breakpoints
 
@@ -113,7 +115,7 @@ Enable-PSBreakpoint -Breakpoint $B
 
 This example is equivalent to running `Enable-PSBreakpoint -Id 3, 5`.
 
-## PARAMETERS
+## Parameters
 
 ### -Breakpoint
 
@@ -168,6 +170,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Runspace
+
+Specifies the Id of a **Runspace** object so you can interact with breakpoints in the specified
+runspace.
+
+```yaml
+Type: Runspace
+Parameter Sets: Id
+Aliases: RunspaceId
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -Confirm
 
 Prompts you for confirmation before running the cmdlet.
@@ -204,21 +223,23 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### System.Management.Automation.Breakpoint
 
 You can pipe a breakpoint object to `Enable-PSBreakpoint`.
 
-## OUTPUTS
+## Outputs
 
 ### None or System.Management.Automation.Breakpoint
 
-When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpoint object that represents that breakpoint that was enabled. Otherwise, this cmdlet doesn't generate any output.
+When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpoint object that
+represents that breakpoint that was enabled. Otherwise, this cmdlet doesn't generate any output.
 
-## NOTES
+## Notes
 
 - The `Enable-PSBreakpoint` cmdlet doesn't generate an error if you try to enable a breakpoint that
   is already enabled. As such, you can enable all breakpoints without error, even when only a few
@@ -227,7 +248,7 @@ When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpo
 - Breakpoints are enabled when you create them by using the `Set-PSBreakpoint` cmdlet. You don't
   need to enable newly created breakpoints.
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 
@@ -238,4 +259,3 @@ When you use the **PassThru** parameter, `Enable-PSBreakpoint` returns a breakpo
 [Remove-PSBreakpoint](Remove-PSBreakpoint.md)
 
 [Set-PSBreakpoint](Set-PSBreakpoint.md)
-

--- a/reference/7.2/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
@@ -2,150 +2,151 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 05/15/2019
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-psbreakpoint?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-PSBreakpoint
 ---
 # Get-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Gets the breakpoints that are set in the current session.
 
-## SYNTAX
+## Syntax
 
-### Script (Default)
-
-```
-Get-PSBreakpoint [-Script <String[]>] [<CommonParameters>]
-```
-
-### Variable
+### Line (Default)
 
 ```
-Get-PSBreakpoint [-Script <String[]>] -Variable <String[]> [<CommonParameters>]
+Get-PSBreakpoint [[-Script] <String[]>] [-Runspace <Runspace>] [<CommonParameters>]
 ```
 
 ### Command
 
 ```
-Get-PSBreakpoint [-Script <String[]>] -Command <String[]> [<CommonParameters>]
+Get-PSBreakpoint [[-Script] <String[]>] -Command <String[]> [-Runspace <Runspace>] [<CommonParameters>]
+```
+
+### Variable
+
+```
+Get-PSBreakpoint [[-Script] <String[]>] -Variable <String[]> [-Runspace <Runspace>] [<CommonParameters>]
 ```
 
 ### Type
 
 ```
-Get-PSBreakpoint [-Script <String[]>] [-Type] <BreakpointType[]> [<CommonParameters>]
+Get-PSBreakpoint [[-Script] <String[]>] [-Type] <BreakpointType[]> [-Runspace <Runspace>] [<CommonParameters>]
 ```
 
 ### Id
 
 ```
-Get-PSBreakpoint [-Id] <Int32[]> [<CommonParameters>]
+Get-PSBreakpoint [-Id] <Int32[]> [-Runspace <Runspace>] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
-The **Get-PSBreakPoint** cmdlet gets the breakpoints that are set in the current session.
-You can use the cmdlet parameters to get particular breakpoints.
+The `Get-PSBreakPoint` cmdlet gets the breakpoints that are set in the current session. You can use
+the cmdlet parameters to get particular breakpoints.
 
 A breakpoint is a point in a command or script where execution stops temporarily so that you can
-examine the instructions.
-**Get-PSBreakpoint** is one of several cmdlets designed for debugging PowerShell scripts and
-commands. For more information about the PowerShell debugger, see about_Debuggers.
+examine the instructions. `Get-PSBreakpoint` is one of several cmdlets designed for debugging
+PowerShell scripts and commands. For more information about the PowerShell debugger, see
+[about_Debuggers](../microsoft.powershell.core/about/about_debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Get all breakpoints for all scripts and functions
 
-```
-PS C:\> Get-PSBreakpoint
-```
-
 This command gets all breakpoints set on all scripts and functions in the current session.
+
+```powershell
+Get-PSBreakpoint
+```
 
 ### Example 2: Get breakpoints by ID
 
-```
-PS C:\> Get-PSBreakpoint -Id 2
-Function   :
-IncrementAction     :
-Enabled    :
-TrueHitCount   : 0
-Id         : 2
-Script     : C:\ps-test\sample.ps1
-ScriptName : C:\ps-test\sample.ps1
-```
-
 This command gets the breakpoint with breakpoint ID 2.
 
-### Example 3: Pipe an ID to Get-PSBreakpoint
-
-```
-PS C:\> $B = Set-PSBreakpoint -Script "sample.ps1" -Command "Increment"
-PS C:\> $B.Id | Get-PSBreakpoint
+```powershell
+Get-PSBreakpoint -Id 2
 ```
 
-These commands show how to get a breakpoint by piping a breakpoint ID to **Get-PSBreakpoint**.
+```Output
+Function         :
+IncrementAction  :
+Enabled          :
+TrueHitCount     : 0
+Id               : 2
+Script           : C:\ps-test\sample.ps1
+ScriptName       : C:\ps-test\sample.ps1
+```
 
-The first command uses the Set-PSBreakpoint cmdlet to create a breakpoint on the Increment function
-in the Sample.ps1 script. It saves the breakpoint object in the $B variable.
+### Example 3: Pipe an ID to `Get-PSBreakpoint`
 
-The second command uses the dot operator (.) to get the Id property of the breakpoint object in the
-$B variable. It uses a pipeline operator (|) to send the ID to the **Get-PSBreakpoint** cmdlet.
+These commands show how to get a breakpoint by piping a breakpoint ID to `Get-PSBreakpoint`.
 
-As a result, **Get-PSBreakpoint** gets the breakpoint with the specified ID.
+```powershell
+$B = `Set-PSBreakpoint` -Script "sample.ps1" -Command "Increment"
+$B.Id | Get-PSBreakpoint
+```
+
+The `Set-PSBreakpoint` cmdlet creates a breakpoint on the Increment function in the `Sample.ps1`
+script and saves the breakpoint object in the `$B` variable. The **Id** property of the breakpoint
+object in the `$B` variable is piped to the `Get-PSBreakpoint` cmdlet to display the breakpoint
+information.
 
 ### Example 4: Get breakpoints in specified script files
 
-```
-PS C:\> Get-PSBreakpoint -Script "Sample.ps1, SupportScript.ps1"
-```
+This command gets all of the breakpoints in the `Sample.ps1` and `SupportScript.ps1` files.
 
-This command gets all of the breakpoints in the Sample.ps1 and SupportScript.ps1 files.
+```powershell
+Get-PSBreakpoint -Script "Sample.ps1, SupportScript.ps1"
+```
 
 This command does not get other breakpoints that might be set in other scripts or on functions in
 the session.
 
 ### Example 5: Get breakpoints in specified cmdlets
 
-```
-PS C:\> Get-PSBreakpoint -Command "Read-Host, Write-Host" -Script "Sample.ps1"
-```
+This command gets all Command breakpoints that are set on `Read-Host` or `Write-Host` commands in
+the `Sample.ps1` file.
 
-This command gets all Command breakpoints that are set on Read-Host or Write-Host commands in the
-Sample.ps1 file.
+```powershell
+Get-PSBreakpoint -Command "Read-Host, Write-Host" -Script "Sample.ps1"
+```
 
 ### Example 6: Get Command breakpoints in a specified file
 
-```
-PS C:\> Get-PSBreakpoint -Type Command -Script "Sample.ps1"
+```powershell
+Get-PSBreakpoint -Type Command -Script "Sample.ps1"
 ```
 
 This command gets all Command breakpoints in the Sample.ps1 file.
 
 ### Example 7: Get breakpoints by variable
 
-```
-PS C:\> Get-PSBreakpoint -Variable "Index, Swap"
-```
+This command gets breakpoints that are set on the `$Index` and `$Swap` variables in the current
+session.
 
-This command gets breakpoints that are set on the $Index and $Swap variables in the current session.
+```powershell
+Get-PSBreakpoint -Variable "Index, Swap"
+```
 
 ### Example 8: Get all Line and Variable breakpoints in a file
 
-```
-PS C:\> Get-PSBreakpoint -Type Line, Variable -Script "Sample.ps1"
+This command gets all line and variable breakpoints in the `Sample.ps1` script.
+
+```powershell
+Get-PSBreakpoint -Type Line, Variable -Script "Sample.ps1"
 ```
 
-This command gets all line and variable breakpoints in the Sample.ps1 script.
-
-## PARAMETERS
+## Parameters
 
 ### -Command
 
-Specifies an array of command breakpoints that are set on the specified command names.
-Enter the command names, such as the name of a cmdlet or function.
+Specifies an array of command breakpoints that are set on the specified command names. Enter the
+command names, such as the name of a cmdlet or function.
 
 ```yaml
 Type: System.String[]
@@ -161,9 +162,8 @@ Accept wildcard characters: False
 
 ### -Id
 
-Specifies the breakpoint IDs that this cmdlet gets.
-Enter the IDs in a comma-separated list.
-You can also pipe breakpoint IDs to **Get-PSBreakpoint**.
+Specifies the breakpoint IDs that this cmdlet gets. Enter the IDs in a comma-separated list. You can
+also pipe breakpoint IDs to `Get-PSBreakpoint`.
 
 ```yaml
 Type: System.Int32[]
@@ -177,11 +177,27 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
+### -Runspace
+
+Specifies the Id of a **Runspace** object so you can interact with breakpoints in the specified
+runspace.
+
+```yaml
+Type: Runspace
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Script
 
-Specifies an array of scripts that contain the breakpoints.
-Enter the path (optional) and names of one or more script files.
-If you omit the path, the default location is the current directory.
+Specifies an array of scripts that contain the breakpoints. Enter the path (optional) and names of
+one or more script files. If you omit the path, the default location is the current directory.
 
 ```yaml
 Type: System.String[]
@@ -197,15 +213,14 @@ Accept wildcard characters: False
 
 ### -Type
 
-Specifies an array of breakpoint types that this cmdlet gets.
-Enter one or more types.
-The acceptable values for this parameter are:
+Specifies an array of breakpoint types that this cmdlet gets. Enter one or more types. The
+acceptable values for this parameter are:
 
 - Line
 - Command
 - Variable
 
-You can also pipe breakpoint types to **Get-PSBreakPoint**.
+You can also pipe breakpoint types to `Get-PSBreakPoint`.
 
 ```yaml
 Type: Microsoft.PowerShell.Commands.BreakpointType[]
@@ -222,8 +237,8 @@ Accept wildcard characters: False
 
 ### -Variable
 
-Specifies an array of variable breakpoints that are set on the specified variable names.
-Enter the variable names without dollar signs.
+Specifies an array of variable breakpoints that are set on the specified variable names. Enter the
+variable names without dollar signs.
 
 ```yaml
 Type: System.String[]
@@ -241,26 +256,34 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see about_CommonParameters
-(https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
-### System.Int32, Microsoft.PowerShell.Commands.BreakpointType
+### System.Int32
 
-You can pipe breakpoint IDs and breakpoint types to **Get-PSBreakPoint**.
+### Microsoft.PowerShell.Commands.BreakpointType
 
-## OUTPUTS
+You can pipe breakpoint IDs and breakpoint types to `Get-PSBreakPoint`.
+
+## Outputs
+
+### System.Management.Automation.CommandBreakpoint
+
+### System.Management.Automation.LineBreakpoint
+
+### System.Management.Automation.VariableBreakpoint
 
 ### System.Management.Automation.Breakpoint
 
-**Get-PSBreakPoint** returns objects that represent the breakpoints in the session.
+`Get-PSBreakPoint` returns objects that represent the breakpoints in the session.
 
-## NOTES
+## Notes
 
-* You can use **Get-PSBreakpoint** or its alias, "gbp".
+You can use `Get-PSBreakpoint` or its alias, "gbp".
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 
@@ -271,4 +294,3 @@ You can pipe breakpoint IDs and breakpoint types to **Get-PSBreakPoint**.
 [Remove-PSBreakpoint](Remove-PSBreakpoint.md)
 
 [Set-PSBreakpoint](Set-PSBreakpoint.md)
-

--- a/reference/7.2/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/remove-psbreakpoint?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Remove-PSBreakpoint
@@ -10,10 +10,10 @@ title: Remove-PSBreakpoint
 
 # Remove-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Deletes breakpoints from the current console.
 
-## SYNTAX
+## Syntax
 
 ### Breakpoint (Default)
 
@@ -24,75 +24,74 @@ Remove-PSBreakpoint [-Breakpoint] <Breakpoint[]> [-WhatIf] [-Confirm] [<CommonPa
 ### Id
 
 ```
-Remove-PSBreakpoint [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-PSBreakpoint [-Id] <Int32[]> [-Runspace <Runspace>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-## DESCRIPTION
-The **Remove-PSBreakpoint** cmdlet deletes a breakpoint.
-Enter a breakpoint object or a breakpoint ID.
+## Description
 
-When you remove a breakpoint, the breakpoint object is no longer available or functional.
-If you have saved a breakpoint object in a variable, the reference still exists, but the breakpoint does not function.
+The `Remove-PSBreakpoint` cmdlet deletes a breakpoint. Enter a breakpoint object or a breakpoint ID.
 
-**Remove-PSBreakpoint** is one of several cmdlets designed for debugging PowerShell scripts.
-For more information about the PowerShell debugger, see about_Debuggers.
+When you remove a breakpoint, the breakpoint object is no longer available or functional. If you
+have saved a breakpoint object in a variable, the reference still exists, but the breakpoint does
+not function.
 
-## EXAMPLES
+`Remove-PSBreakpoint` is one of several cmdlets designed for debugging PowerShell scripts. For more
+information about the PowerShell debugger, see
+[about_Debuggers](../microsoft.powershell.core/about/about_debuggers.md).
+
+## Examples
 
 ### Example 1: Remove all breakpoints
 
-```
-PS C:\> Get-PSBreakpoint | Remove-PSBreakpoint
-```
-
 This command deletes all of the breakpoints in the current console.
+
+```powershell
+Get-PSBreakpoint | Remove-PSBreakpoint
+```
 
 ### Example 2: Remove a specified breakpoint
 
-```
-PS C:\> $B = Set-PSBreakpoint -Script "sample.ps1" -Variable "Name"
-PS C:\> $B | Remove-PSBreakpoint
-```
-
 This command deletes a breakpoint.
 
-The first command uses the Set-PSBreakpoint cmdlet to create a breakpoint on the Name variable in the Sample.ps1 script.
-Then, it saves the breakpoint object in the $B variable.
+```powershell
+$B = Set-PSBreakpoint -Script "sample.ps1" -Variable "Name"
+$B | Remove-PSBreakpoint
+```
 
-The second command uses the **Remove-PSBreakpoint** cmdlet to delete the new breakpoint.
-It uses a pipeline operator (|) to send the breakpoint object in the $B variable to the **Remove-PSBreakpoint** cmdlet.
+The `Set-PSBreakpoint` cmdlet creates a breakpoint on the `$Name` variable in the `Sample.ps1`
+script and saves the breakpoint object in the `$B` variable. The `Remove-PSBreakpoint` cmdlet
+deletes the new breakpoint. It uses a pipeline operator (`|`) to send the breakpoint object in the
+`$B` variable to the `Remove-PSBreakpoint` cmdlet.
 
-As a result of this command, if you run the script, it runs to completion without stopping.
-Also, the **Get-PSBreakpoint** cmdlet does not return this breakpoint.
+As a result of this command, if you run the script, it runs to completion without stopping. Also,
+the `Get-PSBreakpoint` cmdlet does not return this breakpoint.
 
 ### Example 3: Remove a breakpoint by ID
 
-```
-PS C:\> Remove-PSBreakpoint -Id 2
-```
-
 This command deletes the breakpoint with breakpoint ID 2.
+
+```powershell
+Remove-PSBreakpoint -Id 2
+```
 
 ### Example 4: Use a function to remove all breakpoints
 
-```
-PS C:\> function del-psb { get-psbreakpoint | remove-psbreakpoint }
-```
-
 This simple function deletes all of the breakpoints in the current console.
-It uses the Get-PSBreakpoint cmdlet to get the breakpoints.
-Then, it uses a pipeline operator (|) to send the breakpoints to the **Remove-PSBreakpoint** cmdlet, which deletes them.
 
-As a result, you can type `del-psb` instead of the longer command.
+```powershell
+function del-psb { Get-PSBreakpoint | Remove-PSBreakpoint }
+```
 
-To save the function, add it to your PowerShell profile.
+It uses the `Get-PSBreakpoint` cmdlet to get the breakpoints. Then, it uses a pipeline operator
+(`|`) to send the breakpoints to the `Remove-PSBreakpoint` cmdlet, which deletes them.
 
-## PARAMETERS
+## Parameters
 
 ### -Breakpoint
-Specifies the breakpoints to delete.
-Enter a variable that contains breakpoint objects or a command that gets breakpoint objects, such as a **Get-PSBreakpoint** command.
-You can also pipe breakpoint objects to **Remove-PSBreakpoint**.
+
+Specifies the breakpoints to delete. Enter a variable that contains breakpoint objects or a command
+that gets breakpoint objects, such as a `Get-PSBreakpoint` command. You can also pipe breakpoint
+objects to `Remove-PSBreakpoint`.
 
 ```yaml
 Type: System.Management.Automation.Breakpoint[]
@@ -107,6 +106,7 @@ Accept wildcard characters: False
 ```
 
 ### -Id
+
 Specifies breakpoint IDs for which this cmdlet deletes breakpoints.
 
 ```yaml
@@ -116,6 +116,23 @@ Aliases:
 
 Required: True
 Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Runspace
+
+Specifies the Id of a **Runspace** object so you can interact with breakpoints in the specified
+runspace.
+
+```yaml
+Type: Runspace
+Parameter Sets: Id
+Aliases: RunspaceId
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -153,21 +170,31 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-### System.Management.Automation.Breakpoint
-You can pipe breakpoint objects to **Remove-PSBreakpoint**.
+## Inputs
 
-## OUTPUTS
+### System.Management.Automation.Breakpoint[]
+
+You can pipe breakpoint objects to `Remove-PSBreakpoint`.
+
+### System.Int32[]
+
+### System.Management.Automation.Runspaces.Runspace
+
+## Outputs
 
 ### None
+
 The cmdlet does not generate any output.
 
-## NOTES
+## Notes
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 
@@ -178,4 +205,3 @@ The cmdlet does not generate any output.
 [Get-PSCallStack](Get-PSCallStack.md)
 
 [Set-PSBreakpoint](Set-PSBreakpoint.md)
-

--- a/reference/7.2/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -2,39 +2,40 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/24/2019
+ms.date: 08/19/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/set-psbreakpoint?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSBreakpoint
 ---
 # Set-PSBreakpoint
 
-## SYNOPSIS
+## Synopsis
 Sets a breakpoint on a line, command, or variable.
 
-## SYNTAX
+## Syntax
 
 ### Line (Default)
 
 ```
 Set-PSBreakpoint [-Action <ScriptBlock>] [[-Column] <Int32>] [-Line] <Int32[]> [-Script] <String[]>
- [<CommonParameters>]
+ [-Runspace <Runspace>] [<CommonParameters>]
 ```
 
 ### Command
 
 ```
-Set-PSBreakpoint [-Action <ScriptBlock>] -Command <String[]> [[-Script] <String[]>] [<CommonParameters>]
+Set-PSBreakpoint [-Action <ScriptBlock>] -Command <String[]> [[-Script] <String[]>] [-Runspace <Runspace>]
+ [<CommonParameters>]
 ```
 
 ### Variable
 
 ```
 Set-PSBreakpoint [-Action <ScriptBlock>] [[-Script] <String[]>] -Variable <String[]>
- [-Mode <VariableAccessMode>] [<CommonParameters>]
+ [-Mode <VariableAccessMode>] [-Runspace <Runspace>] [<CommonParameters>]
 ```
 
-## DESCRIPTION
+## Description
 
 The `Set-PSBreakpoint` cmdlet sets a breakpoint in a script or in any command run in the current
 session. You can use `Set-PSBreakpoint` to set a breakpoint before executing a script or running a
@@ -58,9 +59,10 @@ you can use the **Action** parameter to specify an alternate response, such as c
 breakpoint or instructions to perform additional tasks such as logging or diagnostics.
 
 The `Set-PSBreakpoint` cmdlet is one of several cmdlets designed for debugging PowerShell scripts.
-For more information about the PowerShell debugger, see [about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
+For more information about the PowerShell debugger, see
+[about_Debuggers](../Microsoft.PowerShell.Core/About/about_Debuggers.md).
 
-## EXAMPLES
+## Examples
 
 ### Example 1: Set a breakpoint on a line
 
@@ -129,8 +131,8 @@ Set-PSBreakpoint -Script Sample.ps1 -Command "write*"
 
 ### Example 5: Set a breakpoint depending on the value of a variable
 
-This example stops execution at the `DiskTest` function in the Test.ps1 script only when the value of
-the `$Disk` variable is greater than 2.
+This example stops execution at the `DiskTest` function in the `Test.ps1` script only when the value
+of the `$Disk` variable is greater than 2.
 
 ```powershell
 Set-PSBreakpoint -Script "test.ps1" -Command "DiskTest" -Action { if ($Disk -gt 2) { break } }
@@ -207,7 +209,7 @@ Script     : C:\ps-test\sample.ps1
 ScriptName : C:\ps-test\sample.ps1
 ```
 
-## PARAMETERS
+## Parameters
 
 ### -Action
 
@@ -243,10 +245,10 @@ Accept wildcard characters: False
 Specifies the column number of the column in the script file on which execution stops. Enter only
 one column number. The default is column 1.
 
-The Column value is used with the value of the **Line** parameter to specify the breakpoint. If the **Line**
-parameter specifies multiple lines, the **Column** parameter sets a breakpoint at the specified column
-on each of the specified lines. PowerShell stops executing before the statement or expression that
-includes the character at the specified line and column position.
+The Column value is used with the value of the **Line** parameter to specify the breakpoint. If the
+**Line** parameter specifies multiple lines, the **Column** parameter sets a breakpoint at the
+specified column on each of the specified lines. PowerShell stops executing before the statement or
+expression that includes the character at the specified line and column position.
 
 Columns are counted from the top left margin beginning with column number 1 (not 0). If you specify
 a column that does not exist in the script, an error is not declared, but the breakpoint is never
@@ -331,6 +333,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Runspace
+{{ Fill Runspace Description }}
+
+```yaml
+Type: Runspace
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Script
 
 Specifies an array of script files that this cmdlet sets a breakpoint in. Enter the paths and file
@@ -376,20 +393,25 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-## INPUTS
+## Inputs
 
 ### None
 You cannot pipe input to `Set-PSBreakpoint`.
 
 ## OUTPUTS
 
-### Breakpoint object (System.Management.Automation.LineBreakpoint, System.Management.Automation.VariableBreakpoint, System.Management.Automation.CommandBreakpoint)
+### System.Management.Automation.CommandBreakpoint
+
+### System.Management.Automation.LineBreakpoint
+
+### System.Management.Automation.VariableBreakpoint
 
 `Set-PSBreakpoint` returns an object that represents each breakpoint that it sets.
 
-## NOTES
+## Notes
 
 - `Set-PSBreakpoint` cannot set a breakpoint on a remote computer. To debug a script on a remote
   computer, copy the script to the local computer and then debug it locally.
@@ -398,7 +420,7 @@ You cannot pipe input to `Set-PSBreakpoint`.
 - When setting a breakpoint on a function or variable at the command prompt, you can set the
   breakpoint before or after you create the function or variable.
 
-## RELATED LINKS
+## Related links
 
 [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
 
@@ -409,4 +431,3 @@ You cannot pipe input to `Set-PSBreakpoint`.
 [Get-PSCallStack](Get-PSCallStack.md)
 
 [Remove-PSBreakpoint](Remove-PSBreakpoint.md)
-

--- a/reference/docs-conceptual/learn/experimental-features.md
+++ b/reference/docs-conceptual/learn/experimental-features.md
@@ -50,6 +50,9 @@ Legend
 
 ## Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace
 
+> [!NOTE]
+> This feature became mainstream in PowerShell 7.2.
+
 In PowerShell 7.0, the experiment enables the **BreakAll** parameter on the `Debug-Runspace` and
 `Debug-Job` cmdlets to allow users to decide if they want PowerShell to break immediately in the
 current location when they attach a debugger.
@@ -153,6 +156,9 @@ v2.0.5 module from the PowerShell Gallery and enable the feature using `Enable-E
 
 ## PSImplicitRemotingBatching
 
+> [!NOTE]
+> This experimental feature was removed in PowerShell 7.2 and is no longer supported.
+
 This feature examines the command typed in the shell, and if all the commands are implicit remoting
 proxy commands that form a simple pipeline, then the commands are batched together and invoked as a
 single remote pipeline.
@@ -190,9 +196,6 @@ As seen above, with the batching feature enabled, all three implicit remoting pr
 the pipeline is the only data returned to the client. This decreases the amount of data sent back
 and forth between client and remote session, and also reduces the amount of object serialization and
 de-serialization.
-
-> [!NOTE]
-> This experimental feature was removed in PowerShell 7.2 and is no longer supported.
 
 ## PSLoadAssemblyFromNativeCode
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Fixes [AB#1869268](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1869268) - Fixes #6560 - PSManageBreakpointsInRunspace no longer experimental

<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords