### PR TITLE
(AB-57942) Add Retry-Interval note to web cmdlet docs

### DIFF
--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 01/03/2023
+ms.date: 01/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -989,6 +989,9 @@ Accept wildcard characters: False
 Specifies the interval between retries for the connection when a failure code between 400 and 599,
 inclusive or 304 is received. Also see **MaximumRetryCount** parameter for specifying number of
 retries. The value must be between `1` and `[int]::MaxValue`.
+
+When the failure code is 429 and the response includes the **Retry-After** property in its headers,
+the cmdlet uses that value for the retry interval, even if this parameter is specified.
 
 ```yaml
 Type: System.Int32

--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 01/03/2023
+ms.date: 01/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -986,6 +986,9 @@ Accept wildcard characters: False
 Specifies the interval between retries for the connection when a failure code between 400 and 599,
 inclusive or 304 is received. Also see **MaximumRetryCount** parameter for specifying number of
 retries. The value must be between `1` and `[int]::MaxValue`.
+
+When the failure code is 429 and the response includes the **Retry-After** property in its headers,
+the cmdlet uses that value for the retry interval, even if this parameter is specified.
 
 ```yaml
 Type: System.Int32


### PR DESCRIPTION
# PR Summary

This change updates the documentation for the **RetryInterval** parameter of the web cmdlets (`Invoke-WebRequest` and `Invoke-RestMethod`) to note the new behavior in PowerShell 7.4-preview.1 for using the **Retry-Interval** property of responses with failure code 429 if possible.

- Resolves #9651
- Fixes AB#57942

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
