### PR TITLE
Fixing inconsistent case used for filenames in example 2

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -109,8 +109,8 @@ session as text.
 The first command uses the `Enter-PSSession` cmdlet to start an interactive session with Server01, a
 remote computer. When the session starts, the command prompt changes to include the computer name.
 
-The second command gets the PowerShell process and redirects the output to the Process.txt file. The
-command is submitted to the remote computer, and the file is saved on the remote computer.
+The second command gets the PowerShell process and redirects the output to the 	Process.txt` file.
+The command is submitted to the remote computer, and the file is saved on the remote computer.
 
 The third command uses the **Exit** keyword to end the interactive session and close the connection.
 The fourth command confirms that the Process.txt file is on the remote computer. A `Get-ChildItem`
@@ -122,10 +122,10 @@ PS C:\> Enter-PSSession -ComputerName Server01
 [Server01]: PS C:\> Get-Process PowerShell > C:\ps-test\Process.txt
 [Server01]: PS C:\> exit
 PS C:\>
-PS C:\> dir C:\ps-test\process.txt
-Get-ChildItem : Cannot find path 'C:\ps-test\process.txt' because it does not exist.
+PS C:\> dir C:\ps-test\Process.txt
+Get-ChildItem : Cannot find path 'C:\ps-test\Process.txt' because it does not exist.
 At line:1 char:4
-+ dir <<<<  c:\ps-test\process.txt
++ dir <<<<  c:\ps-test\Process.txt
 ```
 
 This command shows how to work in an interactive session with a remote computer.
@@ -133,9 +133,9 @@ This command shows how to work in an interactive session with a remote computer.
 ### Example 3: Use the Session parameter
 
 ```powershell
-PS C:\> $s = New-PSSession -ComputerName Server01
-PS C:\> Enter-PSSession -Session $s
-[Server01]: PS C:\>
+PS> $s = New-PSSession -ComputerName Server01
+PS> Enter-PSSession -Session $s
+[Server01]: PS>
 ```
 
 These commands use the **Session** parameter of `Enter-PSSession` to run the interactive session in
@@ -144,8 +144,8 @@ an existing PowerShell session (**PSSession**).
 ### Example 4: Start an interactive session and specify the Port and Credential parameters
 
 ```powershell
-PS C:\> Enter-PSSession -ComputerName Server01 -Port 90 -Credential Domain01\User01
-[Server01]: PS C:\>
+PS> Enter-PSSession -ComputerName Server01 -Port 90 -Credential Domain01\User01
+[Server01]: PS>
 ```
 
 This command starts an interactive session with the Server01 computer. It uses the **Port**
@@ -155,9 +155,9 @@ has permission to connect to the remote computer.
 ### Example 5: Stop an interactive session
 
 ```powershell
-PS C:\> Enter-PSSession -ComputerName Server01
-[Server01]: PS C:\> Exit-PSSession
-PS C:\>
+PS> Enter-PSSession -ComputerName Server01
+[Server01]: PS> Exit-PSSession
+PS>
 ```
 
 This example shows how to start and stop an interactive session. The first command uses the

--- a/reference/5.1/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -109,7 +109,7 @@ session as text.
 The first command uses the `Enter-PSSession` cmdlet to start an interactive session with Server01, a
 remote computer. When the session starts, the command prompt changes to include the computer name.
 
-The second command gets the PowerShell process and redirects the output to the 	Process.txt` file.
+The second command gets the PowerShell process and redirects the output to the `Process.txt` file.
 The command is submitted to the remote computer, and the file is saved on the remote computer.
 
 The third command uses the **Exit** keyword to end the interactive session and close the connection.

--- a/reference/7.0/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -124,7 +124,7 @@ session as text.
 The first command uses the `Enter-PSSession` cmdlet to start an interactive session with Server01, a
 remote computer. When the session starts, the command prompt changes to include the computer name.
 
-The second command gets the PowerShell process and redirects the output to the 	Process.txt` file.
+The second command gets the PowerShell process and redirects the output to the `Process.txt` file.
 The command is submitted to the remote computer, and the file is saved on the remote computer.
 
 The third command uses the **Exit** keyword to end the interactive session and close the connection.

--- a/reference/7.0/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -124,8 +124,8 @@ session as text.
 The first command uses the `Enter-PSSession` cmdlet to start an interactive session with Server01, a
 remote computer. When the session starts, the command prompt changes to include the computer name.
 
-The second command gets the PowerShell process and redirects the output to the Process.txt file. The
-command is submitted to the remote computer, and the file is saved on the remote computer.
+The second command gets the PowerShell process and redirects the output to the 	Process.txt` file.
+The command is submitted to the remote computer, and the file is saved on the remote computer.
 
 The third command uses the **Exit** keyword to end the interactive session and close the connection.
 The fourth command confirms that the Process.txt file is on the remote computer. A `Get-ChildItem`
@@ -137,10 +137,10 @@ PS C:\> Enter-PSSession -ComputerName Server01
 [Server01]: PS C:\> Get-Process PowerShell > C:\ps-test\Process.txt
 [Server01]: PS C:\> exit
 PS C:\>
-PS C:\> dir C:\ps-test\process.txt
-Get-ChildItem : Cannot find path 'C:\ps-test\process.txt' because it does not exist.
+PS C:\> dir C:\ps-test\Process.txt
+Get-ChildItem : Cannot find path 'C:\ps-test\Process.txt' because it does not exist.
 At line:1 char:4
-+ dir <<<<  c:\ps-test\process.txt
++ dir <<<<  c:\ps-test\Process.txt
 ```
 
 This command shows how to work in an interactive session with a remote computer.

--- a/reference/7.2/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -138,10 +138,10 @@ PS C:\> Enter-PSSession -ComputerName Server01
 [Server01]: PS C:\> Get-Process PowerShell > C:\ps-test\Process.txt
 [Server01]: PS C:\> exit
 PS C:\>
-PS C:\> dir C:\ps-test\process.txt
-Get-ChildItem : Cannot find path 'C:\ps-test\process.txt' because it does not exist.
+PS C:\> dir C:\ps-test\Process.txt
+Get-ChildItem : Cannot find path 'C:\ps-test\Process.txt' because it does not exist.
 At line:1 char:4
-+ dir <<<<  c:\ps-test\process.txt
++ dir <<<<  c:\ps-test\Process.txt
 ```
 
 This command shows how to work in an interactive session with a remote computer.

--- a/reference/7.2/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -125,8 +125,8 @@ session as text.
 The first command uses the `Enter-PSSession` cmdlet to start an interactive session with Server01, a
 remote computer. When the session starts, the command prompt changes to include the computer name.
 
-The second command gets the PowerShell process and redirects the output to the Process.txt file. The
-command is submitted to the remote computer, and the file is saved on the remote computer.
+The second command gets the PowerShell process and redirects the output to the 	Process.txt` file.
+The command is submitted to the remote computer, and the file is saved on the remote computer.
 
 The third command uses the **Exit** keyword to end the interactive session and close the connection.
 The fourth command confirms that the Process.txt file is on the remote computer. A `Get-ChildItem`

--- a/reference/7.2/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -125,7 +125,7 @@ session as text.
 The first command uses the `Enter-PSSession` cmdlet to start an interactive session with Server01, a
 remote computer. When the session starts, the command prompt changes to include the computer name.
 
-The second command gets the PowerShell process and redirects the output to the 	Process.txt` file.
+The second command gets the PowerShell process and redirects the output to the `Process.txt` file.
 The command is submitted to the remote computer, and the file is saved on the remote computer.
 
 The third command uses the **Exit** keyword to end the interactive session and close the connection.

--- a/reference/7.3/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -125,8 +125,8 @@ session as text.
 The first command uses the `Enter-PSSession` cmdlet to start an interactive session with Server01, a
 remote computer. When the session starts, the command prompt changes to include the computer name.
 
-The second command gets the PowerShell process and redirects the output to the Process.txt file. The
-command is submitted to the remote computer, and the file is saved on the remote computer.
+The second command gets the PowerShell process and redirects the output to the 	Process.txt` file.
+The command is submitted to the remote computer, and the file is saved on the remote computer.
 
 The third command uses the **Exit** keyword to end the interactive session and close the connection.
 The fourth command confirms that the Process.txt file is on the remote computer. A `Get-ChildItem`
@@ -138,10 +138,10 @@ PS C:\> Enter-PSSession -ComputerName Server01
 [Server01]: PS C:\> Get-Process PowerShell > C:\ps-test\Process.txt
 [Server01]: PS C:\> exit
 PS C:\>
-PS C:\> dir C:\ps-test\process.txt
-Get-ChildItem : Cannot find path 'C:\ps-test\process.txt' because it does not exist.
+PS C:\> dir C:\ps-test\Process.txt
+Get-ChildItem : Cannot find path 'C:\ps-test\Process.txt' because it does not exist.
 At line:1 char:4
-+ dir <<<<  c:\ps-test\process.txt
++ dir <<<<  c:\ps-test\Process.txt
 ```
 
 This command shows how to work in an interactive session with a remote computer.

--- a/reference/7.3/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -125,7 +125,7 @@ session as text.
 The first command uses the `Enter-PSSession` cmdlet to start an interactive session with Server01, a
 remote computer. When the session starts, the command prompt changes to include the computer name.
 
-The second command gets the PowerShell process and redirects the output to the 	Process.txt` file.
+The second command gets the PowerShell process and redirects the output to the `Process.txt` file.
 The command is submitted to the remote computer, and the file is saved on the remote computer.
 
 The third command uses the **Exit** keyword to end the interactive session and close the connection.


### PR DESCRIPTION
Fixing inconsistent case used for filenames in example 2.

# PR Summary
Example 2 uses inconsistent filename cases which could lead to confusion (e.g. "Process.txt" vs "process.txt"). This PR rectifies this.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide