### PR TITLE
Correct typo

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -309,7 +309,7 @@ foreach ($job in $jobs) {
 ### Example 9: Skipping Header Validation
 
 By default, the `Invoke-WebRequest` cmdlet validates the values of well-known headers that have a
-standardards-defined value format. The following example shows how this validation can raise an
+standards-defined value format. The following example shows how this validation can raise an
 error and how you can use the **SkipHeaderValidation** parameter to avoid validating values for
 endpoints that tolerate invalidly formatted values.
 

--- a/reference/7.3/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -307,7 +307,7 @@ foreach ($job in $jobs) {
 ### Example 9: Skipping Header Validation
 
 By default, the `Invoke-WebRequest` cmdlet validates the values of well-known headers that have a
-standardards-defined value format. The following example shows how this validation can raise an
+standards-defined value format. The following example shows how this validation can raise an
 error and how you can use the **SkipHeaderValidation** parameter to avoid validating values for
 endpoints that tolerate invalidly formatted values.
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -310,7 +310,7 @@ foreach ($job in $jobs) {
 ### Example 9: Skipping Header Validation
 
 By default, the `Invoke-WebRequest` cmdlet validates the values of well-known headers that have a
-standardards-defined value format. The following example shows how this validation can raise an
+standards-defined value format. The following example shows how this validation can raise an
 error and how you can use the **SkipHeaderValidation** parameter to avoid validating values for
 endpoints that tolerate invalidly formatted values.
 


### PR DESCRIPTION
# Invoke-WebRequest documentation typo

This changes "standardard" to "standard" in the documentation for example 9 of Invoke-WebRequest.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
