### PR TITLE
(GH-8983) Fix example in About Comment-Based Help

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to write comment-based help topics for functions and scripts.
 Locale: en-US
-ms.date: 10/08/2021
+ms.date: 07/05/2022
 no-loc: [.SYNOPSIS, .DESCRIPTION, .PARAMETER, .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES, .LINK, .COMPONENT, .ROLE, .FUNCTIONALITY, .FORWARDHELPTARGETNAME, .FORWARDHELPCATEGORY, .REMOTEHELPRUNSPACE, .EXTERNALHELP]
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comment_based_help?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -693,7 +693,7 @@ directory that is listed in the `$env:Path` environment variable, the
 `Get-Help` command that gets the script help must specify the script path.
 
 ```powershell
-Get-Help -Path .\update-month.ps1 -Full
+Get-Help -Name .\update-month.ps1 -Full
 ```
 
 ```Output

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to write comment-based help topics for functions and scripts.
 Locale: en-US
-ms.date: 10/08/2021
+ms.date: 07/05/2022
 no-loc: [.SYNOPSIS, .DESCRIPTION, .PARAMETER, .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES, .LINK, .COMPONENT, .ROLE, .FUNCTIONALITY, .FORWARDHELPTARGETNAME, .FORWARDHELPCATEGORY, .REMOTEHELPRUNSPACE, .EXTERNALHELP]
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comment_based_help?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -693,7 +693,7 @@ directory that is listed in the `$env:Path` environment variable, the
 `Get-Help` command that gets the script help must specify the script path.
 
 ```powershell
-Get-Help -Path .\update-month.ps1 -Full
+Get-Help -Name .\update-month.ps1 -Full
 ```
 
 ```Output

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to write comment-based help topics for functions and scripts.
 Locale: en-US
-ms.date: 10/08/2021
+ms.date: 07/05/2022
 no-loc: [.SYNOPSIS, .DESCRIPTION, .PARAMETER, .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES, .LINK, .COMPONENT, .ROLE, .FUNCTIONALITY, .FORWARDHELPTARGETNAME, .FORWARDHELPCATEGORY, .REMOTEHELPRUNSPACE, .EXTERNALHELP]
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comment_based_help?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -693,7 +693,7 @@ directory that is listed in the `$env:Path` environment variable, the
 `Get-Help` command that gets the script help must specify the script path.
 
 ```powershell
-Get-Help -Path .\update-month.ps1 -Full
+Get-Help -Name .\update-month.ps1 -Full
 ```
 
 ```Output

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to write comment-based help topics for functions and scripts.
 Locale: en-US
-ms.date: 10/08/2021
+ms.date: 07/05/2022
 no-loc: [.SYNOPSIS, .DESCRIPTION, .PARAMETER, .EXAMPLE, .INPUTS, .OUTPUTS, .NOTES, .LINK, .COMPONENT, .ROLE, .FUNCTIONALITY, .FORWARDHELPTARGETNAME, .FORWARDHELPCATEGORY, .REMOTEHELPRUNSPACE, .EXTERNALHELP]
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comment_based_help?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -693,7 +693,7 @@ directory that is listed in the `$env:Path` environment variable, the
 `Get-Help` command that gets the script help must specify the script path.
 
 ```powershell
-Get-Help -Path .\update-month.ps1 -Full
+Get-Help -Name .\update-month.ps1 -Full
 ```
 
 ```Output


### PR DESCRIPTION
# PR Summary

Prior to this change, an example in the article specified the **Path** parameter instead of **Name** for retrieving the comment-based help from a script file.

This change:

- Corrects the example
- Resolves #8983

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide