### PR TITLE
Add to definition of parameter

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -35,7 +35,7 @@ The following requirements apply to all parameter sets.
 - If no parameter set is specified for a parameter, the parameter belongs to
   all parameter sets.
 
-- Function with parameter sets specified must be called with parameters from a single subset.
+- Function with parameter sets specified must be called with parameters from a single parameter set.
 
 > [!NOTE]
 > There is a limit of 32 parameter sets.

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -35,6 +35,8 @@ The following requirements apply to all parameter sets.
 - If no parameter set is specified for a parameter, the parameter belongs to
   all parameter sets.
 
+- Function with parameter sets specified must be called with parameters from a single subset.
+
 > [!NOTE]
 > There is a limit of 32 parameter sets.
 


### PR DESCRIPTION
This seems like the most important property of parameter sets but it's not specified?

# PR Summary
<!-- Summarize your changes and list related issues here -->

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
