### PR TITLE
Add needs-triage label to templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/New_Document.yml
+++ b/.github/ISSUE_TEMPLATE/New_Document.yml
@@ -1,6 +1,8 @@
 name: New Document Request/Idea 🆕
 description: Suggest a new document or major rewrite of an existing one.
-labels: doc-idea
+labels:
+  - needs-triage
+  - doc-idea
 body:
 - type: checkboxes
   attributes:

--- a/.github/ISSUE_TEMPLATE/New_Feature.yml
+++ b/.github/ISSUE_TEMPLATE/New_Feature.yml
@@ -1,6 +1,8 @@
 name: Describe new feature or change in behavior 🚀
 description: Update existing documentation for a change in behavior or add new documentation for a new feature.
-labels: doc-idea
+labels:
+  - needs-triage
+  - doc-idea
 body:
 - type: checkboxes
   attributes:

--- a/.github/ISSUE_TEMPLATE/New_Issue.yml
+++ b/.github/ISSUE_TEMPLATE/New_Issue.yml
@@ -1,6 +1,8 @@
 name: Documentation issue report 🐛
 description: Report an issue with current documentation.
-labels: doc-bug
+labels:
+  - needs-triage
+  - doc-bug
 body:
 - type: markdown
   attributes:


### PR DESCRIPTION
# PR Summary
<!--
    Summarize your changes and list related issues here. For example:

    This changes fixes problem X in the documentation for Y.
    - Fixes #1234
    - Fixes #1235
-->
Add needs-triage label to templates

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [x] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [ ] Preview content
- [ ] Version 7.2 content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords