### PR TITLE
(MAINT) Add GitHub Actions

### DIFF
--- a/.github/actions/.pwsh/module/functions/api/Add-PullRequestComment.ps1
+++ b/.github/actions/.pwsh/module/functions/api/Add-PullRequestComment.ps1
@@ -1,0 +1,85 @@
+<#
+.SYNOPSIS
+    Adds a comment to a pull request via GitHub CLI.
+.DESCRIPTION
+    This cmdlet adds a comment to a pull request via GitHub CLI by specifying a raw Markdown string
+    or the path to a markdown file containing the comment to write.
+.PARAMETER Owner
+    The owner of the repository the pull request is in. For `https://github.com/foo/bar/pull/10` the
+    owner is `foo`.
+.PARAMETER Repo
+    The name of the repository the pull request is in. For `https://github.com/foo/bar/pull/10` the
+    repo is `bar`.
+.PARAMETER Number
+    The number of the pull request to comment on. For `https://github.com/foo/bar/pull/10` the
+    number is `10`.
+.PARAMETER BodyText
+    The raw markdown text to write as a comment on the PR.
+.PARAMETER BodyFile
+    The  path to the markdown file to write as a comment on the PR. Due to the way GitHub mistreats
+    soft line breaks as hard line breaks in comments (unlike files), the markdown in a body file is
+    converted to HTML when writing the comment. From the user perspective, it's a normal comment.
+.EXAMPLE
+    Add-PullRequestComment -Owner foo -Repo bar -Number 10 -BodyText @'
+    Hello, _world_! How are **you**?
+    '@
+    
+    The cmdlet adds a comment to `https://github/foo/bar/pull/10`, rendering the body text' markdown
+    in the comment.
+.EXAMPLE
+    Add-PullRequestComment -Owner foo -Repo bar -Number 10 -BodyFile ./messages/hello.md
+
+    The cmdlet adds a comment to `https://github/foo/bar/pull/10`, rendering the contents of
+    `hello.md` in the comment.
+#>
+
+function Add-PullRequestComment {
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory)]
+        [string]$Owner,
+        [parameter(Mandatory)]
+        [string]$Repo,
+        [parameter(Mandatory)]
+        [int]$Number,
+        [Parameter(Mandatory, ParameterSetName = 'Text')]
+        [string]$BodyText,
+        [Parameter(Mandatory, ParameterSetName = 'File')]
+        [string]$BodyFile
+    )
+  
+    begin {
+        $AddCommentParams = @(
+            'pr', 'comment', $Number
+            '--repo', "$Owner/$Repo"
+        )
+        if (![string]::IsNullOrEmpty($BodyText)) {
+            $AddCommentParams += '--body'
+            $AddCommentParams += $BodyText
+        } else {
+            $AddCommentParams += '--body-file'
+            $AddCommentParams += $BodyFile
+        }
+    }
+  
+    process {
+        [string]$ResultString = gh @AddCommentParams 2>&1
+        $ExitCode = $LASTEXITCODE
+  
+        if ($ExitCode -ne 0) {
+            $ErrorParameters = @{
+                ResultString = $ResultString
+                ExitCode     = $ExitCode
+                CliParams    = $AddCommentParams
+                Intent       = "write expectations comment on PR $Number in $Owner/$Repo"
+                ErrorID      = 'GitHub.ApiPostFailure'
+            }
+            $Record = New-CliErrorRecord @ErrorParameters
+            $PSCmdlet.ThrowTerminatingError($Record)
+        }
+  
+        $ResultString
+    }
+  
+    end {}
+}

--- a/.github/actions/.pwsh/module/functions/api/Get-AuthorPermission.ps1
+++ b/.github/actions/.pwsh/module/functions/api/Get-AuthorPermission.ps1
@@ -1,0 +1,81 @@
+<#
+.SYNOPSIS
+    Retrieves repository permissions for a user.
+.DESCRIPTION
+    This cmdlet retrieves repository permissions for a user, returning a hashtable that enumerates
+    whether the user can admin, maintain, push, triage, and/or pull.
+.PARAMETER Owner
+    The owner of the repository to check the user's permissions in. For `https://github.com/foo/bar`
+    the owner is `foo`.
+.PARAMETER Repo
+    The name of the repository to check the user's permissions in. For `https://github.com/foo/bar`
+    the repo is `bar`.
+.PARAMETER Author
+    The username to retrieve permissions for.
+.EXAMPLE
+    Get-AuthorPermission -Owner foo -Repo bar -Author baz
+    
+    The cmdlet checks the `baz` user's permissions in the `https://github.com/foo/bar` repository.
+#>
+
+function Get-AuthorPermission {
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory)]
+        [string]$Owner,
+        [parameter(Mandatory)]
+        [string]$Repo,
+        [parameter(Mandatory)]
+        [string]$Author
+    )
+  
+    begin {
+        $ApiQueryParams = @(
+            'api', "repos/$Owner/$Repo/collaborators/$Author/permission"
+        )
+
+        $ReturnProperties = @(
+            @{
+                Name = 'Admin'
+                Expression = { $_.user.permissions.admin }
+            }
+            @{
+                Name = 'Maintain'
+                Expression = { $_.user.permissions.maintain }
+            }
+            @{
+                Name = 'Push'
+                Expression = { $_.user.permissions.push }
+            }
+            @{
+                Name = 'Triage'
+                Expression = { $_.user.permissions.triage }
+            }
+            @{
+                Name = 'Pull'
+                Expression = { $_.user.permissions.pull }
+            }
+        )
+    }
+  
+    process {
+        [string]$ResultString = gh @ApiQueryParams 2>&1
+        $ExitCode = $LASTEXITCODE
+      
+        if ($ExitCode -ne 0) {
+            $ErrorParameters = @{
+                ResultString = $ResultString
+                ExitCode     = $ExitCode
+                CliParams    = $ApiQueryParams
+                Intent       = "retrieve permissions for author '$Author' in $Owner/$Repo"
+                ErrorID      = 'GitHub.ApiQueryFailure'
+            }
+            $Record = New-CliErrorRecord @ErrorParameters
+            $PSCmdlet.ThrowTerminatingError($Record)
+        }
+  
+        $ResultString | ConvertFrom-Json | Select-Object -Property $ReturnProperties
+    }
+  
+    end {}
+}

--- a/.github/actions/.pwsh/module/functions/api/Get-OpenPRWithoutExpectation.ps1
+++ b/.github/actions/.pwsh/module/functions/api/Get-OpenPRWithoutExpectation.ps1
@@ -1,0 +1,74 @@
+<#
+.SYNOPSIS
+    Retrieves open PRs without an expectations comment.
+.DESCRIPTION
+    This cmdlet searches a repository for open pull requests targeting the `main` branch which do
+    not have an expectations comment on them already. It returns a hashtable with the author and
+    number of every pull request in the repository matching these criteria.
+.PARAMETER Owner
+    The owner of the repository to search for uncommented PRs. For `https://github.com/foo/bar`, the
+    owner is `foo`.
+.PARAMETER Repo
+    The name of the repository to search for uncommented PRs. For `https://github.com/foo/bar`, the
+    repo is `bar`.
+.EXAMPLE
+    Get-OpenPRWithoutExpectations -Owner foo -Repo bar
+
+    The cmdlet searches the `https://github.com/foo/bar` repository for open pull requests to the
+    `main` branch which do not have an expectations comment on them already.
+#>
+function Get-OpenPRWithoutExpectation {
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory)]
+        [string]$Owner,
+        [parameter(Mandatory)]
+        [string]$Repo
+    )
+  
+    begin {
+        $ApiQueryParams = @(
+            'search', 'prs'
+            '--repo', "$Owner/$Repo"
+            '--base', 'main'
+            '--state', 'open'
+            '--json', 'author'
+            '--json', 'number'
+            'NOT', 'in:comments', 'GHA.Comment.Id.Community.Expectations'
+        )
+
+        $ReturnProperties = @(
+            @{
+                Name = 'Author'
+                Expression = { $_.author.login }
+            }
+            @{
+                Name = 'Number'
+                Expression = { $_.number }
+            }
+        )
+    }
+  
+    process {
+        [string[]]$ResultString = gh @ApiQueryParams 2>&1
+        Write-Verbose -Message "Command:`n`tgh $($ApiQueryParams -join ' ')"
+        Write-Verbose -Message "Result String:`n`t$($ResultString -join "`n`t")"
+        $ExitCode = $LASTEXITCODE
+      
+        if ($ExitCode -ne 0) {
+            $ErrorParameters = @{
+                ResultString = ($ResultString -join "`n")
+                ExitCode     = $ExitCode
+                CliParams    = $ApiQueryParams
+                Intent       = 'retrieve open PRs without an expectations comment'
+                ErrorID      = 'GitHub.ApiQueryFailure'
+            }
+            $Record = New-CliErrorRecord @ErrorParameters
+            $PSCmdlet.ThrowTerminatingError($Record)
+        }
+  
+        $ResultString | ConvertFrom-Json | Select-Object -Property $ReturnProperties
+    }
+  
+    end {}
+}

--- a/.github/actions/.pwsh/module/functions/api/Get-PullRequestChangedFile.ps1
+++ b/.github/actions/.pwsh/module/functions/api/Get-PullRequestChangedFile.ps1
@@ -1,0 +1,67 @@
+<#
+.SYNOPSIS
+    Retrieves the list of file changes for a PR
+.DESCRIPTION
+    This cmdlet retrieves the list of file changes for a PR, returning an array of relative file
+    paths and the change type: `added`, `removed`, `modified`, `renamed`, `copied`, `changed`, or
+    `unchanged`.
+.PARAMETER Owner
+    The owner of the repository the pull request is in. For `https://github.com/foo/bar/pull/10` the
+    owner is `foo`.
+.PARAMETER Repo
+    The name of the repository the pull request is in. For `https://github.com/foo/bar/pull/10` the
+    repo is `bar`.
+.PARAMETER Number
+    The number of the pull request to get changed files from. For `https://github.com/foo/bar/pull/10` the
+    number is `10`.
+.PARAMETER All
+    Indicates that the query should return all files; by default, returns only the first 30.
+.EXAMPLE
+    Get-AuthorPermission -Owner foo -Repo bar -Author baz
+    
+    The cmdlet checks the `baz` user's permissions in the `https://github.com/foo/bar` repository.
+#>
+
+function Get-PullRequestChangedFile {
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory)]
+        [string]$Owner,
+        [parameter(Mandatory)]
+        [string]$Repo,
+        [parameter(Mandatory)]
+        [int]$Number,
+        [switch]$All
+    )
+  
+    begin {
+        $ApiQueryParams = @(
+            'api', "repos/$Owner/$Repo/pulls/$Number/files"
+            '--jq', '.[] | { Path: .filename, ChangeType: .status }'
+        )
+        if ($All) {
+            $ApiQueryParams += '--paginate'
+        }
+    }
+  
+    process {
+        [string[]]$ResultString = gh @ApiQueryParams 2>&1
+        $ExitCode = $LASTEXITCODE
+      
+        if ($ExitCode -ne 0) {
+            $ErrorParameters = @{
+                ResultString = ($ResultString -join "`n")
+                ExitCode     = $ExitCode
+                CliParams    = $ApiQueryParams
+                Intent       = "retrieve files for PR $Number in $Owner/$Repo"
+                ErrorID      = 'GitHub.ApiQueryFailure'
+            }
+            $Record = New-CliErrorRecord @ErrorParameters
+            $PSCmdlet.ThrowTerminatingError($Record)
+        }
+  
+        $ResultString | ConvertFrom-Json
+    }
+  
+    end {}
+}

--- a/.github/actions/.pwsh/module/functions/utility/Format-ConsoleBoolean.ps1
+++ b/.github/actions/.pwsh/module/functions/utility/Format-ConsoleBoolean.ps1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+    Returns a decorated string for writing a boolean in the console.
+.DESCRIPTION
+    The cmdlet decorates a boolean value for console viewing and returns it. If the **Value** is
+    `$true`, it is returned bright blue. If the **Value** is `$false`, it is returned bright
+    magenta.
+.PARAMETER Value
+    The boolean value to format as a decorated string for console viewing.
+.EXAMPLE
+    Format-ConsoleBoolean -Value $true
+    Format-ConsoleBoolean -Value $false
+
+    The cmdlet shows the styling for console viewing; the first statement shows "True" in bright
+    blue, the second shows "False" in bright magenta.
+#>
+function Format-ConsoleBoolean {
+    [CmdletBinding(DefaultParameterSetName='Components')]
+    [OutputType([String])]
+    param (
+        [Parameter(Mandatory)]
+        [bool]$Value
+    )
+
+    begin {
+        $Styles = @{
+            True  = $PSStyle.Foreground.BrightBlue
+            False = $PSStyle.Foreground.BrightMagenta
+        }
+    }
+
+    process {
+        "$($Styles."$Value")$Value$($PSStyle.Reset)"
+    }
+
+    end {}
+}

--- a/.github/actions/.pwsh/module/functions/utility/Format-ConsoleStyle.ps1
+++ b/.github/actions/.pwsh/module/functions/utility/Format-ConsoleStyle.ps1
@@ -1,0 +1,70 @@
+<#
+.SYNOPSIS
+    Stylize text for console viewing.
+.DESCRIPTION
+    This cmdlet stylizes input text for viewing in the console.
+.PARAMETER Text
+    The text to stylize. The styles are applied to the entire string.
+.PARAMETER StyleComponent
+    Specifies one or more PSStyle components to apply to the text.
+.PARAMETER DefinedStyle
+    Specifies a pre-defined style to apply to the text. Select one of:
+
+    - `Success`: Bold and bright blue
+    - `UserName`: Bright yellow
+    - `Target`: Bold and bright magenta
+.EXAMPLE
+    ```powershell
+    Format-ConsoleStyle -Text 'foo bar' -StyleComponent @(
+        $PSStyle.Underline
+        $PSStyle.Foreground.BrightGreen
+    )
+    ```
+
+    The cmdlet returns the string `foo bar` in bright green and underlined.
+.EXAMPLE
+    ```powershell
+    Format-ConsoleStyle -Text 'hooray!' -DefinedStyle Success
+    ```
+
+    The cmdlet returns  the string `hooray!` in bright blue and bolded.
+#>
+function Format-ConsoleStyle {
+    [CmdletBinding(DefaultParameterSetName='Components')]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Text,
+        [Parameter(Mandatory, ParameterSetName='Components')]
+        [string[]]$StyleComponent,
+        [Parameter(Mandatory, ParameterSetName='DefinedStyle')]
+        [ValidateSet('Success', 'Target', 'UserName')]
+        [string]$DefinedStyle
+    )
+
+    begin {
+        $Styles = @{
+            Success = @(
+                $PSStyle.Bold
+                $PSStyle.Foreground.BrightBlue
+            )
+            UserName = @(
+                $PSStyle.Foreground.BrightYellow
+            )
+            Target = @(
+                $PSStyle.Bold
+                $PSStyle.Foreground.BrightMagenta
+            )
+        }
+    }
+
+    process {
+        if ($StyleComponent.Count -eq 0) {
+            $StyleComponent = $Styles.$DefinedStyle
+        }
+
+        @(($StyleComponent -join ''), $Text, $PSStyle.Reset) -join ''
+    }
+
+    end {}
+}

--- a/.github/actions/.pwsh/module/functions/utility/Format-GHAConsoleText.ps1
+++ b/.github/actions/.pwsh/module/functions/utility/Format-GHAConsoleText.ps1
@@ -1,0 +1,98 @@
+<#
+.SYNOPSIS
+    Reflows a text string at a specified length for easier console reading.
+.DESCRIPTION
+    This cmdlet reflows a text string at a specified length for easier console reading. It respects
+    leading whitespace, keeping the indent for wrapped lines. It converts tabs to four spaces for
+    consistency in viewing. It breaks lines on whitespace; not complex, but usually fine in console.
+
+    Primarily useful for converting error messages into readable lines.
+.PARAMETER Text
+    Specifies input text to reflow.
+.PARAMETER MaxWidth
+    Specifies the maximum length in visible characters a line can be before reflowing. Defaults to
+    72 characters.
+.EXAMPLE
+    ```powershell
+    $Text = @'
+    This is a very long string with multiple paragraphs. It will certainly need to be reflowed in a few different places. It's not always easy to read long lines like this in the console.
+
+        It also respects leading whitespace. When a line is too long for reading in the console, it will happily reflow the leading whitespace to make sure that things don't look weird after.
+    '@
+    Format-GHAConsoleText -Text $Text
+    ```
+
+    ```output
+    This is a very long string with multiple paragraphs. It will certainly
+    need to be reflowed in a few different places. It's not always easy to
+    read long lines like this in the console.
+
+        It also respects leading whitespace. When a line is too long for
+        reading in the console, it will happily reflow the leading
+        whitespace to make sure that things don't look weird after.
+    ```
+
+    The cmdlet wraps the input text at 72 characters, making the long input strings more readable
+    and preserving the leading whitespace.
+#>
+function Format-GHAConsoleText {
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory)]
+        [string]$Text,
+        [int]$MaxWidth = 72
+    )
+
+    begin {}
+
+    process {
+        # Replace tabs with four spaces for consistent reflow with console width.
+        $Text = $Text -replace "`t", '    '
+        # Make all lines terminate as LF even if they terminated as CRLF to simplify the rest of the
+        # process. Then split on LF to process each line for reflow.
+        if ($Text -match "`r`n") {
+            $Text = $Text -replace "`r`n", "`n"
+        }
+        $InputLines = $Text -split "`n"
+
+        # Process every input line separately, reflowing them as needed.
+        $Output = New-Object -TypeName System.Text.StringBuilder
+        foreach ($Line in $InputLines) {
+            if ($Line.Length -lt $MaxWidth) {
+                $null = $Output.AppendLine($Line.TrimEnd())
+                continue
+            }
+            # If there is any leading whitespace for a line, discover it so it can be preserved for
+            # reflowed lines. Make sure to trim trailing whitespace to account for lines that are
+            # only whitespace; they break the flow badly.
+            $Line = $Line.TrimEnd()
+            $Prefix = $Line -match '^(\s+)' ? $Matches[1] : ''
+            # Simple split on whitespace; not perfect, but okay for action logs. Trim whitespace
+            # ahead of splitting; we already have the prefix.
+            $Words = $Line.Trim() -split '\s+'
+            # Set the new line with the discovered prefix before adding words.
+            $NewLine = $Prefix
+            # Loop over the words, appending a space and the word; if the updated line length is
+            # over the max, write the existing line to output and reset the newline to the prefix,
+            # continuing through the loop.
+            foreach ($Word in $Words) {
+                $UpdatedNewLine = $NewLine -eq $Prefix ? "$Newline$Word" : "$NewLine $Word"
+                if ($UpdatedNewLine.Length -gt $MaxWidth) {
+                    $null = $Output.AppendLine($NewLine.TrimEnd())
+                    $NewLine = "$Prefix$Word"
+                }
+                else {
+                    $NewLine = $UpdatedNewLine
+                }
+            }
+            # Make sure to write any remaining text to the output.
+            if ($NewLine.Length -gt 0) {
+                $null = $Output.AppendLine($NewLine.TrimEnd())
+            }
+        }
+
+        $Output.ToString()
+    }
+
+    end {}
+}

