### PR TITLE
Fixes #8595 - Add note about WordDelimiters property

### DIFF
--- a/reference/5.1/PSReadLine/About/about_PSReadLine.md
+++ b/reference/5.1/PSReadLine/About/about_PSReadLine.md
@@ -633,7 +633,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### BeginningOfLine
 
@@ -679,7 +679,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### GotoBrace
 
@@ -727,7 +727,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### NextWordEnd
 
@@ -742,7 +742,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### PreviousLine
 
@@ -763,7 +763,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ShellForwardWord
 
@@ -777,7 +777,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ShellNextWord
 
@@ -791,7 +791,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViBackwardWord
 
@@ -806,7 +806,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViEndOfGlob
 
@@ -845,7 +845,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ## History functions
 
@@ -1387,7 +1387,7 @@ IEnumerable[Microsoft.PowerShell.KeyHandler]
 
 ```
 
-This function is used by Get-PSReadLineKeyHandler and probably isn't useful in
+This function is used by `Get-PSReadLineKeyHandler` and probably isn't useful in
 a custom key binding.
 
 ```csharp

--- a/reference/5.1/PSReadLine/About/about_PSReadLine.md
+++ b/reference/5.1/PSReadLine/About/about_PSReadLine.md
@@ -1,7 +1,7 @@
 ---
 description: PSReadLine provides an improved command-line editing experience in the PowerShell console.
 Locale: en-US
-ms.date: 10/14/2021
+ms.date: 02/17/2022
 online version: https://docs.microsoft.com/powershell/module/psreadline/about/about_psreadline?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSReadLine
@@ -628,6 +628,13 @@ set of characters.
 - Vi insert mode: `<Ctrl+LeftArrow>`
 - Vi command mode: `<Ctrl+LeftArrow>`
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### BeginningOfLine
 
 If the input has multiple lines, move to the start of the current line, or if
@@ -666,6 +673,13 @@ to the end of the next word. Word boundaries are defined by a configurable set
 of characters.
 
 - Emacs: `<Alt+f>`, `<Escape,f>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### GotoBrace
 
@@ -708,6 +722,13 @@ defined by a configurable set of characters.
 - Vi insert mode: `<Ctrl+RightArrow>`
 - Vi command mode: `<Ctrl+RightArrow>`
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### NextWordEnd
 
 Move the cursor forward to the end of the current word, or if between words,
@@ -715,6 +736,13 @@ to the end of the next word. Word boundaries are defined by a configurable set
 of characters.
 
 - Vi command mode: `<e>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### PreviousLine
 
@@ -730,12 +758,26 @@ tokens.
 
 - Function is unbound.
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### ShellForwardWord
 
 Move the cursor forward to the start of the next word. Word boundaries are
 defined by PowerShell tokens.
 
 - Function is unbound.
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ShellNextWord
 
@@ -744,6 +786,13 @@ to the end of the next word. Word boundaries are defined by PowerShell tokens.
 
 - Function is unbound.
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### ViBackwardWord
 
 Move the cursor back to the start of the current word, or if between words,
@@ -751,6 +800,13 @@ the start of the previous word. Word boundaries are defined by a configurable
 set of characters.
 
 - Vi command mode: `<b>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViEndOfGlob
 
@@ -783,6 +839,13 @@ Move the cursor forward to the start of the next word. Word boundaries are
 defined by a configurable set of characters.
 
 - Vi command mode: `<w>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ## History functions
 

--- a/reference/7.0/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.0/PSReadLine/About/about_PSReadLine.md
@@ -652,7 +652,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### BeginningOfLine
 
@@ -698,7 +698,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### GotoBrace
 
@@ -746,7 +746,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### NextWordEnd
 
@@ -761,7 +761,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### PreviousLine
 
@@ -782,7 +782,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ShellForwardWord
 
@@ -796,7 +796,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ShellNextWord
 
@@ -810,7 +810,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViBackwardWord
 
@@ -825,7 +825,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViEndOfGlob
 
@@ -864,7 +864,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ## History functions
 

