### PR TITLE
(GH-9650) Document ValidateNotNullOrWhiteSpace

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to add parameters to advanced functions.
 Locale: en-US
-ms.date: 11/29/2022
+ms.date: 01/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Functions Advanced Parameters
@@ -959,14 +959,14 @@ Param(
 ### ValidateNotNull validation attribute
 
 The **ValidateNotNull** attribute specifies that the parameter value can't be
-`$null`. PowerShell generates an error if the parameter value is `$null`.
+`$null`. When the value is `$null`, PowerShell raises an exception.
 
 The **ValidateNotNull** attribute is designed to be used when the parameter is
 optional and the type is undefined or has a type converter that can't
 implicitly convert a null value like **object**. If you specify a type that
-that implicitly converts a null value, such as a **string**, the null value
-is converted to an empty string even when using the **ValidateNotNull**
-attribute. For this scenario use the **ValidateNotNullOrEmpty**
+that implicitly converts a null value, such as a **string**, the null value is
+converted to an empty string even when using the **ValidateNotNull** attribute.
+For this scenario use the **ValidateNotNullOrEmpty** attribute.
 
 In the following example, the value of the **ID** parameter can't be `$null`.
 
@@ -980,10 +980,14 @@ Param(
 
 ### ValidateNotNullOrEmpty validation attribute
 
-The **ValidateNotNullOrEmpty** attribute specifies that the parameter value
-can't be `$null` and can't be an empty string (`""`). PowerShell generates an
-error if the parameter is used in a function call, but its value is `$null`, an
-empty string (`""`), or an empty array `@()`.
+The **ValidateNotNullOrEmpty** attribute specifies that the assigned value
+can't be any of the following values:
+
+- `$null`
+- an empty string (`""`)
+- an empty array (`@()`)
+
+When the value is invalid, PowerShell raises an exception.
 
 ```powershell
 Param(

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to add parameters to advanced functions.
 Locale: en-US
-ms.date: 11/29/2022
+ms.date: 01/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Functions Advanced Parameters
@@ -1027,14 +1027,14 @@ Param(
 ### ValidateNotNull validation attribute
 
 The **ValidateNotNull** attribute specifies that the parameter value can't be
-`$null`. PowerShell generates an error if the parameter value is `$null`.
+`$null`. When the value is `$null`, PowerShell raises an exception.
 
 The **ValidateNotNull** attribute is designed to be used when the parameter is
 optional and the type is undefined or has a type converter that can't
 implicitly convert a null value like **object**. If you specify a type that
-that implicitly converts a null value, such as a **string**, the null value
-is converted to an empty string even when using the **ValidateNotNull**
-attribute. For this scenario use the **ValidateNotNullOrEmpty**
+that implicitly converts a null value, such as a **string**, the null value is
+converted to an empty string even when using the **ValidateNotNull** attribute.
+For this scenario use the **ValidateNotNullOrEmpty** attribute.
 
 In the following example, the value of the **ID** parameter can't be `$null`.
 
@@ -1048,10 +1048,14 @@ Param(
 
 ### ValidateNotNullOrEmpty validation attribute
 
-The **ValidateNotNullOrEmpty** attribute specifies that the parameter value
-can't be `$null` and can't be an empty string (`""`). PowerShell generates an
-error if the parameter is used in a function call, but its value is `$null`, an
-empty string (`""`), or an empty array `@()`.
+The **ValidateNotNullOrEmpty** attribute specifies that the assigned value
+can't be any of the following values:
+
+- `$null`
+- an empty string (`""`)
+- an empty array (`@()`)
+
+When the value is invalid, PowerShell raises an exception.
 
 ```powershell
 Param(

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to add parameters to advanced functions.
 Locale: en-US
-ms.date: 11/29/2022
+ms.date: 01/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Functions Advanced Parameters
@@ -1027,14 +1027,14 @@ Param(
 ### ValidateNotNull validation attribute
 
 The **ValidateNotNull** attribute specifies that the parameter value can't be
-`$null`. PowerShell generates an error if the parameter value is `$null`.
+`$null`. When the value is `$null`, PowerShell raises an exception.
 
 The **ValidateNotNull** attribute is designed to be used when the parameter is
 optional and the type is undefined or has a type converter that can't
 implicitly convert a null value like **object**. If you specify a type that
-that implicitly converts a null value, such as a **string**, the null value
-is converted to an empty string even when using the **ValidateNotNull**
-attribute. For this scenario use the **ValidateNotNullOrEmpty**
+that implicitly converts a null value, such as a **string**, the null value is
+converted to an empty string even when using the **ValidateNotNull** attribute.
+For this scenario use the **ValidateNotNullOrEmpty** attribute.
 
 In the following example, the value of the **ID** parameter can't be `$null`.
 
@@ -1048,10 +1048,14 @@ Param(
 
 ### ValidateNotNullOrEmpty validation attribute
 
-The **ValidateNotNullOrEmpty** attribute specifies that the parameter value
-can't be `$null` and can't be an empty string (`""`). PowerShell generates an
-error if the parameter is used in a function call, but its value is `$null`, an
-empty string (`""`), or an empty array `@()`.
+The **ValidateNotNullOrEmpty** attribute specifies that the assigned value
+can't be any of the following values:
+
+- `$null`
+- an empty string (`""`)
+- an empty array (`@()`)
+
+When the value is invalid, PowerShell raises an exception.
 
 ```powershell
 Param(

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to add parameters to advanced functions.
 Locale: en-US
-ms.date: 11/29/2022
+ms.date: 01/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Functions Advanced Parameters
@@ -1027,14 +1027,15 @@ Param(
 ### ValidateNotNull validation attribute
 
 The **ValidateNotNull** attribute specifies that the parameter value can't be
-`$null`. PowerShell generates an error if the parameter value is `$null`.
+`$null`. When the value is `$null`, PowerShell raises an exception.
 
 The **ValidateNotNull** attribute is designed to be used when the parameter is
 optional and the type is undefined or has a type converter that can't
 implicitly convert a null value like **object**. If you specify a type that
-that implicitly converts a null value, such as a **string**, the null value
-is converted to an empty string even when using the **ValidateNotNull**
-attribute. For this scenario use the **ValidateNotNullOrEmpty**
+that implicitly converts a null value, such as a **string**, the null value is
+converted to an empty string even when using the **ValidateNotNull** attribute.
+For this scenario use the **ValidateNotNullOrEmpty** attribute or the
+**ValidateNotNullOrWhiteSpace** attribute.
 
 In the following example, the value of the **ID** parameter can't be `$null`.
 
@@ -1048,15 +1049,43 @@ Param(
 
 ### ValidateNotNullOrEmpty validation attribute
 
-The **ValidateNotNullOrEmpty** attribute specifies that the parameter value
-can't be `$null` and can't be an empty string (`""`). PowerShell generates an
-error if the parameter is used in a function call, but its value is `$null`, an
-empty string (`""`), or an empty array `@()`.
+The **ValidateNotNullOrEmpty** attribute specifies that the assigned value
+can't be any of the following values:
+
+- `$null`
+- an empty string (`""`)
+- an empty array (`@()`)
+
+When the value is invalid, PowerShell raises an exception.
 
 ```powershell
 Param(
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
+    [string[]]
+    $UserName
+)
+```
+
+### ValidateNotNullOrWhiteSpace validation attribute
+
+The **ValidateNotNullOrWhiteSpace** attribute specifies that the assigned value
+can't be any of the following values:
+
+- `$null`
+- an empty string (`""`)
+- an empty array `@()`
+- a string that contains only whitespace characters, like tabs, spaces,
+  carriage returns, and newlines
+- an array that contains any strings that are empty or contain only whitespace
+  characters
+
+When the value is invalid, PowerShell raises an exception.
+
+```powershell
+Param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrWhiteSpace()]
     [string[]]
     $UserName
 )


### PR DESCRIPTION
# PR Summary

This change documents the `ValidateNotNullOrWhiteSpace` validation attribution added in PowerShell 7.4-preview.1.

- Resolves #9650
- Fixes [AB#57939](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/57939)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
