### PR TITLE
(GH-9480) Update validation attribute & examples

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to add parameters to advanced functions.
 Locale: en-US
-ms.date: 10/27/2022
+ms.date: 11/29/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Functions Advanced Parameters
@@ -641,17 +641,53 @@ is only applied to the input provided and any other values like default values
 aren't validated.
 
 You can also use the validation attributes to restrict the values that users
-can specify for variables. When you use a type converter along with a
-validation attribute, the type converter has to be defined before the
-attribute.
+can specify for variables.
 
 ```powershell
-[int32][AllowNull()] $number = 7
+[AllowNull()][int]$number = 7
 ```
 
+Validation attributes can be applied to any variable, not just parameters. You
+can define validation for any variable within a script.
+
 > [!NOTE]
-> Validation attributes can be applied to any variable, not just parameters.
-> You can define validation for any variable within a script.
+> When using any attributes with a typed variable, it's best practice to
+> declare the attribute before the type.
+>
+> If you declare a type with a line break before the attribute and variable
+> name, the type is treated as its own statement.
+>
+> ```powershell
+> [string]
+> [ValidateLength(1,5)] $Text = 'Okay'
+> ```
+>
+> ```output
+> IsPublic IsSerial Name                                     BaseType
+> -------- -------- ----                                     --------
+> True     True     String                                   System.Object
+> ```
+>
+> If you declare a validation attribute after a type, the value being assigned
+> is validated before type conversion, which can lead to unexpected validation
+> failures.
+>
+> ```powershell
+> [string][ValidateLength(1,5)]$TicketIDFromInt        = 43
+> [string][ValidateLength(1,5)]$TicketIDFromString     = '43'
+> [ValidateLength(1,5)][string]$TicketIDAttributeFirst = 43
+> ```
+>
+> ```output
+> The attribute cannot be added because variable TicketIDFromInt with
+> value 43 would no longer be valid.
+> At line:1 char:1
+> + [string][ValidateLength(1,5)]$TicketIDFromInt        = 43
+> + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+>     + CategoryInfo          : MetadataError: (:) [], ValidationMetadata
+>    Exception
+>     + FullyQualifiedErrorId : ValidateSetFailure
+> ```
 
 ### AllowNull validation attribute
 
@@ -740,17 +776,12 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$number` must be a minimum
+In the following example, the value of the variable `$text` must be a minimum
 of one character in length, and a maximum of ten characters.
 
 ```powershell
-[Int32][ValidateLength(1,10)]$number = '01'
+[ValidateLength(1,10)][string] $text = 'valid'
 ```
-
-> [!NOTE]
-> In this example, the value of `01` is wrapped in single quotes. The
-> **ValidateLength** attribute won't accept a number without being wrapped in
-> quotes.
 
 ### ValidatePattern validation attribute
 
@@ -770,11 +801,11 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$number` must be exactly a
-four-digit number, and each digit must be a number zero to nine.
+In the following example, the value of the variable `$ticketID` must be exactly
+a four-digit number, and each digit must be a number zero to nine.
 
 ```powershell
-[Int32][ValidatePattern("^[0-9][0-9][0-9][0-9]$")]$number = 1111
+[ValidatePattern("^[0-9][0-9][0-9][0-9]$")][string]$ticketID = 1111
 ```
 
 ### ValidateRange validation attribute
@@ -799,7 +830,7 @@ In the following example, the value of the variable `$number` must be between
 zero and ten.
 
 ```powershell
-[Int32][ValidateRange(0,10)]$number = 5
+[ValidateRange(0,10)][int]$number = 5
 ```
 
 ### ValidateScript validation attribute
@@ -825,11 +856,11 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$date` must be greater
-than or equal to the current date and time.
+In the following example, the value of the variable `$date` must be less than
+or equal to the current date and time.
 
 ```powershell
-[DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
+[ValidateScript({$_ -le (Get-Date)})][DateTime]$date = (Get-Date)
 ```
 
 > [!NOTE]

--- a/reference/7.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to add parameters to advanced functions.
 Locale: en-US
-ms.date: 10/27/2022
+ms.date: 11/29/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Functions Advanced Parameters
@@ -650,17 +650,47 @@ is only applied to the input provided and any other values like default values
 aren't validated.
 
 You can also use the validation attributes to restrict the values that users
-can specify for variables. When you use a type converter along with a
-validation attribute, the type converter has to be defined before the
-attribute.
+can specify for variables.
 
 ```powershell
-[int32][AllowNull()] $number = 7
+[AllowNull()][int]$number = 7
 ```
 
+Validation attributes can be applied to any variable, not just parameters. You
+can define validation for any variable within a script.
+
 > [!NOTE]
-> Validation attributes can be applied to any variable, not just parameters.
-> You can define validation for any variable within a script.
+> When using any attributes with a typed variable, it's best practice to
+> declare the attribute before the type.
+>
+> If you declare a type with a line break before the attribute and variable
+> name, the type is treated as its own statement.
+>
+> ```powershell
+> [string]
+> [ValidateLength(1,5)] $Text = 'Okay'
+> ```
+>
+> ```output
+> IsPublic IsSerial Name                                     BaseType
+> -------- -------- ----                                     --------
+> True     True     String                                   System.Object
+> ```
+>
+> If you declare a validation attribute after a type, the value being assigned
+> is validated before type conversion, which can lead to unexpected validation
+> failures.
+>
+> ```powershell
+> [string][ValidateLength(1,5)]$TicketIDFromInt        = 43
+> [string][ValidateLength(1,5)]$TicketIDFromString     = '43'
+> [ValidateLength(1,5)][string]$TicketIDAttributeFirst = 43
+> ```
+>
+> ```output
+> MetadataError: The attribute cannot be added because variable
+> TicketIDFromInt with value 43 would no longer be valid.
+> ```
 
 ### AllowNull validation attribute
 
@@ -749,17 +779,12 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$number` must be a minimum
+In the following example, the value of the variable `$text` must be a minimum
 of one character in length, and a maximum of ten characters.
 
 ```powershell
-[Int32][ValidateLength(1,10)]$number = '01'
+[ValidateLength(1,10)][string] $text = 'valid'
 ```
-
-> [!NOTE]
-> In this example, the value of `01` is wrapped in single quotes. The
-> **ValidateLength** attribute won't accept a number without being wrapped in
-> quotes.
 
 ### ValidatePattern validation attribute
 
@@ -779,11 +804,11 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$number` must be exactly a
-four-digit number, and each digit must be a number zero to nine.
+In the following example, the value of the variable `$ticketID` must be exactly
+a four-digit number, and each digit must be a number zero to nine.
 
 ```powershell
-[Int32][ValidatePattern("^[0-9][0-9][0-9][0-9]$")]$number = 1111
+[ValidatePattern("^[0-9][0-9][0-9][0-9]$")][string]$ticketID = 1111
 ```
 
 ### ValidateRange validation attribute
@@ -815,14 +840,14 @@ In the following example, the value of the variable `$number` must be between
 zero and ten.
 
 ```powershell
-[Int32][ValidateRange(0,10)]$number = 5
+[ValidateRange(0,10)][int]$number = 5
 ```
 
 In the following example, the value of the variable `$number` must be greater
 than zero.
 
 ```powershell
-[Int32][ValidateRange("Positive")]$number = 1
+[ValidateRange("Positive")][int]$number = 1
 ```
 
 ### ValidateScript validation attribute
@@ -848,11 +873,11 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$date` must be greater
-than or equal to the current date and time.
+In the following example, the value of the variable `$date` must be less than
+or equal to the current date and time.
 
 ```powershell
-[DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
+[ValidateScript({$_ -le (Get-Date)})][DateTime]$date = (Get-Date)
 ```
 
 > [!NOTE]

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to add parameters to advanced functions.
 Locale: en-US
-ms.date: 10/27/2022
+ms.date: 11/29/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Functions Advanced Parameters
@@ -650,17 +650,47 @@ is only applied to the input provided and any other values like default values
 aren't validated.
 
 You can also use the validation attributes to restrict the values that users
-can specify for variables. When you use a type converter along with a
-validation attribute, the type converter has to be defined before the
-attribute.
+can specify for variables.
 
 ```powershell
-[int32][AllowNull()] $number = 7
+[AllowNull()][int]$number = 7
 ```
 
+Validation attributes can be applied to any variable, not just parameters. You
+can define validation for any variable within a script.
+
 > [!NOTE]
-> Validation attributes can be applied to any variable, not just parameters.
-> You can define validation for any variable within a script.
+> When using any attributes with a typed variable, it's best practice to
+> declare the attribute before the type.
+>
+> If you declare a type with a line break before the attribute and variable
+> name, the type is treated as its own statement.
+>
+> ```powershell
+> [string]
+> [ValidateLength(1,5)] $Text = 'Okay'
+> ```
+>
+> ```output
+> IsPublic IsSerial Name                                     BaseType
+> -------- -------- ----                                     --------
+> True     True     String                                   System.Object
+> ```
+>
+> If you declare a validation attribute after a type, the value being assigned
+> is validated before type conversion, which can lead to unexpected validation
+> failures.
+>
+> ```powershell
+> [string][ValidateLength(1,5)]$TicketIDFromInt        = 43
+> [string][ValidateLength(1,5)]$TicketIDFromString     = '43'
+> [ValidateLength(1,5)][string]$TicketIDAttributeFirst = 43
+> ```
+>
+> ```output
+> MetadataError: The attribute cannot be added because variable
+> TicketIDFromInt with value 43 would no longer be valid.
+> ```
 
 ### AllowNull validation attribute
 
@@ -749,17 +779,12 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$number` must be a minimum
+In the following example, the value of the variable `$text` must be a minimum
 of one character in length, and a maximum of ten characters.
 
 ```powershell
-[Int32][ValidateLength(1,10)]$number = '01'
+[ValidateLength(1,10)][string] $text = 'valid'
 ```
-
-> [!NOTE]
-> In this example, the value of `01` is wrapped in single quotes. The
-> **ValidateLength** attribute won't accept a number without being wrapped in
-> quotes.
 
 ### ValidatePattern validation attribute
 
@@ -779,11 +804,11 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$number` must be exactly a
-four-digit number, and each digit must be a number zero to nine.
+In the following example, the value of the variable `$ticketID` must be exactly
+a four-digit number, and each digit must be a number zero to nine.
 
 ```powershell
-[Int32][ValidatePattern("^[0-9][0-9][0-9][0-9]$")]$number = 1111
+[ValidatePattern("^[0-9][0-9][0-9][0-9]$")][string]$ticketID = 1111
 ```
 
 ### ValidateRange validation attribute
@@ -815,14 +840,14 @@ In the following example, the value of the variable `$number` must be between
 zero and ten.
 
 ```powershell
-[Int32][ValidateRange(0,10)]$number = 5
+[ValidateRange(0,10)][int]$number = 5
 ```
 
 In the following example, the value of the variable `$number` must be greater
 than zero.
 
 ```powershell
-[Int32][ValidateRange("Positive")]$number = 1
+[ValidateRange("Positive")][int]$number = 1
 ```
 
 ### ValidateScript validation attribute
@@ -848,11 +873,11 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$date` must be greater
-than or equal to the current date and time.
+In the following example, the value of the variable `$date` must be less than
+or equal to the current date and time.
 
 ```powershell
-[DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
+[ValidateScript({$_ -le (Get-Date)})][DateTime]$date = (Get-Date)
 ```
 
 > [!NOTE]

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to add parameters to advanced functions.
 Locale: en-US
-ms.date: 10/27/2022
+ms.date: 11/29/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Functions Advanced Parameters
@@ -650,17 +650,47 @@ is only applied to the input provided and any other values like default values
 aren't validated.
 
 You can also use the validation attributes to restrict the values that users
-can specify for variables. When you use a type converter along with a
-validation attribute, the type converter has to be defined before the
-attribute.
+can specify for variables.
 
 ```powershell
-[int32][AllowNull()] $number = 7
+[AllowNull()][int]$number = 7
 ```
 
+Validation attributes can be applied to any variable, not just parameters. You
+can define validation for any variable within a script.
+
 > [!NOTE]
-> Validation attributes can be applied to any variable, not just parameters.
-> You can define validation for any variable within a script.
+> When using any attributes with a typed variable, it's best practice to
+> declare the attribute before the type.
+>
+> If you declare a type with a line break before the attribute and variable
+> name, the type is treated as its own statement.
+>
+> ```powershell
+> [string]
+> [ValidateLength(1,5)] $Text = 'Okay'
+> ```
+>
+> ```output
+> IsPublic IsSerial Name                                     BaseType
+> -------- -------- ----                                     --------
+> True     True     String                                   System.Object
+> ```
+>
+> If you declare a validation attribute after a type, the value being assigned
+> is validated before type conversion, which can lead to unexpected validation
+> failures.
+>
+> ```powershell
+> [string][ValidateLength(1,5)]$TicketIDFromInt        = 43
+> [string][ValidateLength(1,5)]$TicketIDFromString     = '43'
+> [ValidateLength(1,5)][string]$TicketIDAttributeFirst = 43
+> ```
+>
+> ```output
+> MetadataError: The attribute cannot be added because variable
+> TicketIDFromInt with value 43 would no longer be valid.
+> ```
 
 ### AllowNull validation attribute
 
@@ -749,17 +779,12 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$number` must be a minimum
+In the following example, the value of the variable `$text` must be a minimum
 of one character in length, and a maximum of ten characters.
 
 ```powershell
-[Int32][ValidateLength(1,10)]$number = '01'
+[ValidateLength(1,10)][string] $text = 'valid'
 ```
-
-> [!NOTE]
-> In this example, the value of `01` is wrapped in single quotes. The
-> **ValidateLength** attribute won't accept a number without being wrapped in
-> quotes.
 
 ### ValidatePattern validation attribute
 
@@ -779,11 +804,11 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$number` must be exactly a
-four-digit number, and each digit must be a number zero to nine.
+In the following example, the value of the variable `$ticketID` must be exactly
+a four-digit number, and each digit must be a number zero to nine.
 
 ```powershell
-[Int32][ValidatePattern("^[0-9][0-9][0-9][0-9]$")]$number = 1111
+[ValidatePattern("^[0-9][0-9][0-9][0-9]$")][string]$ticketID = 1111
 ```
 
 ### ValidateRange validation attribute
@@ -815,14 +840,14 @@ In the following example, the value of the variable `$number` must be between
 zero and ten.
 
 ```powershell
-[Int32][ValidateRange(0,10)]$number = 5
+[ValidateRange(0,10)][int]$number = 5
 ```
 
 In the following example, the value of the variable `$number` must be greater
 than zero.
 
 ```powershell
-[Int32][ValidateRange("Positive")]$number = 1
+[ValidateRange("Positive")][int]$number = 1
 ```
 
 ### ValidateScript validation attribute
@@ -848,11 +873,11 @@ Param(
 )
 ```
 
-In the following example, the value of the variable `$date` must be greater
-than or equal to the current date and time.
+In the following example, the value of the variable `$date` must be less than
+or equal to the current date and time.
 
 ```powershell
-[DateTime][ValidateScript({$_ -ge (Get-Date)})]$date = (Get-Date)
+[ValidateScript({$_ -le (Get-Date)})][DateTime]$date = (Get-Date)
 ```
 
 > [!NOTE]


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for validation attributes in the about topic `about_Functions_Advanced_Parameters` stated:

> When you use a type converter along with a validation attribute,
> the type converter has to be defined before the attribute

This isn't true and several of the examples don't follow this claim. The origin of this note appears to be a workaround for using the **ValidateLength** attribute with an integer parameter or variable.

With the attribute to the left of the type, the statement fails because an integer doesn't have a length and the attribute can't be satisfied. With the attribute to the right of the type, the first assignment can be successful, but you can't assign values to the variable afterward.

This is usage is an anti-pattern that shouldn't be recommended, used as default advice, or shown since it's not only an anti-pattern but also a confusing and non-obvious usage.

This change:

- Replaces the direction for placing attributes to the right of types with direction for placing attributes to the left of types with supporting reasoning and examples
- Updates the examples to show coherent usages for each attribute
- Corrects the **ValidateScript** example to actually pass
- Resolves #9480
- Fixes [AB#43577](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/43577)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
