### PR TITLE
WIP: Update documentation about switch parameter

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -174,7 +174,7 @@ value is required.
 - Explicitly setting a switch from a boolean can be done with
   `-MySwitch:$boolValue` and in splatting with
   `$params = @{ MySwitch = $boolValue }`.
-- Switch parameters are of type `SwitchParameter` which implicitly converts to
+- Switch parameters are of type `SwitchParameter`, which implicitly converts to
   Boolean. The parameter variable can be used directly in a conditional
   expression. For example:
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -161,17 +161,20 @@ value is required.
 
 - Switch parameters should not be given default values. They should always
   default to false.
+- Switch parameters are excluded from positional parameters by default. 
+  Even when other parameters are implicitly positional, switch parameters are not. 
+  You _can_ override that in the Parameter attribute, but it will confuse users.
 - Switch parameters should be designed so that setting them moves a command
   from its default functionality to a less common or more complicated mode. The
   simplest behavior of a command should be the default behavior that does not
   require the use of switch parameters.
-- Switch parameters should not be mandatory since a switch, when used, can only
-  be `$true`. The only case where it is necessary to make a switch parameter
+- Switch parameters should not be mandatory.
+  The only case where it is necessary to make a switch parameter
   mandatory is when it is needed to differentiate a parameter set.
 - Explicitly setting a switch from a boolean can be done with
   `-MySwitch:$boolValue` and in splatting with
   `$params = @{ MySwitch = $boolValue }`.
-- Switch parameters are of type `SwitchParameter` but implicitly convert to
+- Switch parameters are of type `SwitchParameter` which implicitly converts to
   Boolean. The parameter variable can be used directly in a conditional
   expression. For example:
 


### PR DESCRIPTION
# PR Summary

- Addressing confusion in https://github.com/PowerShell/PowerShell/issues/15884
- Adding explicitly the fact that switch parameters aren't positional.
- Removing the incorrect claim that switch parameters, when specified, can only be $true

## PR Context
Applies to all versions. I didn't check out the code, so I missed changing the old versions. I will be happy to merge this back to those after someone reviews and OKs it.

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [x] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