--- a/.github/actions/.pwsh/module/functions/utility/Get-ActionScriptParameter.ps1
+++ b/.github/actions/.pwsh/module/functions/utility/Get-ActionScriptParameter.ps1
@@ -1,0 +1,147 @@
+<#
+.SYNOPSIS
+    Retrieves and validates parameters for GHA
+.DESCRIPTION
+    This cmdlet uses parameter handlers to retrieve and validate the inputs from a GitHub Action,
+    returning a hashtable of parameters to splat on an action script.
+.PARAMETER ParameterHandler
+    Specify one or more parameter handlers, such as those as kept in an action's `Parameters.psd1`
+    file. Make sure the hashtable in those data files is converted to a **PSCustomObject**.
+    
+    Parameter handlers have the following properties:
+
+    - **Name:** The name of the _input_ parameter to the action. This is
+      used to retrieve the value from the environment variable (`INPUT_*`)
+      and is distinct from the parameters that need to be passed to the
+      script.
+    - **Type:** The dotnet type of the input. Currently unused, but may be
+      useful for casting later.
+    - **IfNullOrEmpty:** A scriptblock that will be invoked if the value
+      retrieval for that parameter returns `$null` or an empty string or
+      array. It takes one input (`$ErrorTarget`) and should either throw
+      an exception (if the parameter is mandatory and may not be null) or
+      do nothing. It should not return any objects to the output stream.
+    - **Process:** A scriptblock that will be invoked if prior steps for
+      the parameter do not throw any exceptions. It takes three arguments
+      (`$Parameters`, `$Value`, and `$ErrorTarget`). `$Parameters` is the
+      current hashtable with any already-validated parameters defined. It
+      is what will eventually be splatted to the action script. This
+      scriptblock should validate the script parameter(s) it gets from the
+      action's inputs, add them to the hash, and return the hash. If the
+      parameters fail validation, it should throw an exception to avoid
+      calling the script in a broken state.
+.EXAMPLE
+    ```powershell
+    $ParameterHandlers = Join-Path -Path $ActionPath -ChildPath Parameters.psd1 |
+        ForEach-Object -Process { Import-PowerShellDataFile -Path $_ } |
+        Select -ExpandProperty Parameters |
+        ForEach-Object -Process { [pscustomobject]$_ }
+    $Parameters = Get-ActionScriptParameter -ParameterHandler $ParameterHandlers
+    ```
+
+    This example reads in the data file containing the parameter handlers and converts them to
+    **PSCustomObjects** before passing them to the cmdlet. The cmdlet retrieves the inputs from
+    environment variables and uses the handlers to process them, eventually returning a hashtable
+    containing the parameters for that action. If any parameter fails validation, the cmdlet throws
+    an exception and the run ends.
+#>
+function Get-ActionScriptParameter {
+    [CmdletBinding()]
+    param(
+        [pscustomobject[]]$ParameterHandler
+    )
+
+    begin {
+        $ActionParameters = @{}
+        $ErrorTarget = if ($env:GITHUB_ACTIONS) {
+            $env:GITHUB_ACTION
+        } else {
+            $PSCmdlet.MyInvocation.InvocationName
+        }
+
+        function Update-ScriptBlockFromDataFile {
+            [CmdletBinding()]
+            param(
+                [scriptblock]$ScriptBlock
+            )
+
+            begin {
+                $Predicate = {
+                    param([System.Management.Automation.Language.Ast]$AstObject)
+                    return ($AstObject -is [System.Management.Automation.Language.ScriptBlockAst])
+                }
+            }
+
+            process {
+                $Stringified = $ScriptBlock.Ast.EndBlock.Extent.Text?.Trim()
+                # Scriptblocks from data files get wrapped in extra curly braces, preventing them
+                # from being invokable. Normally just the contents shows up when calling ToString()
+                # on a scriptblock, so this is one way to tell.
+                if ($Stringified -match '^\{') {
+                    $NestedBlock = $ScriptBlock.Ast.FindAll($Predicate, $true)
+                    | Where-Object -FilterScript { $_.EndBlock.Extent.Text.Trim() -notmatch '^\{' }
+                    | Select-Object -First 1
+                }
+
+                if ($NestedBlock -is [System.Management.Automation.Language.ScriptBlockAst]) {
+                    return $NestedBlock.GetScriptBlock()
+                }
+
+                return $ScriptBlock
+            }
+
+            end {}
+        }
+    }
+
+    process {
+        foreach ($Handler in $ParameterHandler) {
+            $Value = Get-Item "Env:\INPUT_$($Handler.Name)" | Select-Object -ExpandProperty Value
+            if ($Handler.Type -match 'String') {
+                $NullHandler = Update-ScriptBlockFromDataFile -ScriptBlock $Handler.IfNullOrEmpty
+                if ([string]::IsNullOrEmpty($Value) -and ($null -ne $NullHandler)) {
+                    Set-Variable -Name InvocationParameters -Value @{
+                        ScriptBlock  = $NullHandler
+                        NoNewScope   = $true
+                        ArgumentList = @(
+                            $ErrorTarget
+                        )
+                    }
+                    Invoke-Command @InvocationParameters
+                }
+            } else {
+                $NullHandler = Update-ScriptBlockFromDataFile -ScriptBlock $Handler.IfNull
+                if ($null -eq $Value -and ($null -ne $NullHandler)) {
+                    Set-Variable -Name InvocationParameters -Value @{
+                        ScriptBlock  = $NullHandler
+                        NoNewScope   = $true
+                        ArgumentList = @(
+                            $ErrorTarget
+                        )
+                    }
+                    Invoke-Command @InvocationParameters
+                }
+            }
+
+            $ProcessScriptBlock = Update-ScriptBlockFromDataFile -ScriptBlock $Handler.Process
+            if ($null -eq $ProcessScriptBlock) {
+                throw 'no go bud, need a process script block'
+            }
+
+            Set-Variable -Name InvocationParameters -Value @{
+                ScriptBlock  = $ProcessScriptBlock
+                NoNewScope   = $true
+                ArgumentList = @(
+                    $ActionParameters
+                    $Value
+                    $ErrorTarget
+                )
+            }
+            $ActionParameters = Invoke-Command @InvocationParameters
+        }
+    }
+
+    end {
+        $ActionParameters
+    }
+}

--- a/.github/actions/.pwsh/module/functions/utility/Get-GHAConsoleError.ps1
+++ b/.github/actions/.pwsh/module/functions/utility/Get-GHAConsoleError.ps1
@@ -1,0 +1,59 @@
+<#
+.SYNOPSIS
+    Returns an alternate view of an error record for the GH CLI
+.DESCRIPTION
+    This cmdlet returns an alternate view of an error record for the GH CLI. It limits the object
+    properties to the fully qualified ID, the type of the error, the error message, and the target
+    object (which for GH CLI errors is always the command-line arguments for the failing command).
+
+    It can retrieve errors from the `$error` variable or act on an input object.
+.PARAMETER Newest
+    Specifies the number of error records to return, from newest to oldest.
+.PARAMETER InputObject
+    Specifies an error record to get the alternate view for.
+.EXAMPLE
+    ```powershell
+    Get-GHAConsoleError -Newest 1
+    ```
+
+    The cmdlet gets the alternate view for the last error in the session.
+.EXAMPLE
+    ```powershell
+    Get-GHAConsoleError -InputObject $error[0]
+    ```
+
+    The cmdlet gets the alternate view for the last error in the session.
+#>
+function Get-GHAConsoleError {
+    [CmdletBinding()]
+    param(
+        [int]$Newest,
+        [parameter(ValueFromPipeline)]
+        [psobject]$InputObject
+    )
+  
+    begin {
+        $Properties = @(
+            'FullyQualifiedErrorId'
+            @{
+                Name       = 'Type'
+                Expression = { $_.CategoryInfo.Reason }
+            }
+            @{
+                Name       = 'Message'
+                Expression = { $_.Exception.Message }
+            }
+            @{
+                Name       = 'Command Parameters'
+                Expression = { $_.TargetObject }
+            }
+            'ScriptStackTrace'
+        )
+    }
+  
+    process {
+        Get-Error @PSBoundParameters | Select-Object -Property $Properties
+    }
+  
+    end {}
+}

--- a/.github/actions/.pwsh/module/functions/utility/Get-VersionedContentStatus.ps1
+++ b/.github/actions/.pwsh/module/functions/utility/Get-VersionedContentStatus.ps1
@@ -1,0 +1,165 @@
+<#
+.SYNOPSIS
+    Returns the change status of versioned content for a pull request.
+.DESCRIPTION
+    This cmdlet returns the change status of versioned content for a pull request. This information
+    can be used to analyze whether a pull request has modified every file it should.
+
+    Pull requests for versioned content can be tricky, requiring an author to modify the same file
+    in multiple folders. This cmdlet helps clarify if changes have been made across all the versions
+    a file exists in, but does not process the information itself.
+
+    The output of this cmdlet is an array of objects with the following properties:
+
+    - **VersionRelativePath**: The path to the changed file from the version folder
+    - **BaseFolder**: The path to the parent folder of multiple versions; the grandparent of the
+      **VersionRelativePath**.
+    - **Versions**: An array of objects representing every version of the content the file exists
+      in. Each entry has a **Version** (like `5.1` or `7.2`) and **ChangeType** (whether the file
+      was `added`, `removed`, `modified`, `renamed`, `copied`, `changed`, or `unchanged`).
+.PARAMETER ChangedContent
+    The list of changed files from a pull request and their change type. This should usually be
+    retrieved by running `Get-PullRequestChangedFile`.
+.EXAMPLE
+    ```powershell
+    $Changes = @(
+        @{
+            ChangeType = 'modified'
+            Path = '.openpublishing.redirection.json'
+        }
+        @{
+            ChangeType = 'modified'
+            Path = 'README.md'
+        }
+        @{
+            ChangeType = 'modified'
+            Path = 'reference/7.0/Microsoft.PowerShell.Core/About/about_Pwsh.md'
+        }
+        @{
+            ChangeType = 'removed'
+            Path = 'reference/7.1/CimCmdlets/CimCmdlets.md'
+        }
+        @{
+            ChangeType = 'removed'
+            Path = 'reference/7.2/CimCmdlets/CimCmdlets.md'
+        }
+    )
+    Get-VersionedContentChangeStatus -ChangedContent $Changes | ConvertTo-Json -Depth 3
+    ```
+
+    ```output
+    [
+        {
+            "VersionRelativePath": "Microsoft.PowerShell.Core/About/about_Pwsh.md",
+            "BaseFolder": "reference",
+            "Versions": [
+                { "Version": "7.0", "ChangeType": "modified"  },
+                { "Version": "7.0", "ChangeType": "unchanged" },
+                { "Version": "7.2", "ChangeType": "unchanged" },
+                { "Version": "7.3", "ChangeType": "unchanged" }
+            ]
+        },
+        {
+            "VersionRelativePath": "CimCmdlets/CimCmdlets.md",
+            "BaseFolder": "reference",
+            "Versions": [
+                { "Version": "7.1", "ChangeType": "removed"   },
+                { "Version": "5.1", "ChangeType": "unchanged" },
+                { "Version": "7.0", "ChangeType": "unchanged" },
+                { "Version": "7.2", "ChangeType": "removed"   },
+                { "Version": "7.3", "ChangeType": "unchanged" }
+            ]
+        }
+    ]
+    ```
+
+    The cmdlet inspects each of the changed files to see if the file is versioned content or not;
+    that is, if it exists in a folder with a version number in its ancestor path. If the file is not
+    version content, it is skipped. If the file is versioned content, the cmdlet creates a result
+    object for that file which includes its version-relative path (the path to the file from the
+    version folder it live in), base folder (the path to the folder above the version folders),
+    and an array of version changes, which enumerates all the versions that file exists in and
+    its change status. Any versioned content not modified in the PR is listed as `unchanged`.
+#>
+function Get-VersionedContentChangeStatus {
+    [CmdletBinding()]
+    param(
+        $ChangedContent
+    )
+
+    begin {
+        $VersionedContent = @()
+        $VersionPattern = '(?<version>(v(\d+\.){0,}\d+(-[^\/]+)*)|(\d+\.){1,}\d+(-[^\/]+)*)'
+        $Pattern = "^(?<BaseFolder>.+)\/$VersionPattern\/(?<VersionRelativePath>.+)`$"
+    }
+
+    process {
+        # Associates the changed files together as an array of entries, like:
+        # [pscustomobject]@{
+        #     VersionRelativePath = 'Microsoft.PowerShell.Core/Enter-PSHostProcess.md'
+        #     BaseFolder          = 'reference'
+        #     Versions            = @(
+        #         [pscustomobject]@{ Version = '5.1' ; ChangeType = 'modified' }
+        #         [pscustomobject]@{ Version = '7.1' ; ChangeType = 'removed'  }
+        #     )
+        # }
+        foreach ($Item in $ChangedContent) {
+            if ($Item.Path -match $Pattern) {
+                $BaseFolder = $Matches.BaseFolder
+                $Version = $Matches.Version
+                $VersionRelativePath = $Matches.VersionRelativePath
+
+                $AddEntry = $true
+                for ($i = 0 ; $i -lt $VersionedContent.Count ; $i++){
+                    $Entry = $VersionedContent[$i]
+                    $MatchingVersionRelativePath = $Entry.VersionRelativePath -eq $VersionRelativePath
+                    $MatchingBaseFolder = $Entry.BaseFolder -eq $BaseFolder
+                    if ($MatchingVersionRelativePath -and $MatchingBaseFolder) {
+                        $AddEntry = $false
+                        $VersionedContent[$i].Versions += [PSCustomObject]@{
+                            Version    = $Version
+                            ChangeType = $Item.ChangeType
+                        }
+                        break
+                    }
+                }
+                
+                if ($AddEntry) {
+                    $VersionedContent += [pscustomobject]@{
+                        VersionRelativePath = $VersionRelativePath
+                        BaseFolder          = $BaseFolder
+                        Versions            = @(
+                            [pscustomobject]@{
+                                Version    = $Version
+                                ChangeType = $Item.ChangeType
+                            }
+                        )
+                    }
+                }
+            }
+        }
+        # Loops over the items after initial processing to find unchanged files in other versions.
+        foreach ($Item in $VersionedContent) {
+            $VersionRelativePath = $Item.VersionRelativePath
+            $BaseFolder = $Item.BaseFolder
+            Get-Item -Path "$BaseFolder/*.*/$VersionRelativePath" | ForEach-Object {
+                $FilePath = $_.FullName -replace '\\', '/'
+                if ($FilePath -match $Pattern) {
+                    $Version = $Matches.Version
+                    if ($Item.Versions.Version -notcontains $Version) {
+                        $Item.Versions += [PSCustomObject]@{
+                            Version = $Version
+                            ChangeType = 'unchanged'
+                        }
+                    }
+                }
+            }
+            # Make sure to sort versions not by discovery order but by version number
+            $Item.Versions = $Item.Versions | Sort-Object -Property { [version]$_.Version }
+            # Send the result to the pipeline
+            $Item
+        }
+    }
+
+    end {}
+}

--- a/.github/actions/.pwsh/module/functions/utility/New-CliErrorRecord.ps1
+++ b/.github/actions/.pwsh/module/functions/utility/New-CliErrorRecord.ps1
@@ -1,0 +1,96 @@
+<#
+.SYNOPSIS
+    Generates an error record for a failed `gh` command.
+.DESCRIPTION
+    This cmdlet generates an error record for a failed `gh` command. It enables the API commands in
+    this module to write useful error messages.
+
+    The exception type is always **System.ApplicationException** and the error category is always
+    `FromStdErr`.
+.PARAMETER ResultString
+    Specifies the output from the failed `gh` command. This becomes part of the exception message.
+.PARAMETER ExitCode
+    Specifies the exit code from the failed `gh` command. This is included in the exception message.
+.PARAMETER CliParams
+    Specifies the parameters passed to the failed `gh` command. This defines the target of the error
+    record so a user can understand what was called when the command failed.
+.PARAMETER Intent
+    Specifies what the `gh` command was supposed to do at a high level. This becomes part of the
+    expection messge.
+.PARAMETER ErrorID
+    Specifies an identifier for the error record.
+.EXAMPLE
+    The cmdlet creates an error record for a failed GH command.
+    ```powershell
+    $ErrorInfo = @{
+        ResultString = 'Unknown command'
+        ExitCode = 1
+        CliParams = @('repo', 'get', '--owner', 'foo')
+        Intent = 'get the foo repo'
+        ErrorID = 'gha.repo.get'
+    }
+    New-CliErrorRecord @ErrorInfo
+    ```
+
+    ```output
+    Exception             : 
+        Type       : System.ApplicationException
+        TargetSite : 
+            Name          : ThrowTerminatingError
+            DeclaringType : System.Management.Automation.MshCommandRuntime, System.Management.Automation, Version=7.2.4.500, Culture=neutral, PublicKeyToken=31bf3856ad364e35
+            MemberType    : Method
+            Module        : System.Management.Automation.dll
+        Message    : Author (markekraus) may not target file paths:
+                    .github/pwsh
+                    .github/workflows
+
+        Source     : System.Management.Automation
+        HResult    : -2146232832
+        StackTrace : 
+    at System.Management.Automation.MshCommandRuntime.ThrowTerminatingError(ErrorRecord errorRecord)
+    CategoryInfo          : PermissionDenied: (:String) [Test-Authorization.ps1], ApplicationException
+    FullyQualifiedErrorId : GHA.NotPermittedToTarget,Test-Authorization.ps1
+    InvocationInfo        : 
+        MyCommand        : Test-Authorization.ps1
+        ScriptLineNumber : 1
+        OffsetInLine     : 1
+        HistoryId        : 125
+        Line             : .\.github\pwsh\scripts\Test-Authorization.ps1 -Owner michaeltlombardi -Repo ghe -Author markekraus -TargetPath '.github/pwsh', '.github/workflows'
+        PositionMessage  : At line:1 char:1
+                        + .\.github\pwsh\scripts\Test-Authorization.ps1 -Owner michaeltlombardi …
+                        + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        InvocationName   : .\.github\pwsh\scripts\Test-Authorization.ps1
+        CommandOrigin    : Internal
+    ScriptStackTrace      : at <ScriptBlock><Process>, C:\code\personal\ghe\.github\pwsh\scripts\Test-Authorization.ps1: line 134
+                            at <ScriptBlock>, <No file>: line 1
+    ```
+#>
+function New-CliErrorRecord {
+    [CmdletBinding()]
+    param(
+        [string]$ResultString,
+        [int]$ExitCode,
+        [string[]]$CliParams,
+        [string]$Intent,
+        [string]$ErrorID
+    )
+    
+    begin {}
+  
+    process {
+        $Message = New-Object -TypeName System.Text.StringBuilder
+        $null = $Message.AppendLine("GitHub API call to $Intent failed with exit code ${ExitCode}:")
+        $null = $Message.AppendLine("    $ResultString")
+        $Message = Format-GHAConsoleText -Text $Message.ToString()
+        $Exception = [System.ApplicationException]::new($Message)
+        $TargetObject = Format-GHAConsoleText -Text "gh $($CliParams -join ' ')"
+        [System.Management.Automation.ErrorRecord]::new(
+            $Exception,
+            $ErrorID,
+            [System.Management.Automation.ErrorCategory]::FromStdErr,
+            $TargetObject
+        )
+    }
+  
+    end {}
+}

--- a/.github/actions/.pwsh/module/functions/utility/New-InvalidParameterError.ps1
+++ b/.github/actions/.pwsh/module/functions/utility/New-InvalidParameterError.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+    Returns an error record about an invalid action parameter.
+.DESCRIPTION
+    This cmdlet composes and returns an error record for when a parameter handler determines that
+    the input for a GitHub Action cannot be validly converted to a parameter for an action script.
+
+    It returns the error record but does not throw it or write it to the error stream.
+.PARAMETER Name
+    Specify the name of the parameter that failed validation.
+.PARAMETER Message
+    Specify the string to write as the message for how/why the parameter failed validation.
+.PARAMETER Target
+    Specify the name of the action or step the validation failed during.
+.PARAMETER Type
+    Specify how the parameter failed validation. Currently supported values are `Missing` and
+    `Invalid`. By default, the **Type** is `Missing`.
+
+    Specify `Missing` when the value could not be discovered at all. Specify `Invalid` when the
+    value was discovered but did not meet the requirements.
+.EXAMPLE
+    ```powershell
+    $Details = @{
+        Name = 'Foo'
+        Message = 'Foo must be bigger than 10 but was: 5'
+        Target  = 'Test-BigNumber.ps1'
+        Type    = 'Invalid'
+    }
+    New-InvalidParameterError @Details
+    ```
+
+    This example creates a new error record indicating that while the value found for **Foo** was
+    the correct type, it was not large enough to pass validation.
+#>
+function New-InvalidParameterError {
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory)]
+        [string]$Name,
+        [parameter(Mandatory)]
+        [string]$Message,
+        [parameter(Mandatory)]
+        [string]$Target,
+        [ValidateSet('Missing', 'Invalid')]
+        [string]$Type = 'Missing'
+    )
+
+    begin {}
+
+    process {
+        $Message   = Format-GHAConsoleText -Text $Message
+        switch ($Type) {
+            'Missing' {
+                $Exception = [System.Management.Automation.PSArgumentNullException]::new(
+                    $Name,
+                    $Message
+                )
+                $ErrorID =  'GHA.MissingParameter'
+            }
+            default { # Includes 'Invalid'
+                $Exception = [System.Management.Automation.PSArgumentException]::new(
+                    $Message,
+                    $Name
+                )
+                $ErrorID =  'GHA.InvalidParameter'
+            }
+        }
+        $Target    = Format-GHAConsoleText -Text $Target
+        [System.Management.Automation.ErrorRecord]::new(
+            $Exception,
+            $ErrorID,
+            [System.Management.Automation.ErrorCategory]::InvalidArgument,
+            $Target
+        )
+    }
+
+    end {}
+}

--- a/.github/actions/.pwsh/module/functions/utility/Write-ActionFailureSummary.ps1
+++ b/.github/actions/.pwsh/module/functions/utility/Write-ActionFailureSummary.ps1
@@ -1,0 +1,44 @@
+<#
+.SYNOPSIS
+    Writes a standardized summary entry when a GHA fails due to thrown error.
+.DESCRIPTION
+    Writes a standardized summary entry when a GHA fails due to thrown error. It includes the record
+    of the error in a Markdown codeblock under the heading "Action Failure."
+.PARAMETER Synopsis
+    Specifies a synopsis for what the action was trying to do when it failed.
+.PARAMETER Record
+    Specifies a record object to write in the error details. Does not have to be an error record.
+.EXAMPLE
+    $Record = Get-GHAConsoleError -Newest 1
+    Write-ActionFailureSummary -Synopsis 'Unable to retrieve open pull requests.' -Record $Record
+
+    The cmdlet writes the details of the failed `gh` command as markdown into the summary for this
+    workflow step.
+#>
+function Write-ActionFailureSummary {
+    [CmdletBinding()]
+    param (
+        [string]$Synopsis,
+        [psobject]$Record
+    )
+    
+    begin {
+    }
+    
+    process {
+        $Summary = New-Object -TypeName System.Text.StringBuilder
+        $PSStyle.OutputRendering = $Plain
+        $null = $Summary.AppendLine('## Action Failure').AppendLine()
+        $null = $Summary.AppendLine("$Synopsis Error details:").AppendLine()
+        $null = $Summary.AppendLine('```text')
+        $RecordBlock = $Record | Format-List -Property * | Out-String
+        $null = $Summary.AppendLine($RecordBlock.Trim())
+        $null = $Summary.AppendLine('```').AppendLine()
+        $PSStyle.OutputRendering = $Ansi
+        $Summary.ToString() >> $ENV:GITHUB_STEP_SUMMARY
+    }
+    
+    end {
+        
+    }
+}

--- a/.github/actions/.pwsh/module/functions/utility/Write-HostParameter.ps1
+++ b/.github/actions/.pwsh/module/functions/utility/Write-HostParameter.ps1
@@ -1,0 +1,60 @@
+<#
+.SYNOPSIS
+    Writes a console log message displaying the parameter value, colorized.
+.DESCRIPTION
+    This cmdlet writes a console log message declaring that a parameter value has been determined,
+    including the name and colorized value. It uses `Write-Host` to avoid polluting the output
+    stream, allowing it to be log this information in parameter handler scriptblocks invoked by the
+    `Get-ActionScriptParameter` cmdlet.
+.PARAMETER Name
+    Specify the name of the parameter to display.
+.PARAMETER Value
+    Specify the value of the parameter. This value will be colorized.
+.PARAMETER MultiLine
+    Specify whether the value should be displayed as a multi-line string. Specifying this switch
+    causes the indentation and wrapping to handle differently than for single-lines.
+.PARAMETER Color
+    Specify the color to apply to the value. By default, it is bright magenta.
+.EXAMPLE
+    ```powershell
+    Write-HostParameter -Name Foo -Value 'Apple'
+    ```
+
+    This example will write the message `Foo: Apple` with `Apple` bolded and colored bright magenta.
+#>
+function Write-HostParameter {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [Parameter(Mandatory)]
+        [string[]]$Value,
+        [switch]$MultiLine,
+        [string]$Color = $PSStyle.Foreground.BrightMagenta
+        
+    )
+
+    begin {}
+
+    process {
+        $Prefix = "${Name}: ".PadLeft(20)
+        if ($MultiLine) {
+            $MultilineValue = $Value -split "`n"
+            | ForEach-Object -Process { "$(' ' * 20)$_" }
+            | Join-String -Separator "`n"
+            Write-Verbose "Body:`n$MultiLineValue"
+            $MultilineValue = $PSStyle.Bold + $Color + $MultilineValue + $PSStyle.Reset
+            Write-Verbose "After formatting:`n$MultilineValue"
+            $Message = "$Prefix`n$MultilineValue"
+        } else {
+            $Values = $Value
+            | ForEach-Object -Process { $PSStyle.Bold + $Color + $_ + $PSStyle.Reset }
+            | Join-String -Separator ', '
+            $Message = $Prefix + $Values
+        }
+
+        Write-Host $Message
+    }
+
+    end {}
+}

--- a/.github/actions/.pwsh/module/gha.psd1
+++ b/.github/actions/.pwsh/module/gha.psd1
@@ -1,0 +1,101 @@
+@{
+    # Script module or binary module file associated with this manifest.
+    RootModule           = 'gha.psm1'
+
+    # Version number of this module.
+    ModuleVersion        = '0.0.1'
+
+    # ID used to uniquely identify this module
+    GUID                 = '8e4299da-59ae-4b46-ab06-dc8da81d1c3c'
+
+    # Author of this module
+    Author               = 'PowerShell Docs Team'
+
+    # Copyright statement for this module
+    Copyright            = '(c) Microsoft. All rights reserved.'
+
+    # Description of the functionality provided by this module
+    Description          = 'Helper module for GitHub Actions'
+
+    # Minimum version of the PowerShell engine required by this module
+    PowerShellVersion    = '7.2'
+
+    # Modules that must be imported into the global environment prior to importing this module
+    RequiredModules      = @()
+
+    # Assemblies that must be loaded prior to importing this module
+    RequiredAssemblies   = @()
+
+    # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+    ScriptsToProcess     = @()
+
+    # Type files (.ps1xml) to be loaded when importing this module
+    TypesToProcess       = @()
+
+    # Format files (.ps1xml) to be loaded when importing this module
+    FormatsToProcess     = @()
+
+    # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+    NestedModules        = @()
+
+    # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+    FunctionsToExport    = @(
+        # API Functions
+        'Add-PullRequestComment'
+        'Get-AuthorPermission'
+        'Get-OpenPRWithoutExpectation'
+        'Get-PullRequestChangedFile'
+        # Utility Functions
+        'Format-ConsoleBoolean'
+        'Format-ConsoleStyle'
+        'Format-GHAConsoleText'
+        'Get-ActionScriptParameter'
+        'Get-GHAConsoleError'
+        'Get-VersionedContentStatus'
+        'New-CliErrorRecord'
+        'New-InvalidParameterError'
+        'Write-ActionFailureSummary'
+        'Write-HostParameter'
+    )
+
+    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+    CmdletsToExport      = @()
+
+    # Variables to export from this module
+    VariablesToExport    = '*'
+
+    # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+    AliasesToExport      = @()
+
+    # List of all modules packaged with this module
+    ModuleList           = @()
+
+    # HelpInfo URI of this module
+    # HelpInfoURI          = ''
+
+    # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+    # DefaultCommandPrefix = ''
+
+    # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+    PrivateData          = @{
+
+      PSData = @{
+
+        # Tags applied to this module. These help with module discovery in online galleries.
+        Tags       = @()
+
+        # A URL to the license for this module.
+        LicenseUri = ''
+
+        # A URL to the main website for this project.
+        ProjectUri = ''
+
+        # A URL to an icon representing this module.
+        IconUri    = ''
+
+        # ReleaseNotes of this module
+        # ReleaseNotes = ''
+      } # End of PSData hashtable
+
+    } # End of PrivateData hashtable
+  }

--- a/.github/actions/.pwsh/module/gha.psm1
+++ b/.github/actions/.pwsh/module/gha.psm1
@@ -1,0 +1,13 @@
+$FunctionFinderParams = @{
+    Path    = "$PSScriptRoot/functions"
+    Include = '*-*.ps1'
+    Exclude = '*.Tests.ps1'
+    Recurse = $true
+}
+
+Get-ChildItem @FunctionFinderParams
+| ForEach-Object -Process {
+    . $_.FullName
+}
+
+Export-ModuleMember -Function *

--- a/.github/actions/.pwsh/module/readme.md
+++ b/.github/actions/.pwsh/module/readme.md
@@ -1,0 +1,156 @@
+# GHA Module
+
+The GitHub Actions (GHA) module includes helper functions for the scripts used by the actions in
+this repository. Those functions are broken up across broad usage:
+
+- API: Functions in the [`api` folder][api-folder] make specific structured calls to GitHub's API
+  with the GitHub CLI (`gh`). Each of these functions performs a very specific query and returns
+  predictably structured data.
+- Utility: Functions in the [`utility` folder][utility-folder] are more general-purpose and are used
+  by the API functions and the action scripts alike.
+
+## API Functions
+
+### `Add-PullRequestComment`
+
+This cmdlet adds a comment to a pull request via GitHub CLI by specifying a raw Markdown string or
+the path to a Markdown file containing the comment to write.
+
+For more information, review the [source code][api-Add-PullRequestComment].
+
+### `Get-AuthorPermission`
+
+This cmdlet retrieves repository permissions for a user, returning a hashtable that enumerates
+whether the user can admin, maintain, push, triage, and/or pull.
+
+For more information, review the [source code][api-Get-AuthorPermission].
+
+### `Get-OpenPRWithoutExpectation`
+
+This cmdlet searches a repository for open pull requests targeting the `main` branch which do not
+have an expectations comment on them already. It returns a hashtable with the author and number of
+every pull request in the repository matching these criteria.
+
+For more information, review the [source code][api-Get-OpenPRWithoutExpectation]
+
+### `Get-PullRequestChangedFile`
+
+This cmdlet retrieves the list of file changes for a PR, returning an array of relative file paths
+and the change type: `added`, `removed`, `modified`, `renamed`, `copied`, `changed`, or `unchanged`.
+
+For more information, review the [source code][api-Get-PullRequestChangedFile]
+
+## Utility Functions
+
+### `Format-ConsoleBoolean`
+
+The cmdlet decorates a boolean value for console viewing and returns it. If the **Value** is
+`$true`, it is returned bright blue. If the **Value** is `$false`, it is returned bright magenta.
+
+For more information, review the [source code][utility-Format-ConsoleBoolean]
+
+### `Format-ConsoleStyle`
+
+This cmdlet stylizes input text for viewing in the console.
+
+For more information, review the [source code][utility-Format-ConsoleStyle]
+
+### `Format-GHAConsoleText`
+
+This cmdlet reflows a text string at a specified length for easier console reading. It respects
+leading whitespace, keeping the indent for wrapped lines. It converts tabs to four spaces for
+consistency in viewing. It breaks lines on whitespace; not complex, but usually fine in console.
+
+Primarily useful for converting error messages into readable lines.
+
+For more information, review the [source code][utility-Format-GHAConsoleText]
+
+### `Get-ActionScriptParameter`
+
+This cmdlet uses parameter handlers to retrieve and validate the inputs from a GitHub Action,
+returning a hashtable of parameters to splat on an action script.
+
+For more information, review the [source code][utility-Get-ActionScriptParameter]
+
+### `Get-GHAConsoleError`
+
+This cmdlet returns an alternate view of an error record for the GH CLI. It limits the object
+properties to the fully qualified ID, the type of the error, the error message, and the target
+object (which for GH CLI errors is always the command-line arguments for the failing command).
+
+It can retrieve errors from the `$error` variable or act on an input object.
+
+For more information, review the [source code][utility-Get-GHAConsoleError]
+
+### `Get-VersionedContentStatus`
+
+This cmdlet returns the change status of versioned content for a pull request. This information can
+be used to analyze whether a pull request has modified every file it should.
+
+Pull requests for versioned content can be tricky, requiring an author to modify the same file in
+multiple folders. This cmdlet helps clarify if changes have been made across all the versions a file
+exists in, but does not process the information itself.
+
+The output of this cmdlet is an array of objects with the following properties:
+
+- **VersionRelativePath**: The path to the changed file from the version folder
+- **BaseFolder**: The path to the parent folder of multiple versions; the grandparent of the
+  **VersionRelativePath**.
+- **Versions**: An array of objects representing every version of the content the file exists in.
+  Each entry has a **Version** (like `5.1` or `7.2`) and **ChangeType** (whether the file was
+  `added`, `removed`, `modified`, `renamed`, `copied`, `changed`, or `unchanged`).
+
+For more information, review the [source code][utility-Get-VersionedContentStatus]
+
+### `New-CliErrorRecord`
+
+This cmdlet generates an error record for a failed `gh` command. It enables the API commands in this
+module to write useful error messages.
+
+The exception type is always **System.ApplicationException** and the error category is always
+`FromStdErr`.
+
+For more information, review the [source code][utility-New-CliErrorRecord]
+
+### `New-InvalidParameterError`
+
+This cmdlet composes and returns an error record for when a parameter handler determines that the
+input for a GitHub Action cannot be validly converted to a parameter for an action script.
+
+It returns the error record but does not throw it or write it to the error stream.
+
+For more information, review the [source code][utility-New-InvalidParameterError]
+
+### `Write-ActionFailureSummary`
+
+Writes a standardized summary entry when a GHA fails due to thrown error. It includes the record
+of the error in a Markdown codeblock under the heading "Action Failure."
+
+For more information, review the [source code][utility-Write-ActionFailureSummary]
+
+### `Write-HostParameter`
+
+This cmdlet writes a console log message declaring that a parameter value has been determined,
+including the name and colorized value. It uses `Write-Host` to avoid polluting the output stream,
+allowing it to be log this information in parameter handler scriptblocks invoked by the
+`Get-ActionScriptParameter` cmdlet.
+
+For more information, review the [source code][utility-Write-HostParameter]
+
+<!-- Reference Links -->
+[api-folder]:                         ./functions/api/
+[api-Add-PullRequestComment]:         ./functions/api/Add-PullRequestComment.ps1
+[api-Get-AuthorPermission]:           ./functions/api/Get-AuthorPermission.ps1
+[api-Get-OpenPRWithoutExpectation]:   ./functions/api/Get-OpenPRWithoutExpectation.ps1
+[api-Get-PullRequestChangedFile]:     ./functions/api/Get-PullRequestChangedFile.ps1
+[utility-folder]:                     ./functions/utility/
+[utility-Format-ConsoleBoolean]:      ./functions/utility/Format-ConsoleBoolean.ps1
+[utility-Format-ConsoleStyle]:        ./functions/utility/Format-ConsoleStyle.ps1
+[utility-Format-GHAConsoleText]:      ./functions/utility/Format-GHAConsoleText.ps1
+[utility-Get-GHAConsoleError]:        ./functions/utility/Get-GHAConsoleError.ps1
+[utility-Get-ActionScriptParameter]:              ./functions/utility/Get-ActionScriptParameter.ps1
+[utility-Get-VersionedContentStatus]: ./functions/utility/Get-VersionedContentStatus.ps1
+[utility-New-CliErrorRecord]:         ./functions/utility/New-CliErrorRecord.ps1
+[utility-New-InvalidParameterError]:  ./functions/utility/New-InvalidParameterError.ps1
+[utility-Write-ActionFailureSummary]: ./functions/utility/Write-ActionFailureSummary.ps1
+[utility-Write-HostParameter]:        ./functions/utility/Write-HostParameter.ps1

--- a/.github/actions/.pwsh/readme.md
+++ b/.github/actions/.pwsh/readme.md
@@ -1,0 +1,17 @@
+# Actions PowerShell Code
+
+This folder contains the PowerShell used in these actions.
+
+The [scripts folder][scripts] holds the actual scripts which are used by the actions. To
+keep the action definitions relatively minimal and to ensure the code can be tested, documented,
+and more easily maintained, the functionality of each action is kept in a separate script file. For
+more information, check that folder's [readme][scripts] or each script's reference documentation in
+that same folder.
+
+The [**gha** module][module] includes helper functions and is only intended to be used by the
+scripts in this folder. In the future, much of this functionality _may_ be abstracted away into a
+publicly published module. For more information, see the [module's readme][module] or review the
+reference documentation for each function.
+
+[module]: ./module/readme.md
+[scripts]: ./scripts/readme.md

--- a/.github/actions/.pwsh/scripts/Add-Expectations.md
+++ b/.github/actions/.pwsh/scripts/Add-Expectations.md
@@ -1,0 +1,98 @@
+# Add-Expectations
+
+## Synopsis
+
+Ensures all open community PRs have an expectations comment.
+
+## Syntax
+
+### __AllParameterSets (default)
+
+```syntax
+.\Add-Expectations.ps1
+    [-Owner] <string>
+    [-Repo] <string>
+    [-Message] <string>
+    [<CommonParameters>]
+```
+
+## Description
+
+This script ensures all open community PRs have an expectations comment. It searches the repository
+for open pull requests without the comment (identified by an HTML comment with a special ID in it)
+and then checks each open pull request to see if the author is a maintainer or a community member.
+If the author is a maintainer, the script skips that PR. If the author is a community member, it
+writes the contents of the message rendered as HTML from Markdown as a comment on the PR.
+
+## Examples
+
+### Example 1
+
+```powershell
+$Message = Get-Content -Raw ./messages/expectations.md
+./Add-Expectations.ps1 -Owner Foo -Repo Bar -Message $Message
+```
+
+The script searches `https://github.com/foo/bar` for open pull requests targeting the `main` branch
+which do not already have an expectations comment. If the PR author is not a maintainer, it adds the
+text from the `expectations.md` file rendered as HTML as a comment on the PR.
+
+## Parameters
+
+### `Owner`
+
+The owner of the repository to search for uncommented PRs. For `https://github.com/foo/bar`, the
+owner is `foo`.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### `Repo`
+
+The name of the repository to search for uncommented PRs. For `https://github.com/foo/bar`, the repo
+is `bar`.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### `Message`
+
+The message to write on uncommented PRs. Must be a single string and should be written as markdown
+for best results. The message should include somewhere in it the following HTML comment:
+
+```html
+<!-- GHA.Comment.Id.Community.Expectations -->
+```
+
+Failure to include that comment in the message causes the script to add the comment to PRs it
+already commented on, as it uses the presence of that annotation to find the expectations comment.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases: [Markdown, Text]
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```

--- a/.github/actions/.pwsh/scripts/Add-Expectations.ps1
+++ b/.github/actions/.pwsh/scripts/Add-Expectations.ps1
@@ -1,0 +1,204 @@
+<#
+.SYNOPSIS
+  Ensures all open community PRs have an expectations comment.
+.DESCRIPTION
+  This script ensures all open community PRs have an expectations comment. It searches the
+  repository for open pull requests without the comment (identified by an HTML comment with a
+  special ID in it) and then checks each open pull request to see if the author is a maintainer or
+  a community member. If the author is a maintainer, the script skips that PR. If the author is a
+  community member, writes the contents of the message rendered as HTML from Markdown as a comment
+  on the PR.
+.PARAMETER Owner
+  The owner of the repository to search for uncommented PRs. For `https://github.com/foo/bar`, the
+  owner is `foo`.
+.PARAMETER Repo
+  The name of the repository to search for uncommented PRs. For `https://github.com/foo/bar`, the
+  repo is `bar`.
+.PARAMETER Message
+  The message to write on uncommented PRs. Must be a single string and should be written as markdown
+  for best results. The message should include somewhere in it the following HTML comment:
+
+  `<!-- GHA.Comment.Id.Community.Expectations -->`
+
+  Failure to include that comment in the message causes the script to add the comment to PRs it
+  already commented on, as it uses the presence of that annotation to find the expectations comment.
+.EXAMPLE
+  ```powershell
+  $Message = Get-Content -Raw ./messages/expectations.md
+  ./Add-Expectations.ps1 -Owner Foo -Repo Bar -Message $Message
+  ```
+
+  The script searches `https://github.com/foo/bar` for open pull requests targeting the `main`
+  branch which do not already have an expectations comment. If the PR author is not a maintainer, it
+  adds the text from the `expectations.md` file rendered as HTML as a comment on the PR.
+#>
+[cmdletbinding()]
+param(
+  [Parameter(Mandatory)]
+  [string]$Owner,
+  [Parameter(Mandatory)]
+  [string]$Repo,
+  [Parameter(Mandatory)]
+  [Alias('Markdown', 'Text')]
+  [string]$Message
+)
+
+begin {
+  <#
+    Setup steps:
+
+    - Need to import the GHA module, which contains all of the functions that interact with the API
+      and includes helper utilities for console formatting.
+    - Need a string builder to generate the markdown summary for this step.
+    - Need to grab the values for ANSI and PlainText output rendering so the markdown in the summary
+      doesn't include ANSI decorations.
+    - Need to create empty arrays to grab the data on comments and failures.
+    - Need to grab the path to the body file for the PR comment.
+  #>
+  $GitHubFolder = Split-Path -Parent $PSScriptRoot | Split-Path -Parent
+  $ModuleFile = Resolve-Path -Path "$GitHubFolder/.pwsh/module/gha.psd1"
+  | Select-Object -ExpandProperty Path
+  Import-Module $ModuleFile -Force
+  $Summary = New-Object -TypeName System.Text.StringBuilder
+  $Ansi = [System.Management.Automation.OutputRendering]::Ansi
+  $Plain = [System.Management.Automation.OutputRendering]::PlainText
+  $Failures = @()
+  $Comments = @()
+  $CachedAuthors = @{}
+  # We convert to HTML to deal with GitHub's bad markdown parsing for comments, which treats soft
+  # line breaks like hard line breaks. Because this comment isn't edited by a human, that's fine.
+  $BodyText = $Message
+  | ConvertFrom-Markdown
+  | Select-Object -ExpandProperty Html
+}
+
+process {
+  # Retrieve open PRs to this repo without an expectation comment; if this fails, end the script.
+  # Nothing else will work anyway.
+  try {
+    $OpenPRsWithoutExpectations = Get-OpenPRWithoutExpectation -Owner $Owner -Repo $Repo
+  } catch {
+    $Record = $_ | Get-GHAConsoleError
+    Write-ActionFailureSummary -Record $Record -Synopsis 'Unable to find open PRs.'
+    $PSCmdlet.ThrowTerminatingError($_)
+  }
+  
+  $null = $Summary.AppendLine("## Open Pull Requests").AppendLine()
+  if ($OpenPRsWithoutExpectations.Count -eq 0) {
+    $OpenPRsMessage = 'Found no open PRs without an expectations comment.'
+    Format-ConsoleStyle -Text "$OpenPRsMessage" -StyleComponent $PSStyle.Foreground.BrightYellow
+    $null = $Summary.AppendLine($OpenPRsMessage).AppendLine()
+  } else {
+    $OpenPRsMessage = 'Found open PRs without an expectations comment:'
+    $null = $Summary.AppendLine($OpenPRsMessage).AppendLine()
+    Format-ConsoleStyle -Text "$OpenPRsMessage" -StyleComponent $PSStyle.Foreground.BrightYellow
+    $OpenPRsWithoutExpectations
+    | Sort-Object -Property Number -OutVariable OpenPRsWithoutExpectations
+    | Format-Table | Out-String | ForEach-Object -Process { $_.Trim() }
+    $OpenPRsWithoutExpectations | ForEach-Object -Process {
+      $PullRequestLink = "[#$($_.Number)](https://github.com/$Owner/$Repo/pull/$($_.Number))"
+      $OpenPullRequestMarkdown = "- $PullRequestLink by ``$($_.Author)``"
+      $null = $Summary.AppendLine($OpenPullRequestMarkdown)
+    }
+    $null = $Summary.AppendLine()
+  }
+
+  foreach ($OpenPR in $OpenPRsWithoutExpectations) {
+    $Author = $OpenPR.Author
+    $Number = $OpenPR.Number
+    $ConsoleNumber = Format-ConsoleStyle -Text $Number -StyleComponent @(
+      $PSStyle.Bold
+      $PSStyle.Foreground.BrightBlue
+    )
+    $ConsoleAuthor = Format-ConsoleStyle -Text $Author -StyleComponent @(
+      $PSStyle.Bold
+      $PSStyle.Foreground.BrightYellow
+    )
+    try {
+      # Check if the PR author is an admin or a maintainer; if they are, skip them. If this fails,
+      # we immediately go to the catch block and skip this PR for commenting. If the author is not
+      # an admin or maintainer, comment on the PR with expectations for the process.
+      $AuthorStatus = $CachedAuthors.$Author
+      if ($AuthorStatus -eq 'Community') {
+        "`nAttempting to comment on PR $ConsoleNumber by $ConsoleAuthor..."
+      } elseif ($AuthorStatus -eq 'Maintainer') {
+        "`nSkipping PR $ConsoleNumber; $ConsoleAuthor is admin or maintainer."
+        continue
+      } else {
+        # These log messages only shows up in the console logs; would clutter the markdown summary
+        # if included there.
+        "`nChecking to see if author ($ConsoleAuthor) of PR $ConsoleNumber is a community member..."
+        $Permissions = Get-AuthorPermission -Owner $Owner -Repo $Repo -Author $Author
+        if ($Permissions.Admin -or $Permissions.Maintain) {
+          "Skipping PR $ConsoleNumber; $ConsoleAuthor is admin or maintainer."
+          $CachedAuthors.$Author = 'Maintainer'
+          continue
+        } else {
+          "Attempting to comment on PR $ConsoleNumber..."
+          $CachedAuthors.$Author = 'Community'
+        }
+      }
+
+      $CommentParameters = @{
+        Owner    = $Owner
+        Repo     = $Repo
+        Number   = $OpenPR.Number
+        BodyText = $BodyText
+      }
+      $Uri = Add-PullRequestComment @CommentParameters
+      "Commented on PR $ConsoleNumber by $ConsoleAuthor at: $Uri"
+
+      $Comments += @{
+        Author     = $Author
+        Number     = $Number
+        TimeStamp  = [datetime]::Now
+        CommentUri = $Uri
+      }
+    }
+    catch {
+      $Failures += $_ | Get-GHAConsoleError
+      continue
+    }
+  }
+}
+
+end {
+  # Add a section to the summary markdown to list all of the commented-on PRs. Includes the link to
+  # the comment, the author's handle (without @-mentioning them), and the timestamp for the comment.
+  if ($Comments.Count -gt 0) {
+    $null = $Summary.AppendLine('## Added Expectation Comments').AppendLine()
+    $Comments | Sort-Object -Property Number | ForEach-Object -Process {
+      $CommentMarkdown = @(
+        "- [$Owner/$Repo/pull/$($_.Number)]($($_.CommentUri))"
+        "by ``$($_.Author)``"
+        "at ``$($_.TimeStamp.ToUniversalTime().ToString('u'))``."
+      ) -join ' '
+      $null = $Summary.AppendLine($CommentMarkdown)
+    }
+    $null = $Summary.AppendLine()
+  }
+  # Add a section to the summary markdown to list all of the failures in readable code blocks. The
+  # errors are also written into the run log.
+  if ($Failures.Count -gt 0) {
+    $null = $Summary.AppendLine('## Action Failures').AppendLine()
+    $FailureMessage = 'Error(s) occurred during action. Error details:'
+    $null = $Summary.AppendLine($FailureMessage).AppendLine()
+    Format-ConsoleStyle -Text $FailureMessage -StyleComponent @(
+      $PSStyle.Bold
+      $PSStyle.Foreground.Magenta
+    )
+    $Failures | ForEach-Object -Process {
+      $PSStyle.OutputRendering = $Plain
+      $null = $Summary.AppendLine('```text')
+      $RecordBlock = $Record | Format-List -Property * | Out-String
+      $null = $Summary.AppendLine($RecordBlock.Trim())
+      $null = $Summary.AppendLine('```').AppendLine()
+      $PSStyle.OutputRendering = $Ansi
+      $Record | Format-List -Property *
+    }
+  }
+  # Write the summary file and exit; if any failures happened, exit code is number of failures. Any
+  # exit code other than 0 is interpreted as job failure.
+  $Summary.ToString() >> $ENV:GITHUB_STEP_SUMMARY
+  exit $Failures.Count
+}

--- a/.github/actions/.pwsh/scripts/Get-VersionedContentReport.ps1
+++ b/.github/actions/.pwsh/scripts/Get-VersionedContentReport.ps1
@@ -1,0 +1,173 @@
+<#
+.SYNOPSIS
+  Analyzes changes for versioned content.
+.DESCRIPTION
+  This script analyzes a changeset to discover versioned content and writes a report in the console
+  and as a GitHub Action summary, enumerating the versioned content changes and whether those
+  changes were made across all versions of the content.
+
+  It does not analyze whether such changes are needed or correct, only how each version of the
+  content was changed (or that it was not changed). This report still requires human analysis and
+  investigation but is intended to provide an easier way to see the aggregated changes across
+  versioned content to understand if all affected versions have been updated or not.
+.PARAMETER Owner
+  The owner of the repository with the PR to inspect for changes. For `https://github.com/foo/bar`,
+  the owner is `foo`.
+.PARAMETER Repo
+  The name of the repository with the PR to inspect for changes. For `https://github.com/foo/bar`,
+  the repo is `bar`.
+.PARAMETER Number
+  The number of the PR to inspect for changes.
+.EXAMPLE
+  ./.github/pwsh/scripts/Add-Expectations.ps1 -Owner Foo -Repo Bar -Number 123
+
+  The script finds the changes made in https://github.com/foo/bar/pulls/123` and analyzes those
+  changes to find changes to versioned content. It then writes a report for each changed folder and
+  file enumerating the high-level changes across all versions that file belongs in.
+#>
+[cmdletbinding()]
+param(
+  [Parameter(Mandatory)]
+  [string]$Owner,
+  [Parameter(Mandatory)]
+  [string]$Repo,
+  [Parameter(Mandatory)]
+  [int]$Number
+)
+
+begin {
+  <#
+    Setup steps:
+
+    - Need to import the GHA module, which contains all of the functions that interact with the API
+      and includes helper utilities for console formatting.
+    - Need a string builder to generate the markdown summary for this step.
+    - Need to grab the values for ANSI and PlainText output rendering so the markdown in the summary
+      doesn't include ANSI decorations.
+    - Need to create empty arrays to grab the data on comments and failures.
+    - Need to grab the path to the body file for the PR comment.
+  #>
+  $GitHubFolder = Split-Path -Parent $PSScriptRoot | Split-Path -Parent
+  $ModuleFile = Resolve-Path -Path "$GitHubFolder/pwsh/gha/gha.psm1"
+  | Select-Object -ExpandProperty Path
+  Import-Module $ModuleFile -Force
+  $Summary = New-Object -TypeName System.Text.StringBuilder
+  $Ansi = [System.Management.Automation.OutputRendering]::Ansi
+  $Plain = [System.Management.Automation.OutputRendering]::PlainText
+}
+
+process {
+  try {
+    $ChangedContent = Get-PullRequestChangedFile -Owner $Owner -Repo $Repo -Number $Number -All
+  } catch {
+    $Record = $_ | Get-GHAConsoleError
+    Write-ActionFailureSummary -Record $Record -Synopsis 'Unable to find open PRs.'
+    $PSCmdlet.ThrowTerminatingError($_)
+  }
+  
+  $ChangeSetsWithStatus = Get-VersionedContentChangeStatus -ChangedContent $ChangedContent
+  | Sort-Object -Stable -Property BaseFolder, VersionRelativePath
+
+  $null = $Summary.AppendLine('# Versioned Content Change Report').AppendLine()
+  $null = $Summary.AppendJoin(
+    ' ',
+    'This report is organized by base folder (a folder containing multiple versions of content)',
+    'with child folders beneath. Each child folder section enumerates all of the changes to files',
+    'in that folder across the versions in tables.'
+  ).AppendLine().AppendLine()
+  $null = $Summary.AppendJoin(
+    ' ',
+    'Each table includes the version-relative path to the files and the change status of those',
+    'files for each version. The version-relative path is the remainder of the path from the',
+    'version folder. For example, the file `reference/5.1/Foo/Bar/Baz.md` is in the `reference`',
+    'base folder and has a version-relative path of `Foo/Bar/Baz.md`. For change status, every',
+    'versioned file will have one of the following statuses:'
+  ).AppendLine().AppendLine()
+  $null = $Summary.AppendLine('- `added`: The file was added. Git status `A`.')
+  $null = $Summary.AppendLine("- ``changed``: The file's type was changed. Git status `T`.")
+  $null = $Summary.AppendLine('- `copied`: The file was copied. Git status `C`.')
+  $null = $Summary.AppendLine("- ``modified``: The file's contents were changed. Git status `M`.")
+  $null = $Summary.AppendLine('- `removed`: The file was deleted. Git status `D`.')
+  $null = $Summary.AppendLine('- `renamed`: The file was renamed. Git status `R`.')
+  $null = $Summary.AppendLine('- `unchanged`: The file was not modified.')
+  $null = $Summary.AppendLine('- `n/a`: The file does not exist for this version.')
+  $null = $Summary.AppendLine().AppendJoin(
+    ' ',
+    'In cases where the change status of a file is not the same across versions, the Pull Request',
+    'author and reviewer should both double check the file to understand if the discrepancy is',
+    'intentional or accidental.'
+  ).AppendLine().AppendLine()
+
+  [string[]]$BaseFolders = $ChangeSetsWithStatus.BaseFolder | Select-Object -Unique
+
+  foreach ($BaseFolder in $BaseFolders) {
+    $null = $Summary.AppendLine("## Base Folder: ``$BaseFolder``").AppendLine()
+    $ChangeSetsInBaseFolder = $ChangeSetsWithStatus | Where-Object -FilterScript {
+      $_.BaseFolder -eq $BaseFolder
+    }
+    $null = $Summary.AppendJoin(
+      ' ',
+      "Changed **$($ChangeSetsInBaseFolder.Count)** versioned files in ``$BaseFolder``.",
+      "See below for details per folder."
+    ).AppendLine().AppendLine()
+
+    [string[]]$ChangeSetFolders = $ChangeSetsInBaseFolder | ForEach-Object {
+      $Folder = Split-Path -Parent $_.VersionRelativePath
+      while (![string]::IsNullOrEmpty($Folder)) {
+        $Folder -replace '\\', '/'
+        $Folder = Split-Path -Parent $Folder
+      }
+    } | Select-Object -Unique | Sort-Object
+
+    foreach($Folder in $ChangeSetFolders) {
+      $ChangeSets = $ChangeSetsInBaseFolder | Where-Object -FilterScript {
+        $_.VersionRelativePath -match "$Folder\/[^\/]+`$"
+      }
+      if ($null -eq $ChangeSets) {
+        continue
+      }
+      $null = $Summary.AppendLine("### Change Sets for ``$Folder``").AppendLine()
+      $RelativePathWidth = 30
+      $ChangeSets.VersionRelativePath | ForEach-Object -Process {
+        if (($_.Length + 4) -gt $RelativePathWidth) {
+          $RelativePathWidth = $_.Length + 4
+        }
+      }
+      $VersionList = $ChangeSets.Versions.Version | Select-Object -Unique
+      $VersionWidth = 14
+      $VersionList | ForEach-Object -Process {
+        if (($_.Length + 4) -gt $VersionWidth) {
+          $VersionWidth = $_.Length + 4
+        }
+      }
+      # Setup table header
+      $null = $Summary.Append("|$(' Version-Relative Path'.PadRight($RelativePathWidth))")
+      foreach ($Version in $VersionList) {
+        $null = $Summary.Append("|$(" $Version".PadRight($VersionWidth))")
+      }
+      $null = $Summary.AppendLine('|')
+      $null = $Summary.Append("|:$('-' * ($RelativePathWidth - 1))")
+      foreach($Version in $VersionList) {
+        $null = $Summary.Append("|:$('-' * ($VersionWidth - 2)):")
+      }
+      $null = $Summary.AppendLine('|')
+      # loop over change sets; version status or `N/A` if it doesn't exist.
+      foreach ($ChangeSet in $ChangeSets) {
+        $RelativePath = $ChangeSet.VersionRelativePath
+        $null = $Summary.Append("|$(" ``$RelativePath`` ".PadRight($RelativePathWidth))")
+        foreach ($Version in $VersionList) {
+          $ChangeType = $ChangeSet.Versions.Where({$_.Version -eq $Version}).ChangeType
+          if ([string]::IsNullOrEmpty($ChangeType)) {
+            $ChangeType = 'n/a'
+          }
+          $null = $Summary.Append("|$(" ``$ChangeType`` ".PadRight($VersionWidth))")
+        }
+        $null = $summary.AppendLine('|')
+      }
+      $null = $Summary.AppendLine()
+    }
+  }
+  $Summary.ToString()
+}
+
+end {}

--- a/.github/actions/.pwsh/scripts/Test-Authorization.md
+++ b/.github/actions/.pwsh/scripts/Test-Authorization.md
@@ -1,0 +1,181 @@
+# Test-Authorization
+
+## Synopsis
+
+Checks if a user may perform an action.
+
+## Syntax
+
+### Branch (Default)
+
+```syntax
+.\Test-Authorization.ps1
+    -Owner <string>
+    -Repo <string>
+    -User <string>
+    -TargetBranch <string>
+    [-ValidPermissions <string[]>]
+    [<CommonParameters>]
+```
+
+### Path
+
+```syntax
+.\Test-Authorization.ps1
+    -Owner <string>
+    -Repo <string>
+    -User <string>
+    -TargetPath <string[]>
+    [-ValidPermissions <string[]>]
+    [<CommonParameters>]
+```
+
+## Description
+
+Checks if a user may perform an action. A user is authorized if they have one or more of the
+specified permissions. If the user is not authorized, the script (and any GHA workflow calling it)
+fails.
+
+## Examples
+
+### Example 1
+
+```powershell
+  ./Test-Authorization.ps1 -Owner foo -Repo bar -Author baz -TargetBranch live
+```
+
+The script checks the permissions of the `baz` user for `https://github.com/foo/bar`. If `baz` has
+maintainer or admin permissions, the script exits without error. If they do not, the script throws
+an error declaring the `baz` does not have enough permissions to target the `live` branch.
+
+### Example 2
+
+```powershell
+$Paths = @(
+  '.github/pwsh'
+  '.github/workflows'
+)
+./Test-Authorization.ps1 -Owner foo -Repo bar -Author baz -TargetPath $Paths
+```
+
+The script checks the permissions of the `baz` user for `https://github.com/foo/bar`. If `baz` has
+maintainer or admin permissions, the script exits without error. If they do not, the script throws
+an error declaring the `baz` does not have enough permissions to target either the `pwsh` or
+`workflows` folder.
+
+## Parameters
+
+### `Owner`
+
+The owner of the repository to check the user's permissions in. For `https://github.com/foo/bar` the
+owner is `foo`.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### `Repo`
+
+The name of the repository to check the user's permissions in. For `https://github.com/foo/bar` the
+name is `bar`.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### `User`
+
+The GitHub login to retrieve permissions for.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### `TargetBranch`
+
+Specifies the name of a branch requiring permissions to target.
+
+```yaml
+Type: System.String
+Parameter Sets: (Branch)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### `TargetPath`
+
+Specifies the path to one or more files requiring permissions to modify.
+
+```yaml
+Type: System.String[]
+Parameter Sets: (Path)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### `ValidPermissions`
+
+One or more GitHub permissions the user must have. If the user has any of the specified permissions,
+they are authorized for the action. By default, a user must have the `Admin` or `Maintain`
+permission.
+
+GitHub permissions include:
+
+- `Admin`
+- `Maintain`
+- `Pull`
+- `Push`
+- `Triage`
+
+```yaml
+Type: System.String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### Notes
+
+The **TargetBranch** and **TargetPath** parameters are for convenience; GitHub repositories do not
+have a built-in way to define permissions for branches or folders except for branch protection,
+which isn't enough for this purpose. To ensure this script is effective, use the **branches**
+and **paths** settings in the workflow when defining a **pull_request_target** job trigger.

--- a/.github/actions/.pwsh/scripts/Test-Authorization.ps1
+++ b/.github/actions/.pwsh/scripts/Test-Authorization.ps1
@@ -1,0 +1,198 @@
+<#
+.SYNOPSIS
+  Checks if a user may perform an action.
+.DESCRIPTION
+  Checks if a user may perform an action. A user is authorized if they have one or more of the
+  specified permissions. If the user is not authorized, the script (and any GHA workflow calling it)
+  fails.
+.PARAMETER Owner
+  The owner of the repository to check the user's permissions in. For `https://github.com/foo/bar`
+  the owner is `foo`.
+.PARAMETER Repo
+  The name of the repository to check the user's permissions in. For `https://github.com/foo/bar`
+  the name is `bar`.
+.PARAMETER User
+  The GitHub login to retrieve permissions for.
+.PARAMETER TargetBranch
+  Specifies the name of a branch requiring permissions to target.
+.PARAMETER TargetPath
+  Specifies the path to one or more files requiring permissions to modify.
+.PARAMETER ValidPermissions
+  One or more GitHub permissions the user must have. If the user has any of the specified
+  permissions, they are authorized for the action. By default, a user must have the `Admin` or
+  `Maintain` permission.
+
+  GitHub permissions include:
+
+  - `Admin`
+  - `Maintain`
+  - `Pull`
+  - `Push`
+  - `Triage`
+.EXAMPLE
+  ```powershell
+  ./.github/pwsh/scripts/Test-Authorization.ps1 -Owner foo -Repo bar -Author baz -TargetBranch live
+  ```
+
+  The script checks the permissions of the `baz` user for `https://github.com/foo/bar`. If `baz` has
+  maintainer or admin permissions, the script exits without error. If they do not, the script throws
+  an error declaring the `baz` does not have enough permissions to target the `live` branch.
+.EXAMPLE
+  ```powershell
+  $Paths = @(
+    '.github/pwsh'
+    '.github/workflows'
+  )
+  ./.github/pwsh/scripts/Test-Authorization.ps1 -Owner foo -Repo bar -Author baz -TargetPath $Paths
+  ```
+
+  The script checks the permissions of the `baz` user for https://github.com/foo/bar`. If `baz` has
+  maintainer or admin permissions, the script exits without error. If they do not, the script throws
+  an error declaring the `baz` does not have enough permissions to target either the `pwsh` or
+  `workflows` folder.
+.NOTES
+  The **TargetBranch** and **TargetPath** parameters are for convenience; GitHub repositories do not
+  have a built-in way to define permissions for branches or folders except for branch protection,
+  which isn't enough for this purpose. To ensure this script is effective, use the **branches** and
+  **paths** settings in the workflow when defining a **pull_request_target** job trigger.
+  #>
+[cmdletbinding(DefaultParameterSetName='Branch')]
+param(
+  [Parameter(Mandatory)]
+  [string]$Owner,
+  [Parameter(Mandatory)]
+  [string]$Repo,
+  [Parameter(Mandatory)]
+  [string]$User,
+  [Parameter(Mandatory, ParameterSetName='Branch')]
+  [string]$TargetBranch,
+  [Parameter(Mandatory, ParameterSetName='Path')]
+  [string[]]$TargetPath,
+  [ValidateSet('Admin', 'Maintain', 'Pull', 'Push', 'Triage')]
+  [string[]]$ValidPermissions = @('Admin', 'Maintain')
+)
+
+begin {
+  <#
+    Setup steps:
+
+    - Need to import the GHA module, which contains all of the functions that interact with the API
+      and includes helper utilities for console formatting.
+    - Need a string builder to generate the markdown summary for this step.
+    - Need to grab the values for ANSI and PlainText output rendering so the markdown in the summary
+      doesn't include ANSI decorations.
+    - Need to create empty arrays to grab the data on comments and failures.
+    - Need to grab the path to the body file for the PR comment.
+  #>
+  $GitHubFolder = Split-Path -Parent $PSScriptRoot | Split-Path -Parent
+  $ModuleFile = Resolve-Path -Path "$GitHubFolder/.pwsh/module/gha.psd1"
+  | Select-Object -ExpandProperty Path
+  Import-Module $ModuleFile -Force
+  $Summary = New-Object -TypeName System.Text.StringBuilder
+  $Ansi = [System.Management.Automation.OutputRendering]::Ansi
+  $Plain = [System.Management.Automation.OutputRendering]::PlainText
+  $TargetStyle = @($PSStyle.Bold, $PSStyle.Foreground.BrightMagenta)
+  $Texts = @{
+    Success = @{
+      Console = Format-ConsoleStyle -Text 'Success' -DefinedStyle Success
+      Markdown = "**Success**"
+    }
+    Author = @{
+      Console = Format-ConsoleStyle -Text $User -DefinedStyle UserName
+      Markdown = "``$User``"
+    }
+  }
+  if (![string]::IsNullOrEmpty($TargetBranch)) {
+    $ConsoleBranch = Format-ConsoleStyle -Text $TargetBranch -StyleComponent $TargetStyle
+    $Texts.Target = @{
+      Console = "target the $ConsoleBranch branch."
+      Markdown = "target the ``$TargetBranch`` branch."
+      Error = "target the '$TargetBranch' branch."
+    }
+  } Else {
+    $ConsolePaths = $TargetPath | Foreach-Object -Process {
+      Format-ConsoleStyle -Text $_ -StyleComponent $TargetStyle
+    }
+    $MarkdownPaths = $TargetPath | ForEach-Object -Process {"- ``$_``"}
+    $Texts.Target = @{
+      Console = "modify file paths:`n`t$($ConsolePaths -join "`n`t")"
+      Markdown = "modify file paths:`n`n$($MarkdownPaths -join "`n")"
+      Error = "modify file paths:`n`t$($TargetPath -join "`n`t")"
+    }
+  }
+}
+
+process {
+  try {
+    $Permissions = Get-AuthorPermission -Owner $Owner -Repo $Repo -Author $User
+  } catch {
+    $Record = $_ | Get-GHAConsoleError
+    Write-ActionFailureSummary -Record $Record -Synopsis 'Unable to retrieve permissions.'
+    $PSCmdlet.ThrowTerminatingError($_)
+  }
+
+  #region    Permission Retrieval Messaging
+  # Markdown Summary
+  $null = $Summary.AppendLine('## Retrieved Permissions').AppendLine()
+  $null = $Summary.AppendLine("Retrieved permissions for for ``$User``. Details:").AppendLine()
+  $null = $Summary.AppendLine('```text')
+  $PSStyle.OutputRendering = $Plain
+  $PermissionsBlock = $Permissions | Format-List -Property * | Out-String
+  $PSStyle.OutputRendering = $Ansi
+  $null = $Summary.AppendLine($PermissionsBlock.Trim())
+  $null = $Summary.AppendLine('```').AppendLine()
+  # Console Logging
+  "Retrieved permissions for $($Texts.Author.Console):"
+  foreach ($Permission in @('Admin', 'Maintain', 'Pull', 'Push', 'Triage')) {
+    $Prefix = "`t$($PSStyle.Bold)${Permission}:$($PSStyle.BoldOff)".PadRight(20)
+    $Setting = Format-ConsoleBoolean -Value $Permissions.$Permission
+    "$Prefix`t$Setting"
+  }
+  #endregion Permission Retrieval Messaging
+  
+  $null = $Summary.AppendLine('## Result').AppendLine()
+
+  # Check for authorization; if the user has any of the valid permissions, they
+  # are authorized for this action.
+  $Authorized = $false
+  foreach ($Permission in $ValidPermissions) {
+    if ($Permissions.$Permission) {
+      $Authorized = $true
+      break
+    }
+  }
+
+  if ($Authorized) {
+    # Markdown Summary
+    $null = $Summary.AppendLine(
+      "**Success:** Author (``$User``) may $($Texts.Target.Markdown)"
+    )
+    $Summary.ToString() >> $ENV:GITHUB_STEP_SUMMARY
+    # Console Logging
+    $ConsoleMessage = New-Object -TypeName System.Text.StringBuilder
+    $null = $ConsoleMessage.Append("$($Texts.Success.Console): ")
+    $null = $ConsoleMessage.Append("author ($($Texts.Author.Console)) ")
+    $null = $ConsoleMessage.Append("may $($Texts.Target.Console)")
+    $ConsoleMessage.ToString()
+  } else {
+    # Markdown Summary
+    $null = $Summary.AppendLine(
+      "**Failure:** Author (``$User``) may not $($Texts.Target.Markdown)"
+    )
+    $Summary.ToString() >> $ENV:GITHUB_STEP_SUMMARY
+    # Console Logging / Throw Error
+    $Message = "Author ($($Texts.Author.Console)) may not $($Texts.Target.Error)"
+    $Message = Format-GHAConsoleText -Text $Message
+    $Exception = [System.ApplicationException]::new($Message)
+    $TargetObject = $TargetBranch || $TargetPath
+    $Record = [System.Management.Automation.ErrorRecord]::new(
+        $Exception,
+        'GHA.NotPermittedToTarget',
+        [System.Management.Automation.ErrorCategory]::PermissionDenied,
+        $TargetObject
+    )
+    $PSCmdlet.ThrowTerminatingError($Record)
+  }
+}
+
+end {}

--- a/.github/actions/.pwsh/scripts/Test-Checklist.md
+++ b/.github/actions/.pwsh/scripts/Test-Checklist.md
@@ -1,0 +1,83 @@
+# Test-Checklist
+
+## Synopsis
+
+Inspects Markdown to find checklist items and their status
+
+## Syntax
+
+### __AllParameterSets (Default)
+
+```syntax
+.\Test-Checklist.ps1
+    [-Body] <string>
+    [[-ReferenceUrl] <string>]
+    [<CommonParameters>]
+```
+
+## Description
+
+This script inspects the Markdown body of a Pull Request or GitHub comment to find mandatory
+checklist items and determine if they are checked or not. It writes console messages and a GitHub
+summary annotating the findings. If any mandatory checklist items are discovered and not checked,
+the script throws an exception, failing both the script and associated GitHub Action.
+
+To discover mandatory checklist items, it looks for checklist entries that are bolded with
+double-asterisks and a colon suffix. For example:
+
+```markdown
+- Not a checklist item
+- [ ] Not a _mandatory_ checklist item
+- [ ] **Foo:** a mandatory checklist item that _is not_ checked
+- [x] **Bar:** a mandatory checklist item that _is_ checked.
+```
+
+## Examples
+
+### Example 1
+
+```powershell
+$PullRequest = gh pr view --repo 'foo/bar' 123 --json body --json url | ConvertFrom-Json
+./Test-Checklist.ps1 -Body $PullRequest.Body -ReferenceUrl $PullRequest.Url
+```
+
+This example gets pull request 123 from the `bar` repository owned by `foo`, retrieving the body and
+URL of that pull request. It then passes those values to the script, which then inspects the body
+for mandatory checklist items and report their status.
+
+## Parameters
+
+### `Body`
+
+A block of Markdown text to inspect. This can come from a pull request or comment or you can pass an
+arbitrary block of Markdown to verify what mandatory checklist items exist and what their status is
+while developing a checklist.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### `ReferenceUrl`
+
+The URL to the pull request, comment, or other source of the Markdown passed in the **Body**. This
+is only used for the error generation/reporting if the checklist is not fully filled out.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```

--- a/.github/actions/.pwsh/scripts/Test-Checklist.ps1
+++ b/.github/actions/.pwsh/scripts/Test-Checklist.ps1
@@ -1,0 +1,127 @@
+<#
+.SYNOPSIS
+  Inspects Markdown to find checklist items and their status
+.DESCRIPTION
+  This script inspects the Markdown body of a Pull Request or GitHub comment to find mandatory
+  checklist items and determine if they are checked or not. It writes console messages and a GitHub
+  summary annotating the findings. If any mandatory checklist items are discovered and not checked,
+  the script throws an exception, failing both the script and associated GitHub Action.
+
+  To discover mandatory checklist items, it looks for checklist entries that are bolded with
+  double-asterisks and a colon suffix. For example:
+
+  ```markdown
+  - Not a checklist item
+  - [ ] Not a _mandatory_ checklist item
+  - [ ] **Foo:** a mandatory checklist item that _is not_ checked
+  - [x] **Bar:** a mandatory checklist item that _is_ checked.
+  ```
+.PARAMETER Body
+  A block of Markdown text to inspect. This can come from a pull request or comment or you can pass
+  an arbitrary block of Markdown to verify what mandatory checklist items exist and what their
+  status is while developing a checklist.
+.PARAMETER ReferenceUrl
+  The URL to the pull request, comment, or other source of the Markdown passed in the **Body**. This
+  is only used for the error generation/reporting if the checklist is not fully filled out.
+.EXAMPLE
+  ```pwsh
+  $PullRequest = gh pr view --repo 'foo/bar' 123 --json body --json url | ConvertFrom-Json
+  ./Test-Checklist.ps1 -Body $PullRequest.Body -ReferenceUrl $PullRequest.Url
+  ```
+
+  This example gets pull request 123 from the `bar` repository owned by `foo`, retrieving the body
+  and URL of that pull request. It then passes those values to the script, which then inspects the
+  body for mandatory checklist items and report their status.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)]
+  [string]$Body,
+  [string]$ReferenceUrl = 'Arbitrary'
+)
+
+begin {
+  $GitHubFolder = Split-Path -Parent $PSScriptRoot | Split-Path -Parent
+  $ModuleFile = Resolve-Path -Path "$GitHubFolder/.pwsh/module/gha.psd1"
+  | Select-Object -ExpandProperty Path
+  Import-Module $ModuleFile -Force
+  # Style Setup
+  $NameStyle = $PSStyle.Foreground.BrightYellow
+  $StatusStyle = @{
+    Symbol = @{
+      Checked = '✔ '
+      Missing = '✖ '
+    }
+    Font = @{
+      Checked = $PSStyle.Bold + $PSStyle.Foreground.BrightBlue
+      Missing = $PSStyle.Bold + $PSStyle.Foreground.BrightMagenta
+    }
+  }
+  $Summary = New-Object -TypeName System.Text.StringBuilder
+  # Initialize variables
+  $MissingItemCount = 0
+}
+
+process {
+  # Get Checklist Items
+  $null = $Summary.AppendLine('# Pull Request Checklist').AppendLine()
+  $null = $Summary.AppendLine('| Item | State |')
+  $null = $Summary.AppendLine('|:-----|:-----:|')
+  $CheckListItems = $Body -split "`n" | ForEach-Object {
+    if ($_ -match '- \[(?<Checked>.)\] \*\*(?<Name>.+):') {
+      $Status = $Matches.Checked -eq 'x' ? 'Checked' : 'Missing'
+      $Font = $StatusStyle.Font.$Status
+      $Name = $Matches.Name
+      [PSCustomObject]@{
+        Name = $NameStyle + $Name + $PSStyle.Reset
+        Prefix = $Font + $StatusStyle.Symbol.$Status + $PSStyle.Reset
+        Status = $Font + $Status + $PSStyle.Reset
+      }
+      $null = $Summary.AppendLine("| **$Name** | $($StatusStyle.Symbol.$Status) |")
+    }
+  }
+
+  # Add final newline and write summary; at this point we know everything we need for
+  # the summary itself, the rest is for console logging and failure reporting
+  $null = $Summary.AppendLine()
+  $Summary.ToString() >> $ENV:GITHUB_STEP_SUMMARY
+  
+  # Get an appropriate padding width so the status values line up
+  $PaddingWidth = 0
+  $CheckListItems | ForEach-Object -Process {
+    $Width = ($_.Prefix + "`t" + $_.Name).Length + 3 # pad right for the colon and space
+    if ($PaddingWidth -lt $Width) {
+      $PaddingWidth = $Width
+    }
+  }
+  
+  
+  # Display Results
+  foreach ($Item in $CheckListItems) {
+    if ($Item.Prefix -notmatch '✔') {
+      $MissingItemCount++
+    }
+    
+    "$($Item.Prefix)$($Item.Name): ".PadRight($PaddingWidth) + $Item.Status
+  }
+  
+  # Write summary message + exit if any checks are missing
+  if ($MissingItemCount) {
+    "" # Add a blank line before message
+    $Message = @(
+      "Missing $MissingItemCount of the checklist items."
+      'Please review the PR checklist.'
+    ) -join ' '
+    $Message = Format-GHAConsoleText -Text $Message
+    $Exception = [System.ApplicationException]::new($Message)
+    $Record = [System.Management.Automation.ErrorRecord]::new(
+      $Exception,
+      'GHA.Checklist.NotComplete',
+      [System.Management.Automation.ErrorCategory]::InvalidResult,
+      $ReferenceUrl
+    )
+    $PSCmdlet.ThrowTerminatingError($Record)
+  }
+}
+
+end {}

--- a/.github/actions/.pwsh/scripts/readme.md
+++ b/.github/actions/.pwsh/scripts/readme.md
@@ -1,0 +1,58 @@
+# Action Scripts
+
+This folder contains the scripts used by the GitHub Actions (GHA). Each script is used by a different
+action:
+
+|                   Script                   |                       Action                       |
+| :----------------------------------------- | :------------------------------------------------- |
+| [Add-Expectations][expectations-script]    | [commenting/expectations][expectations-action]     |
+| [Test-Authorization][authorization-script] | [verification/authorization][authorization-action] |
+| [Test-Checklist][checklist-script]         | [verification/checklist][checklist-action]         |
+
+## Add-Expectations
+
+This script ensures all open community PRs have an expectations comment. It searches the repository
+for open pull requests without the comment (identified by an HTML comment with a special ID in it)
+and then checks each open pull request to see if the author is a maintainer or a community member.
+If the author is a maintainer, the script skips that PR. If the author is a community member, it
+writes the contents of the message rendered as HTML from Markdown as a comment on the PR.
+
+For more information, see [the reference document][expectations-doc].
+
+## Test-Authorization
+
+Checks if a user may perform an action. An author is authorized if they have one or more of the
+specified permissions. If the author is not authorized, the script (and any GHA workflow calling it)
+fails.
+
+For more information, see [the reference document][authorization-doc].
+
+## Test-Checklist
+
+This script inspects the Markdown body of a Pull Request or GitHub comment to find mandatory
+checklist items and determine if they are checked or not. It writes console messages and a GitHub
+summary annotating the findings. If any mandatory checklist items are discovered and not checked,
+the script throws an exception, failing both the script and associated GitHub Action.
+
+To discover mandatory checklist items, it looks for checklist entries that are bolded with
+double-asterisks and a colon suffix. For example:
+
+```markdown
+- Not a checklist item
+- [ ] Not a _mandatory_ checklist item
+- [ ] **Foo:** a mandatory checklist item that _is not_ checked
+- [x] **Bar:** a mandatory checklist item that _is_ checked.
+```
+
+For more information, see [the reference document][checklist-doc].
+
+<!-- reference links -->
+[authorization-action]: ../../verification/authorization/v1/readme.md
+[authorization-doc]:    ./Test-Authorization.md
+[authorization-script]: ./Test-Authorization.ps1
+[checklist-action]:     ../../verification/checklist/v1/readme.md
+[checklist-doc]:        ./Add-Expectations.md
+[checklist-script]:     ./Add-Expectations.ps1
+[expectations-action]:  ../../commenting/expectations/v1/readme.md
+[expectations-doc]:     ./Add-Expectations.md
+[expectations-script]:  ./Add-Expectations.ps1

--- a/.github/actions/commenting/expectations/v1/Parameters.psd1
+++ b/.github/actions/commenting/expectations/v1/Parameters.psd1
@@ -1,0 +1,122 @@
+@{
+    Parameters = @(
+      @{
+        Name = 'Repository'
+        Type = 'string'
+        IfNullOrEmpty = {
+          param($ErrorTarget)
+
+          $ErrorDetails = @{
+            Name    = 'Repository'
+            Type    = 'Missing'
+            Message = @(
+              'Could not determine repository;'
+              'was it passed as an input to the action?'
+            ) -join ' '
+            Target  = $ErrorTarget
+          }
+          $Record = New-InvalidParameterError @ErrorDetails
+
+          throw $Record
+        }
+        Process = {
+          param($Parameters, $Value, $ErrorTarget)
+
+          $Parameters.Owner, $Parameters.Repo = $Value -split '/'
+          Write-HostParameter -Name Owner -Value $Parameters.Owner
+          Write-HostParameter -Name Repo -Value $Parameters.Repo
+
+          return $Parameters
+        }
+      }
+
+      @{
+        Name = 'Message_Body'
+        Type = 'String'
+        IfNullOrEmpty = {
+          param($ErrorTarget)
+
+          if ([string]::IsNullOrEmpty($env:INPUT_MESSAGE_PATH)) {
+            $Message = @(
+              'Could not determine the message body or path to write as the expectation comment;'
+              'was either value passed as an input to the action?'
+            ) -join ' '
+            $Message = Format-GHAConsoleText -Text $Message
+            $ErrorDetails = @{
+              Name    = 'Message'
+              Type    = 'Missing'
+              Message = $Message
+              Target  = $ErrorTarget
+            }
+            $Record = New-InvalidParameterError @ErrorDetails
+
+            throw $Record
+          }
+        }
+        Process = {
+          param($Parameters, $Value, $ErrorTarget)
+
+          if (![string]::IsNullOrEmpty($Value)) {
+            if ($null -ne $Parameters.Message) {
+              $Warning = @(
+                'Specified both message body and path; preferring the explicitly passed'
+                'body over the path. If you want to comment with a file, do not specify'
+                'the message_body parameter.'
+              ) -join ' '
+              Write-Warning $Warning
+            }
+  
+            $Parameters.Message = $Value
+            Write-HostParameter -Name Message -Value $Parameters.Message -MultiLine
+          }
+
+          return $Parameters
+        }
+      }
+
+      @{
+        Name = 'Message_Path'
+        Type = 'String'
+        IfNullOrEmpty = {
+          param($ErrorTarget)
+
+          if ([string]::IsNullOrEmpty($env:INPUT_MESSAGE_BODY)) {
+            $Message = @(
+              'Could not determine the message body or path to write as the expectation comment;'
+              'was either value passed as an input to the action?'
+            ) -join ' '
+            $Message = Format-GHAConsoleText -Text $Message
+            $ErrorDetails = @{
+              Name    = 'Message'
+              Type    = 'Missing'
+              Message = $Message
+              Target  = $ErrorTarget
+            }
+            $Record = New-InvalidParameterError @ErrorDetails
+
+            throw $Record
+          }
+        }
+        Process = {
+          param($Parameters, $Value, $ErrorTarget)
+
+          if (![string]::IsNullOrEmpty($Value)) {
+            if ($null -eq $Parameters.Message) {
+              $Message = Get-Content -Raw -Path $Value
+              $Parameters.Message = $Message
+              Write-HostParameter -Name Message -Value $Parameters.Message -MultiLine
+            } else {
+              $Warning = @(
+                'Specified both message body and path; preferring the explicitly passed'
+                'body over the path. If you want to comment with a file, do not specify'
+                'the message_body parameter.'
+              ) -join ' '
+              Write-Warning $Warning
+            }
+          }
+
+          return $Parameters
+        }
+      }
+    )
+  }

--- a/.github/actions/commenting/expectations/v1/action.yml
+++ b/.github/actions/commenting/expectations/v1/action.yml
@@ -1,0 +1,80 @@
+name: Expectations
+description: |
+  Writes a comment on newly opened PRs by community members to set their expectations for how the PR
+  review process will proceed.
+author: PowerShell Docs Team
+inputs:
+  repository:
+    description: |
+      The full name of a repository; to target `https://github.com/MicrosoftDocs/PowerShell-Docs`,
+      the value should be `MicrosoftDocs/PowerShell-Docs`.
+    required: true
+    default: ${{ github.repository }}
+  message_body:
+    description: |
+      The message in Markdown to write as the comment body. This input should not be used with
+      **message_path**; if it is, the action will write a warning in the logs and use the
+      **message_body** when commenting on community Pull Requests.
+    required: false
+  message_path:
+    description: |
+      The path to the Markdown file to write as the comment body. This input should not be used with
+      **message_body**; if it is, the action will write a warning in the logs and use the
+      **message_body** when commenting on community Pull Requests.
+    required: false
+  token:
+    description: |
+      The `GITHUB_TOKEN` to use to authenticate API calls to verify whether a Pull Request's author
+      is a maintainer or community member and to comment on open community Pull Requests.
+
+      This **must** be passed to the action.
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: pwsh
+      env:
+        INPUT_REPOSITORY: ${{ inputs.repository }}
+        INPUT_MESSAGE_BODY: ${{ inputs.message_body }}
+        INPUT_MESSAGE_PATH: ${{ inputs.message_path }}
+        GITHUB_TOKEN: ${{ inputs.token }}
+      run: |
+        Write-Output "::group::Generic Setup"
+        $ActionPath = Resolve-Path '${{ github.action_path }}' | Select-Object -ExpandProperty Path
+        $ParameterHandlers = Join-Path -Path $ActionPath -ChildPath Parameters.psd1
+        | ForEach-Object -Process { Import-PowerShellDataFile -Path $_ }
+        | Select -ExpandProperty Parameters
+        | ForEach-Object -Process { [pscustomobject]$_ }
+        "Action Path: $ActionPath"
+
+        $ActionRootPath = Split-Path -Parent -Path $ActionPath
+        while ((Split-Path -Leaf -Path $ActionRootPath) -ne 'actions') {
+          $ActionRootPath = Split-Path -Parent -Path $ActionRootPath
+        }
+        "Action Root Path: $ActionRootPath"
+        
+        $JoinPathParams = @{
+          Path = $ActionRootPath
+          ChildPath = '.pwsh'
+        }
+
+        $ModulePath = Join-Path @JoinPathParams -AdditionalChildPath @(
+          'module'
+          'gha.psd1'
+        )
+        "Module Path: $ModulePath"
+        Import-Module -Name $ModulePath -PassThru | Format-List
+
+        $ScriptPath = Join-Path @JoinPathParams -AdditionalChildPath @(
+          'scripts',
+          'Add-Expectations.ps1'
+        )
+        "Script Path: $ScriptPath"
+        Write-Output "::endgroup::"
+        Write-Output "::group::Parameter Validation"
+        $ErrorView = 'DetailedView'
+        $Parameters = Get-ActionScriptParameter -ParameterHandler $ParameterHandlers
+        Write-Output "::endgroup::"
+        Write-Output "::group::Add Expectations"
+        . $ScriptPath @Parameters
+        Write-Output "::endgroup::"

--- a/.github/actions/commenting/expectations/v1/readme.md
+++ b/.github/actions/commenting/expectations/v1/readme.md
@@ -1,0 +1,179 @@
+# Expectations
+
+Writes a comment on newly opened PRs by community members to set their expectations for how the PR
+review process will proceed. You can specify either a message body in Markdown as input with the
+**message_body** parameter or specify the path to a Markdown file containing the message body in
+your repository.
+
+In either case, the message _must_ include the following HTML comment somewhere in it:
+
+```html
+<!-- GHA.Comment.Id.Community.Expectations -->
+```
+
+If this comment annotation is not included in the message, the action will not be able to determine
+whether the comment (or another version of it) has already been added.
+
+## Versioning
+
+This action uses a simplified versioning that only tracks major versions. This is the documentation
+for `v1`. Any _backwards-compatible_ improvements to this action will update this version. If and
+when the maintainers decide to make a backwards-incompatible change - one that will require manual
+updates on the part of anyone using this action - we will create a new folder for the next major
+version, `v2`.
+
+We do not have any plans to delete prior versions, but once we move onto a new major version we will
+not be investing time and effort into updating the older versions.
+
+## Permissions
+
+This action requires the following permissions:
+
+- **contents:** `read` to inspect the repository and determine whether the Pull Request author is
+  a member of the community or the maintainer team. Anyone who does not have the **Admin** or
+  **Maintain** permission is considered a community member by this action.
+- **pull-requests:** `write` to add a comment to open Pull Requests by community members.
+
+Because this action requires a `write` permission, the `pull_request` trigger will not be able to
+write any comments if the Pull Request comes from a fork of the repository. If you want to use
+this action on Pull Requests, you will need to use the `pull_request_target` trigger, which runs
+in the context of the base branch the Pull Request is targeting and allows the GitHub token to
+have `write` permissions.
+
+Since this action does not use or inspect any of the source files a pull request might change, it
+does not need to have access to those changes and the `pull_request_target` trigger will be
+functional for this purpose.
+
+Also be aware that whether this action runs on the `pull_request` or `pull_request_target`
+trigger, the action gets added to the list of checks for that Pull Request. There is currently no
+way in GitHub to mark an action on those triggers as not being a check of the Pull Request itself.
+
+Instead, we suggest that you use this action with the `schedule` trigger to inspect the open Pull
+Requests in your repository regularly and comment when needed. This means that there will be a delay
+between when a Pull Request is filed and the comment is added, no additional care needs to be taken
+with the action and contributors will not see the action in the list of checks on their Pull
+Request.
+
+## Examples
+
+### Using a Markdown file
+
+```yaml
+name: Commenting
+on:
+  schedule:
+    - cron: 0/15 * * * * # run every 15 minutes
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  Expectations:
+    name: Share Expectations on Community PRs
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout Repository
+        id: checkout_repo
+        uses: actions/checkout@v3
+      - name: Comment on Community PRs
+        uses: MicrosoftDocs/PowerShell-Docs/.github/actions/commenting/expectations/v1@main
+        with:
+          message_path: .github/messages/expectations.md
+          token: ${{ github.token }}
+```
+
+This example workflow uses the `schedule` trigger to run every fifteen minutes. It specifies the
+minimum permissions needed for this action. For inputs, it specifies the default GitHub token and
+the path to a Markdown document in the repository which holds the body text to be written as a
+comment on community Pull Requests.
+
+Because it is specifying the path to a document, this workflow also uses the `checkout` action to
+clone a copy of the repository. This step _must_ happen before the `expectations` action or it will
+not be able to find the file containing the Markdown.
+
+### Using inline Markdown
+
+```yaml
+name: Commenting
+on:
+  schedule:
+    - cron: 0 * * * *
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  Expectations:
+    name: Share Expectations on Community PRs
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Comment on Community PRs
+        uses: MicrosoftDocs/PowerShell-Docs/.github/actions/commenting/expectations/v1@main
+        with:
+          token: ${{ github.token }}
+          message_body: |
+            <!-- GHA.Comment.Id.Community.Expectations -->
+            # Expectations
+
+            Thank you for submitting this contribution! Please make sure
+            to read our [style guide][style-guide], fill out the PR
+            checklist, and make sure all tests are passing.
+
+            If you have any questions or need any help, please ping the
+            maintainers team! We're happy to help.
+
+            If your work isn't ready for review or merge, please make
+            sure your PR is in draft mode or the title has a `WIP`
+            prefix.
+
+            [style-guide]: https://docs.contoso.com/project/guide/style
+```
+
+This example workflow uses the `schedule` trigger to run at the top of every hour. It specifies the
+minimum permissions needed for this action. For inputs, it specifies the default GitHub token and
+the Markdown content to be written as a comment on community Pull Requests.
+
+## Inputs
+
+### `message_body`
+
+The message in Markdown to write as the comment body. This input should not be used with
+**message_path**; if it is, the action will write a warning in the logs and use the **message_body**
+when commenting on community Pull Requests.
+
+### `message_path`
+
+The path to the Markdown file to write as the comment body. This input should not be used with
+**message_body**; if it is, the action will write a warning in the logs and use the **message_body**
+when commenting on community Pull Requests.
+
+### `repository`
+
+The full name of a repository; to target `https://github.com/MicrosoftDocs/PowerShell-Docs`, the
+value should be `MicrosoftDocs/PowerShell-Docs`.
+
+By default, the value is the repository the _workflow_ is defined in. Unless you are running this
+action against another repository, you should not need to specify this value.
+
+```yaml
+required: true
+type: string
+default: ${{ github.repository }}
+```
+
+### `token`
+
+The `GITHUB_TOKEN` to use to authenticate API calls to verify whether a Pull Request's author is a
+maintainer or community member and to comment on open community Pull Requests.
+
+This **must** be passed to the action.
+
+```yaml
+required: true
+type: string
+default: No
+```

--- a/.github/actions/reporting/versioned-content/v1/action.yml
+++ b/.github/actions/reporting/versioned-content/v1/action.yml
@@ -1,0 +1,21 @@
+name: Versioned Content
+description: |
+  Writes a report on the changes to versioned content in a repository on a PR.
+author: PowerShell Docs Team
+inputs:
+  repository:
+    description: |
+      The full name of a repository; to target `https://github.com/MicrosoftDocs/PowerShell-Docs`,
+      the value should be `MicrosoftDocs/PowerShell-Docs`.
+    required: true
+    default: ${{ github.repository }}
+  number:
+    description: |
+      The numerical ID of the PR to check for versioned content. If not specified, the report will
+      run against all open PRs to main.
+    required: false
+runs:
+  using: composite
+  steps:
+    - run: 'hello world'
+      shell: pwsh

--- a/.github/actions/verification/authorization/v1/Parameters.psd1
+++ b/.github/actions/verification/authorization/v1/Parameters.psd1
@@ -1,0 +1,182 @@
+@{
+  Parameters = @(
+    @{
+      Name = 'Repository'
+      Type = 'string'
+      IfNullOrEmpty = {
+        param($ErrorTarget)
+
+        $ErrorDetails = @{
+          Name    = 'Repository'
+          Type    = 'Missing'
+          Message = @(
+            'Could not determine repository;'
+            'was it passed as an input to the action?'
+          ) -join ' '
+          Target  = $ErrorTarget
+        }
+        $Record = New-InvalidParameterError @ErrorDetails
+
+        throw $Record
+      }
+      Process = {
+        param($Parameters, $Value, $ErrorTarget)
+
+        $Parameters.Owner, $Parameters.Repo = $Value -split '/'
+        Write-HostParameter -Name Owner -Value $Parameters.Owner
+        Write-HostParameter -Name Repo -Value $Parameters.Repo
+
+        return $Parameters
+      }
+    }
+
+    @{
+      Name = 'Permissions'
+      Type = 'String[]'
+      IfNullOrEmpty = {
+          param($ErrorTarget)
+
+          $ErrorDetails = @{
+              Name    = 'Permissions'
+              Type    = 'Missing'
+              Message = @(
+                  'Could not determine valid permission list;'
+                  'was it passed as an input to the action?'
+              ) -join ' '
+              Target  = $ErrorTarget
+          }
+          $Record = New-InvalidParameterError @ErrorDetails
+
+          throw $Record
+      }
+      Process = {
+        param($Parameters, $Value, $ErrorTarget)
+
+        $SpecifiedPermissions = $Value -split ','
+
+        $InvalidPermissions = @()
+        $ValidPermissions = @(
+          'Admin'
+          'Maintain'
+          'Pull'
+          'Push'
+          'Triage'
+        )
+        $Parameters.ValidPermissions = $SpecifiedPermissions | ForEach-Object {
+          if ($_ -notin $ValidPermissions) {
+            $InvalidPermissions += $_
+          } else {
+            $_
+          }
+        }
+        if ($InvalidPermissions.Count -gt 0) {
+          $Message = New-Object -TypeName System.Text.StringBuilder
+          $null = $Message.Append('Specified invalid permissions;')
+          $null = $Message.AppendLine('Permissions must be any of:')
+          foreach ($Permission in $ValidPermissions) {
+            $null = $Message.AppendLine("`t$Permission")
+          }
+          $null = $Message.AppendLine(
+            'But the following invalid permissions were specified:'
+          )
+          foreach ($Permission in $InvalidPermissions) {
+            $null = $Message.AppendLine("`t$Permission")
+          }
+          $ErrorDetails = @{
+            Name    = 'Permissions'
+            Type    = 'Invalid'
+            Message = $Message.ToString()
+            Target  = $ErrorTarget
+          }
+          $Record = New-InvalidParameterError @ErrorDetails
+          throw $Record
+        } else {
+          Write-HostParameter -Name Permissions -Value $Parameters.ValidPermissions
+
+          return $Parameters
+        }
+      }
+    }
+
+    @{
+      Name = 'Target'
+      Type = 'String[]'
+      IfNullOrEmpty = {
+        param($ErrorTarget)
+
+        $ErrorDetails = @{
+          Name    = 'Target'
+          Type    = 'Missing'
+          Message = @(
+            'Could not determine target to check for authorization;'
+            'was it passed as an input to the action?'
+          ) -join ' '
+          Target  = $ErrorTarget
+        }
+        $Record = New-InvalidParameterError @ErrorDetails
+
+        throw $Record
+      }
+      Process = {
+        param($Parameters, $Value, $ErrorTarget)
+
+        $Type, $Targets = $Value -split ':'
+        
+        if ($Type -ne 'Path') {
+          $Type = 'Branch'
+        }
+
+        if ($null -eq $Targets -and $Type -eq 'Branch') {
+          $Targets = 'live'
+        } elseif ($Targets -match ',') {
+          $Targets = $Targets -split ','
+        }
+
+        switch ($Type) {
+          'Path' {
+            $Parameters.TargetPath = $Targets
+            Write-HostParameter -Name TargetPath -Value $Parameters.TargetPath
+          }
+          default {
+            $Parameters.TargetBranch = $Targets
+            Write-HostParameter -Name TargetBranch -Value $Parameters.TargetBranch
+          }
+        }
+
+        return $Parameters
+      }
+    }
+
+    @{
+      Name = 'User'
+      Type = 'String'
+      IfNullOrEmpty = {
+        param($ErrorTarget)
+
+        $ErrorDetails = @{
+          Name    = 'User'
+          Type    = 'Missing'
+          Message = @(
+            'Could not determine user to check for authorization;'
+            'was it passed as an input to the action?'
+            'If the action was not triggered on pull request,'
+            'it needs to pass the user explicitly.'
+          ) -join ' '
+          Target  = $ErrorTarget
+        }
+        $Record = New-InvalidParameterError @ErrorDetails
+
+        throw $Record
+      }
+      Process = {
+        param($Parameters, $Value, $ErrorTarget)
+
+        $Parameters.User = $Value
+
+        Write-HostParameter -Name User -Value $Parameters.User
+
+        return $Parameters
+      }
+    }
+  )
+}

--- a/.github/actions/verification/authorization/v1/action.yml
+++ b/.github/actions/verification/authorization/v1/action.yml
@@ -1,0 +1,100 @@
+name: Authorization
+description: |
+  Checks to see whether a user may perform a certain action. For example, to target the `live`
+  branch of a repository or to submit a PR editing repo configuration.
+author: PowerShell Docs Team
+inputs:
+  permissions:
+    description: |
+      The permissions a user requires to perform a given task. Must be a comma-separated string of
+      valid permissions. Valid permissions are (case-insensitive):
+      
+      - `Admin`
+      - `Maintain`
+      - `Pull`
+      - `Push`
+      - `Triage`
+
+      If a user has _any_ of the specified permissions, they are authorized.
+    required: false
+    default: 'Maintain,Admin'
+  repository:
+    description: |
+      The full name of a repository; to target `https://github.com/MicrosoftDocs/PowerShell-Docs`,
+      the value should be `MicrosoftDocs/PowerShell-Docs`.
+
+      By default, the value is the repository the _workflow_ is defined in. Unless you are running
+      this action against another repository, you should not need to specify this value.
+    required: true
+    default: ${{ github.repository }}
+  target:
+    description: |
+      The branches or globbed file paths to verify authorization to target for changes. To specify
+      a branch, type a string like `branch:live`. To specify multiple branches, separate each branch
+      by a comma, like `branch:live,production`. To specify a filepath, specify one or more path
+      separated by a comma, like `path:foo/**/*.md,bar/*.json`.
+
+      If you do not specify a prefix like `branch:` or `path:` or specify an invalid prefix, it will
+      be interpreted as branch. The default is `branch:live`.
+    required: true
+    default: branch:live
+  token:
+    description: |
+      The GITHUB_TOKEN to use to authenticate API calls to verify the user's permissions for the
+      repository. This **must** be passed to the action.
+    required: true
+  user:
+    description: |
+      The GitHub login ID to check permissions for.
+    required: true
+    default: ${{ github.event.pull_request.user.login }}
+runs:
+  using: composite
+  steps:
+    - shell: pwsh
+      env:
+        INPUT_REPOSITORY:  ${{ inputs.repository }}
+        INPUT_PERMISSIONS: ${{ inputs.permissions }}
+        INPUT_TARGET: ${{ inputs.target }}
+        INPUT_USER: ${{ inputs.user }}
+        GITHUB_TOKEN: ${{ inputs.token }}
+      run: |
+        Write-Output "::group::Generic Setup"
+        $ActionPath = Resolve-Path '${{ github.action_path }}' | Select-Object -ExpandProperty Path
+        $ParameterHandlers = Join-Path -Path $ActionPath -ChildPath Parameters.psd1
+        | ForEach-Object -Process { Import-PowerShellDataFile -Path $_ }
+        | Select -ExpandProperty Parameters
+        | ForEach-Object -Process { [pscustomobject]$_ }
+        "Action Path: $ActionPath"
+
+        $ActionRootPath = Split-Path -Parent -Path $ActionPath
+        while ((Split-Path -Leaf -Path $ActionRootPath) -ne 'actions') {
+          $ActionRootPath = Split-Path -Parent -Path $ActionRootPath
+        }
+        "Action Root Path: $ActionRootPath"
+        
+        $JoinPathParams = @{
+          Path = $ActionRootPath
+          ChildPath = '.pwsh'
+        }
+
+        $ModulePath = Join-Path @JoinPathParams -AdditionalChildPath @(
+          'module'
+          'gha.psd1'
+        )
+        "Module Path: $ModulePath"
+        Import-Module -Name $ModulePath -PassThru | Format-List
+
+        $ScriptPath = Join-Path @JoinPathParams -AdditionalChildPath @(
+          'scripts',
+          'Test-Authorization.ps1'
+        )
+        "Script Path: $ScriptPath"
+        Write-Output "::endgroup::"
+        Write-Output "::group::Parameter Validation"
+        $Parameters = Get-ActionScriptParameter -ParameterHandler $ParameterHandlers
+        Write-Output "::endgroup::"
+        Write-Output "::group::Check Authorization"
+        . $ScriptPath @Parameters
+        Write-Output "::endgroup::"
+

--- a/.github/actions/verification/authorization/v1/readme.md
+++ b/.github/actions/verification/authorization/v1/readme.md
@@ -1,0 +1,172 @@
+# Authorization
+
+Checks to see whether a user may perform a certain action. For example, to target the `live` branch
+of a repository or to submit a PR editing repository configuration.
+
+## Versioning
+
+This action uses a simplified versioning that only tracks major versions. This is the documentation
+for `v1`. Any _backwards-compatible_ improvements to this action will update this version. If and
+when the maintainers decide to make a backwards-incompatible change - one that will require manual
+updates on the part of anyone using this action - we will create a new folder for the next major
+version, `v2`.
+
+We do not have any plans to delete prior versions, but once we move onto a new major version we will
+not be investing time and effort into updating the older versions.
+
+## Permissions
+
+This action requires the following permissions:
+
+- **metadata:** `read` to inspect the repository and determine the permissions of a user for that
+  repository.
+
+Unfortunately, GitHub Actions does not allow a workflow author to specify **metadata** in the list
+of permissions for a job or step. It does however allow you to specify **contents**, which seems to
+enable the same behavior while minimizing the risk.
+
+Note that the `pull_request` trigger will not be able to retrieve the permissions of users if the
+Pull Request comes from a fork of the repository. If you want to use this action on Pull Requests,
+you must use the `pull_request_target` trigger, which runs in the context of the base branch the
+Pull Request is targeting and allows the GitHub token to retrieve those permissions.
+
+## Examples
+
+### Verifying authorization to target a branch
+
+```yaml
+name: Authorization
+on:
+  pull_request_target:
+    branches:
+      - live
+permissions:
+  contents: read
+jobs:
+  Test:
+    name: Check Branch Permissions
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Authorized to Target Live Branch?
+        uses: MicrosoftDocs/PowerShell-Docs/.github/actions/verification/authorization/v1@main
+        with:
+          token: ${{ github.token }}
+```
+
+This workflow uses the `pull_request_target` trigger to check whether a Pull Request author is
+permitted to submit their Pull Request to the `live` branch. It only runs on Pull Requests which
+target the `live` branch, so other Pull Requests don't get a skipped message for this check.
+
+It passes the GitHub token to the action but does not specify a target, relying on the default for
+that input, which is the `live` branch.
+
+### Verifying authorization to change sensitive files
+
+```yaml
+name: Authorization
+on:
+  pull_request_target:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+permissions:
+  contents: read
+jobs:
+  Test:
+    name: Check Repo File Permissions
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Authorized to Modify Repo Files?
+        uses: ./.github/actions/verification/authorization/v1
+        with:
+          token: ${{ github.token }}
+          permissions: Maintain,Admin
+          target: path:.github/workflows/
+```
+
+This workflow uses the `pull_request_target` trigger to checker whether a Pull Request author is
+permitted to submit a Pull Request that modifies files in the `.github/workflows` or `.config`
+folders. It only runs on Pull Requests which modify files in those folders, so other Pull Requests
+don't get a skipped message for this check.
+
+It passes the GitHub token to the action and specifies that it requires the user to have the
+`Maintain` or `Admin` permissions. Because GitHub Actions cannot have arrays as input, the input
+needed to be specified as a comma-separated string. Finally, it specifies the **target** as
+`path:.github/workflows/,.config/`. The `path:` prefix tells the action to write a message about
+authorization to change files in those paths.
+
+## Inputs
+
+### `permissions`
+
+The permissions a user requires to perform a given task. Must be a comma-separated string of valid
+permissions. Valid permissions are (case-insensitive):
+
+- `Admin`
+- `Maintain`
+- `Pull`
+- `Push`
+- `Triage`
+
+If a user has _any_ of the specified permissions, they are authorized.
+
+```yaml
+required: true
+type: string
+default: Admin,Maintain
+```
+
+### `repository`
+
+The full name of a repository; to target `https://github.com/MicrosoftDocs/PowerShell-Docs`, the
+value should be `MicrosoftDocs/PowerShell-Docs`.
+
+By default, the value is the repository the _workflow_ is defined in. Unless you are running this
+action against another repository, you should not need to specify this value.
+
+### `target`
+
+The branches or globbed file paths to verify authorization to target for changes. To specify a
+branch, type a string like `branch:live`. To specify multiple branches, separate each branch by a
+comma, like `branch:live,production`. To specify a filepath, specify one or more path separated by a
+comma, like `path:foo/**/*.md,bar/*.json`.
+
+If you do not specify a prefix like `branch:` or `path:` or specify an invalid prefix, it will be
+interpreted as branch.
+
+```yaml
+required: true
+type: string
+default: branch:live
+```
+
+### `token`
+
+The GITHUB_TOKEN to use to authenticate API calls to verify the user's permissions for the
+repository. This **must** be passed to the action.
+
+```yaml
+required: true
+type: string
+default: no
+```
+
+### `user`
+
+The GitHub login ID to check permissions for.
+
+By default, the value is the author of the Pull Request when the workflow uses the `pull_request` or
+`pull_request_target` trigger. For any other trigger, you will need to specify this value.
+
+```yaml
+required: true
+type: string
+default: ${{ github.event.pull_request.user.login }}
+```

--- a/.github/actions/verification/checklist/v1/Parameters.psd1
+++ b/.github/actions/verification/checklist/v1/Parameters.psd1
@@ -1,0 +1,61 @@
+@{
+  Parameters = @(
+    @{
+      Name = 'Body'
+      Type = 'string'
+      IfNullOrEmpty = {
+        param($ErrorTarget)
+
+        $ErrorDetails = @{
+          Name  = 'Body'
+          Type  = 'Missing'
+          Message = @(
+            'Could not determine the body of the PR;'
+            'was it passed as an input to the action?'
+          ) -join ' '
+          Target  = $ErrorTarget
+        }
+        $Record = New-InvalidParameterError @ErrorDetails
+
+        throw $Record
+      }
+      Process = {
+        param($Parameters, $Value, $ErrorTarget)
+
+        $Parameters.Body = $Value
+        Write-HostParameter -Name Body -Value $Parameters.Body -MultiLine
+
+        return $Parameters
+      }
+    }
+
+    @{
+      Name          = 'Reference_Url'
+      Type          = 'string'
+      IfNullOrEmpty = {
+        param($ErrorTarget)
+
+        $ErrorDetails = @{
+          Name    = 'ReferenceUrl'
+          Type    = 'Missing'
+          Message = @(
+            'Could not determine the URL of the item;'
+            'was it passed as an input to the action?'
+          ) -join ' '
+          Target  = $ErrorTarget
+        }
+        $Record = New-InvalidParameterError @ErrorDetails
+
+        throw $Record
+      }
+      Process = {
+        param($Parameters, $Value, $ErrorTarget)
+
+        $Parameters.ReferenceUrl = $Value
+        Write-HostParameter -Name ReferenceUrl -Value $Parameters.ReferenceUrl
+
+        return $Parameters
+      }
+    }
+  )
+}

--- a/.github/actions/verification/checklist/v1/action.yml
+++ b/.github/actions/verification/checklist/v1/action.yml
@@ -1,0 +1,103 @@
+name: Checklist
+description: |
+  Inspects the checklist items on a pull request to see if they have all been filled out. It only
+  looks for mandatory checklist items. If any mandatory checklist items are not checked, the action
+  fails. It writes a summary and console logs indicating which mandatory checklist items were not
+  checked.
+
+  To be interpreted by this action as mandatory checklist items, they must be formatted in Markdown to
+  follow a specific syntax:
+
+  ```markdown
+  - [ ] **Item Name:** Explanation of the item`
+  ```
+
+  To be recognized as a mandatory checklist item by this action, the item must:
+
+  - use valid syntax for checklists on GitHub (i.e. `- [ ]` for an unchecked item and `- [x]` for a
+    checked item)
+  - immediately follow the checklist syntax with a single space and then two asterisks (`**`)
+  - include one or more characters, specifying the name of the mandatory checklist item
+  - close the name of the item with a colon followed by two asterisks (`:**`)
+
+  Including explanatory text after the mandatory checklist item declaration is strictly optional but
+  strongly encouraged.
+
+  This example code block illustrates how this action parses Markdown and what is interpreted as a
+  valid mandatory checklist item for this action to verify:
+
+  ```markdown
+  A paragraph is not a checklist item
+
+  - This is a list item, but not a checklist item.
+  - [ ] This is a checklist item, but not mandatory.
+  - [ ] Not Bold: This is a checklist item, but not recognized as mandatory.
+  - [ ] **Colon Outside**: This is a checklist item, but not recognized as mandatory.
+  - [ ] **Foo:** This is a mandatory checklist item named `Foo`. It is not checked.
+  - [x] **Bar:** This is a mandatory checklist item named `Bar`. It is checked.
+  ```
+author: PowerShell Docs Team
+inputs:
+  body:
+    description: |
+      The body of the GitHub Pull Request to inspect for checklist completion. If using this action
+      on a `pull_request` or `pull_request_target` event, this is handled automatically. Otherwise,
+      it must be specified.
+    required: true
+    default: ${{ github.event.pull_request.body }}
+  reference_url:
+    description: |
+      The URL of the GitHub Pull Request, issue, discussion, or comment to inspect for checklist
+      completion. If using this action on a `pull_request` or `pull_request_target` event, this is
+      handled automatically. Otherwise, it must be specified.
+    required: true
+    default: ${{ github.event.pull_request.url }}
+runs:
+  using: composite
+  steps:
+    - shell: pwsh
+      env:
+        INPUT_REFERENCE_URL: ${{ inputs.reference_url }}
+        INPUT_BODY:  ${{ inputs.body }}
+      run: |
+        Write-Output "::group::Generic Setup"
+        $ActionPath = Resolve-Path '${{ github.action_path }}' | Select-Object -ExpandProperty Path
+        $ParameterHandlers = Join-Path -Path $ActionPath -ChildPath Parameters.psd1
+        | ForEach-Object -Process { Import-PowerShellDataFile -Path $_ }
+        | Select -ExpandProperty Parameters
+        | ForEach-Object -Process { [pscustomobject]$_ }
+        "Action Path: $ActionPath"
+
+        $ActionRootPath = Split-Path -Parent -Path $ActionPath
+        while ((Split-Path -Leaf -Path $ActionRootPath) -ne 'actions') {
+          $ActionRootPath = Split-Path -Parent -Path $ActionRootPath
+        }
+        "Action Root Path: $ActionRootPath"
+        
+        $JoinPathParams = @{
+          Path = $ActionRootPath
+          ChildPath = '.pwsh'
+        }
+
+        $ModulePath = Join-Path @JoinPathParams -AdditionalChildPath @(
+          'module'
+          'gha.psd1'
+        )
+        "Module Path: $ModulePath"
+        Import-Module -Name $ModulePath -PassThru | Format-List
+
+        $ScriptPath = Join-Path @JoinPathParams -AdditionalChildPath @(
+          'scripts',
+          'Test-Checklist.ps1'
+        )
+        "Script Path: $ScriptPath"
+        Write-Output "::endgroup::"
+
+        Write-Output "::group::Parameter Validation"
+        $Parameters = Get-ActionScriptParameter -ParameterHandler $ParameterHandlers
+        Write-Output "::endgroup::"
+        
+        Write-Output "::group::Verify Checklist"
+        . $ScriptPath @Parameters
+        Write-Output "::endgroup::"
+

--- a/.github/actions/verification/checklist/v1/readme.md
+++ b/.github/actions/verification/checklist/v1/readme.md
@@ -1,0 +1,127 @@
+# Checklist
+
+Inspects the checklist items on a pull request to see if they have all been filled out. It only
+looks for mandatory checklist items. If any mandatory checklist items are not checked, the action
+fails. It writes a summary and console logs indicating which mandatory checklist items were not
+checked.
+
+To be interpreted by this action as mandatory checklist items, they must be formatted in Markdown to
+follow a specific syntax:
+
+```markdown
+- [ ] **Item Name:** Explanation of the item`
+```
+
+To be recognized as a mandatory checklist item by this action, the item must:
+
+- use valid syntax for checklists on GitHub (i.e. `- [ ]` for an unchecked item and `- [x]` for a
+  checked item)
+- immediately follow the checklist syntax with a single space and then two asterisks (`**`)
+- include one or more characters, specifying the name of the mandatory checklist item
+- close the name of the item with a colon followed by two asterisks (`:**`)
+
+Including explanatory text after the mandatory checklist item declaration is strictly optional but
+strongly encouraged.
+
+This example code block illustrates how this action parses Markdown and what is interpreted as a
+valid mandatory checklist item for this action to verify:
+
+```markdown
+A paragraph is not a checklist item
+
+- This is a list item, but not a checklist item.
+- [ ] This is a checklist item, but not mandatory.
+- [ ] Not Bold: This is a checklist item, but not recognized as mandatory.
+- [ ] **Colon Outside**: This is a checklist item, but not recognized as mandatory.
+- [ ] **Foo:** This is a mandatory checklist item named `Foo`. It is not checked.
+- [x] **Bar:** This is a mandatory checklist item named `Bar`. It is checked.
+```
+
+## Versioning
+
+This action uses a simplified versioning that only tracks major versions. This is the documentation
+for `v1`. Any _backwards-compatible_ improvements to this action will update this version. If and
+when the maintainers decide to make a backwards-incompatible change - one that will require manual
+updates on the part of anyone using this action - we will create a new folder for the next major
+version, `v2`.
+
+We do not have any plans to delete prior versions, but once we move onto a new major version we will
+not be investing time and effort into updating the older versions.
+
+## Permissions
+
+This action requires no read or write permissions as long as it is used with the `pull_request` or
+`pull_request_target` trigger because the necessary information is included in the event payload for
+those triggers.
+
+## Examples
+
+```yml
+name: Checklist
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - edited
+      - synchronize
+permissions:
+  contents: read
+jobs:
+  Test:
+    name: Verify Status
+    runs-on: windows-latest
+    if: |
+      !contains(github.event.pull_request.title, 'WIP') &&
+      !github.event.pull_request.draft
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Verify Checklist
+        id: verify_checklist
+        uses: MicrosoftDocs/PowerShell-Docs/.github/actions/verification/checklist/v1@main
+```
+
+This workflow uses the `pull_request` trigger to verify whether the checklist included in the Pull
+Request template has been filled out. It only runs on Pull Requests targeting the `main` branch when
+they are opened, reopened, specifically request a review, the body is edited, or the author updates
+their Pull Request (as with a force push).
+
+The job only runs if the title of the Pull Request does not include `WIP` anywhere in it and the
+Pull Request is not marked as a draft - if it's WIP or a draft, there's no reason to verify the
+checklist because the Pull Request is not ready for final review or merge.
+
+When the Pull Request meets those criteria, this action is called and it inspects the body of the
+Pull Request to discover any mandatory checklist items. It then reports whether those items are
+checked or not. If any mandatory checklist items are not checked, the action fails with an error,
+reporting which mandatory items have not yet been checked.
+
+## Inputs
+
+### `body`
+
+The body of the GitHub Pull Request to inspect for checklist completion. If using this action on a
+`pull_request` or `pull_request_target` event, this is handled automatically. Otherwise, it must be
+specified.
+
+```yaml
+required: true
+type: string
+default: ${{ github.event.pull_request.body }}
+```
+
+### `pull_request_url`
+
+The URL of the GitHub Pull Request, issue, discussion, or comment to inspect for checklist
+completion. If using this action on a `pull_request` or `pull_request_target` event, this is handled
+automatically. Otherwise, it must be specified.
+
+```yaml
+required: true
+type: string
+default: ${{ github.event.pull_request.url }}
+```

--- a/.github/messages/expectations.md
+++ b/.github/messages/expectations.md
@@ -1,0 +1,37 @@
+<!-- GHA.Comment.Id.Community.Expectations -->
+
+# Expectations
+
+Thanks for your submission! Here's a quick note to provide you with some context for what to expect
+from the docs team and the process now that you've submitted a PR. Even if you've contributed to
+this repo before, we strongly suggest reading this information; it might have changed since you last
+read it.
+
+To see our process for reviewing PRs, please read our [editor's checklist][contrib-checklist] and
+process for [managing pull requests][contrib-managing-prs] in particular. Below is a brief,
+high-level summary of what to expect, but our contributor guide has expanded details.
+
+The docs team begins to review your PR if you [request them to][gh-review-request] or if your PR
+meets these conditions:
+
+- It is not a [draft PR][gh-drafts].
+- It does not have a `WIP` prefix in the title.
+- It passes validation and build steps.
+- It does not have any merge conflicts.
+- You have checked every box in the [PR Checklist](#pr-checklist), indicating you have completed all
+  required steps and marked your PR as **Ready to Merge**.
+
+You can **always** request a review at any stage in your authoring process, the docs team is here to
+help! You do not need to submit a fully polished and finished draft; the docs team can help you get
+content ready for merge.
+
+While reviewing your PR, the docs team may make suggestions, write comments, and ask questions. When
+all requirements are satisfied, the docs team marks your PR as **Approved** and merges it. Once your
+PR is merged, it is included the next time the documentation is published. For this project, the
+documentation is published daily at 3 p.m. Pacific Standard Time (PST).
+
+[contrib-checklist]: https://docs.microsoft.com/powershell/scripting/community/contributing/editorial-checklist
+[contrib-managing-prs]: https://docs.microsoft.com/powershell/scripting/community/contributing/managing-pull-requests
+[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
+[gh-drafts]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
+[gh-review-request]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review

--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -1,0 +1,30 @@
+name: Checklist
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - edited
+      - synchronize
+permissions:
+  contents: read
+jobs:
+  Test:
+    name: Verify Status
+    runs-on: windows-latest
+    if: |
+      !contains(github.event.pull_request.title, 'WIP') &&
+      !github.event.pull_request.draft
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout Repository
+        id: checkout_repo
+        uses: actions/checkout@v3
+      - name: Verify Checklist
+        id: verify_checklist
+        uses: ./.github/actions/verification/checklist/v1

--- a/.github/workflows/expectations.yml
+++ b/.github/workflows/expectations.yml
@@ -1,0 +1,28 @@
+# This action comments on a PR by a community member with the expectations they
+# should have for the process. It runs every five minutes to find uncommented
+# community PRs targeting the main branch. It uses a markdown file in the
+# .github folder for the content.
+name: Commenting
+on:
+  schedule:
+    - cron: 0/5 * * * *
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  Expectations:
+    name: Share Expectations on Community PRs
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout Repository
+        id: checkout_repo
+        uses: actions/checkout@v3
+      - name: Comment on Community PRs
+        uses: ./.github/actions/commenting/expectations/v1
+        with:
+          message_path: .github/messages/expectations.md
+          token: ${{ github.token }}
+

--- a/.github/workflows/targeting-repo-files.yml
+++ b/.github/workflows/targeting-repo-files.yml
@@ -1,0 +1,35 @@
+# This workflow verifies that an author submitting a pull request to the main
+# branch to modify repository files is authorized to do so; only users with
+# maintainer or admin rights may modify the actions or the workflow definitions.
+name: Authorization
+on:
+  pull_request_target:
+    branches:
+      - main
+    paths:
+      - /.github/actions/**
+      - /.github/workflows/**
+      - /.github/CODEOWNERS
+      - /.localization-config
+      - /openpublishing*
+      - /*.yml
+      - LICENSE*
+      - ThirdPartyNotices
+permissions:
+  contents: read
+jobs:
+  Test:
+    name: Check Repo File Permissions
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout Repository
+        id: checkout_repo
+        uses: actions/checkout@v3
+      - name: Authorized to Modify Repo Files?
+        uses: ./.github/actions/verification/authorization/v1
+        with:
+          token: ${{ github.token }}
+          target: path:.github/actions/,.github/workflows/,.github/CODEOWNERS,.localization-config,openpublishing*,*.yml,LICENSE*,ThirdPartyNotices

--- a/.github/workflows/targeting-valid-branch.yml
+++ b/.github/workflows/targeting-valid-branch.yml
@@ -1,50 +1,25 @@
-name: Targeting Valid Branch
+# This workflow verifies that an author submitting a pull request to the live
+# branch is authorized to do so; only users with maintainer or admin rights may
+# target the live branch directly.
+name: Authorization
 on:
   pull_request_target:
-    types:
-      - opened
-      - reopened
-      - synchronize
+    branches:
+      - live
 permissions:
   contents: read
-
 jobs:
   Test:
-    permissions:
-      contents: none
+    name: Check Branch Permissions
     runs-on: windows-latest
     defaults:
       run:
         shell: pwsh
-    if: github.base_ref == 'live'
     steps:
+      - name: Checkout Repository
+        id: checkout_repo
+        uses: actions/checkout@v3
       - name: Authorized to Target Live Branch?
-        env:
-          GITHUB_TOKEN: ${{ secrets.VALID_BRANCH_TOKEN }}
-        run: |
-          $Owner = '${{ github.event.pull_request.base.repo.owner.login}}'
-          $Repo  = '${{ github.event.pull_request.base.repo.name }}'
-          $Actor = '${{ github.event.pull_request.user.login }}'
-
-          $ResultString = gh api repos/$Owner/$Repo/collaborators/$Actor/permission
-          $ExitCode = $LASTEXITCODE
-          if ($ExitCode -ne 0) {
-            throw "GitHub API call failed with exit code ${ExitCode}:`n$ResultString"
-          }
-
-          $Permissions = $ResultString
-          | ConvertFrom-Json
-          | Select-Object -Property @{ Name = 'Permissions' ; Expression = { $_.user.permissions } }
-          | Select-Object -ExpandProperty Permissions
-
-          if ($null -eq $Permissions) {
-            throw "Unable to retrieve permissions for author '$Actor':`n$ResultString"
-          }
-
-          echo "Author '$Actor' has permissions:`n$($Permissions | Format-List | Out-String)"
-
-          if ($Permissions.admin -or $Permissions.maintain) {
-            echo "Author has permissions to target ${{ github.base_ref }}"
-          } else {
-            throw "Author does not have permissions to target ${{ github.base_ref }}"
-          }
+        uses: ./.github/actions/verification/authorization/v1
+        with:
+          token: ${{ github.token }}


### PR DESCRIPTION
# PR Summary

Prior to this change, the workflow in this repository used inline code to perform its functions. Adopting this across repositories required copying the workflow to each repository and implied needing to distribute improvements/fixes across N repositories.

This change implements an alternate approach, converting the discrete functionality into private (that is, not published to the marketplace) GitHub Actions in this repository. It also adds three new workflows, enumerated below.

The new actions are organized by folder: first by category, then name, then version. The actual files live in the version folder. This implementation uses `vX` (like `v1` or `v2`) for the final folder segment because we can't use tagging to clarify the version of these actions like a user might expect for actions published to the marketplace. Instead, major/breaking changes will involve copying the action into a new version folder to make updating an explicit choice.

The new categories include commenting, reporting, and verification.

- In `commenting`, the only new action is `expectations`, which inspects open PRs to see if they have an expectations comment and, if not, if they are by a community member. It will comment on any open PR by a community member with the specified expectations comment (passed as either a markdown blob or the path to a markdown file).
- In `reporting`, the only new action is `versioned-content`, which is not yet implemented but will write a report on changes to versioned content in the PR it is associated with.
- In `verification`, there are two new actions: `authorization`, which determines whether a particular user has sufficient permissions to perform an action, and `checklist` which inspects the body of a PR to see if all checklist items have been filled out or not.

This change adds new workflows and updates the existing workflow to call the new actions:

- `checklist.yml` utilizes `verification/checklist`
- `targeting-repo-files.yml` utilizes `verification/authorization`
- `targeting-valid-branch.yml` now utilizes `verification/authorization`
- `expectations.yml` utilizes `commenting/expectations`

This change also adds an in-repo PowerShell module into the new `actions` folder to make it obvious that it is _only_ for GHA.

Of particular note, the public API surface for defining the parameters of GitHub Actions is very limited: you can pass a string, a boolean, or an integer. You cannot pass arrays of any sort or more complex object types at all.

To work around this limitation, all of the new actions share boilerplate code and the same model for parameter validation. In short, each action also has a `Parameters.psd1` file associated with it which is used to retrieve and validate the parameters to pass to the action script.

The parameters' data files all share the same structure:

- They have a top-level **Parameters** key, which holds an array of hashtables.
- Each parameter hashtable has the following keys:
  - **Name:** The name of the _input_ parameter to the action. This is used to retrieve the value from the environment variable (`INPUT_*`) and is distinct from the parameters that need to be passed to the script.
  - **Type:** The dotnet type of the input. Currently unused, but may be useful for casting later.
  - **IfNullOrEmpty:** A scriptblock that will be invoked if the value retrieval for that parameter returns `$null` or an empty string or array. It takes one input (`$ErrorTarget`) and should either throw an exception (if the parameter is mandatory and may not be null) or do nothing. It should not return any objects to the output stream.
  - **Process:** A scriptblock that will be invoked if prior steps for the parameter do not throw any exceptions. It takes three arguments (`$Parameters`, `$Value`, and `$ErrorTarget`). `$Parameters` is the current hashtable with any already-validated parameters defined. It is what will eventually be splatted to the action script. This scriptblock should validate the script parameter(s) it gets from the action's inputs, add them to the hash, and return the hash. If the parameters fail validation, it should throw an exception to avoid calling the script in a broken state.

For the specific actions, the only difference in their `run` definition is the name of the script they use - for example, `Test-Authorization` for `authorization` and `Add-Expectations` for `expectations`.

The rest of the PowerShell code in those definitions is the same. We could investigate further abstracting those steps into a shared bit of code but it might be better to leave it as-is for clarity and ease of troubleshooting.

Finally, this change includes documentation for every cmdlet in the module, every script used by the new actions, and each of the actions themselves.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide