### PR TITLE
fix small typo in New-Alias.md example ("quick wmi alias" to "quick gci alias")

### DIFF
--- a/reference/7.3/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/New-Alias.md
@@ -45,7 +45,7 @@ Get-Alias -Name "C" | Format-List *
 ```
 
 This command creates an alias named `C` to represent the `Get-ChildItem` cmdlet. It creates a
-description "quick gci alias", for the alias and makes it read-only. The last line of the command
+description, `quick gci alias`, for the alias and makes it read-only. The last line of the command
 uses `Get-Alias` to get the new alias and pipes it to Format-List to display all of the information
 about it.
 


### PR DESCRIPTION
# PR Summary

The example uses `-Description "quick gci alias"` yet the explanation said
> It creates a description, quick wmi alias, for the alias

This PR fixes the explanation (and puts the description in quotation marks for easier readability).

Note: it might be desirable to replace "gci" with "Get-ChildItem" in both the example and the explanation.


## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].


[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
