### PR TITLE
op[]: mention lists of indices and non-collections

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -451,6 +451,18 @@ intro
 -----
 Once upon a time...
 ```
+Given a list of indices, the operator returns a list of members corresponding to those indices.
+
+```powershell
+-JOIN '123'[ 2 .. 0 ] -EQ '321'
+```
+
+If an object is not an indexed collection, its first element is the object itself.  Index lists are not supported.
+
+```powershell
+(0)[0] -EQ 0
+(0)[0,0] -EQ $NULL
+```
 
 ### Pipeline operator `|`
 


### PR DESCRIPTION
# PR Summary
<!-- Summarize your changes and list related issues here -->
Add missing information about the behaviour of `operator[]` with lists of indices and with non-collections.

## PR Context
<!--
There is a numbered folder for each version of the PowerShell cmdlet content.
Changes to cmdlet reference should be made to all versions where applicable.
The /docs-conceptual folder tree does not have version folders.
-->

Select the area of the Table of Contents containing the documents being changed.

**Conceptual content**
- [ ] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [X] Preview content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
