### PR TITLE
(GH-9547) Bulk Update: PSReadLine and 5.1-only modules

### DIFF
--- a/reference/5.1/ISE/Get-IseSnippet.md
+++ b/reference/5.1/ISE/Get-IseSnippet.md
@@ -2,7 +2,7 @@
 external help file: ISE-help.xml
 Locale: en-US
 Module Name: ISE
-ms.date: 06/09/2017
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/ise/get-isesnippet?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-IseSnippet
@@ -122,15 +122,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### None
+
+You can't pipe objects to this cmdlet.
+
 ## OUTPUTS
 
 ### System.IO.FileInfo
 
-This cmdlet returns a file object that represents the snippet file.
+This cmdlet returns a file object representing the snippet file.
 
 ## NOTES
 
-* The `New-IseSnippet` cmdlet stores new user-created snippets in unsigned .ps1xml files. As such,
+- The `New-IseSnippet` cmdlet stores new user-created snippets in unsigned .ps1xml files. As such,
   Windows PowerShell cannot add them to a session in which the execution policy is **AllSigned** or
   **Restricted**. In a **Restricted** or **AllSigned** session, you can create, get, and import
   unsigned user-created snippets, but you cannot use them in the session.

--- a/reference/5.1/ISE/Import-IseSnippet.md
+++ b/reference/5.1/ISE/Import-IseSnippet.md
@@ -2,7 +2,7 @@
 external help file: ISE-help.xml
 Locale: en-US
 Module Name: ISE
-ms.date: 05/17/2022
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/ise/import-isesnippet?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Import-IseSnippet
@@ -199,13 +199,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-This cmdlet does not take input from the pipeline.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/ISE/New-IseSnippet.md
+++ b/reference/5.1/ISE/New-IseSnippet.md
@@ -2,7 +2,7 @@
 external help file: ISE-help.xml
 Locale: en-US
 Module Name: ISE
-ms.date: 06/09/2017
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/ise/new-isesnippet?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-IseSnippet
@@ -208,13 +208,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-This cmdlet does not take input from the pipeline.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Add-LocalGroupMember.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Add-LocalGroupMember.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 04/09/2020
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/add-localgroupmember?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Add-LocalGroupMember
@@ -170,15 +170,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Management.Automation.SecurityAccountsManager.LocalGroup, System.String, System.Security.Principal.SecurityIdentifier
+### System.Management.Automation.SecurityAccountsManager.LocalGroup
 
-You can pipe a local principal, a string, or a SID to this cmdlet.
+You can pipe a local principal to this cmdlet.
+
+### System.String
+
+You can pipe a string to this cmdlet.
+
+### System.Security.Principal.SecurityIdentifier
+
+You can pipe a SID to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Disable-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Disable-LocalUser.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 09/28/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/disable-localuser?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Disable-LocalUser
@@ -152,19 +152,27 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Management.Automation.SecurityAccountsManager.LocalUser, System.String, System.Security.Principal.SecurityIdentifier
+### System.Management.Automation.SecurityAccountsManager.LocalUser
 
-You can pipe a local user, a string, or a SID to this cmdlet.
+You can pipe a local user this cmdlet.
+
+### System.String
+
+You can pipe a string to this cmdlet.
+
+### System.Security.Principal.SecurityIdentifier
+
+You can pipe a SID to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 
-* The **PrincipalSource** property is a property on **LocalUser**, **LocalGroup**, and
+- The **PrincipalSource** property is a property on **LocalUser**, **LocalGroup**, and
   **LocalPrincipal** objects that describes the source of the object. The possible sources are as
   follows:
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Enable-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Enable-LocalUser.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 09/28/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/enable-localuser?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enable-LocalUser
@@ -153,15 +153,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Management.Automation.SecurityAccountsManager.LocalUser, System.String, System.Security.Principal.SecurityIdentifier
+### System.Management.Automation.SecurityAccountsManager.LocalUser
 
-You can pipe a local user, a string, or a SID to this cmdlet.
+You can pipe a local user to this cmdlet.
+
+### System.String
+
+You can pipe a string to this cmdlet.
+
+### System.Security.Principal.SecurityIdentifier
+
+You can pipe a SID to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Get-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Get-LocalGroup.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 09/28/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/get-localgroup?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-LocalGroup
@@ -90,9 +90,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.String, System.Security.Principal.SecurityIdentifier
+### System.String
 
