### PR TITLE
Insert missing angle bracket in class syntax block

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -39,7 +39,7 @@ properties.
 Classes are declared using the following syntax:
 
 ```syntax
-class <class-name> [: [<base-class>][,<interface-list]] {
+class <class-name> [: [<base-class>][,<interface-list>]] {
     [[<attribute>] [hidden] [static] <property-definition> ...]
     [<class-name>([<constructor-argument-list>])
       {<constructor-statement-list>} ...]

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -39,7 +39,7 @@ properties.
 Classes are declared using the following syntax:
 
 ```syntax
-class <class-name> [: [<base-class>][,<interface-list]] {
+class <class-name> [: [<base-class>][,<interface-list>]] {
     [[<attribute>] [hidden] [static] <property-definition> ...]
     [<class-name>([<constructor-argument-list>])
       {<constructor-statement-list>} ...]

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -39,7 +39,7 @@ properties.
 Classes are declared using the following syntax:
 
 ```syntax
-class <class-name> [: [<base-class>][,<interface-list]] {
+class <class-name> [: [<base-class>][,<interface-list>]] {
     [[<attribute>] [hidden] [static] <property-definition> ...]
     [<class-name>([<constructor-argument-list>])
       {<constructor-statement-list>} ...]

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -39,7 +39,7 @@ properties.
 Classes are declared using the following syntax:
 
 ```syntax
-class <class-name> [: [<base-class>][,<interface-list]] {
+class <class-name> [: [<base-class>][,<interface-list>]] {
     [[<attribute>] [hidden] [static] <property-definition> ...]
     [<class-name>([<constructor-argument-list>])
       {<constructor-statement-list>} ...]

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -39,7 +39,7 @@ properties.
 Classes are declared using the following syntax:
 
 ```syntax
-class <class-name> [: [<base-class>][,<interface-list]] {
+class <class-name> [: [<base-class>][,<interface-list>]] {
     [[<attribute>] [hidden] [static] <property-definition> ...]
     [<class-name>([<constructor-argument-list>])
       {<constructor-statement-list>} ...]


### PR DESCRIPTION
# PR Summary

This adds a missing angle bracket in all versions of the class syntax block in about_Classes.md

## PR Context

Check the boxes below to indicate the content affected by this PR.

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [x] Version 7.2 content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
