### PR TITLE
Update color names in the doc

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_ANSI_Terminals.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_ANSI_Terminals.md
@@ -63,7 +63,7 @@ bold to underlined. The property names makes it easier for you to create
 decorated strings using tab completion:
 
 ```powershell
-"$($PSStyle.Background.LightCyan)Power$($PSStyle.Underline)$($PSStyle.Bold)Shell$($PSStyle.Reset)"
+"$($PSStyle.Background.BrightCyan)Power$($PSStyle.Underline)$($PSStyle.Bold)Shell$($PSStyle.Reset)"
 ```
 
 The following members control how or when ANSI formatting is used:
@@ -81,21 +81,21 @@ The following members control how or when ANSI formatting is used:
   contain the ANSI escape sequences for the 16 standard console colors.
 
   - Black
+  - BrightBlack
   - White
-  - DarkGray
-  - LightGray
+  - BrightWhite
   - Red
-  - LightRed
+  - BrightRed
   - Magenta
-  - LightMagenta
+  - BrightMagenta
   - Blue
-  - LightBlue
+  - BrightBlue
   - Cyan
-  - LightCyan
+  - BrightCyan
   - Green
-  - LightGreen
+  - BrightGreen
   - Yellow
-  - LightYellow
+  - BrightYellow
 
   The values are settable and can contain any number of ANSI escape sequences.
   There is also an `FromRgb()` method to specify 24-bit color. There are two

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -672,7 +672,7 @@ bold to underlined. The property names makes it easier for you to create
 decorated strings using tab completion:
 
 ```powershell
-"$($PSStyle.Background.LightCyan)Power$($PSStyle.Underline)$($PSStyle.Bold)Shell$($PSStyle.Reset)"
+"$($PSStyle.Background.BrightCyan)Power$($PSStyle.Underline)$($PSStyle.Bold)Shell$($PSStyle.Reset)"
 ```
 
 The following members control how or when ANSI formatting is used:
@@ -690,21 +690,21 @@ The following members control how or when ANSI formatting is used:
   contain the ANSI escape sequences for the 16 standard console colors.
 
   - Black
+  - BrightBlack
   - White
-  - DarkGray
-  - LightGray
+  - BrightWhite
   - Red
-  - LightRed
+  - BrightRed
   - Magenta
-  - LightMagenta
+  - BrightMagenta
   - Blue
-  - LightBlue
+  - BrightBlue
   - Cyan
-  - LightCyan
+  - BrightCyan
   - Green
-  - LightGreen
+  - BrightGreen
   - Yellow
-  - LightYellow
+  - BrightYellow
 
   The values are settable and can contain any number of ANSI escape sequences.
   There is also an `FromRgb()` method to specify 24-bit color. There are two


### PR DESCRIPTION
# PR Summary

The properties for the corresponding VT sequences were misnamed. Update the doc to reflect the correct names.
PR that update the properties names: https://github.com/PowerShell/PowerShell/pull/16212

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
