### PR TITLE
Activity Parameter: Renamed second 'Create' parameter back to 'Delete'

### DIFF
--- a/reference/docs-conceptual/developer/cmdlet/activity-parameters.md
+++ b/reference/docs-conceptual/developer/cmdlet/activity-parameters.md
@@ -2,7 +2,7 @@
 description: Activity Parameters
 ms.date: 02/03/2022
 ms.topic: reference
-no-loc: [Append, Command, String, System.Version, Compress, Keyword, Continuous, Create, array, Drain, Erase, Include, Incremental, Insert, Interval, Notify, Object, Prompt, Quiet, Retry, Select, Strict, Truncate, Verify]
+no-loc: [Append, Command, String, System.Version, Compress, Keyword, Continuous, Create, Delete, array, Drain, Erase, Include, Incremental, Insert, Interval, Notify, Object, Prompt, Quiet, Retry, Select, Strict, Truncate, Verify]
 title: Activity Parameters
 ---
 # Activity Parameters
@@ -19,7 +19,7 @@ The following table lists the recommended names and functionality for activity p
 |**Compress**<br>Data type: Keyword|Implement this parameter so that the user can specify the algorithm to use for data compression.|
 |**Continuous**<br>Data type: SwitchParameter|Implement this parameter so that data is processed until the user terminates the cmdlet when the parameter is specified. If the parameter is not specified, the cmdlet processes a predefined amount of data and then terminates the operation.|
 |**Create**<br>Data type: SwitchParameter|Implement this parameter to indicate that a resource is created if one does not already exist when the parameter is specified.|
-|**Create**<br>Data type: SwitchParameter|Implement this parameter so that resources are deleted when the cmdlet has completed its operation when the parameter is specified.|
+|**Delete**<br>Data type: SwitchParameter|Implement this parameter so that resources are deleted when the cmdlet has completed its operation when the parameter is specified.|
 |**Drain**<br>Data type: SwitchParameter|Implement this parameter to indicate that outstanding work items are processed before the cmdlet processes new data when the parameter is specified. If the parameter is not specified, the work items are processed immediately.|
 |**Erase**<br>Data type: Int32|Implement this parameter so that the user can specify the number of times a resource is erased before it is deleted.|
 |**ErrorLevel**<br>Data type: Int32|Implement this parameter so that the user can specify the level of errors to report.|


### PR DESCRIPTION
# PR Summary

'Create' is listed twice as [activity parameter](https://docs.microsoft.com/en-us/powershell/scripting/developer/cmdlet/activity-parameters?view=powershell-7.2). Based on the Functionality description it should be 'Delete'.

![image](https://user-images.githubusercontent.com/5731299/175297330-3e097c8b-7606-43b5-8baa-9ae594fdab5c.png)

Changes:
- Renamed 'Create' to 'Delete'
- Added 'Delete' to 'no-loc'

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide