### PR TITLE
(GH-9692) Update Join-String docs

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Utility/Join-String.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Join-String.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2019
+ms.date: 01/13/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/join-string?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Join-String
@@ -53,6 +53,11 @@ The `Join-String` cmdlet joins, or combines, text from pipeline objects into a s
 If no parameters are specified, the pipeline objects are converted to a string and joined with the
 default separator `$OFS`.
 
+> [!NOTE]
+> When you set `$OFS` its value is used to join arrays when they're converted to strings until the
+> variable is reset to `$null`. Because using `$OFS` can have unintended effects elsewhere in your
+> code, it's best to use the **Separator** parameter instead.
+
 By specifying a property name, the property's value is converted to a string and joined into a
 string.
 
@@ -78,11 +83,11 @@ Get-ChildItem -Directory C:\ | Join-String -Property Name -DoubleQuote -Separato
 "PerfLogs", "Program Files", "Program Files (x86)", "Users", "Windows"
 ```
 
-`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\` drive.
-The objects are sent down the pipeline to `Join-String`. The **Property** parameter specifies the
-directory names. The **DoubleQuote** parameter wraps the directory names with double-quote marks.
-The **Separator** parameter specifies to use a comma and space (`, `) to separate the directory
-names.
+`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\`
+drive. The objects are sent down the pipeline to `Join-String`. The **Property** parameter
+specifies the directory names. The **DoubleQuote** parameter wraps the directory names with
+double-quote marks. The **Separator** parameter specifies to use a comma and space (`, `) to
+separate the directory names.
 
 The `Get-ChildItem` objects are **System.IO.DirectoryInfo** and `Join-String` converts the objects
 to **System.String**.
@@ -100,8 +105,8 @@ Get-ChildItem -Directory C:\ | Join-String -Property {$_.Name.SubString(0,4)} -S
 'Perf';'Prog';'Prog';'User';'Wind'
 ```
 
-`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\` drive.
-The objects are sent down the pipeline to `Join-String`.
+`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\`
+drive. The objects are sent down the pipeline to `Join-String`.
 
 The **Property** parameter script block uses automatic variable (`$_`) to specify each object's
 **Name** property substring. The substring gets the first four letters of each directory name. The
@@ -109,9 +114,8 @@ substring specifies the character start and end positions. The **SingleQuote** p
 directory names with single-quote marks. The **Separator** parameter specifies to use a semicolon
 (`;`) to separate the directory names.
 
-For more information about automatic variables and substrings, see
-[about_Automatic_Variables](../microsoft.powershell.core/about/about_automatic_variables.md) and
-[Substring](/dotnet/api/system.string.substring).
+For more information about automatic variables and substrings, see [about_Automatic_Variables][02]
+and [Substring][07].
 
 ### Example 3: Display join output on a separate line
 
@@ -139,18 +143,19 @@ asterisk (`*`) is a wildcard for any character.
 
 The objects are sent down the pipeline to `Join-String` that uses the **Property** parameter to
 specify the service names. The **Separator** parameter specifies three special characters that
-represent a carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``). The **OutputPrefix**
-inserts a label **Services:** with a new line and tab before the first line of output.
+represent a carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``). The
+**OutputPrefix** inserts a label `Services:` with a new line and tab before the first line of
+output.
 
 For more information about special characters, see
-[about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md).
+[about_Special_Characters][01].
 
 ### Example 4: Create a class definition from an object
 
 This example generates a PowerShell class definition using an existing object as a template.
 
 This code sample uses splatting to reduce the line length and improve readability. For more
-information, see [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).
+information, see [about_Splatting][05].
 
 ```powershell
 $obj = [pscustomobject] @{Name = "Joe"; Age = 42}
@@ -191,7 +196,12 @@ Accept wildcard characters: False
 
 ### -FormatString
 
-A format string that specifies how each item should be formatted.
+Specifies a format string that specifies how each pipeline object should be formatted before
+joining them. Use the `{0}` placeholder to represent the current object. If you need to keep the
+curly braces (`{}`) in the formatted string, you can escape them by doubling the curly braces (`{{`
+and `}}`).
+
+For more information, see the [String.Format][06] method and [Composite Formatting][08].
 
 ```yaml
 Type: System.String
@@ -277,6 +287,15 @@ Accept wildcard characters: False
 Text or characters such as a comma or semicolon that's inserted between the text for each pipeline
 object.
 
+By default, the pipeline objects are joined without a separator. If the
+[Output Field Separator][03] preference variable (`$OFS`) is set, that value is used unless this
+parameter is specified.
+
+> [!NOTE]
+> When you set `$OFS` its value is used to join arrays when they're converted to strings until the
+> variable is reset to `$null`. Because using `$OFS` can have unintended effects elsewhere in your
+> code, it's best to use the **Separator** parameter instead.
+
 ```yaml
 Type: System.String
 Parameter Sets: (All)
@@ -327,7 +346,7 @@ Accept wildcard characters: False
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+[about_CommonParameters][09].
 
 ## INPUTS
 
@@ -341,9 +360,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[about_Automatic_Variables](../microsoft.powershell.core/about/about_automatic_variables.md)
+[about_Automatic_Variables][02]
 
-[about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md)
+[about_Special_Characters][04]
 
-[Substring](/dotnet/api/system.string.substring)
+[Substring][07]
 
+<!-- Link References -->
+[01]: ../microsoft.powershell.core/about/about_special_characters.md
+[02]: ../microsoft.powershell.core/about/about_automatic_variables.md
+[03]: ../microsoft.powershell.core/about/about_preference_variables.md#ofs
+[04]: ../microsoft.powershell.core/about/about_special_characters.md
+[05]: ../Microsoft.PowerShell.Core/About/about_Splatting.md
+[06]: /dotnet/api/system.string.format
+[07]: /dotnet/api/system.string.substring
+[08]: /dotnet/standard/base-types/composite-formatting
+[09]: https://go.microsoft.com/fwlink/?LinkID=113216

--- a/reference/7.3/Microsoft.PowerShell.Utility/Join-String.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Join-String.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2019
+ms.date: 01/13/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/join-string?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Join-String
@@ -53,6 +53,11 @@ The `Join-String` cmdlet joins, or combines, text from pipeline objects into a s
 If no parameters are specified, the pipeline objects are converted to a string and joined with the
 default separator `$OFS`.
 
+> [!NOTE]
+> When you set `$OFS` its value is used to join arrays when they're converted to strings until the
+> variable is reset to `$null`. Because using `$OFS` can have unintended effects elsewhere in your
+> code, it's best to use the **Separator** parameter instead.
+
 By specifying a property name, the property's value is converted to a string and joined into a
 string.
 
@@ -78,11 +83,11 @@ Get-ChildItem -Directory C:\ | Join-String -Property Name -DoubleQuote -Separato
 "PerfLogs", "Program Files", "Program Files (x86)", "Users", "Windows"
 ```
 
-`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\` drive.
-The objects are sent down the pipeline to `Join-String`. The **Property** parameter specifies the
-directory names. The **DoubleQuote** parameter wraps the directory names with double-quote marks.
-The **Separator** parameter specifies to use a comma and space (`, `) to separate the directory
-names.
+`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\`
+drive. The objects are sent down the pipeline to `Join-String`. The **Property** parameter
+specifies the directory names. The **DoubleQuote** parameter wraps the directory names with
+double-quote marks. The **Separator** parameter specifies to use a comma and space (`, `) to
+separate the directory names.
 
 The `Get-ChildItem` objects are **System.IO.DirectoryInfo** and `Join-String` converts the objects
 to **System.String**.
@@ -100,8 +105,8 @@ Get-ChildItem -Directory C:\ | Join-String -Property {$_.Name.SubString(0,4)} -S
 'Perf';'Prog';'Prog';'User';'Wind'
 ```
 
-`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\` drive.
-The objects are sent down the pipeline to `Join-String`.
+`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\`
+drive. The objects are sent down the pipeline to `Join-String`.
 
 The **Property** parameter script block uses automatic variable (`$_`) to specify each object's
 **Name** property substring. The substring gets the first four letters of each directory name. The
@@ -109,9 +114,8 @@ substring specifies the character start and end positions. The **SingleQuote** p
 directory names with single-quote marks. The **Separator** parameter specifies to use a semicolon
 (`;`) to separate the directory names.
 
-For more information about automatic variables and substrings, see
-[about_Automatic_Variables](../microsoft.powershell.core/about/about_automatic_variables.md) and
-[Substring](/dotnet/api/system.string.substring).
+For more information about automatic variables and substrings, see [about_Automatic_Variables][02]
+and [Substring][07].
 
 ### Example 3: Display join output on a separate line
 
@@ -139,18 +143,19 @@ asterisk (`*`) is a wildcard for any character.
 
 The objects are sent down the pipeline to `Join-String` that uses the **Property** parameter to
 specify the service names. The **Separator** parameter specifies three special characters that
-represent a carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``). The **OutputPrefix**
-inserts a label **Services:** with a new line and tab before the first line of output.
+represent a carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``). The
+**OutputPrefix** inserts a label `Services:` with a new line and tab before the first line of
+output.
 
 For more information about special characters, see
-[about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md).
+[about_Special_Characters][01].
 
 ### Example 4: Create a class definition from an object
 
 This example generates a PowerShell class definition using an existing object as a template.
 
 This code sample uses splatting to reduce the line length and improve readability. For more
-information, see [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).
+information, see [about_Splatting][05].
 
 ```powershell
 $obj = [pscustomobject] @{Name = "Joe"; Age = 42}
@@ -191,7 +196,12 @@ Accept wildcard characters: False
 
 ### -FormatString
 
-A format string that specifies how each item should be formatted.
+Specifies a format string that specifies how each pipeline object should be formatted before
+joining them. Use the `{0}` placeholder to represent the current object. If you need to keep the
+curly braces (`{}`) in the formatted string, you can escape them by doubling the curly braces (`{{`
+and `}}`).
+
+For more information, see the [String.Format][06] method and [Composite Formatting][08].
 
 ```yaml
 Type: System.String
@@ -277,6 +287,15 @@ Accept wildcard characters: False
 Text or characters such as a comma or semicolon that's inserted between the text for each pipeline
 object.
 
+By default, the pipeline objects are joined without a separator. If the
+[Output Field Separator][03] preference variable (`$OFS`) is set, that value is used unless this
+parameter is specified.
+
+> [!NOTE]
+> When you set `$OFS` its value is used to join arrays when they're converted to strings until the
+> variable is reset to `$null`. Because using `$OFS` can have unintended effects elsewhere in your
+> code, it's best to use the **Separator** parameter instead.
+
 ```yaml
 Type: System.String
 Parameter Sets: (All)
@@ -327,7 +346,7 @@ Accept wildcard characters: False
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+[about_CommonParameters][09].
 
 ## INPUTS
 
@@ -341,9 +360,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[about_Automatic_Variables](../microsoft.powershell.core/about/about_automatic_variables.md)
+[about_Automatic_Variables][02]
 
-[about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md)
+[about_Special_Characters][04]
 
-[Substring](/dotnet/api/system.string.substring)
+[Substring][07]
 
+<!-- Link References -->
+[01]: ../microsoft.powershell.core/about/about_special_characters.md
+[02]: ../microsoft.powershell.core/about/about_automatic_variables.md
+[03]: ../microsoft.powershell.core/about/about_preference_variables.md#ofs
+[04]: ../microsoft.powershell.core/about/about_special_characters.md
+[05]: ../Microsoft.PowerShell.Core/About/about_Splatting.md
+[06]: /dotnet/api/system.string.format
+[07]: /dotnet/api/system.string.substring
+[08]: /dotnet/standard/base-types/composite-formatting
+[09]: https://go.microsoft.com/fwlink/?LinkID=113216

--- a/reference/7.4/Microsoft.PowerShell.Utility/Join-String.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Join-String.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2019
+ms.date: 01/13/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/join-string?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Join-String
@@ -53,6 +53,11 @@ The `Join-String` cmdlet joins, or combines, text from pipeline objects into a s
 If no parameters are specified, the pipeline objects are converted to a string and joined with the
 default separator `$OFS`.
 
+> [!NOTE]
+> When you set `$OFS` its value is used to join arrays when they're converted to strings until the
+> variable is reset to `$null`. Because using `$OFS` can have unintended effects elsewhere in your
+> code, it's best to use the **Separator** parameter instead.
+
 By specifying a property name, the property's value is converted to a string and joined into a
 string.
 
@@ -78,11 +83,11 @@ Get-ChildItem -Directory C:\ | Join-String -Property Name -DoubleQuote -Separato
 "PerfLogs", "Program Files", "Program Files (x86)", "Users", "Windows"
 ```
 
-`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\` drive.
-The objects are sent down the pipeline to `Join-String`. The **Property** parameter specifies the
-directory names. The **DoubleQuote** parameter wraps the directory names with double-quote marks.
-The **Separator** parameter specifies to use a comma and space (`, `) to separate the directory
-names.
+`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\`
+drive. The objects are sent down the pipeline to `Join-String`. The **Property** parameter
+specifies the directory names. The **DoubleQuote** parameter wraps the directory names with
+double-quote marks. The **Separator** parameter specifies to use a comma and space (`, `) to
+separate the directory names.
 
 The `Get-ChildItem` objects are **System.IO.DirectoryInfo** and `Join-String` converts the objects
 to **System.String**.
@@ -100,8 +105,8 @@ Get-ChildItem -Directory C:\ | Join-String -Property {$_.Name.SubString(0,4)} -S
 'Perf';'Prog';'Prog';'User';'Wind'
 ```
 
-`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\` drive.
-The objects are sent down the pipeline to `Join-String`.
+`Get-ChildItem` uses the **Directory** parameter to get all the directory names for the `C:\`
+drive. The objects are sent down the pipeline to `Join-String`.
 
 The **Property** parameter script block uses automatic variable (`$_`) to specify each object's
 **Name** property substring. The substring gets the first four letters of each directory name. The
@@ -109,9 +114,8 @@ substring specifies the character start and end positions. The **SingleQuote** p
 directory names with single-quote marks. The **Separator** parameter specifies to use a semicolon
 (`;`) to separate the directory names.
 
-For more information about automatic variables and substrings, see
-[about_Automatic_Variables](../microsoft.powershell.core/about/about_automatic_variables.md) and
-[Substring](/dotnet/api/system.string.substring).
+For more information about automatic variables and substrings, see [about_Automatic_Variables][02]
+and [Substring][07].
 
 ### Example 3: Display join output on a separate line
 
@@ -139,18 +143,19 @@ asterisk (`*`) is a wildcard for any character.
 
 The objects are sent down the pipeline to `Join-String` that uses the **Property** parameter to
 specify the service names. The **Separator** parameter specifies three special characters that
-represent a carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``). The **OutputPrefix**
-inserts a label **Services:** with a new line and tab before the first line of output.
+represent a carriage return (`` `r ``), newline (`` `n ``), and tab (`` `t ``). The
+**OutputPrefix** inserts a label `Services:` with a new line and tab before the first line of
+output.
 
 For more information about special characters, see
-[about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md).
+[about_Special_Characters][01].
 
 ### Example 4: Create a class definition from an object
 
 This example generates a PowerShell class definition using an existing object as a template.
 
 This code sample uses splatting to reduce the line length and improve readability. For more
-information, see [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).
+information, see [about_Splatting][05].
 
 ```powershell
 $obj = [pscustomobject] @{Name = "Joe"; Age = 42}
@@ -191,7 +196,12 @@ Accept wildcard characters: False
 
 ### -FormatString
 
-A format string that specifies how each item should be formatted.
+Specifies a format string that specifies how each pipeline object should be formatted before
+joining them. Use the `{0}` placeholder to represent the current object. If you need to keep the
+curly braces (`{}`) in the formatted string, you can escape them by doubling the curly braces (`{{`
+and `}}`).
+
+For more information, see the [String.Format][06] method and [Composite Formatting][08].
 
 ```yaml
 Type: System.String
@@ -277,6 +287,15 @@ Accept wildcard characters: False
 Text or characters such as a comma or semicolon that's inserted between the text for each pipeline
 object.
 
+By default, the pipeline objects are joined without a separator. If the
+[Output Field Separator][03] preference variable (`$OFS`) is set, that value is used unless this
+parameter is specified.
+
+> [!NOTE]
+> When you set `$OFS` its value is used to join arrays when they're converted to strings until the
+> variable is reset to `$null`. Because using `$OFS` can have unintended effects elsewhere in your
+> code, it's best to use the **Separator** parameter instead.
+
 ```yaml
 Type: System.String
 Parameter Sets: (All)
@@ -327,7 +346,7 @@ Accept wildcard characters: False
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see
-[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+[about_CommonParameters][09].
 
 ## INPUTS
 
@@ -341,9 +360,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[about_Automatic_Variables](../microsoft.powershell.core/about/about_automatic_variables.md)
+[about_Automatic_Variables][02]
 
-[about_Special_Characters](..//microsoft.powershell.core/about/about_special_characters.md)
+[about_Special_Characters][04]
 
-[Substring](/dotnet/api/system.string.substring)
+[Substring][07]
 
+<!-- Link References -->
+[01]: ../microsoft.powershell.core/about/about_special_characters.md
+[02]: ../microsoft.powershell.core/about/about_automatic_variables.md
+[03]: ../microsoft.powershell.core/about/about_preference_variables.md#ofs
+[04]: ../microsoft.powershell.core/about/about_special_characters.md
+[05]: ../Microsoft.PowerShell.Core/About/about_Splatting.md
+[06]: /dotnet/api/system.string.format
+[07]: /dotnet/api/system.string.substring
+[08]: /dotnet/standard/base-types/composite-formatting
+[09]: https://go.microsoft.com/fwlink/?LinkID=113216


### PR DESCRIPTION


# PR Summary

This change updates the documentation for the `Join-String` cmdlet to clarify how the **FormatString** parameter works and that users should avoid setting `$OFS` instead of using the **Separator** parameter.

- Resolves #9692
- Fixes [AB#59375](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/59375)
## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
