### PR TITLE
Add cd~ to about_Built-in_Functions.md

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
@@ -33,6 +33,12 @@ In the Windows CMD shell it is common to run the `cd` command without any spaces
 between the command and the destination path. This function runs
 `Set-Location \` to change to the root folder.
 
+## `cd~`
+
+In the Windows CMD shell it is common to run the `cd` command without any spaces
+between the command and the destination path. This function runs
+`Set-Location ~` to change to the user's home folder.
+
 ## `Pause`
 
 This function replicates the behavior of CMD's `pause` command. The script

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
@@ -33,6 +33,12 @@ In the Windows CMD shell it is common to run the `cd` command without any spaces
 between the command and the destination path. This function runs
 `Set-Location \` to change to the root folder.
 
+## `cd~`
+
+In the Windows CMD shell it is common to run the `cd` command without any spaces
+between the command and the destination path. This function runs
+`Set-Location ~` to change to the user's home folder.
+
 ## `Pause`
 
 This function replicates the behavior of CMD's `pause` command. The script


### PR DESCRIPTION
Add support for cd~

# PR Summary
This Pull Request should resolve #9329.
The issue is tagged as [hold-for-release](https://github.com/MicrosoftDocs/PowerShell-Docs/labels/hold-for-release) bit I figured there was no harm in creating the PR now that the issue fix has gone in. 
Functionality that allows `cd~` to work as a built in alias for `Set-Location ~` was introduced in pull request https://github.com/PowerShell/PowerShell/pull/18308 as a fix for issue https://github.com/PowerShell/PowerShell/issues/17140.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
