### PR TITLE
(AB#1942543) Ensure PSConsoleHostReadLine is translatable

### DIFF
--- a/reference/5.1/PSReadLine/PSConsoleHostReadLine.md
+++ b/reference/5.1/PSReadLine/PSConsoleHostReadLine.md
@@ -2,7 +2,7 @@
 external help file: PSReadLine-help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/07/2018
+ms.date: 04/25/2022
 online version: https://docs.microsoft.com/powershell/module/psreadline/psconsolehostreadline?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: PSConsoleHostReadLine
@@ -10,16 +10,16 @@ title: PSConsoleHostReadLine
 
 # PSConsoleHostReadLine
 
-## Synopsis
+## SYNOPSIS
 This function is the main entry point for PSReadLine.
 
-## Syntax
+## SYNTAX
 
 ```
 PSConsoleHostReadLine
 ```
 
-## Description
+## DESCRIPTION
 
 `PSConsoleHostReadLine` is the main entry point for the PSReadLine module. The PowerShell console
 host automatically loads the PSReadLine module and calls this function. Under normal operating
@@ -29,24 +29,24 @@ The extension point `PSConsoleHostReadLine` is special to the console host. The 
 alias, function, or script with this name. PSReadLine defines this function so that it is called
 from the console host.
 
-## Examples
+## EXAMPLES
 
 ### Example 1
 
 This function is not intended to be used from the command line.
 
-## Parameters
+## PARAMETERS
 
-## Inputs
-
-### None
-
-## Outputs
+## INPUTS
 
 ### None
 
-## Notes
+## OUTPUTS
 
-## Related links
+### None
+
+## NOTES
+
+## RELATED LINKS
 
 [about_PSReadLine](./About/about_PSReadLine.md)

--- a/reference/7.0/PSReadLine/PSConsoleHostReadLine.md
+++ b/reference/7.0/PSReadLine/PSConsoleHostReadLine.md
@@ -2,7 +2,7 @@
 external help file: PSReadLine-help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/07/2018
+ms.date: 04/25/2022
 online version: https://docs.microsoft.com/powershell/module/psreadline/psconsolehostreadline?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: PSConsoleHostReadLine
@@ -10,16 +10,16 @@ title: PSConsoleHostReadLine
 
 # PSConsoleHostReadLine
 
-## Synopsis
+## SYNOPSIS
 This function is the main entry point for PSReadLine.
 
-## Syntax
+## SYNTAX
 
 ```
 PSConsoleHostReadLine
 ```
 
-## Description
+## DESCRIPTION
 
 `PSConsoleHostReadLine` is the main entry point for the PSReadLine module. The PowerShell console
 host automatically loads the PSReadLine module and calls this function. Under normal operating
@@ -29,24 +29,24 @@ The extension point `PSConsoleHostReadLine` is special to the console host. The 
 alias, function, or script with this name. PSReadLine defines this function so that it is called
 from the console host.
 
-## Examples
+## EXAMPLES
 
 ### Example 1
 
 This function is not intended to be used from the command line.
 
-## Parameters
+## PARAMETERS
 
-## Inputs
-
-### None
-
-## Outputs
+## INPUTS
 
 ### None
 
-## Notes
+## OUTPUTS
 
-## Related links
+### None
+
+## NOTES
+
+## RELATED LINKS
 
 [about_PSReadLine](./About/about_PSReadLine.md)

--- a/reference/7.1/PSReadLine/PSConsoleHostReadLine.md
+++ b/reference/7.1/PSReadLine/PSConsoleHostReadLine.md
@@ -2,7 +2,7 @@
 external help file: PSReadLine-help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/07/2018
+ms.date: 04/25/2022
 online version: https://docs.microsoft.com/powershell/module/psreadline/psconsolehostreadline?view=powershell-7.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: PSConsoleHostReadLine
@@ -10,16 +10,16 @@ title: PSConsoleHostReadLine
 
 # PSConsoleHostReadLine
 
-## Synopsis
+## SYNOPSIS
 This function is the main entry point for PSReadLine.
 
-## Syntax
+## SYNTAX
 
 ```
 PSConsoleHostReadLine
 ```
 
-## Description
+## DESCRIPTION
 
 `PSConsoleHostReadLine` is the main entry point for the PSReadLine module. The PowerShell console
 host automatically loads the PSReadLine module and calls this function. Under normal operating
@@ -29,25 +29,24 @@ The extension point `PSConsoleHostReadLine` is special to the console host. The 
 alias, function, or script with this name. PSReadLine defines this function so that it is called
 from the console host.
 
-## Examples
+## EXAMPLES
 
 ### Example 1
 
 This function is not intended to be used from the command line.
 
-## Parameters
+## PARAMETERS
 
-## Inputs
-
-### None
-
-## Outputs
+## INPUTS
 
 ### None
 
-## Notes
+## OUTPUTS
 
-## Related links
+### None
+
+## NOTES
+
+## RELATED LINKS
 
 [about_PSReadLine](./About/about_PSReadLine.md)
-

--- a/reference/7.2/PSReadLine/PSConsoleHostReadLine.md
+++ b/reference/7.2/PSReadLine/PSConsoleHostReadLine.md
@@ -2,7 +2,7 @@
 external help file: PSReadLine-help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/07/2018
+ms.date: 04/25/2022
 online version: https://docs.microsoft.com/powershell/module/psreadline/psconsolehostreadline?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: PSConsoleHostReadLine
@@ -10,16 +10,16 @@ title: PSConsoleHostReadLine
 
 # PSConsoleHostReadLine
 
-## Synopsis
+## SYNOPSIS
 This function is the main entry point for PSReadLine.
 
-## Syntax
+## SYNTAX
 
 ```
 PSConsoleHostReadLine
 ```
 
-## Description
+## DESCRIPTION
 
 `PSConsoleHostReadLine` is the main entry point for the PSReadLine module. The PowerShell console
 host automatically loads the PSReadLine module and calls this function. Under normal operating
@@ -29,25 +29,24 @@ The extension point `PSConsoleHostReadLine` is special to the console host. The 
 alias, function, or script with this name. PSReadLine defines this function so that it is called
 from the console host.
 
-## Examples
+## EXAMPLES
 
 ### Example 1
 
 This function is not intended to be used from the command line.
 
-## Parameters
+## PARAMETERS
 
-## Inputs
-
-### None
-
-## Outputs
+## INPUTS
 
 ### None
 
-## Notes
+## OUTPUTS
 
-## Related links
+### None
+
+## NOTES
+
+## RELATED LINKS
 
 [about_PSReadLine](./About/about_PSReadLine.md)
-

--- a/reference/7.3/PSReadLine/PSConsoleHostReadLine.md
+++ b/reference/7.3/PSReadLine/PSConsoleHostReadLine.md
@@ -2,7 +2,7 @@
 external help file: PSReadLine-help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/07/2018
+ms.date: 04/25/2022
 online version: https://docs.microsoft.com/powershell/module/psreadline/psconsolehostreadline?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: PSConsoleHostReadLine
@@ -10,16 +10,16 @@ title: PSConsoleHostReadLine
 
 # PSConsoleHostReadLine
 
-## Synopsis
+## SYNOPSIS
 This function is the main entry point for PSReadLine.
 
-## Syntax
+## SYNTAX
 
 ```
 PSConsoleHostReadLine
 ```
 
-## Description
+## DESCRIPTION
 
 `PSConsoleHostReadLine` is the main entry point for the PSReadLine module. The PowerShell console
 host automatically loads the PSReadLine module and calls this function. Under normal operating
@@ -29,25 +29,24 @@ The extension point `PSConsoleHostReadLine` is special to the console host. The 
 alias, function, or script with this name. PSReadLine defines this function so that it is called
 from the console host.
 
-## Examples
+## EXAMPLES
 
 ### Example 1
 
 This function is not intended to be used from the command line.
 
-## Parameters
+## PARAMETERS
 
-## Inputs
-
-### None
-
-## Outputs
+## INPUTS
 
 ### None
 
-## Notes
+## OUTPUTS
 
-## Related links
+### None
+
+## NOTES
+
+## RELATED LINKS
 
 [about_PSReadLine](./About/about_PSReadLine.md)
-


### PR DESCRIPTION


# PR Summary
Prior to this PR, the documentation for `PSConsoleHostReadLine` did not correctly translate due to the casing of the H2s, which are required to be fully upcased.

This PR upcases those items to ensure the documentation can be properly translated.

- Resolves AB#1942543.

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [x] Version 7.2 content
- [x] Version 7.1 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
