### PR TITLE
Split code block from regular text

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -71,7 +71,7 @@ session.
 
 ## Examples
 
-### Example 1: Start debugging a runspace within the PowerShell ISE process
+### Example Part 1: Start debugging a runspace within the PowerShell ISE process
 
 In this example, you run `Enter-PSHostProcess` from within the PowerShell console to enter the
 PowerShell ISE process. In the resulting interactive session, you can find a runspace that you want
@@ -79,12 +79,6 @@ to debug by running `Get-Runspace`, and then debug the runspace.
 
 ```
 PS C:\> Enter-PSHostProcess -Name powershell_ise
-[Process:1520]: PS C:\Test\Documents>
-```
-
-Next, get available runspaces within the process you have entered.
-
-```
 [Process:1520]: PS C:\>  Get-Runspace
 Id    Name          InstanceId                               State           Availability
 --    -------       -----------                              ------          -------------
@@ -95,11 +89,13 @@ Id    Name          InstanceId                               State           Ava
 5     Runspace8     3e517382-a97a-49ba-9c3c-fd21f6664288     Broken          None
 ```
 
-The runspace objects returned by Get-Runspace also have a NoteProperty called ScriptStackTrace of
-the running command stack, if available. Next, debug runspace ID 4, that is running another user's
-long-running script. From the list returned from Get-Runspace, note that the runspace state is
-Opened, and Availability is Busy, meaning that the runspace is still running the long-running
-script.
+### Example part 2: Debug a specific runspace
+
+Next, debug runspace ID 4, that is running another user's long-running script. From the list
+returned from `Get-Runspace`, note that the runspace **State** is Opened, and **Availability** is
+Busy, meaning that the runspace is still running the long-running script. The runspace objects
+returned by `Get-Runspace` also have a **NoteProperty** called **ScriptStackTrace** of the running
+command stack, if available.
 
 ```
 [Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
@@ -109,11 +105,7 @@ MyModuleWorkflowF1         {}                                  TestNoFile3.psm1:
 WFTest1                    {}                                  TestNoFile2.ps1: line 14
 TestNoFile2.ps1            {}                                  TestNoFile2.ps1: line 22
 <ScriptBlock>              {}                                  <No file>
-```
 
-Start an interactive debugging session with this runspace by running the Debug-Runspace cmdlet.
-
-```
 [Process: 1520]: PS C:\>  Debug-Runspace -Id 4
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 
@@ -121,22 +113,23 @@ At C:\TestWFVar1.ps1:83 char:1
 + $scriptVar = "Script Variable"
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-[Process: 1520]: [RSDBG: 4]: PS C:\> >
+[Process: 1520]: [RSDBG: 4]: PS C:\>
 ```
+
+Start an interactive debugging session with this runspace by running the `Debug-Runspace` cmdlet.
+
+### Example part 3: Finish the debugging session and exit
 
 After you are finished debugging, allow the script to continue running without the debugger attached
 by running the exit debugger command. Alternatively, you can quit the debugger with the q or Stop
 commands.
 
-```
-[Process:346]: [RSDBG: 3]: PS C:\> > exit
-[Process:1520]: PS C:\>
-```
-
 When you are finished working in the process, exit the process by running the `Exit-PSHostProcess`
 cmdlet. This returns you to the `PS C:\>` prompt.
 
 ```
+[Process:346]: [RSDBG: 3]: PS C:\> exit
+[Process:1520]: PS C:\>
 [Process:1520]: PS C:\>  Exit-PSHostProcess
 PS C:\>
 ```

--- a/reference/5.1/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -2,8 +2,8 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
-online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/enter-pshostprocess?view=powershell-5.1&WT.mc_id=ps-gethelp
+ms.date: 01/31/2022
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/enter-pshostprocess?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enter-PSHostProcess
 ---
@@ -80,9 +80,12 @@ to debug by running `Get-Runspace`, and then debug the runspace.
 ```
 PS C:\> Enter-PSHostProcess -Name powershell_ise
 [Process:1520]: PS C:\Test\Documents>
+```
 
 Next, get available runspaces within the process you have entered.
-PS C:\> [Process:1520]: PS C:\>  Get-Runspace
+
+```
+[Process:1520]: PS C:\>  Get-Runspace
 Id    Name          InstanceId                               State           Availability
 --    -------       -----------                              ------          -------------
 1     Runspace1     2d91211d-9cce-42f0-ab0e-71ac258b32b5     Opened          Available
@@ -90,24 +93,28 @@ Id    Name          InstanceId                               State           Ava
 3     MyLocalRS     2236dbd8-2105-4dec-a15a-a27d0bfaacb5     Opened          LocalDebug
 4     MyRunspace    771356e9-8c44-4b70-9de5-dd17cb41e48e     Opened          Busy
 5     Runspace8     3e517382-a97a-49ba-9c3c-fd21f6664288     Broken          None
+```
 
 The runspace objects returned by Get-Runspace also have a NoteProperty called ScriptStackTrace of
-the running command stack, if available.Next, debug runspace ID 4, that is running another user's
+the running command stack, if available. Next, debug runspace ID 4, that is running another user's
 long-running script. From the list returned from Get-Runspace, note that the runspace state is
 Opened, and Availability is Busy, meaning that the runspace is still running the long-running
 script.
 
-PS C:\> [Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
+```
+[Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
 Command                    Arguments                           Location
 -------                    ---------                           --------
 MyModuleWorkflowF1         {}                                  TestNoFile3.psm1: line 6
 WFTest1                    {}                                  TestNoFile2.ps1: line 14
 TestNoFile2.ps1            {}                                  TestNoFile2.ps1: line 22
 <ScriptBlock>              {}                                  <No file>
+```
 
 Start an interactive debugging session with this runspace by running the Debug-Runspace cmdlet.
 
-PS C:\> [Process: 1520]: PS C:\>  Debug-Runspace -Id 4
+```
+[Process: 1520]: PS C:\>  Debug-Runspace -Id 4
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 
 At C:\TestWFVar1.ps1:83 char:1
@@ -115,18 +122,22 @@ At C:\TestWFVar1.ps1:83 char:1
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [Process: 1520]: [RSDBG: 4]: PS C:\> >
+```
 
 After you are finished debugging, allow the script to continue running without the debugger attached
 by running the exit debugger command. Alternatively, you can quit the debugger with the q or Stop
 commands.
 
-PS C:\> [Process:346]: [RSDBG: 3]: PS C:\> > exit
+```
+[Process:346]: [RSDBG: 3]: PS C:\> > exit
 [Process:1520]: PS C:\>
+```
 
-When you are finished working in the process, exit the process by running the Exit-PSHostProcess
-cmdlet. This returns you to the PS C:\> prompt.
+When you are finished working in the process, exit the process by running the `Exit-PSHostProcess`
+cmdlet. This returns you to the `PS C:\>` prompt.
 
-PS C:\> [Process:1520]: PS C:\>  Exit-PSHostProcess
+```
+[Process:1520]: PS C:\>  Exit-PSHostProcess
 PS C:\>
 ```
 

--- a/reference/7.0/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 11/04/2019
+ms.date: 01/31/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/enter-pshostprocess?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enter-PSHostProcess
@@ -86,9 +86,12 @@ to debug by running `Get-Runspace`, and then debug the runspace.
 ```
 PS C:\> Enter-PSHostProcess -Name powershell_ise
 [Process:1520]: PS C:\Test\Documents>
+```
 
 Next, get available runspaces within the process you have entered.
-PS C:\> [Process:1520]: PS C:\>  Get-Runspace
+
+```
+[Process:1520]: PS C:\>  Get-Runspace
 Id    Name          InstanceId                               State           Availability
 --    -------       -----------                              ------          -------------
 1     Runspace1     2d91211d-9cce-42f0-ab0e-71ac258b32b5     Opened          Available
@@ -96,24 +99,28 @@ Id    Name          InstanceId                               State           Ava
 3     MyLocalRS     2236dbd8-2105-4dec-a15a-a27d0bfaacb5     Opened          LocalDebug
 4     MyRunspace    771356e9-8c44-4b70-9de5-dd17cb41e48e     Opened          Busy
 5     Runspace8     3e517382-a97a-49ba-9c3c-fd21f6664288     Broken          None
+```
 
 The runspace objects returned by Get-Runspace also have a NoteProperty called ScriptStackTrace of
-the running command stack, if available.Next, debug runspace ID 4, that is running another user's
+the running command stack, if available. Next, debug runspace ID 4, that is running another user's
 long-running script. From the list returned from Get-Runspace, note that the runspace state is
 Opened, and Availability is Busy, meaning that the runspace is still running the long-running
 script.
 
-PS C:\> [Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
+```
+[Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
 Command                    Arguments                           Location
 -------                    ---------                           --------
 MyModuleWorkflowF1         {}                                  TestNoFile3.psm1: line 6
 WFTest1                    {}                                  TestNoFile2.ps1: line 14
 TestNoFile2.ps1            {}                                  TestNoFile2.ps1: line 22
 <ScriptBlock>              {}                                  <No file>
+```
 
 Start an interactive debugging session with this runspace by running the Debug-Runspace cmdlet.
 
-PS C:\> [Process: 1520]: PS C:\>  Debug-Runspace -Id 4
+```
+[Process: 1520]: PS C:\>  Debug-Runspace -Id 4
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 
 At C:\TestWFVar1.ps1:83 char:1
@@ -121,18 +128,22 @@ At C:\TestWFVar1.ps1:83 char:1
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [Process: 1520]: [RSDBG: 4]: PS C:\> >
+```
 
 After you are finished debugging, allow the script to continue running without the debugger attached
 by running the exit debugger command. Alternatively, you can quit the debugger with the q or Stop
 commands.
 
-PS C:\> [Process:346]: [RSDBG: 3]: PS C:\> > exit
+```
+[Process:346]: [RSDBG: 3]: PS C:\> > exit
 [Process:1520]: PS C:\>
+```
 
-When you are finished working in the process, exit the process by running the Exit-PSHostProcess
-cmdlet. This returns you to the PS C:\> prompt.
+When you are finished working in the process, exit the process by running the `Exit-PSHostProcess`
+cmdlet. This returns you to the `PS C:\>` prompt.
 
-PS C:\> [Process:1520]: PS C:\>  Exit-PSHostProcess
+```
+[Process:1520]: PS C:\>  Exit-PSHostProcess
 PS C:\>
 ```
 

--- a/reference/7.0/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -77,7 +77,7 @@ session.
 
 ## Examples
 
-### Example 1: Start debugging a runspace within the PowerShell ISE process
+### Example Part 1: Start debugging a runspace within the PowerShell ISE process
 
 In this example, you run `Enter-PSHostProcess` from within the PowerShell console to enter the
 PowerShell ISE process. In the resulting interactive session, you can find a runspace that you want
@@ -85,12 +85,6 @@ to debug by running `Get-Runspace`, and then debug the runspace.
 
 ```
 PS C:\> Enter-PSHostProcess -Name powershell_ise
-[Process:1520]: PS C:\Test\Documents>
-```
-
-Next, get available runspaces within the process you have entered.
-
-```
 [Process:1520]: PS C:\>  Get-Runspace
 Id    Name          InstanceId                               State           Availability
 --    -------       -----------                              ------          -------------
@@ -101,11 +95,13 @@ Id    Name          InstanceId                               State           Ava
 5     Runspace8     3e517382-a97a-49ba-9c3c-fd21f6664288     Broken          None
 ```
 
-The runspace objects returned by Get-Runspace also have a NoteProperty called ScriptStackTrace of
-the running command stack, if available. Next, debug runspace ID 4, that is running another user's
-long-running script. From the list returned from Get-Runspace, note that the runspace state is
-Opened, and Availability is Busy, meaning that the runspace is still running the long-running
-script.
+### Example part 2: Debug a specific runspace
+
+Next, debug runspace ID 4, that is running another user's long-running script. From the list
+returned from `Get-Runspace`, note that the runspace **State** is Opened, and **Availability** is
+Busy, meaning that the runspace is still running the long-running script. The runspace objects
+returned by `Get-Runspace` also have a **NoteProperty** called **ScriptStackTrace** of the running
+command stack, if available.
 
 ```
 [Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
@@ -115,11 +111,7 @@ MyModuleWorkflowF1         {}                                  TestNoFile3.psm1:
 WFTest1                    {}                                  TestNoFile2.ps1: line 14
 TestNoFile2.ps1            {}                                  TestNoFile2.ps1: line 22
 <ScriptBlock>              {}                                  <No file>
-```
 
-Start an interactive debugging session with this runspace by running the Debug-Runspace cmdlet.
-
-```
 [Process: 1520]: PS C:\>  Debug-Runspace -Id 4
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 
@@ -127,22 +119,23 @@ At C:\TestWFVar1.ps1:83 char:1
 + $scriptVar = "Script Variable"
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-[Process: 1520]: [RSDBG: 4]: PS C:\> >
+[Process: 1520]: [RSDBG: 4]: PS C:\>
 ```
+
+Start an interactive debugging session with this runspace by running the `Debug-Runspace` cmdlet.
+
+### Example part 3: Finish the debugging session and exit
 
 After you are finished debugging, allow the script to continue running without the debugger attached
 by running the exit debugger command. Alternatively, you can quit the debugger with the q or Stop
 commands.
 
-```
-[Process:346]: [RSDBG: 3]: PS C:\> > exit
-[Process:1520]: PS C:\>
-```
-
 When you are finished working in the process, exit the process by running the `Exit-PSHostProcess`
 cmdlet. This returns you to the `PS C:\>` prompt.
 
 ```
+[Process:346]: [RSDBG: 3]: PS C:\> exit
+[Process:1520]: PS C:\>
 [Process:1520]: PS C:\>  Exit-PSHostProcess
 PS C:\>
 ```

--- a/reference/7.1/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -86,8 +86,11 @@ to debug by running `Get-Runspace`, and then debug the runspace.
 ```
 PS C:\> Enter-PSHostProcess -Name powershell_ise
 [Process:1520]: PS C:\Test\Documents>
+```
 
 Next, get available runspaces within the process you have entered.
+
+```
 PS C:\> [Process:1520]: PS C:\>  Get-Runspace
 Id    Name          InstanceId                               State           Availability
 --    -------       -----------                              ------          -------------
@@ -96,13 +99,15 @@ Id    Name          InstanceId                               State           Ava
 3     MyLocalRS     2236dbd8-2105-4dec-a15a-a27d0bfaacb5     Opened          LocalDebug
 4     MyRunspace    771356e9-8c44-4b70-9de5-dd17cb41e48e     Opened          Busy
 5     Runspace8     3e517382-a97a-49ba-9c3c-fd21f6664288     Broken          None
+```
 
 The runspace objects returned by Get-Runspace also have a NoteProperty called ScriptStackTrace of
-the running command stack, if available.Next, debug runspace ID 4, that is running another user's
+the running command stack, if available. Next, debug runspace ID 4, that is running another user's
 long-running script. From the list returned from Get-Runspace, note that the runspace state is
 Opened, and Availability is Busy, meaning that the runspace is still running the long-running
 script.
 
+```
 PS C:\> [Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
 Command                    Arguments                           Location
 -------                    ---------                           --------
@@ -110,9 +115,11 @@ MyModuleWorkflowF1         {}                                  TestNoFile3.psm1:
 WFTest1                    {}                                  TestNoFile2.ps1: line 14
 TestNoFile2.ps1            {}                                  TestNoFile2.ps1: line 22
 <ScriptBlock>              {}                                  <No file>
+```
 
 Start an interactive debugging session with this runspace by running the Debug-Runspace cmdlet.
 
+```
 PS C:\> [Process: 1520]: PS C:\>  Debug-Runspace -Id 4
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 
@@ -121,17 +128,21 @@ At C:\TestWFVar1.ps1:83 char:1
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [Process: 1520]: [RSDBG: 4]: PS C:\> >
+```
 
 After you are finished debugging, allow the script to continue running without the debugger attached
 by running the exit debugger command. Alternatively, you can quit the debugger with the q or Stop
 commands.
 
+```
 PS C:\> [Process:346]: [RSDBG: 3]: PS C:\> > exit
 [Process:1520]: PS C:\>
+```
 
-When you are finished working in the process, exit the process by running the Exit-PSHostProcess
+When you are finished working in the process, exit the process by running the `Exit-PSHostProcess`
 cmdlet. This returns you to the PS C:\> prompt.
 
+```
 PS C:\> [Process:1520]: PS C:\>  Exit-PSHostProcess
 PS C:\>
 ```

--- a/reference/7.1/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 07/23/2020
+ms.date: 01/31/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/enter-pshostprocess?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enter-PSHostProcess
@@ -91,7 +91,7 @@ PS C:\> Enter-PSHostProcess -Name powershell_ise
 Next, get available runspaces within the process you have entered.
 
 ```
-PS C:\> [Process:1520]: PS C:\>  Get-Runspace
+[Process:1520]: PS C:\>  Get-Runspace
 Id    Name          InstanceId                               State           Availability
 --    -------       -----------                              ------          -------------
 1     Runspace1     2d91211d-9cce-42f0-ab0e-71ac258b32b5     Opened          Available
@@ -108,7 +108,7 @@ Opened, and Availability is Busy, meaning that the runspace is still running the
 script.
 
 ```
-PS C:\> [Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
+[Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
 Command                    Arguments                           Location
 -------                    ---------                           --------
 MyModuleWorkflowF1         {}                                  TestNoFile3.psm1: line 6
@@ -120,7 +120,7 @@ TestNoFile2.ps1            {}                                  TestNoFile2.ps1: 
 Start an interactive debugging session with this runspace by running the Debug-Runspace cmdlet.
 
 ```
-PS C:\> [Process: 1520]: PS C:\>  Debug-Runspace -Id 4
+[Process: 1520]: PS C:\>  Debug-Runspace -Id 4
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 
 At C:\TestWFVar1.ps1:83 char:1
@@ -135,15 +135,15 @@ by running the exit debugger command. Alternatively, you can quit the debugger w
 commands.
 
 ```
-PS C:\> [Process:346]: [RSDBG: 3]: PS C:\> > exit
+[Process:346]: [RSDBG: 3]: PS C:\> > exit
 [Process:1520]: PS C:\>
 ```
 
 When you are finished working in the process, exit the process by running the `Exit-PSHostProcess`
-cmdlet. This returns you to the PS C:\> prompt.
+cmdlet. This returns you to the `PS C:\>` prompt.
 
 ```
-PS C:\> [Process:1520]: PS C:\>  Exit-PSHostProcess
+[Process:1520]: PS C:\>  Exit-PSHostProcess
 PS C:\>
 ```
 

--- a/reference/7.1/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -77,7 +77,7 @@ session.
 
 ## Examples
 
-### Example 1: Start debugging a runspace within the PowerShell ISE process
+### Example Part 1: Start debugging a runspace within the PowerShell ISE process
 
 In this example, you run `Enter-PSHostProcess` from within the PowerShell console to enter the
 PowerShell ISE process. In the resulting interactive session, you can find a runspace that you want
@@ -85,12 +85,6 @@ to debug by running `Get-Runspace`, and then debug the runspace.
 
 ```
 PS C:\> Enter-PSHostProcess -Name powershell_ise
-[Process:1520]: PS C:\Test\Documents>
-```
-
-Next, get available runspaces within the process you have entered.
-
-```
 [Process:1520]: PS C:\>  Get-Runspace
 Id    Name          InstanceId                               State           Availability
 --    -------       -----------                              ------          -------------
@@ -101,11 +95,13 @@ Id    Name          InstanceId                               State           Ava
 5     Runspace8     3e517382-a97a-49ba-9c3c-fd21f6664288     Broken          None
 ```
 
-The runspace objects returned by Get-Runspace also have a NoteProperty called ScriptStackTrace of
-the running command stack, if available. Next, debug runspace ID 4, that is running another user's
-long-running script. From the list returned from Get-Runspace, note that the runspace state is
-Opened, and Availability is Busy, meaning that the runspace is still running the long-running
-script.
+### Example part 2: Debug a specific runspace
+
+Next, debug runspace ID 4, that is running another user's long-running script. From the list
+returned from `Get-Runspace`, note that the runspace **State** is Opened, and **Availability** is
+Busy, meaning that the runspace is still running the long-running script. The runspace objects
+returned by `Get-Runspace` also have a **NoteProperty** called **ScriptStackTrace** of the running
+command stack, if available.
 
 ```
 [Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
@@ -115,11 +111,7 @@ MyModuleWorkflowF1         {}                                  TestNoFile3.psm1:
 WFTest1                    {}                                  TestNoFile2.ps1: line 14
 TestNoFile2.ps1            {}                                  TestNoFile2.ps1: line 22
 <ScriptBlock>              {}                                  <No file>
-```
 
-Start an interactive debugging session with this runspace by running the Debug-Runspace cmdlet.
-
-```
 [Process: 1520]: PS C:\>  Debug-Runspace -Id 4
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 
@@ -127,22 +119,23 @@ At C:\TestWFVar1.ps1:83 char:1
 + $scriptVar = "Script Variable"
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-[Process: 1520]: [RSDBG: 4]: PS C:\> >
+[Process: 1520]: [RSDBG: 4]: PS C:\>
 ```
+
+Start an interactive debugging session with this runspace by running the `Debug-Runspace` cmdlet.
+
+### Example part 3: Finish the debugging session and exit
 
 After you are finished debugging, allow the script to continue running without the debugger attached
 by running the exit debugger command. Alternatively, you can quit the debugger with the q or Stop
 commands.
 
-```
-[Process:346]: [RSDBG: 3]: PS C:\> > exit
-[Process:1520]: PS C:\>
-```
-
 When you are finished working in the process, exit the process by running the `Exit-PSHostProcess`
 cmdlet. This returns you to the `PS C:\>` prompt.
 
 ```
+[Process:346]: [RSDBG: 3]: PS C:\> exit
+[Process:1520]: PS C:\>
 [Process:1520]: PS C:\>  Exit-PSHostProcess
 PS C:\>
 ```
@@ -287,4 +280,3 @@ capability was limited to sessions using WinRM. PowerShell 7.1 allows `Enter-PSS
 [Exit-PSHostProcess](Exit-PSHostProcess.md)
 
 [Get-PSHostProcessInfo](Get-PSHostProcessInfo.md)
-

--- a/reference/7.2/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -86,8 +86,11 @@ to debug by running `Get-Runspace`, and then debug the runspace.
 ```
 PS C:\> Enter-PSHostProcess -Name powershell_ise
 [Process:1520]: PS C:\Test\Documents>
+```
 
 Next, get available runspaces within the process you have entered.
+
+```
 PS C:\> [Process:1520]: PS C:\>  Get-Runspace
 Id    Name          InstanceId                               State           Availability
 --    -------       -----------                              ------          -------------
@@ -96,13 +99,15 @@ Id    Name          InstanceId                               State           Ava
 3     MyLocalRS     2236dbd8-2105-4dec-a15a-a27d0bfaacb5     Opened          LocalDebug
 4     MyRunspace    771356e9-8c44-4b70-9de5-dd17cb41e48e     Opened          Busy
 5     Runspace8     3e517382-a97a-49ba-9c3c-fd21f6664288     Broken          None
+```
 
 The runspace objects returned by Get-Runspace also have a NoteProperty called ScriptStackTrace of
-the running command stack, if available.Next, debug runspace ID 4, that is running another user's
+the running command stack, if available. Next, debug runspace ID 4, that is running another user's
 long-running script. From the list returned from Get-Runspace, note that the runspace state is
 Opened, and Availability is Busy, meaning that the runspace is still running the long-running
 script.
 
+```
 PS C:\> [Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
 Command                    Arguments                           Location
 -------                    ---------                           --------
@@ -110,9 +115,11 @@ MyModuleWorkflowF1         {}                                  TestNoFile3.psm1:
 WFTest1                    {}                                  TestNoFile2.ps1: line 14
 TestNoFile2.ps1            {}                                  TestNoFile2.ps1: line 22
 <ScriptBlock>              {}                                  <No file>
+```
 
 Start an interactive debugging session with this runspace by running the Debug-Runspace cmdlet.
 
+```
 PS C:\> [Process: 1520]: PS C:\>  Debug-Runspace -Id 4
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 
@@ -121,17 +128,21 @@ At C:\TestWFVar1.ps1:83 char:1
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [Process: 1520]: [RSDBG: 4]: PS C:\> >
+```
 
 After you are finished debugging, allow the script to continue running without the debugger attached
 by running the exit debugger command. Alternatively, you can quit the debugger with the q or Stop
 commands.
 
+```
 PS C:\> [Process:346]: [RSDBG: 3]: PS C:\> > exit
 [Process:1520]: PS C:\>
+```
 
-When you are finished working in the process, exit the process by running the Exit-PSHostProcess
+When you are finished working in the process, exit the process by running the `Exit-PSHostProcess`
 cmdlet. This returns you to the PS C:\> prompt.
 
+```
 PS C:\> [Process:1520]: PS C:\>  Exit-PSHostProcess
 PS C:\>
 ```

--- a/reference/7.2/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 07/23/2020
+ms.date: 01/31/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/enter-pshostprocess?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enter-PSHostProcess
@@ -91,7 +91,7 @@ PS C:\> Enter-PSHostProcess -Name powershell_ise
 Next, get available runspaces within the process you have entered.
 
 ```
-PS C:\> [Process:1520]: PS C:\>  Get-Runspace
+[Process:1520]: PS C:\>  Get-Runspace
 Id    Name          InstanceId                               State           Availability
 --    -------       -----------                              ------          -------------
 1     Runspace1     2d91211d-9cce-42f0-ab0e-71ac258b32b5     Opened          Available
@@ -108,7 +108,7 @@ Opened, and Availability is Busy, meaning that the runspace is still running the
 script.
 
 ```
-PS C:\> [Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
+[Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
 Command                    Arguments                           Location
 -------                    ---------                           --------
 MyModuleWorkflowF1         {}                                  TestNoFile3.psm1: line 6
@@ -120,7 +120,7 @@ TestNoFile2.ps1            {}                                  TestNoFile2.ps1: 
 Start an interactive debugging session with this runspace by running the Debug-Runspace cmdlet.
 
 ```
-PS C:\> [Process: 1520]: PS C:\>  Debug-Runspace -Id 4
+[Process: 1520]: PS C:\>  Debug-Runspace -Id 4
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 
 At C:\TestWFVar1.ps1:83 char:1
@@ -135,15 +135,15 @@ by running the exit debugger command. Alternatively, you can quit the debugger w
 commands.
 
 ```
-PS C:\> [Process:346]: [RSDBG: 3]: PS C:\> > exit
+[Process:346]: [RSDBG: 3]: PS C:\> > exit
 [Process:1520]: PS C:\>
 ```
 
 When you are finished working in the process, exit the process by running the `Exit-PSHostProcess`
-cmdlet. This returns you to the PS C:\> prompt.
+cmdlet. This returns you to the `PS C:\>` prompt.
 
 ```
-PS C:\> [Process:1520]: PS C:\>  Exit-PSHostProcess
+[Process:1520]: PS C:\>  Exit-PSHostProcess
 PS C:\>
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -77,7 +77,7 @@ session.
 
 ## Examples
 
-### Example 1: Start debugging a runspace within the PowerShell ISE process
+### Example Part 1: Start debugging a runspace within the PowerShell ISE process
 
 In this example, you run `Enter-PSHostProcess` from within the PowerShell console to enter the
 PowerShell ISE process. In the resulting interactive session, you can find a runspace that you want
@@ -85,12 +85,6 @@ to debug by running `Get-Runspace`, and then debug the runspace.
 
 ```
 PS C:\> Enter-PSHostProcess -Name powershell_ise
-[Process:1520]: PS C:\Test\Documents>
-```
-
-Next, get available runspaces within the process you have entered.
-
-```
 [Process:1520]: PS C:\>  Get-Runspace
 Id    Name          InstanceId                               State           Availability
 --    -------       -----------                              ------          -------------
@@ -101,11 +95,13 @@ Id    Name          InstanceId                               State           Ava
 5     Runspace8     3e517382-a97a-49ba-9c3c-fd21f6664288     Broken          None
 ```
 
-The runspace objects returned by Get-Runspace also have a NoteProperty called ScriptStackTrace of
-the running command stack, if available. Next, debug runspace ID 4, that is running another user's
-long-running script. From the list returned from Get-Runspace, note that the runspace state is
-Opened, and Availability is Busy, meaning that the runspace is still running the long-running
-script.
+### Example part 2: Debug a specific runspace
+
+Next, debug runspace ID 4, that is running another user's long-running script. From the list
+returned from `Get-Runspace`, note that the runspace **State** is Opened, and **Availability** is
+Busy, meaning that the runspace is still running the long-running script. The runspace objects
+returned by `Get-Runspace` also have a **NoteProperty** called **ScriptStackTrace** of the running
+command stack, if available.
 
 ```
 [Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
@@ -115,11 +111,7 @@ MyModuleWorkflowF1         {}                                  TestNoFile3.psm1:
 WFTest1                    {}                                  TestNoFile2.ps1: line 14
 TestNoFile2.ps1            {}                                  TestNoFile2.ps1: line 22
 <ScriptBlock>              {}                                  <No file>
-```
 
-Start an interactive debugging session with this runspace by running the Debug-Runspace cmdlet.
-
-```
 [Process: 1520]: PS C:\>  Debug-Runspace -Id 4
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 
@@ -127,22 +119,23 @@ At C:\TestWFVar1.ps1:83 char:1
 + $scriptVar = "Script Variable"
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-[Process: 1520]: [RSDBG: 4]: PS C:\> >
+[Process: 1520]: [RSDBG: 4]: PS C:\>
 ```
+
+Start an interactive debugging session with this runspace by running the `Debug-Runspace` cmdlet.
+
+### Example part 3: Finish the debugging session and exit
 
 After you are finished debugging, allow the script to continue running without the debugger attached
 by running the exit debugger command. Alternatively, you can quit the debugger with the q or Stop
 commands.
 
-```
-[Process:346]: [RSDBG: 3]: PS C:\> > exit
-[Process:1520]: PS C:\>
-```
-
 When you are finished working in the process, exit the process by running the `Exit-PSHostProcess`
 cmdlet. This returns you to the `PS C:\>` prompt.
 
 ```
+[Process:346]: [RSDBG: 3]: PS C:\> exit
+[Process:1520]: PS C:\>
 [Process:1520]: PS C:\>  Exit-PSHostProcess
 PS C:\>
 ```

--- a/reference/7.3/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -86,8 +86,11 @@ to debug by running `Get-Runspace`, and then debug the runspace.
 ```
 PS C:\> Enter-PSHostProcess -Name powershell_ise
 [Process:1520]: PS C:\Test\Documents>
+```
 
 Next, get available runspaces within the process you have entered.
+
+```
 PS C:\> [Process:1520]: PS C:\>  Get-Runspace
 Id    Name          InstanceId                               State           Availability
 --    -------       -----------                              ------          -------------
@@ -96,6 +99,7 @@ Id    Name          InstanceId                               State           Ava
 3     MyLocalRS     2236dbd8-2105-4dec-a15a-a27d0bfaacb5     Opened          LocalDebug
 4     MyRunspace    771356e9-8c44-4b70-9de5-dd17cb41e48e     Opened          Busy
 5     Runspace8     3e517382-a97a-49ba-9c3c-fd21f6664288     Broken          None
+```
 
 The runspace objects returned by Get-Runspace also have a NoteProperty called ScriptStackTrace of
 the running command stack, if available.Next, debug runspace ID 4, that is running another user's
@@ -103,6 +107,7 @@ long-running script. From the list returned from Get-Runspace, note that the run
 Opened, and Availability is Busy, meaning that the runspace is still running the long-running
 script.
 
+```
 PS C:\> [Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
 Command                    Arguments                           Location
 -------                    ---------                           --------
@@ -110,9 +115,11 @@ MyModuleWorkflowF1         {}                                  TestNoFile3.psm1:
 WFTest1                    {}                                  TestNoFile2.ps1: line 14
 TestNoFile2.ps1            {}                                  TestNoFile2.ps1: line 22
 <ScriptBlock>              {}                                  <No file>
+```
 
 Start an interactive debugging session with this runspace by running the Debug-Runspace cmdlet.
 
+```
 PS C:\> [Process: 1520]: PS C:\>  Debug-Runspace -Id 4
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 
@@ -121,17 +128,21 @@ At C:\TestWFVar1.ps1:83 char:1
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [Process: 1520]: [RSDBG: 4]: PS C:\> >
+```
 
 After you are finished debugging, allow the script to continue running without the debugger attached
 by running the exit debugger command. Alternatively, you can quit the debugger with the q or Stop
 commands.
 
+```
 PS C:\> [Process:346]: [RSDBG: 3]: PS C:\> > exit
 [Process:1520]: PS C:\>
+```
 
-When you are finished working in the process, exit the process by running the Exit-PSHostProcess
+When you are finished working in the process, exit the process by running the `Exit-PSHostProcess`
 cmdlet. This returns you to the PS C:\> prompt.
 
+```
 PS C:\> [Process:1520]: PS C:\>  Exit-PSHostProcess
 PS C:\>
 ```

--- a/reference/7.3/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -77,7 +77,7 @@ session.
 
 ## Examples
 
-### Example 1: Start debugging a runspace within the PowerShell ISE process
+### Example Part 1: Start debugging a runspace within the PowerShell ISE process
 
 In this example, you run `Enter-PSHostProcess` from within the PowerShell console to enter the
 PowerShell ISE process. In the resulting interactive session, you can find a runspace that you want
@@ -85,12 +85,6 @@ to debug by running `Get-Runspace`, and then debug the runspace.
 
 ```
 PS C:\> Enter-PSHostProcess -Name powershell_ise
-[Process:1520]: PS C:\Test\Documents>
-```
-
-Next, get available runspaces within the process you have entered.
-
-```
 [Process:1520]: PS C:\>  Get-Runspace
 Id    Name          InstanceId                               State           Availability
 --    -------       -----------                              ------          -------------
@@ -101,11 +95,13 @@ Id    Name          InstanceId                               State           Ava
 5     Runspace8     3e517382-a97a-49ba-9c3c-fd21f6664288     Broken          None
 ```
 
-The runspace objects returned by Get-Runspace also have a NoteProperty called ScriptStackTrace of
-the running command stack, if available. Next, debug runspace ID 4, that is running another user's
-long-running script. From the list returned from Get-Runspace, note that the runspace state is
-Opened, and Availability is Busy, meaning that the runspace is still running the long-running
-script.
+### Example part 2: Debug a specific runspace
+
+Next, debug runspace ID 4, that is running another user's long-running script. From the list
+returned from `Get-Runspace`, note that the runspace **State** is Opened, and **Availability** is
+Busy, meaning that the runspace is still running the long-running script. The runspace objects
+returned by `Get-Runspace` also have a **NoteProperty** called **ScriptStackTrace** of the running
+command stack, if available.
 
 ```
 [Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
@@ -115,11 +111,7 @@ MyModuleWorkflowF1         {}                                  TestNoFile3.psm1:
 WFTest1                    {}                                  TestNoFile2.ps1: line 14
 TestNoFile2.ps1            {}                                  TestNoFile2.ps1: line 22
 <ScriptBlock>              {}                                  <No file>
-```
 
-Start an interactive debugging session with this runspace by running the Debug-Runspace cmdlet.
-
-```
 [Process: 1520]: PS C:\>  Debug-Runspace -Id 4
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 
@@ -127,22 +119,23 @@ At C:\TestWFVar1.ps1:83 char:1
 + $scriptVar = "Script Variable"
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-[Process: 1520]: [RSDBG: 4]: PS C:\> >
+[Process: 1520]: [RSDBG: 4]: PS C:\>
 ```
+
+Start an interactive debugging session with this runspace by running the `Debug-Runspace` cmdlet.
+
+### Example part 3: Finish the debugging session and exit
 
 After you are finished debugging, allow the script to continue running without the debugger attached
 by running the exit debugger command. Alternatively, you can quit the debugger with the q or Stop
 commands.
 
-```
-[Process:346]: [RSDBG: 3]: PS C:\> > exit
-[Process:1520]: PS C:\>
-```
-
 When you are finished working in the process, exit the process by running the `Exit-PSHostProcess`
 cmdlet. This returns you to the `PS C:\>` prompt.
 
 ```
+[Process:346]: [RSDBG: 3]: PS C:\> exit
+[Process:1520]: PS C:\>
 [Process:1520]: PS C:\>  Exit-PSHostProcess
 PS C:\>
 ```
@@ -287,4 +280,3 @@ capability was limited to sessions using WinRM. PowerShell 7.1 allows `Enter-PSS
 [Exit-PSHostProcess](Exit-PSHostProcess.md)
 
 [Get-PSHostProcessInfo](Get-PSHostProcessInfo.md)
-

--- a/reference/7.3/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 07/23/2020
+ms.date: 01/31/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/enter-pshostprocess?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enter-PSHostProcess
@@ -91,7 +91,7 @@ PS C:\> Enter-PSHostProcess -Name powershell_ise
 Next, get available runspaces within the process you have entered.
 
 ```
-PS C:\> [Process:1520]: PS C:\>  Get-Runspace
+[Process:1520]: PS C:\>  Get-Runspace
 Id    Name          InstanceId                               State           Availability
 --    -------       -----------                              ------          -------------
 1     Runspace1     2d91211d-9cce-42f0-ab0e-71ac258b32b5     Opened          Available
@@ -102,13 +102,13 @@ Id    Name          InstanceId                               State           Ava
 ```
 
 The runspace objects returned by Get-Runspace also have a NoteProperty called ScriptStackTrace of
-the running command stack, if available.Next, debug runspace ID 4, that is running another user's
+the running command stack, if available. Next, debug runspace ID 4, that is running another user's
 long-running script. From the list returned from Get-Runspace, note that the runspace state is
 Opened, and Availability is Busy, meaning that the runspace is still running the long-running
 script.
 
 ```
-PS C:\> [Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
+[Process:1520]: PS C:\>  (Get-Runspace -Id 4).ScriptStackTrace
 Command                    Arguments                           Location
 -------                    ---------                           --------
 MyModuleWorkflowF1         {}                                  TestNoFile3.psm1: line 6
@@ -120,7 +120,7 @@ TestNoFile2.ps1            {}                                  TestNoFile2.ps1: 
 Start an interactive debugging session with this runspace by running the Debug-Runspace cmdlet.
 
 ```
-PS C:\> [Process: 1520]: PS C:\>  Debug-Runspace -Id 4
+[Process: 1520]: PS C:\>  Debug-Runspace -Id 4
 Hit Line breakpoint on 'C:\TestWFVar1.ps1:83'
 
 At C:\TestWFVar1.ps1:83 char:1
@@ -135,15 +135,15 @@ by running the exit debugger command. Alternatively, you can quit the debugger w
 commands.
 
 ```
-PS C:\> [Process:346]: [RSDBG: 3]: PS C:\> > exit
+[Process:346]: [RSDBG: 3]: PS C:\> > exit
 [Process:1520]: PS C:\>
 ```
 
 When you are finished working in the process, exit the process by running the `Exit-PSHostProcess`
-cmdlet. This returns you to the PS C:\> prompt.
+cmdlet. This returns you to the `PS C:\>` prompt.
 
 ```
-PS C:\> [Process:1520]: PS C:\>  Exit-PSHostProcess
+[Process:1520]: PS C:\>  Exit-PSHostProcess
 PS C:\>
 ```
 


### PR DESCRIPTION
# PR Summary

The existing code block contained not only "code" but also regular text, I've added the code block delimiters to ensure that regular text is outside a code block.


## PR Context

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [ ] Preview content
- [x] Version 7.3 content
- [x] Version 7.2 content
- [x] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
