### PR TITLE
(GH-9093) Clarify web cmdlet header validation

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 03/25/2022
+ms.date: 08/08/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -98,7 +98,7 @@ deserializes, the content into `[PSCustomObject]` objects.
 This cmdlet is introduced in Windows PowerShell 3.0.
 
 Beginning in PowerShell 7.0, `Invoke-RestMethod` supports proxy configuration defined by environment
-variables. See the [Notes](#notes) section of this article.
+variables. See the [Notes][1] section of this article.
 
 ## EXAMPLES
 
@@ -158,10 +158,9 @@ for the resulting CSV output file.
 
 ### Example 3: Follow relation links
 
-Some REST APIs support pagination via Relation Links per
-[RFC5988](https://tools.ietf.org/html/rfc5988#page-6). Instead of parsing the header to get the URL
-for the next page, you can have the cmdlet do this for you. This example returns the first two pages
-of issues from the PowerShell GitHub repository.
+Some REST APIs support pagination via Relation Links per [RFC5988][2]. Instead of parsing the header
+to get the URL for the next page, you can have the cmdlet do this for you. This example returns the
+first two pages of issues from the PowerShell GitHub repository.
 
 ```powershell
 $url = 'https://api.github.com/repos/powershell/powershell/issues'
@@ -240,6 +239,47 @@ Invoke-RestMethod -Uri $uri | Write-Output | ForEach-Object { $x++ }
 $x
 30
 ```
+
+### Example 7: Skipping Header Validation
+
+By default, the `Invoke-RestMethod` cmdlet validates the values of well-known headers that have a
+standardards-defined value format. The following example shows how this validation can raise an
+error and how you can use the **SkipHeaderValidation** parameter to avoid validating values for
+endpoints that tolerate invalidly formatted values.
+
+```powershell
+$Uri = 'https://httpbin.org/headers'
+$InvalidHeaders = @{
+    'If-Match' = '12345'
+}
+
+Invoke-RestMethod -Uri $Uri -Headers $InvalidHeaders
+
+Invoke-RestMethod -Uri $Uri -Headers $InvalidHeaders -SkipHeaderValidation |
+    Format-List
+```
+
+```Output
+Invoke-RestMethod: The format of value '12345' is invalid.
+
+headers : @{Host=httpbin.org; If-Match=12345; User-Agent=Mozilla/5.0 (Windows NT 10.0; Microsoft Windows
+          10.0.19044; en-US) PowerShell/7.2.5;  X-Amzn-Trace-Id=Root=1-62f150a6-27754fd4226f31b43a3d2874}
+```
+
+[httpbin.org][3] is a service that returns information about web requests and responses for
+troubleshooting. The `$Uri` variable is assigned to the `/headers` endpoint of the service, which
+returns a request's headers as the content in its response.
+
+The `If-Match` request header is defined in [RFC-7232 section 3.1][4] and requires the value for
+that header to be defined with surrounding quotes. The `$InvalidHeaders` variable is assigned a hash
+table where the value of `If-Match` is invalid because it's defined as `12345` instead of `"12345"`.
+
+Calling `Invoke-RestMethod` with the invalid headers returns an error reporting that the formatted
+value is invalid. The request is not sent to the endpoint.
+
+Calling `Invoke-RestMethod` with the **SkipHeaderValidation** parameter ignores the validation
+failure and sends the request to the endpoint. Because the endpoint tolerates non-compliant header
+values, the cmdlet returns the response object without error.
 
 ## PARAMETERS
 
@@ -418,12 +458,11 @@ options. When used alone, it will only supply credentials to the remote server i
 sends an authentication challenge request. When used with **Authentication** options, the
 credentials will be explicitly sent.
 
-Credentials are stored in a [PSCredential](/dotnet/api/system.management.automation.pscredential)
-object and the password is stored as a [SecureString](/dotnet/api/system.security.securestring).
+Credentials are stored in a [PSCredential][5] object and the password is stored as a
+[SecureString][6].
 
 > [!NOTE]
-> For more information about **SecureString** data protection, see
-> [How secure is SecureString?](/dotnet/api/system.security.securestring#how-secure-is-securestring).
+> For more information about **SecureString** data protection, see [How secure is SecureString?][7].
 
 ```yaml
 Type: System.Management.Automation.PSCredential
@@ -485,10 +524,9 @@ Accept wildcard characters: False
 
 Indicates the cmdlet should follow relation links.
 
-Some REST APIs support pagination via Relation Links per
-[RFC5988](https://tools.ietf.org/html/rfc5988#page-6). Instead of parsing the header to get the URL
-for the next page, you can have the cmdlet do this for you. To set how many times to follow relation
-links, use the **MaximumFollowRelLink** parameter.
+Some REST APIs support pagination via Relation Links per [RFC5988][8]. Instead of parsing the header
+to get the URL for the next page, you can have the cmdlet do this for you. To set how many times to
+follow relation links, use the **MaximumFollowRelLink** parameter.
 
 When using this switch, the cmdlet returns a collection of pages of results. Each page of results
 may contain multiple result items.
@@ -728,8 +766,7 @@ is to have the results written to the file and to the pipeline.
 
 > [!NOTE]
 > When you use the **PassThru** parameter, the output is written to the pipeline but the file is not
-> created. For more information, see
-> [PowerShell Issue #15409](https://github.com/PowerShell/PowerShell/issues/15409).
+> created. For more information, see [PowerShell Issue #15409][9].
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -969,8 +1006,8 @@ This switch should be used for sites that require header values that do not conf
 Specifying this switch disables validation to allow the value to be passed unchecked. When
 specified, all headers are added without validation.
 
-This will disable validation for values passed to the **ContentType**, **Headers**, and **UserAgent**
-parameters.
+This will disable validation for values passed to the **ContentType**, **Headers**, and
+**UserAgent** parameters.
 
 This feature was added in PowerShell 6.0.0.
 
@@ -1192,8 +1229,8 @@ The default user agent is similar to
 variations for each operating system and platform.
 
 To test a website with the standard user agent string that is used by most internet browsers, use
-the properties of the [PSUserAgent](/dotnet/api/microsoft.powershell.commands.psuseragent) class,
-such as Chrome, FireFox, InternetExplorer, Opera, and Safari.
+the properties of the [PSUserAgent][10] class, such as Chrome, FireFox, InternetExplorer, Opera, and
+Safari.
 
 ```yaml
 Type: System.String
@@ -1244,8 +1281,7 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters][11].
 
 ## INPUTS
 
@@ -1269,8 +1305,7 @@ strings.
 Some features may not be available on all platforms.
 
 Because of changes in .NET Core 3.1, PowerShell 7.0 and higher use the
-[HttpClient.DefaultProxy](/dotnet/api/system.net.http.httpclient.defaultproxy?view=netcore-3.1)
-property to determine the proxy configuration.
+[HttpClient.DefaultProxy][12] property to determine the proxy configuration.
 
 The value of this property is different rules depending on your platform:
 
@@ -1292,8 +1327,25 @@ are:
 
 ## RELATED LINKS
 
-[ConvertTo-Json](ConvertTo-Json.md)
+[ConvertTo-Json][13]
 
-[ConvertFrom-Json](ConvertFrom-Json.md)
+[ConvertFrom-Json][14]
 
-[Invoke-WebRequest](Invoke-WebRequest.md)
+[Invoke-WebRequest][15]
+
+<!-- Reference Links -->
+[1]: #notes
+[2]: https://tools.ietf.org/html/rfc5988#page-6
+[3]: https://httpbin.org/
+[4]: https://www.rfc-editor.org/rfc/rfc7232.html#section-3.1
+[5]: /dotnet/api/system.management.automation.pscredential
+[6]: /dotnet/api/system.security.securestring
+[7]: /dotnet/api/system.security.securestring#how-secure-is-securestring
+[8]: https://tools.ietf.org/html/rfc5988#page-6
+[9]: https://github.com/PowerShell/PowerShell/issues/15409
+[10]: /dotnet/api/microsoft.powershell.commands.psuseragent
+[11]: https://go.microsoft.com/fwlink/?LinkID=113216
+[12]: /dotnet/api/system.net.http.httpclient.defaultproxy?view=netcore-3.1
+[13]: ConvertTo-Json.md
+[14]: ConvertFrom-Json.md
+[15]: Invoke-WebRequest.md

--- a/reference/7.0/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 07/29/2022
+ms.date: 08/08/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -85,12 +85,12 @@ the response and returns collections of links, images, and other significant HTM
 This cmdlet was introduced in PowerShell 3.0.
 
 Beginning in PowerShell 7.0, `Invoke-WebRequest` supports proxy configuration defined by environment
-variables. See the [Notes](#notes) section of this article.
+variables. See the [Notes][1] section of this article.
 
 > [!IMPORTANT]
 > The examples in this article reference hosts in the `contoso.com` domain. This is a fictitious
 > domain used by Microsoft for examples. The examples are designed to show how to use the cmdlets.
-> However, since the `contoso.com` sites do not exist, the examples do not work. Adapt the examples
+> However, since the `contoso.com` sites don't exist, the examples don't work. Adapt the examples
 > to hosts in your environment.
 
 ## EXAMPLES
@@ -123,11 +123,16 @@ filtered results are piped to `Select-Object` to select the **Name** and **Value
 This example shows how to use the `Invoke-WebRequest` cmdlet with a stateful web service.
 
 ```powershell
-$Body = @{
-    User = 'jdoe'
-    password = 'P@S$w0rd!'
+$LoginParameters = @{
+    Uri             = 'https://www.contoso.com/login/'
+    SessionVariable = 'Session'
+    Method          = 'POST'
+    Body            = @{
+        User     = 'jdoe'
+        Password = 'P@S$w0rd!'
+    }
 }
-$LoginResponse = Invoke-WebRequest 'https://www.contoso.com/login/' -SessionVariable 'Session' -Body $Body -Method 'POST'
+$LoginResponse = Invoke-WebRequest @LoginParameters
 $ProfileResponse = Invoke-WebRequest 'https://www.contoso.com/profile/' -WebSession $Session
 ```
 
@@ -160,8 +165,7 @@ $Response = Invoke-WebRequest -Uri "https://aka.ms/pscore6-docs"
 $Stream = [System.IO.StreamWriter]::new('.\docspage.html', $false, $Response.Encoding)
 try {
     $Stream.Write($Response.Content)
-}
-finally {
+} finally {
     $Stream.Dispose()
 }
 ```
@@ -246,9 +250,7 @@ try
     $Response = Invoke-WebRequest -Uri "www.microsoft.com/unkownhost"
     # This will only execute if the Invoke-WebRequest is successful.
     $StatusCode = $Response.StatusCode
-}
-catch
-{
+} catch {
     $StatusCode = $_.Exception.Response.StatusCode.value__
 }
 $StatusCode
@@ -303,6 +305,65 @@ foreach ($job in $jobs) {
     Receive-Job -Job $job
 }
 ```
+
+### Example 9: Skipping Header Validation
+
+By default, the `Invoke-WebRequest` cmdlet validates the values of well-known headers that have a
+standardards-defined value format. The following example shows how this validation can raise an
+error and how you can use the **SkipHeaderValidation** parameter to avoid validating values for
+endpoints that tolerate invalidly formatted values.
+
+```powershell
+$Uri = 'https://httpbin.org/headers'
+$InvalidHeaders = @{
+    'If-Match' = '12345'
+}
+
+Invoke-WebRequest -Uri $Uri -Headers $InvalidHeaders
+
+Invoke-WebRequest -Uri $Uri -Headers $InvalidHeaders -SkipHeaderValidation
+```
+
+```Output
+Invoke-WebRequest: The format of value '12345' is invalid.
+
+StatusCode        : 200
+StatusDescription : OK
+Content           : {
+                      "headers": {
+                        "Host": "httpbin.org",
+                        "If-Match": "12345",
+                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.19044; en-US) PowerShell/7.2.5",
+                        "X-Amzn-Trace-Id": …
+RawContent        : HTTP/1.1 200 OK
+                    Date: Mon, 08 Aug 2022 16:24:24 GMT
+                    Connection: keep-alive
+                    Server: gunicorn/19.9.0
+                    Access-Control-Allow-Origin: *
+                    Access-Control-Allow-Credentials: true
+                    Content-Type: application…
+Headers           : {[Date, System.String[]], [Connection, System.String[]], [Server, System.String[]], [Access-Control-Allow-Origin, System.String[]]…}
+Images            : {}
+InputFields       : {}
+Links             : {}
+RawContentLength  : 249
+RelationLink      : {}
+```
+
+[httpbin.org][2] is a service that returns information about web requests and responses for
+troubleshooting. The `$Uri` variable is assigned to the `/headers` endpoint of the service, which
+returns a request's headers as the content in its response.
+
+The `If-Match` request header is defined in [RFC-7232 section 3.1][3] and requires the value for
+that header to be defined with surrounding quotes. The `$InvalidHeaders` variable is assigned a hash
+table where the value of `If-Match` is invalid because it's defined as `12345` instead of `"12345"`.
+
+Calling `Invoke-WebRequest` with the invalid headers returns an error reporting that the formatted
+value is invalid. The request is not sent to the endpoint.
+
+Calling `Invoke-WebRequest` with the **SkipHeaderValidation** parameter ignores the validation
+failure and sends the request to the endpoint. Because the endpoint tolerates non-compliant header
+values, the cmdlet returns the response object without error.
 
 ## PARAMETERS
 
@@ -477,12 +538,11 @@ options. When used alone, it only supplies credentials to the remote server if t
 sends an authentication challenge request. When used with **Authentication** options, the
 credentials are explicitly sent.
 
-Credentials are stored in a [PSCredential](/dotnet/api/system.management.automation.pscredential)
-object and the password is stored as a [SecureString](/dotnet/api/system.security.securestring).
+Credentials are stored in a [PSCredential][4] object and the password is stored as a
+[SecureString][5].
 
 > [!NOTE]
-> For more information about **SecureString** data protection, see
-> [How secure is SecureString?](/dotnet/api/system.security.securestring#how-secure-is-securestring).
+> For more information about **SecureString** data protection, see [How secure is SecureString?][6].
 
 ```yaml
 Type: System.Management.Automation.PSCredential
@@ -1149,9 +1209,9 @@ The default user agent is similar to
 `Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.15063; en-US) PowerShell/6.0.0` with slight
 variations for each operating system and platform.
 
-To test a website with the standard user agent string that's used by most internet browsers, use
-the properties of the [PSUserAgent](/dotnet/api/microsoft.powershell.commands.psuseragent) class,
-such as Chrome, FireFox, InternetExplorer, Opera, and Safari.
+To test a website with the standard user agent string that's used by most internet browsers, use the
+properties of the [PSUserAgent][7] class, such as Chrome, FireFox, InternetExplorer, Opera, and
+Safari.
 
 For example, the following command uses the user agent string for Internet Explorer:
 `Invoke-WebRequest -Uri https://website.com/ -UserAgent ([Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer)`
@@ -1205,8 +1265,7 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters][8].
 
 ## INPUTS
 
@@ -1222,12 +1281,10 @@ You can pipe the body of a web request to `Invoke-WebRequest`.
 
 Beginning with PowerShell 6.0.0 `Invoke-WebRequest` supports basic parsing only.
 
-For more information, see
-[BasicHtmlWebResponseObject](/dotnet/api/microsoft.powershell.commands.basichtmlwebresponseobject).
+For more information, see [BasicHtmlWebResponseObject][9].
 
 Because of changes in .NET Core 3.1, PowerShell 7.0 and higher use the
-[HttpClient.DefaultProxy](/dotnet/api/system.net.http.httpclient.defaultproxy?view=netcore-3.1)
-Property to determine the proxy configuration.
+[HttpClient.DefaultProxy][10] Property to determine the proxy configuration.
 
 The value of this property is determined by your platform:
 
@@ -1249,8 +1306,23 @@ are:
 
 ## RELATED LINKS
 
-[Invoke-RestMethod](Invoke-RestMethod.md)
+[Invoke-RestMethod][11]
 
-[ConvertFrom-Json](ConvertFrom-Json.md)
+[ConvertFrom-Json][12]
 
-[ConvertTo-Json](ConvertTo-Json.md)
+[ConvertTo-Json][13]
+
+<!-- Reference Links -->
+[1]: #notes
+[2]: https://httpbin.org/
+[3]: https://www.rfc-editor.org/rfc/rfc7232.html#section-3.1
+[4]: /dotnet/api/system.management.automation.pscredential
+[5]: /dotnet/api/system.security.securestring
+[6]: /dotnet/api/system.security.securestring#how-secure-is-securestring
+[7]: /dotnet/api/microsoft.powershell.commands.psuseragent
+[8]: https://go.microsoft.com/fwlink/?LinkID=113216
+[9]: /dotnet/api/microsoft.powershell.commands.basichtmlwebresponseobject
+[10]: /dotnet/api/system.net.http.httpclient.defaultproxy?view=netcore-3.1
+[11]: Invoke-RestMethod.md
+[12]: ConvertFrom-Json.md
+[13]: ConvertTo-Json.md

--- a/reference/7.2/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 03/25/2022
+ms.date: 08/08/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -98,7 +98,7 @@ deserializes, the content into `[PSCustomObject]` objects.
 This cmdlet is introduced in Windows PowerShell 3.0.
 
 Beginning in PowerShell 7.0, `Invoke-RestMethod` supports proxy configuration defined by environment
-variables. See the [Notes](#notes) section of this article.
+variables. See the [Notes][1] section of this article.
 
 ## EXAMPLES
 
@@ -158,10 +158,9 @@ for the resulting CSV output file.
 
 ### Example 3: Follow relation links
 
-Some REST APIs support pagination via Relation Links per
-[RFC5988](https://tools.ietf.org/html/rfc5988#page-6). Instead of parsing the header to get the URL
-for the next page, you can have the cmdlet do this for you. This example returns the first two pages
-of issues from the PowerShell GitHub repository.
+Some REST APIs support pagination via Relation Links per [RFC5988][2]. Instead of parsing the header
+to get the URL for the next page, you can have the cmdlet do this for you. This example returns the
+first two pages of issues from the PowerShell GitHub repository.
 
 ```powershell
 $url = 'https://api.github.com/repos/powershell/powershell/issues'
@@ -240,6 +239,47 @@ Invoke-RestMethod -Uri $uri | Write-Output | ForEach-Object { $x++ }
 $x
 30
 ```
+
+### Example 7: Skipping Header Validation
+
+By default, the `Invoke-RestMethod` cmdlet validates the values of well-known headers that have a
+standardards-defined value format. The following example shows how this validation can raise an
+error and how you can use the **SkipHeaderValidation** parameter to avoid validating values for
+endpoints that tolerate invalidly formatted values.
+
+```powershell
+$Uri = 'https://httpbin.org/headers'
+$InvalidHeaders = @{
+    'If-Match' = '12345'
+}
+
+Invoke-RestMethod -Uri $Uri -Headers $InvalidHeaders
+
+Invoke-RestMethod -Uri $Uri -Headers $InvalidHeaders -SkipHeaderValidation |
+    Format-List
+```
+
+```Output
+Invoke-RestMethod: The format of value '12345' is invalid.
+
+headers : @{Host=httpbin.org; If-Match=12345; User-Agent=Mozilla/5.0 (Windows NT 10.0; Microsoft Windows
+          10.0.19044; en-US) PowerShell/7.2.5;  X-Amzn-Trace-Id=Root=1-62f150a6-27754fd4226f31b43a3d2874}
+```
+
+[httpbin.org][3] is a service that returns information about web requests and responses for
+troubleshooting. The `$Uri` variable is assigned to the `/headers` endpoint of the service, which
+returns a request's headers as the content in its response.
+
+The `If-Match` request header is defined in [RFC-7232 section 3.1][4] and requires the value for
+that header to be defined with surrounding quotes. The `$InvalidHeaders` variable is assigned a hash
+table where the value of `If-Match` is invalid because it's defined as `12345` instead of `"12345"`.
+
+Calling `Invoke-RestMethod` with the invalid headers returns an error reporting that the formatted
+value is invalid. The request is not sent to the endpoint.
+
+Calling `Invoke-RestMethod` with the **SkipHeaderValidation** parameter ignores the validation
+failure and sends the request to the endpoint. Because the endpoint tolerates non-compliant header
+values, the cmdlet returns the response object without error.
 
 ## PARAMETERS
 
@@ -418,12 +458,11 @@ options. When used alone, it will only supply credentials to the remote server i
 sends an authentication challenge request. When used with **Authentication** options, the
 credentials will be explicitly sent.
 
-Credentials are stored in a [PSCredential](/dotnet/api/system.management.automation.pscredential)
-object and the password is stored as a [SecureString](/dotnet/api/system.security.securestring).
+Credentials are stored in a [PSCredential][5] object and the password is stored as a
+[SecureString][6].
 
 > [!NOTE]
-> For more information about **SecureString** data protection, see
-> [How secure is SecureString?](/dotnet/api/system.security.securestring#how-secure-is-securestring).
+> For more information about **SecureString** data protection, see [How secure is SecureString?][7].
 
 ```yaml
 Type: System.Management.Automation.PSCredential
@@ -485,10 +524,9 @@ Accept wildcard characters: False
 
 Indicates the cmdlet should follow relation links.
 
-Some REST APIs support pagination via Relation Links per
-[RFC5988](https://tools.ietf.org/html/rfc5988#page-6). Instead of parsing the header to get the URL
-for the next page, you can have the cmdlet do this for you. To set how many times to follow relation
-links, use the **MaximumFollowRelLink** parameter.
+Some REST APIs support pagination via Relation Links per [RFC5988][8]. Instead of parsing the header
+to get the URL for the next page, you can have the cmdlet do this for you. To set how many times to
+follow relation links, use the **MaximumFollowRelLink** parameter.
 
 When using this switch, the cmdlet returns a collection of pages of results. Each page of results
 may contain multiple result items.
@@ -729,8 +767,7 @@ is to have the results written to the file and to the pipeline.
 
 > [!NOTE]
 > When you use the **PassThru** parameter, the output is written to the pipeline but the file is not
-> created. For more information, see
-> [PowerShell Issue #15409](https://github.com/PowerShell/PowerShell/issues/15409).
+> created. For more information, see [PowerShell Issue #15409][9].
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -970,8 +1007,8 @@ This switch should be used for sites that require header values that do not conf
 Specifying this switch disables validation to allow the value to be passed unchecked. When
 specified, all headers are added without validation.
 
-This will disable validation for values passed to the **ContentType**, **Headers**, and **UserAgent**
-parameters.
+This will disable validation for values passed to the **ContentType**, **Headers**, and
+**UserAgent** parameters.
 
 This feature was added in PowerShell 6.0.0.
 
@@ -1197,8 +1234,8 @@ The default user agent is similar to
 variations for each operating system and platform.
 
 To test a website with the standard user agent string that is used by most internet browsers, use
-the properties of the [PSUserAgent](/dotnet/api/microsoft.powershell.commands.psuseragent) class,
-such as Chrome, FireFox, InternetExplorer, Opera, and Safari.
+the properties of the [PSUserAgent][10] class, such as Chrome, FireFox, InternetExplorer, Opera, and
+Safari.
 
 ```yaml
 Type: System.String
@@ -1249,8 +1286,7 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters][11].
 
 ## INPUTS
 
@@ -1274,8 +1310,7 @@ strings.
 Some features may not be available on all platforms.
 
 Because of changes in .NET Core 3.1, PowerShell 7.0 and higher use the
-[HttpClient.DefaultProxy](/dotnet/api/system.net.http.httpclient.defaultproxy?view=netcore-3.1)
-property to determine the proxy configuration.
+[HttpClient.DefaultProxy][12] property to determine the proxy configuration.
 
 The value of this property is different rules depending on your platform:
 
@@ -1297,8 +1332,25 @@ are:
 
 ## RELATED LINKS
 
-[ConvertTo-Json](ConvertTo-Json.md)
+[ConvertTo-Json][13]
 
-[ConvertFrom-Json](ConvertFrom-Json.md)
+[ConvertFrom-Json][14]
 
-[Invoke-WebRequest](Invoke-WebRequest.md)
+[Invoke-WebRequest][15]
+
+<!-- Reference Links -->
+[1]: #notes
+[2]: https://tools.ietf.org/html/rfc5988#page-6
+[3]: https://httpbin.org/
+[4]: https://www.rfc-editor.org/rfc/rfc7232.html#section-3.1
+[5]: /dotnet/api/system.management.automation.pscredential
+[6]: /dotnet/api/system.security.securestring
+[7]: /dotnet/api/system.security.securestring#how-secure-is-securestring
+[8]: https://tools.ietf.org/html/rfc5988#page-6
+[9]: https://github.com/PowerShell/PowerShell/issues/15409
+[10]: /dotnet/api/microsoft.powershell.commands.psuseragent
+[11]: https://go.microsoft.com/fwlink/?LinkID=113216
+[12]: /dotnet/api/system.net.http.httpclient.defaultproxy?view=netcore-3.1
+[13]: ConvertTo-Json.md
+[14]: ConvertFrom-Json.md
+[15]: Invoke-WebRequest.md

--- a/reference/7.2/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 07/29/2022
+ms.date: 08/08/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -85,7 +85,7 @@ the response and returns collections of links, images, and other significant HTM
 This cmdlet was introduced in PowerShell 3.0.
 
 Beginning in PowerShell 7.0, `Invoke-WebRequest` supports proxy configuration defined by environment
-variables. See the [Notes](#notes) section of this article.
+variables. See the [Notes][1] section of this article.
 
 > [!IMPORTANT]
 > The examples in this article reference hosts in the `contoso.com` domain. This is a fictitious
@@ -123,11 +123,16 @@ filtered results are piped to `Select-Object` to select the **Name** and **Value
 This example shows how to use the `Invoke-WebRequest` cmdlet with a stateful web service.
 
 ```powershell
-$Body = @{
-    User = 'jdoe'
-    password = 'P@S$w0rd!'
+$LoginParameters = @{
+    Uri             = 'https://www.contoso.com/login/'
+    SessionVariable = 'Session'
+    Method          = 'POST'
+    Body            = @{
+        User     = 'jdoe'
+        Password = 'P@S$w0rd!'
+    }
 }
-$LoginResponse = Invoke-WebRequest 'https://www.contoso.com/login/' -SessionVariable 'Session' -Body $Body -Method 'POST'
+$LoginResponse = Invoke-WebRequest @LoginParameters
 $ProfileResponse = Invoke-WebRequest 'https://www.contoso.com/profile/' -WebSession $Session
 ```
 
@@ -160,8 +165,7 @@ $Response = Invoke-WebRequest -Uri "https://aka.ms/pscore6-docs"
 $Stream = [System.IO.StreamWriter]::new('.\docspage.html', $false, $Response.Encoding)
 try {
     $Stream.Write($Response.Content)
-}
-finally {
+} finally {
     $Stream.Dispose()
 }
 ```
@@ -246,9 +250,7 @@ try
     $Response = Invoke-WebRequest -Uri "www.microsoft.com/unkownhost"
     # This will only execute if the Invoke-WebRequest is successful.
     $StatusCode = $Response.StatusCode
-}
-catch
-{
+} catch {
     $StatusCode = $_.Exception.Response.StatusCode.value__
 }
 $StatusCode
@@ -303,6 +305,65 @@ foreach ($job in $jobs) {
     Receive-Job -Job $job
 }
 ```
+
+### Example 9: Skipping Header Validation
+
+By default, the `Invoke-WebRequest` cmdlet validates the values of well-known headers that have a
+standardards-defined value format. The following example shows how this validation can raise an
+error and how you can use the **SkipHeaderValidation** parameter to avoid validating values for
+endpoints that tolerate invalidly formatted values.
+
+```powershell
+$Uri = 'https://httpbin.org/headers'
+$InvalidHeaders = @{
+    'If-Match' = '12345'
+}
+
+Invoke-WebRequest -Uri $Uri -Headers $InvalidHeaders
+
+Invoke-WebRequest -Uri $Uri -Headers $InvalidHeaders -SkipHeaderValidation
+```
+
+```Output
+Invoke-WebRequest: The format of value '12345' is invalid.
+
+StatusCode        : 200
+StatusDescription : OK
+Content           : {
+                      "headers": {
+                        "Host": "httpbin.org",
+                        "If-Match": "12345",
+                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.19044; en-US) PowerShell/7.2.5",
+                        "X-Amzn-Trace-Id": …
+RawContent        : HTTP/1.1 200 OK
+                    Date: Mon, 08 Aug 2022 16:24:24 GMT
+                    Connection: keep-alive
+                    Server: gunicorn/19.9.0
+                    Access-Control-Allow-Origin: *
+                    Access-Control-Allow-Credentials: true
+                    Content-Type: application…
+Headers           : {[Date, System.String[]], [Connection, System.String[]], [Server, System.String[]], [Access-Control-Allow-Origin, System.String[]]…}
+Images            : {}
+InputFields       : {}
+Links             : {}
+RawContentLength  : 249
+RelationLink      : {}
+```
+
+[httpbin.org][2] is a service that returns information about web requests and responses for
+troubleshooting. The `$Uri` variable is assigned to the `/headers` endpoint of the service, which
+returns a request's headers as the content in its response.
+
+The `If-Match` request header is defined in [RFC-7232 section 3.1][3] and requires the value for
+that header to be defined with surrounding quotes. The `$InvalidHeaders` variable is assigned a hash
+table where the value of `If-Match` is invalid because it's defined as `12345` instead of `"12345"`.
+
+Calling `Invoke-WebRequest` with the invalid headers returns an error reporting that the formatted
+value is invalid. The request is not sent to the endpoint.
+
+Calling `Invoke-WebRequest` with the **SkipHeaderValidation** parameter ignores the validation
+failure and sends the request to the endpoint. Because the endpoint tolerates non-compliant header
+values, the cmdlet returns the response object without error.
 
 ## PARAMETERS
 
@@ -477,12 +538,11 @@ options. When used alone, it only supplies credentials to the remote server if t
 sends an authentication challenge request. When used with **Authentication** options, the
 credentials are explicitly sent.
 
-Credentials are stored in a [PSCredential](/dotnet/api/system.management.automation.pscredential)
-object and the password is stored as a [SecureString](/dotnet/api/system.security.securestring).
+Credentials are stored in a [PSCredential][4] object and the password is stored as a
+[SecureString][5].
 
 > [!NOTE]
-> For more information about **SecureString** data protection, see
-> [How secure is SecureString?](/dotnet/api/system.security.securestring#how-secure-is-securestring).
+> For more information about **SecureString** data protection, see [How secure is SecureString?][6].
 
 ```yaml
 Type: System.Management.Automation.PSCredential
@@ -1152,9 +1212,9 @@ The default user agent is similar to
 `Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.15063; en-US) PowerShell/6.0.0` with slight
 variations for each operating system and platform.
 
-To test a website with the standard user agent string that's used by most internet browsers, use
-the properties of the [PSUserAgent](/dotnet/api/microsoft.powershell.commands.psuseragent) class,
-such as Chrome, FireFox, InternetExplorer, Opera, and Safari.
+To test a website with the standard user agent string that's used by most internet browsers, use the
+properties of the [PSUserAgent][7] class, such as Chrome, FireFox, InternetExplorer, Opera, and
+Safari.
 
 For example, the following command uses the user agent string for Internet Explorer:
 `Invoke-WebRequest -Uri https://website.com/ -UserAgent ([Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer)`
@@ -1208,8 +1268,7 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters][8].
 
 ## INPUTS
 
@@ -1225,12 +1284,10 @@ You can pipe the body of a web request to `Invoke-WebRequest`.
 
 Beginning with PowerShell 6.0.0 `Invoke-WebRequest` supports basic parsing only.
 
-For more information, see
-[BasicHtmlWebResponseObject](/dotnet/api/microsoft.powershell.commands.basichtmlwebresponseobject).
+For more information, see [BasicHtmlWebResponseObject][9].
 
 Because of changes in .NET Core 3.1, PowerShell 7.0 and higher use the
-[HttpClient.DefaultProxy](/dotnet/api/system.net.http.httpclient.defaultproxy?view=netcore-3.1)
-Property to determine the proxy configuration.
+[HttpClient.DefaultProxy][10] Property to determine the proxy configuration.
 
 The value of this property is determined by your platform:
 
@@ -1252,8 +1309,23 @@ are:
 
 ## RELATED LINKS
 
-[Invoke-RestMethod](Invoke-RestMethod.md)
+[Invoke-RestMethod][11]
 
-[ConvertFrom-Json](ConvertFrom-Json.md)
+[ConvertFrom-Json][12]
 
-[ConvertTo-Json](ConvertTo-Json.md)
+[ConvertTo-Json][13]
+
+<!-- Reference Links -->
+[1]: #notes
+[2]: https://httpbin.org/
+[3]: https://www.rfc-editor.org/rfc/rfc7232.html#section-3.1
+[4]: /dotnet/api/system.management.automation.pscredential
+[5]: /dotnet/api/system.security.securestring
+[6]: /dotnet/api/system.security.securestring#how-secure-is-securestring
+[7]: /dotnet/api/microsoft.powershell.commands.psuseragent
+[8]: https://go.microsoft.com/fwlink/?LinkID=113216
+[9]: /dotnet/api/microsoft.powershell.commands.basichtmlwebresponseobject
+[10]: /dotnet/api/system.net.http.httpclient.defaultproxy?view=netcore-3.1
+[11]: Invoke-RestMethod.md
+[12]: ConvertFrom-Json.md
+[13]: ConvertTo-Json.md

--- a/reference/7.3/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 03/25/2022
+ms.date: 08/08/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -102,7 +102,7 @@ deserializes, the content into `[PSCustomObject]` objects.
 This cmdlet is introduced in Windows PowerShell 3.0.
 
 Beginning in PowerShell 7.0, `Invoke-RestMethod` supports proxy configuration defined by environment
-variables. See the [Notes](#notes) section of this article.
+variables. See the [Notes][1] section of this article.
 
 ## EXAMPLES
 
@@ -162,10 +162,9 @@ for the resulting CSV output file.
 
 ### Example 3: Follow relation links
 
-Some REST APIs support pagination via Relation Links per
-[RFC5988](https://tools.ietf.org/html/rfc5988#page-6). Instead of parsing the header to get the URL
-for the next page, you can have the cmdlet do this for you. This example returns the first two pages
-of issues from the PowerShell GitHub repository.
+Some REST APIs support pagination via Relation Links per [RFC5988][2]. Instead of parsing the header
+to get the URL for the next page, you can have the cmdlet do this for you. This example returns the
+first two pages of issues from the PowerShell GitHub repository.
 
 ```powershell
 $url = 'https://api.github.com/repos/powershell/powershell/issues'
@@ -245,7 +244,48 @@ $x
 30
 ```
 
-### Example 7: Send a request using HTTP 2.0
+### Example 7: Skipping Header Validation
+
+By default, the `Invoke-RestMethod` cmdlet validates the values of well-known headers that have a
+standardards-defined value format. The following example shows how this validation can raise an
+error and how you can use the **SkipHeaderValidation** parameter to avoid validating values for
+endpoints that tolerate invalidly formatted values.
+
+```powershell
+$Uri = 'https://httpbin.org/headers'
+$InvalidHeaders = @{
+    'If-Match' = '12345'
+}
+
+Invoke-RestMethod -Uri $Uri -Headers $InvalidHeaders
+
+Invoke-RestMethod -Uri $Uri -Headers $InvalidHeaders -SkipHeaderValidation |
+    Format-List
+```
+
+```Output
+Invoke-RestMethod: The format of value '12345' is invalid.
+
+headers : @{Host=httpbin.org; If-Match=12345; User-Agent=Mozilla/5.0 (Windows NT 10.0; Microsoft Windows
+          10.0.19044; en-US) PowerShell/7.2.5;  X-Amzn-Trace-Id=Root=1-62f150a6-27754fd4226f31b43a3d2874}
+```
+
+[httpbin.org][3] is a service that returns information about web requests and responses for
+troubleshooting. The `$Uri` variable is assigned to the `/headers` endpoint of the service, which
+returns a request's headers as the content in its response.
+
+The `If-Match` request header is defined in [RFC-7232 section 3.1][4] and requires the value for
+that header to be defined with surrounding quotes. The `$InvalidHeaders` variable is assigned a hash
+table where the value of `If-Match` is invalid because it's defined as `12345` instead of `"12345"`.
+
+Calling `Invoke-RestMethod` with the invalid headers returns an error reporting that the formatted
+value is invalid. The request is not sent to the endpoint.
+
+Calling `Invoke-RestMethod` with the **SkipHeaderValidation** parameter ignores the validation
+failure and sends the request to the endpoint. Because the endpoint tolerates non-compliant header
+values, the cmdlet returns the response object without error.
+
+### Example 8: Send a request using HTTP 2.0
 
 This example queries for GitHub issue using the HTTP 2.0 protocol.
 
@@ -431,12 +471,11 @@ options. When used alone, it will only supply credentials to the remote server i
 sends an authentication challenge request. When used with **Authentication** options, the
 credentials will be explicitly sent.
 
-Credentials are stored in a [PSCredential](/dotnet/api/system.management.automation.pscredential)
-object and the password is stored as a [SecureString](/dotnet/api/system.security.securestring).
+Credentials are stored in a [PSCredential][5] object and the password is stored as a
+[SecureString][6].
 
 > [!NOTE]
-> For more information about **SecureString** data protection, see
-> [How secure is SecureString?](/dotnet/api/system.security.securestring#how-secure-is-securestring).
+> For more information about **SecureString** data protection, see [How secure is SecureString?][7].
 
 ```yaml
 Type: System.Management.Automation.PSCredential
@@ -498,10 +537,9 @@ Accept wildcard characters: False
 
 Indicates the cmdlet should follow relation links.
 
-Some REST APIs support pagination via Relation Links per
-[RFC5988](https://tools.ietf.org/html/rfc5988#page-6). Instead of parsing the header to get the URL
-for the next page, you can have the cmdlet do this for you. To set how many times to follow relation
-links, use the **MaximumFollowRelLink** parameter.
+Some REST APIs support pagination via Relation Links per [RFC5988][8]. Instead of parsing the header
+to get the URL for the next page, you can have the cmdlet do this for you. To set how many times to
+follow relation links, use the **MaximumFollowRelLink** parameter.
 
 When using this switch, the cmdlet returns a collection of pages of results. Each page of results
 may contain multiple result items.
@@ -765,8 +803,7 @@ is to have the results written to the file and to the pipeline.
 
 > [!NOTE]
 > When you use the **PassThru** parameter, the output is written to the pipeline but the file is not
-> created. For more information, see
-> [PowerShell Issue #15409](https://github.com/PowerShell/PowerShell/issues/15409).
+> created. For more information, see [PowerShell Issue #15409][9].
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -1006,8 +1043,8 @@ This switch should be used for sites that require header values that do not conf
 Specifying this switch disables validation to allow the value to be passed unchecked. When
 specified, all headers are added without validation.
 
-This will disable validation for values passed to the **ContentType**, **Headers**, and **UserAgent**
-parameters.
+This will disable validation for values passed to the **ContentType**, **Headers**, and
+**UserAgent** parameters.
 
 This feature was added in PowerShell 6.0.0.
 
@@ -1233,8 +1270,8 @@ The default user agent is similar to
 variations for each operating system and platform.
 
 To test a website with the standard user agent string that is used by most internet browsers, use
-the properties of the [PSUserAgent](/dotnet/api/microsoft.powershell.commands.psuseragent) class,
-such as Chrome, FireFox, InternetExplorer, Opera, and Safari.
+the properties of the [PSUserAgent][10] class, such as Chrome, FireFox, InternetExplorer, Opera, and
+Safari.
 
 ```yaml
 Type: System.String
@@ -1285,8 +1322,7 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
--WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+-WarningAction, and -WarningVariable. For more information, see [about_CommonParameters][11].
 
 ## INPUTS
 
@@ -1310,8 +1346,7 @@ strings.
 Some features may not be available on all platforms.
 
 Because of changes in .NET Core 3.1, PowerShell 7.0 and higher use the
-[HttpClient.DefaultProxy](/dotnet/api/system.net.http.httpclient.defaultproxy?view=netcore-3.1)
-property to determine the proxy configuration.
+[HttpClient.DefaultProxy][12] property to determine the proxy configuration.
 
 The value of this property is different rules depending on your platform:
 
@@ -1333,8 +1368,25 @@ are:
 
 ## RELATED LINKS
 
-[ConvertTo-Json](ConvertTo-Json.md)
+[ConvertTo-Json][13]
 
-[ConvertFrom-Json](ConvertFrom-Json.md)
+[ConvertFrom-Json][14]
 
-[Invoke-WebRequest](Invoke-WebRequest.md)
+[Invoke-WebRequest][15]
+
+<!-- Reference Links -->
+[1]: #notes
+[2]: https://tools.ietf.org/html/rfc5988#page-6
+[3]: https://httpbin.org/
+[4]: https://www.rfc-editor.org/rfc/rfc7232.html#section-3.1
+[5]: /dotnet/api/system.management.automation.pscredential
+[6]: /dotnet/api/system.security.securestring
+[7]: /dotnet/api/system.security.securestring#how-secure-is-securestring
+[8]: https://tools.ietf.org/html/rfc5988#page-6
+[9]: https://github.com/PowerShell/PowerShell/issues/15409
+[10]: /dotnet/api/microsoft.powershell.commands.psuseragent
+[11]: https://go.microsoft.com/fwlink/?LinkID=113216
+[12]: /dotnet/api/system.net.http.httpclient.defaultproxy?view=netcore-3.1
+[13]: ConvertTo-Json.md
+[14]: ConvertFrom-Json.md
+[15]: Invoke-WebRequest.md


### PR DESCRIPTION
# PR Summary

Prior to this change, the `Invoke-WebRequest` and `Invoke-RestMethod`
cmdlets in 7.0.0 and higher included the **SkipHeaderValidation**
parameter but not a specific example showing its use.

This change adds a new example for both cmdlets to show:

- How the cmdlets behave when an invalidly formatted value is specified
  for a header that has validation
- How the cmdlets behave when the value is valid
- How the **SkipHeaderValidation** parameter allows users to use values
  that would normally fail validation.

This change also updates the formatting for the updated files to ease
future maintenance.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide