### PR TITLE
Fix typo in execution policy examples in about_PowerShell_config

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
@@ -1,7 +1,7 @@
 ---
 description: Configuration files for PowerShell, replacing Registry configuration.
 Locale: en-US
-ms.date: 10/22/2021
+ms.date: 10/11/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_powershell_config?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PowerShell Config
@@ -78,7 +78,7 @@ The following example sets the execution policy of PowerShell to `RemoteSigned`.
 
 ```json
 {
-  "Microsoft.PowerShell.ExecutionPolicy": "RemoteSigned"
+  "Microsoft.PowerShell:ExecutionPolicy": "RemoteSigned"
 }
 ```
 
@@ -365,7 +365,7 @@ This configuration has more settings explicitly set:
 
 ```json
 {
-  "Microsoft.PowerShell.ExecutionPolicy": "AllSigned",
+  "Microsoft.PowerShell:ExecutionPolicy": "AllSigned",
   "PSModulePath": "Z:\\Marisol's Shared Drive\\Modules",
   "ExperimentalFeatures": ["PSImplicitRemotingBatching"],
 }

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
@@ -1,7 +1,7 @@
 ---
 description: Configuration files for PowerShell, replacing Registry configuration.
 Locale: en-US
-ms.date: 10/22/2021
+ms.date: 10/11/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_powershell_config?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PowerShell Config
@@ -78,7 +78,7 @@ The following example sets the execution policy of PowerShell to `RemoteSigned`.
 
 ```json
 {
-  "Microsoft.PowerShell.ExecutionPolicy": "RemoteSigned"
+  "Microsoft.PowerShell:ExecutionPolicy": "RemoteSigned"
 }
 ```
 
@@ -365,7 +365,7 @@ This configuration has more settings explicitly set:
 
 ```json
 {
-  "Microsoft.PowerShell.ExecutionPolicy": "AllSigned",
+  "Microsoft.PowerShell:ExecutionPolicy": "AllSigned",
   "PSModulePath": "Z:\\Marisol's Shared Drive\\Modules",
   "ExperimentalFeatures": ["PSImplicitRemotingBatching"],
 }

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
@@ -1,7 +1,7 @@
 ---
 description: Configuration files for PowerShell, replacing Registry configuration.
 Locale: en-US
-ms.date: 10/22/2021
+ms.date: 10/11/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_powershell_config?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PowerShell Config
@@ -78,7 +78,7 @@ The following example sets the execution policy of PowerShell to `RemoteSigned`.
 
 ```json
 {
-  "Microsoft.PowerShell.ExecutionPolicy": "RemoteSigned"
+  "Microsoft.PowerShell:ExecutionPolicy": "RemoteSigned"
 }
 ```
 
@@ -365,7 +365,7 @@ This configuration has more settings explicitly set:
 
 ```json
 {
-  "Microsoft.PowerShell.ExecutionPolicy": "AllSigned",
+  "Microsoft.PowerShell:ExecutionPolicy": "AllSigned",
   "PSModulePath": "Z:\\Marisol's Shared Drive\\Modules",
   "ExperimentalFeatures": ["PSImplicitRemotingBatching"],
 }


### PR DESCRIPTION
# PR Summary

Fix typos in the JSON for execution policy changes in PowerShell.config.json. 

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].
