### PR TITLE
Rename PowerShell.exe to pwsh.exe in help_aboutProfile

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to create and use a PowerShell profile.
 Locale: en-US
-ms.date: 09/06/2022
+ms.date: 10/18/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Profiles
@@ -27,7 +27,7 @@ doesn't create the profiles for you. This topic describes the profiles, and it
 describes how to create and maintain profiles on your computer.
 
 It explains how to use the **NoProfile** parameter of the PowerShell console
-(PowerShell.exe) to start PowerShell without any profiles. And, it explains the
+(`PowerShell.exe`) to start PowerShell without any profiles. And, it explains the
 effect of the PowerShell execution policy on profiles.
 
 ## The Profile Files
@@ -252,7 +252,7 @@ For more information about the PowerShell prompt, see
 ## The NoProfile parameter
 
 To start PowerShell without profiles, use the **NoProfile** parameter of
-**PowerShell.exe**, the program that starts PowerShell.
+`PowerShell.exe`, the program that starts PowerShell.
 
 To begin, open a program that can start PowerShell, such as Cmd.exe or
 PowerShell itself. You can also use the Run dialog box in Windows.

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -240,7 +240,7 @@ function Get-CmdletAlias ($cmdletname) {
 function Color-Console {
   $Host.ui.rawui.backgroundcolor = "white"
   $Host.ui.rawui.foregroundcolor = "black"
-  $hosttime = (Get-ChildItem -Path $PSHOME\PowerShell.exe).CreationTime
+  $hosttime = (Get-ChildItem -Path $PSHOME\pwsh.exe).CreationTime
   $hostversion="$($Host.Version.Major)`.$($Host.Version.Minor)"
   $Host.UI.RawUI.WindowTitle = "PowerShell $hostversion ($hosttime)"
   Clear-Host

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to create and use a PowerShell profile.
 Locale: en-US
-ms.date: 08/29/2022
+ms.date: 10/18/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Profiles
@@ -27,7 +27,7 @@ doesn't create the profiles for you. This topic describes the profiles, and it
 describes how to create and maintain profiles on your computer.
 
 It explains how to use the **NoProfile** parameter of the PowerShell console
-(PowerShell.exe) to start PowerShell without any profiles. And, it explains the
+(`pwsh.exe`) to start PowerShell without any profiles. And, it explains the
 effect of the PowerShell execution policy on profiles.
 
 ## The Profile Files
@@ -263,21 +263,21 @@ For more information about the PowerShell prompt, see
 ## The NoProfile parameter
 
 To start PowerShell without profiles, use the **NoProfile** parameter of
-**PowerShell.exe**, the program that starts PowerShell.
+`pwsh.exe`, the program that starts PowerShell.
 
 To begin, open a program that can start PowerShell, such as Cmd.exe or
 PowerShell itself. You can also use the Run dialog box in Windows.
 
 Type:
 
-```
-PowerShell -NoProfile
+```powershell
+pwsh -NoProfile
 ```
 
-For a complete list of the parameters of PowerShell.exe, type:
+For a complete list of the parameters of `pwsh.exe`, type:
 
-```
-PowerShell -?
+```powershell
+pwsh -?
 ```
 
 ## Profiles and Execution Policy

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -240,7 +240,7 @@ function Get-CmdletAlias ($cmdletname) {
 function Color-Console {
   $Host.ui.rawui.backgroundcolor = "white"
   $Host.ui.rawui.foregroundcolor = "black"
-  $hosttime = (Get-ChildItem -Path $PSHOME\PowerShell.exe).CreationTime
+  $hosttime = (Get-ChildItem -Path $PSHOME\pwsh.exe).CreationTime
   $hostversion="$($Host.Version.Major)`.$($Host.Version.Minor)"
   $Host.UI.RawUI.WindowTitle = "PowerShell $hostversion ($hosttime)"
   Clear-Host

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to create and use a PowerShell profile.
 Locale: en-US
-ms.date: 08/29/2022
+ms.date: 10/18/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Profiles
@@ -27,7 +27,7 @@ doesn't create the profiles for you. This topic describes the profiles, and it
 describes how to create and maintain profiles on your computer.
 
 It explains how to use the **NoProfile** parameter of the PowerShell console
-(PowerShell.exe) to start PowerShell without any profiles. And, it explains the
+(`pwsh.exe`) to start PowerShell without any profiles. And, it explains the
 effect of the PowerShell execution policy on profiles.
 
 ## The Profile Files
@@ -263,21 +263,21 @@ For more information about the PowerShell prompt, see
 ## The NoProfile parameter
 
 To start PowerShell without profiles, use the **NoProfile** parameter of
-**PowerShell.exe**, the program that starts PowerShell.
+`pwsh.exe`, the program that starts PowerShell.
 
 To begin, open a program that can start PowerShell, such as Cmd.exe or
 PowerShell itself. You can also use the Run dialog box in Windows.
 
 Type:
 
-```
-PowerShell -NoProfile
+```powershell
+pwsh -NoProfile
 ```
 
-For a complete list of the parameters of PowerShell.exe, type:
+For a complete list of the parameters of `pwsh.exe`, type:
 
-```
-PowerShell -?
+```powershell
+pwsh -?
 ```
 
 ## Profiles and Execution Policy

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to create and use a PowerShell profile.
 Locale: en-US
-ms.date: 08/29/2022
+ms.date: 10/18/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Profiles
@@ -27,7 +27,7 @@ doesn't create the profiles for you. This topic describes the profiles, and it
 describes how to create and maintain profiles on your computer.
 
 It explains how to use the **NoProfile** parameter of the PowerShell console
-(PowerShell.exe) to start PowerShell without any profiles. And, it explains the
+(`pwsh.exe`) to start PowerShell without any profiles. And, it explains the
 effect of the PowerShell execution policy on profiles.
 
 ## The Profile Files
@@ -263,21 +263,21 @@ For more information about the PowerShell prompt, see
 ## The NoProfile parameter
 
 To start PowerShell without profiles, use the **NoProfile** parameter of
-**PowerShell.exe**, the program that starts PowerShell.
+`pwsh.exe`, the program that starts PowerShell.
 
 To begin, open a program that can start PowerShell, such as Cmd.exe or
 PowerShell itself. You can also use the Run dialog box in Windows.
 
 Type:
 
-```
-PowerShell -NoProfile
+```powershell
+pwsh -NoProfile
 ```
 
-For a complete list of the parameters of PowerShell.exe, type:
+For a complete list of the parameters of `pwsh.exe`, type:
 
-```
-PowerShell -?
+```powershell
+pwsh -?
 ```
 
 ## Profiles and Execution Policy

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -240,7 +240,7 @@ function Get-CmdletAlias ($cmdletname) {
 function Color-Console {
   $Host.ui.rawui.backgroundcolor = "white"
   $Host.ui.rawui.foregroundcolor = "black"
-  $hosttime = (Get-ChildItem -Path $PSHOME\PowerShell.exe).CreationTime
+  $hosttime = (Get-ChildItem -Path $PSHOME\pwsh.exe).CreationTime
   $hostversion="$($Host.Version.Major)`.$($Host.Version.Minor)"
   $Host.UI.RawUI.WindowTitle = "PowerShell $hostversion ($hosttime)"
   Clear-Host


### PR DESCRIPTION
# PR Summary

At location `$PSHOME` there is no `PowerShell.exe` but there is `pwsh.exe`. Maybe that help is from before renaming? Should that affect all occurences of `PowerShell.exe` in this file?

![image](https://user-images.githubusercontent.com/20944885/196440870-80a774b2-2dae-409b-9025-63e6875d9918.png)


## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
