### PR TITLE
Update type used to differ from compiled cmdlets

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -66,7 +66,7 @@ with the Begin and End blocks, is described in the
 Advanced functions differ from compiled cmdlets in the following ways:
 
 - Advanced function parameter binding does not throw an exception when an array
-  of strings is bound to a Boolean parameter.
+  of strings is bound to a `Switch` parameter.
 - The ValidateSet attribute and the ValidatePattern attribute cannot pass named
   parameters.
 - Advanced functions cannot be used in transactions.

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -66,7 +66,7 @@ with the Begin and End blocks, is described in the
 Advanced functions differ from compiled cmdlets in the following ways:
 
 - Advanced function parameter binding does not throw an exception when an array
-  of strings is bound to a Boolean parameter.
+  of strings is bound to a `Switch` parameter.
 - The ValidateSet attribute and the ValidatePattern attribute cannot pass named
   parameters.
 - Advanced functions cannot be used in transactions.

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -66,7 +66,7 @@ with the Begin and End blocks, is described in the
 Advanced functions differ from compiled cmdlets in the following ways:
 
 - Advanced function parameter binding does not throw an exception when an array
-  of strings is bound to a Boolean parameter.
+  of strings is bound to a `Switch` parameter.
 - The ValidateSet attribute and the ValidatePattern attribute cannot pass named
   parameters.
 - Advanced functions cannot be used in transactions.

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -66,7 +66,7 @@ with the Begin and End blocks, is described in the
 Advanced functions differ from compiled cmdlets in the following ways:
 
 - Advanced function parameter binding does not throw an exception when an array
-  of strings is bound to a Boolean parameter.
+  of strings is bound to a `Switch` parameter.
 - The ValidateSet attribute and the ValidatePattern attribute cannot pass named
   parameters.
 - Advanced functions cannot be used in transactions.


### PR DESCRIPTION
# PR Summary

This is a simple update. The docs say cmdlets don't throw on `[Boolean]`, but it's not quite true

> Advanced function parameter binding does not throw an exception when an array
  of strings is bound to a `Boolean` parameter.

When tested, it does throw. It looks like it should be `[switch]` . That's what the tests below show

```ps1
WinPS5>
>> function bool_cmdletParam {
>>     [CmdletBinding()]
>>     param( [Parameter()][bool]$Obj )
>> }
>>
>> $text = 'a', 'b', 'c'
>> bool_cmdlet -Obj $Text

bool_cmdlet : A positional parameter cannot be found that accepts argument 'System.String[]'.
At line:8 char:1
+ bool_cmdlet -Obj $Text
+ ~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [bool_cmdlet], ParameterBindingException
    + FullyQualifiedErrorId : PositionalParameterNotFound,bool_cmdlet
```

## Only `Switch` does not throw

I tested all combinations of `Cmdlets` and `Bool` vs `Switch` parameters.
- `[bool]` always throws, 

In order for the binding to not throw , It must both

- not have `cmdletbinding`, and
- be a `[switch]` not `[bool]`

It was the same for WinPS5.1 and Pwsh 7.2

## To Reproduce

```ps1
function switch_basic {
    param( [switch]$Obj )
}
function switch_cmdlet {
    [CmdletBinding()]
    param( [switch]$Obj )
}
function switch_cmdletParam {
    [CmdletBinding()]
    param(
        [Parameter()][switch]$Obj )
}
function bool_basic {
    param( [bool]$Obj )
}
function bool_cmdlet {
    [CmdletBinding()]
    param( [bool]$Obj )
}
function bool_cmdletParam {
    [CmdletBinding()]
    param(
        [Parameter()][bool]$Obj )
}

switch_Basic $Text
switch_cmdlet $Text
switch_cmdletParam $Text
Bool_Basic $Text
Bool_cmdlet $Text
Bool_cmdletParam $Text
```


## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide

![image](https://user-images.githubusercontent.com/3892031/188330805-4933baf4-4755-48c9-bb70-ece7df35ada0.png)


![image](https://user-images.githubusercontent.com/3892031/188330844-be0b3b0c-f816-43b9-8bf8-24f74cc32438.png)
