### PR TITLE
(GH-9033) Add casing functions for PSReadLine 2.3.0

### DIFF
--- a/reference/7.3/PSReadLine/About/about_PSReadLine_Functions.md
+++ b/reference/7.3/PSReadLine/About/about_PSReadLine_Functions.md
@@ -133,6 +133,16 @@ the host so the prompt is evaluated again.
 - Vi insert mode: `<Ctrl+c>`
 - Vi command mode: `<Ctrl+c>`
 
+### CapitalizeWord
+
+> Added in PSReadLine 2.3.0
+
+Convert the first character of the next word to upper case and the remaining
+characters to lower case.
+
+- Cmd: `<Alt+c>`
+- Emacs: `<Escape,c>`
+
 ### Copy
 
 Copy selected region to the system clipboard. If no region is selected, copy
@@ -236,6 +246,15 @@ Delete to the end of the line.
 Delete the next word.
 
 - Vi command mode: `<d,w>`
+
+### DowncaseWord
+
+> Added in PSReadLine 2.3.0
+
+Convert the next word to lower case.
+
+- Cmd: `<Alt+l>`
+- Emacs: `<Escape,l>`
 
 ### ForwardDeleteInput
 
@@ -403,6 +422,15 @@ is between words, the input is cleared from the start of the previous word to
 the cursor. The cleared text is placed in the kill-ring.
 
 - Emacs: `<Ctrl+w>`
+
+### UpcaseWord
+
+> Added in PSReadLine 2.3.0
+
+Convert the next word to upper case.
+
+- Cmd: `<Alt+u>`
+- Emacs: `<Escape,u>`
 
 ### ValidateAndAcceptLine
 


### PR DESCRIPTION
# PR Summary

The change in PowerShell/PSReadLine#3365 added three new functions for modifying the casing of text with PSReadLine. This change:

- Adds an entry for each new function in the "Basic editing functions" section of `about_PSReadLine_Functions.md`
- Resolves #9033
- Resolves [AB#4387](https://dev.azure.com/content-learn/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/4387)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide