### PR TITLE
Fix `PSNativeArgumentPassing` typo

### DIFF
--- a/reference/docs-conceptual/learn/experimental-features.md
+++ b/reference/docs-conceptual/learn/experimental-features.md
@@ -353,7 +353,7 @@ use the `Legacy` style argument passing.
 - ending with `.vbs`
 - ending with `.wsf`
 
-If the `$PSNativeArgumentPassing` is set to either `Legacy` or `Standard`, the check for these files
+If the `$PSNativeCommandArgumentPassing` is set to either `Legacy` or `Standard`, the check for these files
 doesn't occur. The default behavior is platform specific. On Windows platforms, the default setting
 is `Windows` and non-Windows platforms is `Standard`.
 


### PR DESCRIPTION
# PR Summary

In one place, it said `PSNativeArgumentPassing` instead of the correct `PSNativeCommandArgumentPassing` that's also used everywhere else.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

