### PR TITLE
Describe how to run Homebrew when PS is used as login shell

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -261,7 +261,7 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```sh
   chsh -s /usr/bin/pwsh
   ```
-- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. Depending on your environment, this could be achieved by adding the following code to `~/.config/powershell/profile.ps1`:
+- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew adjust your environment variables. Depending on your environment, this could be achieved by adding the following code to `~/.config/powershell/profile.ps1`:
 
   ```powershell
   $(

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -264,7 +264,16 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
 - If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
 
   ```powershell
-  $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue
+  $(
+    if (Test-Path -PathType Leaf ~/.linuxbrew/bin/brew)
+      {~/.linuxbrew/bin/brew shellenv}
+    elseif (Test-Path -PathType Leaf /home/linuxbrew/.linuxbrew/bin/brew)
+      {/home/linuxbrew/.linuxbrew/bin/brew shellenv}
+    elseif (Test-Path -PathType Leaf /opt/homebrew/bin/brew)
+      {/opt/homebrew/bin/brew shellenv}
+    elseif (Test-Path -PathType Leaf /usr/local/bin/brew)
+      {/usr/local/bin/brew shellenv}
+  ) | Invoke-Expression -ErrorAction SilentlyContinue
   ```
 
 > [!WARNING]

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -263,7 +263,7 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```
 - If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew adjust your environment variables. Depending on your environment, this could be achieved by adding the following code to `~/.config/powershell/profile.ps1`:
 
