### PR TITLE
(GH-9534) Update about_PSItem

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PSItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PSItem.md
@@ -2,7 +2,7 @@
 description: The automatic variable that contains the current object in the pipeline object.
 Locale: en-US
 ms.date: 12/06/2022
-online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_psitem?view=powershell-7.3&WT.mc_id=ps-gethelp
+online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_psitem?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSItem
 ---
@@ -15,9 +15,9 @@ The automatic variable that contains the current object in the pipeline object.
 ## Long description
 
 PowerShell includes the `$PSItem` variable and its alias, `$_`, as
-[automatic variables][01] in scriptblocks that process pipeline objects. This
-article uses `$PSItem` in the examples, but `$PSItem` can be replaced with `$_`
-in every example.
+[automatic variables][01] in scriptblocks that process the current object, such
+as in the pipeline. This article uses `$PSItem` in the examples, but `$PSItem`
+can be replaced with `$_` in every example.
 
 You can use this variable in commands that perform an action on every object in
 a pipeline.
@@ -33,7 +33,7 @@ There are a few common use cases for `$PSItem`:
 - in a `switch` statement's conditional values and associated scriptblocks
 - in the `process` block of a function
 - in a `filter` definition
-- in the substitution operand scriptblock of the `-replace` operator
+- in the scriptblock of the **ValidateScript** attribute
 
 The rest of this article includes examples of using `$PSItem` for these use
 cases.
@@ -294,6 +294,64 @@ False
 In this example, the `Test-IsEven` filter outputs `$true` if the current object
 is an even number and `$false` if it isn't.
 
+## The ValidateScript attribute scriptblock
+
+You can use `$PSItem` in the scriptblock of a [ValidateScript][15] attribute.
+When used with **ValidateScript**, `$PSItem` is the value of the current object
+being validated. When the variable or parameter value is an array, the
+scriptblock is called once for each object in the array with `$PSItem` as the
+current object.
+
+```powershell
+function Add-EvenNumber {
+    param(
+        [ValidateScript({ 0 -eq ($PSItem % 2) })]
+        [int[]]$Number
+    )
+
+    begin {
+        [int]$total = 0
+    }
+
+    process {
+        foreach ($n in $Number) {
+            $total += $n
+        }
+    }
+
+    end {
+        $total
+    }
+}
+
+Add-EvenNumber -Number 2, 4, 6
+
+Add-EvenNumber -Number 1, 2
+```
+
+```output
+12
+
+Add-EvenNumber : Cannot validate argument on parameter 'Number'. The
+" 0 -eq ($PSItem % 2) " validation script for the argument with value "1"
+did not return a result of True. Determine why the validation script
+failed, and then try the command again.
+At line:1 char:24
++ Add-EvenNumber -Number 1, 2
++                        ~~~~
+    + CategoryInfo          : InvalidData: (:) [Add-EvenNumber],
+   ParameterBindingValidationException
+    + FullyQualifiedErrorId : ParameterArgumentValidationError,
+   Add-EvenNumber
+```
+
+In this example the scriptblock for the **ValidateScript** attribute runs once
+for each value passed to the **Number** parameter, returning an error if any
+value isn't even.
+
+The `Add-EvenNumber` function adds the valid input numbers and returns the
+total.
+
 ## See also
 
 - [about_Arrays][04]
@@ -319,3 +377,4 @@ is an even number and `$false` if it isn't.
 [11]: about_Functions.md#filters
 [12]: about_Comparison_Operators.md#replacement-operator
 [14]: about_Script_Blocks.md
+[15]: about_Functions_Advanced_Parameters.md#validatescript-validation-attribute

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_PSItem.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_PSItem.md
@@ -2,7 +2,7 @@
 description: The automatic variable that contains the current object in the pipeline object.
 Locale: en-US
 ms.date: 12/06/2022
-online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_psitem?view=powershell-7.3&WT.mc_id=ps-gethelp
+online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_psitem?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSItem
 ---
@@ -15,9 +15,9 @@ The automatic variable that contains the current object in the pipeline object.
 ## Long description
 
 PowerShell includes the `$PSItem` variable and its alias, `$_`, as
-[automatic variables][01] in scriptblocks that process pipeline objects. This
-article uses `$PSItem` in the examples, but `$PSItem` can be replaced with `$_`
-in every example.
+[automatic variables][01] in scriptblocks that process the current object, such
+as in the pipeline. This article uses `$PSItem` in the examples, but `$PSItem`
+can be replaced with `$_` in every example.
 
 You can use this variable in commands that perform an action on every object in
 a pipeline.
@@ -33,6 +33,7 @@ There are a few common use cases for `$PSItem`:
 - in a `switch` statement's conditional values and associated scriptblocks
 - in the `process` block of a function
 - in a `filter` definition
+- in the scriptblock of the **ValidateScript** attribute
 - in the substitution operand scriptblock of the `-replace` operator
 
 The rest of this article includes examples of using `$PSItem` for these use
@@ -294,6 +295,62 @@ False
 In this example, the `Test-IsEven` filter outputs `$true` if the current object
 is an even number and `$false` if it isn't.
 
+## The ValidateScript attribute scriptblock
+
+You can use `$PSItem` in the scriptblock of a [ValidateScript][15] attribute.
+When used with **ValidateScript**, `$PSItem` is the value of the current object
+being validated. When the variable or parameter value is an array, the
+scriptblock is called once for each object in the array with `$PSItem` as the
+current object.
+
+```powershell
+function Add-EvenNumber {
+    param(
+        [ValidateScript({ 0 -eq ($PSItem % 2) })]
+        [int[]]$Number
+    )
+
+    begin {
+        [int]$total = 0
+    }
+
+    process {
+        foreach ($n in $Number) {
+            $total += $n
+        }
+    }
+
+    end {
+        $total
+    }
+}
+
+Add-EvenNumber -Number 2, 4, 6
+
+Add-EvenNumber -Number 1, 2
+```
+
+```output
+12
+
+Add-EvenNumber: 
+Line |
+  24 |  Add-EvenNumber -Number 1, 2
+     |                         ~~~~
+     | Cannot validate argument on parameter 'Number'. The
+" 0 -eq ($PSItem % 2) " validation script for the argument
+with value "1" did not return a result of True. Determine
+why the validation script failed, and then try the command
+again.
+```
+
+In this example the scriptblock for the **ValidateScript** attribute runs once
+for each value passed to the **Number** parameter, returning an error if any
+value isn't even.
+
+The `Add-EvenNumber` function adds the valid input numbers and returns the
+total.
+
 ## The -replace operator's substitution scriptblock
 
 Starting in PowerShell 6, you can use `$PSItem` when calling the [replace][12]
@@ -339,3 +396,4 @@ with the default format for the current culture by casting the value to
 [12]: about_Comparison_Operators.md#replacement-operator
 [13]: about_Comparison_Operators.md#replacement-with-a-script-block
 [14]: about_Script_Blocks.md
+[15]: about_Functions_Advanced_Parameters.md#validatescript-validation-attribute

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_PSItem.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_PSItem.md
@@ -15,9 +15,9 @@ The automatic variable that contains the current object in the pipeline object.
 ## Long description
 
 PowerShell includes the `$PSItem` variable and its alias, `$_`, as
-[automatic variables][01] in scriptblocks that process pipeline objects. This
-article uses `$PSItem` in the examples, but `$PSItem` can be replaced with `$_`
-in every example.
+[automatic variables][01] in scriptblocks that process the current object, such
+as in the pipeline. This article uses `$PSItem` in the examples, but `$PSItem`
+can be replaced with `$_` in every example.
 
 You can use this variable in commands that perform an action on every object in
 a pipeline.
@@ -33,6 +33,7 @@ There are a few common use cases for `$PSItem`:
 - in a `switch` statement's conditional values and associated scriptblocks
 - in the `process` block of a function
 - in a `filter` definition
+- in the scriptblock of the **ValidateScript** attribute
 - in the substitution operand scriptblock of the `-replace` operator
 
 The rest of this article includes examples of using `$PSItem` for these use
@@ -293,6 +294,62 @@ False
 
 In this example, the `Test-IsEven` filter outputs `$true` if the current object
 is an even number and `$false` if it isn't.
+
+## The ValidateScript attribute scriptblock
+
+You can use `$PSItem` in the scriptblock of a [ValidateScript][15] attribute.
+When used with **ValidateScript**, `$PSItem` is the value of the current object
+being validated. When the variable or parameter value is an array, the
+scriptblock is called once for each object in the array with `$PSItem` as the
+current object.
+
+```powershell
+function Add-EvenNumber {
+    param(
+        [ValidateScript({ 0 -eq ($PSItem % 2) })]
+        [int[]]$Number
+    )
+
+    begin {
+        [int]$total = 0
+    }
+
+    process {
+        foreach ($n in $Number) {
+            $total += $n
+        }
+    }
+
+    end {
+        $total
+    }
+}
+
+Add-EvenNumber -Number 2, 4, 6
+
+Add-EvenNumber -Number 1, 2
+```
+
+```output
+12
+
+Add-EvenNumber: 
+Line |
+  24 |  Add-EvenNumber -Number 1, 2
+     |                         ~~~~
+     | Cannot validate argument on parameter 'Number'. The
+" 0 -eq ($PSItem % 2) " validation script for the argument
+with value "1" did not return a result of True. Determine
+why the validation script failed, and then try the command
+again.
+```
+
+In this example the scriptblock for the **ValidateScript** attribute runs once
+for each value passed to the **Number** parameter, returning an error if any
+value isn't even.
+
+The `Add-EvenNumber` function adds the valid input numbers and returns the
+total.
 
 ## The -replace operator's substitution scriptblock
 


### PR DESCRIPTION
# PR Summary

This change updates the new documentation about the `$PSItem` automatic variable by:

1. Rewording the synopsis of the variable for clarity and accuracy
1. Removing the erroneous inclusion of the `-replace` operator scriptblock in the overview list for Windows PowerShell
1. Adding the **ValidateScript** attribute as a use case and example
1. Correcting the `Get-Help` URLs

This change:

- Resolves #9534
- Fixes [AB#48597](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/48597)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