--- a/reference/7.0/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.0/PSReadLine/About/about_PSReadLine.md
@@ -1,7 +1,7 @@
 ---
 description: PSReadLine provides an improved command-line editing experience in the PowerShell console.
 Locale: en-US
-ms.date: 10/14/2021
+ms.date: 02/17/2022
 online version: https://docs.microsoft.com/powershell/module/psreadline/about/about_psreadline?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSReadLine
@@ -647,6 +647,13 @@ set of characters.
 - Vi insert mode: `<Ctrl+LeftArrow>`
 - Vi command mode: `<Ctrl+LeftArrow>`
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### BeginningOfLine
 
 If the input has multiple lines, move to the start of the current line, or if
@@ -685,6 +692,13 @@ to the end of the next word. Word boundaries are defined by a configurable set
 of characters.
 
 - Emacs: `<Alt+f>`, `<Escape,f>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### GotoBrace
 
@@ -727,6 +741,13 @@ defined by a configurable set of characters.
 - Vi insert mode: `<Ctrl+RightArrow>`
 - Vi command mode: `<Ctrl+RightArrow>`
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### NextWordEnd
 
 Move the cursor forward to the end of the current word, or if between words,
@@ -734,6 +755,13 @@ to the end of the next word. Word boundaries are defined by a configurable set
 of characters.
 
 - Vi command mode: `<e>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### PreviousLine
 
@@ -749,12 +777,26 @@ tokens.
 
 - Function is unbound.
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### ShellForwardWord
 
 Move the cursor forward to the start of the next word. Word boundaries are
 defined by PowerShell tokens.
 
 - Function is unbound.
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ShellNextWord
 
@@ -763,6 +805,13 @@ to the end of the next word. Word boundaries are defined by PowerShell tokens.
 
 - Function is unbound.
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### ViBackwardWord
 
 Move the cursor back to the start of the current word, or if between words,
@@ -770,6 +819,13 @@ the start of the previous word. Word boundaries are defined by a configurable
 set of characters.
 
 - Vi command mode: `<b>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViEndOfGlob
 
@@ -802,6 +858,13 @@ Move the cursor forward to the start of the next word. Word boundaries are
 defined by a configurable set of characters.
 
 - Vi command mode: `<w>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ## History functions
 
@@ -1343,7 +1406,7 @@ IEnumerable[Microsoft.PowerShell.KeyHandler]
 
 ```
 
-This function is used by Get-PSReadLineKeyHandler and probably isn't useful in
+This function is used by `Get-PSReadLineKeyHandler` and probably isn't useful in
 a custom key binding.
 
 ```csharp

--- a/reference/7.1/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.1/PSReadLine/About/about_PSReadLine.md
@@ -683,7 +683,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### BeginningOfLine
 
@@ -729,7 +729,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### GotoBrace
 
@@ -777,7 +777,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### NextWordEnd
 
@@ -792,7 +792,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### PreviousLine
 
@@ -813,7 +813,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ShellForwardWord
 
@@ -827,7 +827,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ShellNextWord
 
@@ -841,7 +841,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViBackwardChar
 
@@ -864,7 +864,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViForwardChar
 
@@ -911,7 +911,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ## History functions
 

--- a/reference/7.1/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.1/PSReadLine/About/about_PSReadLine.md
@@ -1,7 +1,7 @@
 ---
 description: PSReadLine provides an improved command-line editing experience in the PowerShell console.
 Locale: en-US
-ms.date: 10/14/2021
+ms.date: 02/17/2022
 online version: https://docs.microsoft.com/powershell/module/psreadline/about/about_psreadline?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSReadLine
@@ -678,6 +678,13 @@ set of characters.
 - Vi insert mode: `<Ctrl+LeftArrow>`
 - Vi command mode: `<Ctrl+LeftArrow>`
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### BeginningOfLine
 
 If the input has multiple lines, move to the start of the current line, or if
