### PR TITLE
(GH-8853) Internationalize Show-Calendar example

### DIFF
--- a/reference/docs-conceptual/developer/module/how-to-write-a-powershell-script-module.md
+++ b/reference/docs-conceptual/developer/module/how-to-write-a-powershell-script-module.md
@@ -47,7 +47,7 @@ The following steps describe how to create a PowerShell module.
        [DateTime] $end = $start,
        $firstDayOfWeek,
        [int[]] $highlightDay,
-       [string[]] $highlightDate = [DateTime]::Today.ToString()
+       [string[]] $highlightDate = [DateTime]::Today.ToString('yyyy-MM-dd')
        )
 
        #actual code for the function goes here see the end of the topic for the complete code sample
@@ -168,7 +168,7 @@ member.
 
  .Example
    # Highlight a range of days.
-   Show-Calendar -HighlightDay (1..10 + 22) -HighlightDate "December 25, 2008"
+   Show-Calendar -HighlightDay (1..10 + 22) -HighlightDate "2008-12-25"
 #>
 function Show-Calendar {
 param(
@@ -176,7 +176,7 @@ param(
     [DateTime] $end = $start,
     $firstDayOfWeek,
     [int[]] $highlightDay,
-    [string[]] $highlightDate = [DateTime]::Today.ToString()
+    [string[]] $highlightDate = [DateTime]::Today.ToString('yyyy-MM-dd')
     )
 
 ## Determine the first day of the start and end months.


### PR DESCRIPTION
# PR Summary

Prior to this commit, the `Show-Calendar` example in the "How to write a PowerShell script module" conceptual article defined the **highlightDate** parameter with a default string that failed to cast when used on computers if their Culture does not use ISO or US date formats.

This commit updates the example code to function on a reader's computer regardless of their defined **DateTime** formats.

- Resolves #8853

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [x] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [ ] Preview content
- [ ] Version 7.2 content
- [ ] Version 7.1 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _main_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
