### PR TITLE
(GH-8984) Add intro version for escape/unicode chars

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the special character sequences that control how PowerShell interprets the next characters in the sequence.
 Locale: en-US
-ms.date: 05/16/2022
+ms.date: 07/05/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_special_characters?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Special Characters
@@ -29,18 +29,18 @@ strings.
 
 PowerShell recognizes these escape sequences:
 
-|  Sequence   |       Description       |
-| ----------- | ----------------------- |
-| `` `0 ``    | Null                    |
-| `` `a ``    | Alert                   |
-| `` `b ``    | Backspace               |
-| `` `e ``    | Escape                  |
-| `` `f ``    | Form feed               |
-| `` `n ``    | New line                |
-| `` `r ``    | Carriage return         |
-| `` `t ``    | Horizontal tab          |
-| `` `u{x} `` | Unicode escape sequence |
-| `` `v ``    | Vertical tab            |
+|  Sequence   |                   Description                   |
+| :---------: | :---------------------------------------------- |
+|  `` `0 ``   | Null                                            |
+|  `` `a ``   | Alert                                           |
+|  `` `b ``   | Backspace                                       |
+|  `` `e ``   | Escape (added in PowerShell 6)                  |
+|  `` `f ``   | Form feed                                       |
+|  `` `n ``   | New line                                        |
+|  `` `r ``   | Carriage return                                 |
+|  `` `t ``   | Horizontal tab                                  |
+| `` `u{x} `` | Unicode escape sequence (added in PowerShell 6) |
+|  `` `v ``   | Vertical tab                                    |
 
 PowerShell also has a special token to mark where you want parsing to stop. All
 characters that follow this token are used as literal values that aren't
@@ -88,6 +88,9 @@ back out
 ```
 
 ## Escape (`e)
+
+> [!NOTE]
+> This special character was added in PowerShell 6.0.
 
 The escape (`` `e ``) character is most commonly used to specify a virtual
 terminal sequence (ANSI escape sequence) that modifies the color of text and
@@ -171,6 +174,9 @@ Column1         Column2         Column3
 ```
 
 ## Unicode character (`u{x})
+
+> [!NOTE]
+> This special character was added in PowerShell 6.0.
 
 The Unicode escape sequence (`` `u{x} ``) allows you to specify any Unicode
 character by the hexadecimal representation of its code point. This includes

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the special character sequences that control how PowerShell interprets the next characters in the sequence.
 Locale: en-US
-ms.date: 05/16/2022
+ms.date: 07/05/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_special_characters?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Special Characters
@@ -29,18 +29,18 @@ strings.
 
 PowerShell recognizes these escape sequences:
 
-|  Sequence   |       Description       |
-| ----------- | ----------------------- |
-| `` `0 ``    | Null                    |
-| `` `a ``    | Alert                   |
-| `` `b ``    | Backspace               |
-| `` `e ``    | Escape                  |
-| `` `f ``    | Form feed               |
-| `` `n ``    | New line                |
-| `` `r ``    | Carriage return         |
-| `` `t ``    | Horizontal tab          |
-| `` `u{x} `` | Unicode escape sequence |
-| `` `v ``    | Vertical tab            |
+|  Sequence   |                   Description                   |
+| :---------: | :---------------------------------------------- |
+|  `` `0 ``   | Null                                            |
+|  `` `a ``   | Alert                                           |
+|  `` `b ``   | Backspace                                       |
+|  `` `e ``   | Escape (added in PowerShell 6)                  |
+|  `` `f ``   | Form feed                                       |
+|  `` `n ``   | New line                                        |
+|  `` `r ``   | Carriage return                                 |
+|  `` `t ``   | Horizontal tab                                  |
+| `` `u{x} `` | Unicode escape sequence (added in PowerShell 6) |
+|  `` `v ``   | Vertical tab                                    |
 
 PowerShell also has a special token to mark where you want parsing to stop. All
 characters that follow this token are used as literal values that aren't
@@ -88,6 +88,9 @@ back out
 ```
 
 ## Escape (`e)
+
+> [!NOTE]
+> This special character was added in PowerShell 6.0.
 
 The escape (`` `e ``) character is most commonly used to specify a virtual
 terminal sequence (ANSI escape sequence) that modifies the color of text and
@@ -171,6 +174,9 @@ Column1         Column2         Column3
 ```
 
 ## Unicode character (`u{x})
+
+> [!NOTE]
+> This special character was added in PowerShell 6.0.
 
 The Unicode escape sequence (`` `u{x} ``) allows you to specify any Unicode
 character by the hexadecimal representation of its code point. This includes

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the special character sequences that control how PowerShell interprets the next characters in the sequence.
 Locale: en-US
-ms.date: 05/16/2022
+ms.date: 07/05/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_special_characters?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Special Characters
@@ -29,18 +29,18 @@ strings.
 
 PowerShell recognizes these escape sequences:
 
-|  Sequence   |       Description       |
-| ----------- | ----------------------- |
-| `` `0 ``    | Null                    |
-| `` `a ``    | Alert                   |
-| `` `b ``    | Backspace               |
-| `` `e ``    | Escape                  |
-| `` `f ``    | Form feed               |
-| `` `n ``    | New line                |
-| `` `r ``    | Carriage return         |
-| `` `t ``    | Horizontal tab          |
-| `` `u{x} `` | Unicode escape sequence |
-| `` `v ``    | Vertical tab            |
+|  Sequence   |                   Description                   |
+| :---------: | :---------------------------------------------- |
+|  `` `0 ``   | Null                                            |
+|  `` `a ``   | Alert                                           |
+|  `` `b ``   | Backspace                                       |
+|  `` `e ``   | Escape (added in PowerShell 6)                  |
+|  `` `f ``   | Form feed                                       |
+|  `` `n ``   | New line                                        |
+|  `` `r ``   | Carriage return                                 |
+|  `` `t ``   | Horizontal tab                                  |
+| `` `u{x} `` | Unicode escape sequence (added in PowerShell 6) |
+|  `` `v ``   | Vertical tab                                    |
 
 PowerShell also has a special token to mark where you want parsing to stop. All
 characters that follow this token are used as literal values that aren't
@@ -88,6 +88,9 @@ back out
 ```
 
 ## Escape (`e)
+
+> [!NOTE]
+> This special character was added in PowerShell 6.0.
 
 The escape (`` `e ``) character is most commonly used to specify a virtual
 terminal sequence (ANSI escape sequence) that modifies the color of text and
@@ -171,6 +174,9 @@ Column1         Column2         Column3
 ```
 
 ## Unicode character (`u{x})
+
+> [!NOTE]
+> This special character was added in PowerShell 6.0.
 
 The Unicode escape sequence (`` `u{x} ``) allows you to specify any Unicode
 character by the hexadecimal representation of its code point. This includes


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for special characters did not include information around when the escape or unicode characters were introduced.

This change:

- Updates the overview table for _About Special Characters_ to note that the escape and unicode characters were added in PowerShell 6
- Updates the sections for each of those characters to include an alert noting that they were introduced in PowerShell 6.
- Resolves #8984

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide