### PR TITLE
(MAINT) Standardize on UTC in `Set-TimeZone`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Set-TimeZone.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-TimeZone.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 09/18/2019
+ms.date: 03/24/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/set-timezone?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-TimeZone
@@ -40,27 +40,27 @@ The `Set-TimeZone` cmdlet sets the system time zone to a specified time zone.
 
 ### Example 1: Set the time zone by Id
 
-This example sets the time zone on the local computer to Russian Standard Time.
+This example sets the time zone on the local computer to UTC.
 
 ```powershell
-Set-TimeZone -Id "Russian Standard Time" -PassThru
+Set-TimeZone -Name 'Coordinated Universal Time' -PassThru
 ```
 
 ```Output
-Id                         : Russian Standard Time
-DisplayName                : (UTC+03:00) Moscow, St. Petersburg
-StandardName               : Russia TZ 2 Standard Time
-DaylightName               : Russia TZ 2 Daylight Time
-BaseUtcOffset              : 03:00:00
-SupportsDaylightSavingTime : True
+Id                         : UTC
+DisplayName                : (UTC) Coordinated Universal Time
+StandardName               : Coordinated Universal Time
+DaylightName               : Coordinated Universal Time
+BaseUtcOffset              : 00:00:00
+SupportsDaylightSavingTime : False
 ```
 
 ### Example 2: Set the time zone by name
 
-This example sets the time zone on the local computer to Russian Standard Time.
+This example sets the time zone on the local computer to UTC.
 
 ```powershell
-Set-TimeZone -Name "Russia TZ 2 Standard Time"
+Set-TimeZone -Name "UTC"
 ```
 
 As we saw in the previous example, the **Id** and the **Name** of the Time Zone do not always match.

--- a/reference/7.0/Microsoft.PowerShell.Management/Set-TimeZone.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Set-TimeZone.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 09/18/2019
+ms.date: 03/24/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/set-timezone?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-TimeZone
@@ -42,27 +42,27 @@ The `Set-TimeZone` cmdlet sets the system time zone to a specified time zone.
 
 ### Example 1: Set the time zone by Id
 
-This example sets the time zone on the local computer to Russian Standard Time.
+This example sets the time zone on the local computer to UTC.
 
 ```powershell
-Set-TimeZone -Id "Russian Standard Time" -PassThru
+Set-TimeZone -Name 'Coordinated Universal Time' -PassThru
 ```
 
 ```Output
-Id                         : Russian Standard Time
-DisplayName                : (UTC+03:00) Moscow, St. Petersburg
-StandardName               : Russia TZ 2 Standard Time
-DaylightName               : Russia TZ 2 Daylight Time
-BaseUtcOffset              : 03:00:00
-SupportsDaylightSavingTime : True
+Id                         : UTC
+DisplayName                : (UTC) Coordinated Universal Time
+StandardName               : Coordinated Universal Time
+DaylightName               : Coordinated Universal Time
+BaseUtcOffset              : 00:00:00
+SupportsDaylightSavingTime : False
 ```
 
 ### Example 2: Set the time zone by name
 
-This example sets the time zone on the local computer to Russian Standard Time.
+This example sets the time zone on the local computer to UTC.
 
 ```powershell
-Set-TimeZone -Name "Russia TZ 2 Standard Time"
+Set-TimeZone -Name "UTC"
 ```
 
 As we saw in the previous example, the **Id** and the **Name** of the Time Zone do not always match.

--- a/reference/7.1/Microsoft.PowerShell.Management/Set-TimeZone.md
+++ b/reference/7.1/Microsoft.PowerShell.Management/Set-TimeZone.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 09/18/2019
+ms.date: 03/24/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/set-timezone?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-TimeZone
@@ -42,27 +42,27 @@ The `Set-TimeZone` cmdlet sets the system time zone to a specified time zone.
 
 ### Example 1: Set the time zone by Id
 
-This example sets the time zone on the local computer to Russian Standard Time.
+This example sets the time zone on the local computer to UTC.
 
 ```powershell
-Set-TimeZone -Id "Russian Standard Time" -PassThru
+Set-TimeZone -Name 'Coordinated Universal Time' -PassThru
 ```
 
 ```Output
-Id                         : Russian Standard Time
-DisplayName                : (UTC+03:00) Moscow, St. Petersburg
-StandardName               : Russia TZ 2 Standard Time
-DaylightName               : Russia TZ 2 Daylight Time
-BaseUtcOffset              : 03:00:00
-SupportsDaylightSavingTime : True
+Id                         : UTC
+DisplayName                : (UTC) Coordinated Universal Time
+StandardName               : Coordinated Universal Time
+DaylightName               : Coordinated Universal Time
+BaseUtcOffset              : 00:00:00
+SupportsDaylightSavingTime : False
 ```
 
 ### Example 2: Set the time zone by name
 
-This example sets the time zone on the local computer to Russian Standard Time.
+This example sets the time zone on the local computer to UTC.
 
 ```powershell
-Set-TimeZone -Name "Russia TZ 2 Standard Time"
+Set-TimeZone -Name "UTC"
 ```
 
 As we saw in the previous example, the **Id** and the **Name** of the Time Zone do not always match.

--- a/reference/7.2/Microsoft.PowerShell.Management/Set-TimeZone.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Set-TimeZone.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 09/18/2019
+ms.date: 03/24/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/set-timezone?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-TimeZone
@@ -42,27 +42,28 @@ The `Set-TimeZone` cmdlet sets the system time zone to a specified time zone.
 
 ### Example 1: Set the time zone by Id
 
-This example sets the time zone on the local computer to Central European Standard Time.
+This example sets the time zone on the local computer to UTC.
 
 ```powershell
-Set-TimeZone -Id "Central European Standard Time" -PassThru
+Set-TimeZone -Name 'Coordinated Universal Time' -PassThru
 ```
 
 ```Output
-Id                         : Central European Standard Time
-DisplayName                : (UTC+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague
-StandardName               : Central Europe Standard Time
-DaylightName               : Central Europe Daylight Time
-BaseUtcOffset              : 01:00:00
-SupportsDaylightSavingTime : True
+Id                         : UTC
+HasIanaId                  : True
+DisplayName                : (UTC) Coordinated Universal Time
+StandardName               : Coordinated Universal Time
+DaylightName               : Coordinated Universal Time
+BaseUtcOffset              : 00:00:00
+SupportsDaylightSavingTime : False
 ```
 
 ### Example 2: Set the time zone by name
 
-This example sets the time zone on the local computer to Central European Standard Time.
+This example sets the time zone on the local computer to UTC.
 
 ```powershell
-Set-TimeZone -Name "Central European Standard Time"
+Set-TimeZone -Name "UTC"
 ```
 
 As we saw in the previous example, the **Id** and the **Name** of the Time Zone do not always match.

--- a/reference/7.3/Microsoft.PowerShell.Management/Set-TimeZone.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Set-TimeZone.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 09/18/2019
+ms.date: 03/24/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/set-timezone?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-TimeZone
@@ -42,27 +42,28 @@ The `Set-TimeZone` cmdlet sets the system time zone to a specified time zone.
 
 ### Example 1: Set the time zone by Id
 
-This example sets the time zone on the local computer to Russian Standard Time.
+This example sets the time zone on the local computer to UTC.
 
 ```powershell
-Set-TimeZone -Id "Russian Standard Time" -PassThru
+Set-TimeZone -Name 'Coordinated Universal Time' -PassThru
 ```
 
 ```Output
-Id                         : Russian Standard Time
-DisplayName                : (UTC+03:00) Moscow, St. Petersburg
-StandardName               : Russia TZ 2 Standard Time
-DaylightName               : Russia TZ 2 Daylight Time
-BaseUtcOffset              : 03:00:00
-SupportsDaylightSavingTime : True
+Id                         : UTC
+HasIanaId                  : True
+DisplayName                : (UTC) Coordinated Universal Time
+StandardName               : Coordinated Universal Time
+DaylightName               : Coordinated Universal Time
+BaseUtcOffset              : 00:00:00
+SupportsDaylightSavingTime : False
 ```
 
 ### Example 2: Set the time zone by name
 
-This example sets the time zone on the local computer to Russian Standard Time.
+This example sets the time zone on the local computer to UTC.
 
 ```powershell
-Set-TimeZone -Name "Russia TZ 2 Standard Time"
+Set-TimeZone -Name "UTC"
 ```
 
 As we saw in the previous example, the **Id** and the **Name** of the Time Zone do not always match.


### PR DESCRIPTION
# PR Summary
Standardizes the examples for `Set-TimeZone` to use UTC.

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [x] Version 7.2 content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
