### PR TITLE
Update ForEach-Object.md - ParallelParameterSet UseNewRunSpace syntax formatting

### DIFF
--- a/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -32,7 +32,7 @@ ForEach-Object [-InputObject <PSObject>] [-MemberName] <String> [-ArgumentList <
 
 ```
 ForEach-Object -Parallel <scriptblock> [-InputObject <PSObject>] [-ThrottleLimit <int>]
-[-UseNewRunspace] [-TimeoutSeconds <int>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-UseNewRunspace] [-TimeoutSeconds <int>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7.2/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -32,7 +32,7 @@ ForEach-Object [-InputObject <PSObject>] [-MemberName] <String> [-ArgumentList <
 
 ```
 ForEach-Object -Parallel <scriptblock> [-InputObject <PSObject>] [-ThrottleLimit <int>]
-[-UseNewRunspace] [-TimeoutSeconds <int>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-UseNewRunspace] [-TimeoutSeconds <int>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/7.3/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -32,7 +32,7 @@ ForEach-Object [-InputObject <PSObject>] [-MemberName] <String> [-ArgumentList <
 
 ```
 ForEach-Object -Parallel <scriptblock> [-InputObject <PSObject>] [-ThrottleLimit <int>]
-[-UseNewRunspace] [-TimeoutSeconds <int>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-UseNewRunspace] [-TimeoutSeconds <int>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION


### PR DESCRIPTION
# PR Summary
Added a leading space on line 35 to match the new line formatting on lines 21 and 28.  I expect this to result in better formatting when this document is rendered in a browser.

- Fixes #8707

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [x] Version 7.2 content
- [x] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
