### PR TITLE
(GH-8602) Add OS-specific notes to about help

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_CimSession.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_CimSession.md
@@ -1,7 +1,7 @@
 ---
 description: Describes a **CimSession** object and the difference between CIM sessions and PowerShell sessions.
 Locale: en-US
-ms.date: 05/13/2020
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_cimsession?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about CimSession
@@ -69,3 +69,4 @@ understand the **ThrottleLimit**.
 [New-CimSession](xref:CimCmdlets.New-CimSession)
 
 [about_PSSessions](about_PSSessions.md)
+

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_CimSession.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_CimSession.md
@@ -14,14 +14,16 @@ PowerShell sessions.
 
 ## Long description
 
+> This information only applies to PowerShell running on Windows.
+
 A Common Information Model (CIM) session is a client-side object that
 represents a connection to a local computer or a remote computer. You can use
 CIM sessions as an alternative to PowerShell sessions (PSSessions). Both
 approaches have advantages.
 
-You can use the `New-CimSession` cmdlet to create a CIM session that contains
-information about a connection, such as computer name, the protocol used for
-the connection, session ID, and instance ID.
+You can use the `New-CimSession` cmdlet on a Windows computer to create a CIM
+session that contains information about a connection, such as computer name,
+the protocol used for the connection, session ID, and instance ID.
 
 After you create a **CimSession** object that specifies information required to
 establish a connection, PowerShell does not establish the connection

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -205,8 +205,14 @@ FullLanguage
 ```
 
 On other session configurations, you can find the language mode indirectly by
-finding the language mode of a session that is created by using the session
+finding the language mode of a session that is created with the session
 configuration.
+
+> [!NOTE]
+> Session configurations are a feature of WSMan-based PowerShell remoting. They are used only when you
+> use the `New-PSSession`, `Invoke-Command`, or `Enter-PSSession` cmdlets
+> to connect to a remote Windows computer. The `Get-PSSessionConfiguration`
+> cmdlet is only available on Windows computers.
 
 ### Finding the language mode of a session
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -1,7 +1,7 @@
 ---
 description: Explains language modes and their effect on PowerShell sessions.
 Locale: en-US
-ms.date: 08/03/2021
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Language Modes

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
@@ -1,7 +1,7 @@
 ---
 description: Provides detailed information about PowerShell sessions and the role they play in remote commands.
 Locale: en-US
-ms.date: 06/09/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pssession_details?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSSession Details

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
@@ -150,13 +150,13 @@ and manage only the PSSessions that you created.
 
 ## Can I Connect to a PSSession From a Different Computer?
 
-Beginning in Windows PowerShell 3.0, PSSessions are independent
-of the sessions in which they were created. Active PSSessions
+Beginning in Windows PowerShell 3.0, PSSessions on Windows computers are
+independent of the sessions in which they were created. Active PSSessions
 are maintained on the computer at the remote or "server-side" of
 a connection.
 
-You can use the `Disconnect-PSSession` cmdlet to disconnect
-from a PSSession. The PSSession is disconnected from the
+On a Windows computer, you can use the `Disconnect-PSSession` cmdlet to
+disconnect from a PSSession. The PSSession is disconnected from the
 local session, but is maintained on the remote computer.
 Commands continue to run in the disconnected PSSession. You
 can close PowerShell and shut down the originating computer
@@ -164,7 +164,7 @@ without interrupting the PSSession.
 
 Then, even hours later, you can use the `Get-PSSession` cmdlet to
 get the PSSession and the `Connect-PSSession` cmdlet to connect to the
-PSSession from a new session on a different computer.
+PSSession from a new session on a different Windows computer.
 
 For more information, see [about_Remote_Disconnected_Sessions](about_Remote_Disconnected_Sessions.md).
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_PSSessions.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_PSSessions.md
@@ -1,7 +1,7 @@
 ---
 description: Describes PowerShell sessions (PSSessions) and explains how to establish a persistent connection to a remote computer.
 Locale: en-US
-ms.date: 01/03/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pssessions?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSSessions
@@ -291,3 +291,4 @@ For more information about PSSessions, see [about_PSSession_Details](about_PSSes
 [New-PSSession](xref:Microsoft.PowerShell.Core.New-PSSession)
 
 [Remove-PSSession](xref:Microsoft.PowerShell.Core.Remove-PSSession)
+

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_PSSessions.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_PSSessions.md
@@ -27,11 +27,12 @@ You can also create a PSSession on the local computer and run commands in it.
 A local PSSession uses the PowerShell remoting infrastructure to
 create and maintain the PSSession.
 
-Beginning in Windows PowerShell 3.0, PSSessions are independent of the
-sessions in which they are created. Active PSSessions are maintained on the
-remote computer (or the computer at the remote end or "server-side" of the
-connection). As a result, you can disconnect from the PSSession and reconnect
-to it at a later time from the same computer or from a different computer.
+Beginning in Windows PowerShell 3.0, PSSessions on Windows are independent
+of the sessions in which they are created. Active PSSessions are maintained
+on the remote computer (or the computer at the remote end or "server-side"
+of the connection). As a result, on Windows you can disconnect from a PSSession
+on a remote Windows computer and reconnect to it at a later time from the
+same computer or from a different Windows computer.
 
 This topic explains how to create, use, get, and delete PSSessions. For more
 advanced information, see
@@ -256,6 +257,12 @@ Get-Help *-PSSession
 - Receive-PSSession: Gets the results of commands that ran in a disconnected
   session
 - Remove-PSSession: Deletes the PSSessions in the current session
+
+> [!NOTE]
+> Disconnected sessions are only supported on Windows. The `Connect-PSSession`,
+> `Disconnect-PSSession`, and `Receive-PSSession` cmdlets are only available
+> on Windows. For more information about disconnected sessions, see
+> [about_Remote_Disconnected_Session](about_Remote_Disconnected_Sessions.md)
 
 ## For More Information
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how PowerShell providers provide access to data and components that wouldn't otherwise be easily accessible at the command line. The data is presented in a consistent format that resembles a file system drive.
 Locale: en-US
-ms.date: 03/27/2020
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_providers?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Providers
@@ -359,3 +359,4 @@ Get-Help * -Category Provider
 [about_Locations](about_Locations.md)
 
 [about_Path_Syntax](about_Path_Syntax.md)
+

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -54,6 +54,10 @@ your session, type:
 Get-PSProvider
 ```
 
+> [!NOTE]
+> The **Certificate**, **Registry**, and **WSMan** providers are only
+> available on the Windows platform.
+
 ## Installing and removing providers
 
 Providers are typically installed via PowerShell modules. Importing the module

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to use the `pwsh` command-line interface. Displays the command-line parameters and describes the syntax.
 Locale: en-US
-ms.date: 10/22/2020
+ms.date: 03/07/2022
 no-loc: [-File, -f, -Command, -c, -ConfigurationName, -config, -CustomPipeName, -EncodedCommand, -e, -ec, -ExecutionPolicy, -ex, -ep, -InputFormat, -inp, -if, -Interactive, -i, -Login, -l, -MTA, -NoExit, -noe, -NoLogo, -nol, -NonInteractive, -noni, -NoProfile, -nop, -OutputFormat, -o, -of, -SettingsFile, -settings, -SSHServerMode, -sshs, -STA, -Version, -v, -WindowStyle, -w, -WorkingDirectory, -wd, -Help]
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -322,7 +322,7 @@ intended or supported for any other use.
 ### -STA
 
 Start PowerShell using a single-threaded apartment. This is the default. This
-switch is only available on Windows.
+switch is only available on the Windows platform.
 
 ### -Version | -v
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: Registry
 Locale: en-US
-ms.date: 09/28/2021
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_registry_provider?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Registry Provider

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -26,6 +26,8 @@ Provides access to the registry keys, entries, and values in PowerShell.
 
 ## Detailed description
 
+> This information only applies to PowerShell running on Windows.
+
 The PowerShell **Registry** provider lets you get, add, change,
 clear, and delete registry keys, entries, and values in PowerShell.
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
@@ -21,7 +21,8 @@ state is maintained and commands in the PSSession continue to run while the
 session is disconnected.
 
 The Disconnected Sessions feature is only available when the remote computer is
-running PowerShell 3.0 or a later version.
+a Windows computer running PowerShell 3.0 or a later version and the local
+computer is running Windows.
 
 The Disconnected Sessions feature allows you to close the session in which a
 PSSession was created, and even close PowerShell, and shut down the computer,
@@ -29,7 +30,7 @@ without disrupting commands running in the PSSession. Disconnected sessions are
 useful for running commands that take an extended time to complete, and
 provides the time and device flexibility that IT professionals require.
 
-You can't disconnect from an interactive session that is started by using the
+You can't disconnect from an interactive session that is started with the
 `Enter-PSSession` cmdlet.
 
 You can use disconnected sessions to manage PSSessions that were disconnected

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to disconnect and reconnect to a PowerShell Session (PSSession).
 Locale: en-US
-ms.date: 12/01/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_remote_disconnected_sessions?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Remote Disconnected Sessions
@@ -692,3 +692,4 @@ PowerShell doesn't attempt to maintain the PSSession.
 [Receive-PSSession](xref:Microsoft.PowerShell.Core.Receive-PSSession)
 
 [Invoke-Command](xref:Microsoft.PowerShell.Core.Invoke-Command)
+

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Output.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Output.md
@@ -175,8 +175,8 @@ in a streaming list.
 
 When objects are not formatted automatically, you can use the formatting
 cmdlets, such as Format-Table or Format-List, to format and display
-selected properties. Or, you can use the Out-GridView cmdlet to display
-the objects in a table.
+selected properties. On a Windows computer, you can use the `Out-GridView`
+cmdlet to display the objects in a table.
 
 Also, if you run a command on a remote computer that uses cmdlets that you
 do not have on your local computer, the objects that the command returns

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Output.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Remote_Output.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to interpret and format the output of remote commands.
 Locale: en-US
-ms.date: 12/01/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_remote_output?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Remote Output
@@ -215,3 +215,4 @@ computers are interspersed.
 [Invoke-Command](xref:Microsoft.PowerShell.Core.Invoke-Command)
 
 [Select-Object](xref:Microsoft.PowerShell.Utility.Select-Object)
+

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -15,6 +15,8 @@ sessions that use the session configuration.
 
 ## Long description
 
+> This information only applies to PowerShell running on Windows.
+
 A "session configuration file" is a text file with a .pssc file name extension
 that contains a hash table of session configuration properties and values. You
 can use a session configuration file to set the properties of a session

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -1,7 +1,7 @@
 ---
 description: Describes session configuration files, which are used in a session configuration (also known as an endpoint) to define the environment of sessions that use the session configuration.
 Locale: en-US
-ms.date: 01/03/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_session_configuration_files?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Session Configuration Files
@@ -402,3 +402,4 @@ working with an empty session.
 [Get-PSSessionCapability](xref:Microsoft.PowerShell.Core.Get-PSSessionCapability)
 
 [New-PSRoleCapabilityFile](xref:Microsoft.PowerShell.Core.New-PSRoleCapabilityFile)
+

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -1,7 +1,7 @@
 ---
 description: Describes session configurations, which determine the users who can connect to the computer remotely and the commands they can run.
 Locale: en-US
-ms.date: 12/09/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_session_configurations?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Session Configurations
@@ -356,3 +356,4 @@ about_SessionConfigurations
 [Test-PSSessionConfigurationFile](xref:Microsoft.PowerShell.Core.Test-PSSessionConfigurationFile)
 
 [Unregister-PSSessionConfiguration](xref:Microsoft.PowerShell.Core.Unregister-PSSessionConfiguration)
+

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -36,13 +36,12 @@ New-PSSessionConfiguration cmdlet. For more information about session
 configuration files, see
 [about_Session_Configuration_Files](about_Session_Configuration_Files.md).
 
-Session configurations are a feature of Web Services for Management
-(WS-Management) based PowerShell remoting. They are used only when you use the
-New-PSSession, Invoke-Command, or Enter-PSSession cmdlets to connect to a
-remote computer.
+Session configurations are a feature of WSMAN-based PowerShell remoting. They
+are used only when you use the `New-PSSession`, `Invoke-Command`, or
+`Enter-PSSession` cmdlets to connect to a remote Windows computer.
 
-Note: To manage the session configurations, start PowerShell with the
-"Run as administrator" option.
+To manage the session configurations on a Windows computer, start
+PowerShell with the **Run as administrator** option.
 
 About Session Configurations
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to sign scripts so that they comply with the PowerShell execution policies.
 Locale: en-US
-ms.date: 01/21/2022
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_signing?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Signing

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -14,6 +14,8 @@ policies.
 
 ## Long description
 
+> This information only applies to PowerShell running on Windows.
+
 The Restricted execution policy does not permit any scripts to run. The
 **AllSigned** and **RemoteSigned** execution policies prevent PowerShell from
 running scripts that do not have a digital signature.

--- a/reference/7.0/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
+++ b/reference/7.0/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
@@ -26,6 +26,8 @@ Provides access to X.509 certificate stores and certificates in PowerShell.
 
 ## Detailed description
 
+> This information only applies to PowerShell running on Windows.
+
 The PowerShell **Certificate** provider lets you get, add, change, clear, and
 delete certificates and certificate stores in PowerShell.
 

--- a/reference/7.0/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
+++ b/reference/7.0/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: Information about the Certificate provider.
 Locale: en-US
-ms.date: 06/04/2020
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.security/about/about_certificate_provider?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Certificate Provider

--- a/reference/7.0/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
+++ b/reference/7.0/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: WSMan
 Locale: en-US
-ms.date: 10/18/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.wsman.management/about/about_wsman_provider?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about WSMan Provider

--- a/reference/7.0/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
+++ b/reference/7.0/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
@@ -23,6 +23,8 @@ information.
 
 ## Detailed description
 
+> This information only applies to PowerShell running on Windows.
+
 The **WSMan** provider for PowerShell lets you add, change, clear, and
 delete WS-Management configuration data on local or remote computers.
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_CimSession.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_CimSession.md
@@ -1,7 +1,7 @@
 ---
 description: Describes a **CimSession** object and the difference between CIM sessions and PowerShell sessions.
 Locale: en-US
-ms.date: 05/13/2020
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_cimsession?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about CimSession
@@ -14,14 +14,16 @@ PowerShell sessions.
 
 ## Long description
 
+> This information only applies to PowerShell running on Windows.
+
 A Common Information Model (CIM) session is a client-side object that
 represents a connection to a local computer or a remote computer. You can use
 CIM sessions as an alternative to PowerShell sessions (PSSessions). Both
 approaches have advantages.
 
-You can use the `New-CimSession` cmdlet to create a CIM session that contains
-information about a connection, such as computer name, the protocol used for
-the connection, session ID, and instance ID.
+You can use the `New-CimSession` cmdlet on a Windows computer to create a CIM
+session that contains information about a connection, such as computer name,
+the protocol used for the connection, session ID, and instance ID.
 
 After you create a **CimSession** object that specifies information required to
 establish a connection, PowerShell does not establish the connection

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -1,7 +1,7 @@
 ---
 description: Explains language modes and their effect on PowerShell sessions.
 Locale: en-US
-ms.date: 08/03/2021
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Language Modes
@@ -208,8 +208,14 @@ FullLanguage
 ```
 
 On other session configurations, you can find the language mode indirectly by
-finding the language mode of a session that is created by using the session
+finding the language mode of a session that is created with the session
 configuration.
+
+> [!NOTE]
+> Session configurations are a feature of WSMan-based PowerShell remoting. They are used only when you
+> use the `New-PSSession`, `Invoke-Command`, or `Enter-PSSession` cmdlets
+> to connect to a remote Windows computer. The `Get-PSSessionConfiguration`
+> cmdlet is only available on Windows computers.
 
 ### Finding the language mode of a session
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
@@ -1,7 +1,7 @@
 ---
 description: Provides detailed information about PowerShell sessions and the role they play in remote commands.
 Locale: en-US
-ms.date: 06/09/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pssession_details?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSSession Details
@@ -150,13 +150,13 @@ and manage only the PSSessions that you created.
 
 ## Can I Connect to a PSSession From a Different Computer?
 
-Beginning in Windows PowerShell 3.0, PSSessions are independent
-of the sessions in which they were created. Active PSSessions
+Beginning in Windows PowerShell 3.0, PSSessions on Windows computers are
+independent of the sessions in which they were created. Active PSSessions
 are maintained on the computer at the remote or "server-side" of
 a connection.
 
-You can use the `Disconnect-PSSession` cmdlet to disconnect
-from a PSSession. The PSSession is disconnected from the
+On a Windows computer, you can use the `Disconnect-PSSession` cmdlet to
+disconnect from a PSSession. The PSSession is disconnected from the
 local session, but is maintained on the remote computer.
 Commands continue to run in the disconnected PSSession. You
 can close PowerShell and shut down the originating computer
@@ -164,7 +164,7 @@ without interrupting the PSSession.
 
 Then, even hours later, you can use the `Get-PSSession` cmdlet to
 get the PSSession and the `Connect-PSSession` cmdlet to connect to the
-PSSession from a new session on a different computer.
+PSSession from a new session on a different Windows computer.
 
 For more information, see [about_Remote_Disconnected_Sessions](about_Remote_Disconnected_Sessions.md).
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_PSSessions.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_PSSessions.md
@@ -1,7 +1,7 @@
 ---
 description: Describes PowerShell sessions (PSSessions) and explains how to establish a persistent connection to a remote computer.
 Locale: en-US
-ms.date: 01/03/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pssessions?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSSessions
@@ -27,11 +27,12 @@ You can also create a PSSession on the local computer and run commands in it.
 A local PSSession uses the PowerShell remoting infrastructure to
 create and maintain the PSSession.
 
-Beginning in Windows PowerShell 3.0, PSSessions are independent of the
-sessions in which they are created. Active PSSessions are maintained on the
-remote computer (or the computer at the remote end or "server-side" of the
-connection). As a result, you can disconnect from the PSSession and reconnect
-to it at a later time from the same computer or from a different computer.
+Beginning in Windows PowerShell 3.0, PSSessions on Windows are independent
+of the sessions in which they are created. Active PSSessions are maintained
+on the remote computer (or the computer at the remote end or "server-side"
+of the connection). As a result, on Windows you can disconnect from a PSSession
+on a remote Windows computer and reconnect to it at a later time from the
+same computer or from a different Windows computer.
 
 This topic explains how to create, use, get, and delete PSSessions. For more
 advanced information, see
@@ -256,6 +257,12 @@ Get-Help *-PSSession
 - Receive-PSSession: Gets the results of commands that ran in a disconnected
   session
 - Remove-PSSession: Deletes the PSSessions in the current session
+
+> [!NOTE]
+> Disconnected sessions are only supported on Windows. The `Connect-PSSession`,
+> `Disconnect-PSSession`, and `Receive-PSSession` cmdlets are only available
+> on Windows. For more information about disconnected sessions, see
+> [about_Remote_Disconnected_Session](about_Remote_Disconnected_Sessions.md)
 
 ## For More Information
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how PowerShell providers provide access to data and components that wouldn't otherwise be easily accessible at the command line. The data is presented in a consistent format that resembles a file system drive.
 Locale: en-US
-ms.date: 03/27/2020
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_providers?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Providers
@@ -53,6 +53,10 @@ your session, type:
 ```powershell
 Get-PSProvider
 ```
+
+> [!NOTE]
+> The **Certificate**, **Registry**, and **WSMan** providers are only
+> available on the Windows platform.
 
 ## Installing and removing providers
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to use the `pwsh` command-line interface. Displays the command-line parameters and describes the syntax.
 Locale: en-US
-ms.date: 10/22/2020
+ms.date: 03/07/2022
 no-loc: [-File, -f, -Command, -c, -ConfigurationName, -config, -CustomPipeName, -EncodedCommand, -e, -ec, -ExecutionPolicy, -ex, -ep, -InputFormat, -inp, -if, -Interactive, -i, -Login, -l, -MTA, -NoExit, -noe, -NoLogo, -nol, -NonInteractive, -noni, -NoProfile, -nop, -OutputFormat, -o, -of, -SettingsFile, -settings, -SSHServerMode, -sshs, -STA, -Version, -v, -WindowStyle, -w, -WorkingDirectory, -wd, -Help]
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -322,7 +322,7 @@ intended or supported for any other use.
 ### -STA
 
 Start PowerShell using a single-threaded apartment. This is the default. This
-switch is only available on Windows.
+switch is only available on the Windows platform.
 
 ### -Version | -v
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: Registry
 Locale: en-US
-ms.date: 09/28/2021
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_registry_provider?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Registry Provider
@@ -25,6 +25,8 @@ Registry
 Provides access to the registry keys, entries, and values in PowerShell.
 
 ## Detailed description
+
+> This information only applies to PowerShell running on Windows.
 
 The PowerShell **Registry** provider lets you get, add, change,
 clear, and delete registry keys, entries, and values in PowerShell.

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to disconnect and reconnect to a PowerShell Session (PSSession).
 Locale: en-US
-ms.date: 12/01/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_remote_disconnected_sessions?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Remote Disconnected Sessions
@@ -21,7 +21,8 @@ state is maintained and commands in the PSSession continue to run while the
 session is disconnected.
 
 The Disconnected Sessions feature is only available when the remote computer is
-running PowerShell 3.0 or a later version.
+a Windows computer running PowerShell 3.0 or a later version and the local
+computer is running Windows.
 
 The Disconnected Sessions feature allows you to close the session in which a
 PSSession was created, and even close PowerShell, and shut down the computer,
@@ -29,7 +30,7 @@ without disrupting commands running in the PSSession. Disconnected sessions are
 useful for running commands that take an extended time to complete, and
 provides the time and device flexibility that IT professionals require.
 
-You can't disconnect from an interactive session that is started by using the
+You can't disconnect from an interactive session that is started with the
 `Enter-PSSession` cmdlet.
 
 You can use disconnected sessions to manage PSSessions that were disconnected

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -1,7 +1,7 @@
 ---
 description: Describes session configurations, which determine the users who can connect to the computer remotely and the commands they can run.
 Locale: en-US
-ms.date: 12/09/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_session_configurations?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Session Configurations
@@ -36,13 +36,12 @@ New-PSSessionConfiguration cmdlet. For more information about session
 configuration files, see
 [about_Session_Configuration_Files](about_Session_Configuration_Files.md).
 
-Session configurations are a feature of Web Services for Management
-(WS-Management) based PowerShell remoting. They are used only when you use the
-New-PSSession, Invoke-Command, or Enter-PSSession cmdlets to connect to a
-remote computer.
+Session configurations are a feature of WSMAN-based PowerShell remoting. They
+are used only when you use the `New-PSSession`, `Invoke-Command`, or
+`Enter-PSSession` cmdlets to connect to a remote Windows computer.
 
-Note: To manage the session configurations, start PowerShell with the
-"Run as administrator" option.
+To manage the session configurations on a Windows computer, start
+PowerShell with the **Run as administrator** option.
 
 About Session Configurations
 

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to sign scripts so that they comply with the PowerShell execution policies.
 Locale: en-US
-ms.date: 01/21/2022
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_signing?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Signing
@@ -13,6 +13,8 @@ Explains how to sign scripts so that they comply with the PowerShell execution
 policies.
 
 ## Long description
+
+> This information only applies to PowerShell running on Windows.
 
 The Restricted execution policy does not permit any scripts to run. The
 **AllSigned** and **RemoteSigned** execution policies prevent PowerShell from

--- a/reference/7.1/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
+++ b/reference/7.1/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: Information about the Certificate provider.
 Locale: en-US
-ms.date: 06/04/2020
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.security/about/about_certificate_provider?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Certificate Provider
@@ -25,6 +25,8 @@ Certificate
 Provides access to X.509 certificate stores and certificates in PowerShell.
 
 ## Detailed description
+
+> This information only applies to PowerShell running on Windows.
 
 The PowerShell **Certificate** provider lets you get, add, change, clear, and
 delete certificates and certificate stores in PowerShell.

--- a/reference/7.1/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
+++ b/reference/7.1/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: WSMan
 Locale: en-US
-ms.date: 10/18/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.wsman.management/about/about_wsman_provider?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about WSMan Provider
@@ -22,6 +22,8 @@ Provides access to Web Services for Management (WS-Management) configuration
 information.
 
 ## Detailed description
+
+> This information only applies to PowerShell running on Windows.
 
 The **WSMan** provider for PowerShell lets you add, change, clear, and
 delete WS-Management configuration data on local or remote computers.

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_CimSession.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_CimSession.md
@@ -1,7 +1,7 @@
 ---
 description: Describes a **CimSession** object and the difference between CIM sessions and PowerShell sessions.
 Locale: en-US
-ms.date: 05/13/2020
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_cimsession?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about CimSession
@@ -14,14 +14,16 @@ PowerShell sessions.
 
 ## Long description
 
+> This information only applies to PowerShell running on Windows.
+
 A Common Information Model (CIM) session is a client-side object that
 represents a connection to a local computer or a remote computer. You can use
 CIM sessions as an alternative to PowerShell sessions (PSSessions). Both
 approaches have advantages.
 
-You can use the `New-CimSession` cmdlet to create a CIM session that contains
-information about a connection, such as computer name, the protocol used for
-the connection, session ID, and instance ID.
+You can use the `New-CimSession` cmdlet on a Windows computer to create a CIM
+session that contains information about a connection, such as computer name,
+the protocol used for the connection, session ID, and instance ID.
 
 After you create a **CimSession** object that specifies information required to
 establish a connection, PowerShell does not establish the connection

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -1,7 +1,7 @@
 ---
 description: Explains language modes and their effect on PowerShell sessions.
 Locale: en-US
-ms.date: 08/03/2021
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Language Modes
@@ -211,8 +211,14 @@ FullLanguage
 ```
 
 On other session configurations, you can find the language mode indirectly by
-finding the language mode of a session that is created by using the session
+finding the language mode of a session that is created with the session
 configuration.
+
+> [!NOTE]
+> Session configurations are a feature of WSMan-based PowerShell remoting. They are used only when you
+> use the `New-PSSession`, `Invoke-Command`, or `Enter-PSSession` cmdlets
+> to connect to a remote Windows computer. The `Get-PSSessionConfiguration`
+> cmdlet is only available on Windows computers.
 
 ### Finding the language mode of a session
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
@@ -1,7 +1,7 @@
 ---
 description: Provides detailed information about PowerShell sessions and the role they play in remote commands.
 Locale: en-US
-ms.date: 06/09/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pssession_details?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSSession Details
@@ -150,13 +150,13 @@ and manage only the PSSessions that you created.
 
 ## Can I Connect to a PSSession From a Different Computer?
 
-Beginning in Windows PowerShell 3.0, PSSessions are independent
-of the sessions in which they were created. Active PSSessions
+Beginning in Windows PowerShell 3.0, PSSessions on Windows computers are
+independent of the sessions in which they were created. Active PSSessions
 are maintained on the computer at the remote or "server-side" of
 a connection.
 
-You can use the `Disconnect-PSSession` cmdlet to disconnect
-from a PSSession. The PSSession is disconnected from the
+On a Windows computer, you can use the `Disconnect-PSSession` cmdlet to
+disconnect from a PSSession. The PSSession is disconnected from the
 local session, but is maintained on the remote computer.
 Commands continue to run in the disconnected PSSession. You
 can close PowerShell and shut down the originating computer
@@ -164,7 +164,7 @@ without interrupting the PSSession.
 
 Then, even hours later, you can use the `Get-PSSession` cmdlet to
 get the PSSession and the `Connect-PSSession` cmdlet to connect to the
-PSSession from a new session on a different computer.
+PSSession from a new session on a different Windows computer.
 
 For more information, see [about_Remote_Disconnected_Sessions](about_Remote_Disconnected_Sessions.md).
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_PSSessions.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_PSSessions.md
@@ -1,7 +1,7 @@
 ---
 description: Describes PowerShell sessions (PSSessions) and explains how to establish a persistent connection to a remote computer.
 Locale: en-US
-ms.date: 01/03/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pssessions?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSSessions
@@ -27,11 +27,12 @@ You can also create a PSSession on the local computer and run commands in it.
 A local PSSession uses the PowerShell remoting infrastructure to
 create and maintain the PSSession.
 
-Beginning in Windows PowerShell 3.0, PSSessions are independent of the
-sessions in which they are created. Active PSSessions are maintained on the
-remote computer (or the computer at the remote end or "server-side" of the
-connection). As a result, you can disconnect from the PSSession and reconnect
-to it at a later time from the same computer or from a different computer.
+Beginning in Windows PowerShell 3.0, PSSessions on Windows are independent
+of the sessions in which they are created. Active PSSessions are maintained
+on the remote computer (or the computer at the remote end or "server-side"
+of the connection). As a result, on Windows you can disconnect from a PSSession
+on a remote Windows computer and reconnect to it at a later time from the
+same computer or from a different Windows computer.
 
 This topic explains how to create, use, get, and delete PSSessions. For more
 advanced information, see
@@ -256,6 +257,12 @@ Get-Help *-PSSession
 - Receive-PSSession: Gets the results of commands that ran in a disconnected
   session
 - Remove-PSSession: Deletes the PSSessions in the current session
+
+> [!NOTE]
+> Disconnected sessions are only supported on Windows. The `Connect-PSSession`,
+> `Disconnect-PSSession`, and `Receive-PSSession` cmdlets are only available
+> on Windows. For more information about disconnected sessions, see
+> [about_Remote_Disconnected_Session](about_Remote_Disconnected_Sessions.md)
 
 ## For More Information
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how PowerShell providers provide access to data and components that wouldn't otherwise be easily accessible at the command line. The data is presented in a consistent format that resembles a file system drive.
 Locale: en-US
-ms.date: 03/27/2020
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_providers?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Providers
@@ -53,6 +53,10 @@ your session, type:
 ```powershell
 Get-PSProvider
 ```
+
+> [!NOTE]
+> The **Certificate**, **Registry**, and **WSMan** providers are only
+> available on the Windows platform.
 
 ## Installing and removing providers
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to use the `pwsh` command-line interface. Displays the command-line parameters and describes the syntax.
 Locale: en-US
-ms.date: 10/22/2020
+ms.date: 03/07/2022
 no-loc: [-File, -f, -Command, -c, -ConfigurationName, -config, -CustomPipeName, -EncodedCommand, -e, -ec, -ExecutionPolicy, -ex, -ep, -InputFormat, -inp, -if, -Interactive, -i, -Login, -l, -MTA, -NoExit, -noe, -NoLogo, -nol, -NonInteractive, -noni, -NoProfile, -nop, -OutputFormat, -o, -of, -SettingsFile, -settings, -SSHServerMode, -sshs, -STA, -Version, -v, -WindowStyle, -w, -WorkingDirectory, -wd, -Help]
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -328,7 +328,7 @@ intended or supported for any other use.
 ### -STA
 
 Start PowerShell using a single-threaded apartment. This is the default. This
-switch is only available on Windows.
+switch is only available on the Windows platform.
 
 ### -Version | -v
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: Registry
 Locale: en-US
-ms.date: 09/28/2021
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_registry_provider?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Registry Provider
@@ -25,6 +25,8 @@ Registry
 Provides access to the registry keys, entries, and values in PowerShell.
 
 ## Detailed description
+
+> This information only applies to PowerShell running on Windows.
 
 The PowerShell **Registry** provider lets you get, add, change,
 clear, and delete registry keys, entries, and values in PowerShell.

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to disconnect and reconnect to a PowerShell Session (PSSession).
 Locale: en-US
-ms.date: 12/01/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_remote_disconnected_sessions?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Remote Disconnected Sessions
@@ -21,7 +21,8 @@ state is maintained and commands in the PSSession continue to run while the
 session is disconnected.
 
 The Disconnected Sessions feature is only available when the remote computer is
-running PowerShell 3.0 or a later version.
+a Windows computer running PowerShell 3.0 or a later version and the local
+computer is running Windows.
 
 The Disconnected Sessions feature allows you to close the session in which a
 PSSession was created, and even close PowerShell, and shut down the computer,
@@ -29,7 +30,7 @@ without disrupting commands running in the PSSession. Disconnected sessions are
 useful for running commands that take an extended time to complete, and
 provides the time and device flexibility that IT professionals require.
 
-You can't disconnect from an interactive session that is started by using the
+You can't disconnect from an interactive session that is started with the
 `Enter-PSSession` cmdlet.
 
 You can use disconnected sessions to manage PSSessions that were disconnected

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -1,7 +1,7 @@
 ---
 description: Describes session configurations, which determine the users who can connect to the computer remotely and the commands they can run.
 Locale: en-US
-ms.date: 12/09/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_session_configurations?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Session Configurations
@@ -36,13 +36,12 @@ New-PSSessionConfiguration cmdlet. For more information about session
 configuration files, see
 [about_Session_Configuration_Files](about_Session_Configuration_Files.md).
 
-Session configurations are a feature of Web Services for Management
-(WS-Management) based PowerShell remoting. They are used only when you use the
-New-PSSession, Invoke-Command, or Enter-PSSession cmdlets to connect to a
-remote computer.
+Session configurations are a feature of WSMAN-based PowerShell remoting. They
+are used only when you use the `New-PSSession`, `Invoke-Command`, or
+`Enter-PSSession` cmdlets to connect to a remote Windows computer.
 
-Note: To manage the session configurations, start PowerShell with the
-"Run as administrator" option.
+To manage the session configurations on a Windows computer, start
+PowerShell with the **Run as administrator** option.
 
 About Session Configurations
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to sign scripts so that they comply with the PowerShell execution policies.
 Locale: en-US
-ms.date: 01/21/2022
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_signing?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Signing
@@ -13,6 +13,8 @@ Explains how to sign scripts so that they comply with the PowerShell execution
 policies.
 
 ## Long description
+
+> This information only applies to PowerShell running on Windows.
 
 The Restricted execution policy does not permit any scripts to run. The
 **AllSigned** and **RemoteSigned** execution policies prevent PowerShell from

--- a/reference/7.2/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
+++ b/reference/7.2/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: Information about the Certificate provider.
 Locale: en-US
-ms.date: 06/04/2020
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.security/about/about_certificate_provider?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Certificate Provider
@@ -25,6 +25,8 @@ Certificate
 Provides access to X.509 certificate stores and certificates in PowerShell.
 
 ## Detailed description
+
+> This information only applies to PowerShell running on Windows.
 
 The PowerShell **Certificate** provider lets you get, add, change, clear, and
 delete certificates and certificate stores in PowerShell.

--- a/reference/7.2/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
+++ b/reference/7.2/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: WSMan
 Locale: en-US
-ms.date: 10/18/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.wsman.management/about/about_wsman_provider?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about WSMan Provider
@@ -22,6 +22,8 @@ Provides access to Web Services for Management (WS-Management) configuration
 information.
 
 ## Detailed description
+
+> This information only applies to PowerShell running on Windows.
 
 The **WSMan** provider for PowerShell lets you add, change, clear, and
 delete WS-Management configuration data on local or remote computers.

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_CimSession.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_CimSession.md
@@ -1,8 +1,8 @@
 ---
 description: Describes a **CimSession** object and the difference between CIM sessions and PowerShell sessions.
 Locale: en-US
-ms.date: 05/13/2020
-online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_cimsession?view=powershell-7.3&WT.mc_id=ps-gethelp
+ms.date: 03/07/2022
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_cimsession?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about CimSession
 ---
@@ -14,14 +14,16 @@ PowerShell sessions.
 
 ## Long description
 
