### PR TITLE
(GH-9744) Fix about_Using examples

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Using.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Using.md
@@ -1,7 +1,7 @@
 ---
 description: Allows you to indicate which namespaces are used in the session.
 Locale: en-US
-ms.date: 08/18/2022
+ms.date: 01/25/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_using?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Using
@@ -133,8 +133,8 @@ $hashfromstream.Hash.ToString()
 In this example, we have a PowerShell script module named **CardGames** that
 defines the following classes:
 
-- **CardGames.Deck**
-- **CardGames.Card**
+- **Deck**
+- **Card**
 
 `Import-Module` and the `#requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes are not imported. The
@@ -142,7 +142,6 @@ aliases, and variables, as defined by the module. Classes are not imported. The
 
 ```powershell
 using module CardGames
-using namespace CardGames
 
 [Deck]$deck = [Deck]::new()
 $deck.Shuffle()
@@ -153,32 +152,31 @@ $deck.Shuffle()
 
 ### Example 3 - Load classes from an assembly
 
-This example loads an assembly so that its classes can be used to create new
-PowerShell classes. The following script creates a new PowerShell class that is
-derived from **DirectoryContext** class.
+This example loads an assembly so that its classes can be used when processing
+data. The following script converts data into a YAML format.
 
 ```powershell
-using assembly 'C:\Program Files\PowerShell\7\System.DirectoryServices.dll'
-using namespace System.DirectoryServices.ActiveDirectory
+using assembly './YamlDotNet.dll'
+using namespace YamlDotNet
 
-class myDirectoryClass : System.DirectoryServices.ActiveDirectory.DirectoryContext
-{
+$yamlSerializer = [Serialization.Serializer]::new()
 
-  [DirectoryContext]$domain
-
-  myDirectoryClass([DirectoryContextType]$ctx) : base($ctx)
-  {
-    $this.domain = [DirectoryContext]::new([DirectoryContextType]$ctx)
-  }
-
+$info = [ordered]@{
+  Inventory = @(
+    @{ Name = 'Apples' ; Count = 1234 }
+    @{ Name = 'Bagels' ; Count = 5678 }
+  )
+  CheckedAt = [datetime]'2023-01-01T01:01:01'
 }
 
-$myDomain = [myDirectoryClass]::new([DirectoryContextType]::Domain)
-$myDomain
+$yamlSerializer.Serialize($info)
 ```
 
 ```Output
-domain                                                    Name UserName ContextType
-------                                                    ---- -------- -----------
-System.DirectoryServices.ActiveDirectory.DirectoryContext                    Domain
+Inventory:
+- Name: Apples
+  Count: 1234
+- Name: Bagels
+  Count: 5678
+CheckedAt: 2023-01-01T01:01:01.0000000
 ```

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Using.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Using.md
@@ -1,7 +1,7 @@
 ---
 description: Allows you to indicate which namespaces are used in the session.
 Locale: en-US
-ms.date: 08/18/2022
+ms.date: 01/25/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_using?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Using
@@ -128,8 +128,8 @@ $hashfromstream.Hash.ToString()
 In this example, we have a PowerShell script module named **CardGames** that
 defines the following classes:
 
-- **CardGames.Deck**
-- **CardGames.Card**
+- **Deck**
+- **Card**
 
 `Import-Module` and the `#requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes are not imported. The
@@ -137,7 +137,6 @@ aliases, and variables, as defined by the module. Classes are not imported. The
 
 ```powershell
 using module CardGames
-using namespace CardGames
 
 [Deck]$deck = [Deck]::new()
 $deck.Shuffle()
@@ -148,32 +147,31 @@ $deck.Shuffle()
 
 ### Example 3 - Load classes from an assembly
 
-This example loads an assembly so that its classes can be used to create new
-PowerShell classes. The following script creates a new PowerShell class that is
-derived from **DirectoryContext** class.
+This example loads an assembly so that its classes can be used when processing
+data. The following script converts data into a YAML format.
 
 ```powershell
-using assembly 'C:\Program Files\PowerShell\7\System.DirectoryServices.dll'
-using namespace System.DirectoryServices.ActiveDirectory
+using assembly './YamlDotNet.dll'
+using namespace YamlDotNet
 
-class myDirectoryClass : System.DirectoryServices.ActiveDirectory.DirectoryContext
-{
+$yamlSerializer = [Serialization.Serializer]::new()
 
-  [DirectoryContext]$domain
-
-  myDirectoryClass([DirectoryContextType]$ctx) : base($ctx)
-  {
-    $this.domain = [DirectoryContext]::new([DirectoryContextType]$ctx)
-  }
-
+$info = [ordered]@{
+  Inventory = @(
+    @{ Name = 'Apples' ; Count = 1234 }
+    @{ Name = 'Bagels' ; Count = 5678 }
+  )
+    CheckedAt = [datetime]'2023-01-01T01:01:01'
 }
 
-$myDomain = [myDirectoryClass]::new([DirectoryContextType]::Domain)
-$myDomain
+$yamlSerializer.Serialize($info)
 ```
 
 ```Output
-domain                                                    Name UserName ContextType
-------                                                    ---- -------- -----------
-System.DirectoryServices.ActiveDirectory.DirectoryContext                    Domain
+Inventory:
+- Name: Apples
+  Count: 1234
+- Name: Bagels
+  Count: 5678
+CheckedAt: 2023-01-01T01:01:01.0000000
 ```

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Using.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Using.md
@@ -1,7 +1,7 @@
 ---
 description: Allows you to indicate which namespaces are used in the session.
 Locale: en-US
-ms.date: 08/18/2022
+ms.date: 01/25/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_using?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Using
@@ -128,8 +128,8 @@ $hashfromstream.Hash.ToString()
 In this example, we have a PowerShell script module named **CardGames** that
 defines the following classes:
 
-- **CardGames.Deck**
-- **CardGames.Card**
+- **Deck**
+- **Card**
 
 `Import-Module` and the `#requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes are not imported. The
@@ -137,7 +137,6 @@ aliases, and variables, as defined by the module. Classes are not imported. The
 
 ```powershell
 using module CardGames
-using namespace CardGames
 
 [Deck]$deck = [Deck]::new()
 $deck.Shuffle()
@@ -148,32 +147,31 @@ $deck.Shuffle()
 
 ### Example 3 - Load classes from an assembly
 
-This example loads an assembly so that its classes can be used to create new
-PowerShell classes. The following script creates a new PowerShell class that is
-derived from **DirectoryContext** class.
+This example loads an assembly so that its classes can be used when processing
+data. The following script converts data into a YAML format.
 
 ```powershell
-using assembly 'C:\Program Files\PowerShell\7\System.DirectoryServices.dll'
-using namespace System.DirectoryServices.ActiveDirectory
+using assembly './YamlDotNet.dll'
+using namespace YamlDotNet
 
-class myDirectoryClass : System.DirectoryServices.ActiveDirectory.DirectoryContext
-{
+$yamlSerializer = [Serialization.Serializer]::new()
 
-  [DirectoryContext]$domain
-
-  myDirectoryClass([DirectoryContextType]$ctx) : base($ctx)
-  {
-    $this.domain = [DirectoryContext]::new([DirectoryContextType]$ctx)
-  }
-
+$info = [ordered]@{
+  Inventory = @(
+    @{ Name = 'Apples' ; Count = 1234 }
+    @{ Name = 'Bagels' ; Count = 5678 }
+  )
+    CheckedAt = [datetime]'2023-01-01T01:01:01'
 }
 
-$myDomain = [myDirectoryClass]::new([DirectoryContextType]::Domain)
-$myDomain
+$yamlSerializer.Serialize($info)
 ```
 
 ```Output
-domain                                                    Name UserName ContextType
-------                                                    ---- -------- -----------
-System.DirectoryServices.ActiveDirectory.DirectoryContext                    Domain
+Inventory:
+- Name: Apples
+  Count: 1234
+- Name: Bagels
+  Count: 5678
+CheckedAt: 2023-01-01T01:01:01.0000000
 ```

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Using.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Using.md
@@ -1,7 +1,7 @@
 ---
 description: Allows you to indicate which namespaces are used in the session.
 Locale: en-US
-ms.date: 08/18/2022
+ms.date: 01/25/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_using?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Using
@@ -128,8 +128,8 @@ $hashfromstream.Hash.ToString()
 In this example, we have a PowerShell script module named **CardGames** that
 defines the following classes:
 
-- **CardGames.Deck**
-- **CardGames.Card**
+- **Deck**
+- **Card**
 
 `Import-Module` and the `#requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes are not imported. The
@@ -137,7 +137,6 @@ aliases, and variables, as defined by the module. Classes are not imported. The
 
 ```powershell
 using module CardGames
-using namespace CardGames
 
 [Deck]$deck = [Deck]::new()
 $deck.Shuffle()
@@ -148,32 +147,31 @@ $deck.Shuffle()
 
 ### Example 3 - Load classes from an assembly
 
-This example loads an assembly so that its classes can be used to create new
-PowerShell classes. The following script creates a new PowerShell class that is
-derived from **DirectoryContext** class.
+This example loads an assembly so that its classes can be used when processing
+data. The following script converts data into a YAML format.
 
 ```powershell
-using assembly 'C:\Program Files\PowerShell\7\System.DirectoryServices.dll'
-using namespace System.DirectoryServices.ActiveDirectory
+using assembly './YamlDotNet.dll'
+using namespace YamlDotNet
 
-class myDirectoryClass : System.DirectoryServices.ActiveDirectory.DirectoryContext
-{
+$yamlSerializer = [Serialization.Serializer]::new()
 
-  [DirectoryContext]$domain
-
-  myDirectoryClass([DirectoryContextType]$ctx) : base($ctx)
-  {
-    $this.domain = [DirectoryContext]::new([DirectoryContextType]$ctx)
-  }
-
+$info = [ordered]@{
+  Inventory = @(
+    @{ Name = 'Apples' ; Count = 1234 }
+    @{ Name = 'Bagels' ; Count = 5678 }
+  )
+    CheckedAt = [datetime]'2023-01-01T01:01:01'
 }
 
-$myDomain = [myDirectoryClass]::new([DirectoryContextType]::Domain)
-$myDomain
+$yamlSerializer.Serialize($info)
 ```
 
 ```Output
-domain                                                    Name UserName ContextType
-------                                                    ---- -------- -----------
-System.DirectoryServices.ActiveDirectory.DirectoryContext                    Domain
+Inventory:
+- Name: Apples
+  Count: 1234
+- Name: Bagels
+  Count: 5678
+CheckedAt: 2023-01-01T01:01:01.0000000
 ```


### PR DESCRIPTION
# PR Summary

Prior to this change, examples 2 and 3 for about_Using were misleading. Example 2 implied that the classes from a script module could be namespaced. Example 3 implied that authors could call `using` to use classes from the assembly when defining a class in PowerShell, which actually raises a parsing exception.

This change reworks both examples to function without errors or incorrect implications.

- Resolves #9744
- Fixes [AB#60738](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/60738)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
