### PR TITLE
Fix typo in "Adding and Invoking commands"

### DIFF
--- a/reference/docs-conceptual/developer/hosting/adding-and-invoking-commands.md
+++ b/reference/docs-conceptual/developer/hosting/adding-and-invoking-commands.md
@@ -6,7 +6,7 @@ title: Adding and invoking commands
 ---
 # Adding and invoking commands
 
-After creating a runspace, you can add Windows PowerShellcommands and scripts to a pipeline, and
+After creating a runspace, you can add Windows PowerShell commands and scripts to a pipeline, and
 then invoke the pipeline synchronously or asynchronously.
 
 ## Creating a pipeline


### PR DESCRIPTION
# PR Summary

Replace "PowerShellcommands" with "PowerShell commands" in the Adding and invoking commands MSFT documentation.

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