+> This information only applies to PowerShell running on Windows.
+
 A Common Information Model (CIM) session is a client-side object that
 represents a connection to a local computer or a remote computer. You can use
 CIM sessions as an alternative to PowerShell sessions (PSSessions). Both
 approaches have advantages.
 
-You can use the `New-CimSession` cmdlet to create a CIM session that contains
-information about a connection, such as computer name, the protocol used for
-the connection, session ID, and instance ID.
+You can use the `New-CimSession` cmdlet on a Windows computer to create a CIM
+session that contains information about a connection, such as computer name,
+the protocol used for the connection, session ID, and instance ID.
 
 After you create a **CimSession** object that specifies information required to
 establish a connection, PowerShell does not establish the connection

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -1,7 +1,7 @@
 ---
 description: Explains language modes and their effect on PowerShell sessions.
 Locale: en-US
-ms.date: 08/03/2021
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Language Modes
@@ -211,8 +211,14 @@ FullLanguage
 ```
 
 On other session configurations, you can find the language mode indirectly by
-finding the language mode of a session that is created by using the session
+finding the language mode of a session that is created with the session
 configuration.
+
+> [!NOTE]
+> Session configurations are a feature of WSMan-based PowerShell remoting. They are used only when you
+> use the `New-PSSession`, `Invoke-Command`, or `Enter-PSSession` cmdlets
+> to connect to a remote Windows computer. The `Get-PSSessionConfiguration`
+> cmdlet is only available on Windows computers.
 
 ### Finding the language mode of a session
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
@@ -1,7 +1,7 @@
 ---
 description: Provides detailed information about PowerShell sessions and the role they play in remote commands.
 Locale: en-US
-ms.date: 06/09/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pssession_details?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSSession Details
@@ -150,13 +150,13 @@ and manage only the PSSessions that you created.
 
 ## Can I Connect to a PSSession From a Different Computer?
 
-Beginning in Windows PowerShell 3.0, PSSessions are independent
-of the sessions in which they were created. Active PSSessions
+Beginning in Windows PowerShell 3.0, PSSessions on Windows computers are
+independent of the sessions in which they were created. Active PSSessions
 are maintained on the computer at the remote or "server-side" of
 a connection.
 
-You can use the `Disconnect-PSSession` cmdlet to disconnect
-from a PSSession. The PSSession is disconnected from the
+On a Windows computer, you can use the `Disconnect-PSSession` cmdlet to
+disconnect from a PSSession. The PSSession is disconnected from the
 local session, but is maintained on the remote computer.
 Commands continue to run in the disconnected PSSession. You
 can close PowerShell and shut down the originating computer
@@ -164,7 +164,7 @@ without interrupting the PSSession.
 
 Then, even hours later, you can use the `Get-PSSession` cmdlet to
 get the PSSession and the `Connect-PSSession` cmdlet to connect to the
-PSSession from a new session on a different computer.
+PSSession from a new session on a different Windows computer.
 
 For more information, see [about_Remote_Disconnected_Sessions](about_Remote_Disconnected_Sessions.md).
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_PSSessions.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_PSSessions.md
@@ -1,7 +1,7 @@
 ---
 description: Describes PowerShell sessions (PSSessions) and explains how to establish a persistent connection to a remote computer.
 Locale: en-US
-ms.date: 01/03/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pssessions?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSSessions
@@ -27,11 +27,12 @@ You can also create a PSSession on the local computer and run commands in it.
 A local PSSession uses the PowerShell remoting infrastructure to
 create and maintain the PSSession.
 
-Beginning in Windows PowerShell 3.0, PSSessions are independent of the
-sessions in which they are created. Active PSSessions are maintained on the
-remote computer (or the computer at the remote end or "server-side" of the
-connection). As a result, you can disconnect from the PSSession and reconnect
-to it at a later time from the same computer or from a different computer.
+Beginning in Windows PowerShell 3.0, PSSessions on Windows are independent
+of the sessions in which they are created. Active PSSessions are maintained
+on the remote computer (or the computer at the remote end or "server-side"
+of the connection). As a result, on Windows you can disconnect from a PSSession
+on a remote Windows computer and reconnect to it at a later time from the
+same computer or from a different Windows computer.
 
 This topic explains how to create, use, get, and delete PSSessions. For more
 advanced information, see
@@ -256,6 +257,12 @@ Get-Help *-PSSession
 - Receive-PSSession: Gets the results of commands that ran in a disconnected
   session
 - Remove-PSSession: Deletes the PSSessions in the current session
+
+> [!NOTE]
+> Disconnected sessions are only supported on Windows. The `Connect-PSSession`,
+> `Disconnect-PSSession`, and `Receive-PSSession` cmdlets are only available
+> on Windows. For more information about disconnected sessions, see
+> [about_Remote_Disconnected_Session](about_Remote_Disconnected_Sessions.md)
 
 ## For More Information
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how PowerShell providers provide access to data and components that wouldn't otherwise be easily accessible at the command line. The data is presented in a consistent format that resembles a file system drive.
 Locale: en-US
-ms.date: 03/27/2020
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_providers?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Providers
@@ -53,6 +53,10 @@ your session, type:
 ```powershell
 Get-PSProvider
 ```
+
+> [!NOTE]
+> The **Certificate**, **Registry**, and **WSMan** providers are only
+> available on the Windows platform.
 
 ## Installing and removing providers
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to use the `pwsh` command-line interface. Displays the command-line parameters and describes the syntax.
 Locale: en-US
-ms.date: 01/18/2022
+ms.date: 03/07/2022
 no-loc: [-File, -f, -Command, -c, -ConfigurationName, -config, -CustomPipeName, -EncodedCommand, -e, -ec, -ExecutionPolicy, -ex, -ep, -InputFormat, -inp, -if, -Interactive, -i, -Login, -l, -MTA, -NoExit, -noe, -NoLogo, -nol, -NonInteractive, -noni, -NoProfile, -nop, -OutputFormat, -o, -of, -SettingsFile, -settings, -SSHServerMode, -sshs, -STA, -Version, -v, -WindowStyle, -w, -WorkingDirectory, -wd, -Help]
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -328,7 +328,7 @@ intended or supported for any other use.
 ### -STA
 
 Start PowerShell using a single-threaded apartment. This is the default. This
-switch is only available on Windows.
+switch is only available on the Windows platform.
 
 ### -Version | -v
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: Registry
 Locale: en-US
-ms.date: 09/28/2021
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_registry_provider?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Registry Provider
@@ -25,6 +25,8 @@ Registry
 Provides access to the registry keys, entries, and values in PowerShell.
 
 ## Detailed description
+
+> This information only applies to PowerShell running on Windows.
 
 The PowerShell **Registry** provider lets you get, add, change,
 clear, and delete registry keys, entries, and values in PowerShell.

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to disconnect and reconnect to a PowerShell Session (PSSession).
 Locale: en-US
-ms.date: 12/01/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_remote_disconnected_sessions?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Remote Disconnected Sessions
@@ -21,7 +21,8 @@ state is maintained and commands in the PSSession continue to run while the
 session is disconnected.
 
 The Disconnected Sessions feature is only available when the remote computer is
-running PowerShell 3.0 or a later version.
+a Windows computer running PowerShell 3.0 or a later version and the local
+computer is running Windows.
 
 The Disconnected Sessions feature allows you to close the session in which a
 PSSession was created, and even close PowerShell, and shut down the computer,
@@ -29,7 +30,7 @@ without disrupting commands running in the PSSession. Disconnected sessions are
 useful for running commands that take an extended time to complete, and
 provides the time and device flexibility that IT professionals require.
 
-You can't disconnect from an interactive session that is started by using the
+You can't disconnect from an interactive session that is started with the
 `Enter-PSSession` cmdlet.
 
 You can use disconnected sessions to manage PSSessions that were disconnected

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Remote_Output.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Remote_Output.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to interpret and format the output of remote commands.
 Locale: en-US
-ms.date: 12/01/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_remote_output?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Remote Output
@@ -175,8 +175,8 @@ in a streaming list.
 
 When objects are not formatted automatically, you can use the formatting
 cmdlets, such as Format-Table or Format-List, to format and display
-selected properties. Or, you can use the Out-GridView cmdlet to display
-the objects in a table.
+selected properties. On a Windows computer, you can use the `Out-GridView`
+cmdlet to display the objects in a table.
 
 Also, if you run a command on a remote computer that uses cmdlets that you
 do not have on your local computer, the objects that the command returns

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -1,7 +1,7 @@
 ---
 description: Describes session configuration files, which are used in a session configuration (also known as an endpoint) to define the environment of sessions that use the session configuration.
 Locale: en-US
-ms.date: 01/03/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_session_configuration_files?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Session Configuration Files
@@ -14,6 +14,8 @@ configuration (also known as an "endpoint") to define the environment of
 sessions that use the session configuration.
 
 ## Long description
+
+> This information only applies to PowerShell running on Windows.
 
 A "session configuration file" is a text file with a .pssc file name extension
 that contains a hash table of session configuration properties and values. You

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -1,7 +1,7 @@
 ---
 description: Describes session configurations, which determine the users who can connect to the computer remotely and the commands they can run.
 Locale: en-US
-ms.date: 12/09/2017
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_session_configurations?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Session Configurations
@@ -36,13 +36,12 @@ New-PSSessionConfiguration cmdlet. For more information about session
 configuration files, see
 [about_Session_Configuration_Files](about_Session_Configuration_Files.md).
 
-Session configurations are a feature of Web Services for Management
-(WS-Management) based PowerShell remoting. They are used only when you use the
-New-PSSession, Invoke-Command, or Enter-PSSession cmdlets to connect to a
-remote computer.
+Session configurations are a feature of WSMAN-based PowerShell remoting. They
+are used only when you use the `New-PSSession`, `Invoke-Command`, or
+`Enter-PSSession` cmdlets to connect to a remote Windows computer.
 
-Note: To manage the session configurations, start PowerShell with the
-"Run as administrator" option.
+To manage the session configurations on a Windows computer, start
+PowerShell with the **Run as administrator** option.
 
 About Session Configurations
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to sign scripts so that they comply with the PowerShell execution policies.
 Locale: en-US
-ms.date: 01/21/2022
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_signing?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Signing
@@ -13,6 +13,8 @@ Explains how to sign scripts so that they comply with the PowerShell execution
 policies.
 
 ## Long description
+
+> This information only applies to PowerShell running on Windows.
 
 The Restricted execution policy does not permit any scripts to run. The
 **AllSigned** and **RemoteSigned** execution policies prevent PowerShell from

--- a/reference/7.3/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
+++ b/reference/7.3/Microsoft.PowerShell.Security/About/about_Certificate_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: Information about the Certificate provider.
 Locale: en-US
-ms.date: 06/04/2020
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.security/about/about_certificate_provider?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Certificate Provider
@@ -25,6 +25,8 @@ Certificate
 Provides access to X.509 certificate stores and certificates in PowerShell.
 
 ## Detailed description
+
+> This information only applies to PowerShell running on Windows.
 
 The PowerShell **Certificate** provider lets you get, add, change, clear, and
 delete certificates and certificate stores in PowerShell.

--- a/reference/7.3/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
+++ b/reference/7.3/Microsoft.WSMan.Management/About/about_WSMan_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: WSMan
 Locale: en-US
-ms.date: 10/18/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.wsman.management/about/about_wsman_provider?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about WSMan Provider
@@ -22,6 +22,8 @@ Provides access to Web Services for Management (WS-Management) configuration
 information.
 
 ## Detailed description
+
+> This information only applies to PowerShell running on Windows.
 
 The **WSMan** provider for PowerShell lets you add, change, clear, and
 delete WS-Management configuration data on local or remote computers.


### PR DESCRIPTION
# PR Summary

Prior to this commit, the about help inconsistently clarified what functionality was available on the Windows platform only. This commit updates the help to add clarity for users to reduce confusion and attempts to call commands and use features which may be unavailable to them.

Fixes #8602.

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [ ] Preview content
- [ ] Version 7.2 content
- [ ] Version 7.1 content
- [x] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
