### PR TITLE
Fix mismatching key bindings for PSReadLine 2.2

### DIFF
--- a/reference/7.2/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.2/PSReadLine/About/about_PSReadLine.md
@@ -92,6 +92,8 @@ The following functions are available in the class
 Abort current action, for example: incremental history search.
 
 - Emacs: `<Ctrl+g>`
+- Vi insert mode: `<Ctrl+g>`
+- Vi command mode: `<Ctrl+g>`
 
 ### AcceptAndGetNext
 
@@ -719,8 +721,6 @@ previous line of multi-line input.
 
 - Cmd: `<LeftArrow>`
 - Emacs: `<LeftArrow>`, `<Ctrl+b>`
-- Vi insert mode: `<LeftArrow>`
-- Vi command mode: `<LeftArrow>`, `<Backspace>`, `<h>`
 
 ### BackwardWord
 
@@ -761,8 +761,6 @@ next line of multi-line input.
 
 - Cmd: `<RightArrow>`
 - Emacs: `<RightArrow>`, `<Ctrl+f>`
-- Vi insert mode: `<RightArrow>`
-- Vi command mode: `<RightArrow>`, `<Space>`, `<l>`
 
 ### ForwardWord
 
@@ -931,6 +929,8 @@ Perform an incremental forward search through history.
 
 - Cmd: `<Ctrl+s>`
 - Emacs: `<Ctrl+s>`
+- Vi insert mode: `<Ctrl+s>`
+- Vi command mode: `<Ctrl+s>`
 
 ### HistorySearchBackward
 
@@ -970,13 +970,14 @@ Perform an incremental backward search through history.
 
 - Cmd: `<Ctrl+r>`
 - Emacs: `<Ctrl+r>`
+- Vi insert mode: `<Ctrl+r>`
+- Vi command mode: `<Ctrl+r>`
 
 ### ViSearchHistoryBackward
 
 Prompts for a search string and initiates search upon AcceptLine.
 
-- Vi insert mode: `<Ctrl+r>`
-- Vi command mode: `</>`, `<Ctrl+r>`
+- Vi command mode: `</>`
 
 ## Completion functions
 
@@ -1429,8 +1430,7 @@ character. This is for 't' functionality.
 
 Prompts for a search string and initiates search upon AcceptLine.
 
-- Vi insert mode: `<Ctrl+s>`
-- Vi command mode: `<?>`, `<Ctrl+s>`
+- Vi command mode: `<?>`
 
 ## Custom Key Bindings
 
@@ -1674,6 +1674,15 @@ ConvertTo-SecureString stringValue -AsPlainText # '-AsPlainText' is an alert.
 Invoke-WebRequest -Token xxx # Expr-value as argument to '-Token'.
 Get-ResultFromTwo -Secret1 (Get-Secret -Name blah -AsPlainText) -Secret2 sdv87ysdfayf798hfasd8f7ha # '-Secret2' has expr-value argument.
 ```
+
+### Behavior of the OnIdle event
+
+When PSReadLine is in use, the **OnIdle** event is fired when `ReadKey()` times out (no typing in
+300ms). The event could be signaled while the user is in the middle of editing a command line, for
+example, the user is reading help to decide which parameter to use.
+
+Beginning in PSReadLine 2.2.0-beta4, **OnIdle** behavior changed to signal the event only if there
+is a `ReadKey()` timeout and the current editing buffer is empty.
 
 ### Feedback & Contributing To PSReadLine
 

--- a/reference/7.3/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.3/PSReadLine/About/about_PSReadLine.md
@@ -92,6 +92,8 @@ The following functions are available in the class
 Abort current action, for example: incremental history search.
 
 - Emacs: `<Ctrl+g>`
+- Vi insert mode: `<Ctrl+g>`
+- Vi command mode: `<Ctrl+g>`
 
 ### AcceptAndGetNext
 
@@ -719,8 +721,6 @@ previous line of multi-line input.
 
 - Cmd: `<LeftArrow>`
 - Emacs: `<LeftArrow>`, `<Ctrl+b>`
-- Vi insert mode: `<LeftArrow>`
-- Vi command mode: `<LeftArrow>`, `<Backspace>`, `<h>`
 
 ### BackwardWord
 
@@ -761,8 +761,6 @@ next line of multi-line input.
 
 - Cmd: `<RightArrow>`
 - Emacs: `<RightArrow>`, `<Ctrl+f>`
-- Vi insert mode: `<RightArrow>`
-- Vi command mode: `<RightArrow>`, `<Space>`, `<l>`
 
 ### ForwardWord
 
@@ -931,6 +929,8 @@ Perform an incremental forward search through history.
 
 - Cmd: `<Ctrl+s>`
 - Emacs: `<Ctrl+s>`
+- Vi insert mode: `<Ctrl+s>`
+- Vi command mode: `<Ctrl+s>`
 
 ### HistorySearchBackward
 
@@ -970,13 +970,14 @@ Perform an incremental backward search through history.
 
 - Cmd: `<Ctrl+r>`
 - Emacs: `<Ctrl+r>`
+- Vi insert mode: `<Ctrl+r>`
+- Vi command mode: `<Ctrl+r>`
 
 ### ViSearchHistoryBackward
 
 Prompts for a search string and initiates search upon AcceptLine.
 
-- Vi insert mode: `<Ctrl+r>`
-- Vi command mode: `</>`, `<Ctrl+r>`
+- Vi command mode: `</>`
 
 ## Completion functions
 
@@ -1429,8 +1430,7 @@ character. This is for 't' functionality.
 
 Prompts for a search string and initiates search upon AcceptLine.
 
-- Vi insert mode: `<Ctrl+s>`
-- Vi command mode: `<?>`, `<Ctrl+s>`
+- Vi command mode: `<?>`
 
 ## Custom Key Bindings
 


### PR DESCRIPTION
# PR Summary

Fix mismatching key bindings for PSReadLine 2.2.
Also, copy the content about "Behavior of the OnIdle event" to 7.2 about doc.
PSReadLine 2.2 doesn't ship along with PowerShell 7.2. It will reach GA mid next month. So, I think we should get the 7.2 about doc up to date.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [x] Version 7.2 content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
