### PR TITLE
(AB-4196) Codify markdownlint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,36 @@
+# Rule definitions live in .markdownlint.json
+
+# Include a custom rule package
+# customRules:
+#   - markdownlint-rule-titlecase
+
+# Fix any fixable errors
+fix: true
+
+# Define a custom front matter pattern
+# frontMatter: (^---\s*$[^]*?^---\s*$)(\r\n|\r|\n|$)
+
+# Define glob expressions to use (only valid at root)
+# globs:
+#   - "!*bout.md"
+
+# Define glob expressions to ignore
+ignores:
+  - .vscode
+  - assets
+  - tests
+  - tools
+
+# Use a plugin to recognize math
+# markdownItPlugins:
+#   - - "@iktakahiro/markdown-it-katex"
+
+# Disable inline config comments
+noInlineConfig: false
+
+# Disable progress on stdout (only valid at root)
+noProgress: true
+
+# Use a specific formatter (only valid at root)
+# outputFormatters:
+#   - [markdownlint-cli2-formatter-default]

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -37,7 +37,8 @@
     "style": "---"
   },
   "line-length": {
-    "code_blocks": false,
+    "code_block_line_length": 90,
+    "code_blocks": true,
     "heading_line_length": 100,
     "headings": true,
     "line_length": 100,
@@ -124,5 +125,8 @@
   "ul-start-left": true,
   "ul-style": {
     "style": "dash"
-  }
+  },
+  "link-fragments": true,
+  "reference-links-images": true,
+  "link-image-reference-definitions": true
 }

--- a/reference/5.1/Microsoft.PowerShell.Core/About/.markdownlint.json
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/5.1/Microsoft.PowerShell.Security/About/.markdownlint.json
+++ b/reference/5.1/Microsoft.PowerShell.Security/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/5.1/Microsoft.WSMan.Management/About/.markdownlint.json
+++ b/reference/5.1/Microsoft.WSMan.Management/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/5.1/PSReadLine/About/.markdownlint.json
+++ b/reference/5.1/PSReadLine/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/5.1/PSScheduledJob/About/.markdownlint.json
+++ b/reference/5.1/PSScheduledJob/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/5.1/PSWorkflow/About/.markdownlint.json
+++ b/reference/5.1/PSWorkflow/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/7.0/Microsoft.PowerShell.Core/About/.markdownlint.json
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/7.0/Microsoft.PowerShell.Security/About/.markdownlint.json
+++ b/reference/7.0/Microsoft.PowerShell.Security/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/7.0/Microsoft.WSMan.Management/About/.markdownlint.json
+++ b/reference/7.0/Microsoft.WSMan.Management/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/7.0/PSReadLine/About/.markdownlint.json
+++ b/reference/7.0/PSReadLine/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/7.2/Microsoft.PowerShell.Core/About/.markdownlint.json
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/7.2/Microsoft.PowerShell.Security/About/.markdownlint.json
+++ b/reference/7.2/Microsoft.PowerShell.Security/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/7.2/Microsoft.WSMan.Management/About/.markdownlint.json
+++ b/reference/7.2/Microsoft.WSMan.Management/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/7.2/PSReadLine/About/.markdownlint.json
+++ b/reference/7.2/PSReadLine/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/7.3/Microsoft.PowerShell.Core/About/.markdownlint.json
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/7.3/Microsoft.PowerShell.Security/About/.markdownlint.json
+++ b/reference/7.3/Microsoft.PowerShell.Security/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/7.3/Microsoft.WSMan.Management/About/.markdownlint.json
+++ b/reference/7.3/Microsoft.WSMan.Management/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/7.3/PSReadLine/About/.markdownlint.json
+++ b/reference/7.3/PSReadLine/About/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../.markdownlint.json",
+  "line-length": {
+    "code_block_line_length": 74,
+    "code_blocks": true,
+    "heading_line_length": 79,
+    "headings": true,
+    "line_length": 79,
+    "stern": true,
+    "tables": false
+  }
+}

--- a/reference/includes/alpine-support.md
+++ b/reference/includes/alpine-support.md
@@ -5,6 +5,7 @@ ms.date: 07/12/2022
 ms.prod: powershell
 ms.topic: include
 ---
+<!-- markdownlint-disable first-line-h1 -->
 The following table lists the supported PowerShell releases and the versions of Alpine they're
 supported on. These versions are supported until either the version of
 [PowerShell reaches end-of-support][lifecycle] or the version of

--- a/reference/includes/debian-support.md
+++ b/reference/includes/debian-support.md
@@ -5,6 +5,7 @@ ms.date: 06/30/2022
 ms.prod: powershell
 ms.topic: include
 ---
+<!-- markdownlint-disable first-line-h1 -->
 The following table is a list of currently supported PowerShell releases and the versions of Debian
 they're supported on. These versions remain supported until either the version of
 [PowerShell reaches end-of-support][lifecycle] or the version of

--- a/reference/includes/dsc-resources.md
+++ b/reference/includes/dsc-resources.md
@@ -5,6 +5,7 @@ ms.date: 10/30/2020
 ms.prod: powershell
 ms.topic: include
 ---
