### PR TITLE
(GH-8645) Add PSModuleAutoloadingPreference note

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Variables that customize the behavior of PowerShell.
 Locale: en-US
-ms.date: 02/09/2022
+ms.date: 03/11/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Preference Variables
@@ -1098,8 +1098,14 @@ cmdlet.
 ## \$PSModuleAutoloadingPreference
 
 Enables and disables automatic importing of modules in the session. **All** is
-the default. Regardless of the variable's value, you can use
-[Import-Module](xref:Microsoft.PowerShell.Core.Import-Module) to import a module.
+the default. To import a module, get or use any command in the module. For
+example, use `Get-Command`. The `$PSModuleAutoloadingPreference` variable does
+not exist by default. The default behavior when the variable is not defined is
+the same as `$PSModuleAutoloadingPreference = 'All'`.
+
+Regardless of the variable's value, you can use
+[Import-Module](xref:Microsoft.PowerShell.Core.Import-Module) to import a
+module.
 
 The `$PSModuleAutoloadingPreference` variable takes one of the
 [`PSModuleAutoLoadingPreference`](/dotnet/api/system.management.automation.psmoduleautoloadingpreference)
@@ -1108,8 +1114,7 @@ enumeration values:
 
 Valid values are:
 
-- **All**: Modules are imported automatically on first-use. To import a module,
-  get or use any command in the module. For example, use `Get-Command`.
+- **All**: Modules are imported automatically on first-use.
 - **ModuleQualified**: Modules are imported automatically only when a user uses
   the module-qualified name of a command in the module. For example, if the
   user types `MyModule\MyCommand`, PowerShell imports the **MyModule** module.

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Variables that customize the behavior of PowerShell.
 Locale: en-US
-ms.date: 02/09/2022
+ms.date: 03/11/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Preference Variables
@@ -975,8 +975,14 @@ cmdlet.
 ## \$PSModuleAutoloadingPreference
 
 Enables and disables automatic importing of modules in the session. **All** is
-the default. Regardless of the variable's value, you can use
-[Import-Module](xref:Microsoft.PowerShell.Core.Import-Module) to import a module.
+the default. To import a module, get or use any command in the module. For
+example, use `Get-Command`. The `$PSModuleAutoloadingPreference` variable does
+not exist by default. The default behavior when the variable is not defined is
+the same as `$PSModuleAutoloadingPreference = 'All'`.
+
+Regardless of the variable's value, you can use
+[Import-Module](xref:Microsoft.PowerShell.Core.Import-Module) to import a
+module.
 
 The `$PSModuleAutoloadingPreference` variable takes one of the
 [`PSModuleAutoLoadingPreference`](/dotnet/api/system.management.automation.psmoduleautoloadingpreference)
@@ -985,8 +991,7 @@ enumeration values:
 
 Valid values are:
 
-- **All**: Modules are imported automatically on first-use. To import a module,
-  get or use any command in the module. For example, use `Get-Command`.
+- **All**: Modules are imported automatically on first-use.
 - **ModuleQualified**: Modules are imported automatically only when a user uses
   the module-qualified name of a command in the module. For example, if the
   user types `MyModule\MyCommand`, PowerShell imports the **MyModule** module.

--- a/reference/7.1/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Variables that customize the behavior of PowerShell.
 Locale: en-US
-ms.date: 02/09/2022
+ms.date: 03/11/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Preference Variables
@@ -975,8 +975,14 @@ cmdlet.
 ### \$PSModuleAutoloadingPreference
 
 Enables and disables automatic importing of modules in the session. **All** is
-the default. Regardless of the variable's value, you can use
-[Import-Module](xref:Microsoft.PowerShell.Core.Import-Module) to import a module.
+the default. To import a module, get or use any command in the module. For
+example, use `Get-Command`. The `$PSModuleAutoloadingPreference` variable does
+not exist by default. The default behavior when the variable is not defined is
+the same as `$PSModuleAutoloadingPreference = 'All'`.
+
+Regardless of the variable's value, you can use
+[Import-Module](xref:Microsoft.PowerShell.Core.Import-Module) to import a
+module.
 
 The `$PSModuleAutoloadingPreference` variable takes one of the
 [`PSModuleAutoLoadingPreference`](/dotnet/api/system.management.automation.psmoduleautoloadingpreference)
@@ -985,8 +991,7 @@ enumeration values:
 
 Valid values are:
 
-- **All**: Modules are imported automatically on first-use. To import a module,
-  get or use any command in the module. For example, use `Get-Command`.
+- **All**: Modules are imported automatically on first-use.
 - **ModuleQualified**: Modules are imported automatically only when a user uses
   the module-qualified name of a command in the module. For example, if the
   user types `MyModule\MyCommand`, PowerShell imports the **MyModule** module.

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Variables that customize the behavior of PowerShell.
 Locale: en-US
-ms.date: 02/09/2022
+ms.date: 03/11/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Preference Variables
@@ -976,8 +976,14 @@ cmdlet.
 ## \$PSModuleAutoloadingPreference
 
 Enables and disables automatic importing of modules in the session. **All** is
-the default. Regardless of the variable's value, you can use
-[Import-Module](xref:Microsoft.PowerShell.Core.Import-Module) to import a module.
+the default. To import a module, get or use any command in the module. For
+example, use `Get-Command`. The `$PSModuleAutoloadingPreference` variable does
+not exist by default. The default behavior when the variable is not defined is
+the same as `$PSModuleAutoloadingPreference = 'All'`.
+
+Regardless of the variable's value, you can use
+[Import-Module](xref:Microsoft.PowerShell.Core.Import-Module) to import a
+module.
 
 The `$PSModuleAutoloadingPreference` variable takes one of the
 [`PSModuleAutoLoadingPreference`](/dotnet/api/system.management.automation.psmoduleautoloadingpreference)
@@ -986,8 +992,7 @@ enumeration values:
 
 Valid values are:
 
-- **All**: Modules are imported automatically on first-use. To import a module,
-  get or use any command in the module. For example, use `Get-Command`.
+- **All**: Modules are imported automatically on first-use.
 - **ModuleQualified**: Modules are imported automatically only when a user uses
   the module-qualified name of a command in the module. For example, if the
   user types `MyModule\MyCommand`, PowerShell imports the **MyModule** module.

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Variables that customize the behavior of PowerShell.
 Locale: en-US
-ms.date: 02/09/2022
+ms.date: 03/11/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Preference Variables
@@ -976,8 +976,14 @@ cmdlet.
 ## \$PSModuleAutoloadingPreference
 
 Enables and disables automatic importing of modules in the session. **All** is
-the default. Regardless of the variable's value, you can use
-[Import-Module](xref:Microsoft.PowerShell.Core.Import-Module) to import a module.
+the default. To import a module, get or use any command in the module. For
+example, use `Get-Command`. The `$PSModuleAutoloadingPreference` variable does
+not exist by default. The default behavior when the variable is not defined is
+the same as `$PSModuleAutoloadingPreference = 'All'`.
+
+Regardless of the variable's value, you can use
+[Import-Module](xref:Microsoft.PowerShell.Core.Import-Module) to import a
+module.
 
 The `$PSModuleAutoloadingPreference` variable takes one of the
 [`PSModuleAutoLoadingPreference`](/dotnet/api/system.management.automation.psmoduleautoloadingpreference)
@@ -986,8 +992,7 @@ enumeration values:
 
 Valid values are:
 
-- **All**: Modules are imported automatically on first-use. To import a module,
-  get or use any command in the module. For example, use `Get-Command`.
+- **All**: Modules are imported automatically on first-use.
 - **ModuleQualified**: Modules are imported automatically only when a user uses
   the module-qualified name of a command in the module. For example, if the
   user types `MyModule\MyCommand`, PowerShell imports the **MyModule** module.


### PR DESCRIPTION
# PR Summary

Prior to this PR, the `$PSModuleAutoloadingPreference` section of the `about_Preference_Variables` document explained how to use the variable in the list item for the **All** setting and did not explicitly indicate PowerShell's behavior when the variable is not set.

This PR updates the `$PSModuleAutoloadingPreference` section of the `about_Preference_Variables` document to clarify that the variable is not instantiated automatically but the behavior is still the described default of **All**.

It also moves the behavior explanation from the list item for the **All** setting into the opening paragraph to improve clarity.

Finally, this PR moves the note on using `Import-Module` to import modules regardless of the variable's setting into its own paragraph.

- Fixes #8645

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [x] Version 7.2 content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
