### PR TITLE
(GH-9698) Fix example 9 in ForEach-Object

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 11/04/2022
+ms.date: 01/13/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -219,7 +219,7 @@ process
 
 ### Example 9: Using ForEach-Object with more than two script blocks
 
-In this example, we pass two script blocks positionally. All the script blocks bind to the
+In this example, we pass four script blocks positionally. All the script blocks bind to the
 **Process** parameter. However, they are treated as if they had been passed to the **Begin**,
 **Process**, and **End** parameters.
 

--- a/reference/7.2/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 11/04/2022
+ms.date: 01/13/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -244,7 +244,7 @@ process
 
 ### Example 9: Using ForEach-Object with more than two script blocks
 
-In this example, we pass two script blocks positionally. All the script blocks bind to the
+In this example, we pass four script blocks positionally. All the script blocks bind to the
 **Process** parameter. However, they are treated as if they had been passed to the **Begin**,
 **Process**, and **End** parameters.
 

--- a/reference/7.3/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 11/04/2022
+ms.date: 01/13/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -244,7 +244,7 @@ process
 
 ### Example 9: Using ForEach-Object with more than two script blocks
 
-In this example, we pass two script blocks positionally. All the script blocks bind to the
+In this example, we pass four script blocks positionally. All the script blocks bind to the
 **Process** parameter. However, they are treated as if they had been passed to the **Begin**,
 **Process**, and **End** parameters.
 

--- a/reference/7.4/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 11/04/2022
+ms.date: 01/13/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object


### PR DESCRIPTION


# PR Summary

This change corrects the example description from specifying "two" script blocks to the actually used "four" scriptblocks.

- Resolves #9698
- Fixes [AB#59374](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/59374)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
