### PR TITLE
Update note for Example 2

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Copy-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 08/25/2020
+ms.date: 01/18/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/copy-item?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Copy-Item
@@ -75,6 +75,9 @@ Copy-Item -Path "C:\Logfiles\*" -Destination "C:\Drawings" -Recurse
 > For example:
 >
 > `Copy-Item -Path "C:\Logfiles" -Destination "C:\Drawings" -Recurse`
+>
+> If the path `C:\Drawings` does not exist the cmdlet copies all the files from the `Logfiles` folder
+> into a single file `C:\Drawings`.
 
 ### Example 3: Copy directory and contents to a new directory
 

--- a/reference/7.0/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Copy-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 08/25/2020
+ms.date: 01/18/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/copy-item?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Copy-Item
@@ -73,6 +73,9 @@ Copy-Item -Path "C:\Logfiles\*" -Destination "C:\Drawings" -Recurse
 > For example:
 >
 > `Copy-Item -Path "C:\Logfiles" -Destination "C:\Drawings" -Recurse`
+>
+> If the path `C:\Drawings` does not exist the cmdlet copies all the files from the `Logfiles` folder
+> into a single file `C:\Drawings`.
 
 ### Example 3: Copy directory and contents to a new directory
 

--- a/reference/7.1/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Copy-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 08/25/2020
+ms.date: 01/18/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/copy-item?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Copy-Item
@@ -73,6 +73,9 @@ Copy-Item -Path "C:\Logfiles\*" -Destination "C:\Drawings" -Recurse
 > For example:
 >
 > `Copy-Item -Path "C:\Logfiles" -Destination "C:\Drawings" -Recurse`
+>
+> If the path `C:\Drawings` does not exist the cmdlet copies all the files from the `Logfiles` folder
+> into a single file `C:\Drawings`.
 
 ### Example 3: Copy directory and contents to a new directory
 

--- a/reference/7.2/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Copy-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 08/25/2020
+ms.date: 01/18/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/copy-item?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Copy-Item
@@ -73,9 +73,9 @@ Copy-Item -Path "C:\Logfiles\*" -Destination "C:\Drawings" -Recurse
 > For example:
 >
 > `Copy-Item -Path "C:\Logfiles" -Destination "C:\Drawings" -Recurse`
-
-> [!NOTE]
-> If the path `C:\Drawings` does not exist the cmdlet copies all the files from the `Logfiles` folder into a single file `C:\Drawings`.
+>
+> If the path `C:\Drawings` does not exist the cmdlet copies all the files from the `Logfiles` folder
+> into a single file `C:\Drawings`.
 
 ### Example 3: Copy directory and contents to a new directory
 

--- a/reference/7.2/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Copy-Item.md
@@ -75,7 +75,7 @@ Copy-Item -Path "C:\Logfiles\*" -Destination "C:\Drawings" -Recurse
 > `Copy-Item -Path "C:\Logfiles" -Destination "C:\Drawings" -Recurse`
 
 > [!NOTE]
-> if the path `C:\Drawings` does not exist the result of the above will be to copy all the files from the `Logfiles` folder into a single file `Drawings` in the root of C:\
+> If the path `C:\Drawings` does not exist the cmdlet copies all the files from the `Logfiles` folder into a single file `C:\Drawings`.
 
 ### Example 3: Copy directory and contents to a new directory
 

--- a/reference/7.2/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Copy-Item.md
@@ -74,6 +74,9 @@ Copy-Item -Path "C:\Logfiles\*" -Destination "C:\Drawings" -Recurse
 >
 > `Copy-Item -Path "C:\Logfiles" -Destination "C:\Drawings" -Recurse`
 
+> [!NOTE]
+> if the path `C:\Drawings` does not exist the result of the above will be to copy all the files from the `Logfiles` folder into a single file `Drawings` in the root of C:\
+
 ### Example 3: Copy directory and contents to a new directory
 
 This example copies the contents of the `C:\Logfiles` source directory and creates a new destination

--- a/reference/7.3/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Copy-Item.md
@@ -73,6 +73,9 @@ Copy-Item -Path "C:\Logfiles\*" -Destination "C:\Drawings" -Recurse
 > For example:
 >
 > `Copy-Item -Path "C:\Logfiles" -Destination "C:\Drawings" -Recurse`
+>
+> If the path `C:\Drawings` does not exist the cmdlet copies all the files from the `Logfiles` folder
+> into a single file `C:\Drawings`.
 
 ### Example 3: Copy directory and contents to a new directory
 


### PR DESCRIPTION
The second example can have undesired side effects if the target folder does not exist. The result will be to copy all the files from the source into a single file. It seems Copy-Item assumes that if the path does not exist the intended target is a file.

# PR Summary
<!--
    Summarize your changes and list related issues here. For example:

    This changes fixes problem X in the documentation for Y.
    - Fixes #1234
    - Fixes #1235
-->

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [ ] Preview content
- [ ] Version 7.2 content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _staging_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
