### PR TITLE
(MAINT) Fix preamble markup in VC Reporting

### DIFF
--- a/.github/actions/.pwsh/scripts/Get-VersionedContentReport.ps1
+++ b/.github/actions/.pwsh/scripts/Get-VersionedContentReport.ps1
@@ -157,9 +157,9 @@ process {
     'versioned file will have one of the following statuses:'
   ).AppendLine().AppendLine()
   $null = $Summary.AppendLine('- **Added:** The file was added. Git status `A`.')
-  $null = $Summary.AppendLine("- **Changed:** The file's type was changed. Git status `T`.")
+  $null = $Summary.AppendLine("- **Changed:** The file's type was changed. Git status ``T``.")
   $null = $Summary.AppendLine('- **Copied:** The file was copied. Git status `C`.')
-  $null = $Summary.AppendLine("- **Modified:** The file's contents were changed. Git status `M`.")
+  $null = $Summary.AppendLine("- **Modified:** The file's contents were changed. Git status ``M``.")
   $null = $Summary.AppendLine('- **Removed:** The file was deleted. Git status `D`.')
   $null = $Summary.AppendLine('- **Renamed:** The file was renamed. Git status `R`.')
   $null = $Summary.AppendLine('- **Unchanged:** The file was not modified.')


### PR DESCRIPTION
# PR Summary

Prior to this change, the preamble section of the Versioned Content Report summary did not render the git statuses for "changed" or "modified" files correctly.

This change corrects the string syntax to ensure proper rendering.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide