### PR TITLE
Fix Send-MailMessage Default Encoding value from UTF8-NoBOM to ASCII

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Character_Encoding.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Character_Encoding.md
@@ -117,7 +117,7 @@ For cmdlets that write output to files:
 
 - `New-Item -Type File -Value` creates a BOM-less UTF-8 file.
 
-- `Send-MailMessage` uses `Default` encoding by default.
+- `Send-MailMessage` uses `Ascii` encoding by default.
 
 - `Start-Transcript` creates `Utf8` files with a BOM. When the **Append**
   parameter is used, the encoding can be different (see below).

--- a/reference/7.2/Microsoft.PowerShell.Utility/Send-MailMessage.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Send-MailMessage.md
@@ -270,7 +270,7 @@ Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UT
 
 Required: False
 Position: Named
-Default value: UTF8NoBOM
+Default value: ASCII
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Character_Encoding.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Character_Encoding.md
@@ -117,7 +117,7 @@ For cmdlets that write output to files:
 
 - `New-Item -Type File -Value` creates a BOM-less UTF-8 file.
 
-- `Send-MailMessage` uses `Default` encoding by default.
+- `Send-MailMessage` uses `Ascii` encoding by default.
 
 - `Start-Transcript` creates `Utf8` files with a BOM. When the **Append**
   parameter is used, the encoding can be different (see below).

--- a/reference/7.3/Microsoft.PowerShell.Utility/Send-MailMessage.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Send-MailMessage.md
@@ -270,7 +270,7 @@ Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UT
 
 Required: False
 Position: Named
-Default value: UTF8NoBOM
+Default value: ASCII
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Character_Encoding.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Character_Encoding.md
@@ -117,7 +117,7 @@ For cmdlets that write output to files:
 
 - `New-Item -Type File -Value` creates a BOM-less UTF-8 file.
 
-- `Send-MailMessage` uses `Default` encoding by default.
+- `Send-MailMessage` uses `Ascii` encoding by default.
 
 - `Start-Transcript` creates `Utf8` files with a BOM. When the **Append**
   parameter is used, the encoding can be different (see below).

--- a/reference/7.4/Microsoft.PowerShell.Utility/Send-MailMessage.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Send-MailMessage.md
@@ -270,7 +270,7 @@ Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UT
 
 Required: False
 Position: Named
-Default value: UTF8NoBOM
+Default value: ASCII
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```


### PR DESCRIPTION

[The default encoding is ASCII.](https://github.com/PowerShell/PowerShell/blob/7dc4587014bfa22919c933607bf564f0ba53db2e/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs#L80)

Fixes Powershell/Powershell#18808

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
