### PR TITLE
Fix example 13 for `Export-Csv`

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -412,7 +412,7 @@ In PowerShell 7.2 and above, when you export a hashtable that has additional pro
 file.
 
 ```powershell
-$allPeople | Add-Member -Name ExtraProp -Value 42
+$allPeople | Add-Member -Name ExtraProp -Value 42 -MemberType NoteProperty
 $allPeople | Export-Csv
 
 Get-Content -Path .\People.csv -Path .\People.csv

--- a/reference/7.2/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/22/2021
+ms.date: 10/24/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/export-csv?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Export-Csv

--- a/reference/7.2/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -413,9 +413,9 @@ file.
 
 ```powershell
 $allPeople | Add-Member -Name ExtraProp -Value 42 -MemberType NoteProperty
-$allPeople | Export-Csv
+$allPeople | Export-Csv -Path .\People.csv
 
-Get-Content -Path .\People.csv -Path .\People.csv
+Get-Content -Path .\People.csv
 ```
 
 ```Output

--- a/reference/7.3/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/22/2021
+ms.date: 10/24/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/export-csv?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Export-Csv
@@ -412,10 +412,10 @@ In PowerShell 7.2 and above, when you export a hashtable that has additional pro
 file.
 
 ```powershell
-$allPeople | Add-Member -Name ExtraProp -Value 42
-$allPeople | Export-Csv
+$allPeople | Add-Member -Name ExtraProp -Value 42 -MemberType NoteProperty
+$allPeople | Export-Csv -Path .\People.csv
 
-Get-Content -Path .\People.csv -Path .\People.csv
+Get-Content -Path .\People.csv
 ```
 
 ```Output


### PR DESCRIPTION
# PR Summary
This changes fixes problem where Example 13 runs with error.  Missing required parameter.  Screenshot below.

Line today reads"$allPeople | Add-Member -Name ExtraProp -Value 42"
Should instead read "$allPeople | Add-Member -Name ExtraProp -Value 42 -MemberType NoteProperty"

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X ] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"
    This helps us understand whether or not your PR is ready to review.
-->

Absolutely.  Title prefix with "(WIP)".  Appreciate the help to review.

![image](https://user-images.githubusercontent.com/5648223/197527693-09d02086-1dc1-41b1-bfcb-4aa3e384f819.png)


[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