-You can pipe a string or a SID to this cmdlet.
+You can pipe a string to this cmdlet.
+
+### System.Security.Principal.SecurityIdentifier
+
+You can pipe a SID to this cmdlet.
 
 ## OUTPUTS
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Get-LocalGroupMember.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Get-LocalGroupMember.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 09/28/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/get-localgroupmember?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-LocalGroupMember
@@ -127,9 +127,17 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Management.Automation.SecurityAccountsManager.LocalGroup, System.String, System.Security.Principal.SecurityIdentifier
+### System.Management.Automation.SecurityAccountsManager.LocalGroup
 
-You can pipe a local group, a string, or a SID to this cmdlet.
+You can pipe a local group to this cmdlet.
+
+### System.String
+
+You can pipe a string to this cmdlet.
+
+### System.Security.Principal.SecurityIdentifier
+
+You can pipe a SID to this cmdlet.
 
 ## OUTPUTS
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Get-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Get-LocalUser.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 02/10/2020
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/get-localuser?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-LocalUser
@@ -126,9 +126,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.String, System.Security.Principal.SecurityIdentifier
+### System.String
 
-You can pipe a string or SID to this cmdlet.
+You can pipe a string to this cmdlet.
+
+### System.Security.Principal.SecurityIdentifier
+
+You can pipe a SID to this cmdlet.
 
 ## OUTPUTS
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalGroup.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 09/28/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/new-localgroup?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-LocalGroup
@@ -119,7 +119,7 @@ You can pipe a string to this cmdlet.
 
 ### System.Management.Automation.SecurityAccountsManager.LocalGroup
 
-This cmdlet returns a security group.
+This cmdlet returns a **LocalGroup** object representing the created security group.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 06/09/2017
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/new-localuser?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-LocalUser
@@ -283,21 +283,33 @@ Accept wildcard characters: False
 ### CommonParameters
 
 This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`,
-`-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`,
-`-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+`-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`,
+`-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### System.String, System.DateTime, System.Boolean, System.Security.SecureString
+### System.String
 
-You can pipe a string, a **DateTime** object, a boolean value, or a secure string to this cmdlet.
+You can pipe a string to this cmdlet.
+
+### System.DateTime
+
+You can pipe a **DateTime** object to this cmdlet.
+
+### System.Boolean
+
+You can pipe a boolean value to this cmdlet.
+
+### System.Security.SecureString
+
+You can pipe a secure string to this cmdlet.
 
 ## OUTPUTS
 
 ### System.Management.Automation.SecurityAccountsManager.LocalUser
 
-This cmdlet returns a **LocalUser** object.
-This object provides information about the user account.
+This cmdlet returns a **LocalUser** object representing the created user account.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalGroup.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 09/28/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/remove-localgroup?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Remove-LocalGroup
@@ -148,15 +148,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Management.Automation.SecurityAccountsManager.LocalGroup, System.String, System.Security.Principal.SecurityIdentifier
+### System.Management.Automation.SecurityAccountsManager.LocalGroup
 
-You can pipe a security group, a string, or a SID to this cmdlet.
+You can pipe a security group to this cmdlet.
+
+### System.String
+
+You can pipe a string to this cmdlet.
+
+### System.Security.Principal.SecurityIdentifier
+
+You can pipe a SID to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalGroupMember.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalGroupMember.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 09/28/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/remove-localgroupmember?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Remove-LocalGroupMember
@@ -166,15 +166,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Management.Automation.SecurityAccountsManager.LocalPrincipal, System.String, System.Security.Principal.SecurityIdentifier
+### System.Management.Automation.SecurityAccountsManager.LocalPrincipal
 
-You can pipe a local principal, a string, or a SID to this cmdlet.
+You can pipe a local principal to this cmdlet.
+
+### System.String
+
+You can pipe a string to this cmdlet.
+
+### System.Security.Principal.SecurityIdentifier
+
+You can pipe a SID to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalUser.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 06/09/2017
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/remove-localuser?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Remove-LocalUser
@@ -142,15 +142,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Management.Automation.SecurityAccountsManager.LocalUser, System.String, System.Security.Principal.SecurityIdentifier
+### System.Management.Automation.SecurityAccountsManager.LocalUser
 
-You can pipe a local user, a string, or a SID to this cmdlet.
+You can pipe a local user to this cmdlet.
+
+### System.String
+
+You can pipe a string to this cmdlet.
+
+### System.Security.Principal.SecurityIdentifier
+
+You can pipe a SID to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Rename-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Rename-LocalGroup.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 09/30/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/rename-localgroup?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Rename-LocalGroup
@@ -160,15 +160,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Management.Automation.SecurityAccountsManager.LocalGroup, System.String, System.Security.Principal.SecurityIdentifier
+### System.Management.Automation.SecurityAccountsManager.LocalGroup
 
-You can pipe a security group, a string, or a SID to this cmdlet.
+You can pipe a security group to this cmdlet.
+
+### System.String
+
+You can pipe a string to this cmdlet.
+
+### System.Security.Principal.SecurityIdentifier
+
+You can pipe a SID to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Rename-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Rename-LocalUser.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 09/30/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/rename-localuser?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Rename-LocalUser
@@ -158,15 +158,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Management.Automation.SecurityAccountsManager.LocalUser, System.String, System.Security.Principal.SecurityIdentifier
+### System.Management.Automation.SecurityAccountsManager.LocalUser
 
-You can pipe a local user, a string, or a SID to this cmdlet.
+You can pipe a local user to this cmdlet.
+
+### System.String
+
+You can pipe a string to this cmdlet.
+
+### System.Security.Principal.SecurityIdentifier
+
+You can pipe a SID to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalGroup.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 09/30/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/set-localgroup?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-LocalGroup
@@ -159,15 +159,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Management.Automation.SecurityAccountsManager.LocalGroup, System.String, System.Security.Principal.SecurityIdentifier
+### System.Management.Automation.SecurityAccountsManager.LocalGroup
 
-You can pipe a security group, a string, or a SID to this cmdlet.
+You can pipe a security group to this cmdlet.
+
+### System.String
+
+You can pipe a string to this cmdlet.
+
+### System.Security.Principal.SecurityIdentifier
+
+You can pipe a SID to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalUser.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 09/30/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/set-localuser?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-LocalUser
@@ -287,15 +287,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Management.Automation.SecurityAccountsManager.LocalUser, System.String, System.Security.Principal.SecurityIdentifier
+### System.Management.Automation.SecurityAccountsManager.LocalUser
 
-You can pipe a local user, a string, or a SID to this cmdlet.
+You can pipe a local user to this cmdlet.
+
+### System.String
+
+You can pipe a string to this cmdlet.
+
+### System.Security.Principal.SecurityIdentifier
+
+You can pipe a SID to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.Operation.Validation/Get-OperationValidation.md
+++ b/reference/5.1/Microsoft.PowerShell.Operation.Validation/Get-OperationValidation.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Operation.Validation-help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Operation.Validation
-ms.date: 10/01/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.operation.validation/get-operationvalidation?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-OperationValidation
@@ -104,13 +104,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe any input to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
-### PSCustomObject
+### System.Management.Automation.PSCustomObject
 
-The **PSCustomObject** describes the validation.
+This cmdlet returns a **PSCustomObject** describing the validation.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.Operation.Validation/Invoke-OperationValidation.md
+++ b/reference/5.1/Microsoft.PowerShell.Operation.Validation/Invoke-OperationValidation.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Operation.Validation-help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Operation.Validation
-ms.date: 10/01/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.operation.validation/invoke-operationvalidation?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-OperationValidation
@@ -208,15 +208,15 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### PSCustomObject
+### System.Management.Automation.PSCustomObject
 
 You can pipe the output of `Get-OperationValidation` to this cmdlet.
 
 ## OUTPUTS
 
-### PSCustomObject
+### System.Management.Automation.PSCustomObject
 
-The **PSCustomObject** describes whether the validation was successful.
+This cmdlet returns a **PSCustomObject** object describing whether the validation was successful.
 
 ## NOTES
 

--- a/reference/5.1/PSReadLine/Get-PSReadLineKeyHandler.md
+++ b/reference/5.1/PSReadLine/Get-PSReadLineKeyHandler.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 10/04/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/get-psreadlinekeyhandler?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-PSReadLineKeyHandler
@@ -145,11 +145,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe objects to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.KeyHandler
+
+This cmdlet returns a **KeyHandler** object.
 
 ## NOTES
 

--- a/reference/5.1/PSReadLine/Get-PSReadLineOption.md
+++ b/reference/5.1/PSReadLine/Get-PSReadLineOption.md
@@ -2,11 +2,12 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadline
-ms.date: 06/30/2020
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/get-psreadlineoption?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-PSReadLineOption
 ---
+
 # Get-PSReadLineOption
 
 ## SYNOPSIS
@@ -89,14 +90,14 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe objects to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.PSConsoleReadLineOptions
 
-An instance of the current options. Changing the property values of this object updates the settings
-in PSReadLine directly without invoking `Set-PSReadLineOption`.
+This cmdlet returns an instance of the current options. Changing the property values of this object
+updates the settings in PSReadLine directly without invoking `Set-PSReadLineOption`.
 
 ## NOTES
 

--- a/reference/5.1/PSReadLine/Remove-PSReadLineKeyHandler.md
+++ b/reference/5.1/PSReadLine/Remove-PSReadLineKeyHandler.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadline
-ms.date: 12/07/2018
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/remove-psreadlinekeyhandler?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Remove-PSReadLineKeyHandler
@@ -87,11 +87,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe objects to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### None
+
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/PSReadLine/Set-PSReadLineKeyHandler.md
+++ b/reference/5.1/PSReadLine/Set-PSReadLineKeyHandler.md
@@ -2,11 +2,12 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadline
-ms.date: 10/04/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/set-psreadlinekeyhandler?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineKeyHandler
 ---
+
 # Set-PSReadLineKeyHandler
 
 ## SYNOPSIS
@@ -189,13 +190,13 @@ For more information, see
 
 ### None
 
-You cannot pipe objects to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/5.1/PSReadLine/Set-PSReadLineOption.md
@@ -2,11 +2,12 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadline
-ms.date: 06/30/2020
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/set-psreadlineoption?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineOption
 ---
+
 # Set-PSReadLineOption
 
 ## SYNOPSIS
@@ -684,13 +685,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe objects to `Set-PSReadLineOption.`
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Add-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Add-JobTrigger.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 10/05/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/add-jobtrigger?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Add-JobTrigger
@@ -188,15 +188,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### Microsoft.PowerShell.ScheduledJob.ScheduledJobTrigger, Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
+### Microsoft.PowerShell.ScheduledJob.ScheduledJobTrigger
 
-You can pipe job triggers or scheduled jobs to `Add-JobTrigger`.
+You can pipe a job trigger to this cmdlet.
+
+### Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
+
+You can pipe a scheduled job to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not return any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Disable-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Disable-JobTrigger.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 10/05/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/disable-jobtrigger?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Disable-JobTrigger
@@ -182,13 +182,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobTrigger
 
-You can pipe job triggers to `Disable-JobTrigger`.
+You can pipe a job trigger to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Disable-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Disable-ScheduledJob.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 10/05/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/disable-scheduledjob?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Disable-ScheduledJob
@@ -270,10 +270,13 @@ You can pipe a scheduled job to `Disable-ScheduledJob`.
 
 ## OUTPUTS
 
-### None or Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
+### None
 
-If you use the **Passthru** parameter, `Disable-ScheduledJob` returns the scheduled job that was
-disabled. Otherwise, this cmdlet does not generate any output.
+By default, this cmdlet returns no output.
+
+### Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
+
+When you use the **PassThru** parameter, this cmdlet returns the scheduled job that is disabled.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Enable-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Enable-JobTrigger.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 10/05/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/enable-jobtrigger?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enable-JobTrigger
@@ -184,13 +184,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobTrigger
 
-You can pipe job triggers to `Enable-JobTrigger`.
+You can pipe a job trigger to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Enable-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Enable-ScheduledJob.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 10/05/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/enable-scheduledjob?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Enable-ScheduledJob
@@ -228,10 +228,13 @@ You can pipe a scheduled job to `Enable-ScheduledJob`.
 
 ## OUTPUTS
 
-### None or Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
+### None
 
-If you use the **Passthru** parameter, `Enable-ScheduledJob` returns the scheduled job that was
-enabled. Otherwise, this cmdlet does not generate any output.
+By default, this cmdlet returns no output.
+
+### Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
+
+When you use the **PassThru** parameter, this cmdlet returns the scheduled job that it enabled.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Get-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Get-JobTrigger.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 05/17/2022
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/get-jobtrigger?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-JobTrigger
@@ -302,11 +302,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
 
-You can pipe a scheduled job from `Get-ScheduledJob` to `Get-JobTrigger`.
+You can pipe a scheduled job to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobTrigger
+
+This cmdlet returns the scheduled job's trigger.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Get-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Get-ScheduledJob.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 10/05/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/get-scheduledjob?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-ScheduledJob
@@ -136,11 +136,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe input to `Get-ScheduledJob`.
+You cant pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
+
+This cmdlet returns the definition of a scheduled job.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Get-ScheduledJobOption.md
+++ b/reference/5.1/PSScheduledJob/Get-ScheduledJobOption.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 10/05/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/get-scheduledjoboption?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-ScheduledJobOption
@@ -192,11 +192,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
 
-You can pipe a scheduled job from `Get-ScheduledJob` to `Get-ScheduledJobOption`.
+You can pipe a scheduled job object to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobOptions
+
+This cmdlet returns a **ScheduledJobOptions** object.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/New-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/New-JobTrigger.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 05/17/2022
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/new-jobtrigger?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-JobTrigger
@@ -514,11 +514,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe input to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobTrigger
+
+This cmdlet returns a **ScheduledJobTrigger** object representing the created trigger.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/New-ScheduledJobOption.md
+++ b/reference/5.1/PSScheduledJob/New-ScheduledJobOption.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 10/05/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/new-scheduledjoboption?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-ScheduledJobOption
@@ -485,11 +485,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe input to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobOptions
+
+This cmdlet returns a **ScheduledJobOptions** object representing the created options.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Register-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Register-ScheduledJob.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 10/05/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/register-scheduledjob?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Register-ScheduledJob
@@ -581,11 +581,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You can't send input down the pipeline to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
+
+This cmdlet returns a **ScheduledJobDefinition** object representing the registered job.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Remove-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Remove-JobTrigger.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 10/05/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/remove-jobtrigger?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Remove-JobTrigger
@@ -200,13 +200,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
 
-You can pipe scheduled jobs to the `Remove-JobTrigger` cmdlet.
+You can pipe a scheduled job to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-The cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Set-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Set-JobTrigger.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 05/17/2022
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/set-jobtrigger?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-JobTrigger
@@ -558,14 +558,17 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobTrigger
 
-You can pipe multiple job triggers to `Set-JobTrigger`.
+You can pipe a job trigger to this cmdlet.
 
 ## OUTPUTS
 
-### None or Microsoft.PowerShell.ScheduledJob.ScheduledJobTrigger
+### None
 
-When you use the **Passthru** parameter, `Set-JobTrigger` returns the job triggers that were
-changed. Otherwise, this cmdlet does not generate any output.
+By default, this cmdlet returns no output.
+
+### Microsoft.PowerShell.ScheduledJob.ScheduledJobTrigger
+
+When you use the **PassThru** parameter, this cmdlet returns the job triggers that it changed.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Set-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Set-ScheduledJob.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 10/05/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/set-scheduledjob?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-ScheduledJob
@@ -524,14 +524,17 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
 
-You can pipe scheduled jobs to `Set-ScheduledJob`.
+You can pipe a scheduled job to this cmdlet.
 
 ## OUTPUTS
 
-### None or Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
+### None
 
-If you use the **Passthru** parameter, `Set-ScheduledJob` returns the scheduled job that was
-changed. Otherwise, this cmdlet does not generate any output.
+By default, this cmdlet returns no output.
+
+### Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
+
+When you use the **PassThru** parameter, this cmdlet returns the scheduled job that it changed.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Set-ScheduledJobOption.md
+++ b/reference/5.1/PSScheduledJob/Set-ScheduledJobOption.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 10/05/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/set-scheduledjoboption?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-ScheduledJobOption
@@ -478,14 +478,17 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobOptions
 
-You can pipe a scheduled job options object to `Set-ScheduledJobOption`.
+You can pipe a scheduled job options object to this cmdlet.
 
 ## OUTPUTS
 
-### None or Microsoft.PowerShell.ScheduledJob.ScheduledJobOptions
+### None
 
-When you use the **Passthru** parameter, `Set-ScheduledJobOption` returns the job options that were
-changed. Otherwise, this cmdlet does not generate any output.
+By default, this cmdlet returns no output.
+
+### Microsoft.PowerShell.ScheduledJob.ScheduledJobOptions
+
+When you use the **PassThru** parameter, this cmdlet returns the job options that were changed.
 
 ## NOTES
 

--- a/reference/5.1/PSScheduledJob/Unregister-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Unregister-ScheduledJob.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml
 Locale: en-US
 Module Name: PSScheduledJob
-ms.date: 10/05/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psscheduledjob/unregister-scheduledjob?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Unregister-ScheduledJob
@@ -212,13 +212,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition
 
-You can pipe scheduled jobs to Unregister-ScheduledJob
+You can pipe a scheduled job to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/5.1/PSWorkflow/New-PSWorkflowExecutionOption.md
+++ b/reference/5.1/PSWorkflow/New-PSWorkflowExecutionOption.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.Workflow.ServiceCore.dll-help.xml
 Locale: en-US
 Module Name: PSWorkflow
-ms.date: 10/22/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psworkflow/new-psworkflowexecutionoption?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-PSWorkflowExecutionOption
@@ -461,7 +461,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe input to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 

--- a/reference/5.1/PSWorkflow/New-PSWorkflowSession.md
+++ b/reference/5.1/PSWorkflow/New-PSWorkflowSession.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.Workflow.ServiceCore.dll-help.xml
 Locale: en-US
 Module Name: PSWorkflow
-ms.date: 05/17/2022
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psworkflow/new-psworkflowsession?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-PSWorkflowSession
@@ -381,9 +381,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Management.Automation.Runspaces.PSSession[], System.String
+### System.Management.Automation.Runspaces.PSSession
 
-You can pipe a session or a computer name to this cmdlet.
+You can pipe a session to this cmdlet.
+
+### System.String
+
+You can pipe a computer name to this cmdlet.
 
 ## OUTPUTS
 

--- a/reference/5.1/PSWorkflowUtility/Invoke-AsWorkflow.md
+++ b/reference/5.1/PSWorkflowUtility/Invoke-AsWorkflow.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Workflow.ServiceCore.dll-help.xml
 Locale: en-US
 Module Name: PSWorkflowUtility
-ms.date: 06/09/2017
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psworkflowutility/invoke-asworkflow?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-AsWorkflow
@@ -185,14 +185,13 @@ For information, see [about_WorkflowCommonParameters](../PSWorkflow/About/about_
 
 ### System.Object
 
-You can pipe any object to the `InputObject` parameter.
+You can pipe any object to the this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This command does not generate any output.
-However, it runs the workflow, which might generate output.
+This command returns no output of its own, but the workflow it runs might return output.
 
 ## NOTES
 

--- a/reference/7.2/PSReadLine/Get-PSReadLineKeyHandler.md
+++ b/reference/7.2/PSReadLine/Get-PSReadLineKeyHandler.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 10/04/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/get-psreadlinekeyhandler?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-PSReadLineKeyHandler
@@ -187,11 +187,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe objects to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.KeyHandler
+
+This cmdlet returns a **KeyHandler** object.
 
 ## NOTES
 
@@ -204,4 +206,3 @@ You cannot pipe objects to this cmdlet.
 [Set-PSReadLineOption](Set-PSReadLineOption.md)
 
 [Set-PSReadLineKeyHandler](Set-PSReadLineKeyHandler.md)
-

--- a/reference/7.2/PSReadLine/Get-PSReadLineOption.md
+++ b/reference/7.2/PSReadLine/Get-PSReadLineOption.md
@@ -2,11 +2,12 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 06/30/2020
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/get-psreadlineoption?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-PSReadLineOption
 ---
+
 # Get-PSReadLineOption
 
 ## SYNOPSIS
@@ -89,14 +90,14 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe objects to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.PSConsoleReadLineOptions
 
-An instance of the current options. Changing the property values of this object updates the settings
-in PSReadLine directly without invoking `Set-PSReadLineOption`.
+This cmdlet returns an instance of the current options. Changing the property values of this object
+updates the settings in PSReadLine directly without invoking `Set-PSReadLineOption`.
 
 ## NOTES
 

--- a/reference/7.2/PSReadLine/Remove-PSReadLineKeyHandler.md
+++ b/reference/7.2/PSReadLine/Remove-PSReadLineKeyHandler.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/07/2018
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/remove-psreadlinekeyhandler?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Remove-PSReadLineKeyHandler
@@ -87,11 +87,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe objects to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### None
+
+This cmdlet returns no output.
 
 ## NOTES
 
@@ -104,4 +106,3 @@ You cannot pipe objects to this cmdlet.
 [Set-PSReadLineOption](Set-PSReadLineOption.md)
 
 [Set-PSReadLineKeyHandler](Set-PSReadLineKeyHandler.md)
-

--- a/reference/7.2/PSReadLine/Set-PSReadLineKeyHandler.md
+++ b/reference/7.2/PSReadLine/Set-PSReadLineKeyHandler.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 10/04/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/set-psreadlinekeyhandler?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineKeyHandler
@@ -189,13 +189,13 @@ For more information, see
 
 ### None
 
-You cannot pipe objects to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/7.2/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.2/PSReadLine/Set-PSReadLineOption.md
@@ -2,11 +2,12 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/17/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/set-psreadlineoption?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineOption
 ---
+
 # Set-PSReadLineOption
 
 ## SYNOPSIS
@@ -748,13 +749,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe objects to `Set-PSReadLineOption.`
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/7.3/PSReadLine/Get-PSReadLineKeyHandler.md
+++ b/reference/7.3/PSReadLine/Get-PSReadLineKeyHandler.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 10/04/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/get-psreadlinekeyhandler?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-PSReadLineKeyHandler
@@ -187,11 +187,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe objects to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.KeyHandler
+
+This cmdlet returns a **KeyHandler** object.
 
 ## NOTES
 
@@ -204,4 +206,3 @@ You cannot pipe objects to this cmdlet.
 [Set-PSReadLineOption](Set-PSReadLineOption.md)
 
 [Set-PSReadLineKeyHandler](Set-PSReadLineKeyHandler.md)
-

--- a/reference/7.3/PSReadLine/Get-PSReadLineOption.md
+++ b/reference/7.3/PSReadLine/Get-PSReadLineOption.md
@@ -2,11 +2,12 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 06/30/2020
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/get-psreadlineoption?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-PSReadLineOption
 ---
+
 # Get-PSReadLineOption
 
 ## SYNOPSIS
@@ -89,14 +90,14 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe objects to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.PSConsoleReadLineOptions
 
-An instance of the current options. Changing the property values of this object updates the settings
-in PSReadLine directly without invoking `Set-PSReadLineOption`.
+This cmdlet returns an instance of the current options. Changing the property values of this object
+updates the settings in PSReadLine directly without invoking `Set-PSReadLineOption`.
 
 ## NOTES
 

--- a/reference/7.3/PSReadLine/Remove-PSReadLineKeyHandler.md
+++ b/reference/7.3/PSReadLine/Remove-PSReadLineKeyHandler.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/07/2018
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/remove-psreadlinekeyhandler?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Remove-PSReadLineKeyHandler
@@ -87,11 +87,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe objects to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### None
+
+This cmdlet returns no output.
 
 ## NOTES
 
@@ -104,4 +106,3 @@ You cannot pipe objects to this cmdlet.
 [Set-PSReadLineOption](Set-PSReadLineOption.md)
 
 [Set-PSReadLineKeyHandler](Set-PSReadLineKeyHandler.md)
-

--- a/reference/7.3/PSReadLine/Set-PSReadLineKeyHandler.md
+++ b/reference/7.3/PSReadLine/Set-PSReadLineKeyHandler.md
@@ -2,11 +2,12 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 10/04/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/set-psreadlinekeyhandler?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineKeyHandler
 ---
+
 # Set-PSReadLineKeyHandler
 
 ## SYNOPSIS
@@ -189,13 +190,13 @@ For more information, see
 
 ### None
 
-You cannot pipe objects to this cmdlet.
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 

--- a/reference/7.3/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.3/PSReadLine/Set-PSReadLineOption.md
@@ -2,11 +2,12 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/17/2021
+ms.date: 12/13/2022
 online version: https://learn.microsoft.com/powershell/module/psreadline/set-psreadlineoption?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineOption
 ---
+
 # Set-PSReadLineOption
 
 ## SYNOPSIS
@@ -748,13 +749,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe objects to `Set-PSReadLineOption.`
+You can't pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet returns no output.
 
 ## NOTES
 


### PR DESCRIPTION
# PR Summary

This change is the final part of addressing #9547 and [AB#52147](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/52147) by cleaning up the input and output sections of cmdlet reference documentation to have one type per heading and standardize the language.

- Resolves #9547
- Fixes [AB#52147](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/52147)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
