### PR TITLE
(MAINT) Remove 7.1 from PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/New_Issue.yml
+++ b/.github/ISSUE_TEMPLATE/New_Issue.yml
@@ -27,11 +27,10 @@ body:
     description: What version of the documentation is affected? (select all that apply)
     multiple: true
     options:
-      - 5.1
-      - 7.0
-      - 7.1
-      - 7.2
-      - 7.3 (preview)
+      - '5.1'
+      - '7.0'
+      - '7.2'
+      - '7.3 (preview)'
   validations:
     required: true
 - type: input

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,6 @@ relevant versions. Check the boxes below to indicate the versions affected by th
 
 - [ ] Preview content
 - [ ] Version 7.2 content
-- [ ] Version 7.1 content
 - [ ] Version 7.0 content
 - [ ] Version 5.1 content
 


### PR DESCRIPTION
# PR Summary

Removes 7.1 as an option from the PR and issue template for cmdlet reference as those documents are no longer included in this repository. Also places the version entries in strings to ensure valid yaml (instead of relying on interpretation).

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [x] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [ ] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [ ] Preview content
- [ ] Version 7.2 content
- [ ] Version 7.0 content
- [ ] Version 5.1 content

## PR Checklist

- [x] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [x] PR has a meaningful title
- [x] PR is targeted at the _main_ branch
- [x] All relevant versions updated
- [x] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [x] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
