### PR TITLE
(GH-8964) Clarify `Write-Progress` examples

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 09/10/2021
+ms.date: 07/05/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/write-progress?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Progress
@@ -31,8 +31,7 @@ text that appears above and below the progress bar.
 ### Example 1: Display the progress of a For loop
 
 ```powershell
-for ($i = 1; $i -le 100; $i++ )
-{
+for ($i = 1; $i -le 100; $i++ ) {
     Write-Progress -Activity "Search in Progress" -Status "$i% Complete:" -PercentComplete $i
     Start-Sleep -Milliseconds 250
 }
@@ -46,12 +45,24 @@ variable `$i` (the counter in the For loop), which indicates the relative comple
 ### Example 2: Display the progress of nested For loops
 
 ```powershell
-for($I = 1; $I -lt 101; $I++ )
-{
-    Write-Progress -Activity Updating -Status 'Progress->' -PercentComplete $I -CurrentOperation OuterLoop
-    for($j = 1; $j -lt 101; $j++ )
-    {
-        Write-Progress -Id 1 -Activity Updating -Status 'Progress' -PercentComplete $j -CurrentOperation InnerLoop
+for($I = 0; $I -lt 10; $I++ ) {
+    $OuterLoopProgressParameters = @{
+        Activity         = 'Updating'
+        Status           = 'Progress->'
+        PercentComplete  = $I * 10
+        CurrentOperation = 'OuterLoop'
+    }
+    Write-Progress @OuterLoopProgressParameters
+    for($j = 1; $j -lt 101; $j++ ) {
+        $InnerLoopProgressParameters = @{
+            ID               = 1
+            Activity         = 'Updating'
+            Status           = 'Progress'
+            PercentComplete  = $j
+            CurrentOperation = 'InnerLoop'
+        }
+        Write-Progress @InnerLoopProgressParameters
+        Start-Sleep -Milliseconds 25
     }
 }
 ```
@@ -98,9 +109,12 @@ $Events | ForEach-Object -Begin {
     }
     # Increment the $i counter variable which is used to create the progress bar.
     $i = $i+1
+    # Determine the completion percentage
+    $Completed = ($i/$Events.count*100)
     # Use Write-Progress to output a progress bar.
-    # The Activity and Status parameters create the first and second lines of the progress bar heading, respectively.
-    Write-Progress -Activity "Searching Events" -Status "Progress:" -PercentComplete ($i/$Events.count*100)
+    # The Activity and Status parameters create the first and second lines of the progress bar
+    # heading, respectively.
+    Write-Progress -Activity "Searching Events" -Status "Progress:" -PercentComplete $Completed
 } -End {
     # Display the matching messages using the out variable.
     $out
@@ -121,7 +135,8 @@ foreach ( $i in 1..10 ) {
   foreach ( $j in 1..10 ) {
     Write-Progress -Id 1 -ParentId 0 "Step $i - Substep $j"
     foreach ( $k in 1..10 ) {
-      Write-Progress -Id 2  -ParentId 1 "Step $i - Substep $j - iteration $k"; start-sleep -m 150
+      Write-Progress -Id 2  -ParentId 1 "Step $i - Substep $j - iteration $k"
+      Start-Sleep -Milliseconds 150
     }
   }
 }

--- a/reference/7.0/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 09/10/2021
+ms.date: 07/05/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/write-progress?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Progress
@@ -31,8 +31,7 @@ text that appears above and below the progress bar.
 ### Example 1: Display the progress of a For loop
 
 ```powershell
-for ($i = 1; $i -le 100; $i++ )
-{
+for ($i = 1; $i -le 100; $i++ ) {
     Write-Progress -Activity "Search in Progress" -Status "$i% Complete:" -PercentComplete $i
     Start-Sleep -Milliseconds 250
 }
@@ -46,12 +45,24 @@ variable `$i` (the counter in the For loop), which indicates the relative comple
 ### Example 2: Display the progress of nested For loops
 
 ```powershell
-for($I = 1; $I -lt 101; $I++ )
-{
-    Write-Progress -Activity Updating -Status 'Progress->' -PercentComplete $I -CurrentOperation OuterLoop
-    for($j = 1; $j -lt 101; $j++ )
-    {
-        Write-Progress -Id 1 -Activity Updating -Status 'Progress' -PercentComplete $j -CurrentOperation InnerLoop
+for($I = 0; $I -lt 10; $I++ ) {
+    $OuterLoopProgressParameters = @{
+        Activity         = 'Updating'
+        Status           = 'Progress->'
+        PercentComplete  = $I * 10
+        CurrentOperation = 'OuterLoop'
+    }
+    Write-Progress @OuterLoopProgressParameters
+    for($j = 1; $j -lt 101; $j++ ) {
+        $InnerLoopProgressParameters = @{
+            ID               = 1
+            Activity         = 'Updating'
+            Status           = 'Progress'
+            PercentComplete  = $j
+            CurrentOperation = 'InnerLoop'
+        }
+        Write-Progress @InnerLoopProgressParameters
+        Start-Sleep -Milliseconds 25
     }
 }
 ```
@@ -98,9 +109,12 @@ $Events | ForEach-Object -Begin {
     }
     # Increment the $i counter variable which is used to create the progress bar.
     $i = $i+1
+    # Determine the completion percentage
+    $Completed = ($i/$Events.count*100)
     # Use Write-Progress to output a progress bar.
-    # The Activity and Status parameters create the first and second lines of the progress bar heading, respectively.
-    Write-Progress -Activity "Searching Events" -Status "Progress:" -PercentComplete ($i/$Events.count*100)
+    # The Activity and Status parameters create the first and second lines of the progress bar
+    # heading, respectively.
+    Write-Progress -Activity "Searching Events" -Status "Progress:" -PercentComplete $Completed
 } -End {
     # Display the matching messages using the out variable.
     $out
@@ -121,7 +135,8 @@ foreach ( $i in 1..10 ) {
   foreach ( $j in 1..10 ) {
     Write-Progress -Id 1 -ParentId 0 "Step $i - Substep $j"
     foreach ( $k in 1..10 ) {
-      Write-Progress -Id 2  -ParentId 1 "Step $i - Substep $j - iteration $k"; start-sleep -m 150
+      Write-Progress -Id 2  -ParentId 1 "Step $i - Substep $j - iteration $k"
+      Start-Sleep -Milliseconds 150
     }
   }
 }

--- a/reference/7.2/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 09/10/2021
+ms.date: 07/05/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/write-progress?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Progress
@@ -45,8 +45,7 @@ you to control progress view bar rendering.
 ### Example 1: Display the progress of a For loop
 
 ```powershell
-for ($i = 1; $i -le 100; $i++ )
-{
+for ($i = 1; $i -le 100; $i++ ) {
     Write-Progress -Activity "Search in Progress" -Status "$i% Complete:" -PercentComplete $i
     Start-Sleep -Milliseconds 250
 }
@@ -60,12 +59,26 @@ variable `$i` (the counter in the For loop), which indicates the relative comple
 ### Example 2: Display the progress of nested For loops
 
 ```powershell
-for($I = 1; $I -lt 101; $I++ )
-{
-    Write-Progress -Activity Updating -Status 'Progress->' -PercentComplete $I -CurrentOperation OuterLoop
-    for($j = 1; $j -lt 101; $j++ )
-    {
-        Write-Progress -Id 1 -Activity Updating -Status 'Progress' -PercentComplete $j -CurrentOperation InnerLoop
+$PSStyle.Progress.View = 'classic'
+
+for($I = 0; $I -lt 10; $I++ ) {
+    $OuterLoopProgressParameters = @{
+        Activity         = 'Updating'
+        Status           = 'Progress->'
+        PercentComplete  = $I * 10
+        CurrentOperation = 'OuterLoop'
+    }
+    Write-Progress @OuterLoopProgressParameters
+    for($j = 1; $j -lt 101; $j++ ) {
+        $InnerLoopProgressParameters = @{
+            ID               = 1
+            Activity         = 'Updating'
+            Status           = 'Progress'
+            PercentComplete  = $j
+            CurrentOperation = 'InnerLoop'
+        }
+        Write-Progress @InnerLoopProgressParameters
+        Start-Sleep -Milliseconds 25
     }
 }
 ```
@@ -81,8 +94,8 @@ Progress
 InnerLoop
 ```
 
-This example displays the progress of two nested For loops, each of which is represented by a
-progress bar.
+This example sets the progress view to classic and then displays the progress of two nested **for**
+loops, each represented by a progress bar.
 
 The `Write-Progress` command for the second progress bar includes the **Id** parameter that
 distinguishes it from the first progress bar.
@@ -112,9 +125,12 @@ $Events | ForEach-Object -Begin {
     }
     # Increment the $i counter variable which is used to create the progress bar.
     $i = $i+1
+    # Determine the completion percentage
+    $Completed = ($i/$Events.count*100)
     # Use Write-Progress to output a progress bar.
-    # The Activity and Status parameters create the first and second lines of the progress bar heading, respectively.
-    Write-Progress -Activity "Searching Events" -Status "Progress:" -PercentComplete ($i/$Events.count*100)
+    # The Activity and Status parameters create the first and second lines of the progress bar
+    # heading, respectively.
+    Write-Progress -Activity "Searching Events" -Status "Progress:" -PercentComplete $Completed
 } -End {
     # Display the matching messages using the out variable.
     $out
@@ -130,12 +146,15 @@ that result by 100.
 ### Example 4: Display progress for each level of a nested process
 
 ```powershell
+$PSStyle.Progress.View = 'classic'
+
 foreach ( $i in 1..10 ) {
   Write-Progress -Id 0 "Step $i"
   foreach ( $j in 1..10 ) {
     Write-Progress -Id 1 -ParentId 0 "Step $i - Substep $j"
     foreach ( $k in 1..10 ) {
-      Write-Progress -Id 2  -ParentId 1 "Step $i - Substep $j - iteration $k"; start-sleep -m 150
+      Write-Progress -Id 2  -ParentId 1 "Step $i - Substep $j - iteration $k"
+      Start-Sleep -Milliseconds 150
     }
   }
 }

--- a/reference/7.2/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -59,7 +59,7 @@ variable `$i` (the counter in the For loop), which indicates the relative comple
 ### Example 2: Display the progress of nested For loops
 
 ```powershell
-$PSStyle.Progress.View = 'classic'
+$PSStyle.Progress.View = 'Classic'
 
 for($I = 0; $I -lt 10; $I++ ) {
     $OuterLoopProgressParameters = @{
@@ -94,7 +94,7 @@ Progress
 InnerLoop
 ```
 
-This example sets the progress view to classic and then displays the progress of two nested **for**
+This example sets the progress view to `Classic` and then displays the progress of two nested `for`
 loops, each represented by a progress bar.
 
 The `Write-Progress` command for the second progress bar includes the **Id** parameter that
@@ -146,7 +146,7 @@ that result by 100.
 ### Example 4: Display progress for each level of a nested process
 
 ```powershell
-$PSStyle.Progress.View = 'classic'
+$PSStyle.Progress.View = 'Classic'
 
 foreach ( $i in 1..10 ) {
   Write-Progress -Id 0 "Step $i"

--- a/reference/7.3/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -59,7 +59,7 @@ variable `$i` (the counter in the For loop), which indicates the relative comple
 ### Example 2: Display the progress of nested For loops
 
 ```powershell
-$PSStyle.Progress.View = 'classic'
+$PSStyle.Progress.View = 'Classic'
 
 for($I = 0; $I -lt 10; $I++ ) {
     $OuterLoopProgressParameters = @{
@@ -94,7 +94,7 @@ Progress
 InnerLoop
 ```
 
-This example sets the progress view to classic and then displays the progress of two nested **for**
+This example sets the progress view to `Classic` and then displays the progress of two nested `for`
 loops, each represented by a progress bar.
 
 The `Write-Progress` command for the second progress bar includes the **Id** parameter that
@@ -146,7 +146,7 @@ that result by 100.
 ### Example 4: Display progress for each level of a nested process
 
 ```powershell
-$PSStyle.Progress.View = 'classic'
+$PSStyle.Progress.View = 'Classic'
 
 foreach ( $i in 1..10 ) {
   Write-Progress -Id 0 "Step $i"

--- a/reference/7.3/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 09/10/2021
+ms.date: 07/05/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/write-progress?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Progress
@@ -45,8 +45,7 @@ you to control progress view bar rendering.
 ### Example 1: Display the progress of a For loop
 
 ```powershell
-for ($i = 1; $i -le 100; $i++ )
-{
+for ($i = 1; $i -le 100; $i++ ) {
     Write-Progress -Activity "Search in Progress" -Status "$i% Complete:" -PercentComplete $i
     Start-Sleep -Milliseconds 250
 }
@@ -60,12 +59,26 @@ variable `$i` (the counter in the For loop), which indicates the relative comple
 ### Example 2: Display the progress of nested For loops
 
 ```powershell
-for($I = 1; $I -lt 101; $I++ )
-{
-    Write-Progress -Activity Updating -Status 'Progress->' -PercentComplete $I -CurrentOperation OuterLoop
-    for($j = 1; $j -lt 101; $j++ )
-    {
-        Write-Progress -Id 1 -Activity Updating -Status 'Progress' -PercentComplete $j -CurrentOperation InnerLoop
+$PSStyle.Progress.View = 'classic'
+
+for($I = 0; $I -lt 10; $I++ ) {
+    $OuterLoopProgressParameters = @{
+        Activity         = 'Updating'
+        Status           = 'Progress->'
+        PercentComplete  = $I * 10
+        CurrentOperation = 'OuterLoop'
+    }
+    Write-Progress @OuterLoopProgressParameters
+    for($j = 1; $j -lt 101; $j++ ) {
+        $InnerLoopProgressParameters = @{
+            ID               = 1
+            Activity         = 'Updating'
+            Status           = 'Progress'
+            PercentComplete  = $j
+            CurrentOperation = 'InnerLoop'
+        }
+        Write-Progress @InnerLoopProgressParameters
+        Start-Sleep -Milliseconds 25
     }
 }
 ```
@@ -81,8 +94,8 @@ Progress
 InnerLoop
 ```
 
-This example displays the progress of two nested For loops, each of which is represented by a
-progress bar.
+This example sets the progress view to classic and then displays the progress of two nested **for**
+loops, each represented by a progress bar.
 
 The `Write-Progress` command for the second progress bar includes the **Id** parameter that
 distinguishes it from the first progress bar.
@@ -112,9 +125,12 @@ $Events | ForEach-Object -Begin {
     }
     # Increment the $i counter variable which is used to create the progress bar.
     $i = $i+1
+    # Determine the completion percentage
+    $Completed = ($i/$Events.count*100)
     # Use Write-Progress to output a progress bar.
-    # The Activity and Status parameters create the first and second lines of the progress bar heading, respectively.
-    Write-Progress -Activity "Searching Events" -Status "Progress:" -PercentComplete ($i/$Events.count*100)
+    # The Activity and Status parameters create the first and second lines of the progress bar
+    # heading, respectively.
+    Write-Progress -Activity "Searching Events" -Status "Progress:" -PercentComplete $Completed
 } -End {
     # Display the matching messages using the out variable.
     $out
@@ -130,12 +146,15 @@ that result by 100.
 ### Example 4: Display progress for each level of a nested process
 
 ```powershell
+$PSStyle.Progress.View = 'classic'
+
 foreach ( $i in 1..10 ) {
   Write-Progress -Id 0 "Step $i"
   foreach ( $j in 1..10 ) {
     Write-Progress -Id 1 -ParentId 0 "Step $i - Substep $j"
     foreach ( $k in 1..10 ) {
-      Write-Progress -Id 2  -ParentId 1 "Step $i - Substep $j - iteration $k"; start-sleep -m 150
+      Write-Progress -Id 2  -ParentId 1 "Step $i - Substep $j - iteration $k"
+      Start-Sleep -Milliseconds 150
     }
   }
 }


### PR DESCRIPTION
# PR Summary

Fixes AB#1967037 - Fixes #8964

Prior to this change, the examples in the reference documentation of the `Write-Progress` cmdlet included output showing the appearance of progress bars in the classic view. Starting in PowerShell 7.2, which introduced the minimal view, minimal is the default.

This change:

- Updates the examples with output to set the `$PSStyle.Progress.View` value to `classic` before calling `Write-Progress`
- Updates the examples to use our standard styling and limit line length to 100 characters.
- Resolves #8964

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->


- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide