### PR TITLE
(MAINT) Limit cron workflows to upstream

### DIFF
--- a/.github/workflows/expectations.yml
+++ b/.github/workflows/expectations.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   Expectations:
     name: Share Expectations on Community PRs
+    if: github.repository_owner == 'MicrosoftDocs'
     runs-on: windows-latest
     defaults:
       run:

--- a/.github/workflows/stale-content.yml
+++ b/.github/workflows/stale-content.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   Report:
     name: Stale Content
+    if: github.repository_owner == 'MicrosoftDocs'
     runs-on: windows-latest
     defaults:
       run:


### PR DESCRIPTION
# PR Summary

This change limits the workflow that trigger on a schedule to only run when the repository owner is `MicrosoftDocs`, which should prevent it from running on forks and generating any errors or other noise.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide