### PR TITLE
Write-Progress -Id must be non-negative

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -196,7 +196,8 @@ Accept wildcard characters: False
 
 Specifies an ID that distinguishes each progress bar from the others. Use this parameter when you
 are creating more than one progress bar in a single command. If the progress bars do not have
-different IDs, they are superimposed instead of being displayed in a series.
+different IDs, they are superimposed instead of being displayed in a series. Negative values are 
+not allowed.
 
 ```yaml
 Type: System.Int32

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/29/2021
+ms.date: 09/10/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/write-progress?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Progress
@@ -196,7 +196,7 @@ Accept wildcard characters: False
 
 Specifies an ID that distinguishes each progress bar from the others. Use this parameter when you
 are creating more than one progress bar in a single command. If the progress bars do not have
-different IDs, they are superimposed instead of being displayed in a series. Negative values are 
+different IDs, they are superimposed instead of being displayed in a series. Negative values are
 not allowed.
 
 ```yaml

--- a/reference/7.0/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/23/2021
+ms.date: 09/10/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/write-progress?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Progress
@@ -196,7 +196,8 @@ Accept wildcard characters: False
 
 Specifies an ID that distinguishes each progress bar from the others. Use this parameter when you
 are creating more than one progress bar in a single command. If the progress bars do not have
-different IDs, they are superimposed instead of being displayed in a series.
+different IDs, they are superimposed instead of being displayed in a series. Negative values are
+not allowed.
 
 ```yaml
 Type: System.Int32

--- a/reference/7.1/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/23/2021
+ms.date: 09/10/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/write-progress?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Progress
@@ -196,7 +196,8 @@ Accept wildcard characters: False
 
 Specifies an ID that distinguishes each progress bar from the others. Use this parameter when you
 are creating more than one progress bar in a single command. If the progress bars do not have
-different IDs, they are superimposed instead of being displayed in a series.
+different IDs, they are superimposed instead of being displayed in a series. Negative values are
+not allowed.
 
 ```yaml
 Type: System.Int32

--- a/reference/7.2/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/23/2021
+ms.date: 09/10/2021
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/write-progress?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Progress
@@ -210,7 +210,8 @@ Accept wildcard characters: False
 
 Specifies an ID that distinguishes each progress bar from the others. Use this parameter when you
 are creating more than one progress bar in a single command. If the progress bars do not have
-different IDs, they are superimposed instead of being displayed in a series.
+different IDs, they are superimposed instead of being displayed in a series. Negative values are
+not allowed.
 
 ```yaml
 Type: System.Int32


### PR DESCRIPTION
Specify that `-Id` does not allow negative values. Id parameter is listed as Int32, but PS5.1 (at least) enforces that it must also be non-negative.

# PR Summary
Specify that `Write-Progress` `-Id` parameter does not allow negative values.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [X] Version 7.1 content - untested
- [X] Version 7.0 content - untested
- [X] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
