### PR TITLE
Documenting RetryIntervalSec value

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/08/2022
+ms.date: 08/17/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -933,7 +933,7 @@ Accept wildcard characters: False
 
 Specifies the interval between retries for the connection when a failure code between 400 and 599,
 inclusive or 304 is received. Also see **MaximumRetryCount** parameter for specifying number of
-retries.
+retries. The value must be between `1` and `[int]::MaxValue`.
 
 ```yaml
 Type: System.Int32
@@ -942,7 +942,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 5
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.0/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/08/2022
+ms.date: 08/17/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -935,7 +935,7 @@ Accept wildcard characters: False
 
 Specifies the interval between retries for the connection when a failure code between 400 and 599,
 inclusive or 304 is received. Also see **MaximumRetryCount** parameter for specifying number of
-retries.
+retries. The value must be between `1` and `[int]::MaxValue`.
 
 ```yaml
 Type: System.Int32
@@ -944,7 +944,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 5
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.2/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/08/2022
+ms.date: 08/17/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -934,7 +934,7 @@ Accept wildcard characters: False
 
 Specifies the interval between retries for the connection when a failure code between 400 and 599,
 inclusive or 304 is received. Also see **MaximumRetryCount** parameter for specifying number of
-retries.
+retries. The value must be between `1` and `[int]::MaxValue`.
 
 ```yaml
 Type: System.Int32
@@ -943,7 +943,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 5
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.2/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/08/2022
+ms.date: 08/17/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -935,7 +935,7 @@ Accept wildcard characters: False
 
 Specifies the interval between retries for the connection when a failure code between 400 and 599,
 inclusive or 304 is received. Also see **MaximumRetryCount** parameter for specifying number of
-retries.
+retries. The value must be between `1` and `[int]::MaxValue`.
 
 ```yaml
 Type: System.Int32
@@ -944,7 +944,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 5
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.3/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/08/2022
+ms.date: 08/17/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -970,7 +970,7 @@ Accept wildcard characters: False
 
 Specifies the interval between retries for the connection when a failure code between 400 and 599,
 inclusive or 304 is received. Also see **MaximumRetryCount** parameter for specifying number of
-retries.
+retries. The value must be between `1` and `[int]::MaxValue`.
 
 ```yaml
 Type: System.Int32
@@ -979,7 +979,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 5
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.3/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -976,7 +976,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 5
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.3/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/08/2022
+ms.date: 08/17/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -967,7 +967,7 @@ Accept wildcard characters: False
 
 Specifies the interval between retries for the connection when a failure code between 400 and 599,
 inclusive or 304 is received. Also see **MaximumRetryCount** parameter for specifying number of
-retries.
+retries. The value must be between `1` and `[int]::MaxValue`.
 
 ```yaml
 Type: System.Int32


### PR DESCRIPTION
Open to your feedback.  Based on testing the default value for RetryIntervalSec is not "None", it's 5 seconds. Here is sample output.

```
Invoke-WebRequest http://github.com/foo/bar.tar.gz -Outfile bar.tar.gz -MaximumRetryCount 4 -Verbose
VERBOSE: GET with 0-byte payload
VERBOSE: Retrying after interval of 5 seconds. Status code for previous attempt: InternalServerError
VERBOSE: Retrying after interval of 5 seconds. Status code for previous attempt: InternalServerError
VERBOSE: Retrying after interval of 5 seconds. Status code for previous attempt: InternalServerError
```

It's waiting 5 seconds, not 0 seconds.

Another question, the -Verbose flag seems helpful. When I was debugging this issue I searched on the page for the words "debug" and "verbose". There's no mention of those flags.   Could that at least be mentioned somewhere on this page, perhaps use it in one of the examples.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

