### PR TITLE
Fix a typo in one of the wildcard characters examples

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -45,7 +45,7 @@ PowerShell supports the following wildcard characters:
   - `[a-l]ook` doesn't match `took`
 - `[ ]` - Match specific characters
   - `[bc]ook` matches `book` and `cook`
-  - `[bc]ook` doesn't matach `hook`
+  - `[bc]ook` doesn't match `hook`
 - `` `* `` - Match any character as a literal (not a wildcard character)
   - ``12`*4`` matches `12*4`
   - ``12`*4`` doesn't match `1234`

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -45,7 +45,7 @@ PowerShell supports the following wildcard characters:
   - `[a-l]ook` doesn't match `took`
 - `[ ]` - Match specific characters
   - `[bc]ook` matches `book` and `cook`
-  - `[bc]ook` doesn't matach `hook`
+  - `[bc]ook` doesn't match `hook`
 - `` `* `` - Match any character as a literal (not a wildcard character)
   - ``12`*4`` matches `12*4`
   - ``12`*4`` doesn't match `1234`

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -45,7 +45,7 @@ PowerShell supports the following wildcard characters:
   - `[a-l]ook` doesn't match `took`
 - `[ ]` - Match specific characters
   - `[bc]ook` matches `book` and `cook`
-  - `[bc]ook` doesn't matach `hook`
+  - `[bc]ook` doesn't match `hook`
 - `` `* `` - Match any character as a literal (not a wildcard character)
   - ``12`*4`` matches `12*4`
   - ``12`*4`` doesn't match `1234`

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -45,7 +45,7 @@ PowerShell supports the following wildcard characters:
   - `[a-l]ook` doesn't match `took`
 - `[ ]` - Match specific characters
   - `[bc]ook` matches `book` and `cook`
-  - `[bc]ook` doesn't matach `hook`
+  - `[bc]ook` doesn't match `hook`
 - `` `* `` - Match any character as a literal (not a wildcard character)
   - ``12`*4`` matches `12*4`
   - ``12`*4`` doesn't match `1234`


### PR DESCRIPTION
# PR Summary

This fixes a typo in the word "match" in one of the examples used to describe the wildcard characters PowerShell supports.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
