### PR TITLE
(GH-9464) Clarify experimental nature of `$PSNativeCommandErrorActionPreference`

### DIFF
--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -1099,15 +1099,16 @@ Arg 2 is <a b>
 
 ## $PSNativeCommandUseErrorActionPreference
 
-This preference variable is only available in PowerShell 7.3 with the
+This preference variable is available in PowerShell 7.3 and later with the
 `PSNativeCommandErrorActionPreference` feature enabled.
 
 With this feature enabled, native commands with non-zero exit codes issue
 errors according to `$ErrorActionPreference` when
 `$PSNativeCommandUseErrorActionPreference` is `$true`.
 
-For more information, see
-[PSNativeCommandErrorActionPreference][13].
+> [!NOTE]
+> `PSNativeCommandUseErrorActionPreference` is an experimental feature added in
+> PowerShell 7.3. For more information, see [Using experimental features][13].
 
 ## $PSSessionApplicationName
 
@@ -1375,8 +1376,8 @@ objects.
 > [about_Experimental_Features][39] and
 > [Using experimental features][12].
 >
-> In PowerShell 7.3-preview.8, the `PSAnsiRenderingFileInfo` feature became
-> mainstream and available by default.
+> In PowerShell 7.3, the `PSAnsiRenderingFileInfo` feature became mainstream
+> and available by default.
 
 ## $Transcript
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for the preference variable, `$PSNativeCommandErrorActionPreference`, did not clearly denote that it relates to an _experimental_ feature introduced in PowerShell 7.3.

This change clarifies the experimental status of the feature in the documentation for the variable.

- Resolves #9464
- Fixes [AB#41138](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/41138)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
