### PR TITLE
(GH-9360) Remove application type from telemetry

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Telemetry.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Telemetry.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the telemetry collected in PowerShell and how to opt-out.
 Locale: en-US
-ms.date: 09/30/2021
+ms.date: 10/26/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_telemetry?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Telemetry
@@ -31,8 +31,8 @@ The host-based telemetry data includes:
 
 > [!NOTE]
 > Application Insights uses the hosts IP address to determine the geographic
-> location. The IP address is never included in the telemetry data or stored in
-> the database.
+> location. The IP address is never included in the telemetry data or stored
+> in the database.
 
 The following PowerShell activities are recorded:
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Telemetry.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Telemetry.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the telemetry collected in PowerShell and how to opt-out.
 Locale: en-US
-ms.date: 09/30/2021
+ms.date: 10/26/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_telemetry?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Telemetry
@@ -30,19 +30,14 @@ The host-based telemetry data includes:
 - The geographic location of the host, based on the IP address
 
 > [!NOTE]
-> Application Insights uses the hosts IP address to determine the geographic location. The IP
-> address is never included in the telemetry data or stored in the database.
+> Application Insights uses the hosts IP address to determine the geographic
+> location. The IP address is never included in the telemetry data or stored
+> in the database.
 
 The following PowerShell activities are recorded:
 
 - Count of PowerShell Starts by type (API vs console)
 - Count of unique PowerShell usage
-- Count of the following execution types:
-  - Application (native commands)
-  - ExternalScript
-  - Script
-  - Function
-  - Cmdlet
 - Count of enabled Microsoft owned experimental features or experimental
   features shipped with PowerShell
 - Count of hosted sessions

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Telemetry.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Telemetry.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the telemetry collected in PowerShell and how to opt-out.
 Locale: en-US
-ms.date: 09/30/2021
+ms.date: 10/26/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_telemetry?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Telemetry
@@ -30,19 +30,14 @@ The host-based telemetry data includes:
 - The geographic location of the host, based on the IP address
 
 > [!NOTE]
-> Application Insights uses the hosts IP address to determine the geographic location. The IP
-> address is never included in the telemetry data or stored in the database.
+> Application Insights uses the hosts IP address to determine the geographic
+> location. The IP address is never included in the telemetry data or stored
+> in the database.
 
 The following PowerShell activities are recorded:
 
 - Count of PowerShell Starts by type (API vs console)
 - Count of unique PowerShell usage
-- Count of the following execution types:
-  - Application (native commands)
-  - ExternalScript
-  - Script
-  - Function
-  - Cmdlet
 - Count of enabled Microsoft owned experimental features or experimental
   features shipped with PowerShell
 - Count of hosted sessions


### PR DESCRIPTION
# PR Summary

Prior to this change, the `about_Telemetry` documentation included an entry for application type, which was removed in PowerShell 7.0.13, 7.2.7, and 7.3.0-preview.4.

This change:

- removes the now irrelevant and inaccurate entry for the application type data.
- Resolves #9360
- Fixes [AB#26712](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/26712)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
