### PR TITLE
(GH-9545) Fix Get-Process example

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 05/17/2022
+ms.date: 12/08/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-process?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Process
@@ -125,26 +125,27 @@ home directory (`$pshome`).
 ### Example 5: Add a property to the standard Get-Process output display
 
 ```powershell
-Get-Process powershell -ComputerName S1, localhost | Format-Table `
+Get-Process powershell | Format-Table `
     @{Label = "NPM(K)"; Expression = {[int]($_.NPM / 1024)}},
     @{Label = "PM(K)"; Expression = {[int]($_.PM / 1024)}},
     @{Label = "WS(K)"; Expression = {[int]($_.WS / 1024)}},
     @{Label = "VM(M)"; Expression = {[int]($_.VM / 1MB)}},
     @{Label = "CPU(s)"; Expression = {if ($_.CPU) {$_.CPU.ToString("N")}}},
-    Id, MachineName, ProcessName -AutoSize
+    Id, ProcessName, StartTime -AutoSize
 ```
 
 ```Output
-NPM(K) PM(K) WS(K) VM(M) CPU(s)   Id MachineName ProcessName
------- ----- ----- ----- ------   -- ----------- -----------
-     6 23500 31340   142 1.70   1980 S1          powershell
-     6 23500 31348   142 2.75   4016 S1          powershell
-    27 54572 54520   576 5.52   4428 localhost   powershell
+NPM(K)  PM(K) WS(K)   VM(M)  CPU(s)    Id ProcessName StartTime
+------  ----- -----   -----  ------    -- ----------- ---------
+   143 239540 259384 2366162 22.73  12720 powershell  12/5/2022 3:21:51 PM
+   114  61776 104588 2366127 11.45  18336 powershell  12/5/2022 7:30:53 AM
+   156  77924  82060 2366185 10.47  18812 powershell  12/5/2022 7:30:52 AM
+    85  48216 115192 2366074 1.14   24428 powershell  12/8/2022 9:14:15 AM
 ```
 
-This example retrieves processes from the local computer and a remote computer (S1). The retrieved
-processes are piped to the `Format-Table` command that adds the **MachineName** property to the
-standard `Get-Process` output display.
+This example retrieves processes from the local computer. The retrieved processes are piped to the
+`Format-Table` command that adds the **StartTime** property to the standard `Get-Process` output
+display.
 
 ### Example 6: Get version information for a process
 

--- a/reference/7.2/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Get-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 05/17/2022
+ms.date: 12/08/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-process?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Process
@@ -128,20 +128,21 @@ Get-Process pwsh | Format-Table `
     @{Label = "WS(K)"; Expression = {[int]($_.WS / 1024)}},
     @{Label = "VM(M)"; Expression = {[int]($_.VM / 1MB)}},
     @{Label = "CPU(s)"; Expression = {if ($_.CPU) {$_.CPU.ToString("N")}}},
-    Id, MachineName, ProcessName -AutoSize
+    Id, ProcessName, StartTime -AutoSize
 ```
 
 ```Output
-NPM(K) PM(K) WS(K) VM(M) CPU(s)   Id MachineName ProcessName
------- ----- ----- ----- ------   -- ----------- -----------
-     6 23500 31340   142 1.70   1980 .           pwsh
-     6 23500 31348   142 2.75   4016 .           pwsh
-    27 54572 54520   576 5.52   4428 .           pwsh
+NPM(K)  PM(K)  WS(K)   VM(M) CPU(s)    Id ProcessName StartTime
+------  -----  -----   ----- ------    -- ----------- ---------
+   143 239540 259384 2366162 22.73  12720 pwsh        12/5/2022 3:21:51 PM
+   114  61776 104588 2366127 11.45  18336 pwsh        12/5/2022 7:30:53 AM
+   156  77924  82060 2366185 10.47  18812 pwsh        12/5/2022 7:30:52 AM
+    85  48216 115192 2366074 1.14   24428 pwsh        12/8/2022 9:14:15 AM
 ```
 
-This example retrieves processes from the local computer and a remote computer (S1). The retrieved
-processes are piped to the `Format-Table` command that adds the **MachineName** property to the
-standard `Get-Process` output display.
+This example retrieves processes from the local computer. The retrieved processes are piped to the
+`Format-Table` command that adds the **StartTime** property to the standard `Get-Process` output
+display.
 
 ### Example 6: Get version information for a process
 

--- a/reference/7.3/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Get-Process.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 05/17/2022
+ms.date: 12/08/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-process?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Process
@@ -128,20 +128,21 @@ Get-Process pwsh | Format-Table `
     @{Label = "WS(K)"; Expression = {[int]($_.WS / 1024)}},
     @{Label = "VM(M)"; Expression = {[int]($_.VM / 1MB)}},
     @{Label = "CPU(s)"; Expression = {if ($_.CPU) {$_.CPU.ToString("N")}}},
-    Id, MachineName, ProcessName -AutoSize
+    Id, ProcessName, StartTime -AutoSize
 ```
 
 ```Output
-NPM(K) PM(K) WS(K) VM(M) CPU(s)   Id MachineName ProcessName
------- ----- ----- ----- ------   -- ----------- -----------
-     6 23500 31340   142 1.70   1980 .           pwsh
-     6 23500 31348   142 2.75   4016 .           pwsh
-    27 54572 54520   576 5.52   4428 .           pwsh
+NPM(K)  PM(K)  WS(K)   VM(M) CPU(s)    Id ProcessName StartTime
+------  -----  -----   ----- ------    -- ----------- ---------
+   143 239540 259384 2366162 22.73  12720 pwsh        12/5/2022 3:21:51 PM
+   114  61776 104588 2366127 11.45  18336 pwsh        12/5/2022 7:30:53 AM
+   156  77924  82060 2366185 10.47  18812 pwsh        12/5/2022 7:30:52 AM
+    85  48216 115192 2366074 1.14   24428 pwsh        12/8/2022 9:14:15 AM
 ```
 
-This example retrieves processes from the local computer and a remote computer (S1). The retrieved
-processes are piped to the `Format-Table` command that adds the **MachineName** property to the
-standard `Get-Process` output display.
+This example retrieves processes from the local computer. The retrieved processes are piped to the
+`Format-Table` command that adds the **StartTime** property to the standard `Get-Process` output
+display.
 
 ### Example 6: Get version information for a process
 


### PR DESCRIPTION
# PR Summary

This change fixes example 5 for Get-Process, which erroneously mentioned getting processes from a
remote computer. This change updates the wording
and example for local-only usage.

- Resolves #9545
- Fixes [AB#52146](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/52146)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
