### PR TITLE
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute (part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following list describes the main folders in this repository.
   Code)
 - `assets` - contains downloadable files linked in the documentation
 - `reference` - contains the documentation published to
-  [docs.microsoft.com]([https://docs.microsoft.com/powershell/scripting/). This includes both
+  [PowerShell technical documentation](/powershell/scripting/). This includes both
   reference and conceptual content.
   - `5.1` - contains the cmdlet reference and about topics for PowerShell 5.1
   - `7.0` - contains the cmdlet reference and about topics for PowerShell 7.0

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following list describes the main folders in this repository.
   Code)
 - `assets` - contains downloadable files linked in the documentation
 - `reference` - contains the documentation published to
-  [PowerShell technical documentation](/powershell/scripting/). This includes both
+  [docs.microsoft.com]([https://docs.microsoft.com/powershell/scripting/). This includes both
   reference and conceptual content.
   - `5.1` - contains the cmdlet reference and about topics for PowerShell 5.1
   - `7.0` - contains the cmdlet reference and about topics for PowerShell 7.0

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
@@ -284,7 +284,7 @@ Accept wildcard characters: False
 
 This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`,
 `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`,
-`-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](/reference/6/Microsoft.PowerShell.Core/About/about_CommonParameters.md).
+`-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/docs-conceptual/community/2020-updates.md
+++ b/reference/docs-conceptual/community/2020-updates.md
@@ -342,7 +342,7 @@ issues. Thank you!
     - [Variables can be assigned values as part of an expression (with limitations)](https://github.com/MicrosoftDocs/PowerShell-Docs/wiki/Variables-can-be-assigned-values-as-part-of-an-expression-(with-limitations))
 
 - Documentation maintenance
-  - Now publishing updates to docs.microsoft.com on a daily schedule
+  - Now publishing updates to Microsoft Docs on a daily schedule
     - Monday-Friday 3pm Redmond Time (UTC-8)
   - Restructured the Community content
   - Many editorial cleanups

--- a/reference/docs-conceptual/community/2021-updates.md
+++ b/reference/docs-conceptual/community/2021-updates.md
@@ -148,7 +148,7 @@ Content updates
   - [Microsoft Update for PowerShell FAQ](/powershell/scripting/install/microsoft-update-faq)
   - [PowerShell Support Lifecycle](/powershell/scripting/install/powershell-support-lifecycle)
 - Reformatted and updated the PSScriptAnalyzer rules documentation. Next month we plan to publish these
-  docs on docs.microsoft.com.
+  docs on Microsoft Docs.
   - [Rules documentation on GitHub](https://github.com/PowerShell/PSScriptAnalyzer/tree/master/docs/Rules)
 - Lots of general editorial updates across 4500 files
 - PowerShell 7.2-preview.10 documentation updates

--- a/reference/docs-conceptual/community/2022-updates.md
+++ b/reference/docs-conceptual/community/2022-updates.md
@@ -109,7 +109,7 @@ New content migrated from GitHub wiki
 - [Limitations of PowerShell transcripts](/powershell/scripting/learn/deep-dives/output-missing-from-transcript)
 - [Avoid using Invoke-Expression](/powershell/scripting/learn/deep-dives/avoid-using-invoke-expression)
 - [Avoid assigning variables in expressions](/powershell/scripting/learn/deep-dives/avoid-assigning-variables-in-expressions)
-- [about_Case-Sensitivity]( /powershell/module/microsoft.powershell.core/about/about_case-sensitivity)
+- [about_Case-Sensitivity](/powershell/module/microsoft.powershell.core/about/about_case-sensitivity)
 - Updated [about_Arrays](/powershell/module/microsoft.powershell.core/about/about_arrays)
 
 New SecretManagement content
@@ -163,7 +163,7 @@ Content updates
 - Bulk formatting cleanup for many docs
   - PowerShell-Docs content - 272 files
   - Secrets management - 17 files
-- Updated the PSScriptAnalyzer README and deleted docs that were migrated to docs.microsoft.com
+- Updated the PSScriptAnalyzer README and deleted docs that were migrated to Microsoft Docs
 - Removed CentOS and Fedora from docs - no longer supported
 - Retired 7.1 content - no longer supported
   - Collapse release notes into diff article

--- a/reference/docs-conceptual/community/contributing/editorial-checklist.md
+++ b/reference/docs-conceptual/community/contributing/editorial-checklist.md
@@ -109,7 +109,7 @@ articles in the Contributor's Guide for detailed explanations and examples of th
 ## Linking to other documents
 
 - When linking outside the docset or between cmdlet reference and conceptual
-  - Use site-relative URLs when linking to docs.microsoft.com (remove `https://docs.microsoft.com/en-us`)
+  - Use site-relative URLs when linking to Microsoft Docs (remove `https://docs.microsoft.com/en-us`)
   - don't include locales in URLs on Microsoft properties (eg. remove `/en-us` from URL)
   - All URLs to external websites should use HTTPS unless that's not valid for the target site
 - When linking within the docset

--- a/reference/docs-conceptual/community/contributing/general-markdown.md
+++ b/reference/docs-conceptual/community/contributing/general-markdown.md
@@ -186,7 +186,7 @@ highlightint the significance of the content. The following alert types are supp
 > Dangerous certain consequences of an action.
 ```
 
-These alerts look like this on docs.microsoft.com:
+These alerts look like this on Microsoft Docs:
 
 Note block
 

--- a/reference/docs-conceptual/community/contributing/overview.md
+++ b/reference/docs-conceptual/community/contributing/overview.md
@@ -52,7 +52,7 @@ Also, read the [Writing essentials][12] section of the centralized Contributor's
 excellent resource is the [Microsoft Writing Style Guide][13].
 
 Minor corrections or clarifications to documentation and code examples in public repositories are
-covered by the docs.microsoft.com [Terms of Use][14].
+covered by the [docs.microsoft.com Terms of Use][14].
 
 Use the full GitHub workflow when you're making significant changes. If you're not an employee of
 Microsoft, our PR validation system adds a comment to the pull request asking you to sign the online
@@ -62,7 +62,7 @@ repository. You will be asked to sign the CLA for each time you contribute to a 
 
 ## Code of conduct
 
-All repositories that publish to docs.microsoft.com have adopted the
+All repositories that publish to Microsoft Docs have adopted the
 [Microsoft Open Source Code of Conduct][16] or the
 [.NET Foundation Code of Conduct][17]. For more
 information, see the [Code of Conduct FAQ][18].


### PR DESCRIPTION
**Global effort to fix build validation errors**

The Microsoft Skilling team is fixing build validation errors and specific brand inconsistencies in Microsoft technical documentation for the rest of FY23 Q1. This will help address various accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only targeted fixes and minor formatting adjustments.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: Alex Buck
