### PR TITLE
Correct typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Please note that before we can accept your pull request you must sign our
 [Contribution License Agreement](https://cla.microsoft.com/). This is a one-time requirement.
 
 For more information on contributing, read our
-[contributor's guide](https://aka.ms/PSDocsContributor). The contributor's guide contains detail
+[contributor's guide](https://aka.ms/PSDocsContributor). The contributor's guide contains detailed
 information about how to contribute documentation, suggested tools, and style and formatting
 requirements. Please use the Issue and Pull Request templates to help keep documentation consistent
 across versions.


### PR DESCRIPTION
# README typo

This changes "detail information" to "detailed information" in the README.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
