### PR TITLE
Cmdlet reference "Sort-Object" - Add simple example for sorting multiple properties

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -340,6 +340,29 @@ sample code, `[int]` converts the string to an integer and `$_` represents each 
 down the pipeline. The integer objects are sent down the pipeline to the `Sort-Object` cmdlet.
 `Sort-Object` sorts the integer objects in numeric order.
 
+### Example 9: Sort by multiple properties
+
+If you want to sort by multiple properties, separate the properties by commas.
+
+```powershell
+Get-ChildItem -Path C:\Test | Sort-Object Length,Name
+```
+
+```Output
+    Directory: C:\Test
+
+Mode                 LastWriteTime         Length Name
+----                 -------------         ------ ----
+-a---          13/10/2021    22:16              2 File01.txt
+-a---          13/10/2021    22:16              2 File03.txt
+-a---          13/10/2021    22:18             64 File02.txt
+-a---          13/10/2021    22:18             64 File04.txt
+```
+
+The `Get-ChildItem` cmdlet gets the files from the directory specified by the **Path** parameter. The objects are sent
+down the pipeline to the `Sort-Object` cmdlet. `Sort-Object` uses the **Length** and **Name** parameter to sort
+the files by length in ascending order. Since `File01.txt` and `File03.txt` have the same length, they are further sorted by their property **Name**.
+
 ## Parameters
 
 ### -CaseSensitive
@@ -419,7 +442,7 @@ Specifies the property names that `Sort-Object` uses to sort the objects. Wildca
 Objects are sorted based on the property values. If you do not specify a property, `Sort-Object`
 sorts based on default properties for the object type or the objects themselves.
 
-Multiple properties can be sorted in ascending order, descending order, or a combination of sort
+Use commas to separate multiple properties. Multiple properties can be sorted in ascending order, descending order, or a combination of sort
 orders. When you specify multiple properties, the objects are sorted by the first property. If
 multiple objects have the same value for the first property, those objects are sorted by the second
 property. This process continues until there are no more specified properties or no groups of

--- a/reference/7.0/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -422,6 +422,29 @@ The output from the first sort is correctly grouped by the modulus value but the
 are not sorted within the modulus range. The second sort uses the **Stable** option to return a
 stable sort.
 
+### Example 10: Sort by multiple properties
+
+If you want to sort by multiple properties, separate the properties by commas.
+
+```powershell
+Get-ChildItem -Path C:\Test | Sort-Object Length,Name
+```
+
+```Output
+    Directory: C:\Test
+
+Mode                 LastWriteTime         Length Name
+----                 -------------         ------ ----
+-a---          13/10/2021    22:16              2 File01.txt
+-a---          13/10/2021    22:16              2 File03.txt
+-a---          13/10/2021    22:18             64 File02.txt
+-a---          13/10/2021    22:18             64 File04.txt
+```
+
+The `Get-ChildItem` cmdlet gets the files from the directory specified by the **Path** parameter. The objects are sent
+down the pipeline to the `Sort-Object` cmdlet. `Sort-Object` uses the **Length** and **Name** parameter to sort
+the files by length in ascending order. Since `File01.txt` and `File03.txt` have the same length, they are further sorted by their property **Name**.
+
 ## Parameters
 
 ### -Bottom
@@ -520,7 +543,7 @@ Specifies the property names that `Sort-Object` uses to sort the objects. Wildca
 Objects are sorted based on the property values. If you do not specify a property, `Sort-Object`
 sorts based on default properties for the object type or the objects themselves.
 
-Multiple properties can be sorted in ascending order, descending order, or a combination of sort
+Use commas to separate multiple properties. Multiple properties can be sorted in ascending order, descending order, or a combination of sort
 orders. When you specify multiple properties, the objects are sorted by the first property. If
 multiple objects have the same value for the first property, those objects are sorted by the second
 property. This process continues until there are no more specified properties or no groups of

--- a/reference/7.1/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -422,6 +422,29 @@ The output from the first sort is correctly grouped by the modulus value but the
 are not sorted within the modulus range. The second sort uses the **Stable** option to return a
 stable sort.
 
+### Example 10: Sort by multiple properties
+
+If you want to sort by multiple properties, separate the properties by commas.
+
+```powershell
+Get-ChildItem -Path C:\Test | Sort-Object Length,Name
+```
+
+```Output
+    Directory: C:\Test
+
+Mode                 LastWriteTime         Length Name
+----                 -------------         ------ ----
+-a---          13/10/2021    22:16              2 File01.txt
+-a---          13/10/2021    22:16              2 File03.txt
+-a---          13/10/2021    22:18             64 File02.txt
+-a---          13/10/2021    22:18             64 File04.txt
+```
+
+The `Get-ChildItem` cmdlet gets the files from the directory specified by the **Path** parameter. The objects are sent
+down the pipeline to the `Sort-Object` cmdlet. `Sort-Object` uses the **Length** and **Name** parameter to sort
+the files by length in ascending order. Since `File01.txt` and `File03.txt` have the same length, they are further sorted by their property **Name**.
+
 ## Parameters
 
 ### -Bottom
@@ -520,7 +543,7 @@ Specifies the property names that `Sort-Object` uses to sort the objects. Wildca
 Objects are sorted based on the property values. If you do not specify a property, `Sort-Object`
 sorts based on default properties for the object type or the objects themselves.
 
-Multiple properties can be sorted in ascending order, descending order, or a combination of sort
+Use commas to separate multiple properties. Multiple properties can be sorted in ascending order, descending order, or a combination of sort
 orders. When you specify multiple properties, the objects are sorted by the first property. If
 multiple objects have the same value for the first property, those objects are sorted by the second
 property. This process continues until there are no more specified properties or no groups of

--- a/reference/7.2/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -422,6 +422,29 @@ The output from the first sort is correctly grouped by the modulus value but the
 are not sorted within the modulus range. The second sort uses the **Stable** option to return a
 stable sort.
 
+### Example 10: Sort by multiple properties
+
+If you want to sort by multiple properties, separate the properties by commas.
+
+```powershell
+Get-ChildItem -Path C:\Test | Sort-Object Length,Name
+```
+
+```Output
+    Directory: C:\Test
+
+Mode                 LastWriteTime         Length Name
+----                 -------------         ------ ----
+-a---          13/10/2021    22:16              2 File01.txt
+-a---          13/10/2021    22:16              2 File03.txt
+-a---          13/10/2021    22:18             64 File02.txt
+-a---          13/10/2021    22:18             64 File04.txt
+```
+
+The `Get-ChildItem` cmdlet gets the files from the directory specified by the **Path** parameter. The objects are sent
+down the pipeline to the `Sort-Object` cmdlet. `Sort-Object` uses the **Length** and **Name** parameter to sort
+the files by length in ascending order. Since `File01.txt` and `File03.txt` have the same length, they are further sorted by their property **Name**.
+
 ## Parameters
 
 ### -Bottom
@@ -520,7 +543,7 @@ Specifies the property names that `Sort-Object` uses to sort the objects. Wildca
 Objects are sorted based on the property values. If you do not specify a property, `Sort-Object`
 sorts based on default properties for the object type or the objects themselves.
 
-Multiple properties can be sorted in ascending order, descending order, or a combination of sort
+Use commas to separate multiple properties. Multiple properties can be sorted in ascending order, descending order, or a combination of sort
 orders. When you specify multiple properties, the objects are sorted by the first property. If
 multiple objects have the same value for the first property, those objects are sorted by the second
 property. This process continues until there are no more specified properties or no groups of


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->

I added a simple example for using `Sort-Object` with multiple properties.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [x] Preview content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
