### PR TITLE
(GH-9039) Document ordered hash table for ConvertFrom-Json

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/19/2020
+ms.date: 07/19/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/convertfrom-json?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertFrom-Json
@@ -137,11 +137,12 @@ integer.
 Converts the JSON to a hash table object. This switch was introduced in PowerShell 6.0. There are
 several scenarios where it can overcome some limitations of the `ConvertFrom-Json` cmdlet.
 
-- If the JSON contains a list with keys that only differ in casing. Without the switch, those keys
-  would be seen as identical keys and therefore only the last one would get used.
-- If the JSON contains a key that is an empty string. Without the switch, the cmdlet would throw an
-  error since a `PSCustomObject` does not allow for that but a hash table does. An example use case
-  where this can occurs are `project.lock.json` files.
+- Without this switch, when two or more keys in a JSON object are case-insensitively identical, they
+  are treated as identical keys. In that case, only the last of those case-insensitively identical
+  keys is included in the converted object.
+- Without this switch, the cmdlet throws an error whenever the JSON contains a key that is an empty
+  string. **PSCustomObject** can't have property names that are empty strings. For example, this can
+  occur in `project.lock.json` files.
 - Hash tables can be processed faster for certain data structures.
 
 ```yaml

--- a/reference/7.2/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/19/2020
+ms.date: 07/19/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/convertfrom-json?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertFrom-Json
@@ -137,11 +137,12 @@ integer.
 Converts the JSON to a hash table object. This switch was introduced in PowerShell 6.0. There are
 several scenarios where it can overcome some limitations of the `ConvertFrom-Json` cmdlet.
 
-- If the JSON contains a list with keys that only differ in casing. Without the switch, those keys
-  would be seen as identical keys and therefore only the last one would get used.
-- If the JSON contains a key that is an empty string. Without the switch, the cmdlet would throw an
-  error since a `PSCustomObject` does not allow for that but a hash table does. An example use case
-  where this can occurs are `project.lock.json` files.
+- Without this switch, when two or more keys in a JSON object are case-insensitively identical, they
+  are treated as identical keys. In that case, only the last of those case-insensitively identical
+  keys is included in the converted object.
+- Without this switch, the cmdlet throws an error whenever the JSON contains a key that is an empty
+  string. **PSCustomObject** can't have property names that are empty strings. For example, this can
+  occur in `project.lock.json` files.
 - Hash tables can be processed faster for certain data structures.
 
 ```yaml

--- a/reference/7.3/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/19/2020
+ms.date: 07/19/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/convertfrom-json?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertFrom-Json
@@ -134,14 +134,18 @@ integer.
 
 ### -AsHashtable
 
-Converts the JSON to a hash table object. This switch was introduced in PowerShell 6.0. There are
-several scenarios where it can overcome some limitations of the `ConvertFrom-Json` cmdlet.
+Converts the JSON to an hash table object. This switch was introduced in PowerShell 6.0. Starting
+with PowerShell 7.3, the object is an **OrderedHashtable** and preserves the ordering of the keys
+from the JSON. In prior versions, the object is a **Hashtable**.
 
-- If the JSON contains a list with keys that only differ in casing. Without the switch, those keys
-  would be seen as identical keys and therefore only the last one would get used.
-- If the JSON contains a key that is an empty string. Without the switch, the cmdlet would throw an
-  error since a `PSCustomObject` does not allow for that but a hash table does. An example use case
-  where this can occurs are `project.lock.json` files.
+There are several scenarios where it can overcome some limitations of the `ConvertFrom-Json` cmdlet.
+
+- Without this switch, when two or more keys in a JSON object are case-insensitively identical, they
+  are treated as identical keys. In that case, only the last of those case-insensitively identical
+  keys is included in the converted object.
+- Without this switch, the cmdlet throws an error whenever the JSON contains a key that is an empty
+  string. **PSCustomObject** can't have property names that are empty strings. For example, this can
+  occur in `project.lock.json` files.
 - Hash tables can be processed faster for certain data structures.
 
 ```yaml
@@ -232,7 +236,7 @@ You can pipe a JSON string to `ConvertFrom-Json`.
 
 ### PSCustomObject
 
-### System.Collections.Hashtable
+### System.Management.Automation.OrderedHashtable
 
 ## NOTES
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the `ConvertFrom-Json` cmdlet returnedd a **Hashtable** object when used with the **AsHashtable** parameter. Starting with PowerShell 7.3, it instead returns an **OrderedHashtable** object.

This change:

- Modifies the output type and parameter documentation to reflect the updated object type for 7.3.
- Updates the parameter documentation for 7.0+ to better reflect the reasons to use the **AsHashtable** parameter.
- Resolves #9039
- Fixes [AB#4440](https://dev.azure.com/content-learn/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/4440)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide