### PR TITLE
Add examples for + and minus, fix unary -

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -38,9 +38,10 @@ PowerShell supports the following arithmetic operators:
 |        |strings, arrays, and hash tables. |`"file" + "name"`            |
 |        |                                  |`@(1, "one") + @(2.0, "two")`|
 |        |                                  |`@{"one" = 1} + @{"two" = 2}`|
+| +      |Makes a number out of an object   | + 123                       |
 | -      |Subtracts one value from another  |`6 - 2`                      |
 |        |value                             |                             |
-| -      |Makes a number a negative number  |`-6`                         |
+| -      |Calculates the opposite number    |`- -6`                       |
 |        |                                  |`(Get-Date).AddDays(-1)`     |
 | *      |Multiply numbers or copy strings  |`6 * 2`                      |
 |        |and arrays the specified number   |`@("!") * 4`                 |
@@ -178,7 +179,9 @@ operation fails.
 
 The following examples demonstrate the use of the addition and
 multiplication operators; in operations that include different object
-types. Assume `$array = 1,2,3`:
+types.
+Assume `$array = 1,2,3`,
+`$red = [ConsoleColor]::Red`, `$blue = [ConsoleColor]::Blue`:
 
 |Expression       |Result                 |
 |-----------------|-----------------------|
@@ -187,6 +190,10 @@ types. Assume `$array = 1,2,3`:
 |`$array + "file"`|`1`,`2`,`3`,`file`     |
 |`$array * 2`     |`1`,`2`,`3`,`1`,`2`,`3`|
 |`"file" * 3`     |`filefilefile`         |
+|`$blue + 3`      |`Red`                  |
+|`$red - 3`       |`Blue`                 |
+|`$blue - $red`   |`-3`                   |
+|`+ '123'`        |`123`                  |
 
 Because the method that is used to evaluate statements is determined by the
 leftmost object, addition and multiplication in PowerShell are not strictly
@@ -201,7 +208,7 @@ The following examples demonstrate this principle:
 |`16 + "file"`|`Cannot convert value "file" to type "System.Int32".`|
 |             |`Error: "Input string was not in a correct format."` |
 |             |`At line:1 char:1`                                   |
-|             |+ 16 + "file"`                                       |
+|             |`+ 16 + "file"`                                       |
 
 Hash tables are a slightly different case. You can add hash tables to
 another hash table, as long as, the added hash tables don't have duplicate
@@ -305,8 +312,7 @@ result without losing precision. For example:
 
 ```powershell
 2 + 3.1
-
-(2). GetType().FullName
+(2).GetType().FullName
 (2 + 3.1).GetType().FullName
 ```
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -38,9 +38,10 @@ PowerShell supports the following arithmetic operators:
 |        |strings, arrays, and hash tables. |`"file" + "name"`            |
 |        |                                  |`@(1, "one") + @(2.0, "two")`|
 |        |                                  |`@{"one" = 1} + @{"two" = 2}`|
+| +      |Makes a number out of an object   | + 123                       |
 | -      |Subtracts one value from another  |`6 - 2`                      |
 |        |value                             |                             |
-| -      |Makes a number a negative number  |`-6`                         |
+| -      |Calculates the opposite number    |`- -6`                       |
 |        |                                  |`(Get-Date).AddDays(-1)`     |
 | *      |Multiply numbers or copy strings  |`6 * 2`                      |
 |        |and arrays the specified number   |`@("!") * 4`                 |
@@ -178,7 +179,9 @@ operation fails.
 
 The following examples demonstrate the use of the addition and
 multiplication operators; in operations that include different object
-types. Assume `$array = 1,2,3`:
+types.
+Assume `$array = 1,2,3`,
+`$red = [ConsoleColor]::Red`, `$blue = [ConsoleColor]::Blue`:
 
 |Expression       |Result                 |
 |-----------------|-----------------------|
@@ -187,6 +190,10 @@ types. Assume `$array = 1,2,3`:
 |`$array + "file"`|`1`,`2`,`3`,`file`     |
 |`$array * 2`     |`1`,`2`,`3`,`1`,`2`,`3`|
 |`"file" * 3`     |`filefilefile`         |
+|`$blue + 3`      |`Red`                  |
+|`$red - 3`       |`Blue`                 |
+|`$blue - $red`   |`-3`                   |
+|`+ '123'`        |`123`                  |
 
 Because the method that is used to evaluate statements is determined by the
 leftmost object, addition and multiplication in PowerShell are not strictly
@@ -201,7 +208,7 @@ The following examples demonstrate this principle:
 |`16 + "file"`|`Cannot convert value "file" to type "System.Int32".`|
 |             |`Error: "Input string was not in a correct format."` |
 |             |`At line:1 char:1`                                   |
-|             |+ 16 + "file"`                                       |
+|             |`+ 16 + "file"`                                      |
 
 Hash tables are a slightly different case. You can add hash tables to
 another hash table, as long as, the added hash tables don't have duplicate
@@ -305,8 +312,7 @@ result without losing precision. For example:
 
 ```powershell
 2 + 3.1
-
-(2). GetType().FullName
+(2).GetType().FullName
 (2 + 3.1).GetType().FullName
 ```
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -181,7 +181,7 @@ The following examples demonstrate the use of the addition and
 multiplication operators; in operations that include different object
 types.
 Assume `$array = 1,2,3`,
-`$red = [ConsoleColor]::Red`, `$blue = [ConsoleColor]::Blue`
+`$red = [ConsoleColor]::Red`, `$blue = [ConsoleColor]::Blue`:
 
 |Expression       |Result                 |
 |-----------------|-----------------------|

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -38,9 +38,10 @@ PowerShell supports the following arithmetic operators:
 |        |strings, arrays, and hash tables. |`"file" + "name"`            |
 |        |                                  |`@(1, "one") + @(2.0, "two")`|
 |        |                                  |`@{"one" = 1} + @{"two" = 2}`|
+| +      |Makes a number out of an object   | + 123                       |
 | -      |Subtracts one value from another  |`6 - 2`                      |
 |        |value                             |                             |
-| -      |Makes a number a negative number  |`-6`                         |
+| -      |Calculates the opposite number    |`- -6`                       |
 |        |                                  |`(Get-Date).AddDays(-1)`     |
 | *      |Multiply numbers or copy strings  |`6 * 2`                      |
 |        |and arrays the specified number   |`@("!") * 4`                 |
@@ -178,7 +179,9 @@ operation fails.
 
 The following examples demonstrate the use of the addition and
 multiplication operators; in operations that include different object
-types. Assume `$array = 1,2,3`:
+types.
+Assume `$array = 1,2,3`,
+`$red = [ConsoleColor]::Red`, `$blue = [ConsoleColor]::Blue`
 
 |Expression       |Result                 |
 |-----------------|-----------------------|
@@ -187,6 +190,10 @@ types. Assume `$array = 1,2,3`:
 |`$array + "file"`|`1`,`2`,`3`,`file`     |
 |`$array * 2`     |`1`,`2`,`3`,`1`,`2`,`3`|
 |`"file" * 3`     |`filefilefile`         |
+|`$blue + 3`      |`Red`                  |
+|`$red - 3`       |`Blue`                 |
+|`$blue - $red`   |`-3`                   |
+|`+ '123'`        |`123`                  |
 
 Because the method that is used to evaluate statements is determined by the
 leftmost object, addition and multiplication in PowerShell are not strictly
@@ -201,7 +208,7 @@ The following examples demonstrate this principle:
 |`16 + "file"`|`Cannot convert value "file" to type "System.Int32".`|
 |             |`Error: "Input string was not in a correct format."` |
 |             |`At line:1 char:1`                                   |
-|             |+ 16 + "file"`                                       |
+|             |`+ 16 + "file"`                                      |
 
 Hash tables are a slightly different case. You can add hash tables to
 another hash table, as long as, the added hash tables don't have duplicate
@@ -305,8 +312,7 @@ result without losing precision. For example:
 
 ```powershell
 2 + 3.1
-
-(2). GetType().FullName
+(2).GetType().FullName
 (2 + 3.1).GetType().FullName
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -38,9 +38,10 @@ PowerShell supports the following arithmetic operators:
 |        |strings, arrays, and hash tables. |`"file" + "name"`            |
 |        |                                  |`@(1, "one") + @(2.0, "two")`|
 |        |                                  |`@{"one" = 1} + @{"two" = 2}`|
+| +      |Makes a number out of an object   | + 123                       |
 | -      |Subtracts one value from another  |`6 - 2`                      |
 |        |value                             |                             |
-| -      |Makes a number a negative number  |`-6`                         |
+| -      |Calculates the opposite number    |`- -6`                       |
 |        |                                  |`(Get-Date).AddDays(-1)`     |
 | *      |Multiply numbers or copy strings  |`6 * 2`                      |
 |        |and arrays the specified number   |`@("!") * 4`                 |
@@ -178,7 +179,8 @@ operation fails.
 
 The following examples demonstrate the use of the addition and
 multiplication operators; in operations that include different object
-types. Assume `$array = 1,2,3`:
+types.
+Assume `$array = 1,2,3`, `$red = [ConsoleColor]::Red`, `$blue = [ConsoleColor]::Blue`:
 
 |Expression       |Result                 |
 |-----------------|-----------------------|
@@ -187,6 +189,10 @@ types. Assume `$array = 1,2,3`:
 |`$array + "file"`|`1`,`2`,`3`,`file`     |
 |`$array * 2`     |`1`,`2`,`3`,`1`,`2`,`3`|
 |`"file" * 3`     |`filefilefile`         |
+|`$blue + 3`      |`Red`                  |
+|`$red - 3`       |`Blue`                 |
+|`$blue - $red`   |`-3`                   |
+|`+ '123'`        |`123`                  |
 
 Because the method that is used to evaluate statements is determined by the
 leftmost object, addition and multiplication in PowerShell are not strictly
@@ -201,7 +207,7 @@ The following examples demonstrate this principle:
 |`16 + "file"`|`Cannot convert value "file" to type "System.Int32".`|
 |             |`Error: "Input string was not in a correct format."` |
 |             |`At line:1 char:1`                                   |
-|             |+ 16 + "file"`                                       |
+|             |˙+ 16 + "file"`                                      |
 
 Hash tables are a slightly different case. You can add hash tables to
 another hash table, as long as, the added hash tables don't have duplicate
@@ -305,8 +311,7 @@ result without losing precision. For example:
 
 ```powershell
 2 + 3.1
-
-(2). GetType().FullName
+(2).GetType().FullName
 (2 + 3.1).GetType().FullName
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -180,7 +180,8 @@ operation fails.
 The following examples demonstrate the use of the addition and
 multiplication operators; in operations that include different object
 types.
-Assume `$array = 1,2,3`, `$red = [ConsoleColor]::Red`, `$blue = [ConsoleColor]::Blue`:
+Assume `$array = 1,2,3`,
+`$red = [ConsoleColor]::Red`, `$blue = [ConsoleColor]::Blue`:
 
 |Expression       |Result                 |
 |-----------------|-----------------------|


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Fix: the result of unary operator `-` is not always negative.
About unary operator `+`.
Addition and subtraction of enumerated values.
Minor editing corrections.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [X] Preview content
- [X] Version 7.1 content
- [X] Version 7.0 content
- [X] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
