### PR TITLE
(GH-8854) Clarify behavior when #requires not met

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -1,7 +1,7 @@
 ---
 description: Prevents a script from running without the required elements.
 Locale: en-US
-ms.date: 10/22/2021
+ms.date: 05/24/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Requires
@@ -17,7 +17,7 @@ Prevents a script from running without the required elements.
 The `#Requires` statement prevents a script from running unless the PowerShell
 version, modules (and version), or snap-ins (and version), and edition
 prerequisites are met. If the prerequisites aren't met, PowerShell doesn't run
-the script.
+the script or provide other runtime features, such as tab completion.
 
 ### Syntax
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -1,7 +1,7 @@
 ---
 description: Prevents a script from running without the required elements.
 Locale: en-US
-ms.date: 10/22/2021
+ms.date: 05/24/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Requires
@@ -17,7 +17,7 @@ Prevents a script from running without the required elements.
 The `#Requires` statement prevents a script from running unless the PowerShell
 version, modules (and version), or snap-ins (and version), and edition
 prerequisites are met. If the prerequisites aren't met, PowerShell doesn't run
-the script.
+the script or provide other runtime features, such as tab completion.
 
 ### Syntax
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -1,7 +1,7 @@
 ---
 description: Prevents a script from running without the required elements.
 Locale: en-US
-ms.date: 10/22/2021
+ms.date: 05/24/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Requires
@@ -17,7 +17,7 @@ Prevents a script from running without the required elements.
 The `#Requires` statement prevents a script from running unless the PowerShell
 version, modules (and version), or snap-ins (and version), and edition
 prerequisites are met. If the prerequisites aren't met, PowerShell doesn't run
-the script.
+the script or provide other runtime features, such as tab completion.
 
 ### Syntax
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -1,7 +1,7 @@
 ---
 description: Prevents a script from running without the required elements.
 Locale: en-US
-ms.date: 10/22/2021
+ms.date: 05/24/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Requires
@@ -17,7 +17,7 @@ Prevents a script from running without the required elements.
 The `#Requires` statement prevents a script from running unless the PowerShell
 version, modules (and version), or snap-ins (and version), and edition
 prerequisites are met. If the prerequisites aren't met, PowerShell doesn't run
-the script.
+the script or provide other runtime features, such as tab completion.
 
 ### Syntax
 


### PR DESCRIPTION
# PR Summary

This commit adds a short note to the long description of the _about_Requires_ topic, clarifying that not only does a script with an unmet `#requires` statement not run, but also that no other runtime features, including tab-completion, are available either.

- Resolves #8854

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [x] Preview content
- [x] Version 7.2 content
- [x] Version 7.0 content
- [x] Version 5.1 content

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _main_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
