### PR TITLE
(GH-9707) Update Function provider for hyphenated funcs

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Function_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Function_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: Function
 Locale: en-US
-ms.date: 10/18/2018
+ms.date: 01/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_function_provider?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Function Provider
@@ -112,6 +112,13 @@ by the dollar sign (`$`).
 
 ```powershell
 $function:more
+```
+
+To retrieve the definition for a function that has a dash (`-`) in the name,
+wrap the value after the dollar sign in curly braces.
+
+```powershell
+${function:Clear-Host}
 ```
 
 ### Getting selected functions

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Function_Provider.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Function_Provider.md
@@ -113,6 +113,13 @@ by the dollar sign (`$`).
 $function:more
 ```
 
+To retrieve the definition for a function that has a dash (`-`) in the name,
+wrap the value after the dollar sign in curly braces.
+
+```powershell
+${function:Clear-Host}
+```
+
 ### Getting selected functions
 
 This command gets the `man` function from the `Function:` drive. It uses the

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Function_Provider.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Function_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: Function
 Locale: en-US
-ms.date: 10/18/2018
+ms.date: 01/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_function_provider?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Function Provider
@@ -111,6 +111,13 @@ by the dollar sign (`$`).
 
 ```powershell
 $function:more
+```
+
+To retrieve the definition for a function that has a dash (`-`) in the name,
+wrap the value after the dollar sign in curly braces.
+
+```powershell
+${function:Clear-Host}
 ```
 
 ### Getting selected functions

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Function_Provider.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Function_Provider.md
@@ -1,7 +1,7 @@
 ---
 description: Function
 Locale: en-US
-ms.date: 10/18/2018
+ms.date: 01/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_function_provider?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Function Provider
@@ -111,6 +111,13 @@ by the dollar sign (`$`).
 
 ```powershell
 $function:more
+```
+
+To retrieve the definition for a function that has a dash (`-`) in the name,
+wrap the value after the dollar sign in curly braces.
+
+```powershell
+${function:Clear-Host}
 ```
 
 ### Getting selected functions


### PR DESCRIPTION
# PR Summary

This change adds an example for retrieving the definition of a hyphenated function using the variable syntax to `about_Function_Provider`.

- Resolves #9707
- Fixes [AB#59643](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/59643)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
