### PR TITLE
Fixes #9007 - Fix code snippet errors in ShouldProcess deep dive

### DIFF
--- a/reference/docs-conceptual/learn/deep-dives/everything-about-shouldprocess.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-shouldprocess.md
@@ -1,7 +1,7 @@
 ---
 description: ShouldProcess is an important feature that is often overlooked is. The WhatIf and Confirm parameters make it easy to add to your functions.
 ms.custom: contributor-KevinMarquette
-ms.date: 10/05/2021
+ms.date: 08/11/2022
 title: Everything you wanted to know about ShouldProcess
 ---
 # Everything you wanted to know about ShouldProcess
@@ -516,7 +516,7 @@ function Test-ShouldProcess {
         [Switch]$Force
     )
 
-    if ($Force){
+    if ($Force -and -not $Confirm){
         $ConfirmPreference = 'None'
     }
 
@@ -542,7 +542,7 @@ param(
 Focusing in on the `-Force` logic here:
 
 ```powershell
-if ($Force){
+if ($Force -and -not $Confirm){
     $ConfirmPreference = 'None'
 }
 ```
@@ -553,7 +553,7 @@ If the user specifies `-Force`, we want to suppress the confirm prompt unless th
 `$ConfirmPreference` to none, disabling prompt for confirmation.
 
 ```powershell
-if ($Force -or $PSCmdlet.ShouldProcess('TARGET')){
+if ($PSCmdlet.ShouldProcess('TARGET')){
         Write-Output "Some Action"
     }
 ```


### PR DESCRIPTION
# PR Summary

Fixes incorrect code snippets as explained in #9007 (see my [comment there](https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9007#issuecomment-1212310480)). The [original blog post](https://powershellexplained.com/2020-03-15-Powershell-shouldprocess-whatif-confirm-shouldcontinue-everything/#shouldprocess--force) contains the correct versions of the code snippets.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide