### PR TITLE
(GH-9479) Clarify delay-binding

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -1,7 +1,7 @@
 ---
 description: Defines what a script block is and explains how to use script blocks in the PowerShell programming language.
 Locale: en-US
-ms.date: 04/08/2020
+ms.date: 11/29/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_script_blocks?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Script Blocks
@@ -147,27 +147,34 @@ For more information about the call operator, see [about_Operators](about_Operat
 
 ## Using delay-bind script blocks with parameters
 
-A typed parameter that accepts pipeline input (`by Value`) or
-(`by PropertyName`) enables use of **delay-bind** script blocks on the parameter.
-Within the **delay-bind** script block, you can reference the piped in object
+A typed parameter that accepts pipeline input enables use of _delay-bind_
+script blocks on the parameter. You can use delay-bind script blocks as a
+shorthand to define parameters for a pipelined cmdlet before executing it.
+
+Within the delay-bind script block, you can reference the piped in object
 using the pipeline variable `$_`.
 
 ```powershell
-# Renames config.log to old_config.log
-dir config.log | Rename-Item -NewName {"old_" + $_.Name}
+# Both examples rename config.log to old_config.log
+# Without delay-binding
+dir config.log | ForEach-Object -Process {
+  Rename-Item -Path $_ -NewName "old_$($_.Name)"
+}
+# With delay-binding
+dir config.log | Rename-Item -NewName { "old_$($_.Name)" }
 ```
 
 In more complex cmdlets, delay-bind script blocks allow the reuse of one piped
 in object to populate other parameters.
 
-Notes on **delay-bind** script blocks as parameters:
+Notes on delay-bind script blocks as parameters:
 
-- You must explicitly specify any parameter names you use with **delay-bind**
+- You must explicitly specify any parameter names you use with delay-bind
   script blocks.
 - The parameter must not be untyped, and the parameter's type cannot be
   `[scriptblock]` or `[object]`.
-- You receive an error if you use a **delay-bind** script block without
-  providing pipeline input.
+- You receive an error if you use a delay-bind script block without providing
+  pipeline input.
 
   ```powershell
   Rename-Item -NewName {$_.Name + ".old"}

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -1,7 +1,7 @@
 ---
 description: Defines what a script block is and explains how to use script blocks in the PowerShell programming language.
 Locale: en-US
-ms.date: 04/08/2020
+ms.date: 11/29/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_script_blocks?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Script Blocks
@@ -147,27 +147,34 @@ For more information about the call operator, see [about_Operators](about_Operat
 
 ## Using delay-bind script blocks with parameters
 
-A typed parameter that accepts pipeline input (`by Value`) or
-(`by PropertyName`) enables use of **delay-bind** script blocks on the parameter.
-Within the **delay-bind** script block, you can reference the piped in object
+A typed parameter that accepts pipeline input enables use of _delay-bind_
+script blocks on the parameter. You can use delay-bind script blocks as a
+shorthand to define parameters for a pipelined cmdlet before executing it.
+
+Within the delay-bind script block, you can reference the piped in object
 using the pipeline variable `$_`.
 
 ```powershell
-# Renames config.log to old_config.log
-dir config.log | Rename-Item -NewName {"old_" + $_.Name}
+# Both examples rename config.log to old_config.log
+# Without delay-binding
+dir config.log | ForEach-Object -Process {
+  Rename-Item -Path $_ -NewName "old_$($_.Name)"
+}
+# With delay-binding
+dir config.log | Rename-Item -NewName { "old_$($_.Name)" }
 ```
 
 In more complex cmdlets, delay-bind script blocks allow the reuse of one piped
 in object to populate other parameters.
 
-Notes on **delay-bind** script blocks as parameters:
+Notes on delay-bind script blocks as parameters:
 
-- You must explicitly specify any parameter names you use with **delay-bind**
+- You must explicitly specify any parameter names you use with delay-bind
   script blocks.
 - The parameter must not be untyped, and the parameter's type cannot be
   `[scriptblock]` or `[object]`.
-- You receive an error if you use a **delay-bind** script block without
-  providing pipeline input.
+- You receive an error if you use a delay-bind script block without providing
+  pipeline input.
 
   ```powershell
   Rename-Item -NewName {$_.Name + ".old"}

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -1,7 +1,7 @@
 ---
 description: Defines what a script block is and explains how to use script blocks in the PowerShell programming language.
 Locale: en-US
-ms.date: 04/08/2020
+ms.date: 11/29/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_script_blocks?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Script Blocks
@@ -147,27 +147,34 @@ For more information about the call operator, see [about_Operators](about_Operat
 
 ## Using delay-bind script blocks with parameters
 
-A typed parameter that accepts pipeline input (`by Value`) or
-(`by PropertyName`) enables use of **delay-bind** script blocks on the parameter.
-Within the **delay-bind** script block, you can reference the piped in object
+A typed parameter that accepts pipeline input enables use of _delay-bind_
+script blocks on the parameter. You can use delay-bind script blocks as a
+shorthand to define parameters for a pipelined cmdlet before executing it.
+
+Within the delay-bind script block, you can reference the piped in object
 using the pipeline variable `$_`.
 
 ```powershell
-# Renames config.log to old_config.log
-dir config.log | Rename-Item -NewName {"old_" + $_.Name}
+# Both examples rename config.log to old_config.log
+# Without delay-binding
+dir config.log | ForEach-Object -Process {
+  Rename-Item -Path $_ -NewName "old_$($_.Name)"
+}
+# With delay-binding
+dir config.log | Rename-Item -NewName { "old_$($_.Name)" }
 ```
 
 In more complex cmdlets, delay-bind script blocks allow the reuse of one piped
 in object to populate other parameters.
 
-Notes on **delay-bind** script blocks as parameters:
+Notes on delay-bind script blocks as parameters:
 
-- You must explicitly specify any parameter names you use with **delay-bind**
+- You must explicitly specify any parameter names you use with delay-bind
   script blocks.
 - The parameter must not be untyped, and the parameter's type cannot be
   `[scriptblock]` or `[object]`.
-- You receive an error if you use a **delay-bind** script block without
-  providing pipeline input.
+- You receive an error if you use a delay-bind script block without providing
+  pipeline input.
 
   ```powershell
   Rename-Item -NewName {$_.Name + ".old"}

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -1,7 +1,7 @@
 ---
 description: Defines what a script block is and explains how to use script blocks in the PowerShell programming language.
 Locale: en-US
-ms.date: 04/08/2020
+ms.date: 11/29/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_script_blocks?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Script Blocks
@@ -147,27 +147,34 @@ For more information about the call operator, see [about_Operators](about_Operat
 
 ## Using delay-bind script blocks with parameters
 
-A typed parameter that accepts pipeline input (`by Value`) or
-(`by PropertyName`) enables use of **delay-bind** script blocks on the parameter.
-Within the **delay-bind** script block, you can reference the piped in object
+A typed parameter that accepts pipeline input enables use of _delay-bind_
+script blocks on the parameter. You can use delay-bind script blocks as a
+shorthand to define parameters for a pipelined cmdlet before executing it.
+
+Within the delay-bind script block, you can reference the piped in object
 using the pipeline variable `$_`.
 
 ```powershell
-# Renames config.log to old_config.log
-dir config.log | Rename-Item -NewName {"old_" + $_.Name}
+# Both examples rename config.log to old_config.log
+# Without delay-binding
+dir config.log | ForEach-Object -Process {
+  Rename-Item -Path $_ -NewName "old_$($_.Name)"
+}
+# With delay-binding
+dir config.log | Rename-Item -NewName { "old_$($_.Name)" }
 ```
 
 In more complex cmdlets, delay-bind script blocks allow the reuse of one piped
 in object to populate other parameters.
 
-Notes on **delay-bind** script blocks as parameters:
+Notes on delay-bind script blocks as parameters:
 
-- You must explicitly specify any parameter names you use with **delay-bind**
+- You must explicitly specify any parameter names you use with delay-bind
   script blocks.
 - The parameter must not be untyped, and the parameter's type cannot be
   `[scriptblock]` or `[object]`.
-- You receive an error if you use a **delay-bind** script block without
-  providing pipeline input.
+- You receive an error if you use a delay-bind script block without providing
+  pipeline input.
 
   ```powershell
   Rename-Item -NewName {$_.Name + ".old"}


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation in `about_Script_Blocks` showed how to use delay-binding but didn't explain how they're useful and wasn't clear that this is a usability feature for cmdlet users, not for cmdlet authors.

This change adds some clarification and extends the example to show how delay-binding can help users write shorter, more convenient code.

- Resolves #9479
- Fixes [AB#43576](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/43576)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
