### PR TITLE
(GH-9494) Add note about path for Publish-Module

### DIFF
--- a/reference/5.1/PowershellGet/Publish-Module.md
+++ b/reference/5.1/PowershellGet/Publish-Module.md
@@ -2,7 +2,7 @@
 external help file: PSModule-help.xml
 Locale: en-US
 Module Name: PowerShellGet
-ms.date: 10/03/2019
+ms.date: 11/30/2022
 online version: https://learn.microsoft.com/powershell/module/powershellget/publish-module?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Publish-Module
@@ -72,7 +72,14 @@ Directory; a brief release note is added. If MyDscModule is not a valid manifest
 specifies a name, version, description, and author, an error occurs.
 
 ```powershell
-Publish-Module -Name "MyDscModule" -NuGetApiKey "11e4b435-6cb4-4bf7-8611-5162ed75eb73" -LicenseUri "http://contoso.com/license" -Tag "Active Directory","DSC" -ReleaseNote "Updated the ActiveDirectory DSC Resources to support adding users."
+$parameters = @{
+    Name        = "MyDscModule"
+    NuGetApiKey = "11e4b435-6cb4-4bf7-8611-5162ed75eb73"
+    LicenseUri  = "http://contoso.com/license"
+    Tag         = "Active Directory","DSC"
+    ReleaseNote = "Updated the ActiveDirectory DSC Resources to support adding users."
+}
+Publish-Module @parameters
 ```
 
 ## PARAMETERS
@@ -234,7 +241,7 @@ Accept wildcard characters: False
 ### -Path
 
 Specifies the path to the module that you want to publish. This parameter accepts the path to the
-folder that contains the module.
+folder that contains the module. The folder must have the same name as the module.
 
 ```yaml
 Type: System.String

--- a/reference/7.0/PowerShellGet/Publish-Module.md
+++ b/reference/7.0/PowerShellGet/Publish-Module.md
@@ -2,7 +2,7 @@
 external help file: PSModule-help.xml
 Locale: en-US
 Module Name: PowerShellGet
-ms.date: 10/03/2019
+ms.date: 11/30/2022
 online version: https://learn.microsoft.com/powershell/module/powershellget/publish-module?view=powershell-7&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Publish-Module
@@ -72,7 +72,14 @@ Directory; a brief release note is added. If MyDscModule is not a valid manifest
 specifies a name, version, description, and author, an error occurs.
 
 ```powershell
-Publish-Module -Name "MyDscModule" -NuGetApiKey "11e4b435-6cb4-4bf7-8611-5162ed75eb73" -LicenseUri "http://contoso.com/license" -Tag "Active Directory","DSC" -ReleaseNote "Updated the ActiveDirectory DSC Resources to support adding users."
+$parameters = @{
+    Name        = "MyDscModule"
+    NuGetApiKey = "11e4b435-6cb4-4bf7-8611-5162ed75eb73"
+    LicenseUri  = "http://contoso.com/license"
+    Tag         = "Active Directory","DSC"
+    ReleaseNote = "Updated the ActiveDirectory DSC Resources to support adding users."
+}
+Publish-Module @parameters
 ```
 
 ## PARAMETERS
@@ -233,7 +240,7 @@ Accept wildcard characters: False
 ### -Path
 
 Specifies the path to the module that you want to publish. This parameter accepts the path to the
-folder that contains the module.
+folder that contains the module. The folder must have the same name as the module.
 
 ```yaml
 Type: System.String

--- a/reference/7.2/PowerShellGet/Publish-Module.md
+++ b/reference/7.2/PowerShellGet/Publish-Module.md
@@ -2,7 +2,7 @@
 external help file: PSModule-help.xml
 Locale: en-US
 Module Name: PowerShellGet
-ms.date: 10/03/2019
+ms.date: 11/30/2022
 online version: https://learn.microsoft.com/powershell/module/powershellget/publish-module?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Publish-Module
@@ -72,7 +72,14 @@ Directory; a brief release note is added. If MyDscModule is not a valid manifest
 specifies a name, version, description, and author, an error occurs.
 
 ```powershell
-Publish-Module -Name "MyDscModule" -NuGetApiKey "11e4b435-6cb4-4bf7-8611-5162ed75eb73" -LicenseUri "http://contoso.com/license" -Tag "Active Directory","DSC" -ReleaseNote "Updated the ActiveDirectory DSC Resources to support adding users."
+$parameters = @{
+    Name        = "MyDscModule"
+    NuGetApiKey = "11e4b435-6cb4-4bf7-8611-5162ed75eb73"
+    LicenseUri  = "http://contoso.com/license"
+    Tag         = "Active Directory","DSC"
+    ReleaseNote = "Updated the ActiveDirectory DSC Resources to support adding users."
+}
+Publish-Module @parameters
 ```
 
 ## PARAMETERS
@@ -233,7 +240,7 @@ Accept wildcard characters: False
 ### -Path
 
 Specifies the path to the module that you want to publish. This parameter accepts the path to the
-folder that contains the module.
+folder that contains the module. The folder must have the same name as the module.
 
 ```yaml
 Type: System.String

--- a/reference/7.3/PowerShellGet/Publish-Module.md
+++ b/reference/7.3/PowerShellGet/Publish-Module.md
@@ -2,7 +2,7 @@
 external help file: PSModule-help.xml
 Locale: en-US
 Module Name: PowerShellGet
-ms.date: 10/03/2019
+ms.date: 11/30/2022
 online version: https://learn.microsoft.com/powershell/module/powershellget/publish-module?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Publish-Module
@@ -72,7 +72,14 @@ Directory; a brief release note is added. If MyDscModule is not a valid manifest
 specifies a name, version, description, and author, an error occurs.
 
 ```powershell
-Publish-Module -Name "MyDscModule" -NuGetApiKey "11e4b435-6cb4-4bf7-8611-5162ed75eb73" -LicenseUri "http://contoso.com/license" -Tag "Active Directory","DSC" -ReleaseNote "Updated the ActiveDirectory DSC Resources to support adding users."
+$parameters = @{
+    Name        = "MyDscModule"
+    NuGetApiKey = "11e4b435-6cb4-4bf7-8611-5162ed75eb73"
+    LicenseUri  = "http://contoso.com/license"
+    Tag         = "Active Directory","DSC"
+    ReleaseNote = "Updated the ActiveDirectory DSC Resources to support adding users."
+}
+Publish-Module @parameters
 ```
 
 ## PARAMETERS
@@ -233,7 +240,7 @@ Accept wildcard characters: False
 ### -Path
 
 Specifies the path to the module that you want to publish. This parameter accepts the path to the
-folder that contains the module.
+folder that contains the module. The folder must have the same name as the module.
 
 ```yaml
 Type: System.String


### PR DESCRIPTION
# PR Summary

Prior to this change, the **Path** parameter for `Publish-Module` stated that the value must point to the folder where the module exists, but not that the folder must have the same name as the module.

This change:

- Adds a note explicitly stating this requirement
- Resolves #9494
- Fixes [AB#44849](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/44849)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
