### PR TITLE
Update about_Operators.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -288,7 +288,7 @@ $SingleArray = ,1
 Write-Output (,1)
 ```
 
-Since `Write-Object` expects an argument, you must put the expression in
+Since `Write-Output` expects an argument, you must put the expression in
 parentheses.
 
 ### Dot sourcing operator `.`

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -355,7 +355,7 @@ $SingleArray = ,1
 Write-Output (,1)
 ```
 
-Since `Write-Object` expects an argument, you must put the expression in
+Since `Write-Output` expects an argument, you must put the expression in
 parentheses.
 
 ### Dot sourcing operator `.`

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -355,7 +355,7 @@ $SingleArray = ,1
 Write-Output (,1)
 ```
 
-Since `Write-Object` expects an argument, you must put the expression in
+Since `Write-Output` expects an argument, you must put the expression in
 parentheses.
 
 ### Dot sourcing operator `.`

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -355,7 +355,7 @@ $SingleArray = ,1
 Write-Output (,1)
 ```
 
-Since `Write-Object` expects an argument, you must put the expression in
+Since `Write-Output` expects an argument, you must put the expression in
 parentheses.
 
 ### Dot sourcing operator `.`


### PR DESCRIPTION
Fix misprint in cmdlet name

# PR Summary
Write-Object is not recognized as the name of a cmdlet. In code above Write-Output cmdlet is used as an example

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide