### PR TITLE
Remove note about -nologo not being required

### DIFF
--- a/reference/docs-conceptual/learn/remoting/SSH-Remoting-in-PowerShell-Core.md
+++ b/reference/docs-conceptual/learn/remoting/SSH-Remoting-in-PowerShell-Core.md
@@ -209,10 +209,6 @@ remote computer. And, you must enable **password** or **key-based** authenticati
    > The default location of the PowerShell executable is `/usr/local/bin/pwsh`. The location can
    > vary depending on how you installed PowerShell.
 
-   > [!NOTE]
-   > Starting in PowerShell 7.3, you no longer need to use the `-nologo` parameter when running
-   > PowerShell in SSH server mode.
-
    Optionally, enable key authentication:
 
    ```


### PR DESCRIPTION
# PR Summary

A note was added which indicates that -nologo is not required as of Powershell 7.3 but there are many users still experiencing issues with it.  See https://github.com/PowerShell/PowerShell/issues/12852 for details.

## PR Checklist

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