@@ -716,6 +723,13 @@ to the end of the next word. Word boundaries are defined by a configurable set
 of characters.
 
 - Emacs: `<Alt+f>`, `<Escape,f>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### GotoBrace
 
@@ -758,6 +772,13 @@ defined by a configurable set of characters.
 - Vi insert mode: `<Ctrl+RightArrow>`
 - Vi command mode: `<Ctrl+RightArrow>`
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### NextWordEnd
 
 Move the cursor forward to the end of the current word, or if between words,
@@ -765,6 +786,13 @@ to the end of the next word. Word boundaries are defined by a configurable set
 of characters.
 
 - Vi command mode: `<e>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### PreviousLine
 
@@ -780,6 +808,13 @@ tokens.
 
 - Function is unbound.
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### ShellForwardWord
 
 Move the cursor forward to the start of the next word. Word boundaries are
@@ -787,12 +822,26 @@ defined by PowerShell tokens.
 
 - Function is unbound.
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### ShellNextWord
 
 Move the cursor forward to the end of the current word, or if between words,
 to the end of the next word. Word boundaries are defined by PowerShell tokens.
 
 - Function is unbound.
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViBackwardChar
 
@@ -809,6 +858,13 @@ the start of the previous word. Word boundaries are defined by a configurable
 set of characters.
 
 - Vi command mode: `<b>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViForwardChar
 
@@ -849,6 +905,13 @@ Move the cursor forward to the start of the next word. Word boundaries are
 defined by a configurable set of characters.
 
 - Vi command mode: `<w>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ## History functions
 

--- a/reference/7.2/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.2/PSReadLine/About/about_PSReadLine.md
@@ -1,7 +1,7 @@
 ---
 description: PSReadLine provides an improved command-line editing experience in the PowerShell console.
 Locale: en-US
-ms.date: 10/14/2021
+ms.date: 02/17/2022
 online version: https://docs.microsoft.com/powershell/module/psreadline/about/about_psreadline?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSReadLine
@@ -733,6 +733,13 @@ set of characters.
 - Vi insert mode: `<Ctrl+LeftArrow>`
 - Vi command mode: `<Ctrl+LeftArrow>`
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### BeginningOfLine
 
 If the input has multiple lines, move to the start of the current line, or if
@@ -769,6 +776,13 @@ to the end of the next word. Word boundaries are defined by a configurable set
 of characters.
 
 - Emacs: `<Alt+f>`, `<Escape,f>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### GotoBrace
 
@@ -811,6 +825,13 @@ defined by a configurable set of characters.
 - Vi insert mode: `<Ctrl+RightArrow>`
 - Vi command mode: `<Ctrl+RightArrow>`
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### NextWordEnd
 
 Move the cursor forward to the end of the current word, or if between words,
@@ -818,6 +839,13 @@ to the end of the next word. Word boundaries are defined by a configurable set
 of characters.
 
 - Vi command mode: `<e>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### PreviousLine
 
@@ -833,6 +861,13 @@ tokens.
 
 - Function is unbound.
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### ShellForwardWord
 
 Move the cursor forward to the start of the next word. Word boundaries are
@@ -840,12 +875,26 @@ defined by PowerShell tokens.
 
 - Function is unbound.
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### ShellNextWord
 
 Move the cursor forward to the end of the current word, or if between words,
 to the end of the next word. Word boundaries are defined by PowerShell tokens.
 
 - Function is unbound.
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViBackwardChar
 
@@ -862,6 +911,13 @@ the start of the previous word. Word boundaries are defined by a configurable
 set of characters.
 
 - Vi command mode: `<b>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViForwardChar
 
@@ -902,6 +958,13 @@ Move the cursor forward to the start of the next word. Word boundaries are
 defined by a configurable set of characters.
 
 - Vi command mode: `<w>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ## History functions
 

--- a/reference/7.2/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.2/PSReadLine/About/about_PSReadLine.md
@@ -738,7 +738,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### BeginningOfLine
 
@@ -782,7 +782,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### GotoBrace
 
@@ -830,7 +830,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### NextWordEnd
 
@@ -845,7 +845,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### PreviousLine
 
@@ -866,7 +866,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ShellForwardWord
 
@@ -880,7 +880,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ShellNextWord
 
@@ -894,7 +894,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViBackwardChar
 
@@ -917,7 +917,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViForwardChar
 
@@ -964,7 +964,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ## History functions
 

--- a/reference/7.3/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.3/PSReadLine/About/about_PSReadLine.md
@@ -1,7 +1,7 @@
 ---
 description: PSReadLine provides an improved command-line editing experience in the PowerShell console.
 Locale: en-US
-ms.date: 10/14/2021
+ms.date: 02/17/2022
 online version: https://docs.microsoft.com/powershell/module/psreadline/about/about_psreadline?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSReadLine
@@ -733,6 +733,13 @@ set of characters.
 - Vi insert mode: `<Ctrl+LeftArrow>`
 - Vi command mode: `<Ctrl+LeftArrow>`
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### BeginningOfLine
 
 If the input has multiple lines, move to the start of the current line, or if
@@ -769,6 +776,13 @@ to the end of the next word. Word boundaries are defined by a configurable set
 of characters.
 
 - Emacs: `<Alt+f>`, `<Escape,f>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### GotoBrace
 
@@ -811,6 +825,13 @@ defined by a configurable set of characters.
 - Vi insert mode: `<Ctrl+RightArrow>`
 - Vi command mode: `<Ctrl+RightArrow>`
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### NextWordEnd
 
 Move the cursor forward to the end of the current word, or if between words,
@@ -818,6 +839,13 @@ to the end of the next word. Word boundaries are defined by a configurable set
 of characters.
 
 - Vi command mode: `<e>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### PreviousLine
 
@@ -833,6 +861,13 @@ tokens.
 
 - Function is unbound.
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### ShellForwardWord
 
 Move the cursor forward to the start of the next word. Word boundaries are
@@ -840,12 +875,26 @@ defined by PowerShell tokens.
 
 - Function is unbound.
 
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+
 ### ShellNextWord
 
 Move the cursor forward to the end of the current word, or if between words,
 to the end of the next word. Word boundaries are defined by PowerShell tokens.
 
 - Function is unbound.
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViBackwardChar
 
@@ -862,6 +911,13 @@ the start of the previous word. Word boundaries are defined by a configurable
 set of characters.
 
 - Vi command mode: `<b>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViForwardChar
 
@@ -902,6 +958,13 @@ Move the cursor forward to the start of the next word. Word boundaries are
 defined by a configurable set of characters.
 
 - Vi command mode: `<w>`
+
+The characters that define word boundaries are configured in the
+[WordDelimiters](/dotnet/api/microsoft.powershell.psconsolereadlineoptions.worddelimiters#microsoft-powershell-psconsolereadlineoptions-worddelimiters)
+property of the **PSConsoleReadLineOptions** object. To view or change the
+**WordDelimiters** property, see
+[Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
+[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ## History functions
 

--- a/reference/7.3/PSReadLine/About/about_PSReadLine.md
+++ b/reference/7.3/PSReadLine/About/about_PSReadLine.md
@@ -738,7 +738,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### BeginningOfLine
 
@@ -782,7 +782,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### GotoBrace
 
@@ -830,7 +830,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### NextWordEnd
 
@@ -845,7 +845,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### PreviousLine
 
@@ -866,7 +866,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ShellForwardWord
 
@@ -880,7 +880,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ShellNextWord
 
@@ -894,7 +894,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViBackwardChar
 
@@ -917,7 +917,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ### ViForwardChar
 
@@ -964,7 +964,7 @@ The characters that define word boundaries are configured in the
 property of the **PSConsoleReadLineOptions** object. To view or change the
 **WordDelimiters** property, see
 [Get-PSReadLineOption](xref:PSReadLine.Get-PSReadLineOption) and
-[Get-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
+[Set-PSReadLineOption](xref:PSReadLine.Set-PSReadLineOption).
 
 ## History functions
 


### PR DESCRIPTION
# PR Summary
<!--
    Summarize your changes and list related issues here. For example:

    This changes fixes problem X in the documentation for Y.
    - Fixes #1234
    - Fixes #1235
-->
Fixes [AB#1920219](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1920219) - Fixes #8595 - Add note about WordDelimiters property

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [x] Version 7.2 content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords