### PR TITLE
(GH-8583) Correct MountUserDrive path

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 02/14/2022
+ms.date: 03/21/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssessionconfigurationfile?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-PSSessionConfigurationFile
@@ -646,7 +646,7 @@ Configures sessions that use this session configuration to expose the `User:` PS
 are unique for each connecting user and allow users to copy data to and from PowerShell endpoints
 even if the File System provider is not exposed. User drive roots are created under
 `$env:LOCALAPPDATA\Microsoft\Windows\PowerShell\DriveRoots\`. For each user connecting to the
-endpoint, a folder is created with the name `$env:USERDOMAIN_$env:USERNAME`. For computers in
+endpoint, a folder is created with the name `${env:USERDOMAIN}_${env:USERNAME}`. For computers in
 workgroups, the value of `$env:USERDOMAIN` is the hostname.
 
 Contents in the user drive persist across user sessions and are not automatically removed. By

--- a/reference/7.0/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 02/14/2022
+ms.date: 03/21/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssessionconfigurationfile?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-PSSessionConfigurationFile
@@ -648,7 +648,7 @@ Configures sessions that use this session configuration to expose the `User:` PS
 are unique for each connecting user and allow users to copy data to and from PowerShell endpoints
 even if the File System provider is not exposed. User drive roots are created under
 `$env:LOCALAPPDATA\Microsoft\PowerShell\DriveRoots\`. For each user connecting to the endpoint, a
-folder is created with the name `$env:USERDOMAIN_$env:USERNAME`. For computers in workgroups, the
+folder is created with the name `$env:USERDOMAIN\$env:USERNAME`. For computers in workgroups, the
 value of `$env:USERDOMAIN` is the hostname.
 
 Contents in the user drive persist across user sessions and are not automatically removed. By

--- a/reference/7.1/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 02/14/2022
+ms.date: 03/21/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssessionconfigurationfile?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-PSSessionConfigurationFile
@@ -648,7 +648,7 @@ Configures sessions that use this session configuration to expose the `User:` PS
 are unique for each connecting user and allow users to copy data to and from PowerShell endpoints
 even if the File System provider is not exposed. User drive roots are created under
 `$env:LOCALAPPDATA\Microsoft\PowerShell\DriveRoots\`. For each user connecting to the endpoint, a
-folder is created with the name `$env:USERDOMAIN_$env:USERNAME`. For computers in workgroups, the
+folder is created with the name `$env:USERDOMAIN\$env:USERNAME`. For computers in workgroups, the
 value of `$env:USERDOMAIN` is the hostname.
 
 Contents in the user drive persist across user sessions and are not automatically removed. By

--- a/reference/7.2/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 02/14/2022
+ms.date: 03/21/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssessionconfigurationfile?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-PSSessionConfigurationFile
@@ -648,7 +648,7 @@ Configures sessions that use this session configuration to expose the `User:` PS
 are unique for each connecting user and allow users to copy data to and from PowerShell endpoints
 even if the File System provider is not exposed. User drive roots are created under
 `$env:LOCALAPPDATA\Microsoft\PowerShell\DriveRoots\`. For each user connecting to the endpoint, a
-folder is created with the name `$env:USERDOMAIN_$env:USERNAME`. For computers in workgroups, the
+folder is created with the name `$env:USERDOMAIN\$env:USERNAME`. For computers in workgroups, the
 value of `$env:USERDOMAIN` is the hostname.
 
 Contents in the user drive persist across user sessions and are not automatically removed. By

--- a/reference/7.3/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 02/14/2022
+ms.date: 03/21/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssessionconfigurationfile?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-PSSessionConfigurationFile
@@ -648,7 +648,7 @@ Configures sessions that use this session configuration to expose the `User:` PS
 are unique for each connecting user and allow users to copy data to and from PowerShell endpoints
 even if the File System provider is not exposed. User drive roots are created under
 `$env:LOCALAPPDATA\Microsoft\PowerShell\DriveRoots\`. For each user connecting to the endpoint, a
-folder is created with the name `$env:USERDOMAIN_$env:USERNAME`. For computers in workgroups, the
+folder is created with the name `$env:USERDOMAIN\$env:USERNAME`. For computers in workgroups, the
 value of `$env:USERDOMAIN` is the hostname.
 
 Contents in the user drive persist across user sessions and are not automatically removed. By


### PR DESCRIPTION
# PR Summary

This PR corrects the per-user portion of the path created when using the **MountUserDrive**
option for a PSSession configuration file.

For Windows PowerShell, it ensures the string represents what is actually written by
placing the environment variables in backticks; the prior description would not actually
map to the correct value as PowerShell would incorrectly see the variable as `USERDOMAIN_`.

For PowerShell, the option actually creates a folder for the domain and places a folder
per-user inside of that one.

Resolves #8583 - Closes AB#1923612

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [x] Version 7.2 content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
