### PR TITLE
Corrected url pointing to wrong repo

### DIFF
--- a/reference/docs-conceptual/learn/ps101/02-help-system.md
+++ b/reference/docs-conceptual/learn/ps101/02-help-system.md
@@ -663,5 +663,5 @@ methods.
 [Save-Help]: /powershell/module/microsoft.powershell.core/save-help
 [about_Updatable_Help]: /powershell/module/microsoft.powershell.core/about/about_updatable_help
 [about_Command_Syntax]: /powershell/module/microsoft.powershell.core/about/about_command_syntax
-[PowerShell-Docs]: https://github.com/powershell/powershell
+[PowerShell-Docs]: https://github.com/MicrosoftDocs/PowerShell-Docs
 [Appendix A]: appendix-a.md


### PR DESCRIPTION
# PR Summary

Corrected URL that was pointing to the powershell repo instead of the powershell-docs repo.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
