### PR TITLE
Update `resolving-dependency-conflicts.md`

### DIFF
--- a/reference/docs-conceptual/dev-cross-plat/resolving-dependency-conflicts.md
+++ b/reference/docs-conceptual/dev-cross-plat/resolving-dependency-conflicts.md
@@ -766,7 +766,7 @@ dependencies that remains robust over time as more dependencies are added.
 For a more detailed example, go to this
 [GitHub repository](https://github.com/rjmholt/ModuleDependencyIsolationExample). This example
 demonstrates how to migrate a module to use an ALC, while keeping that module working in .NET
-Framework. It also show how to use .NET Standard and PowerShell Standard to simplify the core
+Framework. It also shows how to use .NET Standard and PowerShell Standard to simplify the core
 implementation.
 
 This solution is also used by the [Bicep PowerShell module](https://github.com/PSBicep/PSBicep),
@@ -787,7 +787,7 @@ There is a simplified solution to achieve side-by-side assembly loading, by
 - Hooking up a `Resolving` event to a custom Assembly Load Context
 - Or, hooking up a `Resolving` event to `Assembly.LoadFile()`
 
-It comes with two limitations comparing to the above solution but requires way less efforts from the module author.
+It comes with two limitations comparing to the above solution but requires much more less effort from the module author.
 Check out the [PowerShell-ALC-Samples](https://github.com/daxian-dbw/PowerShell-ALC-Samples/tree/main/Resolving-Event-with-ALC)
 repository for the sample code and the detailed scenario analysis regarding this solution.
 


### PR DESCRIPTION
# PR Summary

Update `resolving-dependency-conflicts.md` about using `Resolving` handler to mitigate the dependency conflicts.

The `Add an AssemblyResolve event handler to create a dynamic binding redirect` is removed because using `Assembly.LoadFrom` within a resolve event handler will never really work, so it's better not discuss about it, so as to make the article focus on the solution that could work.

The `Assembly resolve handler for side-by-side loading with Assembly.LoadFile()` section is replaced with the pointer to https://github.com/daxian-dbw/PowerShell-ALC-Samples/tree/main/Resolving-Event-with-ALC. This is because:
1. the example in that section still requires a wrapper assembly, which is actually meaningless with this solution.
2. the pointed repository contains sample code and detailed scenario analysis for this solution
3. it's actually fine to load multiple versions of the same assembly in .NET Framework, so the conflict issue is really only relevant in PowerShell Core (.NET Core).

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [x] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [ ] Preview content
- [ ] Version 7.2 content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
