### PR TITLE
(AB-4960) Handle rate limiting in GHA

### DIFF
--- a/.github/actions/.pwsh/module/functions/api/Add-PullRequestComment.ps1
+++ b/.github/actions/.pwsh/module/functions/api/Add-PullRequestComment.ps1
@@ -23,7 +23,7 @@
     Add-PullRequestComment -Owner foo -Repo bar -Number 10 -BodyText @'
     Hello, _world_! How are **you**?
     '@
-    
+
     The cmdlet adds a comment to `https://github/foo/bar/pull/10`, rendering the body text' markdown
     in the comment.
 .EXAMPLE
@@ -47,7 +47,7 @@ function Add-PullRequestComment {
         [Parameter(Mandatory, ParameterSetName = 'File')]
         [string]$BodyFile
     )
-  
+
     begin {
         $AddCommentParams = @(
             'pr', 'comment', $Number
@@ -61,11 +61,11 @@ function Add-PullRequestComment {
             $AddCommentParams += $BodyFile
         }
     }
-  
+
     process {
         [string]$ResultString = gh @AddCommentParams 2>&1
         $ExitCode = $LASTEXITCODE
-  
+
         if ($ExitCode -ne 0) {
             $ErrorParameters = @{
                 ResultString = $ResultString
@@ -75,11 +75,18 @@ function Add-PullRequestComment {
                 ErrorID      = 'GitHub.ApiPostFailure'
             }
             $Record = New-CliErrorRecord @ErrorParameters
-            $PSCmdlet.ThrowTerminatingError($Record)
+
+            # If an error record is returned, the error is unhandled and the action should fail.
+            # If no error record is returned, the error is acceptable and the action should exit.
+            if ($Record) {
+                $PSCmdlet.ThrowTerminatingError($Record)
+            } else {
+                exit
+            }
         }
-  
+
         $ResultString
     }
-  
+
     end {}
 }

--- a/.github/actions/.pwsh/module/functions/utility/New-CliErrorRecord.ps1
+++ b/.github/actions/.pwsh/module/functions/utility/New-CliErrorRecord.ps1
@@ -75,9 +75,22 @@ function New-CliErrorRecord {
         [string]$ErrorID
     )
     
-    begin {}
+    begin {
+        $AcceptableErrors = @(
+            @{
+                Pattern = 'HTTP 403: .+ rate limit'
+                Message = 'Rate limited by GitHub API; unable to continue.'
+            }
+        )
+    }
   
     process {
+        foreach ($AcceptableError in $AcceptableErrors) {
+            if ($ResultString -match $AcceptableError.Pattern) {
+                Write-Host -ForegroundColor DarkMagenta $AcceptableError.Message
+                exit
+            }
+        }
         $Message = New-Object -TypeName System.Text.StringBuilder
         $null = $Message.AppendLine("GitHub API call to $Intent failed with exit code ${ExitCode}:")
         $null = $Message.AppendLine("    $ResultString")


### PR DESCRIPTION
# PR Summary

Prior to this change, the GitHub Actions would throw a terminating error if API operations failed for rate limiting. This generated noisy notifications that aren't actionable.

This change updates the `New-CliErrorRecord` to handle well-known errors for the `gh` tool and writes a note to the console log for those errors. Instead of returning an error record for the caller to throw, they don't return an object.

In this implementation, the GHA script exits and the run is considered a success.

Fixes [AB#4960](https://dev.azure.com/content-learn/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/4960)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide