### PR TITLE
Fixes TableColumnItems tag in code block

### DIFF
--- a/reference/docs-conceptual/developer/format/tablecolumnitems-element-for-tablerowentry-for-tablecontrol-format.md
+++ b/reference/docs-conceptual/developer/format/tablecolumnitems-element-for-tablerowentry-for-tablecontrol-format.md
@@ -21,7 +21,7 @@ Defines the properties or scripts whose values are displayed in a row.
 ## Syntax
 
 ```xml
-TableColumnItems>
+<TableColumnItems>
   <TableColumnItem>...</TableColumnItem>
 </TableColumnItems>
 ```


### PR DESCRIPTION
# PR Summary

Very minor edit: Adds a missing '<' character to the `<TableColumnItems>` tag in the example code block.