### PR TITLE
Fix path on "Current User, All Hosts"

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -41,7 +41,7 @@ precedence.
 
 - All Users, All Hosts - `$PSHOME\Profile.ps1`
 - All Users, Current Host - `$PSHOME\Microsoft.PowerShell_profile.ps1`
-- Current User, All Hosts - `$Home\Documents\WindowsPowerShell\\Profile.ps1`
+- Current User, All Hosts - `$Home\Documents\WindowsPowerShell\Profile.ps1`
 - Current user, Current Host -
   `$Home\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
 


### PR DESCRIPTION
# PR Summary

Super tiny change removing a typo in the path for "Current User, All Hosts" - it had a double-backslash but should have a single backslash.

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].
