### PR TITLE
Fixed typo with input parameters "-key"

### DIFF
--- a/reference/5.1/CimCmdlets/Set-CimInstance.md
+++ b/reference/5.1/CimCmdlets/Set-CimInstance.md
@@ -141,7 +141,7 @@ cmdlet, and retrieves its contents in to a variable `$x`. The variable is then p
 Because the **Passthru** parameter is used, This example returns a modified CIM instance object.
 
 ```powershell
-$x = New-CimInstance -ClassName Win32_Environment -Property @{Name="testvar";UserName="domain\user"} -Keys Name,UserName -ClientOnly
+$x = New-CimInstance -ClassName Win32_Environment -Property @{Name="testvar";UserName="domain\user"} -Key Name,UserName -ClientOnly
 Set-CimInstance -CimInstance $x -Property @{VariableValue="somevalue"} -PassThru
 ```
 

--- a/reference/7.0/CimCmdlets/Set-CimInstance.md
+++ b/reference/7.0/CimCmdlets/Set-CimInstance.md
@@ -143,7 +143,7 @@ cmdlet, and retrieves its contents in to a variable `$x`. The variable is then p
 Because the **Passthru** parameter is used, This example returns a modified CIM instance object.
 
 ```powershell
-$x = New-CimInstance -ClassName Win32_Environment -Property @{Name="testvar";UserName="domain\user"} -Keys Name,UserName -ClientOnly
+$x = New-CimInstance -ClassName Win32_Environment -Property @{Name="testvar";UserName="domain\user"} -Key Name,UserName -ClientOnly
 Set-CimInstance -CimInstance $x -Property @{VariableValue="somevalue"} -PassThru
 ```
 

--- a/reference/7.2/CimCmdlets/Set-CimInstance.md
+++ b/reference/7.2/CimCmdlets/Set-CimInstance.md
@@ -143,7 +143,7 @@ cmdlet, and retrieves its contents in to a variable `$x`. The variable is then p
 Because the **Passthru** parameter is used, This example returns a modified CIM instance object.
 
 ```powershell
-$x = New-CimInstance -ClassName Win32_Environment -Property @{Name="testvar";UserName="domain\user"} -Keys Name,UserName -ClientOnly
+$x = New-CimInstance -ClassName Win32_Environment -Property @{Name="testvar";UserName="domain\user"} -Key Name,UserName -ClientOnly
 Set-CimInstance -CimInstance $x -Property @{VariableValue="somevalue"} -PassThru
 ```
 

--- a/reference/7.3/CimCmdlets/Set-CimInstance.md
+++ b/reference/7.3/CimCmdlets/Set-CimInstance.md
@@ -143,7 +143,7 @@ cmdlet, and retrieves its contents in to a variable `$x`. The variable is then p
 Because the **Passthru** parameter is used, This example returns a modified CIM instance object.
 
 ```powershell
-$x = New-CimInstance -ClassName Win32_Environment -Property @{Name="testvar";UserName="domain\user"} -Keys Name,UserName -ClientOnly
+$x = New-CimInstance -ClassName Win32_Environment -Property @{Name="testvar";UserName="domain\user"} -Key Name,UserName -ClientOnly
 Set-CimInstance -CimInstance $x -Property @{VariableValue="somevalue"} -PassThru
 ```
 


### PR DESCRIPTION
# PR Summary

This PR fixes a typo in one of the script examples where used "-Keys" that does not exist. The right parameter is "-Key".

## PR Checklist

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide