### PR TITLE
(GH-8994) Fix over-localization in `Register-CimIndicationEvent`

### DIFF
--- a/reference/5.1/CimCmdlets/Register-CimIndicationEvent.md
+++ b/reference/5.1/CimCmdlets/Register-CimIndicationEvent.md
@@ -2,7 +2,8 @@
 external help file: Microsoft.Management.Infrastructure.CimCmdlets.dll-Help.xml
 Locale: en-US
 Module Name: CimCmdlets
-ms.date: 02/20/2019
+ms.date: 07/06/2022
+no-loc: [-Forward]
 online version: https://docs.microsoft.com/powershell/module/cimcmdlets/register-cimindicationevent?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Register-CimIndicationEvent

--- a/reference/7.0/CimCmdlets/Register-CimIndicationEvent.md
+++ b/reference/7.0/CimCmdlets/Register-CimIndicationEvent.md
@@ -2,7 +2,8 @@
 external help file: Microsoft.Management.Infrastructure.CimCmdlets.dll-Help.xml
 Locale: en-US
 Module Name: CimCmdlets
-ms.date: 02/20/2019
+ms.date: 07/06/2022
+no-loc: [-Forward]
 online version: https://docs.microsoft.com/powershell/module/cimcmdlets/register-cimindicationevent?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Register-CimIndicationEvent

--- a/reference/7.2/CimCmdlets/Register-CimIndicationEvent.md
+++ b/reference/7.2/CimCmdlets/Register-CimIndicationEvent.md
@@ -2,7 +2,8 @@
 external help file: Microsoft.Management.Infrastructure.CimCmdlets.dll-Help.xml
 Locale: en-US
 Module Name: CimCmdlets
-ms.date: 02/20/2019
+ms.date: 07/06/2022
+no-loc: [-Forward]
 online version: https://docs.microsoft.com/powershell/module/cimcmdlets/register-cimindicationevent?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Register-CimIndicationEvent

--- a/reference/7.3/CimCmdlets/Register-CimIndicationEvent.md
+++ b/reference/7.3/CimCmdlets/Register-CimIndicationEvent.md
@@ -2,7 +2,8 @@
 external help file: Microsoft.Management.Infrastructure.CimCmdlets.dll-Help.xml
 Locale: en-US
 Module Name: CimCmdlets
-ms.date: 02/20/2019
+ms.date: 07/06/2022
+no-loc: [-Forward]
 online version: https://docs.microsoft.com/powershell/module/cimcmdlets/register-cimindicationevent?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Register-CimIndicationEvent


### PR DESCRIPTION
# PR Summary

Prior to this change, the **Forward** parameter in the documentation for the `Register-CimIndicationEvent` cmdlet over-localized in de-de to the incorrect _Weiterleiten_.

This change adds `-Forward` to the list of terms not to localize.

- Fixes #8994

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide