### PR TITLE
(GH-8757) Clarify remoting in Managing Services

### DIFF
--- a/reference/docs-conceptual/samples/Managing-Services.md
+++ b/reference/docs-conceptual/samples/Managing-Services.md
@@ -49,14 +49,27 @@ Running  lanmanserver       Server
 Stopped  ServiceLayer       ServiceLayer
 ```
 
-You can use the ComputerName parameter of the Get-Service cmdlet to get the services on remote
-computers. The ComputerName parameter accepts multiple values and wildcard characters, so you can
-get the services on multiple computers with a single command. For example, the following command
-gets the services on the Server01 remote computer.
+## Getting Remote Services
+
+With Windows PowerShell, you can use the **ComputerName** parameter of the `Get-Service` cmdlet to
+get the services on remote computers. The **ComputerName** parameter accepts multiple values and
+wildcard characters, so you can get the services on multiple computers with a single command. For
+example, the following command gets the services on the Server01 remote computer.
 
 ```powershell
 Get-Service -ComputerName Server01
 ```
+
+Starting in PowerShell 6.0, the `*-Service` cmdlets do not have the **ComputerName** parameter. You
+can still get services on remote computers with PowerShell remoting. For example, the following
+command gets the services on the Server02 remote computer.
+
+```powershell
+Invoke-Command -ComputerName Server02 -ScriptBlock { Get-Service }
+```
+
+You can also manage services with the other `*-Service` cmdlets. For more information on PowerShell
+remoting, see [about_Remote](/powershell/module/Microsoft.PowerShell.Core/about_Remote).
 
 ## Getting Required and Dependent Services
 
@@ -177,6 +190,7 @@ For more information, see [Set-Service](/powershell/module/Microsoft.PowerShell.
 
 ## See Also
 
+- [about_Remote](/powershell/module/Microsoft.PowerShell.Core/about_Remote)
 - [Get-Service](/powershell/module/Microsoft.PowerShell.Management/get-service)
 - [Set-Service](/powershell/module/Microsoft.PowerShell.Management/set-service)
 - [Restart-Service](/powershell/module/Microsoft.PowerShell.Management/restart-service)


### PR DESCRIPTION
# PR Summary
Prior to this PR, the Managing Services sample in the conceptual
documentation included example code using the **ComputerName** parameter
for `Get-Service`, but that parameter was removed from the `*-Service`
cmdlets in PowerShell 6.0.

This PR updates the documentation to distinguish between Windows
PowerShell and PowerShell for managing remote services and clarifies
how to do so.

- Resolves #8757 

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [x] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [ ] Preview content
- [ ] Version 7.2 content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _staging_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
