### PR TITLE
(GH-9194) Document `$LastExitCode` behavior for scripts

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 07/01/2022
+ms.date: 09/06/2022
 no-loc: [Reset, Current, Background, Blink, Bold, Foreground, Formatting, Hidden, Italic, Reset, Reverse, Underline]
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -204,9 +204,21 @@ following example is run from the Windows Command shell.
 echo Hello | powershell -Command """$input World!"""
 ```
 
-### $LastExitCode
+### $LASTEXITCODE
 
 Contains the exit code of the last Windows-based program that was run.
+For PowerShell scripts, the value of `$LASTEXITCODE` depends on how the script
+was called and whether the `exit` keyword was used:
+
+- When a script uses the `exit` keyword, `$LASTEXITCODE` is set to the
+  specified value, regardless of how the script was called. For more
+  information, see [about_Language_Keywords](about_language_keywords.md#exit).
+- When a script is called directly, like `./Test.ps1`, or with the
+  [call operator](about_operators.md#call-operator-) (`&`) like `& ./Test.ps1`,
+  the value of `$LASTEXITCODE` isn't changed.
+- When a script is called with `powershell.exe` and the **File** parameter, the
+  value of `$LASTEXITCODE` is set to `1` if the script terminated due to a
+  thrown exception and `0` otherwise.
 
 ### $Matches
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -34,8 +34,8 @@ last command succeeded and **False** if it failed.
 
 For cmdlets and advanced functions that are run at multiple stages in a
 pipeline, for example in both `process` and `end` blocks, calling
-`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point
-sets `$?` to **False**, as does `this.ThrowTerminatingError()` and
+`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point sets
+`$?` to **False**, as does `this.ThrowTerminatingError()` and
 `$PSCmdlet.ThrowTerminatingError()`.
 
 The `Write-Error` cmdlet always sets `$?` to **False** immediately after it's
@@ -59,10 +59,10 @@ is 0, and set to **False** when `$LASTEXITCODE` is any other value.
 
 > [!NOTE]
 > Until PowerShell 7, containing a statement within parentheses `(...)`,
-> subexpression syntax `$(...)` or array expression `@(...)` always reset
-> `$?` to **True**, so that `(Write-Error)` shows `$?` as **True**.
-> This has been changed in PowerShell 7, so that `$?` always reflects
-> the actual success of the last command run in these expressions.
+> subexpression syntax `$(...)` or array expression `@(...)` always reset `$?`
+> to **True**, so that `(Write-Error)` shows `$?` as **True**. This has been
+> changed in PowerShell 7, so that `$?` always reflects the actual success of
+> the last command run in these expressions.
 
 ### $^
 
@@ -78,13 +78,13 @@ selected objects in a pipeline.
 
 Contains an array of values for undeclared parameters that are passed to a
 function, script, or script block. When you create a function, you can declare
-the parameters with the `param` keyword or by adding a comma-separated list
-of parameters in parentheses after the function name.
+the parameters with the `param` keyword or by adding a comma-separated list of
+parameters in parentheses after the function name.
 
 In an event action, the `$args` variable contains objects that represent the
-event arguments of the event that's being processed. This variable is
-populated only within the `Action` block of an event registration command. The
-value of this variable can also be found in the **SourceArgs** property of the
+event arguments of the event that's being processed. This variable is populated
+only within the `Action` block of an event registration command. The value of
+this variable can also be found in the **SourceArgs** property of the
 **PSEventArgs** object that `Get-Event` returns.
 
 ### $ConsoleFileName
@@ -112,9 +112,9 @@ information, see [about_CommonParameters](about_CommonParameters.md).
 Contains a **PSEventArgs** object that represents the event that's being
 processed. This variable is populated only within the `Action` block of an
 event registration command, such as `Register-ObjectEvent`. The value of this
-variable is the same object that the `Get-Event` cmdlet returns. You
-can use the properties of the `Event` variable, such as `$Event.TimeGenerated`,
-in an `Action` script block.
+variable is the same object that the `Get-Event` cmdlet returns. You can use
+the properties of the `Event` variable, such as `$Event.TimeGenerated`, in an
+`Action` script block.
 
 ### $EventArgs
 
@@ -230,8 +230,8 @@ operators. For more information about the `switch` statement, see
 > [!NOTE]
 > When `$Matches` is populated in a session, it retains the matched value until
 > it's overwritten by another match. If `-match` is used again and no match is
-> found, it doesn't reset `$Matches` to `$null`. The previously matched value is
-> kept in `$Matches` until another match is found.
+> found, it doesn't reset `$Matches` to `$null`. The previously matched value
+> is kept in `$Matches` until another match is found.
 
 ### $MyInvocation
 
@@ -289,8 +289,8 @@ PowerShell treats `$null` as an object with a value, that is, as an explicit
 placeholder, so you can use `$null` to represent an empty value in a series of
 values.
 
-For example, when `$null` is included in a collection, it's counted as one
-of the objects.
+For example, when `$null` is included in a collection, it's counted as one of
+the objects.
 
 ```powershell
 $a = "one", $null, "three"
@@ -564,8 +564,9 @@ PS> Get-ChildItem .\README.md | Get-Member BaseName | Format-List
 TypeName   : System.IO.FileInfo
 Name       : BaseName
 MemberType : ScriptProperty
-Definition : System.Object BaseName {get=if ($this.Extension.Length -gt 0){$this.Name.Remove($this.Name.Length -
-             $this.Extension.Length)}else{$this.Name};}
+Definition : System.Object BaseName {get=if ($this.Extension.Length -gt 0)
+             {$this.Name.Remove($this.Name.Length - $this.Extension.Length
+             )}else{$this.Name};}
 ```
 
 For more information, see [about_Types.ps1xml](./about_Types.ps1xml.md).

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -34,12 +34,12 @@ last command succeeded and **False** if it failed.
 
 For cmdlets and advanced functions that are run at multiple stages in a
 pipeline, for example in both `process` and `end` blocks, calling
-`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point will
-set `$?` to **False**, as will `this.ThrowTerminatingError()` and
+`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point
+sets `$?` to **False**, as does `this.ThrowTerminatingError()` and
 `$PSCmdlet.ThrowTerminatingError()`.
 
-The `Write-Error` cmdlet always sets `$?` to **False** immediately after it is
-executed, but will not set `$?` to **False** for a function calling it:
+The `Write-Error` cmdlet always sets `$?` to **False** immediately after it's
+executed, but won't set `$?` to **False** for a function calling it:
 
 ```powershell
 function Test-WriteError
@@ -61,7 +61,7 @@ is 0, and set to **False** when `$LASTEXITCODE` is any other value.
 > Until PowerShell 7, containing a statement within parentheses `(...)`,
 > subexpression syntax `$(...)` or array expression `@(...)` always reset
 > `$?` to **True**, so that `(Write-Error)` shows `$?` as **True**.
-> This has been changed in PowerShell 7, so that `$?` will always reflect
+> This has been changed in PowerShell 7, so that `$?` always reflects
 > the actual success of the last command run in these expressions.
 
 ### $^
@@ -78,11 +78,11 @@ selected objects in a pipeline.
 
 Contains an array of values for undeclared parameters that are passed to a
 function, script, or script block. When you create a function, you can declare
-the parameters by using the `param` keyword or by adding a comma-separated list
+the parameters with the `param` keyword or by adding a comma-separated list
 of parameters in parentheses after the function name.
 
 In an event action, the `$args` variable contains objects that represent the
-event arguments of the event that is being processed. This variable is
+event arguments of the event that's being processed. This variable is
 populated only within the `Action` block of an event registration command. The
 value of this variable can also be found in the **SourceArgs** property of the
 **PSEventArgs** object that `Get-Event` returns.
@@ -96,7 +96,7 @@ export snap-in names to a console file.
 
 When you use the `Export-Console` cmdlet without parameters, it automatically
 updates the console file that was most recently used in the session. You can
-use this automatic variable to determine which file will be updated.
+use this automatic variable to determine the file to update.
 
 ### $Error
 
@@ -109,17 +109,17 @@ information, see [about_CommonParameters](about_CommonParameters.md).
 
 ### $Event
 
-Contains a **PSEventArgs** object that represents the event that is being
+Contains a **PSEventArgs** object that represents the event that's being
 processed. This variable is populated only within the `Action` block of an
 event registration command, such as `Register-ObjectEvent`. The value of this
-variable is the same object that the `Get-Event` cmdlet returns. Therefore, you
+variable is the same object that the `Get-Event` cmdlet returns. You
 can use the properties of the `Event` variable, such as `$Event.TimeGenerated`,
 in an `Action` script block.
 
 ### $EventArgs
 
 Contains an object that represents the first event argument that derives from
-**EventArgs** of the event that is being processed. This variable is populated
+**EventArgs** of the event that's being processed. This variable is populated
 only within the `Action` block of an event registration command. The value of
 this variable can also be found in the **SourceEventArgs** property of the
 **PSEventArgs** object that `Get-Event` returns.
@@ -127,7 +127,7 @@ this variable can also be found in the **SourceEventArgs** property of the
 ### $EventSubscriber
 
 Contains a **PSEventSubscriber** object that represents the event subscriber of
-the event that is being processed. This variable is populated only within the
+the event that's being processed. This variable is populated only within the
 `Action` block of an event registration command. The value of this variable is
 the same object that the `Get-EventSubscriber` cmdlet returns.
 
@@ -140,7 +140,7 @@ that are available to cmdlets.
 ### $false
 
 Contains **False**. You can use this variable to represent **False** in
-commands and scripts instead of using the string "false". The string can be
+commands and scripts instead of using the string `"false"`. The string can be
 interpreted as **True** if it's converted to a non-empty string or to a
 non-zero integer.
 
@@ -165,28 +165,28 @@ variables, typically `C:\Users\<UserName>`.
 Contains an object that represents the current host application for PowerShell.
 You can use this variable to represent the current host in commands or to
 display or change the properties of the host, such as `$Host.version` or
-`$Host.CurrentCulture`, or `$host.ui.rawui.setbackgroundcolor("Red")`.
+`$Host.CurrentCulture`, or `$host.UI.RawUI.SetBackGroundColor("Red")`.
 
 ### $input
 
-Contains an enumerator that enumerates all input that is passed to a function.
+Contains an enumerator that enumerates all input that's passed to a function.
 The `$input` variable is available only to functions and script blocks (which
 are unnamed functions).
 
-- In a function without a `Begin`, `Process`, or `End` block, the `$input`
+- In a function without a `begin`, `process`, or `end` block, the `$input`
   variable enumerates the collection of all input to the function.
 
-- In the `Begin` block, the `$input` variable contains no data.
+- In the `begin` block, the `$input` variable contains no data.
 
-- In the `Process` block, the `$input` variable contains the object that is
+- In the `process` block, the `$input` variable contains the object that's
   currently in the pipeline.
 
-- In the `End` block, the `$input` variable enumerates the collection of all
+- In the `end` block, the `$input` variable enumerates the collection of all
   input to the function.
 
   > [!NOTE]
-  > You cannot use the `$input` variable inside both the Process block and the
-  > End block in the same function or script block.
+  > You can't use the `$input` variable inside both the `process` block and the
+  > `end` block in the same function or script block.
 
 Since `$input` is an enumerator, accessing any of its properties causes
 `$input` to no longer be available. You can store `$input` in another variable
@@ -242,16 +242,16 @@ invoked, such as the name of the script that called the current command.
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
 object that `$MyInvocation` returns in the current script, such as the path and
-file name of the script (`$MyInvocation.MyCommand.Path`) or the name of a
+filename of the script (`$MyInvocation.MyCommand.Path`) or the name of a
 function (`$MyInvocation.MyCommand.Name`) to identify the current command. This
-is particularly useful for finding the name of the current script.
+is useful for finding the name of the current script.
 
 Beginning in PowerShell 3.0, `MyInvocation` has the following new properties.
 
 - **PSScriptRoot** - Contains the full path to the script that invoked the
   current command. The value of this property is populated only when the caller
   is a script.
-- **PSCommandPath** - Contains the full path and file name of the script that
+- **PSCommandPath** - Contains the full path and filename of the script that
   invoked the current command. The value of this property is populated only
   when the caller is a script.
 
@@ -344,7 +344,7 @@ Appointment on Friday: Team lunch
 
 ### $PID
 
-Contains the process identifier (PID) of the process that is hosting the
+Contains the process identifier (PID) of the process that's hosting the
 current PowerShell session.
 
 ### $PROFILE
@@ -426,7 +426,7 @@ and [about_Functions_Advanced](about_Functions_Advanced.md).
 
 ### $PSCommandPath
 
-Contains the full path and file name of the script that's being run. This
+Contains the full path and filename of the script that's being run. This
 variable is valid in all scripts.
 
 ### $PSCulture
@@ -441,11 +441,11 @@ dates, and is stored in a **System.Globalization.CultureInfo** object. Use
 
 While debugging, this variable contains information about the debugging
 environment. Otherwise, it contains a **null** value. As a result, you can use
-it to indicate whether the debugger has control. When populated, it contains a
+it to determine whether the debugger has control. When populated, it contains a
 **PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
 properties. The **InvocationInfo** property has several useful properties,
 including the **Location** property. The **Location** property indicates the
-path of the script that is being debugged.
+path of the script that's being debugged.
 
 ### $PSHOME
 
@@ -495,7 +495,7 @@ use the `Get-UICulture` cmdlet.
 ### $PSVersionTable
 
 Contains a read-only hash table that displays details about the version of
-PowerShell that is running in the current session. The table includes the
+PowerShell that's running in the current session. The table includes the
 following items:
 
 - **BuildVersion** - The build number of the current version
@@ -518,7 +518,7 @@ location for the current PowerShell runspace.
 
 > [!NOTE]
 > PowerShell supports multiple runspaces per process. Each runspace has its own
-> _current directory_. This is not the same as the current directory of the
+> _current directory_. This isn't the same as the current directory of the
 > process: `[System.Environment]::CurrentDirectory`.
 
 ### $Sender
@@ -555,7 +555,7 @@ the instance of the class itself.
 PowerShell's Extensible Type System (ETS) allows you to add properties to
 classes using script blocks. In a script block that defines a script property
 or script method, the `$this` variable refers to an instance of object of the
-class that is being extended. For example, PowerShell uses ETS to add the
+class that's being extended. For example, PowerShell uses ETS to add the
 **BaseName** property to the **FileInfo** class.
 
 ```powershell
@@ -750,11 +750,11 @@ After MoveNext:
 
 ### Example 3: Using the $input.Current property
 
-By using the **Current** property, the current pipeline value can be accessed
+With the **Current** property, the current pipeline value can be accessed
 multiple times without using the **Reset** method. The process block doesn't
 automatically call the **MoveNext** method.
 
-The **Current** property will never be populated unless you explicitly call
+The **Current** property is never populated unless you explicitly call
 **MoveNext**. The **Current** property can be accessed multiple times inside
 the process block without clearing its value.
 
@@ -799,7 +799,7 @@ access the current collection element, and the **Reset** and **MoveNext**
 methods to change its value.
 
 > [!NOTE]
-> Each iteration of the `foreach` loop will automatically call the **MoveNext**
+> Each iteration of the `foreach` loop automatically calls the **MoveNext**
 > method.
 
 The following loop only executes twice. In the second iteration, the collection

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 07/01/2022
+ms.date: 09/06/2022
 no-loc: [Reset, Current, Background, Blink, Bold, Foreground, Formatting, Hidden, Italic, Reset, Reverse, Underline]
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -224,9 +224,23 @@ Otherwise contains `$False`.
 Contains `$TRUE` if the current session is running on a Windows operating
 system. Otherwise contains `$FALSE`.
 
-### $LastExitCode
+### $LASTEXITCODE
 
-Contains the exit code of the last native program that was run.
+Contains the exit code of the last native program or PowerShell script that was
+run.
+
+For PowerShell scripts, the value of `$LASTEXITCODE` depends on how the script
+was called and whether the `exit` keyword was used:
+
+- When a script uses the `exit` keyword, `$LASTEXITCODE` is set to the
+  specified value, regardless of how the script was called. For more
+  information, see [about_Language_Keywords](about_language_keywords.md#exit).
+- When a script is called directly, like `./Test.ps1`, or with the
+  [call operator](about_operators.md#call-operator-) (`&`) like `& ./Test.ps1`,
+  the value of `$LASTEXITCODE` isn't changed.
+- When a script is called with `pwsh` and the **File** parameter, the value of
+  `$LASTEXITCODE` is set to `1` if the script terminated due to a thrown
+  exception and `0` otherwise.
 
 ### $Matches
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -34,12 +34,12 @@ last command succeeded and **False** if it failed.
 
 For cmdlets and advanced functions that are run at multiple stages in a
 pipeline, for example in both `process` and `end` blocks, calling
-`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point will
-set `$?` to **False**, as will `this.ThrowTerminatingError()` and
+`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point
+sets `$?` to **False**, as does `this.ThrowTerminatingError()` and
 `$PSCmdlet.ThrowTerminatingError()`.
 
-The `Write-Error` cmdlet always sets `$?` to **False** immediately after it is
-executed, but will not set `$?` to **False** for a function calling it:
+The `Write-Error` cmdlet always sets `$?` to **False** immediately after it's
+executed, but won't set `$?` to **False** for a function calling it:
 
 ```powershell
 function Test-WriteError
@@ -61,7 +61,7 @@ is 0, and set to **False** when `$LASTEXITCODE` is any other value.
 > Until PowerShell 7, containing a statement within parentheses `(...)`,
 > subexpression syntax `$(...)` or array expression `@(...)` always reset
 > `$?` to **True**, so that `(Write-Error)` shows `$?` as **True**.
-> This has been changed in PowerShell 7, so that `$?` will always reflect
+> This has been changed in PowerShell 7, so that `$?` always reflects
 > the actual success of the last command run in these expressions.
 
 ### $^
@@ -78,11 +78,11 @@ selected objects in a pipeline.
 
 Contains an array of values for undeclared parameters that are passed to a
 function, script, or script block. When you create a function, you can declare
-the parameters by using the `param` keyword or by adding a comma-separated list
+the parameters with the `param` keyword or by adding a comma-separated list
 of parameters in parentheses after the function name.
 
 In an event action, the `$args` variable contains objects that represent the
-event arguments of the event that is being processed. This variable is
+event arguments of the event that's being processed. This variable is
 populated only within the `Action` block of an event registration command. The
 value of this variable can also be found in the **SourceArgs** property of the
 **PSEventArgs** object that `Get-Event` returns.
@@ -96,7 +96,7 @@ export snap-in names to a console file.
 
 When you use the `Export-Console` cmdlet without parameters, it automatically
 updates the console file that was most recently used in the session. You can
-use this automatic variable to determine which file will be updated.
+use this automatic variable to determine the file to update.
 
 ### $Error
 
@@ -109,17 +109,17 @@ information, see [about_CommonParameters](about_CommonParameters.md).
 
 ### $Event
 
-Contains a **PSEventArgs** object that represents the event that is being
+Contains a **PSEventArgs** object that represents the event that's being
 processed. This variable is populated only within the `Action` block of an
 event registration command, such as `Register-ObjectEvent`. The value of this
-variable is the same object that the `Get-Event` cmdlet returns. Therefore, you
+variable is the same object that the `Get-Event` cmdlet returns. You
 can use the properties of the `Event` variable, such as `$Event.TimeGenerated`,
 in an `Action` script block.
 
 ### $EventArgs
 
 Contains an object that represents the first event argument that derives from
-**EventArgs** of the event that is being processed. This variable is populated
+**EventArgs** of the event that's being processed. This variable is populated
 only within the `Action` block of an event registration command. The value of
 this variable can also be found in the **SourceEventArgs** property of the
 **PSEventArgs** object that `Get-Event` returns.
@@ -127,7 +127,7 @@ this variable can also be found in the **SourceEventArgs** property of the
 ### $EventSubscriber
 
 Contains a **PSEventSubscriber** object that represents the event subscriber of
-the event that is being processed. This variable is populated only within the
+the event that's being processed. This variable is populated only within the
 `Action` block of an event registration command. The value of this variable is
 the same object that the `Get-EventSubscriber` cmdlet returns.
 
@@ -140,7 +140,7 @@ that are available to cmdlets.
 ### $false
 
 Contains **False**. You can use this variable to represent **False** in
-commands and scripts instead of using the string "false". The string can be
+commands and scripts instead of using the string `"false"`. The string can be
 interpreted as **True** if it's converted to a non-empty string or to a
 non-zero integer.
 
@@ -165,28 +165,28 @@ variables, typically `C:\Users\<UserName>`.
 Contains an object that represents the current host application for PowerShell.
 You can use this variable to represent the current host in commands or to
 display or change the properties of the host, such as `$Host.version` or
-`$Host.CurrentCulture`, or `$host.ui.rawui.setbackgroundcolor("Red")`.
+`$Host.CurrentCulture`, or `$host.UI.RawUI.SetBackGroundColor("Red")`.
 
 ### $input
 
-Contains an enumerator that enumerates all input that is passed to a function.
+Contains an enumerator that enumerates all input that's passed to a function.
 The `$input` variable is available only to functions and script blocks (which
 are unnamed functions).
 
-- In a function without a `Begin`, `Process`, or `End` block, the `$input`
+- In a function without a `begin`, `process`, or `end` block, the `$input`
   variable enumerates the collection of all input to the function.
 
-- In the `Begin` block, the `$input` variable contains no data.
+- In the `begin` block, the `$input` variable contains no data.
 
-- In the `Process` block, the `$input` variable contains the object that is
+- In the `process` block, the `$input` variable contains the object that's
   currently in the pipeline.
 
-- In the `End` block, the `$input` variable enumerates the collection of all
+- In the `end` block, the `$input` variable enumerates the collection of all
   input to the function.
 
   > [!NOTE]
-  > You cannot use the `$input` variable inside both the Process block and the
-  > End block in the same function or script block.
+  > You can't use the `$input` variable inside both the `process` block and the
+  > `end` block in the same function or script block.
 
 Since `$input` is an enumerator, accessing any of its properties causes
 `$input` to no longer be available. You can store `$input` in another variable
@@ -262,16 +262,16 @@ invoked, such as the name of the script that called the current command.
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
 object that `$MyInvocation` returns in the current script, such as the path and
-file name of the script (`$MyInvocation.MyCommand.Path`) or the name of a
+filename of the script (`$MyInvocation.MyCommand.Path`) or the name of a
 function (`$MyInvocation.MyCommand.Name`) to identify the current command. This
-is particularly useful for finding the name of the current script.
+is useful for finding the name of the current script.
 
 Beginning in PowerShell 3.0, `MyInvocation` has the following new properties.
 
 - **PSScriptRoot** - Contains the full path to the script that invoked the
   current command. The value of this property is populated only when the caller
   is a script.
-- **PSCommandPath** - Contains the full path and file name of the script that
+- **PSCommandPath** - Contains the full path and filename of the script that
   invoked the current command. The value of this property is populated only
   when the caller is a script.
 
@@ -364,7 +364,7 @@ Appointment on Friday: Team lunch
 
 ### $PID
 
-Contains the process identifier (PID) of the process that is hosting the
+Contains the process identifier (PID) of the process that's hosting the
 current PowerShell session.
 
 ### $PROFILE
@@ -446,7 +446,7 @@ and [about_Functions_Advanced](about_Functions_Advanced.md).
 
 ### $PSCommandPath
 
-Contains the full path and file name of the script that's being run. This
+Contains the full path and filename of the script that's being run. This
 variable is valid in all scripts.
 
 ### $PSCulture
@@ -464,11 +464,11 @@ and dates, and is stored in a **System.Globalization.CultureInfo** object. Use
 
 While debugging, this variable contains information about the debugging
 environment. Otherwise, it contains a **null** value. As a result, you can use
-it to indicate whether the debugger has control. When populated, it contains a
+it to determine whether the debugger has control. When populated, it contains a
 **PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
 properties. The **InvocationInfo** property has several useful properties,
 including the **Location** property. The **Location** property indicates the
-path of the script that is being debugged.
+path of the script that's being debugged.
 
 ### $PSHOME
 
@@ -518,14 +518,14 @@ use the `Get-UICulture` cmdlet.
 ### $PSVersionTable
 
 Contains a read-only hash table that displays details about the version of
-PowerShell that is running in the current session. The table includes the
+PowerShell that's running in the current session. The table includes the
 following items:
 
 - **PSVersion** - The PowerShell version number
 - **PSEdition** This property has the value of 'Desktop' for PowerShell 4 and
   below as well as PowerShell 5.1 on full-featured Windows editions. This
-  property has the value of `Core` for PowerShell 6 and above as well as
-  PowerShell PowerShell 5.1 on reduced-footprint editions like Windows Nano
+  property has the value of `Core` for PowerShell 6 and higher as well as
+  Windows PowerShell 5.1 on reduced-footprint editions like Windows Nano
   Server or Windows IoT.
 - **GitCommitId** - The commit Id of the source files, in GitHub,
 - **OS** - Description of the operating system that PowerShell is running on.
@@ -545,7 +545,7 @@ location for the current PowerShell runspace.
 
 > [!NOTE]
 > PowerShell supports multiple runspaces per process. Each runspace has its own
-> _current directory_. This is not the same as the current directory of the
+> _current directory_. This isn't the same as the current directory of the
 > process: `[System.Environment]::CurrentDirectory`.
 
 ### $Sender
@@ -582,7 +582,7 @@ the instance of the class itself.
 PowerShell's Extensible Type System (ETS) allows you to add properties to
 classes using script blocks. In a script block that defines a script property
 or script method, the `$this` variable refers to an instance of object of the
-class that is being extended. For example, PowerShell uses ETS to add the
+class that's being extended. For example, PowerShell uses ETS to add the
 **BaseName** property to the **FileInfo** class.
 
 ```powershell
@@ -777,11 +777,11 @@ After MoveNext:
 
 ### Example 3: Using the $input.Current property
 
-By using the **Current** property, the current pipeline value can be accessed
+With the **Current** property, the current pipeline value can be accessed
 multiple times without using the **Reset** method. The process block doesn't
 automatically call the **MoveNext** method.
 
-The **Current** property will never be populated unless you explicitly call
+The **Current** property is never populated unless you explicitly call
 **MoveNext**. The **Current** property can be accessed multiple times inside
 the process block without clearing its value.
 
@@ -826,7 +826,7 @@ access the current collection element, and the **Reset** and **MoveNext**
 methods to change its value.
 
 > [!NOTE]
-> Each iteration of the `foreach` loop will automatically call the **MoveNext**
+> Each iteration of the `foreach` loop automatically calls the **MoveNext**
 > method.
 
 The following loop only executes twice. In the second iteration, the collection

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -34,8 +34,8 @@ last command succeeded and **False** if it failed.
 
 For cmdlets and advanced functions that are run at multiple stages in a
 pipeline, for example in both `process` and `end` blocks, calling
-`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point
-sets `$?` to **False**, as does `this.ThrowTerminatingError()` and
+`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point sets
+`$?` to **False**, as does `this.ThrowTerminatingError()` and
 `$PSCmdlet.ThrowTerminatingError()`.
 
 The `Write-Error` cmdlet always sets `$?` to **False** immediately after it's
@@ -59,10 +59,10 @@ is 0, and set to **False** when `$LASTEXITCODE` is any other value.
 
 > [!NOTE]
 > Until PowerShell 7, containing a statement within parentheses `(...)`,
-> subexpression syntax `$(...)` or array expression `@(...)` always reset
-> `$?` to **True**, so that `(Write-Error)` shows `$?` as **True**.
-> This has been changed in PowerShell 7, so that `$?` always reflects
-> the actual success of the last command run in these expressions.
+> subexpression syntax `$(...)` or array expression `@(...)` always reset `$?`
+> to **True**, so that `(Write-Error)` shows `$?` as **True**. This has been
+> changed in PowerShell 7, so that `$?` always reflects the actual success of
+> the last command run in these expressions.
 
 ### $^
 
@@ -78,13 +78,13 @@ selected objects in a pipeline.
 
 Contains an array of values for undeclared parameters that are passed to a
 function, script, or script block. When you create a function, you can declare
-the parameters with the `param` keyword or by adding a comma-separated list
-of parameters in parentheses after the function name.
+the parameters with the `param` keyword or by adding a comma-separated list of
+parameters in parentheses after the function name.
 
 In an event action, the `$args` variable contains objects that represent the
-event arguments of the event that's being processed. This variable is
-populated only within the `Action` block of an event registration command. The
-value of this variable can also be found in the **SourceArgs** property of the
+event arguments of the event that's being processed. This variable is populated
+only within the `Action` block of an event registration command. The value of
+this variable can also be found in the **SourceArgs** property of the
 **PSEventArgs** object that `Get-Event` returns.
 
 ### $ConsoleFileName
@@ -112,9 +112,9 @@ information, see [about_CommonParameters](about_CommonParameters.md).
 Contains a **PSEventArgs** object that represents the event that's being
 processed. This variable is populated only within the `Action` block of an
 event registration command, such as `Register-ObjectEvent`. The value of this
-variable is the same object that the `Get-Event` cmdlet returns. You
-can use the properties of the `Event` variable, such as `$Event.TimeGenerated`,
-in an `Action` script block.
+variable is the same object that the `Get-Event` cmdlet returns. You can use
+the properties of the `Event` variable, such as `$Event.TimeGenerated`, in an
+`Action` script block.
 
 ### $EventArgs
 
@@ -250,8 +250,8 @@ operators. For more information about the `switch` statement, see
 > [!NOTE]
 > When `$Matches` is populated in a session, it retains the matched value until
 > it's overwritten by another match. If `-match` is used again and no match is
-> found, it doesn't reset `$Matches` to `$null`. The previously matched value is
-> kept in `$Matches` until another match is found.
+> found, it doesn't reset `$Matches` to `$null`. The previously matched value
+> is kept in `$Matches` until another match is found.
 
 ### $MyInvocation
 
@@ -309,8 +309,8 @@ PowerShell treats `$null` as an object with a value, that is, as an explicit
 placeholder, so you can use `$null` to represent an empty value in a series of
 values.
 
-For example, when `$null` is included in a collection, it's counted as one
-of the objects.
+For example, when `$null` is included in a collection, it's counted as one of
+the objects.
 
 ```powershell
 $a = "one", $null, "three"
@@ -525,8 +525,8 @@ following items:
 - **PSEdition** This property has the value of 'Desktop' for PowerShell 4 and
   below as well as PowerShell 5.1 on full-featured Windows editions. This
   property has the value of `Core` for PowerShell 6 and higher as well as
-  Windows PowerShell 5.1 on reduced-footprint editions like Windows Nano
-  Server or Windows IoT.
+  Windows PowerShell 5.1 on reduced-footprint editions like Windows Nano Server
+  or Windows IoT.
 - **GitCommitId** - The commit Id of the source files, in GitHub,
 - **OS** - Description of the operating system that PowerShell is running on.
 - **Platform** - Platform that the operating system is running on. The value on
@@ -591,8 +591,9 @@ PS> Get-ChildItem .\README.md | Get-Member BaseName | Format-List
 TypeName   : System.IO.FileInfo
 Name       : BaseName
 MemberType : ScriptProperty
-Definition : System.Object BaseName {get=if ($this.Extension.Length -gt 0){$this.Name.Remove($this.Name.Length -
-             $this.Extension.Length)}else{$this.Name};}
+Definition : System.Object BaseName {get=if ($this.Extension.Length -gt 0)
+             {$this.Name.Remove($this.Name.Length - $this.Extension.Length
+             )}else{$this.Name};}
 ```
 
 For more information, see [about_Types.ps1xml](./about_Types.ps1xml.md).

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 07/01/2022
+ms.date: 09/06/2022
 no-loc: [Reset, Current, Background, Blink, Bold, Foreground, Formatting, Hidden, Italic, Reset, Reverse, Underline]
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -224,9 +224,23 @@ Otherwise contains `$False`.
 Contains `$TRUE` if the current session is running on a Windows operating
 system. Otherwise contains `$FALSE`.
 
-### $LastExitCode
+### $LASTEXITCODE
 
-Contains the exit code of the last native program that was run.
+Contains the exit code of the last native program or PowerShell script that was
+run.
+
+For PowerShell scripts, the value of `$LASTEXITCODE` depends on how the script
+was called and whether the `exit` keyword was used:
+
+- When a script uses the `exit` keyword, `$LASTEXITCODE` is set to the
+  specified value, regardless of how the script was called. For more
+  information, see [about_Language_Keywords](about_language_keywords.md#exit).
+- When a script is called directly, like `./Test.ps1`, or with the
+  [call operator](about_operators.md#call-operator-) (`&`) like `& ./Test.ps1`,
+  the value of `$LASTEXITCODE` isn't changed.
+- When a script is called with `pwsh` and the **File** parameter, the value of
+  `$LASTEXITCODE` is set to `1` if the script terminated due to a thrown
+  exception and `0` otherwise.
 
 ### $Matches
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -34,12 +34,12 @@ last command succeeded and **False** if it failed.
 
 For cmdlets and advanced functions that are run at multiple stages in a
 pipeline, for example in both `process` and `end` blocks, calling
-`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point will
-set `$?` to **False**, as will `this.ThrowTerminatingError()` and
+`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point
+sets `$?` to **False**, as does `this.ThrowTerminatingError()` and
 `$PSCmdlet.ThrowTerminatingError()`.
 
-The `Write-Error` cmdlet always sets `$?` to **False** immediately after it is
-executed, but will not set `$?` to **False** for a function calling it:
+The `Write-Error` cmdlet always sets `$?` to **False** immediately after it's
+executed, but won't set `$?` to **False** for a function calling it:
 
 ```powershell
 function Test-WriteError
