### PR TITLE
Fixes #8541 - Remove confusing statement about multiple scopes

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -1,7 +1,7 @@
 ---
 description: Explains the concept of scope in PowerShell and shows how to set and change the scope of elements.
 Locale: en-US
-ms.date: 10/22/2021
+ms.date: 01/31/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scopes?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Scopes
@@ -25,8 +25,10 @@ The following are the basic rules of scope:
   scopes are child scopes of that parent.
 
 - An item is visible in the scope in which it was created and in any child
-  scopes, unless you explicitly make it private. You can place variables,
-  aliases, functions, or PowerShell drives in one or more scopes.
+  scopes, unless you explicitly make it private.
+
+- You can declare variables, aliases, functions, and PowerShell drives in a
+  scope outside of the current scope.
 
 - An item that you created within a scope can be changed only in the scope in
   which it was created, unless you explicitly specify a different scope.

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -1,7 +1,7 @@
 ---
 description: Explains the concept of scope in PowerShell and shows how to set and change the scope of elements.
 Locale: en-US
-ms.date: 10/22/2021
+ms.date: 01/31/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scopes?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Scopes
@@ -25,8 +25,10 @@ The following are the basic rules of scope:
   scopes are child scopes of that parent.
 
 - An item is visible in the scope in which it was created and in any child
-  scopes, unless you explicitly make it private. You can place variables,
-  aliases, functions, or PowerShell drives in one or more scopes.
+  scopes, unless you explicitly make it private.
+
+- You can declare variables, aliases, functions, and PowerShell drives in a
+  scope outside of the current scope.
 
 - An item that you created within a scope can be changed only in the scope in
   which it was created, unless you explicitly specify a different scope.

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -1,7 +1,7 @@
 ---
 description: Explains the concept of scope in PowerShell and shows how to set and change the scope of elements.
 Locale: en-US
-ms.date: 10/22/2021
+ms.date: 01/31/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scopes?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Scopes
@@ -25,8 +25,10 @@ The following are the basic rules of scope:
   scopes are child scopes of that parent.
 
 - An item is visible in the scope in which it was created and in any child
-  scopes, unless you explicitly make it private. You can place variables,
-  aliases, functions, or PowerShell drives in one or more scopes.
+  scopes, unless you explicitly make it private.
+
+- You can declare variables, aliases, functions, and PowerShell drives in a
+  scope outside of the current scope.
 
 - An item that you created within a scope can be changed only in the scope in
   which it was created, unless you explicitly specify a different scope.

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -1,7 +1,7 @@
 ---
 description: Explains the concept of scope in PowerShell and shows how to set and change the scope of elements.
 Locale: en-US
-ms.date: 10/22/2021
+ms.date: 01/31/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scopes?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Scopes
@@ -25,8 +25,10 @@ The following are the basic rules of scope:
   scopes are child scopes of that parent.
 
 - An item is visible in the scope in which it was created and in any child
-  scopes, unless you explicitly make it private. You can place variables,
-  aliases, functions, or PowerShell drives in one or more scopes.
+  scopes, unless you explicitly make it private.
+
+- You can declare variables, aliases, functions, and PowerShell drives in a
+  scope outside of the current scope.
 
 - An item that you created within a scope can be changed only in the scope in
   which it was created, unless you explicitly specify a different scope.

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -1,7 +1,7 @@
 ---
 description: Explains the concept of scope in PowerShell and shows how to set and change the scope of elements.
 Locale: en-US
-ms.date: 10/22/2021
+ms.date: 01/31/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scopes?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Scopes
@@ -25,8 +25,10 @@ The following are the basic rules of scope:
   scopes are child scopes of that parent.
 
 - An item is visible in the scope in which it was created and in any child
-  scopes, unless you explicitly make it private. You can place variables,
-  aliases, functions, or PowerShell drives in one or more scopes.
+  scopes, unless you explicitly make it private.
+
+- You can declare variables, aliases, functions, and PowerShell drives in a
+  scope outside of the current scope.
 
 - An item that you created within a scope can be changed only in the scope in
   which it was created, unless you explicitly specify a different scope.


### PR DESCRIPTION
# PR Summary
<!--
    Summarize your changes and list related issues here. For example:

    This changes fixes problem X in the documentation for Y.
    - Fixes #1234
    - Fixes #1235
-->
Fixes [AB#1913694](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1913694) - Fixes #8541 - Remove confusing statement about multiple scopes

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [x] Version 7.2 content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords