### PR TITLE
PSNativeCommandArgumentPassing: how to sidestep

### DIFF
--- a/reference/docs-conceptual/learn/experimental-features.md
+++ b/reference/docs-conceptual/learn/experimental-features.md
@@ -284,6 +284,9 @@ a native executable.
 > The new behavior is a **breaking change** from current behavior. This may break scripts and
 > automation that work around the various issues when invoking native applications. Historically,
 > quotes must be escaped and it isn't possible to provide empty arguments to a native application.
+>
+> Use the [stop-parsing token][08] (`--%`) or the [`Start-Process`][09] cmdlet to sidestep native
+> argument passing when needed.
 
 This feature adds a new automatic variable `$PSNativeCommandArgumentPassing` that allows you to
 select the behavior at runtime. The valid values are `Legacy`, `Standard`, and `Windows`. `Legacy`
@@ -377,12 +380,6 @@ Arg 0 is <a" "b>
 Arg 1 is <a" "b>
 Arg 2 is <a b>
 ```
-> ![NOTE]
-> Use the
-> [stop&shy;&#8209;parsing token](/powershell/module/Microsoft.PowerShell.Core/About/about_Parsing#the-stop-parsing-token)
-> `--%`
-> or the [`Start-Process`](xref:Microsoft.PowerShell.Management.Start-Process) cmdlet
-> to sidestep native argument passing when needed.
 
 ## PSNativeCommandErrorActionPreference
 
@@ -535,7 +532,7 @@ the PSReadLine module to provide custom prediction plugins. In future, **Job**,
 **CommandCompleter**, **Remoting** and other components could be separated into subsystem assemblies
 outside of `System.Management.Automation.dll`.
 
-The experimental feature includes a new cmdlet, [`Get-PSSubsystem`][07]. This cmdlet is only available
+The experimental feature includes a new cmdlet, [Get-PSSubsystem][07]. This cmdlet is only available
 when the feature is enabled. This cmdlet returns information about the subsystems that are available
 on the system.
 
@@ -547,3 +544,5 @@ on the system.
 [05]: https://github.com/PowerShell/PowerShell-RFC/blob/master/Archive/Experimental/RFC0059-Cleanup-Script-Block.md
 [06]: /powershell/dsc/overview?view=dsc-3.0&preserve-view=true
 [07]: xref:Microsoft.PowerShell.Core.Get-PSSubsystem
+[08]: /powershell/module/Microsoft.PowerShell.Core/About/about_Parsing#the-stop-parsing-token
+[09]: xref:Microsoft.PowerShell.Management.Start-Process

--- a/reference/docs-conceptual/learn/experimental-features.md
+++ b/reference/docs-conceptual/learn/experimental-features.md
@@ -377,6 +377,12 @@ Arg 0 is <a" "b>
 Arg 1 is <a" "b>
 Arg 2 is <a b>
 ```
+> ![NOTE]
+> Use the
+> [stop&shy;&#8209;parsing token](/powershell/module/Microsoft.PowerShell.Core/About/about_Parsing#the-stop-parsing-token)
+> `--%`
+> or the [`Start-Process`](xref:Microsoft.PowerShell.Management.Start-Process) cmdlet
+> to sidestep native argument passing when needed.
 
 ## PSNativeCommandErrorActionPreference
 
@@ -529,7 +535,7 @@ the PSReadLine module to provide custom prediction plugins. In future, **Job**,
 **CommandCompleter**, **Remoting** and other components could be separated into subsystem assemblies
 outside of `System.Management.Automation.dll`.
 
-The experimental feature includes a new cmdlet, [Get-PSSubsystem][07]. This cmdlet is only available
+The experimental feature includes a new cmdlet, [`Get-PSSubsystem`][07]. This cmdlet is only available
 when the feature is enabled. This cmdlet returns information about the subsystems that are available
 on the system.
 


### PR DESCRIPTION
# PR Summary

Since native argument passing is a breaking change, I would find a note about locally disabling it appropriate.


## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
