### PR TITLE
(GH-8630) Update style/grammar in about_Hidden

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Hidden.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Hidden.md
@@ -1,7 +1,7 @@
 ---
-description: Describes the Hidden keyword, which hides class members from default Get-Member results.
+description: Describes the `hidden` keyword, which hides class members from default `Get-Member` results.
 Locale: en-US
-ms.date: 01/04/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_hidden?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Hidden
@@ -9,51 +9,57 @@ title: about Hidden
 # about_Hidden
 
 ## Short description
-Describes the Hidden keyword, which hides class members from default
-Get-Member results.
+Describes the `hidden` keyword, which hides class members from default
+`Get-Member` results.
 
 ## Long description
 
-When you use the Hidden keyword in a script, you hide the members of a class
-by default. The Hidden keyword can hide properties, methods (including
-constructors, events, alias properties, and other member types, including
-static members, from the default results of the Get-Member cmdlet, and from
-IntelliSense and tab completion results. To display members that you have
-hidden with the Hidden keyword, add the -Force parameter to a Get-Member
-command.
+When you use the `hidden` keyword in a script, you hide the members of a class
+by default. Hidden members do not display in the default results of the
+`Get-Member` cmdlet, IntelliSense, or tab completion results. To display members
+that you have hidden with the `hidden` keyword, add the **Force** parameter to a
+`Get-Member` command.
 
-Hidden members are not displayed by using tab completion or IntelliSense,
-unless the completion occurs in the class that defines the hidden member.
+The `hidden` keyword can hide:
 
-A new attribute, System.Management.Automation.HiddenAttribute, has been added,
-so that C\# code can have the same semantics within PowerShell.
+- methods (including constructors)
+- events
+- alias properties
+- other member types (including static members)
 
-The Hidden keyword is useful for creating properties and methods within a
-class that you do not necessarily want other users of the class to see, or
-readily be able to edit.
+Hidden members are not displayed in tab completion or IntelliSense unless the
+completion occurs in the class that defines the hidden member.
 
-The Hidden keyword has no effect on how you can view or make changes to
-members of a class. Like all language keywords in PowerShell, Hidden is not
+The new attribute, **System.Management.Automation.HiddenAttribute**, enables C#
+code to have the same semantics within PowerShell.
+
+The `hidden` keyword is useful for creating properties and methods within a
+class that you do not necessarily want users of the class to see or readily be
+able to edit.
+
+The `hidden` keyword has no effect on how you can view or make changes to
+members of a class. Like all language keywords in PowerShell, `hidden` is not
 case-sensitive, and hidden members are still public.
 
-Hidden, along with custom classes, was introduced in PowerShell 5.0.
+The `hidden` keyword, along with custom classes, was introduced in Windows
+PowerShell 5.0.
 
 ## EXAMPLE
 
-The following example shows how to use the Hidden keyword in a class
-definition. The Car class method, Drive, has a property, rides, that does not
-need to be viewed or changed (it merely tallies the number of times that Drive
-is called on the Car class, a metric that is not important to users of the
-class; consider, for example, that when you are buying a car, you do not ask
-the seller on how many drives the car has been taken.
+The following example shows how to use the `hidden` keyword in a class
+definition. The **Car** class method, **Drive**, has a property, **rides**, that
+does not need to be viewed or changed as it merely tallies the number of times
+that **Drive** is called on the **Car** class. That metric that is not important
+to users of the class (consider, for example, that when you are buying a car,
+you do not ask the seller on how many drives the car has been taken).
 
-Because there is little need for users of the class to change this property,
-we can hide the property from Get-Member and automatic completion results by
-using the Hidden keyword.
+Because there is little need for users of the class to change this property, we
+can hide the property from `Get-Member` and automatic completion results by
+using the `hidden` keyword.
 
-Add the Hidden keyword by entering it on the same statement line as the
+Add the `hidden` keyword by entering it on the same statement line as the
 property and its data type. Although the keyword can be in any order on this
-line, starting the statement with the Hidden keyword makes it easier for you
+line, starting the statement with the `hidden` keyword makes it easier for you
 later to identify all members that you have hidden.
 
 ```powershell
@@ -77,16 +83,16 @@ class Car
 }
 ```
 
-Now, create a new instance of the Car class, and save it in a variable,
-\$TestCar.
+Now, create a new instance of the **Car** class, and save it in a variable,
+`$TestCar`.
 
 ```powershell
 $TestCar = [Car]::new()
 ```
 
-After you create the new instance, pipe the contents of the $TestCar variable
-to Get-Member. Observe that the rides property is not among the members listed
-in the Get-Member command results.
+After you create the new instance, pipe the contents of the `$TestCar` variable
+to `Get-Member`. Observe that the **rides** property is not among the members
+listed in the `Get-Member` command results.
 
 ```output
 PS C:\Windows\system32> $TestCar | Get-Member
@@ -106,8 +112,8 @@ ModelYear   Property   string ModelYear {get;set;}
 
 ```
 
-Now, try running Get-Member again, but this time, add the -Force parameter.
-Note that the results contain the hidden rides property, among other members
+Now, try running `Get-Member` again, but this time, add the `-Force` parameter.
+Note that the results contain the hidden **rides** property, among other members
 that are hidden by default.
 
 ```output
@@ -151,3 +157,4 @@ rides         Property     int rides {get;set;}
 [about_Wildcards](about_Wildcards.md)
 
 [Get-Member](xref:Microsoft.PowerShell.Utility.Get-Member)
+

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Hidden.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Hidden.md
@@ -1,7 +1,7 @@
 ---
-description: Describes the Hidden keyword, which hides class members from default Get-Member results.
+description: Describes the `hidden` keyword, which hides class members from default `Get-Member` results.
 Locale: en-US
-ms.date: 01/04/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_hidden?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Hidden
@@ -9,51 +9,57 @@ title: about Hidden
 # about_Hidden
 
 ## Short description
-Describes the Hidden keyword, which hides class members from default
-Get-Member results.
+Describes the `hidden` keyword, which hides class members from default
+`Get-Member` results.
 
 ## Long description
 
-When you use the Hidden keyword in a script, you hide the members of a class
-by default. The Hidden keyword can hide properties, methods (including
-constructors, events, alias properties, and other member types, including
-static members, from the default results of the Get-Member cmdlet, and from
-IntelliSense and tab completion results. To display members that you have
-hidden with the Hidden keyword, add the -Force parameter to a Get-Member
-command.
+When you use the `hidden` keyword in a script, you hide the members of a class
+by default. Hidden members do not display in the default results of the
+`Get-Member` cmdlet, IntelliSense, or tab completion results. To display members
+that you have hidden with the `hidden` keyword, add the **Force** parameter to a
+`Get-Member` command.
 
-Hidden members are not displayed by using tab completion or IntelliSense,
-unless the completion occurs in the class that defines the hidden member.
+The `hidden` keyword can hide:
 
-A new attribute, System.Management.Automation.HiddenAttribute, has been added,
-so that C\# code can have the same semantics within PowerShell.
+- methods (including constructors)
+- events
+- alias properties
+- other member types (including static members)
 
-The Hidden keyword is useful for creating properties and methods within a
-class that you do not necessarily want other users of the class to see, or
-readily be able to edit.
+Hidden members are not displayed in tab completion or IntelliSense unless the
+completion occurs in the class that defines the hidden member.
 
-The Hidden keyword has no effect on how you can view or make changes to
-members of a class. Like all language keywords in PowerShell, Hidden is not
+The new attribute, **System.Management.Automation.HiddenAttribute**, enables C#
+code to have the same semantics within PowerShell.
+
+The `hidden` keyword is useful for creating properties and methods within a
+class that you do not necessarily want users of the class to see or readily be
+able to edit.
+
+The `hidden` keyword has no effect on how you can view or make changes to
+members of a class. Like all language keywords in PowerShell, `hidden` is not
 case-sensitive, and hidden members are still public.
 
-Hidden, along with custom classes, was introduced in PowerShell 5.0.
+The `hidden` keyword, along with custom classes, was introduced in Windows
+PowerShell 5.0.
 
 ## EXAMPLE
 
-The following example shows how to use the Hidden keyword in a class
-definition. The Car class method, Drive, has a property, rides, that does not
-need to be viewed or changed (it merely tallies the number of times that Drive
-is called on the Car class, a metric that is not important to users of the
-class; consider, for example, that when you are buying a car, you do not ask
-the seller on how many drives the car has been taken.
+The following example shows how to use the `hidden` keyword in a class
+definition. The **Car** class method, **Drive**, has a property, **rides**, that
+does not need to be viewed or changed as it merely tallies the number of times
+that **Drive** is called on the **Car** class. That metric that is not important
+to users of the class (consider, for example, that when you are buying a car,
+you do not ask the seller on how many drives the car has been taken).
 
-Because there is little need for users of the class to change this property,
-we can hide the property from Get-Member and automatic completion results by
-using the Hidden keyword.
+Because there is little need for users of the class to change this property, we
+can hide the property from `Get-Member` and automatic completion results by
+using the `hidden` keyword.
 
-Add the Hidden keyword by entering it on the same statement line as the
+Add the `hidden` keyword by entering it on the same statement line as the
 property and its data type. Although the keyword can be in any order on this
-line, starting the statement with the Hidden keyword makes it easier for you
+line, starting the statement with the `hidden` keyword makes it easier for you
 later to identify all members that you have hidden.
 
 ```powershell
@@ -77,16 +83,16 @@ class Car
 }
 ```
 
-Now, create a new instance of the Car class, and save it in a variable,
-\$TestCar.
+Now, create a new instance of the **Car** class, and save it in a variable,
+`$TestCar`.
 
 ```powershell
 $TestCar = [Car]::new()
 ```
 
-After you create the new instance, pipe the contents of the $TestCar variable
-to Get-Member. Observe that the rides property is not among the members listed
-in the Get-Member command results.
+After you create the new instance, pipe the contents of the `$TestCar` variable
+to `Get-Member`. Observe that the **rides** property is not among the members
+listed in the `Get-Member` command results.
 
 ```output
 PS C:\Windows\system32> $TestCar | Get-Member
@@ -106,8 +112,8 @@ ModelYear   Property   string ModelYear {get;set;}
 
 ```
 
-Now, try running Get-Member again, but this time, add the -Force parameter.
-Note that the results contain the hidden rides property, among other members
+Now, try running `Get-Member` again, but this time, add the `-Force` parameter.
+Note that the results contain the hidden **rides** property, among other members
 that are hidden by default.
 
 ```output
@@ -151,3 +157,4 @@ rides         Property     int rides {get;set;}
 [about_Wildcards](about_Wildcards.md)
 
 [Get-Member](xref:Microsoft.PowerShell.Utility.Get-Member)
+

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Hidden.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Hidden.md
@@ -1,7 +1,7 @@
 ---
-description: Describes the Hidden keyword, which hides class members from default Get-Member results.
+description: Describes the `hidden` keyword, which hides class members from default `Get-Member` results.
 Locale: en-US
-ms.date: 01/04/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_hidden?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Hidden
@@ -9,51 +9,57 @@ title: about Hidden
 # about_Hidden
 
 ## Short description
-Describes the Hidden keyword, which hides class members from default
-Get-Member results.
+Describes the `hidden` keyword, which hides class members from default
+`Get-Member` results.
 
 ## Long description
 
-When you use the Hidden keyword in a script, you hide the members of a class
-by default. The Hidden keyword can hide properties, methods (including
-constructors, events, alias properties, and other member types, including
-static members, from the default results of the Get-Member cmdlet, and from
-IntelliSense and tab completion results. To display members that you have
-hidden with the Hidden keyword, add the -Force parameter to a Get-Member
-command.
+When you use the `hidden` keyword in a script, you hide the members of a class
+by default. Hidden members do not display in the default results of the
+`Get-Member` cmdlet, IntelliSense, or tab completion results. To display members
+that you have hidden with the `hidden` keyword, add the **Force** parameter to a
+`Get-Member` command.
 
-Hidden members are not displayed by using tab completion or IntelliSense,
-unless the completion occurs in the class that defines the hidden member.
+The `hidden` keyword can hide:
 
-A new attribute, System.Management.Automation.HiddenAttribute, has been added,
-so that C\# code can have the same semantics within PowerShell.
+- methods (including constructors)
+- events
+- alias properties
+- other member types (including static members)
 
-The Hidden keyword is useful for creating properties and methods within a
-class that you do not necessarily want other users of the class to see, or
-readily be able to edit.
+Hidden members are not displayed in tab completion or IntelliSense unless the
+completion occurs in the class that defines the hidden member.
 
-The Hidden keyword has no effect on how you can view or make changes to
-members of a class. Like all language keywords in PowerShell, Hidden is not
+The new attribute, **System.Management.Automation.HiddenAttribute**, enables C#
+code to have the same semantics within PowerShell.
+
+The `hidden` keyword is useful for creating properties and methods within a
+class that you do not necessarily want users of the class to see or readily be
+able to edit.
+
+The `hidden` keyword has no effect on how you can view or make changes to
+members of a class. Like all language keywords in PowerShell, `hidden` is not
 case-sensitive, and hidden members are still public.
 
-Hidden, along with custom classes, was introduced in PowerShell 5.0.
+The `hidden` keyword, along with custom classes, was introduced in Windows
+PowerShell 5.0.
 
 ## EXAMPLE
 
-The following example shows how to use the Hidden keyword in a class
-definition. The Car class method, Drive, has a property, rides, that does not
-need to be viewed or changed (it merely tallies the number of times that Drive
-is called on the Car class, a metric that is not important to users of the
-class; consider, for example, that when you are buying a car, you do not ask
-the seller on how many drives the car has been taken.
+The following example shows how to use the `hidden` keyword in a class
+definition. The **Car** class method, **Drive**, has a property, **rides**, that
+does not need to be viewed or changed as it merely tallies the number of times
+that **Drive** is called on the **Car** class. That metric that is not important
+to users of the class (consider, for example, that when you are buying a car,
+you do not ask the seller on how many drives the car has been taken).
 
-Because there is little need for users of the class to change this property,
-we can hide the property from Get-Member and automatic completion results by
-using the Hidden keyword.
+Because there is little need for users of the class to change this property, we
+can hide the property from `Get-Member` and automatic completion results by
+using the `hidden` keyword.
 
-Add the Hidden keyword by entering it on the same statement line as the
+Add the `hidden` keyword by entering it on the same statement line as the
 property and its data type. Although the keyword can be in any order on this
-line, starting the statement with the Hidden keyword makes it easier for you
+line, starting the statement with the `hidden` keyword makes it easier for you
 later to identify all members that you have hidden.
 
 ```powershell
@@ -77,16 +83,16 @@ class Car
 }
 ```
 
-Now, create a new instance of the Car class, and save it in a variable,
-\$TestCar.
+Now, create a new instance of the **Car** class, and save it in a variable,
+`$TestCar`.
 
 ```powershell
 $TestCar = [Car]::new()
 ```
 
-After you create the new instance, pipe the contents of the $TestCar variable
-to Get-Member. Observe that the rides property is not among the members listed
-in the Get-Member command results.
+After you create the new instance, pipe the contents of the `$TestCar` variable
+to `Get-Member`. Observe that the **rides** property is not among the members
+listed in the `Get-Member` command results.
 
 ```output
 PS C:\Windows\system32> $TestCar | Get-Member
@@ -106,8 +112,8 @@ ModelYear   Property   string ModelYear {get;set;}
 
 ```
 
-Now, try running Get-Member again, but this time, add the -Force parameter.
-Note that the results contain the hidden rides property, among other members
+Now, try running `Get-Member` again, but this time, add the `-Force` parameter.
+Note that the results contain the hidden **rides** property, among other members
 that are hidden by default.
 
 ```output

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Hidden.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Hidden.md
@@ -1,7 +1,7 @@
 ---
-description: Describes the Hidden keyword, which hides class members from default Get-Member results.
+description: Describes the `hidden` keyword, which hides class members from default `Get-Member` results.
 Locale: en-US
-ms.date: 01/04/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_hidden?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Hidden
@@ -9,51 +9,57 @@ title: about Hidden
 # about_Hidden
 
 ## Short description
-Describes the Hidden keyword, which hides class members from default
-Get-Member results.
+Describes the `hidden` keyword, which hides class members from default
+`Get-Member` results.
 
 ## Long description
 
-When you use the Hidden keyword in a script, you hide the members of a class
-by default. The Hidden keyword can hide properties, methods (including
-constructors), events, alias properties, and other member types, including
-static members, from the default results of the Get-Member cmdlet, and from
-IntelliSense and tab completion results. To display members that you have
-hidden with the Hidden keyword, add the -Force parameter to a Get-Member
-command.
+When you use the `hidden` keyword in a script, you hide the members of a class
+by default. Hidden members do not display in the default results of the
+`Get-Member` cmdlet, IntelliSense, or tab completion results. To display members
+that you have hidden with the `hidden` keyword, add the **Force** parameter to a
+`Get-Member` command.
 
-Hidden members are not displayed by using tab completion or IntelliSense,
-unless the completion occurs in the class that defines the hidden member.
+The `hidden` keyword can hide:
 
-A new attribute, System.Management.Automation.HiddenAttribute, has been added,
-so that C\# code can have the same semantics within PowerShell.
+- methods (including constructors)
+- events
+- alias properties
+- other member types (including static members)
 
-The Hidden keyword is useful for creating properties and methods within a
-class that you do not necessarily want other users of the class to see, or
-readily be able to edit.
+Hidden members are not displayed in tab completion or IntelliSense unless the
+completion occurs in the class that defines the hidden member.
 
-The Hidden keyword has no effect on how you can view or make changes to
-members of a class. Like all language keywords in PowerShell, Hidden is not
+The new attribute, **System.Management.Automation.HiddenAttribute**, enables C#
+code to have the same semantics within PowerShell.
+
+The `hidden` keyword is useful for creating properties and methods within a
+class that you do not necessarily want users of the class to see or readily be
+able to edit.
+
+The `hidden` keyword has no effect on how you can view or make changes to
+members of a class. Like all language keywords in PowerShell, `hidden` is not
 case-sensitive, and hidden members are still public.
 
-Hidden, along with custom classes, was introduced in PowerShell 5.0.
+The `hidden` keyword, along with custom classes, was introduced in Windows
+PowerShell 5.0.
 
 ## EXAMPLE
 
-The following example shows how to use the Hidden keyword in a class
-definition. The Car class method, Drive, has a property, rides, that does not
-need to be viewed or changed (it merely tallies the number of times that Drive
-is called on the Car class, a metric that is not important to users of the
-class; consider, for example, that when you are buying a car, you do not ask
-the seller on how many drives the car has been taken.
+The following example shows how to use the `hidden` keyword in a class
+definition. The **Car** class method, **Drive**, has a property, **rides**, that
+does not need to be viewed or changed as it merely tallies the number of times
+that **Drive** is called on the **Car** class. That metric that is not important
+to users of the class (consider, for example, that when you are buying a car,
+you do not ask the seller on how many drives the car has been taken).
 
-Because there is little need for users of the class to change this property,
-we can hide the property from Get-Member and automatic completion results by
-using the Hidden keyword.
+Because there is little need for users of the class to change this property, we
+can hide the property from `Get-Member` and automatic completion results by
+using the `hidden` keyword.
 
-Add the Hidden keyword by entering it on the same statement line as the
+Add the `hidden` keyword by entering it on the same statement line as the
 property and its data type. Although the keyword can be in any order on this
-line, starting the statement with the Hidden keyword makes it easier for you
+line, starting the statement with the `hidden` keyword makes it easier for you
 later to identify all members that you have hidden.
 
 ```powershell
@@ -77,16 +83,16 @@ class Car
 }
 ```
 
-Now, create a new instance of the Car class, and save it in a variable,
-\$TestCar.
+Now, create a new instance of the **Car** class, and save it in a variable,
+`$TestCar`.
 
 ```powershell
 $TestCar = [Car]::new()
 ```
 
-After you create the new instance, pipe the contents of the $TestCar variable
-to Get-Member. Observe that the rides property is not among the members listed
-in the Get-Member command results.
+After you create the new instance, pipe the contents of the `$TestCar` variable
+to `Get-Member`. Observe that the **rides** property is not among the members
+listed in the `Get-Member` command results.
 
 ```output
 PS C:\Windows\system32> $TestCar | Get-Member
@@ -106,8 +112,8 @@ ModelYear   Property   string ModelYear {get;set;}
 
 ```
 
-Now, try running Get-Member again, but this time, add the -Force parameter.
-Note that the results contain the hidden rides property, among other members
+Now, try running `Get-Member` again, but this time, add the `-Force` parameter.
+Note that the results contain the hidden **rides** property, among other members
 that are hidden by default.
 
 ```output

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Hidden.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Hidden.md
@@ -1,7 +1,7 @@
 ---
-description: Describes the Hidden keyword, which hides class members from default Get-Member results.
+description: Describes the `hidden` keyword, which hides class members from default `Get-Member` results.
 Locale: en-US
-ms.date: 01/04/2018
+ms.date: 03/07/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_hidden?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Hidden
@@ -9,51 +9,57 @@ title: about Hidden
 # about_Hidden
 
 ## Short description
-Describes the Hidden keyword, which hides class members from default
-Get-Member results.
+Describes the `hidden` keyword, which hides class members from default
+`Get-Member` results.
 
 ## Long description
 
-When you use the Hidden keyword in a script, you hide the members of a class
-by default. The Hidden keyword can hide properties, methods (including
-constructors, events, alias properties, and other member types, including
-static members, from the default results of the Get-Member cmdlet, and from
-IntelliSense and tab completion results. To display members that you have
-hidden with the Hidden keyword, add the -Force parameter to a Get-Member
-command.
+When you use the `hidden` keyword in a script, you hide the members of a class
+by default. Hidden members do not display in the default results of the
+`Get-Member` cmdlet, IntelliSense, or tab completion results. To display members
+that you have hidden with the `hidden` keyword, add the **Force** parameter to a
+`Get-Member` command.
 
-Hidden members are not displayed by using tab completion or IntelliSense,
-unless the completion occurs in the class that defines the hidden member.
+The `hidden` keyword can hide:
 
-A new attribute, System.Management.Automation.HiddenAttribute, has been added,
-so that C\# code can have the same semantics within PowerShell.
+- methods (including constructors)
+- events
+- alias properties
+- other member types (including static members)
 
-The Hidden keyword is useful for creating properties and methods within a
-class that you do not necessarily want other users of the class to see, or
-readily be able to edit.
+Hidden members are not displayed in tab completion or IntelliSense unless the
+completion occurs in the class that defines the hidden member.
 
-The Hidden keyword has no effect on how you can view or make changes to
-members of a class. Like all language keywords in PowerShell, Hidden is not
+The new attribute, **System.Management.Automation.HiddenAttribute**, enables C#
+code to have the same semantics within PowerShell.
+
+The `hidden` keyword is useful for creating properties and methods within a
+class that you do not necessarily want users of the class to see or readily be
+able to edit.
+
+The `hidden` keyword has no effect on how you can view or make changes to
+members of a class. Like all language keywords in PowerShell, `hidden` is not
 case-sensitive, and hidden members are still public.
 
-Hidden, along with custom classes, was introduced in PowerShell 5.0.
+The `hidden` keyword, along with custom classes, was introduced in Windows
+PowerShell 5.0.
 
 ## EXAMPLE
 
-The following example shows how to use the Hidden keyword in a class
-definition. The Car class method, Drive, has a property, rides, that does not
-need to be viewed or changed (it merely tallies the number of times that Drive
-is called on the Car class, a metric that is not important to users of the
-class; consider, for example, that when you are buying a car, you do not ask
-the seller on how many drives the car has been taken.
+The following example shows how to use the `hidden` keyword in a class
+definition. The **Car** class method, **Drive**, has a property, **rides**, that
+does not need to be viewed or changed as it merely tallies the number of times
+that **Drive** is called on the **Car** class. That metric that is not important
+to users of the class (consider, for example, that when you are buying a car,
+you do not ask the seller on how many drives the car has been taken).
 
-Because there is little need for users of the class to change this property,
-we can hide the property from Get-Member and automatic completion results by
-using the Hidden keyword.
+Because there is little need for users of the class to change this property, we
+can hide the property from `Get-Member` and automatic completion results by
+using the `hidden` keyword.
 
-Add the Hidden keyword by entering it on the same statement line as the
+Add the `hidden` keyword by entering it on the same statement line as the
 property and its data type. Although the keyword can be in any order on this
-line, starting the statement with the Hidden keyword makes it easier for you
+line, starting the statement with the `hidden` keyword makes it easier for you
 later to identify all members that you have hidden.
 
 ```powershell
@@ -77,16 +83,16 @@ class Car
 }
 ```
 
-Now, create a new instance of the Car class, and save it in a variable,
-\$TestCar.
+Now, create a new instance of the **Car** class, and save it in a variable,
+`$TestCar`.
 
 ```powershell
 $TestCar = [Car]::new()
 ```
 
-After you create the new instance, pipe the contents of the $TestCar variable
-to Get-Member. Observe that the rides property is not among the members listed
-in the Get-Member command results.
+After you create the new instance, pipe the contents of the `$TestCar` variable
+to `Get-Member`. Observe that the **rides** property is not among the members
+listed in the `Get-Member` command results.
 
 ```output
 PS C:\Windows\system32> $TestCar | Get-Member
@@ -106,8 +112,8 @@ ModelYear   Property   string ModelYear {get;set;}
 
 ```
 
-Now, try running Get-Member again, but this time, add the -Force parameter.
-Note that the results contain the hidden rides property, among other members
+Now, try running `Get-Member` again, but this time, add the `-Force` parameter.
+Note that the results contain the hidden **rides** property, among other members
 that are hidden by default.
 
 ```output


### PR DESCRIPTION
# PR Summary

This commit passes over the `about_Hidden` topic, ensuring that the formatting in the document matches standard styling for PowerShell and clarifying/improving language where needed.

Fixes #8630. 

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [x] Version 7.2 content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
