### PR TITLE
Reference Remove-Alias as it is available in PowerShell 7.x

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Aliases.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Aliases.md
@@ -66,6 +66,7 @@ aliases:
 - `Get-Alias` - Gets all the aliases in the current session.
 - `New-Alias` - Creates a new alias.
 - `Set-Alias` - Creates or changes an alias.
+- `Remove-Alias` - Deletes an alias.
 - `Export-Alias` - Exports one or more aliases to a file.
 - `Import-Alias` - Imports an alias file into PowerShell.
 
@@ -264,6 +265,7 @@ Get-Help Alias
 - [Get-Alias](xref:Microsoft.PowerShell.Utility.Get-Alias)
 - [Import-Alias](xref:Microsoft.PowerShell.Utility.Import-Alias)
 - [New-Alias](xref:Microsoft.PowerShell.Utility.New-Alias)
+- [Remove-Alias](xref:Microsoft.PowerShell.Utility.Remove-Alias)
 - [Set-Alias](xref:Microsoft.PowerShell.Utility.Set-Alias)
 - [Get-PSDrive](xref:Microsoft.PowerShell.Management.Get-PSDrive)
 - [Get-PSProvider](xref:Microsoft.PowerShell.Management.Get-PSProvider)

--- a/reference/7.2/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/New-Alias.md
@@ -253,7 +253,7 @@ PowerShell includes the following aliases for `New-Alias`:
   - `nal`
 
 - To create a new alias, use `Set-Alias` or `New-Alias`. To change an alias, use `Set-Alias`. To delete
-an alias, use `Remove-Item`.
+an alias, use `Remove-Alias`.
 
 ## RELATED LINKS
 
@@ -262,5 +262,7 @@ an alias, use `Remove-Item`.
 [Get-Alias](Get-Alias.md)
 
 [Import-Alias](Import-Alias.md)
+
+[Remove-Alias](Remove-Alias.md)
 
 [Set-Alias](Set-Alias.md)

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Aliases.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Aliases.md
@@ -66,6 +66,7 @@ aliases:
 - `Get-Alias` - Gets all the aliases in the current session.
 - `New-Alias` - Creates a new alias.
 - `Set-Alias` - Creates or changes an alias.
+- `Remove-Alias` - Deletes an alias.
 - `Export-Alias` - Exports one or more aliases to a file.
 - `Import-Alias` - Imports an alias file into PowerShell.
 

--- a/reference/7.3/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/New-Alias.md
@@ -253,7 +253,7 @@ PowerShell includes the following aliases for `New-Alias`:
   - `nal`
 
 - To create a new alias, use `Set-Alias` or `New-Alias`. To change an alias, use `Set-Alias`. To delete
-an alias, use `Remove-Item`.
+an alias, use `Remove-Alias`.
 
 ## RELATED LINKS
 
@@ -262,5 +262,7 @@ an alias, use `Remove-Item`.
 [Get-Alias](Get-Alias.md)
 
 [Import-Alias](Import-Alias.md)
+
+[Remove-Alias](Remove-Alias.md)
 
 [Set-Alias](Set-Alias.md)

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Aliases.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Aliases.md
@@ -66,6 +66,7 @@ aliases:
 - `Get-Alias` - Gets all the aliases in the current session.
 - `New-Alias` - Creates a new alias.
 - `Set-Alias` - Creates or changes an alias.
+- `Remove-Alias` - Deletes an alias.
 - `Export-Alias` - Exports one or more aliases to a file.
 - `Import-Alias` - Imports an alias file into PowerShell.
 
@@ -264,6 +265,7 @@ Get-Help Alias
 - [Get-Alias](xref:Microsoft.PowerShell.Utility.Get-Alias)
 - [Import-Alias](xref:Microsoft.PowerShell.Utility.Import-Alias)
 - [New-Alias](xref:Microsoft.PowerShell.Utility.New-Alias)
+- [Remove-Alias](xref:Microsoft.PowerShell.Utility.Remove-Alias)
 - [Set-Alias](xref:Microsoft.PowerShell.Utility.Set-Alias)
 - [Get-PSDrive](xref:Microsoft.PowerShell.Management.Get-PSDrive)
 - [Get-PSProvider](xref:Microsoft.PowerShell.Management.Get-PSProvider)

--- a/reference/7.4/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/New-Alias.md
@@ -253,7 +253,7 @@ PowerShell includes the following aliases for `New-Alias`:
   - `nal`
 
 - To create a new alias, use `Set-Alias` or `New-Alias`. To change an alias, use `Set-Alias`. To delete
-an alias, use `Remove-Item`.
+an alias, use `Remove-Alias`.
 
 ## RELATED LINKS
 
@@ -262,5 +262,7 @@ an alias, use `Remove-Item`.
 [Get-Alias](Get-Alias.md)
 
 [Import-Alias](Import-Alias.md)
+
+[Remove-Alias](Remove-Alias.md)
 
 [Set-Alias](Set-Alias.md)


### PR DESCRIPTION
# PR Summary

I noticed that the `New-Alias` documentation says to use `Remove-Item` to delete an alias, but I've been using `Remove-Alias` with PowerShell 7.x. It looks like `Remove-Alias` was new in 7.x but was not incorporated into the `about_Aliases` or `New-Alias` documentation.

I've updated 7.2, 7.3, and 7.4 docs to reflect `Remove-Alias` where it looked appropriate.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
