### PR TITLE
Fix two sentence fragments in spec chapter 7.

### DIFF
--- a/reference/docs-conceptual/lang-spec/chapter-07.md
+++ b/reference/docs-conceptual/lang-spec/chapter-07.md
@@ -204,7 +204,7 @@ The result is written to the pipeline, as the top-level expression has no side e
 Syntax:
 
 ```Syntax
-member-access: Note no whitespace is allowed after
+member-access: Note no whitespace is allowed after primary-expression. 
     primary-expression . member-name
     primary-expression :: member-name
 ```
@@ -268,7 +268,7 @@ $a.ID                        # get ID from each element in the array
 Syntax:
 
 ```Syntax
-invocation-expression: Note no whitespace is allowed after
+invocation-expression: Note no whitespace is allowed after primary-expression. 
     primary-expression . member-name argument-list
     primary-expression :: member-name argument-list
 


### PR DESCRIPTION
# PR Summary
I discovered two sentence fragments in the specification and corrected them. 

## PR Context
/docs-conceptual 

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [x] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
