### PR TITLE
(GH-9064) Correct `Set-LocalUser` param info

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalUser.md
@@ -181,7 +181,7 @@ Accept wildcard characters: False
 Specifies a password for the user account. If the user account is connected to a Microsoft account,
 do not set a password.
 
-You can use `Read-Host -GetCredential`, `Get-Credential`, or `ConvertTo-SecureString` to create a
+You can use `Read-Host -AsSecureString`, `Get-Credential`, or `ConvertTo-SecureString` to create a
 **SecureString** object for the password.
 
 If you omit the **Password** and **NoPassword** parameters, `Set-LocalUser` prompts you for the


### PR DESCRIPTION
# PR Summary

Prior to this change the `Set-LocalUser` documentation for the **Password** parameter referenced using `Read-Host -GetCredential` to retrieve a **SecureString**. The **GetCredential** parameter does not exist.

This change:

- Updates the documentation to use **AsPlainText** instead
- Resolves #9064
- Fixes [AB#4682](https://dev.azure.com/content-learn/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/4682)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide