### PR TITLE
Update about_Arrays.md

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -18,7 +18,7 @@ items.
 An array is a data structure that is designed to store a collection of items.
 The items can be the same type or different types.
 
-Beginning in Windows PowerShell 3.0, a collection of zero or one object has
+Beginning in Windows PowerShell 3.0, non-collection objects (and `$null`) have
 some properties of arrays.
 
 ## Creating and initializing an array
@@ -34,8 +34,14 @@ values of 22, 5, 10, 8, 12, 9, and 80, type:
 $A = 22,5,10,8,12,9,80
 ```
 
-The comma can also be used to initialize a single item array by placing the
-comma before the single item.
+Note that empty items are permitted but ignored. Thus
+```powershell
+$A = 22,,10,,12,,80
+```
+produces a four item array containing 22, 10, 12, and 80. This can be used to
+initialize a single item array by placing a comma before the single item. This would
+be an array of two items but the empty first item is ignored leaving only the "second"
+item to form the one item array. Note, however, that trailing commas are not permitted.
 
 For example, to create a single item array named `$B` containing the single
 value of 7, type:
@@ -52,6 +58,32 @@ $C = 5..8
 ```
 
 As a result, `$C` contains four values: 5, 6, 7, and 8.
+
+##### Caution
+Due to the way PowerShell parses a command line, spaces before a single comma prefix are
+ignored. This means that if a single item array parameter is used in a command then
+PowerShell will treat it as the remainder of an array that began with the preceding
+parameter, if this is syntactically valid. For example,
+```powershell
+$ascii_ctls = New-Object string ,[char[]](0..31) # want a string of first 32 ASCII values
+# Expect to invoke New-Object [-TypeName] <string> [[-ArgumentList] <Object[]>] as best match.
+# This New-Object expects 2nd parameter (-ArgumentList) to be an array of constructor parameters
+# but the intended [string] constructor wants one parameter which is itself an array of characters.
+```
+But PowerShell will treat this as
+```powershell
+$ascii_ctls = New-Object string,[char[]](0..31)
+# invalid, expect -TypeName/-ComObject parameter (position 0) to be a string value not an array
+```
+To avoid this, shield the parameter with parentheses
+```powershell
+$ascii_ctls = New-Object string (,[char[]](0..31)) # gives desired result
+```
+Note that shielding is still necessary even when explicitly specifying the
+parameters by name because a prepended comma is not syntactically valid when
+parsing in argument mode, see [about_Parsing](about_Parsing.md#argument-mode)
+
+## Array element type
 
 When no data type is specified, PowerShell creates each array as an object
 array (**System.Object[]**). To determine the data type of an array, use the
@@ -73,15 +105,50 @@ and 4000), type:
 [int32[]]$ia = 1500,2230,3350,4000
 ```
 
-As a result, the `$ia` array can contain only integers.
+As a result, the `$ia` array can contain only integers. In fact, any appended
+elements will be converted to integers, if possible.
 
-You can create arrays that are cast to any supported type in the .NET. For
+```powershell
+$ia += 6502
+$ia.GetType().Name
+$ia += 5.3
+$ia.GetType().Name
+$ia += '4711'
+$ia.GetType().Name
+$ia[-2,-1]
+```
+
+```Output
+Int32[]
+Int32[]
+Int32[]
+5
+4711
+```
+
+You can create arrays that are cast to any type supported by .NET. For
 example, the objects that `Get-Process` retrieves to represent processes are of
 the **System.Diagnostics.Process** type. To create a strongly typed array of
 process objects, enter the following command:
 
 ```powershell
 [Diagnostics.Process[]]$zz = Get-Process
+```
+
+Note the difference between a strongly typed array variable and a variable containing
+a strongly typed array. The latter does not remain strongly typed when manipulated,
+even when appending values of the same type as the current elements.
+
+```powershell
+$ia = [int32[]](1500,2230,3350,4000)
+$ia.GetType().Name
+$ia += 6502
+$ia.GetType().Name
+```
+
+```Output
+Int32[]
+Object[]
 ```
 
 ## The array sub-expression operator
@@ -217,12 +284,15 @@ $a[-1..-3]
 7
 ```
 
-However, be cautious when using this notation. The notation cycles from the
-end boundary to the beginning of the array.
+However, be cautious when using this notation. The index value list proceeds
+from the starting index numerical value towards the ending index numerical
+value, looping between the array's beginning and end, if necessary.
 
 ```powershell
 $a = 0 .. 9
 $a[2..-2]
+''
+$a[-2..2]
 ```
 
 ```Output
@@ -231,15 +301,22 @@ $a[2..-2]
 0
 9
 8
+
+8
+9
+0
+1
+2
 ```
 
 Also, one common mistake is to assume `$a[0..-2]` refers to all the elements
-of the array, except for the last one. It refers to the first, last, and
-second-to-last elements in the array.
+of the array, except for the last one, i.e. `$a[0,1,2,...,-2]`. However, using
+the description above it can be seen that this actually refers to the first,
+last, and second-to-last elements in the array, `$a[0,-1,-2]`.
 
-You can use the plus operator (`+`) to combine a ranges with a list of elements
-in an array. For example, to display the elements at index positions 0, 2, and
-4 through 6, type:
+You can use the plus operator (`+`) to combine ranges, lists or individual
+elements in an array. For example, to display the elements at
+index positions 0, 2, and 4 through 6 in order, type:
 
 ```powershell
 $a = 0 .. 9
@@ -254,13 +331,12 @@ $a[0,2+4..6]
 6
 ```
 
-Also, to list multiple ranges and individual elements you can use the plus
-operator. For example, to list elements zero to two, four to six, and the
-element at eighth positional type:
+Or to list elements zero to two, four to six, and the
+element at position eight, type:
 
 ```powershell
 $a = 0..9
-$a[+0..2+4..6+8]
+$a[0..2+4..6+8]
 ```
 
 ```Output
@@ -272,6 +348,10 @@ $a[+0..2+4..6+8]
 6
 8
 ```
+
+Note that the index list expression must start with an array value
+(list or range) so that the plus operator performs array appending
+instead of attempting numerical addition of a value with an array.
 
 ### Iterations over array elements
 
@@ -341,7 +421,7 @@ while($i -lt 4) {
 3
 ```
 
-## Properties of arrays
+## Properties of PowerShell arrays
 
 ### Count or Length or LongLength
 
@@ -600,9 +680,12 @@ to accept them.
 
 ### Where
 
-Allows to filter or select the elements of the array. The script must evaluate
-to anything different than: zero (0), empty string, `$false` or `$null` for the
-element to show after the `Where`. For more information about boolean
+Allows filtering to select elements of the array. Elements are selected based on
+the result of evaluating a scriptblock for each element in turn (accessable as `$_`
+or `$PSItem` within the scriptblock). An element is "selected" if the script evaluates 
+to anything other than `$false`, after converting to `[Boolean]` if necessary, i.e.
+`$false`, numeric zero (0), empty string, `$null` or an empty collection.
+For more information about boolean
 evaluation, see [about_Booleans](about_Booleans.md).
 
 There is one definition for the `Where` method.
@@ -617,22 +700,25 @@ Where(scriptblock expression[, WhereOperatorSelectionMode mode
 > the scriptblock is the only parameter. Also, there must not be a space
 > between the method and the opening parenthesis or brace.
 
-The `Expression` is scriptblock that is required for filtering, the `mode`
-optional argument allows additional selection capabilities, and the
-`numberToReturn` optional argument allows the ability to limit how many items
-are returned from the filter.
+The `expression` is the scriptblock that is required for filtering, the `mode`
+optional argument allows varying the choice of returned items, and the
+`numberToReturn` optional argument allows the ability to limit the number of
+items that are returned. Note that once the `numberToReturn` criterion has been
+fulfilled, `Where` stops processing the collection. This can affect any side-effects
+of the script block. If there are fewer than `numberToSelect` items to return then
+they are all returned in a collection smaller than `numberToSelect`.
 
-The acceptable values for `mode` are:
+The members, values and effects of the `WhereOperatorSelectionMode` enumeration (in
+conjunction with a specified `numberToReturn` or its default value) are:
 
-- Default (0) - Return all items
-- First (1) - Return the first item
-- Last (2) - Return the last item
-- SkipUntil (3) - Skip items until condition is true, the return the remaining
-  items
-- Until (4) - Return all items until condition is true
-- Split (5) - Return an array of two elements
-  - The first element contains matching items
-  - The second element contains the remaining items
+|Member Name|Value|Effect|`numberToReturn` default value|
+|-|-|------|----------------------------|
+|Default|0|Return the first `numberToReturn` selected items|Unlimited|
+|First|1|Return the first `numberToReturn` selected items|1|
+|Last|2|Return the last `numberToReturn` selected items|1|
+|SkipUntil|3|Skip items until a selected item is found, then return the selected item and *all* subsequent items (selected or not), up to `numberToReturn` items|Unlimited|
+|Until|4|Return *all* items, up to `numberToReturn` items, until but not including the first selected item|Unlimited|
+|Split|5|Return a two element array<br> &bull; The first element contains the first `numberToReturn` selected items<br> &bull; The second element contains *all* the remaining items|Unlimited|
 
 The following example shows how to select all odd numbers from the array.
 
@@ -661,23 +747,31 @@ there
 
 #### Default
 
-The `Default` mode filters items using the `Expression` scriptblock.
+Mode value used if `mode` not specified.
 
-If a `numberToReturn` is provided, it specifies the maximum number of items
-to return.
+#### First
+
+The `Default` and `First` modes both select items using the `expression` scriptblock.
+The difference is the default value of `numberToReturn` if it is not specified.
+If `numberToReturn` is supplied, the `Default` and `First` modes are identical.
 
 ```powershell
 # Get the zip files in the current users profile, sorted by LastAccessTime.
 $Zips = dir $env:userprofile -Recurse '*.zip' | Sort-Object LastAccessTime
 # Get the least accessed file over 100MB
 $Zips.Where({$_.Length -gt 100MB}, 'Default', 1)
+# mode member name strings automatically cast to enumeration type
+$Zips.Where({$_.Length -gt 100MB}, 'First') # same result
 ```
 
-> [!NOTE]
-> Both the `Default` mode and `First` mode return the first
-> (`numberToReturn`) items, and can be used interchangeably.
-
 #### Last
+
+Like `Default` and `First`, the `Last` mode selects items using the `expression` scriptblock.
+However, instead of returning `numberToReturn` selected items starting from the first selected item,
+`Last` returns all the remaining selected items starting `numberToReturn` items from the the end
+of the list of selected items, implying that all items must be tested before `numberToReturn`
+is applied. (note: the last selected item is considered to be one item from the end of the selection
+list).
 
 ```powershell
 $h = (Get-Date).AddHours(-1)
@@ -688,15 +782,13 @@ $logs.Where({$_.CreationTime -gt $h}, 'Last', 5)
 
 #### SkipUntil
 
-The `SkipUntil` mode skips all objects in a collection until an object passes
-the script block expression filter. It then returns **ALL** remaining collection
-items without testing them. _Only one passing item is tested_.
+The `SkipUntil` mode skips items until an item *passes* the script block expression filter.
+It then returns this item and **ALL** subsequent collection
+items without testing them. _Only the **first** returned item has been tested_.
 
-This means the returned collection contains both _passing_ and
-_non-passing_ items that have NOT been tested.
-
-The number of items returned can be limited by passing a value to the
-`numberToReturn` argument.
+This means that the returned collection can contain both _passing_ and
+_non-passing_ items that have NOT been tested. This can affect any side-effects of the
+script block similarly to the effect of `numberToReturn`.
 
 ```powershell
 $computers = "Server01", "Server02", "Server03", "localhost", "Server04"
@@ -710,15 +802,12 @@ localhost
 
 #### Until
 
-The `Until` mode inverts the `SkipUntil` mode.  It returns **ALL** items in a
-collection until an item passes the script block expression. Once an item
-_passes_ the scriptblock expression, the `Where` method stops processing items.
+The `Until` mode inverts the `SkipUntil` mode.  It returns `numberToReturn` items in a
+collection up to, but not including, the first item which *passes* the script block expression.
+Once an item _passes_ the scriptblock expression, the `Where` method stops processing items.
 
 This means that you receive the first set of _non-passing_ items from the
 `Where` method. _After_ one item passes, the rest are NOT tested or returned.
-
-The number of items returned can be limited by passing a value to the
-`numberToReturn` argument.
 
 ```powershell
 # Retrieve the first set of numbers less than or equal to 10.
@@ -740,25 +829,16 @@ The number of items returned can be limited by passing a value to the
 10
 ```
 
-> [!NOTE]
-> Both `Until` and `SkipUntil` operate under the premise of NOT testing a batch
-> of items.
->
-> `Until` returns the items **BEFORE** the first _pass_.
->
-> `SkipUntil` returns all the items **AFTER** the first _pass_, including the
-> first passing item.
-
 #### Split
 
-The `Split` mode splits, or groups collection items into two separate
+The `Split` mode groups the collection items into two separate
 collections. Those that pass the scriptblock expression, and those that do not.
 
-If a `numberToReturn` is specified, the first collection, contains the
-_passing_ items, not to exceed the value specified.
+If `numberToReturn` is specified, the first collection only contains up to this
+many _passing_ items.
 
-The remaining objects, even those that **PASS** the expression filter, are
-returned in the second collection.
+The remaining objects, including those beyond `numberToReturn` that would have
+**PASSED** the expression filter, are returned in the second collection.
 
 ```powershell
 $running, $stopped = (Get-Service).Where({$_.Status -eq 'Running'}, 'Split')
@@ -788,7 +868,14 @@ Stopped  AppIDSvc           Application Identity
 ```
 
 > [!NOTE]
-> Both `foreach` and `where` methods are intrinsic members. For more information
+> Both the `ForEach` and `Where` methods are intrinsic members. This means that all PowerShell
+> objects may invoke them. If an object which is not a collection type (i.e. a type that implements
+> `[System.Collections.IEnumerable]`) invokes `ForEach` or `Where`,
+> it is treated as an array of one element, being the invoking object. See
+[Arrays of zero or one](#arrays-of-zero-or-one). For example,
+> `$nonarrayobj.ForEach{ }` is treated as `@($nonarrayobj).ForEach{ }`. Further, some .NET types
+> already define their own `ForEach` method. In cases where an object type already defines a `ForEach`
+> or `Where` method, these take precedence over the PowerShell intrinsic methods. For more information
 > about intrinsic members, see [about_Instrinsic_Members](about_Intrinsic_Members.md)
 
 ## Get the members of an array
@@ -812,9 +899,9 @@ Get-Member -InputObject $a
 ```
 
 You can also get the members of an array by typing a comma (,) before the
-value that is piped to the `Get-Member` cmdlet. The comma makes the array the
-second item in an array of arrays. PowerShell pipes the arrays one at
-a time and `Get-Member` returns the members of the array. Like the next two
+value that is piped to the `Get-Member` cmdlet. The comma makes the value
+the only item in an array of items. PowerShell pipes the array item as a whole and
+`Get-Member` returns the members of the passed whole array object. Like the next two
 examples.
 
 ```powershell
@@ -850,7 +937,7 @@ You can use the `+=` operator to add an element to an array. The following
 example shows how to add an element to the `$a` array.
 
 ```powershell
-$a = @(0..4)
+$a = 0..4
 $a += 5
 ```
 
@@ -891,19 +978,33 @@ faster, especially for large arrays.
 
 ## Arrays of zero or one
 
-Beginning in Windows PowerShell 3.0, a collection of zero or one object has
-the Count and Length property. Also, you can index into an array of one
-object. This feature helps you to avoid scripting errors that occur when a
-command that expects a collection gets fewer than two items.
+Beginning in Windows PowerShell 3.0, both a single (non-collection) object
+and `$null` can be treated as an array in certain contexts. Within these contexts,
+`$null` is treated as an empty array `@()` while a non-collection object is treated
+as a one item array containing just that object. Thus, you can access the following
+properties and methods of PowerShell arrays,
+
+- Count
+- Length
+- ForEach()
+- Where()
+
+You can also apply indexing to a non-collection object (but not `$null`).
+This feature helps you to
+avoid scripting errors that occur when a command that expects a collection gets
+`$null` or a non-collection object, often because the supplied input was a pipeline
+output that contained fewer than two items.
 
 The following examples demonstrate this feature.
 
-### Zero objects
+### $null
 
 ```powershell
 $a = $null
 $a.Count
 $a.Length
+$a.ForEach({$_}) # valid but no items so
+$a.Where({$True}) # no output, not even $null
 ```
 
 ```Output
@@ -917,14 +1018,18 @@ $a.Length
 $a = 4
 $a.Count
 $a.Length
-$a[0]
-$a[-1]
+$a[0] # first (only) item is object
+$a[-1] # and also last item
+$a.ForEach({ $_ * 2 })
+$a.Where({ $_ -lt 10 })
 ```
 
 ```Output
 1
 1
 4
+4
+8
 4
 ```
 


### PR DESCRIPTION
The current description of `.Where()` is somewhat ambiguous and incomplete.
- Also, included the word "PowerShell" to distinguish between "methods" of PowerShell arrays and `[Array]::ForEach` or other class objects which might have a `ForEach` (or `Where`) method which overrides the PowerShell behaviour (such as `[System.Collections.Generic.List<T>]`).
- Fixed some grammar.
- Fixed capitalisation of parameter names to match definitions.
- Deleted some references to `numberToReturn` as the effect is described clearly in the summary table.
- Removed note regarding `Until` and `SkipUntil` not testing some items since the description covers this and it can also occur due to the effect of `numberToReturn` and so is not limited to these two modes.

Outside `Where` section

- Expanded description of "intrinsic members" since no description in the linked article of the result when `ForEach` and `Where` are used on non-arrays (just a reference to this article).
- Added extra information regarding non-existent elements (the basis of the single prepended comma notation) and included a warning about how this is interpreted by the command line parser.
- Improved wording for "Arrays of zero or one" to clearly state that this feature applies to non-collections, not actual collections of length zero or one. Also added reference to `ForEach` and `Where`. Wanted to describe the difference between `$null` and `[System.Management.Automation.Internal.AutomationNull]::Value` but decided it would be too technically verbose and likely not relevant to this section.
- Added note that array slice list expressions must begin with an array value to correctly invoke array appending.

# PR Summary
<!--
    Summarize your changes and list related issues here. For example:

    This changes fixes problem X in the documentation for Y.
    - Fixes #1234
    - Fixes #1235
-->

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [ ] Preview content
- [X] Version 7.2 content
- [X] Version 7.1 content
- [X] Version 7.0 content
- [X] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