@@ -61,7 +61,7 @@ is 0, and set to **False** when `$LASTEXITCODE` is any other value.
 > Until PowerShell 7, containing a statement within parentheses `(...)`,
 > subexpression syntax `$(...)` or array expression `@(...)` always reset
 > `$?` to **True**, so that `(Write-Error)` shows `$?` as **True**.
-> This has been changed in PowerShell 7, so that `$?` will always reflect
+> This has been changed in PowerShell 7, so that `$?` always reflects
 > the actual success of the last command run in these expressions.
 
 ### $^
@@ -78,11 +78,11 @@ selected objects in a pipeline.
 
 Contains an array of values for undeclared parameters that are passed to a
 function, script, or script block. When you create a function, you can declare
-the parameters by using the `param` keyword or by adding a comma-separated list
+the parameters with the `param` keyword or by adding a comma-separated list
 of parameters in parentheses after the function name.
 
 In an event action, the `$args` variable contains objects that represent the
-event arguments of the event that is being processed. This variable is
+event arguments of the event that's being processed. This variable is
 populated only within the `Action` block of an event registration command. The
 value of this variable can also be found in the **SourceArgs** property of the
 **PSEventArgs** object that `Get-Event` returns.
@@ -96,7 +96,7 @@ export snap-in names to a console file.
 
 When you use the `Export-Console` cmdlet without parameters, it automatically
 updates the console file that was most recently used in the session. You can
-use this automatic variable to determine which file will be updated.
+use this automatic variable to determine the file to update.
 
 ### $Error
 
@@ -109,17 +109,17 @@ information, see [about_CommonParameters](about_CommonParameters.md).
 
 ### $Event
 
-Contains a **PSEventArgs** object that represents the event that is being
+Contains a **PSEventArgs** object that represents the event that's being
 processed. This variable is populated only within the `Action` block of an
 event registration command, such as `Register-ObjectEvent`. The value of this
-variable is the same object that the `Get-Event` cmdlet returns. Therefore, you
+variable is the same object that the `Get-Event` cmdlet returns. You
 can use the properties of the `Event` variable, such as `$Event.TimeGenerated`,
 in an `Action` script block.
 
 ### $EventArgs
 
 Contains an object that represents the first event argument that derives from
-**EventArgs** of the event that is being processed. This variable is populated
+**EventArgs** of the event that's being processed. This variable is populated
 only within the `Action` block of an event registration command. The value of
 this variable can also be found in the **SourceEventArgs** property of the
 **PSEventArgs** object that `Get-Event` returns.
@@ -127,7 +127,7 @@ this variable can also be found in the **SourceEventArgs** property of the
 ### $EventSubscriber
 
 Contains a **PSEventSubscriber** object that represents the event subscriber of
-the event that is being processed. This variable is populated only within the
+the event that's being processed. This variable is populated only within the
 `Action` block of an event registration command. The value of this variable is
 the same object that the `Get-EventSubscriber` cmdlet returns.
 
@@ -140,7 +140,7 @@ that are available to cmdlets.
 ### $false
 
 Contains **False**. You can use this variable to represent **False** in
-commands and scripts instead of using the string "false". The string can be
+commands and scripts instead of using the string `"false"`. The string can be
 interpreted as **True** if it's converted to a non-empty string or to a
 non-zero integer.
 
@@ -165,28 +165,28 @@ variables, typically `C:\Users\<UserName>`.
 Contains an object that represents the current host application for PowerShell.
 You can use this variable to represent the current host in commands or to
 display or change the properties of the host, such as `$Host.version` or
-`$Host.CurrentCulture`, or `$host.ui.rawui.setbackgroundcolor("Red")`.
+`$Host.CurrentCulture`, or `$host.UI.RawUI.SetBackGroundColor("Red")`.
 
 ### $input
 
-Contains an enumerator that enumerates all input that is passed to a function.
+Contains an enumerator that enumerates all input that's passed to a function.
 The `$input` variable is available only to functions and script blocks (which
 are unnamed functions).
 
-- In a function without a `Begin`, `Process`, or `End` block, the `$input`
+- In a function without a `begin`, `process`, or `end` block, the `$input`
   variable enumerates the collection of all input to the function.
 
-- In the `Begin` block, the `$input` variable contains no data.
+- In the `begin` block, the `$input` variable contains no data.
 
-- In the `Process` block, the `$input` variable contains the object that is
+- In the `process` block, the `$input` variable contains the object that's
   currently in the pipeline.
 
-- In the `End` block, the `$input` variable enumerates the collection of all
+- In the `end` block, the `$input` variable enumerates the collection of all
   input to the function.
 
   > [!NOTE]
-  > You cannot use the `$input` variable inside both the Process block and the
-  > End block in the same function or script block.
+  > You can't use the `$input` variable inside both the `process` block and the
+  > `end` block in the same function or script block.
 
 Since `$input` is an enumerator, accessing any of its properties causes
 `$input` to no longer be available. You can store `$input` in another variable
@@ -262,16 +262,16 @@ invoked, such as the name of the script that called the current command.
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
 object that `$MyInvocation` returns in the current script, such as the path and
-file name of the script (`$MyInvocation.MyCommand.Path`) or the name of a
+filename of the script (`$MyInvocation.MyCommand.Path`) or the name of a
 function (`$MyInvocation.MyCommand.Name`) to identify the current command. This
-is particularly useful for finding the name of the current script.
+is useful for finding the name of the current script.
 
 Beginning in PowerShell 3.0, `MyInvocation` has the following new properties.
 
 - **PSScriptRoot** - Contains the full path to the script that invoked the
   current command. The value of this property is populated only when the caller
   is a script.
-- **PSCommandPath** - Contains the full path and file name of the script that
+- **PSCommandPath** - Contains the full path and filename of the script that
   invoked the current command. The value of this property is populated only
   when the caller is a script.
 
@@ -364,7 +364,7 @@ Appointment on Friday: Team lunch
 
 ### $PID
 
-Contains the process identifier (PID) of the process that is hosting the
+Contains the process identifier (PID) of the process that's hosting the
 current PowerShell session.
 
 ### $PROFILE
@@ -446,7 +446,7 @@ and [about_Functions_Advanced](about_Functions_Advanced.md).
 
 ### $PSCommandPath
 
-Contains the full path and file name of the script that's being run. This
+Contains the full path and filename of the script that's being run. This
 variable is valid in all scripts.
 
 ### $PSCulture
@@ -464,11 +464,11 @@ and dates, and is stored in a **System.Globalization.CultureInfo** object. Use
 
 While debugging, this variable contains information about the debugging
 environment. Otherwise, it contains a **null** value. As a result, you can use
-it to indicate whether the debugger has control. When populated, it contains a
+it to determine whether the debugger has control. When populated, it contains a
 **PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
 properties. The **InvocationInfo** property has several useful properties,
 including the **Location** property. The **Location** property indicates the
-path of the script that is being debugged.
+path of the script that's being debugged.
 
 ### $PSHOME
 
@@ -518,14 +518,14 @@ use the `Get-UICulture` cmdlet.
 ### $PSVersionTable
 
 Contains a read-only hash table that displays details about the version of
