### PR TITLE
Updated support tables, removed tables for PS 7.0/7.1 in PowerShell on ARM documentation

### DIFF
--- a/reference/docs-conceptual/install/PowerShell-on-ARM.md
+++ b/reference/docs-conceptual/install/PowerShell-on-ARM.md
@@ -1,6 +1,6 @@
 ---
 description: PowerShell on Arm-based systems
-ms.date: 11/16/2022
+ms.date: 01/02/2023
 title: PowerShell on Arm-based systems
 ---
 
@@ -9,46 +9,28 @@ title: PowerShell on Arm-based systems
 PowerShell 7.3 is based on the [.NET 7.0 Supported OS Lifecycle Policy][net70os] and supports the
 following platforms:
 
-|                 OS                 | Architectures |          Lifecycle           |
-| ---------------------------------- | ------------- | ---------------------------- |
-| Windows 10 Client Version 1607+    | Arm64         | [Windows][Windows-lifecycle] |
-| macOS 10.15+                       | Arm64         | [macOS][macOS-lifecycle]     |
-| Debian 10+                         | Arm32, Arm64  | [Debian][Debian-lifecycle]   |
-| Red Hat Enterprise Linux (RHEL) 7+ | Arm64         | [Red Hat][RHEL-lifecycle]    |
-| Ubuntu 20.04, 18.04                | Arm32, Arm64  | [Ubuntu][Ubuntu-lifecycle]   |
+|                 OS                 | Architectures |           Lifecycle           |
+| ---------------------------------- | ------------- | ----------------------------- |
+| Windows 10 Client Version 1607+    | Arm64         | [Windows][Windows-lifecycle]  |
+| Windows 11 Client Version 22000+   | Arm64         | [Windows][Windows-lifecycle]  |
+| macOS 11.5+                        | Arm64         | [macOS][macOS-lifecycle]      |
+| Debian 10+                         | Arm32, Arm64  | [Debian][Debian-lifecycle]    |
+| RaspberryPi 10+                    | Arm32         | [Raspberry Pi][rpi-lifecycle] |
+| Red Hat Enterprise Linux (RHEL) 7+ | Arm64         | [Red Hat][RHEL-lifecycle]     |
+| Ubuntu 18.04+                      | Arm32, Arm64  | [Ubuntu][Ubuntu-lifecycle]    |
 
 PowerShell 7.2 is based on the [.NET 6.0 Supported OS Lifecycle Policy][net60os] and supports the
 following platforms:
 
-|                 OS                 | Architectures |          Lifecycle           |
-| ---------------------------------- | ------------- | ---------------------------- |
-| Windows 10 Client Version 1607+    | Arm64         | [Windows][Windows-lifecycle] |
-| macOS 10.14+                       | Arm64         | [macOS][macOS-lifecycle]     |
-| Debian 10+                         | Arm32, Arm64  | [Debian][Debian-lifecycle]   |
-| Red Hat Enterprise Linux (RHEL) 7+ | Arm64         | [Red Hat][RHEL-lifecycle]    |
-| Ubuntu 20.04, 18.04, 16.04         | Arm32, Arm64  | [Ubuntu][Ubuntu-lifecycle]   |
-
-PowerShell 7.1 is based on the [.NET 5.0 Supported OS Lifecycle Policy][net50os] and supports the
-following platforms:
-
-|               OS                | Architectures |          Lifecycle           |
-| ------------------------------- | ------------- | ---------------------------- |
-| Windows 10 Client Version 1607+ | Arm64         | [Windows][Windows-lifecycle] |
-| Alpine Linux 3.11+              | Arm64         | [Alpine][Alpine-lifecycle]   |
-| Debian 9+                       | Arm64, Arm32  | [Debian][Debian-lifecycle]   |
-| Ubuntu 20.04, 18.04, 16.04      | Arm32, Arm64  | [Ubuntu][Ubuntu-lifecycle]   |
-
-Support of PowerShell on Arm is based on the **.NET Core Supported OS Lifecycle Policies**.
-
-PowerShell 7.0 is based on the [.NET Core 3.1 Supported OS Lifecycle Policy][net31os] and supports
-the following platforms:
-
-|                OS                 | Architectures |          Lifecycle           |
-| --------------------------------- | ------------- | ---------------------------- |
-| Windows Nano Server Version 1803+ | Arm32         | [Windows][Windows-lifecycle] |
-| Alpine Linux 3.10+                | Arm64         | [Alpine][Alpine-lifecycle]   |
-| Debian 9+                         | Arm32, Arm64  | [Debian][Debian-lifecycle]   |
-| Ubuntu 20.04, 18.04, 16.04        | Arm32, Arm64  | [Ubuntu][Ubuntu-lifecycle]   |
+|                 OS                 | Architectures |           Lifecycle           |
+| ---------------------------------- | ------------- | ----------------------------- |
+| Windows 10 Client Version 1607+    | Arm64         | [Windows][Windows-lifecycle]  |
+| Windows 11 Client Version 22000+   | Arm64         | [Windows][Windows-lifecycle]  |
+| macOS 11.5+                        | Arm64         | [macOS][macOS-lifecycle]      |
+| Debian 10+                         | Arm32, Arm64  | [Debian][Debian-lifecycle]    |
+| RaspberryPi 10+                    | Arm32         | [Raspberry Pi][rpi-lifecycle] |
+| Red Hat Enterprise Linux (RHEL) 7+ | Arm64         | [Red Hat][RHEL-lifecycle]     |
+| Ubuntu 18.04+                      | Arm32, Arm64  | [Ubuntu][Ubuntu-lifecycle]    |
 
 For installation instructions, see the following articles:
 
@@ -77,6 +59,7 @@ Raspbery Pi
 [net50os]: https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0-supported-os.md
 [net60os]: https://github.com/dotnet/core/blob/main/release-notes/6.0/supported-os.md
 [net70os]: https://github.com/dotnet/core/blob/main/release-notes/7.0/supported-os.md
+[Rpi-lifecycle]: https://www.raspberrypi.com/software/operating-systems/
 [RHEL-lifecycle]: https://access.redhat.com/support/policy/updates/errata/
 [Ubuntu-lifecycle]: https://wiki.ubuntu.com/Releases
 [Windows-lifecycle]: https://support.microsoft.com/help/13853/windows-lifecycle-fact-sheet

--- a/reference/docs-conceptual/install/PowerShell-on-ARM.md
+++ b/reference/docs-conceptual/install/PowerShell-on-ARM.md
@@ -15,7 +15,7 @@ following platforms:
 | Windows 11 Client Version 22000+   | Arm64         | [Windows][Windows-lifecycle]  |
 | macOS 11.5+                        | Arm64         | [macOS][macOS-lifecycle]      |
 | Debian 10+                         | Arm32, Arm64  | [Debian][Debian-lifecycle]    |
-| RaspberryPi 10+                    | Arm32         | [Raspberry Pi][rpi-lifecycle] |
+| RaspberryPi 10+                    | Arm32         | [Raspberry Pi][Rpi-lifecycle] |
 | Red Hat Enterprise Linux (RHEL) 7+ | Arm64         | [Red Hat][RHEL-lifecycle]     |
 | Ubuntu 18.04+                      | Arm32, Arm64  | [Ubuntu][Ubuntu-lifecycle]    |
 
@@ -28,7 +28,7 @@ following platforms:
 | Windows 11 Client Version 22000+   | Arm64         | [Windows][Windows-lifecycle]  |
 | macOS 11.5+                        | Arm64         | [macOS][macOS-lifecycle]      |
 | Debian 10+                         | Arm32, Arm64  | [Debian][Debian-lifecycle]    |
-| RaspberryPi 10+                    | Arm32         | [Raspberry Pi][rpi-lifecycle] |
+| RaspberryPi 10+                    | Arm32         | [Raspberry Pi][Rpi-lifecycle] |
 | Red Hat Enterprise Linux (RHEL) 7+ | Arm64         | [Red Hat][RHEL-lifecycle]     |
 | Ubuntu 18.04+                      | Arm32, Arm64  | [Ubuntu][Ubuntu-lifecycle]    |
 


### PR DESCRIPTION
# PR Summary

This change updates support tables in the documentation for "PowerShell on ARM processors":

- Added Raspberry Pi, based on [Installing PowerShell on Raspberry Pi OS](https://learn.microsoft.com/en-us/powershell/scripting/install/install-raspbian?view=powershell-7.3) documentation
- Updated Ubuntu support, based on [PowerShell Support Lifecycle](https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.3) documentation
- Added Windows 11 support, based on [PowerShell Support Lifecycle](https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.3) documentation
- Resolves #9632 

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