-  ```powershell
+  ```PowerShell
   $(
     if (Test-Path -PathType Leaf ~/.linuxbrew/bin/brew)
       {~/.linuxbrew/bin/brew shellenv}

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -261,6 +261,11 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```sh
   chsh -s /usr/bin/pwsh
   ```
+- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line:
+
+  ```powershell
+  $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue
+  ```
 
 > [!WARNING]
 > Setting `pwsh` as the login shell is currently not supported on Windows

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -261,7 +261,7 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```sh
   chsh -s /usr/bin/pwsh
   ```
-- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line:
+- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
 
   ```powershell
   $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -261,7 +261,7 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```sh
   chsh -s /usr/bin/pwsh
   ```
-- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
+- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. Depending on your environment, this could be achieved by adding the following code to `~/.config/powershell/profile.ps1`:
 
   ```powershell
   $(

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -261,7 +261,7 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```sh
   chsh -s /usr/bin/pwsh
   ```
-- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. Depending on your environment, this could be achieved by adding the following code to `~/.config/powershell/profile.ps1`:
+- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew adjust your environment variables. Depending on your environment, this could be achieved by adding the following code to `~/.config/powershell/profile.ps1`:
 
   ```powershell
   $(

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -264,7 +264,16 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
 - If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
 
   ```powershell
-  $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue
+  $(
+    if (Test-Path -PathType Leaf ~/.linuxbrew/bin/brew)
+      {~/.linuxbrew/bin/brew shellenv}
+    elseif (Test-Path -PathType Leaf /home/linuxbrew/.linuxbrew/bin/brew)
+      {/home/linuxbrew/.linuxbrew/bin/brew shellenv}
+    elseif (Test-Path -PathType Leaf /opt/homebrew/bin/brew)
+      {/opt/homebrew/bin/brew shellenv}
+    elseif (Test-Path -PathType Leaf /usr/local/bin/brew)
+      {/usr/local/bin/brew shellenv}
+  ) | Invoke-Expression -ErrorAction SilentlyContinue
   ```
 
 > [!WARNING]

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -263,7 +263,7 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```
 - If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew adjust your environment variables. Depending on your environment, this could be achieved by adding the following code to `~/.config/powershell/profile.ps1`:
 
-  ```powershell
+  ```PowerShell
   $(
     if (Test-Path -PathType Leaf ~/.linuxbrew/bin/brew)
       {~/.linuxbrew/bin/brew shellenv}

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -261,6 +261,11 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```sh
   chsh -s /usr/bin/pwsh
   ```
+- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line:
+
+  ```powershell
+  $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue
+  ```
 
 > [!WARNING]
 > Setting `pwsh` as the login shell is currently not supported on Windows

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -261,7 +261,7 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```sh
   chsh -s /usr/bin/pwsh
   ```
-- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line to ~/.config/powershell/profile.ps1:
+- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
 
   ```powershell
   $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -261,7 +261,7 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```sh
   chsh -s /usr/bin/pwsh
   ```
-- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
+- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. Depending on your environment, this could be achieved by adding the following code to `~/.config/powershell/profile.ps1`:
 
   ```powershell
   $(

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -261,7 +261,7 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```sh
   chsh -s /usr/bin/pwsh
   ```
-- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line:
+- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line to ~/.config/powershell/profile.ps1:
 
   ```powershell
   $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -267,7 +267,7 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```sh
   chsh -s /usr/bin/pwsh
   ```
-- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. Depending on your environment, this could be achieved by adding the following code to `~/.config/powershell/profile.ps1`:
+- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew adjust your environment variables. Depending on your environment, this could be achieved by adding the following code to `~/.config/powershell/profile.ps1`:
 
   ```powershell
   $(

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -269,7 +269,7 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```
 - If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew adjust your environment variables. Depending on your environment, this could be achieved by adding the following code to `~/.config/powershell/profile.ps1`:
 
-  ```powershell
+  ```PowerShell
   $(
     if (Test-Path -PathType Leaf ~/.linuxbrew/bin/brew)
       {~/.linuxbrew/bin/brew shellenv}

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -267,6 +267,11 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```sh
   chsh -s /usr/bin/pwsh
   ```
+- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line:
+
+  ```powershell
+  $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue
+  ```
 
 > [!WARNING]
 > Setting `pwsh` as the login shell is currently not supported on Windows

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -267,7 +267,7 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```sh
   chsh -s /usr/bin/pwsh
   ```
-- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line:
+- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
 
   ```powershell
   $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -267,10 +267,19 @@ To set up `pwsh` as the login shell on UNIX-like operating systems:
   ```sh
   chsh -s /usr/bin/pwsh
   ```
-- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
+- If you are using Homebrew on Linux or macOS, you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. Depending on your environment, this could be achieved by adding the following code to `~/.config/powershell/profile.ps1`:
 
   ```powershell
-  $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue
+  $(
+    if (Test-Path -PathType Leaf ~/.linuxbrew/bin/brew)
+      {~/.linuxbrew/bin/brew shellenv}
+    elseif (Test-Path -PathType Leaf /home/linuxbrew/.linuxbrew/bin/brew)
+      {/home/linuxbrew/.linuxbrew/bin/brew shellenv}
+    elseif (Test-Path -PathType Leaf /opt/homebrew/bin/brew)
+      {/opt/homebrew/bin/brew shellenv}
+    elseif (Test-Path -PathType Leaf /usr/local/bin/brew)
+      {/usr/local/bin/brew shellenv}
+  ) | Invoke-Expression -ErrorAction SilentlyContinue
   ```
 
 > [!WARNING]

--- a/reference/docs-conceptual/install/Installing-PowerShell-on-macOS.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-on-macOS.md
@@ -60,6 +60,12 @@ brew upgrade powershell --cask
 > but then the PowerShell shell must be exited and restarted to complete the upgrade
 > and refresh the values shown in `$PSVersionTable`.
 
+If you are running PowerShell as your login shell, note that you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. Otherwise, Homebrew and the software installed with it will not work. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
+
+  ```powershell
+  $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue
+  ```
+
 [brew]: https://brew.sh/
 
 ## Installation of latest preview release via Homebrew on macOS 10.13 or higher
@@ -120,6 +126,12 @@ brew upgrade powershell
 >
 > If you do decide to use different methods, there are ways to correct the issue using the
 > [Homebrew link method](https://docs.brew.sh/Manpage#link-ln-options-formula).
+
+If you are running PowerShell as your login shell, note that you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. Otherwise, Homebrew and the software installed with it will not work. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
+
+  ```powershell
+  $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue
+  ```
 
 ## Installation via Direct Download
 

--- a/reference/docs-conceptual/install/Installing-PowerShell-on-macOS.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-on-macOS.md
@@ -60,7 +60,7 @@ brew upgrade powershell --cask
 > but then the PowerShell shell must be exited and restarted to complete the upgrade
 > and refresh the values shown in `$PSVersionTable`.
 
-If you are running PowerShell as your login shell, note that you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. Otherwise, Homebrew and the software installed with it will not work. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
+If you are running PowerShell as your login shell, note that you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew adjust your environment variables. Otherwise, Homebrew and the software installed with it will not work. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
 
   ```powershell
   $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue

--- a/reference/docs-conceptual/install/Installing-PowerShell-on-macOS.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-on-macOS.md
@@ -62,7 +62,7 @@ brew upgrade powershell --cask
 
 If you are running PowerShell as your login shell, note that you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew adjust your environment variables. Otherwise, Homebrew and the software installed with it will not work. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
 
-  ```powershell
+  ```PowerShell
   $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue
   ```
 

--- a/reference/docs-conceptual/install/Installing-PowerShell-on-macOS.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-on-macOS.md
@@ -127,9 +127,9 @@ brew upgrade powershell
 > If you do decide to use different methods, there are ways to correct the issue using the
 > [Homebrew link method](https://docs.brew.sh/Manpage#link-ln-options-formula).
 
-If you are running PowerShell as your login shell, note that you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew update your environment variables. Otherwise, Homebrew and the software installed with it will not work. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
+If you are running PowerShell as your login shell, note that you will need to update your [$PROFILE](/powershell/module/microsoft.powershell.core/about/about_profiles) and let Homebrew adjust your environment variables. Otherwise, Homebrew and the software installed with it will not work. This can be achieved by adding the following line to `~/.config/powershell/profile.ps1`:
 
-  ```powershell
+  ```PowerShell
   $(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue
   ```
 


### PR DESCRIPTION
# PR Summary
This extends the installation instructions on macOS and Linux to make Homebrew fully functional inside of a PowerShell session when it was not started from `zsh` but as a direct login shell (see pwsh paramter `--login | -l`).

This PR is related to new functionality that was recently added to Homebrew here:
https://github.com/Homebrew/brew/pull/12494

## PR Context
Changes where made for versions 7.0, 7.1, and 7.2 references.
Also the setup instructions for macOS were updated with similar information. Linux setup instructions were intentionally not updated to avoid confusion about Homebrew there as it is not a common use case.

**Conceptual content**
- [X] Overview and Install
- [ ] Learning PowerShell
  - [ ] PowerShell 101
  - [ ] Deep dives
  - [ ] Sample scripts
  - [ ] Remoting
- [ ] Release notes (What's New)
- [ ] Windows PowerShell
  - WMF, ISE, release notes, etc.
- [ ] DSC articles
- [ ] Community resources
- [ ] Gallery articles
- [ ] Scripting and development
  - [ ] Language Spec
  - [ ] Legacy SDK

**Cmdlet reference & about_ topics**
- [ ] Preview content
- [X] Version 7.2 content
- [X] Version 7.1 content
- [X] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**
  - If the PR is work in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the
    title and remove the prefix when the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
