### PR TITLE
(AB-1948159) Add change-set-specific PR Templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/conceptual.md
+++ b/.github/PULL_REQUEST_TEMPLATE/conceptual.md
@@ -1,0 +1,63 @@
+# PR Summary
+<!--
+    Summarize your changes and list related issues here. For example:
+
+    This changes fixes problem X in the documentation for Y.
+
+    - Fixes #1234
+    - Resolves #1235
+-->
+
+## Affected Files
+
+This PR only affects files in the `reference/docs-conceptual` folder.
+
+## PR Checklist
+
+<!--
+    These items are mandatory. For your PR to be reviewed and merged,
+    ensure you have followed these steps. As you complete the steps,
+    check each box by replacing the space between the brackets with an
+    x or by clicking on the box in the UI after your PR is submitted.
+-->
+
+- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines.
+- [ ] This PR has a meaningful title.
+- [ ] This PR targets the `main` branch.
+- [ ] This PR includes content related to an issue - see [Closing issues using keywords][gh-key].
+- [ ] This PR is **Ready to Merge** and is not **Work in Progress** or **Draft**. If the PR is work
+  in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the
+  prefix when the PR is ready. You can also mark the [PR as a draft][gh-make-draft] in the UI.
+
+## Expectations
+
+To see our process for reviewing PRs, please read our [editor's checklist][contrib-checklist] and
+process for [managing pull requests][contrib-managing-prs] in particular. Below is a brief,
+high-level summary of what to expect, but our [contributor guide][contrib] has expanded details.
+
+The docs team begins to review your PR if you [request them to][gh-review-request] or if your PR
+meets these conditions:
+
+- It is not a [draft PR][gh-drafts].
+- It does not have a `WIP` prefix in the title.
+- It passes validation and build steps.
+- It does not have any merge conflicts.
+- You have checked every box in the [PR Checklist](#pr-checklist), indicating you have completed all
+  required steps and marked your PR as **Ready to Merge**.
+
+You can **always** request a review at any stage in your authoring process, the docs team is here to
+help! You do not need to submit a fully polished and finished draft; the docs team can help you get
+content ready for merge.
+
+While reviewing your PR, the docs team may make suggestions, write comments, and ask questions. When
+all requirements are satisfied, the docs team marks your PR as **Approved** and merges it. Once your
+PR is merged, it is included the next time the documentation is published. For this project, the
+documentation is published daily at 3pm Pacific Standard Time (PST).
+
+[contrib-checklist]: https://docs.microsoft.com/powershell/scripting/community/contributing/editorial-checklist
+[contrib-managing-prs]: https://docs.microsoft.com/powershell/scripting/community/contributing/managing-pull-requests
+[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
+[gh-drafts]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
+[gh-key]: https://help.github.com/en/articles/closing-issues-using-keywords
+[gh-make-draft]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft
+[gh-review-request]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review

--- a/.github/PULL_REQUEST_TEMPLATE/reference.md
+++ b/.github/PULL_REQUEST_TEMPLATE/reference.md
@@ -1,0 +1,73 @@
+# PR Summary
+<!--
+    Summarize your changes and list related issues here. For example:
+
+    This changes fixes problem X in the documentation for Y.
+    - Fixes #1234
+    - Resolves #1235
+-->
+
+## Affected Files
+
+<!--
+    When changing **cmdlet reference** or **about_ topics**, the changes
+    should be copied to all relevant versions. Delete the entries for
+    any version in this list that this PR does not affect:
+-->
+
+- Preview content
+- Version 7.2 content
+- Version 7.1 content
+- Version 7.0 content
+- Version 5.1 content
+
+## PR Checklist
+
+<!--
+    These items are mandatory. For your PR to be reviewed and merged,
+    ensure you have followed these steps. As you complete the steps,
+    check each box by replacing the space between the brackets with an
+    x or by clicking on the box in the UI after your PR is submitted.
+-->
+
+- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines.
+- [ ] This PR has a meaningful title.
+- [ ] This PR targets the `main` branch.
+- [ ] All relevant versions listed in [Affected Files](#affected-files) are updated.
+- [ ] This PR includes content related to an issue - see [Closing issues using keywords][gh-key].
+- [ ] This PR is **Ready to Merge** and is not **Work in Progress** or **Draft**. If the PR is work
+  in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the
+  prefix when the PR is ready. You can also mark the [PR as a draft][gh-make-draft] in the UI.
+
+## Expectations
+
+To see our process for reviewing PRs, please read our [editor's checklist][contrib-checklist] and
+process for [managing pull requests][contrib-managing-prs] in particular. Below is a brief,
+high-level summary of what to expect, but our contributor guide has expanded details.
+
+The docs team begins to review your PR if you [request them to][gh-review-request] or if your PR
+meets these conditions:
+
+- It is not a [draft PR][gh-drafts].
+- It does not have a `WIP` prefix in the title.
+- It passes validation and build steps.
+- It does not have any merge conflicts.
+- You have checked every box in the [PR Checklist](#pr-checklist), indicating you have completed all
+  required steps and marked your PR as **Ready to Merge**.
+
+You can **always** request a review at any stage in your authoring process, the docs team is here to
+help! You do not need to submit a fully polished and finished draft; the docs team can help you get
+content ready for merge.
+
+While reviewing your PR, the docs team may make suggestions, write comments, and ask questions. When
+all requirements are satisfied, the docs team marks your PR as **Approved** and merges it. Once your
+PR is merged, it is included the next time the documentation is published. For this project, the
+documentation is published daily at 3pm Pacific Standard Time (PST).
+
+[contrib-checklist]: https://docs.microsoft.com/powershell/scripting/community/contributing/editorial-checklist
+[contrib-managing-prs]: https://docs.microsoft.com/powershell/scripting/community/contributing/managing-pull-requests
+[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
+[gh-drafts]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
+[gh-key]: https://help.github.com/en/articles/closing-issues-using-keywords
+[gh-make-draft]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft
+[gh-review-request]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review

--- a/.github/PULL_REQUEST_TEMPLATE/repodocs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/repodocs.md
@@ -1,0 +1,68 @@
+# PR Summary
+<!--
+    Summarize your changes and list related issues here. For example:
+
+    This changes fixes problem X in the documentation for Y.
+    - Fixes #1234
+    - Resolves #1235
+-->
+
+## Affected Files
+
+<!--
+    Delete the entries in this list that this PR does not affect:
+-->
+
+- Repository documentation and configuration (.git/.github/.vscode etc.)
+- Docs build files (.openpublishing.* and build scripts)
+- Docset configuration (docfx.json, mapping, bread, module folder)
+
+## PR Checklist
+
+<!--
+    These items are mandatory. For your PR to be reviewed and merged,
+    ensure you have followed these steps. As you complete the steps,
+    check each box by replacing the space between the brackets with an
+    x or by clicking on the box in the UI after your PR is submitted.
+-->
+
+- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines.
+- [ ] This PR has a meaningful title.
+- [ ] This PR targets the `main` branch.
+- [ ] This PR includes content related to an issue - see [Closing issues using keywords][gh-key].
+- [ ] This PR is **Ready to Merge** and is not **Work in Progress** or **Draft**. If the PR is work
+  in progress, please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the
+  prefix when the PR is ready. You can also mark the [PR as a draft][gh-make-draft] in the UI.
+
+## Expectations
+
+To see our process for reviewing PRs, please read our [editor's checklist][contrib-checklist] and
+process for [managing pull requests][contrib-managing-prs] in particular. Below is a brief,
+high-level summary of what to expect, but our contributor guide has expanded details.
+
+The docs team begins to review your PR if you [request them to][gh-review-request] or if your PR
+meets these conditions:
+
+- It is not a [draft PR][gh-drafts].
+- It does not have a `WIP` prefix in the title.
+- It passes validation and build steps.
+- It does not have any merge conflicts.
+- You have checked every box in the [PR Checklist](#pr-checklist), indicating you have completed all
+  required steps and marked your PR as **Ready to Merge**.
+
+You can **always** request a review at any stage in your authoring process, the docs team is here to
+help! You do not need to submit a fully polished and finished draft; the docs team can help you get
+content ready for merge.
+
+While reviewing your PR, the docs team may make suggestions, write comments, and ask questions. When
+all requirements are satisfied, the docs team marks your PR as **Approved** and merges it. Once your
+PR is merged, it is included the next time the documentation is published. For this project, the
+documentation is published daily at 3pm Pacific Standard Time (PST).
+
+[contrib-checklist]: https://docs.microsoft.com/powershell/scripting/community/contributing/editorial-checklist
+[contrib-managing-prs]: https://docs.microsoft.com/powershell/scripting/community/contributing/managing-pull-requests
+[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
+[gh-drafts]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
+[gh-key]: https://help.github.com/en/articles/closing-issues-using-keywords
+[gh-make-draft]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft
+[gh-review-request]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review


### PR DESCRIPTION
# PR Summary

Prior to this commit, the only available PR Template for the project is a catch-all template designed to accommodate every workflow and change type.

This commit introduces three new PR Templates for specific change-sets: conceptual, reference, and repository documentation.

They have specific instructions tailored to those change-sets and can be used for automation in the future, especially around the task lists.

These templates will not be displayed by default when a PR is submitted; they can only be used via a url query suffix which specifies the template, such as `?quick_pull=1&template=repodocs.md`.

Usage documentation and automation tailored to these templates will need to be addressed in future commits and items.

- Resolves AB#1948159

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [x] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [ ] Preview content
- [ ] Version 7.2 content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _main_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
