### PR TITLE
Fixes #8048 - fix OutputRendering

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_ANSI_Terminals.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_ANSI_Terminals.md
@@ -71,8 +71,6 @@ The following members control how or when ANSI formatting is used:
 - `$PSStyle.OutputRendering` is a
   `System.Management.Automation.OutputRendering` enum with the values:
 
-  - **Automatic**: If the host supports VirtualTerminal, then ANSI is always
-    passed as-is, otherwise plaintext
   - **ANSI**: ANSI is always passed through as-is
   - **PlainText**: ANSI escape sequences are always stripped so that it is only
     plain text

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -678,8 +678,6 @@ The following members control how or when ANSI formatting is used:
 - `$PSStyle.OutputRendering` is a
   `System.Management.Automation.OutputRendering` enum with the values:
 
-  - **Automatic**: If the host supports VirtualTerminal, then ANSI is always
-    passed as-is, otherwise plaintext
   - **ANSI**: ANSI is always passed through as-is
   - **PlainText**: ANSI escape sequences are always stripped so that it is only
     plain text


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Fixes [AB#1873499](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1873499) - Fixes #8048 - fix OutputRendering

<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords