### PR TITLE
Update 6.17 remove untrue claim about parameter binding type conversion for boolean

### DIFF
--- a/reference/docs-conceptual/lang-spec/chapter-06.md
+++ b/reference/docs-conceptual/lang-spec/chapter-06.md
@@ -256,7 +256,7 @@ For information about parameter binding see [§8.14][§8.14].
 When the value of an expression is being bound to a parameter, there are extra conversion
 considerations, as described below:
 
-- If the parameter type is switch ([§8.10.5][§8.10.5]) and the parameter has no
+- If the parameter type is switch ([§4.2.5][§4.2.5], [§8.10.5][§8.10.5]) and the parameter has no
   argument, the value of the parameter in the called command is set to `$true`. If the parameter
   type is other than switch, a parameter having no argument is in error.
 - If the parameter type is switch and the argument value is `$null`, the parameter value is set to

--- a/reference/docs-conceptual/lang-spec/chapter-06.md
+++ b/reference/docs-conceptual/lang-spec/chapter-06.md
@@ -256,9 +256,9 @@ For information about parameter binding see [§8.14][§8.14].
 When the value of an expression is being bound to a parameter, there are extra conversion
 considerations, as described below:
 
-- If the parameter type is bool or switch ([§4.2.5][§4.2.5], [§8.10.5][§8.10.5]) and the parameter has no
+- If the parameter type is switch ([§8.10.5][§8.10.5]) and the parameter has no
   argument, the value of the parameter in the called command is set to `$true`. If the parameter
-  type is other than bool or switch, a parameter having no argument is in error.
+  type is other than switch, a parameter having no argument is in error.
 - If the parameter type is switch and the argument value is `$null`, the parameter value is set to
   `$false`.
 - If the parameter type is object or is the same as the type of the argument, the argument's value


### PR DESCRIPTION
In order to specify bool with flagging system, you have to supply an argument or else you get an error. This is different behavior than the `switch` type, which allows you to specify the parameter without an arg value without throwing an error. The current state docs indicate that the type conversion for both a `switch` and `bool` are the same, for the case where no arg value is supplied however this is not true in practice. In practice, if a user does not supply an argument value for a `bool`, PowerShell will error, it will not convert that `bool` into a `$true` value.

This PR changes the docs so that the docs no longer imply that passing no argument to a `bool` parameter results in a `$true` value.

```powershell
    Example1 -MySwitch # this is OK, and $MySwitch will be converted to $true
    Example1 -MyBool # this will actually error, it will not convert $MyBool to be $true
    # Section 6.17 bullet 1 in current state docs suggests this second example would convert $MyBool to $true and not throw an error
```

# PR Summary

This PR changes the docs so that the docs no longer imply that passing no argument to a `bool` parameter results in a `$true` value.

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