+<!-- markdownlint-disable first-line-h1 -->
 > [!NOTE]
 > This documentation of this DSC resource covers the version that is included with PowerShell. The
 > **PSDscResources** module contains new and updated that are officially supported by Microsoft.

--- a/reference/includes/macos-support.md
+++ b/reference/includes/macos-support.md
@@ -5,6 +5,7 @@ ms.date: 07/25/2022
 ms.prod: powershell
 ms.topic: include
 ---
+<!-- markdownlint-disable first-line-h1 -->
 The following table contains a list of PowerShell releases and the status of support for versions of
 macOS. These versions remain supported until either the version of
 [PowerShell reaches end-of-support][lifecycle] or the version of macOS reaches end-of-support.

--- a/reference/includes/nuget-module.md
+++ b/reference/includes/nuget-module.md
@@ -5,6 +5,7 @@ ms.date: 07/19/2022
 ms.prod: powershell
 ms.topic: include
 ---
+<!-- markdownlint-disable first-line-h1 -->
 > [!IMPORTANT]
 > The commands contained in the **PackageManagement** module are different than the commands
 > provided by the **NuGet** module in the Package Manager Console of Visual Studio. Each module has

--- a/reference/includes/product-terms.md
+++ b/reference/includes/product-terms.md
@@ -5,6 +5,7 @@ ms.date: 06/29/2021
 ms.prod: powershell
 ms.topic: include
 ---
+<!-- markdownlint-disable first-line-h1 -->
 ## Product terminology used in the documentation
 
 The documentation for PowerShell consists of two types of content: cmdlet reference and conceptual

--- a/reference/includes/rhel-support.md
+++ b/reference/includes/rhel-support.md
@@ -5,6 +5,7 @@ ms.date: 05/18/2022
 ms.prod: powershell
 ms.topic: include
 ---
+<!-- markdownlint-disable first-line-h1 -->
 The following table is a list of currently supported versions of PowerShell and the versions of RHEL
 they are supported on. These versions remain supported until either the version of
 [PowerShell reaches end-of-support][lifecycle] or the version of

--- a/reference/includes/tls-gallery.md
+++ b/reference/includes/tls-gallery.md
@@ -5,6 +5,7 @@ ms.date: 11/18/2020
 ms.prod: powershell
 ms.topic: include
 ---
+<!-- markdownlint-disable first-line-h1 -->
 > [!IMPORTANT]
 > As of April 2020, the PowerShell Gallery no longer supports Transport Layer Security (TLS)
 > versions 1.0 and 1.1. If you are not using TLS 1.2 or higher, you will receive an error when

--- a/reference/includes/ubuntu-support.md
+++ b/reference/includes/ubuntu-support.md
@@ -5,6 +5,7 @@ ms.date: 05/18/2022
 ms.prod: powershell
 ms.topic: include
 ---
+<!-- markdownlint-disable first-line-h1 -->
 The following table is a list of currently supported PowerShell releases and the versions of
 Ubuntu they are supported on. These versions remain supported until either the version of
 [PowerShell reaches end-of-support][lifecycle] or the version of

--- a/reference/includes/windows-support.md
+++ b/reference/includes/windows-support.md
@@ -5,6 +5,7 @@ ms.date: 05/18/2022
 ms.prod: powershell
 ms.topic: include
 ---
+<!-- markdownlint-disable first-line-h1 -->
 The following table is a list of PowerShell releases and the versions of Windows they are supported
 on. These versions are supported until either the version of
 [PowerShell reaches end-of-support][lifecycle] or the version of


### PR DESCRIPTION
# PR Summary

Prior to this change, the repository had a markdownlint configuration. This change updates that configuration, adds a minimal configuration for markdownlint-cl2 (which the VS Code extension uses), adds a markdownlint configuration to the about folders for reference documentation, and adds a markdownlint ignore directive to the `includes` files.

For the root-folder configuration, this change:

- Adds line length enforcement for code blocks at 90 characters and turns the rule on for code blocks. Previously, it was disabled.
- Adds three new rules, all enabled. These rules are not yet picked up by the VS Code extension, but will be in the next release.

  - `link-fragments` requires that links to anchors are valid.
  - `reference-links-images` requires that reference-style links use a defined label (the `[foo]: https//...` text at the bottom of a doc).
  - `link-image-reference-definitions` requires that definedd labels for reference-style links are used at least once.

The root-folder `.markdownlint-cli2.yaml` file governs the behavior of the linter overall. The settings included are minimal and do not effect the editing experience. This file may require iteration for advanced usage later.

In every include file, this change adds a markdownlint directive to ignore the `first-line-h1` rule. These files are always included in the body of another article and should not start with an H1.

In every `About` folder for reference content, this change adds a `.markdownlint.json` file. When editing Markdown in VS Code, the editor uses the closest configuration file to the edited document. That allows us to override and specify alternate rules on a per-folder basis.

In this change, the new configuration files in the `About` folders:

- Extend the root configuration. Any settings not specified in these configurations is inherited from the configuration at the project root.
- Overrides the `line-length` rule, setting the maximum line length for code blocks to 74 characters and for other text to 79 characters. This is to accomodate the PowerShell Help System's line length requirements.

This change is related to [AB#4196](https://dev.azure.com/content-learn/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/4196) and [AB#4197](https://dev.azure.com/content-learn/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/4197).

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide