### PR TITLE
(GH-9410) Add links to everything about strings

### DIFF
--- a/reference/docs-conceptual/learn/deep-dives/everything-about-string-substitutions.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-string-substitutions.md
@@ -1,7 +1,7 @@
 ---
 description: There are many ways to use variables in strings to create formatted text.
 ms.custom: contributor-KevinMarquette
-ms.date: 11/10/2021
+ms.date: 11/16/2022
 title: Everything you wanted to know about variable substitution in strings
 ---
 # Everything you wanted to know about variable substitution in strings
@@ -11,9 +11,9 @@ referring to any time you want to format a string to include values from variabl
 something that I often find myself explaining to new scripters.
 
 > [!NOTE]
-> The [original version][original version] of this article appeared on the blog written by [@KevinMarquette][@KevinMarquette]. The
-> PowerShell team thanks Kevin for sharing this content with us. Please check out his blog at
-> [PowerShellExplained.com][PowerShellExplained.com].
+> The [original version][14] of this article appeared on the blog written by
+> [@KevinMarquette][16]. The PowerShell team thanks Kevin for sharing this content with us. Please
+> check out his blog at [PowerShellExplained.com][13].
 
 ## Concatenation
 
@@ -129,7 +129,7 @@ This is not splatting because I'm passing the whole array in, but the idea is si
 ## Advanced formatting
 
 I intentionally called these out as coming from .NET because there are lots of formatting options
-already well [documented][documented] on it. There are built in ways to format various data types.
+already well [documented][01] on it. There are built in ways to format various data types.
 
 ```powershell
 "{0:yyyyMMdd}" -f (Get-Date)
@@ -182,7 +182,7 @@ The great thing about this is it works out the backslashes correctly when it put
 together. This is especially important if you are taking values from users or config files.
 
 This also goes well with `Split-Path` and `Test-Path`. I also cover these in my post about
-[reading and saving to files][reading and saving to files].
+[reading and saving to files][15].
 
 ## Strings are arrays
 
@@ -234,7 +234,7 @@ $tester = "Better"
 Write-Host "$test $tester ${test}ter"
 ```
 
-Thank you [/u/real_parbold][/u/real_parbold] for that one.
+Thank you [/u/real_parbold][18] for that one.
 
 Here is an alternate to this approach:
 
@@ -312,7 +312,7 @@ foreach($name in $nameList){
 ```
 
 To keep going on this idea; you could be importing a large email template from a text file to do
-this. I have to thank [Mark Kraus][Mark Kraus] for this [suggestion][suggestion].
+this. I have to thank [Mark Kraus][02] for this [suggestion][17].
 
 ## Whatever works the best for you
 
@@ -323,12 +323,39 @@ if there are multiple variables. On anything that is very short, I may use any o
 
 I covered a lot of ground on this one. My hope is that you walk away learning something new.
 
+## Links
+
+If you'd like to learn more about the methods and features that make string interpolation possible,
+see the following list for the reference documentation.
+
+- Concatenation uses the [addition operator][05]
+- Variable and command substitution follow the [quoting rules][10]
+- Formatting uses the [format operator][09]
+- Joining strings uses the [join operator][08] and references [`Join-Path`][11], but you could also
+  read about [`Join-String`][12]
+- Arrays are documented in [About arrays][06]
+- StringBuilder is a .NET class, with its [own documentation][04]
+- Braces in strings is also covered in the [quoting rules][10]
+- Token replacement uses the [replace operator][07]
+- The `$ExecutionContext.InvokeCommand.ExpandString()` method has
+  [.NET API reference documentation][03]
+
 <!-- link references -->
-[original version]: https://powershellexplained.com/2017-01-13-powershell-variable-substitution-in-strings/
-[powershellexplained.com]: https://powershellexplained.com/
-[@KevinMarquette]: https://twitter.com/KevinMarquette
-[Mark Kraus]: https://get-powershellblog.blogspot.com/
-[suggestion]: https://www.reddit.com/r/PowerShell/comments/5npf8h/kevmar_everything_you_wanted_to_know_about/dcdfia5/
-[/u/real_parbold]: https://www.reddit.com/r/PowerShell/comments/5npf8h/kevmar_everything_you_wanted_to_know_about/dcdfm6p/
-[reading and saving to files]: https://powershellexplained.com/2017-03-18-Powershell-reading-and-saving-data-to-files/
-[documented]: /dotnet/api/system.string.format#overloads
+[01]: /dotnet/api/system.string.format#overloads
+[02]: https://get-powershellblog.blogspot.com/
+[03]: /dotnet/api/system.management.automation.commandinvocationintrinsics.expandstring
+[04]: /dotnet/api/system.text.stringbuilder
+[05]: /powershell/module/microsoft.powershell.core/about/about_arithmetic_operators#adding-and-multiplying-non-numeric-types
+[06]: /powershell/module/microsoft.powershell.core/about/about_arrays
+[07]: /powershell/module/microsoft.powershell.core/about/about_comparison_operators#replacement-operator
+[08]: /powershell/module/microsoft.powershell.core/about/about_join
+[09]: /powershell/module/microsoft.powershell.core/about/about_operators#format-operator--f
+[10]: /powershell/module/microsoft.powershell.core/about/about_quoting_rules
+[11]: /powershell/module/microsoft.powershell.management/join-path
+[12]: /powershell/module/microsoft.powershell.utility/join-string
+[13]: https://powershellexplained.com/
+[14]: https://powershellexplained.com/2017-01-13-powershell-variable-substitution-in-strings/
+[15]: https://powershellexplained.com/2017-03-18-Powershell-reading-and-saving-data-to-files/
+[16]: https://twitter.com/KevinMarquette
+[17]: https://www.reddit.com/r/PowerShell/comments/5npf8h/kevmar_everything_you_wanted_to_know_about/dcdfia5/
+[18]: https://www.reddit.com/r/PowerShell/comments/5npf8h/kevmar_everything_you_wanted_to_know_about/dcdfm6p/


### PR DESCRIPTION
# PR Summary

Prior to this change, the deep dive article on string substition did not link to reference documentation. This change adds a set of reference links to the end of the article for convenience.

- Resolves #9410
- Fixes [AB#38326](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/38326)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
