### PR TITLE
Use AsPSObject() to avoid nesting PSObjects

### DIFF
--- a/reference/docs-conceptual/developer/cmdlet/how-to-support-jobs.md
+++ b/reference/docs-conceptual/developer/cmdlet/how-to-support-jobs.md
@@ -115,7 +115,7 @@ information about background jobs, see [Background Jobs](./background-jobs.md).
 
         foreach (Process pl in p)
         {
-          Output.Add(new PSObject(pl));
+          Output.Add(PSObject.AsPSObject(pl));
         }
         Output.Complete();
       } // End DoProcessLogic.
@@ -140,7 +140,7 @@ information about background jobs, see [Background Jobs](./background-jobs.md).
         }
         else
         {
-          job.ChildJobs[0].Output.Add(new PSObject(pl));
+          job.ChildJobs[0].Output.Add(PSObject.AsPSObject(pl));
         }
       }
     } // End DoProcessLogic.
@@ -296,7 +296,7 @@ namespace Microsoft.Samples.PowerShell.Commands
 
         foreach (Process pl in p)
         {
-          Output.Add(new PSObject(pl));
+          Output.Add(PSObject.AsPSObject(pl));
         }
         Output.Complete();
       } // End DoProcessLogic.
@@ -322,7 +322,7 @@ namespace Microsoft.Samples.PowerShell.Commands
         }
         else
         {
-          job.ChildJobs[0].Output.Add(new PSObject(pl));
+          job.ChildJobs[0].Output.Add(PSObject.AsPSObject(pl));
         }
       }
     } // End DoProcessLogic.


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

Use AsPSObject() to avoid nesting PSObjects - related to #7320 

<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [x] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords