### PR TITLE
(GH-8443) Update help for the SecurityDescriptorSddl parameter of `Set-Service`

### DIFF
--- a/reference/7.3/Microsoft.PowerShell.Management/Set-Service.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Set-Service.md
@@ -341,7 +341,10 @@ Accept wildcard characters: False
 
 ### -SecurityDescriptorSddl
 
-Specifies the **SecurityDescriptor** for the service in **Sddl** format.
+Specifies the **SecurityDescriptor** for the service in **Sddl** format. The account calling
+`Set-Service` with this parameter must have the WRITE_DAC and WRITE_OWNER permissions. For more
+information, see
+[Service security and access rights](/windows/win32/services/service-security-and-access-rights).
 
 ```yaml
 Type: System.String


### PR DESCRIPTION
# PR Summary

This PR updates the help for the SecurityDescriptorSddl parameter
of Set-Service to clarify the necessary permissions for using it.

- Resolves #8443

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [ ] Version 7.2 content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
