### PR TITLE
Fixed typo in the Write-Error section of about_Output_Streams.md

### DIFF
--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Output_Streams.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Output_Streams.md
@@ -48,7 +48,7 @@ The **Error** stream is the default stream for error results. Use the
 `Write-Error` cmdlet to explicitly write to this stream. The **Error** stream
 is connected to the **stderr** stream for native applications. Under most
 conditions, these errors can terminate the execution pipeline. Errors written
-to this stream are also added the the `$Error` automatic variable. For more
+to this stream are also added to the `$Error` automatic variable. For more
 information, see [about_Automatic_Variables][01].
 
 ## Warning stream


### PR DESCRIPTION
Corrected typo "...the the..." to "...to the..."

# PR Summary

This change fixes a typo in the documentation.

    - Fixes typo "the the"

## PR Checklist
- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
