### PR TITLE
Fix typo / grammar error in about_Properties.md

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -27,7 +27,7 @@ object, the file changes too.
 Most objects have properties. Properties are the data that is associated with
 an object. Different types of object have different properties. For example, a
 FileInfo object, which represents a file, has an **IsReadOnly** property that
-contains $True if the file the read-only attribute and $False if it does not.
+contains $True if the file has the read-only attribute and $False if it does not.
 A DirectoryInfo object, which represents a file system directory, has a Parent
 property that contains the path to the parent directory.
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -27,7 +27,7 @@ object, the file changes too.
 Most objects have properties. Properties are the data that is associated with
 an object. Different types of object have different properties. For example, a
 FileInfo object, which represents a file, has an **IsReadOnly** property that
-contains $True if the file the read-only attribute and $False if it does not.
+contains $True if the file has the read-only attribute and $False if it does not.
 A DirectoryInfo object, which represents a file system directory, has a Parent
 property that contains the path to the parent directory.
 


### PR DESCRIPTION
# PR Summary

Fixed typo / grammar error in about_Properties.md page for Powershell-Core versions 7.2 and 7.3. The sentence needed the word 'has'. 

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].


[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide