### PR TITLE
(GH-9463) Correct `$HOME` variable information

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 11/15/2022
+ms.date: 11/21/2022
 no-loc: [Reset, Current, Background, Blink, Bold, Foreground, Formatting, Hidden, Italic, Reset, Reverse, Underline]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -156,13 +156,13 @@ and change the current loop iteration. For more information, see
 
 ### $HOME
 
-Contains the full path of the user's home directory. This variable is the
-equivalent of the `"$env:HOMEDRIVE$env:HOMEPATH"` Windows environment
-variables, typically `C:\Users\<UserName>`.
+Contains the full path of the user's home directory. This variable uses the
+value of the `"$env:USERPROFILE"` Windows environment variable, typically
+`C:\Users\<UserName>`.
 
 > [!IMPORTANT]
 > Windows can redirect the location of the user's profile. This means that
-> `$HOME` may not have the same value as `$env:USERPROFILE`.
+> `$HOME` may not have the same value as `$env:HOMEDRIVE$env:HOMEPATH`.
 
 ### $Host
 

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 11/15/2022
+ms.date: 11/21/2022
 no-loc: [Reset, Current, Background, Blink, Bold, Foreground, Formatting, Hidden, Italic, Reset, Reverse, Underline]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -156,13 +156,14 @@ and change the current loop iteration. For more information, see
 
 ### $HOME
 
-Contains the full path of the user's home directory. This variable is the
-equivalent of the `"$env:HOMEDRIVE$env:HOMEPATH"` Windows environment
-variables, typically `C:\Users\<UserName>`.
+Contains the full path of the user's home directory. On Windows, this variable
+uses the value of the `"$env:USERPROFILE"` Windows environment variable,
+typically `C:\Users\<UserName>`. On Unix, this variable uses the value of the
+`HOME` environment variable.
 
 > [!IMPORTANT]
 > Windows can redirect the location of the user's profile. This means that
-> `$HOME` may not have the same value as `$env:USERPROFILE`.
+> `$HOME` may not have the same value as `$env:HOMEDRIVE$env:HOMEPATH`.
 
 ### $Host
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 11/15/2022
+ms.date: 11/21/2022
 no-loc: [Reset, Current, Background, Blink, Bold, Foreground, Formatting, Hidden, Italic, Reset, Reverse, Underline]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -156,13 +156,14 @@ and change the current loop iteration. For more information, see
 
 ### $HOME
 
-Contains the full path of the user's home directory. This variable is the
-equivalent of the `"$env:HOMEDRIVE$env:HOMEPATH"` Windows environment
-variables, typically `C:\Users\<UserName>`.
+Contains the full path of the user's home directory. On Windows, this variable
+uses the value of the `"$env:USERPROFILE"` Windows environment variable,
+typically `C:\Users\<UserName>`. On Unix, this variable uses the value of the
+`HOME` environment variable.
 
 > [!IMPORTANT]
 > Windows can redirect the location of the user's profile. This means that
-> `$HOME` may not have the same value as `$env:USERPROFILE`.
+> `$HOME` may not have the same value as `$env:HOMEDRIVE$env:HOMEPATH`.
 
 ### $Host
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 11/15/2022
+ms.date: 11/21/2022
 no-loc: [Reset, Current, Background, Blink, Bold, Foreground, Formatting, Hidden, Italic, Reset, Reverse, Underline]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -156,13 +156,14 @@ and change the current loop iteration. For more information, see
 
 ### $HOME
 
-Contains the full path of the user's home directory. This variable is the
-equivalent of the `"$env:HOMEDRIVE$env:HOMEPATH"` Windows environment
-variables, typically `C:\Users\<UserName>`.
+Contains the full path of the user's home directory. On Windows, this variable
+uses the value of the `"$env:USERPROFILE"` Windows environment variable,
+typically `C:\Users\<UserName>`. On Unix, this variable uses the value of the
+`HOME` environment variable.
 
 > [!IMPORTANT]
 > Windows can redirect the location of the user's profile. This means that
-> `$HOME` may not have the same value as `$env:USERPROFILE`.
+> `$HOME` may not have the same value as `$env:HOMEDRIVE$env:HOMEPATH`.
 
 ### $Host
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for the `$HOME` variable noted that the variable was equal to `%HOMEDRIVE%%HOMEPATH%` and didn't clarify its value on Unix systems.

This change:

- corrects the documentation for `$HOME` on Windows to reference the `USERPROFILE` environment variable and on Unix the `HOME` environment variable
- Updates the note about non-matching values to clarify that it may not match `%HOMEDRIVE%%HOMEPATH%` instead of `USERPROFILE`
- Resolves #9463
- Fixes [AB#41140](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/41140)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
