### PR TITLE
Fixes #8526 - Fix $NestedPromptLevel value

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the `Prompt` function and demonstrates how to create a custom `Prompt` function.
 Locale: en-US
-ms.date: 04/15/2020
+ms.date: 01/26/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_prompts?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Prompts
@@ -141,8 +141,8 @@ PS C:\ps-test>
 ```
 
 If you are in a nested prompt, the function adds two angle brackets (`>>`) to
-the prompt. (You are in a nested prompt if the value of the
-`$NestedPromptLevel` automatic variable is greater than 1.)
+the prompt. You are in a nested prompt if the value of the `$NestedPromptLevel`
+automatic variable is greater than 0.
 
 For example, when you are debugging in a nested prompt, the prompt resembles
 the following prompt:

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the `Prompt` function and demonstrates how to create a custom `Prompt` function.
 Locale: en-US
-ms.date: 04/15/2020
+ms.date: 01/26/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_prompts?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Prompts
@@ -141,8 +141,8 @@ PS C:\ps-test>
 ```
 
 If you are in a nested prompt, the function adds two angle brackets (`>>`) to
-the prompt. (You are in a nested prompt if the value of the
-`$NestedPromptLevel` automatic variable is greater than 1.)
+the prompt. You are in a nested prompt if the value of the `$NestedPromptLevel`
+automatic variable is greater than 0.
 
 For example, when you are debugging in a nested prompt, the prompt resembles
 the following prompt:

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the `Prompt` function and demonstrates how to create a custom `Prompt` function.
 Locale: en-US
-ms.date: 04/15/2020
+ms.date: 01/26/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_prompts?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Prompts
@@ -141,8 +141,8 @@ PS C:\ps-test>
 ```
 
 If you are in a nested prompt, the function adds two angle brackets (`>>`) to
-the prompt. (You are in a nested prompt if the value of the
-`$NestedPromptLevel` automatic variable is greater than 1.)
+the prompt. You are in a nested prompt if the value of the `$NestedPromptLevel`
+automatic variable is greater than 0.
 
 For example, when you are debugging in a nested prompt, the prompt resembles
 the following prompt:
@@ -294,4 +294,3 @@ profiles. For more information about profiles, see [about_Profiles](about_Profil
 [about_Debuggers](about_Debuggers.md)
 
 [about_Automatic_Variables](about_Automatic_Variables.md)
-

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the `Prompt` function and demonstrates how to create a custom `Prompt` function.
 Locale: en-US
-ms.date: 04/15/2020
+ms.date: 01/26/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_prompts?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Prompts
@@ -141,8 +141,8 @@ PS C:\ps-test>
 ```
 
 If you are in a nested prompt, the function adds two angle brackets (`>>`) to
-the prompt. (You are in a nested prompt if the value of the
-`$NestedPromptLevel` automatic variable is greater than 1.)
+the prompt. You are in a nested prompt if the value of the `$NestedPromptLevel`
+automatic variable is greater than 0.
 
 For example, when you are debugging in a nested prompt, the prompt resembles
 the following prompt:
@@ -294,4 +294,3 @@ profiles. For more information about profiles, see [about_Profiles](about_Profil
 [about_Debuggers](about_Debuggers.md)
 
 [about_Automatic_Variables](about_Automatic_Variables.md)
-

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the `Prompt` function and demonstrates how to create a custom `Prompt` function.
 Locale: en-US
-ms.date: 04/15/2020
+ms.date: 01/26/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_prompts?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Prompts
@@ -141,8 +141,8 @@ PS C:\ps-test>
 ```
 
 If you are in a nested prompt, the function adds two angle brackets (`>>`) to
-the prompt. (You are in a nested prompt if the value of the
-`$NestedPromptLevel` automatic variable is greater than 1.)
+the prompt. You are in a nested prompt if the value of the `$NestedPromptLevel`
+automatic variable is greater than 0.
 
 For example, when you are debugging in a nested prompt, the prompt resembles
 the following prompt:
@@ -294,4 +294,3 @@ profiles. For more information about profiles, see [about_Profiles](about_Profil
 [about_Debuggers](about_Debuggers.md)
 
 [about_Automatic_Variables](about_Automatic_Variables.md)
-


### PR DESCRIPTION
# PR Summary
<!--
    Summarize your changes and list related issues here. For example:

    This changes fixes problem X in the documentation for Y.
    - Fixes #1234
    - Fixes #1235
-->
Fixes [AB#1912421](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1912421) - Fixes #8526 - Fix $NestedPromptLevel value

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [x] Version 7.2 content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords