### PR TITLE
(GH-9312) Clarify encoding for web cmdlets

### DIFF
--- a/reference/7.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/17/2022
+ms.date: 11/04/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -354,9 +354,18 @@ You can also pipe a body value to `Invoke-RestMethod`.
 The **Body** parameter can be used to specify a list of query parameters or specify the content of
 the response.
 
-When the input is a GET request, and the body is an `IDictionary` (typically, a hash table), the
-body is added to the Uniform Resource Identifier (URI) as query parameters. For other request types
-(such as POST), the body is set as the value of the request body in the standard name=value format.
+When the input is a POST request and the body is a **String**, the value to the left of the first
+equals sign (`=`) is set as a key in the form data and the remaining text is set as the value. To
+specify multiple keys, use an **IDictionary** object, such as a hash table, for the **Body**.
+
+When the input is a GET request and the body is an **IDictionary** (typically, a hash table), the
+body is added to the URI as query parameters. For other request types (such as PATCH), the body is
+set as the value of the request body in the standard `name=value` format with the values
+URL-encoded.
+
+When the input is a **System.Xml.XmlNode** object and the XML declaration specifies an encoding,
+that encoding is used for the data in the request unless overridden by the **ContentType**
+parameter.
 
 When the body is a form, or it's the output of another `Invoke-WebRequest` call, PowerShell sets the
 request content to the form fields.
@@ -429,6 +438,12 @@ Accept wildcard characters: False
 ### -ContentType
 
 Specifies the content type of the web request.
+
+If the value for **ContentType** contains the encoding format (as `charset`), the cmdlet uses that
+format to encode the body of the web request. If the **ContentType** doesn't specify an encoding
+format, the default encoding format is used instead. An example of a **ContentType** with an
+encoding format is `text/plain; charset=iso-8859-5`, which specifies the
+[Latin/Cyrillic](https://www.iso.org/standard/28249.html) alphabet.
 
 If this parameter is omitted and the request method is POST, `Invoke-RestMethod` sets the content
 type to `application/x-www-form-urlencoded`. Otherwise, the content type isn't specified in the

--- a/reference/7.0/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.0/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/17/2022
+ms.date: 11/04/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -437,11 +437,20 @@ You can also pipe a body value to `Invoke-WebRequest`.
 The **Body** parameter can be used to specify a list of query parameters or specify the content of
 the response.
 
-When the input is a GET request and the body is an **IDictionary** (typically, a hash table), the
-body is added to the URI as query parameters. For other request types (such as POST), the body is
-set as the value of the request body in the standard `name=value` format.
+When the input is a POST request and the body is a **String**, the value to the left of the first
+equals sign (`=`) is set as a key in the form data and the remaining text is set as the value. To
+specify multiple keys, use an **IDictionary** object, such as a hash table, for the **Body**.
 
-The **Body** parameter may also accept a `System.Net.Http.MultipartFormDataContent` object. This
+When the input is a GET request and the body is an **IDictionary** (typically, a hash table), the
+body is added to the URI as query parameters. For other request types (such as PATCH), the body is
+set as the value of the request body in the standard `name=value` format with the values
+URL-encoded.
+
+When the input is a **System.Xml.XmlNode** object and the XML declaration specifies an encoding,
+that encoding is used for the data in the request unless overridden by the **ContentType**
+parameter.
+
+The **Body** parameter also accepts a `System.Net.Http.MultipartFormDataContent` object. This
 facilitates `multipart/form-data` requests. When a **MultipartFormDataContent** object is supplied
 for **Body**, any Content related headers supplied to the **ContentType**, **Headers**, or
 **WebSession** parameters is overridden by the Content headers of the **MultipartFormDataContent**
@@ -509,6 +518,12 @@ Accept wildcard characters: False
 ### -ContentType
 
 Specifies the content type of the web request.
+
+If the value for **ContentType** contains the encoding format (as `charset`), the cmdlet uses that
+format to encode the body of the web request. If the **ContentType** doesn't specify an encoding
+format, the default encoding format is used instead. An example of a **ContentType** with an
+encoding format is `text/plain; charset=iso-8859-5`, which specifies the
+[Latin/Cyrillic](https://www.iso.org/standard/28249.html) alphabet.
 
 If this parameter is omitted and the request method is POST, `Invoke-WebRequest` sets the content
 type to `application/x-www-form-urlencoded`. Otherwise, the content type isn't specified in the

--- a/reference/7.2/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/17/2022
+ms.date: 11/04/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -354,9 +354,18 @@ You can also pipe a body value to `Invoke-RestMethod`.
 The **Body** parameter can be used to specify a list of query parameters or specify the content of
 the response.
 
-When the input is a GET request, and the body is an `IDictionary` (typically, a hash table), the
-body is added to the Uniform Resource Identifier (URI) as query parameters. For other request types
-(such as POST), the body is set as the value of the request body in the standard name=value format.
+When the input is a POST request and the body is a **String**, the value to the left of the first
+equals sign (`=`) is set as a key in the form data and the remaining text is set as the value. To
+specify multiple keys, use an **IDictionary** object, such as a hash table, for the **Body**.
+
+When the input is a GET request and the body is an **IDictionary** (typically, a hash table), the
+body is added to the URI as query parameters. For other request types (such as PATCH), the body is
+set as the value of the request body in the standard `name=value` format with the values
+URL-encoded.
+
+When the input is a **System.Xml.XmlNode** object and the XML declaration specifies an encoding,
+that encoding is used for the data in the request unless overridden by the **ContentType**
+parameter.
 
 When the body is a form, or it's the output of another `Invoke-WebRequest` call, PowerShell sets the
 request content to the form fields.
@@ -429,6 +438,12 @@ Accept wildcard characters: False
 ### -ContentType
 
 Specifies the content type of the web request.
+
+If the value for **ContentType** contains the encoding format (as `charset`), the cmdlet uses that
+format to encode the body of the web request. If the **ContentType** doesn't specify an encoding
+format, the default encoding format is used instead. An example of a **ContentType** with an
+encoding format is `text/plain; charset=iso-8859-5`, which specifies the
+[Latin/Cyrillic](https://www.iso.org/standard/28249.html) alphabet.
 
 If this parameter is omitted and the request method is POST, `Invoke-RestMethod` sets the content
 type to `application/x-www-form-urlencoded`. Otherwise, the content type isn't specified in the

--- a/reference/7.2/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/17/2022
+ms.date: 11/04/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -437,11 +437,20 @@ You can also pipe a body value to `Invoke-WebRequest`.
 The **Body** parameter can be used to specify a list of query parameters or specify the content of
 the response.
 
-When the input is a GET request and the body is an **IDictionary** (typically, a hash table), the
-body is added to the URI as query parameters. For other request types (such as POST), the body is
-set as the value of the request body in the standard `name=value` format.
+When the input is a POST request and the body is a **String**, the value to the left of the first
+equals sign (`=`) is set as a key in the form data and the remaining text is set as the value. To
+specify multiple keys, use an **IDictionary** object, such as a hash table, for the **Body**.
 
-The **Body** parameter may also accept a `System.Net.Http.MultipartFormDataContent` object. This
+When the input is a GET request and the body is an **IDictionary** (typically, a hash table), the
+body is added to the URI as query parameters. For other request types (such as PATCH), the body is
+set as the value of the request body in the standard `name=value` format with the values
+URL-encoded.
+
+When the input is a **System.Xml.XmlNode** object and the XML declaration specifies an encoding,
+that encoding is used for the data in the request unless overridden by the **ContentType**
+parameter.
+
+The **Body** parameter also accepts a `System.Net.Http.MultipartFormDataContent` object. This
 facilitates `multipart/form-data` requests. When a **MultipartFormDataContent** object is supplied
 for **Body**, any Content related headers supplied to the **ContentType**, **Headers**, or
 **WebSession** parameters is overridden by the Content headers of the **MultipartFormDataContent**
@@ -509,6 +518,12 @@ Accept wildcard characters: False
 ### -ContentType
 
 Specifies the content type of the web request.
+
+If the value for **ContentType** contains the encoding format (as `charset`), the cmdlet uses that
+format to encode the body of the web request. If the **ContentType** doesn't specify an encoding
+format, the default encoding format is used instead. An example of a **ContentType** with an
+encoding format is `text/plain; charset=iso-8859-5`, which specifies the
+[Latin/Cyrillic](https://www.iso.org/standard/28249.html) alphabet.
 
 If this parameter is omitted and the request method is POST, `Invoke-WebRequest` sets the content
 type to `application/x-www-form-urlencoded`. Otherwise, the content type isn't specified in the

--- a/reference/7.3/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/17/2022
+ms.date: 11/04/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -367,9 +367,18 @@ You can also pipe a body value to `Invoke-RestMethod`.
 The **Body** parameter can be used to specify a list of query parameters or specify the content of
 the response.
 
-When the input is a GET request, and the body is an `IDictionary` (typically, a hash table), the
-body is added to the Uniform Resource Identifier (URI) as query parameters. For other request types
-(such as POST), the body is set as the value of the request body in the standard name=value format.
+When the input is a POST request and the body is a **String**, the value to the left of the first
+equals sign (`=`) is set as a key in the form data and the remaining text is set as the value. To
+specify multiple keys, use an **IDictionary** object, such as a hash table, for the **Body**.
+
+When the input is a GET request and the body is an **IDictionary** (typically, a hash table), the
+body is added to the URI as query parameters. For other request types (such as PATCH), the body is
+set as the value of the request body in the standard `name=value` format with the values
+URL-encoded.
+
+When the input is a **System.Xml.XmlNode** object and the XML declaration specifies an encoding,
+that encoding is used for the data in the request unless overridden by the **ContentType**
+parameter.
 
 When the body is a form, or it's the output of another `Invoke-WebRequest` call, PowerShell sets the
 request content to the form fields.
@@ -442,6 +451,12 @@ Accept wildcard characters: False
 ### -ContentType
 
 Specifies the content type of the web request.
+
+If the value for **ContentType** contains the encoding format (as `charset`), the cmdlet uses that
+format to encode the body of the web request. If the **ContentType** doesn't specify an encoding
+format, the default encoding format is used instead. An example of a **ContentType** with an
+encoding format is `text/plain; charset=iso-8859-5`, which specifies the
+[Latin/Cyrillic](https://www.iso.org/standard/28249.html) alphabet.
 
 If this parameter is omitted and the request method is POST, `Invoke-RestMethod` sets the content
 type to `application/x-www-form-urlencoded`. Otherwise, the content type isn't specified in the

--- a/reference/7.3/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/17/2022
+ms.date: 11/04/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -446,11 +446,20 @@ You can also pipe a body value to `Invoke-WebRequest`.
 The **Body** parameter can be used to specify a list of query parameters or specify the content of
 the response.
 
-When the input is a GET request and the body is an **IDictionary** (typically, a hash table), the
-body is added to the URI as query parameters. For other request types (such as POST), the body is
-set as the value of the request body in the standard `name=value` format.
+When the input is a POST request and the body is a **String**, the value to the left of the first
+equals sign (`=`) is set as a key in the form data and the remaining text is set as the value. To
+specify multiple keys, use an **IDictionary** object, such as a hash table, for the **Body**.
 
-The **Body** parameter may also accept a `System.Net.Http.MultipartFormDataContent` object. This
+When the input is a GET request and the body is an **IDictionary** (typically, a hash table), the
+body is added to the URI as query parameters. For other request types (such as PATCH), the body is
+set as the value of the request body in the standard `name=value` format with the values
+URL-encoded.
+
+When the input is a **System.Xml.XmlNode** object and the XML declaration specifies an encoding,
+that encoding is used for the data in the request unless overridden by the **ContentType**
+parameter.
+
+The **Body** parameter also accepts a `System.Net.Http.MultipartFormDataContent` object. This
 facilitates `multipart/form-data` requests. When a **MultipartFormDataContent** object is supplied
 for **Body**, any Content related headers supplied to the **ContentType**, **Headers**, or
 **WebSession** parameters is overridden by the Content headers of the **MultipartFormDataContent**
@@ -518,6 +527,12 @@ Accept wildcard characters: False
 ### -ContentType
 
 Specifies the content type of the web request.
+
+If the value for **ContentType** contains the encoding format (as `charset`), the cmdlet uses that
+format to encode the body of the web request. If the **ContentType** doesn't specify an encoding
+format, the default encoding format is used instead. An example of a **ContentType** with an
+encoding format is `text/plain; charset=iso-8859-5`, which specifies the
+[Latin/Cyrillic](https://www.iso.org/standard/28249.html) alphabet.
 
 If this parameter is omitted and the request method is POST, `Invoke-WebRequest` sets the content
 type to `application/x-www-form-urlencoded`. Otherwise, the content type isn't specified in the


### PR DESCRIPTION
# PR Summary

This change adds information about how encoding works for the web cmdlets depending on the input:

- Adds information about how **IDictionary**, **String**, and **XmlNode** objects behave for the **Body** for different methods
- Adds information about how **ContentType** can define encoding if the `charset` is specified.
- Resolves #9312
- Fixes [AB#30955](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/30955)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
