### PR TITLE
(GH-9044) Add zero-padding format example

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 03/16/2022
+ms.date: 07/20/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -329,6 +329,18 @@ right side of the operator.
 1 hello      3.14
 ```
 
+You can zero-pad a numeric value with the ["0" custom specifier][zero-padding].
+The number of zeroes following the `:` indicates the maximum width to pad the
+formatted string to.
+
+```powershell
+"{0:00} {1:000} {2:000000}" -f 7, 24, 365
+```
+
+```output
+07 024 000365
+```
+
 If you need to keep the curly braces (`{}`) in the formatted string, you can
 escape them by doubling the curly braces.
 
@@ -471,3 +483,7 @@ of the `Get-Member` cmdlet.  The member name may be an expression.
 - [about_Split](about_Split.md)
 - [about_Join](about_Join.md)
 - [about_Redirection](about_Redirection.md)
+
+<!-- Reference Links -->
+
+[zero-padding]: /dotnet/standard/base-types/custom-numeric-format-strings#Specifier0

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 03/16/2022
+ms.date: 07/20/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -396,6 +396,18 @@ right side of the operator.
 1 hello      3.14
 ```
 
+You can zero-pad a numeric value with the ["0" custom specifier][zero-padding].
+The number of zeroes following the `:` indicates the maximum width to pad the
+formatted string to.
+
+```powershell
+"{0:00} {1:000} {2:000000}" -f 7, 24, 365
+```
+
+```output
+07 024 000365
+```
+
 If you need to keep the curly braces (`{}`) in the formatted string, you can
 escape them by doubling the curly braces.
 
@@ -705,3 +717,7 @@ ${a}?[0]
 - [about_Split](about_Split.md)
 - [about_Join](about_Join.md)
 - [about_Redirection](about_Redirection.md)
+
+<!-- Reference Links -->
+
+[zero-padding]: /dotnet/standard/base-types/custom-numeric-format-strings#Specifier0

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 03/16/2022
+ms.date: 07/20/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -396,6 +396,18 @@ right side of the operator.
 1 hello      3.14
 ```
 
+You can zero-pad a numeric value with the ["0" custom specifier][zero-padding].
+The number of zeroes following the `:` indicates the maximum width to pad the
+formatted string to.
+
+```powershell
+"{0:00} {1:000} {2:000000}" -f 7, 24, 365
+```
+
+```output
+07 024 000365
+```
+
 If you need to keep the curly braces (`{}`) in the formatted string, you can
 escape them by doubling the curly braces.
 
@@ -704,3 +716,7 @@ ${a}?[0]
 - [about_Split](about_Split.md)
 - [about_Join](about_Join.md)
 - [about_Redirection](about_Redirection.md)
+
+<!-- Reference Links -->
+
+[zero-padding]: /dotnet/standard/base-types/custom-numeric-format-strings#Specifier0

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 03/16/2022
+ms.date: 07/20/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -396,6 +396,18 @@ right side of the operator.
 1 hello      3.14
 ```
 
+You can zero-pad a numeric value with the ["0" custom specifier][zero-padding].
+The number of zeroes following the `:` indicates the maximum width to pad the
+formatted string to.
+
+```powershell
+"{0:00} {1:000} {2:000000}" -f 7, 24, 365
+```
+
+```output
+07 024 000365
+```
+
 If you need to keep the curly braces (`{}`) in the formatted string, you can
 escape them by doubling the curly braces.
 
@@ -704,3 +716,7 @@ ${a}?[0]
 - [about_Split](about_Split.md)
 - [about_Join](about_Join.md)
 - [about_Redirection](about_Redirection.md)
+
+<!-- Reference Links -->
+
+[zero-padding]: /dotnet/standard/base-types/custom-numeric-format-strings#Specifier0


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for the format operator was minimal. This change:

- Adds a new example to the format operator documentation in `about_Operators` to cover zero-padding.
- Resolves #9044
- Fixes [AB#4489](https://dev.azure.com/content-learn/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/4489)


## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide