### PR TITLE
Formatting fix in Wait-Job.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Wait-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Wait-Job.md
@@ -498,8 +498,9 @@ By default, `Wait-Job` returns, or ends the wait, when jobs are in one of the fo
 - Failed
 - Stopped
 - Suspended
-- Disconnected To direct `Wait-Job` to continue to wait for Suspended and Disconnected jobs, use the
-  **Force** parameter.
+- Disconnected
+
+To direct `Wait-Job` to continue to wait for Suspended and Disconnected jobs, use the **Force** parameter.
 
 ## RELATED LINKS
 

--- a/reference/7.0/Microsoft.PowerShell.Core/Wait-Job.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Wait-Job.md
@@ -498,8 +498,9 @@ By default, `Wait-Job` returns, or ends the wait, when jobs are in one of the fo
 - Failed
 - Stopped
 - Suspended
-- Disconnected To direct `Wait-Job` to continue to wait for Suspended and Disconnected jobs, use the
-  **Force** parameter.
+- Disconnected
+
+To direct `Wait-Job` to continue to wait for Suspended and Disconnected jobs, use the **Force** parameter.
 
 ## RELATED LINKS
 

--- a/reference/7.1/Microsoft.PowerShell.Core/Wait-Job.md
+++ b/reference/7.1/Microsoft.PowerShell.Core/Wait-Job.md
@@ -498,8 +498,9 @@ By default, `Wait-Job` returns, or ends the wait, when jobs are in one of the fo
 - Failed
 - Stopped
 - Suspended
-- Disconnected To direct `Wait-Job` to continue to wait for Suspended and Disconnected jobs, use the
-  **Force** parameter.
+- Disconnected 
+
+To direct `Wait-Job` to continue to wait for Suspended and Disconnected jobs, use the**Force** parameter.
 
 ## RELATED LINKS
 

--- a/reference/7.2/Microsoft.PowerShell.Core/Wait-Job.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Wait-Job.md
@@ -498,8 +498,9 @@ By default, `Wait-Job` returns, or ends the wait, when jobs are in one of the fo
 - Failed
 - Stopped
 - Suspended
-- Disconnected To direct `Wait-Job` to continue to wait for Suspended and Disconnected jobs, use the
-  **Force** parameter.
+- Disconnected
+
+To direct `Wait-Job` to continue to wait for Suspended and Disconnected jobs, use the **Force** parameter.
 
 ## RELATED LINKS
 

--- a/reference/7.3/Microsoft.PowerShell.Core/Wait-Job.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/Wait-Job.md
@@ -498,8 +498,9 @@ By default, `Wait-Job` returns, or ends the wait, when jobs are in one of the fo
 - Failed
 - Stopped
 - Suspended
-- Disconnected To direct `Wait-Job` to continue to wait for Suspended and Disconnected jobs, use the
-  **Force** parameter.
+- Disconnected
+
+To direct `Wait-Job` to continue to wait for Suspended and Disconnected jobs, use the **Force** parameter.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
Simple formatting fix in NOTES-Section

# PR Summary
The explanation of the `-Force` parameter in connection to suspended and disconnected jobs should not be part of the list of job-states

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [X] Preview content
- [X] Version 7.2 content
- [X] Version 7.1 content
- [X] Version 7.0 content
- [X] Version 5.1 content

## PR Checklist

- [X] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [X] PR has a meaningful title
- [X] PR is targeted at the _staging_ branch
- [X] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [X] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
