### PR TITLE
Add rs.Close() method to "Windows PowerShell Host Quickstart"

### DIFF
--- a/reference/docs-conceptual/developer/hosting/windows-powershell-host-quickstart.md
+++ b/reference/docs-conceptual/developer/hosting/windows-powershell-host-quickstart.md
@@ -157,6 +157,7 @@ PowerShell ps = PowerShell.Create();
 ps.Runspace = rs;
 ps.AddCommand("Get-Command");
 ps.Invoke();
+rs.Close();
 ```
 
 ### Constraining the runspace
@@ -216,6 +217,12 @@ foreach (var entry in result)
 {
     Console.WriteLine(entry.Name);
 }
+```
+
+Close the runspace.
+
+```csharp
+rs.Close();
 ```
 
 When run, the output of this code will look as follows.


### PR DESCRIPTION
Add missing rs.Close() method to "Windows PowerShell Host Quickstart". The intent of this addition is to demonstrate closing the runspace.

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
