### PR TITLE
"core" designation issue

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -23,7 +23,7 @@ a different .NET runtime. As of PowerShell 6.0 there are two editions of PowerSh
 - **Core**, which runs on .NET Core. PowerShell 6.0 and later is installed
   side-by-side with earlier PowerShell releases on full-featured Windows editions, some
   reduced-footprint Windows editions such as Windows Nano Server and Windows IoT, or on non-Windows
-  platforms such as Linux and MacOs.
+  platforms such as Linux and macOS.
 
 Because the edition of PowerShell corresponds to its .NET runtime, it is the primary indicator
 of .NET API and PowerShell module compatibility; some .NET APIs, types or methods are not available

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -14,15 +14,18 @@ Different editions of PowerShell run on different underlying runtimes.
 ## Long description
 
 From PowerShell 5.1, there are multiple *editions* of PowerShell that each run on
-a different .NET runtime. As of PowerShell 6.2 there are two editions of PowerShell:
+a different .NET runtime. As of PowerShell 6.0 there are two editions of PowerShell:
 
-- **Desktop**, which runs on .NET Framework. PowerShell 4 and below, as well as
-  PowerShell 5.1 on full-featured Windows editions like Windows Desktop, Windows Server,
-  Windows Server Core and most other Windows operating systems are Desktop edition.
-  This is the original PowerShell edition.
-- **Core**, which runs on .NET Core. PowerShell 6.0 and above, as well as PowerShell 5.1 on
-  some reduced-footprint Windows editions such as Windows Nano Server and Windows IoT where
-  .NET Framework is unavailable.
+- **Windows PowerShell**, which runs on .NET Framework. PowerShell 4 and below, as well as
+  PowerShell 5.1 are available for full-featured Windows editions like Windows Desktop,
+  Windows Server, Windows Server Core and most other Windows operating systems. This is the original
+  PowerShell edition and is included in the default installation of the operating system.
+- **PowerShell**, which runs on .NET Core. PowerShell 6.0 and later is installed
+  side-by-side with earlier PowerShell releases on full-featured Windows editions, some
+  reduced-footprint Windows editions such as Windows Nano Server and Windows IoT, or on non-Windows
+  platforms such as Linux and MacOs.
+
+PowerShell 6.x included a special naming designation as *PowerShell Core*.
 
 Because the edition of PowerShell corresponds to its .NET runtime, it is the primary indicator
 of .NET API and PowerShell module compatibility; some .NET APIs, types or methods are not available

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -16,16 +16,14 @@ Different editions of PowerShell run on different underlying runtimes.
 From PowerShell 5.1, there are multiple *editions* of PowerShell that each run on
 a different .NET runtime. As of PowerShell 6.0 there are two editions of PowerShell:
 
-- **Windows PowerShell**, which runs on .NET Framework. PowerShell 4 and below, as well as
+- **Desktop**, which runs on .NET Framework. PowerShell 4 and below, as well as
   PowerShell 5.1 are available for full-featured Windows editions like Windows Desktop,
   Windows Server, Windows Server Core and most other Windows operating systems. This is the original
   PowerShell edition and is included in the default installation of the operating system.
-- **PowerShell**, which runs on .NET Core. PowerShell 6.0 and later is installed
+- **Core**, which runs on .NET Core. PowerShell 6.0 and later is installed
   side-by-side with earlier PowerShell releases on full-featured Windows editions, some
   reduced-footprint Windows editions such as Windows Nano Server and Windows IoT, or on non-Windows
   platforms such as Linux and MacOs.
-
-PowerShell 6.x included a special naming designation as *PowerShell Core*.
 
 Because the edition of PowerShell corresponds to its .NET runtime, it is the primary indicator
 of .NET API and PowerShell module compatibility; some .NET APIs, types or methods are not available

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -23,7 +23,7 @@ a different .NET runtime. As of PowerShell 6.0 there are two editions of PowerSh
 - **Core**, which runs on .NET Core. PowerShell 6.0 and later is installed
   side-by-side with earlier PowerShell releases on full-featured Windows editions, some
   reduced-footprint Windows editions such as Windows Nano Server and Windows IoT, or on non-Windows
-  platforms such as Linux and MacOs.
+  platforms such as Linux and macOS.
 
 Because the edition of PowerShell corresponds to its .NET runtime, it is the primary indicator
 of .NET API and PowerShell module compatibility; some .NET APIs, types or methods are not available

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -14,15 +14,18 @@ Different editions of PowerShell run on different underlying runtimes.
 ## Long description
 
 From PowerShell 5.1, there are multiple *editions* of PowerShell that each run on
-a different .NET runtime. As of PowerShell 6.2 there are two editions of PowerShell:
+a different .NET runtime. As of PowerShell 6.0 there are two editions of PowerShell:
 
-- **Desktop**, which runs on .NET Framework. PowerShell 4 and below, as well as
-  PowerShell 5.1 on full-featured Windows editions like Windows Desktop, Windows Server,
-  Windows Server Core and most other Windows operating systems are Desktop edition.
-  This is the original PowerShell edition.
-- **Core**, which runs on .NET Core. PowerShell 6.0 and above, as well as PowerShell 5.1 on
-  some reduced-footprint Windows editions such as Windows Nano Server and Windows IoT where
-  .NET Framework is unavailable.
+- **Windows PowerShell**, which runs on .NET Framework. PowerShell 4 and below, as well as
+  PowerShell 5.1 are available for full-featured Windows editions like Windows Desktop,
+  Windows Server, Windows Server Core and most other Windows operating systems. This is the original
+  PowerShell edition and is included in the default installation of the operating system.
+- **PowerShell**, which runs on .NET Core. PowerShell 6.0 and later is installed
+  side-by-side with earlier PowerShell releases on full-featured Windows editions, some
+  reduced-footprint Windows editions such as Windows Nano Server and Windows IoT, or on non-Windows
+  platforms such as Linux and MacOs.
+
+PowerShell 6.x included a special naming designation as *PowerShell Core*.
 
 Because the edition of PowerShell corresponds to its .NET runtime, it is the primary indicator
 of .NET API and PowerShell module compatibility; some .NET APIs, types or methods are not available

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -16,16 +16,14 @@ Different editions of PowerShell run on different underlying runtimes.
 From PowerShell 5.1, there are multiple *editions* of PowerShell that each run on
 a different .NET runtime. As of PowerShell 6.0 there are two editions of PowerShell:
 
-- **Windows PowerShell**, which runs on .NET Framework. PowerShell 4 and below, as well as
+- **Desktop**, which runs on .NET Framework. PowerShell 4 and below, as well as
   PowerShell 5.1 are available for full-featured Windows editions like Windows Desktop,
   Windows Server, Windows Server Core and most other Windows operating systems. This is the original
   PowerShell edition and is included in the default installation of the operating system.
-- **PowerShell**, which runs on .NET Core. PowerShell 6.0 and later is installed
+- **Core**, which runs on .NET Core. PowerShell 6.0 and later is installed
   side-by-side with earlier PowerShell releases on full-featured Windows editions, some
   reduced-footprint Windows editions such as Windows Nano Server and Windows IoT, or on non-Windows
   platforms such as Linux and MacOs.
-
-PowerShell 6.x included a special naming designation as *PowerShell Core*.
 
 Because the edition of PowerShell corresponds to its .NET runtime, it is the primary indicator
 of .NET API and PowerShell module compatibility; some .NET APIs, types or methods are not available

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -23,7 +23,7 @@ a different .NET runtime. As of PowerShell 6.0 there are two editions of PowerSh
 - **Core**, which runs on .NET Core. PowerShell 6.0 and later is installed
   side-by-side with earlier PowerShell releases on full-featured Windows editions, some
   reduced-footprint Windows editions such as Windows Nano Server and Windows IoT, or on non-Windows
-  platforms such as Linux and MacOs.
+  platforms such as Linux and macOS.
 
 Because the edition of PowerShell corresponds to its .NET runtime, it is the primary indicator
 of .NET API and PowerShell module compatibility; some .NET APIs, types or methods are not available

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -14,15 +14,18 @@ Different editions of PowerShell run on different underlying runtimes.
 ## Long description
 
 From PowerShell 5.1, there are multiple *editions* of PowerShell that each run on
-a different .NET runtime. As of PowerShell 6.2 there are two editions of PowerShell:
+a different .NET runtime. As of PowerShell 6.0 there are two editions of PowerShell:
 
-- **Desktop**, which runs on .NET Framework. PowerShell 4 and below, as well as
-  PowerShell 5.1 on full-featured Windows editions like Windows Desktop, Windows Server,
-  Windows Server Core and most other Windows operating systems are Desktop edition.
-  This is the original PowerShell edition.
-- **Core**, which runs on .NET Core. PowerShell 6.0 and above, as well as PowerShell 5.1 on
-  some reduced-footprint Windows editions such as Windows Nano Server and Windows IoT where
-  .NET Framework is unavailable.
+- **Windows PowerShell**, which runs on .NET Framework. PowerShell 4 and below, as well as
+  PowerShell 5.1 are available for full-featured Windows editions like Windows Desktop,
+  Windows Server, Windows Server Core and most other Windows operating systems. This is the original
+  PowerShell edition and is included in the default installation of the operating system.
+- **PowerShell**, which runs on .NET Core. PowerShell 6.0 and later is installed
+  side-by-side with earlier PowerShell releases on full-featured Windows editions, some
+  reduced-footprint Windows editions such as Windows Nano Server and Windows IoT, or on non-Windows
+  platforms such as Linux and MacOs.
+
+PowerShell 6.x included a special naming designation as *PowerShell Core*.
 
 Because the edition of PowerShell corresponds to its .NET runtime, it is the primary indicator
 of .NET API and PowerShell module compatibility; some .NET APIs, types or methods are not available

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -16,16 +16,14 @@ Different editions of PowerShell run on different underlying runtimes.
 From PowerShell 5.1, there are multiple *editions* of PowerShell that each run on
 a different .NET runtime. As of PowerShell 6.0 there are two editions of PowerShell:
 
-- **Windows PowerShell**, which runs on .NET Framework. PowerShell 4 and below, as well as
+- **Desktop**, which runs on .NET Framework. PowerShell 4 and below, as well as
   PowerShell 5.1 are available for full-featured Windows editions like Windows Desktop,
   Windows Server, Windows Server Core and most other Windows operating systems. This is the original
   PowerShell edition and is included in the default installation of the operating system.
-- **PowerShell**, which runs on .NET Core. PowerShell 6.0 and later is installed
+- **Core**, which runs on .NET Core. PowerShell 6.0 and later is installed
   side-by-side with earlier PowerShell releases on full-featured Windows editions, some
   reduced-footprint Windows editions such as Windows Nano Server and Windows IoT, or on non-Windows
   platforms such as Linux and MacOs.
-
-PowerShell 6.x included a special naming designation as *PowerShell Core*.
 
 Because the edition of PowerShell corresponds to its .NET runtime, it is the primary indicator
 of .NET API and PowerShell module compatibility; some .NET APIs, types or methods are not available


### PR DESCRIPTION
Proposing resolution for two minor issues:

- The original did not clarify that PowerShell 6+ is available for full-featured versions of Windows
- - The original did not clarify that PowerShell 6+ is available cross-platform