### PR TITLE
(GH-9549) Clarify Uninstall-Module

### DIFF
--- a/reference/5.1/PowershellGet/Uninstall-Module.md
+++ b/reference/5.1/PowershellGet/Uninstall-Module.md
@@ -2,7 +2,7 @@
 external help file: PSModule-help.xml
 Locale: en-US
 Module Name: PowerShellGet
-ms.date: 07/02/2019
+ms.date: 12/08/2022
 online version: https://learn.microsoft.com/powershell/module/powershellget/uninstall-module?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Uninstall-Module
@@ -32,7 +32,11 @@ Uninstall-Module [-InputObject] <PSObject[]> [-Force] [-WhatIf] [-Confirm] [<Com
 ## DESCRIPTION
 
 The `Uninstall-Module` cmdlet uninstalls a specified module from the local computer. You can't
-uninstall a module if it has other modules as dependencies.
+uninstall a module if other modules depend on it or the module wasn't installed with the
+`Install-Module` cmdlet.
+
+You can manually delete module files, but doing so may break any modules that depend on the deleted
+module.
 
 ## EXAMPLES
 

--- a/reference/7.2/PowerShellGet/Uninstall-Module.md
+++ b/reference/7.2/PowerShellGet/Uninstall-Module.md
@@ -2,7 +2,7 @@
 external help file: PSModule-help.xml
 Locale: en-US
 Module Name: PowerShellGet
-ms.date: 07/02/2019
+ms.date: 12/08/2022
 online version: https://learn.microsoft.com/powershell/module/powershellget/uninstall-module?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Uninstall-Module
@@ -32,7 +32,11 @@ Uninstall-Module [-InputObject] <PSObject[]> [-Force] [-WhatIf] [-Confirm] [<Com
 ## DESCRIPTION
 
 The `Uninstall-Module` cmdlet uninstalls a specified module from the local computer. You can't
-uninstall a module if it has other modules as dependencies.
+uninstall a module if other modules depend on it or the module wasn't installed with the
+`Install-Module` cmdlet.
+
+You can manually delete module files, but doing so may break any modules that depend on the deleted
+module.
 
 ## EXAMPLES
 

--- a/reference/7.3/PowerShellGet/Uninstall-Module.md
+++ b/reference/7.3/PowerShellGet/Uninstall-Module.md
@@ -2,7 +2,7 @@
 external help file: PSModule-help.xml
 Locale: en-US
 Module Name: PowerShellGet
-ms.date: 07/02/2019
+ms.date: 12/08/2022
 online version: https://learn.microsoft.com/powershell/module/powershellget/uninstall-module?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Uninstall-Module
@@ -32,7 +32,11 @@ Uninstall-Module [-InputObject] <PSObject[]> [-Force] [-WhatIf] [-Confirm] [<Com
 ## DESCRIPTION
 
 The `Uninstall-Module` cmdlet uninstalls a specified module from the local computer. You can't
-uninstall a module if it has other modules as dependencies.
+uninstall a module if other modules depend on it or the module wasn't installed with the
+`Install-Module` cmdlet.
+
+You can manually delete module files, but doing so may break any modules that depend on the deleted
+module.
 
 ## EXAMPLES
 


### PR DESCRIPTION
# PR Summary

This change updates the description for the Uninstall-Module cmdlet to clarify that it only works on modules installed with Install-Module and when the module is not a dependency of other installed modules.

- Resolves #9549
- Fixes [AB#52148](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/52148)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
