### PR TITLE
Fixes #8671 - Add .NET 5 breaking change for string comparisons

### DIFF
--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-71.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-71.md
@@ -99,6 +99,25 @@ The following experimental features were added in this release:
 
 ## Breaking Changes and Improvements
 
+- String comparison behavior changed in .NET 5.0
+
+  PowerShell 7.1 is built on .NET 5.0, which introduced the following breaking change:
+
+  - [Behavior changes when comparing strings on .NET 5+](/dotnet/standard/base-types/string-comparison-net-5-plus)
+
+  As of .NET 5.0, culture invariant string comparisons ignore non-printing control characters.
+
+  For example, the following two strings are considered to be identical:
+
+  ```powershell
+  # Escape sequence "`a" is Ctrl-G or [char]7
+  'Food' -eq "Foo`ad"
+  ```
+
+  ```Output
+  True
+  ```
+
 - Fix `$?` to not be `$false` when native command writes to `stderr`
   ([#13395](https://github.com/PowerShell/PowerShell/pull/13395))
 

--- a/reference/docs-conceptual/whats-new/differences-from-windows-powershell.md
+++ b/reference/docs-conceptual/whats-new/differences-from-windows-powershell.md
@@ -23,7 +23,10 @@ article is to present the current state of PowerShell and how that is different 
 PowerShell. For a detailed discussion of changes between versions and the addition of new features,
 see the **What's New** articles for each version.
 
-- [What's new in PowerShell 7.x](What-s-New-in-PowerShell-71.md)
+- [What's new in PowerShell 7.3](What-s-New-in-PowerShell-73.md)
+- [What's new in PowerShell 7.2](What-s-New-in-PowerShell-72.md)
+- [What's new in PowerShell 7.1](What-s-New-in-PowerShell-71.md)
+- [What's new in PowerShell 7.0](What-s-New-in-PowerShell-70.md)
 - [What's new in PowerShell 6.x](/previous-versions/powershell/scripting/whats-new/what-s-new-in-powershell-core-62?view=powershell-6&preserve-view=true)
 
 ## .NET Framework vs .NET Core
@@ -34,6 +37,17 @@ framework types and methods. As a result, scripts that run on Windows may not ru
 platforms because of the differences in the frameworks. For more information about changes in .NET
 Core, see
 [Breaking changes for migration from .NET Framework to .NET Core](/dotnet/core/compatibility/fx-core).
+
+Each new release of PowerShell is built on a newer version of .NET. There can be breaking changes in
+.NET that affect PowerShell.
+
+- PowerShell 7.3 (preview) - Built on .NET 7.0 (preview)
+- PowerShell 7.2 (LTS-current) - Built on .NET 6.0 (LTS-current)
+- PowerShell 7.1 - Built on .NET 5.0
+- PowerShell 7.0 (LTS) - Built on .NET Core 3.1 (LTS)
+- PowerShell 6.2 - Built on .NET Core 2.1
+- PowerShell 6.1 - Built on .NET Core 2.1
+- PowerShell 6.0 - Built on .NET Core 2.0
 
 With the advent of
 [.NET Standard 2.0](https://devblogs.microsoft.com/dotnet/introducing-net-standard/), PowerShell can
@@ -439,6 +453,25 @@ class M {
 }
 
 [M]::AggregateString((gci).Name, [M]::DoubleStrLen)
+```
+
+### String comparison behavior changed in PowerShell 7.1
+
+PowerShell 7.1 is built on .NET 5.0, which introduced the following breaking change:
+
+- [Behavior changes when comparing strings on .NET 5+](/dotnet/standard/base-types/string-comparison-net-5-plus)
+
+As of .NET 5.0, culture invariant string comparisons ignore non-printing control characters.
+
+For example, the following two strings are considered to be identical:
+
+```powershell
+# Escape sequence "`a" is Ctrl-G or [char]7
+'Food' -eq "Foo`ad"
+```
+
+```Output
+True
 ```
 
 ## Cmdlet changes


### PR DESCRIPTION
# PR Summary
<!--
    Summarize your changes and list related issues here. For example:

    This changes fixes problem X in the documentation for Y.
    - Fixes #1234
    - Fixes #1235
-->
Fixes AB#1931278 - Fixes #8671 - Add .NET 5 breaking change for string comparisons

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [x] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [ ] Preview content
- [ ] Version 7.2 content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords