### PR TITLE
Default *WorkingDirectory* when *FilePath* is bare

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/7.0/Microsoft.PowerShell.Management/Start-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 10/05/2022
+ms.date: 10/31/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/start-process?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Process
@@ -172,8 +172,8 @@ Start-Process nohup 'pwsh -noprofile -c "1..120 | % { Write-Host . -NoNewline; s
 ```
 
 In this example, `Start-Process` is running the Linux `nohup` command, which launches `pwsh` as a
-detached process. For more information, see the man page for
-[nohup](https://linux.die.net/man/1/nohup).
+detached process. For more information, see the [nohup](https://wikipedia.org/wiki/Nohup) article on
+Wikipedia.
 
 ## PARAMETERS
 
@@ -238,7 +238,8 @@ Specifies the optional path and filename of the program that runs in the process
 an executable file or of a document, such as a `.txt` or `.doc` file, that's associated with a
 program on the computer. This parameter is required.
 
-If you specify only a filename, use the **WorkingDirectory** parameter to specify the path.
+If you specify only a filename that does not correspond to a system command, use the
+**WorkingDirectory** parameter to specify the path.
 
 ```yaml
 Type: System.String
@@ -458,9 +459,14 @@ Accept wildcard characters: False
 
 ### -WorkingDirectory
 
-Specifies the location that the new process should start in. The default is the location of the
-executable file or document being started. Wildcards aren't supported. The path must not contain
-characters that would be interpreted as wildcards.
+Specifies the location that the new process should start in.
+
+When not specified, the cmdlet defaults to the fully-qualified location specified in the
+**FilePath** parameter. If the value of the **FilePath** parameter is not fully-qualified, it
+defaults to the current working directory of the calling process.
+
+Wildcards aren't supported. The path must not contain characters that would be interpreted as
+wildcards.
 
 ```yaml
 Type: System.String

--- a/reference/7.2/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Start-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 10/05/2022
+ms.date: 10/31/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/start-process?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Process
@@ -172,8 +172,8 @@ Start-Process nohup 'pwsh -noprofile -c "1..120 | % { Write-Host . -NoNewline; s
 ```
 
 In this example, `Start-Process` is running the Linux `nohup` command, which launches `pwsh` as a
-detached process. For more information, see the man page for
-[nohup](https://linux.die.net/man/1/nohup).
+detached process. For more information, see the [nohup](https://wikipedia.org/wiki/Nohup) article on
+Wikipedia.
 
 ## PARAMETERS
 
@@ -238,7 +238,8 @@ Specifies the optional path and filename of the program that runs in the process
 an executable file or of a document, such as a `.txt` or `.doc` file, that's associated with a
 program on the computer. This parameter is required.
 
-If you specify only a filename, use the **WorkingDirectory** parameter to specify the path.
+If you specify only a filename that does not correspond to a system command, use the
+**WorkingDirectory** parameter to specify the path.
 
 ```yaml
 Type: System.String
@@ -462,9 +463,14 @@ Accept wildcard characters: False
 
 ### -WorkingDirectory
 
-Specifies the location that the new process should start in. The default is the location of the
-executable file or document being started. Wildcards aren't supported. The path must not contain
-characters that would be interpreted as wildcards.
+Specifies the location that the new process should start in.
+
+When not specified, the cmdlet defaults to the fully-qualified location specified in the
+**FilePath** parameter. If the value of the **FilePath** parameter is not fully-qualified, it
+defaults to the current working directory of the calling process.
+
+Wildcards aren't supported. The path must not contain characters that would be interpreted as
+wildcards.
 
 ```yaml
 Type: System.String

--- a/reference/7.3/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Start-Process.md
@@ -172,8 +172,7 @@ Start-Process nohup 'pwsh -noprofile -c "1..120 | % { Write-Host . -NoNewline; s
 ```
 
 In this example, `Start-Process` is running the Linux `nohup` command, which launches `pwsh` as a
-detached process. For more information, see the man page for
-[nohup](https://linux.die.net/man/1/nohup).
+detached process. For more information, type [`man nohup`](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/nohup.html).
 
 ## PARAMETERS
 
@@ -238,7 +237,8 @@ Specifies the optional path and filename of the program that runs in the process
 an executable file or of a document, such as a `.txt` or `.doc` file, that's associated with a
 program on the computer. This parameter is required.
 
-If you specify only a filename, use the **WorkingDirectory** parameter to specify the path.
+If you specify only a filename that does not correspond to a system command,
+use the **WorkingDirectory** parameter to specify the path.
 
 ```yaml
 Type: System.String
@@ -462,8 +462,11 @@ Accept wildcard characters: False
 
 ### -WorkingDirectory
 
-Specifies the location that the new process should start in. The default is the location of the
-executable file or document being started. Wildcards aren't supported. The path must not contain
+Specifies the location that the new process should start in.
+The default is the location of the executable file
+or document being started, if explicitly provided,
+or the current working directory of the calling process.
+Wildcards aren't supported. The path must not contain
 characters that would be interpreted as wildcards.
 
 ```yaml

--- a/reference/7.3/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Start-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 10/05/2022
+ms.date: 10/31/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/start-process?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Start-Process
@@ -172,7 +172,8 @@ Start-Process nohup 'pwsh -noprofile -c "1..120 | % { Write-Host . -NoNewline; s
 ```
 
 In this example, `Start-Process` is running the Linux `nohup` command, which launches `pwsh` as a
-detached process. For more information, type [`man nohup`](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/nohup.html).
+detached process. For more information, see the [nohup](https://wikipedia.org/wiki/Nohup) article on
+Wikipedia.
 
 ## PARAMETERS
 
@@ -237,8 +238,8 @@ Specifies the optional path and filename of the program that runs in the process
 an executable file or of a document, such as a `.txt` or `.doc` file, that's associated with a
 program on the computer. This parameter is required.
 
-If you specify only a filename that does not correspond to a system command,
-use the **WorkingDirectory** parameter to specify the path.
+If you specify only a filename that does not correspond to a system command, use the
+**WorkingDirectory** parameter to specify the path.
 
 ```yaml
 Type: System.String
@@ -463,11 +464,13 @@ Accept wildcard characters: False
 ### -WorkingDirectory
 
 Specifies the location that the new process should start in.
-The default is the location of the executable file
-or document being started, if explicitly provided,
-or the current working directory of the calling process.
-Wildcards aren't supported. The path must not contain
-characters that would be interpreted as wildcards.
+
+When not specified, the cmdlet defaults to the fully-qualified location specified in the
+**FilePath** parameter. If the value of the **FilePath** parameter is not fully-qualified, it
+defaults to the current working directory of the calling process.
+
+Wildcards aren't supported. The path must not contain characters that would be interpreted as
+wildcards.
 
 ```yaml
 Type: System.String


### PR DESCRIPTION
# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

A step towards fixing #9383

1. Mention the possibility of starting system commands by bare name.
2. Also use the standard link to [`man nohup`](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/nohup.html).

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
