### PR TITLE
(GH-8628) Note PSCustomObject Count Behavior

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -896,11 +896,10 @@ Beginning in Windows PowerShell 3.0, a collection of zero or one object has the
 object. This feature helps you to avoid scripting errors that occur when a
 command that expects a collection gets fewer than two items.
 
-> [!TIP]
-> In Windows PowerShell, objects created by casting a **Hashtable** to
-> `[pscustomobject]` are an exception and return `$null` for the **Count** and
-> **Length** properties, though they do support the array indexing
-> functionality.
+> [!NOTE]
+In Windows PowerShell, objects created by casting a **Hashtable** to
+`[pscustomobject]` do not have the **Length** or **Count** properties.
+Attempting to access these members returns `$null`.
 
 The following examples demonstrate this feature.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -891,10 +891,16 @@ faster, especially for large arrays.
 
 ## Arrays of zero or one
 
-Beginning in Windows PowerShell 3.0, a collection of zero or one object has
-the Count and Length property. Also, you can index into an array of one
+Beginning in Windows PowerShell 3.0, a collection of zero or one object has the
+**Count** and **Length** properties. Also, you can index into an array of one
 object. This feature helps you to avoid scripting errors that occur when a
 command that expects a collection gets fewer than two items.
+
+> [!TIP]
+> In Windows PowerShell, objects created by casting a **Hashtable** to
+> `[pscustomobject]` are an exception and return `$null` for the **Count** and
+> **Length** properties, though they do support the array indexing
+> functionality.
 
 The following examples demonstrate this feature.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
@@ -158,8 +158,23 @@ System.Management.Automation.PSCustomObject
 
 ## Notes
 
-Calling `.Length` or its alias `.Count` on an object created by casting a
-**Hashtable** to `[pscustomobject]` returns `$null` in Windows PowerShell.
+In Windows PowerShell, objects created by casting a **Hashtable** to
+`[pscustomobject]` do not have the **Length** or **Count** properties.
+Attempting to access these members returns `$null`.
+
+For example:
+
+```powershell
+PS> $object = [PSCustomObject]@{key = 'value'}
+PS> $object
+
+key
+---
+value
+
+PS> $object.Count
+PS> $object.Length
+```
 
 ## See also
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
@@ -1,7 +1,7 @@
 ---
 description: Explains the differences between PSObject and PSCustomObject.
 Locale: en-US
-ms.date: 08/10/2021
+ms.date: 03/08/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pscustomobject?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSCustomObject
@@ -155,6 +155,11 @@ Int32
 PS> ([PSCustomObject]@{Property = 'Value'}).GetType().FullName
 System.Management.Automation.PSCustomObject
 ```
+
+## Notes
+
+Calling `.Length` or its alias `.Count` on an object created by casting a
+**Hashtable** to `[pscustomobject]` returns `$null` in Windows PowerShell.
 
 ## See also
 


### PR DESCRIPTION
# PR Summary
This PR updates the documentation for `about_PSCustomObject` and `about_Arrays` in Windows PowerShell 5.1 to note the divergent behavior of objects created by casting a hashtable to `[pscustomobject]` which returns `$null` for the automatic **Count** and **Length** properties.

- Fixes #8628 

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [ ] Preview content
- [ ] Version 7.2 content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
