### PR TITLE
(AB#61939) Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+RUN wget https://github.com/errata-ai/vale/releases/download/v2.22.0/vale_2.22.0_Linux_64-bit.tar.gz && \
+    tar -xvzf vale_2.22.0_Linux_64-bit.tar.gz -C bin && \
+    export PATH=./bin:"$PATH"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/powershell:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"darkriszty.markdown-table-prettify",
+				"davidanson.vscode-markdownlint",
+				"docsmsft.docs-authoring-pack",
+				"eamodio.gitlens",
+				"errata-ai.vale-server",
+				"marvhen.reflow-markdown",
+				"ms-vscode.powershell",
+				"ms-vscode.wordcount",
+				"nhoizey.gremlins",
+				"redhat.vscode-yaml",
+				"shuworks.vscode-table-formatter",
+				"streetsidesoftware.code-spell-checker",
+				"tyriar.sort-lines",
+				"usernamehw.errorlens",
+				"wmaurer.change-case",
+				"Acrolinx.vscode-sidebar",
+				"yzane.markdown-pdf"
+			]
+		}
+	}
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,9 @@
 # Declare files that will always have CRLF line endings on checkout.
 *.sln text eol=crlf
 
+# Ensure devcontainer files are always LF
+.devcontainer/** eol=lf
+
 # Denote all files that are truly binary and should not be modified.
 *.png binary
 *.jpg binary


### PR DESCRIPTION


# PR Summary

This change adds a devcontainer definition to the repository. The devcontainer can be used locally or as the backing definition for a codespace and includes:

- PowerShell
- Git
- The GitHub CLI
- Vale
- All suggested VS Code extensions for the repository

This change enables us to move forward with advising contributors to use GitHub Codespaces for their contributions to reduce the friction for setting up their editor.

- Resolves [AB#61939](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/61939)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
