### PR TITLE
(MAINT) Use pull_request_target for checklist

### DIFF
--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -1,6 +1,6 @@
 name: Checklist
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types:


### PR DESCRIPTION
# PR Summary

Prior to this change, the workflow for verifying the PR checklist ran on `pull_request`. When the Azure Boards bot edits a PR body to associate it with an Azure DevOps item, the last `edited` event that triggers the checklist workflow is from the bot, not a user. Because the bot has never contributed to the project in a way GitHub understands---it only edits comments, never commits code or files an issue---it always trips the GitHub configuration for requiring approval for first-time contributors for PRs from forks.

This change is an attempt to work around this limitation by moving the checklist workflow from `pull_request` to `pull_request_target`, which should run in the context of the upstream repository.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
