### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/targeting-valid-branch.yml
+++ b/.github/workflows/targeting-valid-branch.yml
@@ -5,8 +5,13 @@ on:
       - opened
       - reopened
       - synchronize
+permissions:
+  contents: read
+
 jobs:
   Test:
+    permissions:
+      contents: none
     runs-on: windows-latest
     defaults:
       run:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
