### PR TITLE
Fixed missing case in the "Everthing about $null" chapter

### DIFF
--- a/reference/docs-conceptual/learn/deep-dives/everything-about-null.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-null.md
@@ -224,7 +224,7 @@ looking for exactly what you're expecting it to look for. I read that line of co
 
 But that's not the whole story. That line is actually saying:
 
-> If `$value` is not `$null` or `0` or `$false` or an `empty string` or a non-empty `array`
+> If `$value` is not `$null` or `0` or `$false` or an empty string or an empty array.
 
 Here is a more complete sample of that statement.
 


### PR DESCRIPTION
# PR Summary

In the mentioned chapter, in the "Simple if check" section there is a visualization of how values are cast to booleans in `if` expressions. The code snipped missed a case of an empty array which evaluates to `$false`.

- Added the case of empty array in the cast description.
- Fixed a small typo/grammar error

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide