### PR TITLE
Update about_Foreach.md

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Foreach.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Foreach.md
@@ -178,7 +178,7 @@ function Get-FunctionPosition {
       $filesToProcess = if ($_ -is [System.IO.FileSystemInfo]) {
         $_
       } else {
-        $filesToProcess = Get-Item -Path $Path
+        Get-Item -Path $Path
       }
       $parser = [System.Management.Automation.Language.Parser]
       foreach ($item in $filesToProcess) {


### PR DESCRIPTION
The conditional expression is incorrect at line 181
```
$filesToProcess = if ($_ -is [System.IO.FileSystemInfo]) {
        $_
      } else {
        $filesToProcess = Get-Item -Path $Path
      }
```
The else block assigns the `Get-Item` results to `$filesToProcess` but the "value" of an assignment statement is `$null` (strictly, "non-existent") so the "value" of the `if else` statement is `$null` (or rather `[System.Management.Automation.Internal.AutomationNull]::Value` which behaves like `$null` or `@()` depending upon usage) which then overwrites the `Get-Item` results in `$filesToProcess`.

Fix: remove the assignment, just evaluate the `Get-Item` (to become the "value" of the `if else`).

# PR Summary
<!--
    Summarize your changes and list related issues here. For example:

    This changes fixes problem X in the documentation for Y.
    - Fixes #1234
    - Fixes #1235
-->

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [X] Preview content
- [X] Version 7.2 content
- [X] Version 7.1 content
- [X] Version 7.0 content
- [X] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [X] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
