### PR TITLE
(GH-8618) Add note to Measure-Object in 7.3

### DIFF
--- a/reference/7.3/Microsoft.PowerShell.Utility/Measure-Object.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Measure-Object.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 07/15/2021
+ms.date: 03/08/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/measure-object?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Measure-Object
@@ -545,6 +545,13 @@ If you use the **Word** parameter, `Measure-Object` returns a **TextMeasureInfo*
 Otherwise, it returns a **GenericMeasureInfo** object.
 
 ## NOTES
+
+Starting in PowerShell 7.3, `Measure-Object` does not return an error when
+processing an object which is missing the property being measured except in
+**StrictMode**. When `Measure-Object` processes an object which is missing the
+specified property in **StrictMode** it returns a
+`System.Management.Automation.PSArgumentException` error for the **Property**
+argument.
 
 ## RELATED LINKS
 

--- a/reference/7.3/Microsoft.PowerShell.Utility/Measure-Object.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Measure-Object.md
@@ -546,12 +546,11 @@ Otherwise, it returns a **GenericMeasureInfo** object.
 
 ## NOTES
 
-Starting in PowerShell 7.3, `Measure-Object` does not return an error when
-processing an object which is missing the property being measured except in
-**StrictMode**. When `Measure-Object` processes an object which is missing the
-specified property in **StrictMode** it returns a
-`System.Management.Automation.PSArgumentException` error for the **Property**
-argument.
+Starting in PowerShell 7.3, `Measure-Object` no longer returns an error when
+processing an object that is missing the property being measured unless you are
+running in **StrictMode**. In **StrictMode**, `Measure-Object` returns a
+`System.Management.Automation.PSArgumentException` when processing an object
+that is missing the specified property.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
# PR Summary

This commit adds a note to the `Measure-Object` cmdlet reference documentation for PowerShell 7.3 to clarify that it now only returns an argument error when an object is missing the to-measure property in **StrictMode** to pair with the updated implementation from PowerShell/PowerShell#16589.

- Resolves #8618

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [ ] Version 7.2 content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