-PowerShell that is running in the current session. The table includes the
+PowerShell that's running in the current session. The table includes the
 following items:
 
 - **PSVersion** - The PowerShell version number
 - **PSEdition** This property has the value of 'Desktop' for PowerShell 4 and
   below as well as PowerShell 5.1 on full-featured Windows editions. This
-  property has the value of `Core` for PowerShell 6 and above as well as
-  PowerShell PowerShell 5.1 on reduced-footprint editions like Windows Nano
+  property has the value of `Core` for PowerShell 6 and higher as well as
+  Windows PowerShell 5.1 on reduced-footprint editions like Windows Nano
   Server or Windows IoT.
 - **GitCommitId** - The commit Id of the source files, in GitHub,
 - **OS** - Description of the operating system that PowerShell is running on.
@@ -545,7 +545,7 @@ location for the current PowerShell runspace.
 
 > [!NOTE]
 > PowerShell supports multiple runspaces per process. Each runspace has its own
-> _current directory_. This is not the same as the current directory of the
+> _current directory_. This isn't the same as the current directory of the
 > process: `[System.Environment]::CurrentDirectory`.
 
 ### $Sender
@@ -582,7 +582,7 @@ the instance of the class itself.
 PowerShell's Extensible Type System (ETS) allows you to add properties to
 classes using script blocks. In a script block that defines a script property
 or script method, the `$this` variable refers to an instance of object of the
-class that is being extended. For example, PowerShell uses ETS to add the
+class that's being extended. For example, PowerShell uses ETS to add the
 **BaseName** property to the **FileInfo** class.
 
 ```powershell
@@ -777,11 +777,11 @@ After MoveNext:
 
 ### Example 3: Using the $input.Current property
 
-By using the **Current** property, the current pipeline value can be accessed
+With the **Current** property, the current pipeline value can be accessed
 multiple times without using the **Reset** method. The process block doesn't
 automatically call the **MoveNext** method.
 
-The **Current** property will never be populated unless you explicitly call
+The **Current** property is never populated unless you explicitly call
 **MoveNext**. The **Current** property can be accessed multiple times inside
 the process block without clearing its value.
 
@@ -826,7 +826,7 @@ access the current collection element, and the **Reset** and **MoveNext**
 methods to change its value.
 
 > [!NOTE]
-> Each iteration of the `foreach` loop will automatically call the **MoveNext**
+> Each iteration of the `foreach` loop automatically calls the **MoveNext**
 > method.
 
 The following loop only executes twice. In the second iteration, the collection

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -34,8 +34,8 @@ last command succeeded and **False** if it failed.
 
 For cmdlets and advanced functions that are run at multiple stages in a
 pipeline, for example in both `process` and `end` blocks, calling
-`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point
-sets `$?` to **False**, as does `this.ThrowTerminatingError()` and
+`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point sets
+`$?` to **False**, as does `this.ThrowTerminatingError()` and
 `$PSCmdlet.ThrowTerminatingError()`.
 
 The `Write-Error` cmdlet always sets `$?` to **False** immediately after it's
@@ -59,10 +59,10 @@ is 0, and set to **False** when `$LASTEXITCODE` is any other value.
 
 > [!NOTE]
 > Until PowerShell 7, containing a statement within parentheses `(...)`,
-> subexpression syntax `$(...)` or array expression `@(...)` always reset
-> `$?` to **True**, so that `(Write-Error)` shows `$?` as **True**.
-> This has been changed in PowerShell 7, so that `$?` always reflects
-> the actual success of the last command run in these expressions.
+> subexpression syntax `$(...)` or array expression `@(...)` always reset `$?`
+> to **True**, so that `(Write-Error)` shows `$?` as **True**. This has been
+> changed in PowerShell 7, so that `$?` always reflects the actual success of
+> the last command run in these expressions.
 
 ### $^
 
@@ -78,13 +78,13 @@ selected objects in a pipeline.
 
 Contains an array of values for undeclared parameters that are passed to a
 function, script, or script block. When you create a function, you can declare
-the parameters with the `param` keyword or by adding a comma-separated list
-of parameters in parentheses after the function name.
+the parameters with the `param` keyword or by adding a comma-separated list of
+parameters in parentheses after the function name.
 
 In an event action, the `$args` variable contains objects that represent the
-event arguments of the event that's being processed. This variable is
-populated only within the `Action` block of an event registration command. The
-value of this variable can also be found in the **SourceArgs** property of the
+event arguments of the event that's being processed. This variable is populated
+only within the `Action` block of an event registration command. The value of
+this variable can also be found in the **SourceArgs** property of the
 **PSEventArgs** object that `Get-Event` returns.
 
 ### $ConsoleFileName
@@ -112,9 +112,9 @@ information, see [about_CommonParameters](about_CommonParameters.md).
 Contains a **PSEventArgs** object that represents the event that's being
 processed. This variable is populated only within the `Action` block of an
 event registration command, such as `Register-ObjectEvent`. The value of this
-variable is the same object that the `Get-Event` cmdlet returns. You
-can use the properties of the `Event` variable, such as `$Event.TimeGenerated`,
-in an `Action` script block.
+variable is the same object that the `Get-Event` cmdlet returns. You can use
+the properties of the `Event` variable, such as `$Event.TimeGenerated`, in an
+`Action` script block.
 
 ### $EventArgs
 
@@ -250,8 +250,8 @@ operators. For more information about the `switch` statement, see
 > [!NOTE]
 > When `$Matches` is populated in a session, it retains the matched value until
 > it's overwritten by another match. If `-match` is used again and no match is
-> found, it doesn't reset `$Matches` to `$null`. The previously matched value is
-> kept in `$Matches` until another match is found.
+> found, it doesn't reset `$Matches` to `$null`. The previously matched value
+> is kept in `$Matches` until another match is found.
 
 ### $MyInvocation
 
@@ -309,8 +309,8 @@ PowerShell treats `$null` as an object with a value, that is, as an explicit
 placeholder, so you can use `$null` to represent an empty value in a series of
 values.
 
-For example, when `$null` is included in a collection, it's counted as one
-of the objects.
+For example, when `$null` is included in a collection, it's counted as one of
+the objects.
 
 ```powershell
 $a = "one", $null, "three"
@@ -525,8 +525,8 @@ following items:
 - **PSEdition** This property has the value of 'Desktop' for PowerShell 4 and
   below as well as PowerShell 5.1 on full-featured Windows editions. This
   property has the value of `Core` for PowerShell 6 and higher as well as
-  Windows PowerShell 5.1 on reduced-footprint editions like Windows Nano
-  Server or Windows IoT.
+  Windows PowerShell 5.1 on reduced-footprint editions like Windows Nano Server
+  or Windows IoT.
 - **GitCommitId** - The commit Id of the source files, in GitHub,
 - **OS** - Description of the operating system that PowerShell is running on.
 - **Platform** - Platform that the operating system is running on. The value on
@@ -591,8 +591,9 @@ PS> Get-ChildItem .\README.md | Get-Member BaseName | Format-List
 TypeName   : System.IO.FileInfo
 Name       : BaseName
 MemberType : ScriptProperty
-Definition : System.Object BaseName {get=if ($this.Extension.Length -gt 0){$this.Name.Remove($this.Name.Length -
-             $this.Extension.Length)}else{$this.Name};}
+Definition : System.Object BaseName {get=if ($this.Extension.Length -gt 0)
+             {$this.Name.Remove($this.Name.Length - $this.Extension.Length
+             )}else{$this.Name};}
 ```
 
 For more information, see [about_Types.ps1xml](./about_Types.ps1xml.md).

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 07/01/2022
+ms.date: 09/06/2022
 no-loc: [Reset, Current, Background, Blink, Bold, Foreground, Formatting, Hidden, Italic, Reset, Reverse, Underline]
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -224,9 +224,23 @@ Otherwise contains `$False`.
 Contains `$TRUE` if the current session is running on a Windows operating
 system. Otherwise contains `$FALSE`.
 
-### $LastExitCode
+### $LASTEXITCODE
 
-Contains the exit code of the last native program that was run.
+Contains the exit code of the last native program or PowerShell script that was
+run.
+
+For PowerShell scripts, the value of `$LASTEXITCODE` depends on how the script
+was called and whether the `exit` keyword was used:
+
+- When a script uses the `exit` keyword, `$LASTEXITCODE` is set to the
+  specified value, regardless of how the script was called. For more
+  information, see [about_Language_Keywords](about_language_keywords.md#exit).
+- When a script is called directly, like `./Test.ps1`, or with the
+  [call operator](about_operators.md#call-operator-) (`&`) like `& ./Test.ps1`,
+  the value of `$LASTEXITCODE` isn't changed.
+- When a script is called with `pwsh` and the **File** parameter, the value of
+  `$LASTEXITCODE` is set to `1` if the script terminated due to a thrown
+  exception and `0` otherwise.
 
 ### $Matches
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -34,12 +34,12 @@ last command succeeded and **False** if it failed.
 
 For cmdlets and advanced functions that are run at multiple stages in a
 pipeline, for example in both `process` and `end` blocks, calling
-`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point will
-set `$?` to **False**, as will `this.ThrowTerminatingError()` and
+`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point
+sets `$?` to **False**, as does `this.ThrowTerminatingError()` and
 `$PSCmdlet.ThrowTerminatingError()`.
 
-The `Write-Error` cmdlet always sets `$?` to **False** immediately after it is
-executed, but will not set `$?` to **False** for a function calling it:
+The `Write-Error` cmdlet always sets `$?` to **False** immediately after it's
+executed, but won't set `$?` to **False** for a function calling it:
 
 ```powershell
 function Test-WriteError
@@ -61,7 +61,7 @@ is 0, and set to **False** when `$LASTEXITCODE` is any other value.
 > Until PowerShell 7, containing a statement within parentheses `(...)`,
 > subexpression syntax `$(...)` or array expression `@(...)` always reset
 > `$?` to **True**, so that `(Write-Error)` shows `$?` as **True**.
-> This has been changed in PowerShell 7, so that `$?` will always reflect
+> This has been changed in PowerShell 7, so that `$?` always reflects
 > the actual success of the last command run in these expressions.
 
 ### $^
@@ -78,11 +78,11 @@ selected objects in a pipeline.
 
 Contains an array of values for undeclared parameters that are passed to a
 function, script, or script block. When you create a function, you can declare
-the parameters by using the `param` keyword or by adding a comma-separated list
+the parameters with the `param` keyword or by adding a comma-separated list
 of parameters in parentheses after the function name.
 
 In an event action, the `$args` variable contains objects that represent the
-event arguments of the event that is being processed. This variable is
+event arguments of the event that's being processed. This variable is
 populated only within the `Action` block of an event registration command. The
 value of this variable can also be found in the **SourceArgs** property of the
 **PSEventArgs** object that `Get-Event` returns.
@@ -96,7 +96,7 @@ export snap-in names to a console file.
 
 When you use the `Export-Console` cmdlet without parameters, it automatically
 updates the console file that was most recently used in the session. You can
-use this automatic variable to determine which file will be updated.
+use this automatic variable to determine the file to update.
 
 ### $Error
 
@@ -109,17 +109,17 @@ information, see [about_CommonParameters](about_CommonParameters.md).
 
 ### $Event
 
-Contains a **PSEventArgs** object that represents the event that is being
+Contains a **PSEventArgs** object that represents the event that's being
 processed. This variable is populated only within the `Action` block of an
 event registration command, such as `Register-ObjectEvent`. The value of this
-variable is the same object that the `Get-Event` cmdlet returns. Therefore, you
+variable is the same object that the `Get-Event` cmdlet returns. You
 can use the properties of the `Event` variable, such as `$Event.TimeGenerated`,
 in an `Action` script block.
 
 ### $EventArgs
 
 Contains an object that represents the first event argument that derives from
-**EventArgs** of the event that is being processed. This variable is populated
+**EventArgs** of the event that's being processed. This variable is populated
 only within the `Action` block of an event registration command. The value of
 this variable can also be found in the **SourceEventArgs** property of the
 **PSEventArgs** object that `Get-Event` returns.
@@ -127,7 +127,7 @@ this variable can also be found in the **SourceEventArgs** property of the
 ### $EventSubscriber
 
 Contains a **PSEventSubscriber** object that represents the event subscriber of
-the event that is being processed. This variable is populated only within the
+the event that's being processed. This variable is populated only within the
 `Action` block of an event registration command. The value of this variable is
 the same object that the `Get-EventSubscriber` cmdlet returns.
 
@@ -140,7 +140,7 @@ that are available to cmdlets.
 ### $false
 
 Contains **False**. You can use this variable to represent **False** in
-commands and scripts instead of using the string "false". The string can be
+commands and scripts instead of using the string `"false"`. The string can be
 interpreted as **True** if it's converted to a non-empty string or to a
 non-zero integer.
 
@@ -165,28 +165,28 @@ variables, typically `C:\Users\<UserName>`.
 Contains an object that represents the current host application for PowerShell.
 You can use this variable to represent the current host in commands or to
 display or change the properties of the host, such as `$Host.version` or
-`$Host.CurrentCulture`, or `$host.ui.rawui.setbackgroundcolor("Red")`.
+`$Host.CurrentCulture`, or `$host.UI.RawUI.SetBackGroundColor("Red")`.
 
 ### $input
 
-Contains an enumerator that enumerates all input that is passed to a function.
+Contains an enumerator that enumerates all input that's passed to a function.
 The `$input` variable is available only to functions and script blocks (which
 are unnamed functions).
 
-- In a function without a `Begin`, `Process`, or `End` block, the `$input`
+- In a function without a `begin`, `process`, or `end` block, the `$input`
   variable enumerates the collection of all input to the function.
 
-- In the `Begin` block, the `$input` variable contains no data.
+- In the `begin` block, the `$input` variable contains no data.
 
-- In the `Process` block, the `$input` variable contains the object that is
+- In the `process` block, the `$input` variable contains the object that's
   currently in the pipeline.
 
-- In the `End` block, the `$input` variable enumerates the collection of all
+- In the `end` block, the `$input` variable enumerates the collection of all
   input to the function.
 
   > [!NOTE]
-  > You cannot use the `$input` variable inside both the Process block and the
-  > End block in the same function or script block.
+  > You can't use the `$input` variable inside both the `process` block and the
+  > `end` block in the same function or script block.
 
 Since `$input` is an enumerator, accessing any of its properties causes
 `$input` to no longer be available. You can store `$input` in another variable
@@ -262,16 +262,16 @@ invoked, such as the name of the script that called the current command.
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
 object that `$MyInvocation` returns in the current script, such as the path and
-file name of the script (`$MyInvocation.MyCommand.Path`) or the name of a
+filename of the script (`$MyInvocation.MyCommand.Path`) or the name of a
 function (`$MyInvocation.MyCommand.Name`) to identify the current command. This
-is particularly useful for finding the name of the current script.
+is useful for finding the name of the current script.
 
 Beginning in PowerShell 3.0, `MyInvocation` has the following new properties.
 
 - **PSScriptRoot** - Contains the full path to the script that invoked the
   current command. The value of this property is populated only when the caller
   is a script.
-- **PSCommandPath** - Contains the full path and file name of the script that
+- **PSCommandPath** - Contains the full path and filename of the script that
   invoked the current command. The value of this property is populated only
   when the caller is a script.
 
@@ -364,7 +364,7 @@ Appointment on Friday: Team lunch
 
 ### $PID
 
-Contains the process identifier (PID) of the process that is hosting the
+Contains the process identifier (PID) of the process that's hosting the
 current PowerShell session.
 
 ### $PROFILE
@@ -446,7 +446,7 @@ and [about_Functions_Advanced](about_Functions_Advanced.md).
 
 ### $PSCommandPath
 
-Contains the full path and file name of the script that's being run. This
+Contains the full path and filename of the script that's being run. This
 variable is valid in all scripts.
 
 ### $PSCulture
@@ -464,11 +464,11 @@ and dates, and is stored in a **System.Globalization.CultureInfo** object. Use
 
 While debugging, this variable contains information about the debugging
 environment. Otherwise, it contains a **null** value. As a result, you can use
-it to indicate whether the debugger has control. When populated, it contains a
+it to determine whether the debugger has control. When populated, it contains a
 **PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
 properties. The **InvocationInfo** property has several useful properties,
 including the **Location** property. The **Location** property indicates the
-path of the script that is being debugged.
+path of the script that's being debugged.
 
 ### $PSHOME
 
@@ -518,14 +518,14 @@ use the `Get-UICulture` cmdlet.
 ### $PSVersionTable
 
 Contains a read-only hash table that displays details about the version of
-PowerShell that is running in the current session. The table includes the
+PowerShell that's running in the current session. The table includes the
 following items:
 
 - **PSVersion** - The PowerShell version number
 - **PSEdition** This property has the value of 'Desktop' for PowerShell 4 and
   below as well as PowerShell 5.1 on full-featured Windows editions. This
-  property has the value of `Core` for PowerShell 6 and above as well as
-  PowerShell PowerShell 5.1 on reduced-footprint editions like Windows Nano
+  property has the value of `Core` for PowerShell 6 and higher as well as
+  Windows PowerShell 5.1 on reduced-footprint editions like Windows Nano
   Server or Windows IoT.
 - **GitCommitId** - The commit Id of the source files, in GitHub,
 - **OS** - Description of the operating system that PowerShell is running on.
@@ -545,7 +545,7 @@ location for the current PowerShell runspace.
 
 > [!NOTE]
 > PowerShell supports multiple runspaces per process. Each runspace has its own
-> _current directory_. This is not the same as the current directory of the
+> _current directory_. This isn't the same as the current directory of the
 > process: `[System.Environment]::CurrentDirectory`.
 
 ### $Sender
@@ -582,7 +582,7 @@ the instance of the class itself.
 PowerShell's Extensible Type System (ETS) allows you to add properties to
 classes using script blocks. In a script block that defines a script property
 or script method, the `$this` variable refers to an instance of object of the
-class that is being extended. For example, PowerShell uses ETS to add the
+class that's being extended. For example, PowerShell uses ETS to add the
 **BaseName** property to the **FileInfo** class.
 
 ```powershell
@@ -777,11 +777,11 @@ After MoveNext:
 
 ### Example 3: Using the $input.Current property
 
-By using the **Current** property, the current pipeline value can be accessed
+With the **Current** property, the current pipeline value can be accessed
 multiple times without using the **Reset** method. The process block doesn't
 automatically call the **MoveNext** method.
 
-The **Current** property will never be populated unless you explicitly call
+The **Current** property is never populated unless you explicitly call
 **MoveNext**. The **Current** property can be accessed multiple times inside
 the process block without clearing its value.
 
@@ -826,7 +826,7 @@ access the current collection element, and the **Reset** and **MoveNext**
 methods to change its value.
 
 > [!NOTE]
-> Each iteration of the `foreach` loop will automatically call the **MoveNext**
+> Each iteration of the `foreach` loop automatically calls the **MoveNext**
 > method.
 
 The following loop only executes twice. In the second iteration, the collection

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -34,8 +34,8 @@ last command succeeded and **False** if it failed.
 
 For cmdlets and advanced functions that are run at multiple stages in a
 pipeline, for example in both `process` and `end` blocks, calling
-`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point
-sets `$?` to **False**, as does `this.ThrowTerminatingError()` and
+`this.WriteError()` or `$PSCmdlet.WriteError()` respectively at any point sets
+`$?` to **False**, as does `this.ThrowTerminatingError()` and
 `$PSCmdlet.ThrowTerminatingError()`.
 
 The `Write-Error` cmdlet always sets `$?` to **False** immediately after it's
@@ -59,10 +59,10 @@ is 0, and set to **False** when `$LASTEXITCODE` is any other value.
 
 > [!NOTE]
 > Until PowerShell 7, containing a statement within parentheses `(...)`,
-> subexpression syntax `$(...)` or array expression `@(...)` always reset
-> `$?` to **True**, so that `(Write-Error)` shows `$?` as **True**.
-> This has been changed in PowerShell 7, so that `$?` always reflects
-> the actual success of the last command run in these expressions.
+> subexpression syntax `$(...)` or array expression `@(...)` always reset `$?`
+> to **True**, so that `(Write-Error)` shows `$?` as **True**. This has been
+> changed in PowerShell 7, so that `$?` always reflects the actual success of
+> the last command run in these expressions.
 
 ### $^
 
@@ -78,13 +78,13 @@ selected objects in a pipeline.
 
 Contains an array of values for undeclared parameters that are passed to a
 function, script, or script block. When you create a function, you can declare
-the parameters with the `param` keyword or by adding a comma-separated list
-of parameters in parentheses after the function name.
+the parameters with the `param` keyword or by adding a comma-separated list of
+parameters in parentheses after the function name.
 
 In an event action, the `$args` variable contains objects that represent the
-event arguments of the event that's being processed. This variable is
-populated only within the `Action` block of an event registration command. The
-value of this variable can also be found in the **SourceArgs** property of the
+event arguments of the event that's being processed. This variable is populated
+only within the `Action` block of an event registration command. The value of
+this variable can also be found in the **SourceArgs** property of the
 **PSEventArgs** object that `Get-Event` returns.
 
 ### $ConsoleFileName
@@ -112,9 +112,9 @@ information, see [about_CommonParameters](about_CommonParameters.md).
 Contains a **PSEventArgs** object that represents the event that's being
 processed. This variable is populated only within the `Action` block of an
 event registration command, such as `Register-ObjectEvent`. The value of this
-variable is the same object that the `Get-Event` cmdlet returns. You
-can use the properties of the `Event` variable, such as `$Event.TimeGenerated`,
-in an `Action` script block.
+variable is the same object that the `Get-Event` cmdlet returns. You can use
+the properties of the `Event` variable, such as `$Event.TimeGenerated`, in an
+`Action` script block.
 
 ### $EventArgs
 
@@ -250,8 +250,8 @@ operators. For more information about the `switch` statement, see
 > [!NOTE]
 > When `$Matches` is populated in a session, it retains the matched value until
 > it's overwritten by another match. If `-match` is used again and no match is
-> found, it doesn't reset `$Matches` to `$null`. The previously matched value is
-> kept in `$Matches` until another match is found.
+> found, it doesn't reset `$Matches` to `$null`. The previously matched value
+> is kept in `$Matches` until another match is found.
 
 ### $MyInvocation
 
@@ -309,8 +309,8 @@ PowerShell treats `$null` as an object with a value, that is, as an explicit
 placeholder, so you can use `$null` to represent an empty value in a series of
 values.
 
-For example, when `$null` is included in a collection, it's counted as one
-of the objects.
+For example, when `$null` is included in a collection, it's counted as one of
+the objects.
 
 ```powershell
 $a = "one", $null, "three"
@@ -525,8 +525,8 @@ following items:
 - **PSEdition** This property has the value of 'Desktop' for PowerShell 4 and
   below as well as PowerShell 5.1 on full-featured Windows editions. This
   property has the value of `Core` for PowerShell 6 and higher as well as
-  Windows PowerShell 5.1 on reduced-footprint editions like Windows Nano
-  Server or Windows IoT.
+  Windows PowerShell 5.1 on reduced-footprint editions like Windows Nano Server
+  or Windows IoT.
 - **GitCommitId** - The commit Id of the source files, in GitHub,
 - **OS** - Description of the operating system that PowerShell is running on.
 - **Platform** - Platform that the operating system is running on. The value on
@@ -591,8 +591,9 @@ PS> Get-ChildItem .\README.md | Get-Member BaseName | Format-List
 TypeName   : System.IO.FileInfo
 Name       : BaseName
 MemberType : ScriptProperty
-Definition : System.Object BaseName {get=if ($this.Extension.Length -gt 0){$this.Name.Remove($this.Name.Length -
-             $this.Extension.Length)}else{$this.Name};}
+Definition : System.Object BaseName {get=if ($this.Extension.Length -gt 0)
+             {$this.Name.Remove($this.Name.Length - $this.Extension.Length
+             )}else{$this.Name};}
 ```
 
 For more information, see [about_Types.ps1xml](./about_Types.ps1xml.md).


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for `$LastExitCode` in `about_Automatic_Variables` specified that the value was set only by the last native program (for PowerShell) or last Windows-based program (for Windows PowerShell) that was run.

As noted in #9194, this is inaccurate, as the `exit` keyword can be used to set this value when a script is called.

This change:

- Cleans up syntax/prose for maintainability
- Clarifies that `$LastExitCode` can be populated by a PowerShell script
- Clarifies how calling a PowerShell script affects `$LastExitCode`
- Fixes #9194
- Fixes [AB#5371](https://dev.azure.com/content-learn/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/5371)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide