### PR TITLE
Update Example in Convert-FromJson to avoid issue

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/10/2019
+ms.date: 08/30/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/convertfrom-json?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertFrom-Json
@@ -89,12 +89,12 @@ This example shows how to use the `ConvertFrom-Json` cmdlet to convert a JSON fi
 custom object.
 
 ```powershell
-Get-Content JsonFile.JSON | ConvertFrom-Json
+Get-Content -Raw JsonFile.JSON | ConvertFrom-Json
 ```
 
-The command uses Get-Content cmdlet to get the strings in a JSON file. Then it uses the pipeline
-operator to send the delimited string to the `ConvertFrom-Json` cmdlet, which converts it to a
-custom object.
+The command uses Get-Content cmdlet to get the strings in a JSON file. The **Raw** parameter
+returns the whole file as a single JSON object. Then it uses the pipeline operator to send the
+delimited string to the `ConvertFrom-Json` cmdlet, which converts it to a custom object.
 
 ## PARAMETERS
 

--- a/reference/7.0/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 07/19/2022
+ms.date: 08/30/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/convertfrom-json?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertFrom-Json
@@ -92,12 +92,12 @@ This example shows how to use the `ConvertFrom-Json` cmdlet to convert a JSON fi
 custom object.
 
 ```powershell
-Get-Content JsonFile.JSON | ConvertFrom-Json
+Get-Content -Raw JsonFile.JSON | ConvertFrom-Json
 ```
 
-The command uses Get-Content cmdlet to get the strings in a JSON file. Then it uses the pipeline
-operator to send the delimited string to the `ConvertFrom-Json` cmdlet, which converts it to a
-custom object.
+The command uses Get-Content cmdlet to get the strings in a JSON file. The **Raw** parameter
+returns the whole file as a single JSON object. Then it uses the pipeline operator to send the
+delimited string to the `ConvertFrom-Json` cmdlet, which converts it to a custom object.
 
 ### Example 4: Convert a JSON string to a hash table
 

--- a/reference/7.2/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 07/19/2022
+ms.date: 08/30/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/convertfrom-json?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertFrom-Json
@@ -95,9 +95,9 @@ custom object.
 Get-Content -Raw JsonFile.JSON | ConvertFrom-Json
 ```
 
-The command uses Get-Content cmdlet to get the strings in a JSON file. It uses `-Raw` to get the whole file as a single JSON object. Then it uses the pipeline
-operator to send the delimited string to the `ConvertFrom-Json` cmdlet, which converts it to a
-custom object.
+The command uses Get-Content cmdlet to get the strings in a JSON file. The **Raw** parameter
+returns the whole file as a single JSON object. Then it uses the pipeline operator to send the
+delimited string to the `ConvertFrom-Json` cmdlet, which converts it to a custom object.
 
 ### Example 4: Convert a JSON string to a hash table
 

--- a/reference/7.2/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -92,10 +92,10 @@ This example shows how to use the `ConvertFrom-Json` cmdlet to convert a JSON fi
 custom object.
 
 ```powershell
-Get-Content JsonFile.JSON | ConvertFrom-Json
+Get-Content -Raw JsonFile.JSON | ConvertFrom-Json
 ```
 
-The command uses Get-Content cmdlet to get the strings in a JSON file. Then it uses the pipeline
+The command uses Get-Content cmdlet to get the strings in a JSON file. It uses `-Raw` to get the whole file as a single JSON object. Then it uses the pipeline
 operator to send the delimited string to the `ConvertFrom-Json` cmdlet, which converts it to a
 custom object.
 

--- a/reference/7.3/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 07/19/2022
+ms.date: 08/30/2022
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/convertfrom-json?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertFrom-Json
@@ -92,12 +92,12 @@ This example shows how to use the `ConvertFrom-Json` cmdlet to convert a JSON fi
 custom object.
 
 ```powershell
-Get-Content JsonFile.JSON | ConvertFrom-Json
+Get-Content -Raw JsonFile.JSON | ConvertFrom-Json
 ```
 
-The command uses Get-Content cmdlet to get the strings in a JSON file. Then it uses the pipeline
-operator to send the delimited string to the `ConvertFrom-Json` cmdlet, which converts it to a
-custom object.
+The command uses Get-Content cmdlet to get the strings in a JSON file. The **Raw** parameter
+returns the whole file as a single JSON object. Then it uses the pipeline operator to send the
+delimited string to the `ConvertFrom-Json` cmdlet, which converts it to a custom object.
 
 ### Example 4: Convert a JSON string to a hash table
 


### PR DESCRIPTION
# PR Summary
This change helps users avoid [problem #12229 in PowerShell](https://github.com/PowerShell/PowerShell/issues/12229) for the command `ConvertFrom-Json`

Convert-FromJson has a frequent bug, https://github.com/PowerShell/PowerShell/issues/12229, where `.json` files which start with a newline are treated as two different JSON elements. 


From the issue, the proposed fix is to always use `Get-Content -Raw .\file.json | ConvertFrom-Json`, which will treat a `.json` file as a single json object, instead of a file which contains multiple. This is the behaviour most people would expect from `.json` files.


<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist


- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide