### PR TITLE
Update helpinfo-xml-schema.md

### DIFF
--- a/reference/docs-conceptual/developer/help/helpinfo-xml-schema.md
+++ b/reference/docs-conceptual/developer/help/helpinfo-xml-schema.md
@@ -15,7 +15,7 @@ HelpInfo XML files are based on the following XML schema.
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<schema targetNamespace="http://schemas.microsoft.com/powershell/help/2010/05" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/powershell/help/2010/05" xmlns="http://www.w3.org/2001/XMLSchema">
   <element name="HelpInfo">
     <complexType>
       <sequence>


### PR DESCRIPTION
# PR Summary

When trying to validate a [sample help info file](https://docs.microsoft.com/en-us/powershell/scripting/developer/help/helpinfo-xml-sample-file?view=powershell-7.2) against the original schema file presented in the article, it will fail with the [cvc-complex-type.2.4.a](https://wiki.xmldation.com/Support/Validator/cvc-complex-type-2-4-a). As presented in the [HelpInfo XML Sample File](https://docs.microsoft.com/en-us/powershell/scripting/developer/help/helpinfo-xml-sample-file?view=powershell-7.2), setting up the `elementFormDefault` attribute with the value `qualified` on the `schema` element solves the issue. The pull request does precisely that, no more, no less. 


## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide