### PR TITLE
(MAINT) Update *-Item cmdlets for dynamic parameters

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Clear-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Clear-Content.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/12/2022
+ms.date: 02/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/clear-content?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Clear-Content
@@ -15,20 +15,36 @@ Deletes the contents of an item, but does not delete the item.
 
 ## SYNTAX
 
-### Path (Default)
+### Path (Default) - FileSystem provider
 
 ```
-Clear-Content [-Path] <String[]> [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
- [-Force] [-Credential <PSCredential>] [-WhatIf] [-Confirm] [-UseTransaction] [-Stream <String>]
- [<CommonParameters>]
+Clear-Content [-Path] <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [-UseTransaction] [-Stream <String>] [<CommonParameters>]
 ```
 
-### LiteralPath
+### LiteralPath - FileSystem provider
 
 ```
 Clear-Content -LiteralPath <String[]> [-Filter <String>] [-Include <String[]>]
- [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf] [-Confirm] [-UseTransaction]
- [-Stream <String>] [<CommonParameters>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [-UseTransaction] [-Stream <String>] [<CommonParameters>]
+```
+
+### Path (Default) - All providers
+
+```
+Clear-Content [-Path] <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [-UseTransaction] [<CommonParameters>]
+```
+
+### LiteralPath - All providers
+
+```
+Clear-Content -LiteralPath <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -225,20 +241,20 @@ Accept wildcard characters: True
 
 ### -Stream
 
-Specifies an alternative data stream for content.
-If the stream does not exist, this cmdlet creates it.
-Wildcard characters are not supported.
+This is a dynamic parameter made available by the **FileSystem** provider.
 
-**Stream** is a dynamic parameter that the FileSystem provider adds to `Clear-Content`. This
-parameter works only in file system drives, and will clear the content of alternative data streams
-on both files and directories.
+Specifies an alternative data stream for content. If the stream does not exist, this cmdlet creates
+it. Wildcard characters are not supported.
 
 You can use the `Clear-Content` cmdlet to change the content of any alternate data stream, such as
 `Zone.Identifier`. However, we do not recommend this as a way to eliminate security checks that
-block files that are downloaded from the internet. If you verify that a downloaded file is safe, use
-the `Unblock-File` cmdlet.
+block files that are downloaded from the internet. If you verify that a downloaded file is safe,
+use the `Unblock-File` cmdlet.
 
 This parameter was introduced in Windows PowerShell 3.0.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.String

--- a/reference/5.1/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Copy-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/12/2022
+ms.date: 02/14/2023
 Yuponline version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/copy-item?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Copy-Item
@@ -15,22 +15,41 @@ Copies an item from one location to another.
 
 ## SYNTAX
 
-### Path (Default)
+### Path (Default) - FileSystem provider
 
 ```
-Copy-Item [-Path] <String[]> [[-Destination] <String>] [-Container] [-Force] [-Filter <String>]
- [-Include <String[]>] [-Exclude <String[]>] [-Recurse] [-PassThru] [-Credential <PSCredential>]
- [-WhatIf] [-Confirm] [-UseTransaction] [-FromSession <PSSession>] [-ToSession <PSSession>]
+Copy-Item [-Path] <String[]> [[-Destination] <String>] [-Container] [-Force]
+ [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-Recurse]
+ [-PassThru] [-Credential <PSCredential>] [-WhatIf] [-Confirm] [-UseTransaction]
+ [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]
+```
+
+### LiteralPath - FileSystem provider
+
+```
+Copy-Item -LiteralPath <String[]> [[-Destination] <String>] [-Container]
+ [-Force] [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
+ [-Recurse] [-PassThru] [-Credential <PSCredential>] [-WhatIf] [-Confirm]
+ [-UseTransaction] [-FromSession <PSSession>] [-ToSession <PSSession>]
  [<CommonParameters>]
 ```
 
-### LiteralPath
+### Path (Default) - All providers
 
 ```
-Copy-Item -LiteralPath <String[]> [[-Destination] <String>] [-Container] [-Force] [-Filter <String>]
- [-Include <String[]>] [-Exclude <String[]>] [-Recurse] [-PassThru] [-Credential <PSCredential>]
- [-WhatIf] [-Confirm] [-UseTransaction] [-FromSession <PSSession>] [-ToSession <PSSession>]
+Copy-Item [-Path] <String[]> [[-Destination] <String>] [-Container] [-Force]
+ [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-Recurse]
+ [-PassThru] [-Credential <PSCredential>] [-WhatIf] [-Confirm] [-UseTransaction]
  [<CommonParameters>]
+```
+
+### LiteralPath - All providers
+
+```
+Copy-Item -LiteralPath <String[]> [[-Destination] <String>] [-Container]
+ [-Force] [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
+ [-Recurse] [-PassThru] [-Credential <PSCredential>] [-WhatIf] [-Confirm]
+ [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -469,9 +488,14 @@ Accept wildcard characters: False
 
 ### -FromSession
 
-Specifies the **PSSession** object from which a remote file is being copied. When you use this
+This is a dynamic parameter made available by the **FileSystem** provider.
+
+Specify the **PSSession** object from which a remote file is being copied. When you use this
 parameter, the **Path** and **LiteralPath** parameters refer to the local path on the remote
 machine.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.Management.Automation.Runspaces.PSSession
@@ -578,8 +602,13 @@ Accept wildcard characters: False
 
 ### -ToSession
 
-Specifies the **PSSession** object to which a remote file is being copied. When you use this
+This is a dynamic parameter made available by the **FileSystem** provider.
+
+Specify the **PSSession** object to which a remote file is being copied. When you use this
 parameter, the **Destination** parameter refers to the local path on the remote machine.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.Management.Automation.Runspaces.PSSession

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/13/2022
+ms.date: 02/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-item?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Item
@@ -14,18 +14,56 @@ Gets the item at the specified location.
 
 ## SYNTAX
 
-### Path (Default)
+### Path (Default) - FileSystem provider
 
 ```
-Get-Item [-Path] <String[]> [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-Force]
- [-Credential <PSCredential>] [-UseTransaction] [-Stream <String[]>] [<CommonParameters>]
+Get-Item [-Path] <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-UseTransaction]
+ [-Stream <String[]>] [<CommonParameters>]
 ```
 
-### LiteralPath
+### LiteralPath - FileSystem provider
 
 ```
-Get-Item -LiteralPath <String[]> [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-Force]
- [-Credential <PSCredential>] [-UseTransaction] [-Stream <String[]>] [<CommonParameters>]
+Get-Item -LiteralPath <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-UseTransaction]
+ [-Stream <String[]>] [<CommonParameters>]
+```
+
+### Path (Default) - Certificate provider
+
+```
+Get-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>]  [-UseTransaction]
+ [-CodeSigningCert] [-DocumentEncryptionCert] [-SSLServerAuthentication]
+ [-DnsName <string>] [-Eku <string[]>] [-ExpiringInDays <int>]
+ [<CommonParameters>]
+```
+
+### LiteralPath - Certificate provider
+
+```
+Get-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-UseTransaction]
+ [-CodeSigningCert] [-DocumentEncryptionCert] [-SSLServerAuthentication]
+ [-DnsName <string>] [-Eku <string[]>] [-ExpiringInDays <int>]
+ [<CommonParameters>]
+```
+
+### Path (Default) - All providers
+
+```
+Get-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-UseTransaction]
+ [<CommonParameters>]
+```
+
+### LiteralPath - All providers
+
+```
+Get-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-UseTransaction]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -35,6 +73,8 @@ item at the location unless you use a wildcard character (`*`) to request all th
 item.
 
 This cmdlet is used by PowerShell providers to navigate through different types of data stores.
+Some parameters are only available for a specific provider. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## EXAMPLES
 
@@ -130,6 +170,28 @@ Get-Item C:\Windows\*.* -Exclude "w*"
 
 ## PARAMETERS
 
+### -CodeSigningCert
+
+This is a dynamic parameter made available by the **Certificate** provider.
+
+To get certificates that have `Code Signing` in their **EnhancedKeyUsageList** property value, use
+the **CodeSigningCert** parameter.
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Credential
 
 > [!NOTE]
@@ -147,6 +209,78 @@ Position: Named
 Default value: Current user
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
+```
+
+### -DnsName
+
+This is a dynamic parameter made available by the **Certificate** provider.
+
+Specifies a domain name or name pattern to match with the **DNSNameList** property of certificates
+the cmdlet gets. The value of this parameter can either be `Unicode` or `ASCII`. Punycode values
+are converted to Unicode. Wildcard characters (`*`) are permitted.
+
+This parameter was reintroduced in PowerShell 7.1
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: Microsoft.PowerShell.Commands.DnsNameRepresentation
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -DocumentEncryptionCert
+
+This is a dynamic parameter made available by the **Certificate** provider.
+
+To get certificates that have `Document Encryption` in their **EnhancedKeyUsageList** property
+value, use the **DocumentEncryptionCert** parameter.
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Eku
+
+This is a dynamic parameter made available by the **Certificate** provider.
+
+Specifies text or a text pattern to match with the **EnhancedKeyUsageList** property of
+certificates the cmdlet gets. Wildcard characters (`*`) are permitted. The **EnhancedKeyUsageList**
+property contains the friendly name and the OID fields of the EKU.
+
+This parameter was reintroduced in PowerShell 7.1
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
 ```
 
 ### -Exclude
@@ -167,6 +301,30 @@ Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: True
+```
+
+### -ExpiringInDays
+
+This is a dynamic parameter made available by the **Certificate** provider.
+
+Specifies that the cmdlet should only return certificates that are expiring in or before the
+specified number of days. A value of zero (`0`) gets certificates that have expired.
+
+This parameter was reintroduced in PowerShell 7.1
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### -Filter
@@ -270,13 +428,39 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: True
 ```
 
+### -SSLServerAuthentication
+
+This is a dynamic parameter made available by the **Certificate** provider.
+
+To get certificates that have `Server Authentication` in their **EnhancedKeyUsageList** property
+value, use the **SSLServerAuthentication** parameter.
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Stream
+
+This is a dynamic parameter made available by the **FileSystem** provider.
 
 Gets the specified alternate NTFS file stream from the file. Enter the stream name. Wildcards are
 supported. To get all streams, use an asterisk (`*`). This parameter isn't valid on folders.
 
-**Stream** is a dynamic parameter that the **FileSystem** provider adds to the `Get-Item` cmdlet.
-This parameter works only in file system drives.
+This parameter was introduced in PowerShell 3.0.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.String[]

--- a/reference/7.2/Microsoft.PowerShell.Management/Clear-Content.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Clear-Content.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/12/2022
+ms.date: 02/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/clear-content?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Clear-Content
@@ -15,19 +15,36 @@ Deletes the contents of an item, but does not delete the item.
 
 ## SYNTAX
 
-### Path (Default)
+### Path (Default) - FileSystem provider
 
 ```
-Clear-Content [-Path] <String[]> [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
- [-Force] [-Credential <PSCredential>] [-WhatIf] [-Confirm] [-Stream <String>] [<CommonParameters>]
+Clear-Content [-Path] <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [-Stream <String>] [<CommonParameters>]
 ```
 
-### LiteralPath
+### LiteralPath - FileSystem provider
 
 ```
 Clear-Content -LiteralPath <String[]> [-Filter <String>] [-Include <String[]>]
- [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf] [-Confirm] [-Stream <String>]
- [<CommonParameters>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [-Stream <String>] [<CommonParameters>]
+```
+
+### Path (Default) - All providers
+
+```
+Clear-Content [-Path] <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+### LiteralPath - All providers
+
+```
+Clear-Content -LiteralPath <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -224,23 +241,22 @@ Accept wildcard characters: True
 
 ### -Stream
 
-> [!NOTE]
-> This Parameter is only available on Windows.
+This is a dynamic parameter made available by the **FileSystem** provider. This parameter is only
+available on Windows.
 
 Specifies an alternative data stream for content. If the stream does not exist, this cmdlet creates
 it. Wildcard characters are not supported.
 
-**Stream** is a dynamic parameter that the FileSystem provider adds to `Clear-Content`. This
-parameter works only in file system drives, and will clear the content of alternative data streams
-on both files and directories.
-
 You can use the `Clear-Content` cmdlet to change the content of any alternate data stream, such as
 `Zone.Identifier`. However, we do not recommend this as a way to eliminate security checks that
-block files that are downloaded from the internet. If you verify that a downloaded file is safe, use
-the `Unblock-File` cmdlet.
+block files that are downloaded from the internet. If you verify that a downloaded file is safe,
+use the `Unblock-File` cmdlet.
 
 This parameter was introduced in PowerShell 3.0. As of PowerShell 7.2, `Clear-Content` can clear the
 content of alternative data streams from directories as well as files.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.String

--- a/reference/7.2/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Copy-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/12/2022
+ms.date: 02/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/copy-item?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Copy-Item
@@ -15,20 +15,40 @@ Copies an item from one location to another.
 
 ## SYNTAX
 
-### Path (Default)
+### Path (Default) - FileSystem provider
 
 ```
-Copy-Item [-Path] <String[]> [[-Destination] <String>] [-Container] [-Force] [-Filter <String>]
- [-Include <String[]>] [-Exclude <String[]>] [-Recurse] [-PassThru] [-Credential <PSCredential>]
- [-WhatIf] [-Confirm] [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]
+Copy-Item [-Path] <String[]> [[-Destination] <String>] [-Container] [-Force]
+ [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-Recurse]
+ [-PassThru] [-Credential <PSCredential>] [-WhatIf] [-Confirm]
+ [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]
 ```
 
-### LiteralPath
+### LiteralPath - FileSystem provider
 
 ```
-Copy-Item -LiteralPath <String[]> [[-Destination] <String>] [-Container] [-Force] [-Filter <String>]
- [-Include <String[]>] [-Exclude <String[]>] [-Recurse] [-PassThru] [-Credential <PSCredential>]
- [-WhatIf] [-Confirm] [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]
+Copy-Item -LiteralPath <String[]> [[-Destination] <String>] [-Container]
+ [-Force] [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
+ [-Recurse] [-PassThru] [-Credential <PSCredential>] [-WhatIf] [-Confirm]
+ [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]
+```
+
+### Path (Default) - All providers
+
+```
+Copy-Item [-Path] <string[]> [[-Destination] <string>] [-Container] [-Force]
+ [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Recurse]
+ [-PassThru] [-Credential <pscredential>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### LiteralPath - All providers
+
+```
+Copy-Item [[-Destination] <string>] -LiteralPath <string[]> [-Container]
+ [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>]
+ [-Recurse] [-PassThru] [-Credential <pscredential>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -467,9 +487,14 @@ Accept wildcard characters: False
 
 ### -FromSession
 
-Specifies the **PSSession** object from which a remote file is being copied. When you use this
+This is a dynamic parameter made available by the **FileSystem** provider.
+
+Specify the **PSSession** object from which a remote file is being copied. When you use this
 parameter, the **Path** and **LiteralPath** parameters refer to the local path on the remote
 machine.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.Management.Automation.Runspaces.PSSession
@@ -576,8 +601,13 @@ Accept wildcard characters: False
 
 ### -ToSession
 
-Specifies the **PSSession** object to which a remote file is being copied. When you use this
+This is a dynamic parameter made available by the **FileSystem** provider.
+
+Specify the **PSSession** object to which a remote file is being copied. When you use this
 parameter, the **Destination** parameter refers to the local path on the remote machine.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.Management.Automation.Runspaces.PSSession

--- a/reference/7.2/Microsoft.PowerShell.Management/Get-Item.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Get-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/13/2022
+ms.date: 02/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-item?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Item
@@ -14,18 +14,54 @@ Gets the item at the specified location.
 
 ## SYNTAX
 
-### Path (Default)
+### Path (Default) - FileSystem provider
 
 ```
-Get-Item [-Path] <String[]> [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-Force]
- [-Credential <PSCredential>] [-Stream <String[]>] [<CommonParameters>]
+Get-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [-Stream <string[]>] [<CommonParameters>]
 ```
 
-### LiteralPath
+### LiteralPath - FileSystem provider
 
 ```
-Get-Item -LiteralPath <String[]> [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
- [-Force] [-Credential <PSCredential>] [-Stream <String[]>] [<CommonParameters>]
+Get-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [-Stream <string[]>] [<CommonParameters>]
+```
+
+### Path (Default) - Certificate provider
+
+```
+Get-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-CodeSigningCert]
+ [-DocumentEncryptionCert] [-SSLServerAuthentication] [-DnsName <string>]
+ [-Eku <string[]>] [-ExpiringInDays <int>] [<CommonParameters>]
+```
+
+### LiteralPath - Certificate provider
+
+```
+Get-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-CodeSigningCert]
+ [-DocumentEncryptionCert] [-SSLServerAuthentication] [-DnsName <string>]
+ [-Eku <string[]>] [-ExpiringInDays <int>] [<CommonParameters>]
+```
+
+### Path (Default) - All providers
+
+```
+Get-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [<CommonParameters>]
+```
+
+### LiteralPath - All providers
+
+```
+Get-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -35,6 +71,8 @@ item at the location unless you use a wildcard character (`*`) to request all th
 item.
 
 This cmdlet is used by PowerShell providers to navigate through different types of data stores.
+Some parameters are only available for a specific provider. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## EXAMPLES
 
@@ -176,6 +214,29 @@ The new properties that are now part of the output are:
 
 ## PARAMETERS
 
+### -CodeSigningCert
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+To get certificates that have `Code Signing` in their **EnhancedKeyUsageList** property value, use
+the **CodeSigningCert** parameter.
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Credential
 
 > [!NOTE]
@@ -193,6 +254,81 @@ Position: Named
 Default value: Current user
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
+```
+
+### -DnsName
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+Specifies a domain name or name pattern to match with the **DNSNameList** property of certificates
+the cmdlet gets. The value of this parameter can either be `Unicode` or `ASCII`. Punycode values
+are converted to Unicode. Wildcard characters (`*`) are permitted.
+
+This parameter was reintroduced in PowerShell 7.1
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: Microsoft.PowerShell.Commands.DnsNameRepresentation
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -DocumentEncryptionCert
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+To get certificates that have `Document Encryption` in their **EnhancedKeyUsageList** property
+value, use the **DocumentEncryptionCert** parameter.
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Eku
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+Specifies text or a text pattern to match with the **EnhancedKeyUsageList** property of
+certificates the cmdlet gets. Wildcard characters (`*`) are permitted. The **EnhancedKeyUsageList**
+property contains the friendly name and the OID fields of the EKU.
+
+This parameter was reintroduced in PowerShell 7.1
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
 ```
 
 ### -Exclude
@@ -213,6 +349,31 @@ Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: True
+```
+
+### -ExpiringInDays
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+Specifies that the cmdlet should only return certificates that are expiring in or before the
+specified number of days. A value of zero (`0`) gets certificates that have expired.
+
+This parameter was reintroduced in PowerShell 7.1
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### -Filter
@@ -316,10 +477,33 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: True
 ```
 
+### -SSLServerAuthentication
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+To get certificates that have `Server Authentication` in their **EnhancedKeyUsageList** property
+value, use the **SSLServerAuthentication** parameter.
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Stream
 
-> [!NOTE]
-> This Parameter is only available on Windows.
+This is a dynamic parameter made available by the **FileSystem** provider. This parameter is only
+available on Windows.
 
 Gets the specified alternative data stream from the file. Enter the stream name. Wildcards are
 supported. To get all streams, use an asterisk (`*`). This parameter is valid on directories, but
@@ -327,6 +511,9 @@ note that directories do not have data streams by default.
 
 This parameter was introduced in PowerShell 3.0.  As of PowerShell 7.2, `Get-Item` can get
 alternative data streams from directories as well as files.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.String[]

--- a/reference/7.3/Microsoft.PowerShell.Management/Clear-Content.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Clear-Content.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/12/2022
+ms.date: 02/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/clear-content?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Clear-Content
@@ -15,19 +15,36 @@ Deletes the contents of an item, but does not delete the item.
 
 ## SYNTAX
 
-### Path (Default)
+### Path (Default) - FileSystem provider
 
 ```
-Clear-Content [-Path] <String[]> [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
- [-Force] [-Credential <PSCredential>] [-WhatIf] [-Confirm] [-Stream <String>] [<CommonParameters>]
+Clear-Content [-Path] <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [-Stream <String>] [<CommonParameters>]
 ```
 
-### LiteralPath
+### LiteralPath - FileSystem provider
 
 ```
 Clear-Content -LiteralPath <String[]> [-Filter <String>] [-Include <String[]>]
- [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf] [-Confirm] [-Stream <String>]
- [<CommonParameters>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [-Stream <String>] [<CommonParameters>]
+```
+
+### Path (Default) - All providers
+
+```
+Clear-Content [-Path] <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+### LiteralPath - All providers
+
+```
+Clear-Content -LiteralPath <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -224,23 +241,22 @@ Accept wildcard characters: True
 
 ### -Stream
 
-> [!NOTE]
-> This Parameter is only available on Windows.
+This is a dynamic parameter made available by the **FileSystem** provider. This parameter is only
+available on Windows.
 
 Specifies an alternative data stream for content. If the stream does not exist, this cmdlet creates
 it. Wildcard characters are not supported.
 
-**Stream** is a dynamic parameter that the FileSystem provider adds to `Clear-Content`. This
-parameter works only in file system drives, and will clear the content of alternative data streams
-on both files and directories.
-
 You can use the `Clear-Content` cmdlet to change the content of any alternate data stream, such as
 `Zone.Identifier`. However, we do not recommend this as a way to eliminate security checks that
-block files that are downloaded from the internet. If you verify that a downloaded file is safe, use
-the `Unblock-File` cmdlet.
+block files that are downloaded from the internet. If you verify that a downloaded file is safe,
+use the `Unblock-File` cmdlet.
 
 This parameter was introduced in PowerShell 3.0. As of PowerShell 7.2, `Clear-Content` can clear the
 content of alternative data streams from directories as well as files.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.String

--- a/reference/7.3/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Copy-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/12/2022
+ms.date: 02/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/copy-item?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Copy-Item
@@ -15,20 +15,40 @@ Copies an item from one location to another.
 
 ## SYNTAX
 
-### Path (Default)
+### Path (Default) - FileSystem provider
 
 ```
-Copy-Item [-Path] <String[]> [[-Destination] <String>] [-Container] [-Force] [-Filter <String>]
- [-Include <String[]>] [-Exclude <String[]>] [-Recurse] [-PassThru] [-Credential <PSCredential>]
- [-WhatIf] [-Confirm] [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]
+Copy-Item [-Path] <String[]> [[-Destination] <String>] [-Container] [-Force]
+ [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-Recurse]
+ [-PassThru] [-Credential <PSCredential>] [-WhatIf] [-Confirm]
+ [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]
 ```
 
-### LiteralPath
+### LiteralPath - FileSystem provider
 
 ```
-Copy-Item -LiteralPath <String[]> [[-Destination] <String>] [-Container] [-Force] [-Filter <String>]
- [-Include <String[]>] [-Exclude <String[]>] [-Recurse] [-PassThru] [-Credential <PSCredential>]
- [-WhatIf] [-Confirm] [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]
+Copy-Item -LiteralPath <String[]> [[-Destination] <String>] [-Container]
+ [-Force] [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
+ [-Recurse] [-PassThru] [-Credential <PSCredential>] [-WhatIf] [-Confirm]
+ [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]
+```
+
+### Path (Default) - All providers
+
+```
+Copy-Item [-Path] <string[]> [[-Destination] <string>] [-Container] [-Force]
+ [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Recurse]
+ [-PassThru] [-Credential <pscredential>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### LiteralPath - All providers
+
+```
+Copy-Item [[-Destination] <string>] -LiteralPath <string[]> [-Container]
+ [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>]
+ [-Recurse] [-PassThru] [-Credential <pscredential>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -467,9 +487,14 @@ Accept wildcard characters: False
 
 ### -FromSession
 
-Specifies the **PSSession** object from which a remote file is being copied. When you use this
+This is a dynamic parameter made available by the **FileSystem** provider.
+
+Specify the **PSSession** object from which a remote file is being copied. When you use this
 parameter, the **Path** and **LiteralPath** parameters refer to the local path on the remote
 machine.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.Management.Automation.Runspaces.PSSession
@@ -576,8 +601,13 @@ Accept wildcard characters: False
 
 ### -ToSession
 
-Specifies the **PSSession** object to which a remote file is being copied. When you use this
+This is a dynamic parameter made available by the **FileSystem** provider.
+
+Specify the **PSSession** object to which a remote file is being copied. When you use this
 parameter, the **Destination** parameter refers to the local path on the remote machine.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.Management.Automation.Runspaces.PSSession

--- a/reference/7.3/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -19,18 +19,55 @@ Gets the items and child items in one or more specified locations.
 ### Items (Default)
 
 ```
-Get-ChildItem [[-Path] <string[]>] [[-Filter] <string>] [-Include <string[]>] [-Exclude <string[]>]
- [-Recurse] [-Depth <uint32>] [-Force] [-Name] [-Attributes <FlagsExpression[FileAttributes]>]
- [-FollowSymlink] [-Directory] [-File] [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
+Get-ChildItem [[-Path] <string[]>] [[-Filter] <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Recurse] [-Depth <uint>] [-Force] [-Name]
+ [<CommonParameters>]
 ```
 
 ### LiteralItems
 
 ```
 Get-ChildItem [[-Filter] <string>] -LiteralPath <string[]> [-Include <string[]>]
- [-Exclude <string[]>] [-Recurse] [-Depth <uint32>] [-Force] [-Name]
- [-Attributes <FlagsExpression[FileAttributes]>] [-FollowSymlink] [-Directory] [-File] [-Hidden]
- [-ReadOnly] [-System] [<CommonParameters>]
+ [-Exclude <string[]>] [-Recurse] [-Depth <uint>] [-Force] [-Name]
+ [<CommonParameters>]
+```
+
+### Items (Default) - Certificate provider
+
+```
+Get-ChildItem [[-Path] <string[]>] [[-Filter] <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Recurse] [-Depth <uint>] [-Force] [-Name]
+ [-CodeSigningCert] [-DocumentEncryptionCert] [-SSLServerAuthentication]
+ [-DnsName <string>] [-Eku <string[]>] [-ExpiringInDays <int>]
+ [<CommonParameters>]
+```
+
+### LiteralItems - Certificate provider
+
+```
+Get-ChildItem [[-Filter] <string>] -LiteralPath <string[]> [-Include <string[]>]
+ [-Exclude <string[]>] [-Recurse] [-Depth <uint>] [-Force] [-Name]
+ [-CodeSigningCert] [-DocumentEncryptionCert] [-SSLServerAuthentication]
+ [-DnsName <string>] [-Eku <string[]>] [-ExpiringInDays <int>]
+ [<CommonParameters>]
+```
+
+### Items (Default) - Filesystem provider
+
+```
+Get-ChildItem [[-Path] <string[]>] [[-Filter] <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Recurse] [-Depth <uint>] [-Force] [-Name]
+ [-Attributes <FlagsExpression[FileAttributes]>] [-FollowSymlink] [-Directory]
+ [-File] [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
+```
+
+### LiteralItems - FileSystem provider
+
+```
+Get-ChildItem [[-Filter] <string>] -LiteralPath <string[]> [-Include <string[]>]
+ [-Exclude <string[]>] [-Recurse] [-Depth <uint>] [-Force] [-Name]
+ [-Attributes <FlagsExpression[FileAttributes]>] [-FollowSymlink] [-Directory]
+ [-File] [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,7 +81,8 @@ of levels to recurse.
 **Depth** or **Recurse** parameters, empty directories aren't included in the output.
 
 Locations are exposed to `Get-ChildItem` by PowerShell providers. A location can be a file system
-directory, registry hive, or a certificate store. For more information, see
+directory, registry hive, or a certificate store. Some parameters are only available for a specific
+provider. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## EXAMPLES
@@ -110,7 +148,7 @@ ReadOnlyFile.txt
 
 ### Example 3: Get child items in the current directory and subdirectories
 
-This example displays **.txt** files that are located in the current directory and its
+This example displays `.txt` files that are located in the current directory and its
 subdirectories.
 
 ```powershell
@@ -186,10 +224,10 @@ Mode                LastWriteTime         Length Name
 -ar---        2/12/2019     14:31             27 ReadOnlyFile.txt
 ```
 
-The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory **C:\Test**. The
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory `C:\Test`. The
 **Path** parameter includes a trailing asterisk (`*`) wildcard to specify the directory's contents.
 The **Include** parameter uses an asterisk (`*`) wildcard to specify all files with the file name
-extension **.txt**.
+extension `.txt`.
 
 When the **Include** parameter is used, the **Path** parameter needs a trailing asterisk (`*`)
 wildcard to specify the directory's contents. For example, `-Path C:\Test\*`.
@@ -202,7 +240,7 @@ wildcard to specify the directory's contents. For example, `-Path C:\Test\*`.
 
 ### Example 5: Get child items using the Exclude parameter
 
-The example's output shows the contents of the directory **C:\Test\Logs**. The output is a reference
+The example's output shows the contents of the directory `C:\Test\Logs`. The output is a reference
 for the other commands that use the **Exclude** and **Recurse** parameters.
 
 ```powershell
@@ -238,7 +276,7 @@ d-----        2/15/2019     13:21                Backup
 
 The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory `C:\Test\Logs`. The
 **Exclude** parameter uses the asterisk (`*`) wildcard to specify any files or directories that
-begin with **A** or **a** are excluded from the output.
+begin with `A` or `a` are excluded from the output.
 
 When the **Exclude** parameter is used, a trailing asterisk (`*`) in the **Path** parameter is
 optional. For example, `-Path C:\Test\Logs` or `-Path C:\Test\Logs\*`.
@@ -297,18 +335,18 @@ parameter only works on subkeys, not item properties.
 
 ### Example 7: Get all certificates with code-signing authority
 
-This example gets each certificate in the PowerShell **Cert:** drive that has code-signing
-authority.
+This example gets each certificate in the PowerShell `Cert:` drive that has code-signing authority.
 
-The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the **Cert:** provider. The
-**Recurse** parameter searches the directory specified by **Path** and its subdirectories. The
-**CodeSigningCert** parameter gets only certificates that have code-signing authority.
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the Certificate provider with the
+`Cert:` drive. The **Recurse** parameter searches the directory specified by **Path** and its
+subdirectories. The **CodeSigningCert** parameter gets only certificates that have code-signing
+authority.
 
 ```powershell
 Get-ChildItem -Path Cert:\* -Recurse -CodeSigningCert
 ```
 
-For more information about the Certificate provider and the Cert: drive,
+For more information about the Certificate provider and the `Cert:` drive,
 see [about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
 
 ### Example 8: Get items using the Depth parameter
@@ -344,7 +382,7 @@ d-----        2/14/2019     10:22                SubDir_Level3
 -a----        2/13/2019     08:55             26 file.txt
 ```
 
-The `Get-ChildItem` cmdlet uses the **Path** parameter to specify **C:\Parent**. The **Depth**
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify `C:\Parent`. The **Depth**
 parameter specifies two levels of recursion. `Get-ChildItem` displays the contents of the directory
 specified by the **Path** parameter and the two levels of subdirectories.
 
@@ -418,6 +456,10 @@ l----   12/16/2021  9:29 AM           tmp -> C:\Users\user1\AppData\Local\Temp
 
 ### -Attributes
 
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
+
 Gets files and folders with the specified attributes. This parameter supports all attributes and
 lets you specify complex combinations of attributes.
 
@@ -477,6 +519,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -CodeSigningCert
+
+> [!NOTE]
+> This parameter is only available in the
+> [Certificate](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md) provider.
+
+To get a list of certificates that have `Code Signing` in their **EnhancedKeyUsageList** property
+value, use the **CodeSigningCert** parameter.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Depth
 
 This parameter was added in PowerShell 5.0 and enables you to control the depth of recursion. By
@@ -484,7 +547,7 @@ default, `Get-ChildItem` displays the contents of the parent directory. The **De
 determines the number of subdirectory levels that are included in the recursion and displays the
 contents.
 
-For example, `Depth 2` includes the **Path** parameter's directory, first level of subdirectories,
+For example, `-Depth 2` includes the **Path** parameter's directory, first level of subdirectories,
 and second level of subdirectories. By default directory names and filenames are included in the
 output.
 
@@ -506,6 +569,10 @@ Accept wildcard characters: False
 
 ### -Directory
 
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
+
 To get a list of directories, use the **Directory** parameter or the **Attributes** parameter with
 the **Directory** property. You can use the **Recurse** parameter with **Directory**.
 
@@ -519,6 +586,75 @@ Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
+```
+
+### -DnsName
+
+> [!NOTE]
+> This parameter is only available in the
+> [Certificate](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md) provider.
+
+Specifies a domain name or name pattern to match with the **DNSNameList** property of certificates
+the cmdlet gets. The value of this parameter can either be `Unicode` or `ASCII`. Punycode values
+are converted to Unicode. Wildcard characters (`*`) are permitted.
+
+This parameter was reintroduced in PowerShell 7.1
+
+```yaml
+Type: Microsoft.PowerShell.Commands.DnsNameRepresentation
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -DocumentEncryptionCert
+
+> [!NOTE]
+> This parameter is only available in the
+> [Certificate](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md) provider.
+
+To get a list of certificates that have `Document Encryption` in their **EnhancedKeyUsageList**
+property value, use the **DocumentEncryptionCert** parameter.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Eku
+
+> [!NOTE]
+> This parameter is only available in the
+> [Certificate](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md) provider.
+
+Specifies text or a text pattern to match with the **EnhancedKeyUsageList** property of
+certificates the cmdlet gets. Wildcard characters (`*`) are permitted. The **EnhancedKeyUsageList**
+property contains the friendly name and the OID fields of the EKU.
+
+This parameter was reintroduced in PowerShell 7.1
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
 ```
 
 ### -Exclude
@@ -547,7 +683,34 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -ExpiringInDays
+
+> [!NOTE]
+> This parameter is only available in the
+> [Certificate](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md) provider.
+
+Specifies that the cmdlet should only return certificates that are expiring in or before the
+specified number of days. A value of zero (`0`) gets certificates that have expired.
+
+This parameter was reintroduced in PowerShell 7.1
+
+```yaml
+Type: System.Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -File
+
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
 
 To get a list of files, use the **File** parameter. You can use the **Recurse** parameter with
 **File**.
@@ -586,6 +749,10 @@ Accept wildcard characters: True
 ```
 
 ### -FollowSymlink
+
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
 
 By default, the `Get-ChildItem` cmdlet displays symbolic links to directories found during
 recursion, but doesn't recurse into them. Use the **FollowSymlink** parameter to search the
@@ -626,6 +793,10 @@ Accept wildcard characters: False
 ```
 
 ### -Hidden
+
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
 
 To get only hidden items, use the **Hidden** parameter or the **Attributes** parameter with the
 **Hidden** property. By default, `Get-ChildItem` doesn't display hidden items. Use the **Force**
@@ -724,6 +895,10 @@ Accept wildcard characters: True
 
 ### -ReadOnly
 
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
+
 To get only read-only items, use the **ReadOnly** parameter or the **Attributes** parameter
 **ReadOnly** property.
 
@@ -755,7 +930,32 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -SSLServerAuthentication
+
+> [!NOTE]
+> This parameter is only available in the
+> [Certificate](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md) provider.
+
+To get a list of certificates that have `Server Authentication` in their **EnhancedKeyUsageList**
+property value, use the **SSLServerAuthentication** parameter.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -System
+
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
 
 Gets only system files and directories. To get only system files and folders, use the **System**
 parameter or **Attributes** parameter **System** property.

--- a/reference/7.3/Microsoft.PowerShell.Management/Get-Item.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Get-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/13/2022
+ms.date: 02/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-item?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Item
@@ -14,18 +14,54 @@ Gets the item at the specified location.
 
 ## SYNTAX
 
-### Path (Default)
+### Path (Default) - FileSystem provider
 
 ```
-Get-Item [-Path] <String[]> [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-Force]
- [-Credential <PSCredential>] [-Stream <String[]>] [<CommonParameters>]
+Get-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [-Stream <string[]>] [<CommonParameters>]
 ```
 
-### LiteralPath
+### LiteralPath - FileSystem provider
 
 ```
-Get-Item -LiteralPath <String[]> [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
- [-Force] [-Credential <PSCredential>] [-Stream <String[]>] [<CommonParameters>]
+Get-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [-Stream <string[]>] [<CommonParameters>]
+```
+
+### Path (Default) - Certificate provider
+
+```
+Get-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-CodeSigningCert]
+ [-DocumentEncryptionCert] [-SSLServerAuthentication] [-DnsName <string>]
+ [-Eku <string[]>] [-ExpiringInDays <int>] [<CommonParameters>]
+```
+
+### LiteralPath - Certificate provider
+
+```
+Get-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-CodeSigningCert]
+ [-DocumentEncryptionCert] [-SSLServerAuthentication] [-DnsName <string>]
+ [-Eku <string[]>] [-ExpiringInDays <int>] [<CommonParameters>]
+```
+
+### Path (Default) - All providers
+
+```
+Get-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [<CommonParameters>]
+```
+
+### LiteralPath - All providers
+
+```
+Get-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -35,6 +71,8 @@ item at the location unless you use a wildcard character (`*`) to request all th
 item.
 
 This cmdlet is used by PowerShell providers to navigate through different types of data stores.
+Some parameters are only available for a specific provider. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## EXAMPLES
 
@@ -176,6 +214,29 @@ The new properties that are now part of the output are:
 
 ## PARAMETERS
 
+### -CodeSigningCert
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+To get certificates that have `Code Signing` in their **EnhancedKeyUsageList** property value, use
+the **CodeSigningCert** parameter.
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Credential
 
 > [!NOTE]
@@ -193,6 +254,81 @@ Position: Named
 Default value: Current user
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
+```
+
+### -DnsName
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+Specifies a domain name or name pattern to match with the **DNSNameList** property of certificates
+the cmdlet gets. The value of this parameter can either be `Unicode` or `ASCII`. Punycode values
+are converted to Unicode. Wildcard characters (`*`) are permitted.
+
+This parameter was reintroduced in PowerShell 7.1
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: Microsoft.PowerShell.Commands.DnsNameRepresentation
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -DocumentEncryptionCert
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+To get certificates that have `Document Encryption` in their **EnhancedKeyUsageList** property
+value, use the **DocumentEncryptionCert** parameter.
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Eku
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+Specifies text or a text pattern to match with the **EnhancedKeyUsageList** property of
+certificates the cmdlet gets. Wildcard characters (`*`) are permitted. The **EnhancedKeyUsageList**
+property contains the friendly name and the OID fields of the EKU.
+
+This parameter was reintroduced in PowerShell 7.1
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
 ```
 
 ### -Exclude
@@ -213,6 +349,31 @@ Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: True
+```
+
+### -ExpiringInDays
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+Specifies that the cmdlet should only return certificates that are expiring in or before the
+specified number of days. A value of zero (`0`) gets certificates that have expired.
+
+This parameter was reintroduced in PowerShell 7.1
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### -Filter
@@ -316,10 +477,33 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: True
 ```
 
+### -SSLServerAuthentication
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+To get certificates that have `Server Authentication` in their **EnhancedKeyUsageList** property
+value, use the **SSLServerAuthentication** parameter.
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Stream
 
-> [!NOTE]
-> This Parameter is only available on Windows.
+This is a dynamic parameter made available by the **FileSystem** provider. This parameter is only
+available on Windows.
 
 Gets the specified alternative data stream from the file. Enter the stream name. Wildcards are
 supported. To get all streams, use an asterisk (`*`). This parameter is valid on directories, but
@@ -327,6 +511,9 @@ note that directories do not have data streams by default.
 
 This parameter was introduced in PowerShell 3.0.  As of PowerShell 7.2, `Get-Item` can get
 alternative data streams from directories as well as files.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.String[]

--- a/reference/7.4/Microsoft.PowerShell.Management/Clear-Content.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Clear-Content.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/12/2022
+ms.date: 02/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/clear-content?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Clear-Content
@@ -15,19 +15,36 @@ Deletes the contents of an item, but does not delete the item.
 
 ## SYNTAX
 
-### Path (Default)
+### Path (Default) - FileSystem provider
 
 ```
-Clear-Content [-Path] <String[]> [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
- [-Force] [-Credential <PSCredential>] [-WhatIf] [-Confirm] [-Stream <String>] [<CommonParameters>]
+Clear-Content [-Path] <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [-Stream <String>] [<CommonParameters>]
 ```
 
-### LiteralPath
+### LiteralPath - FileSystem provider
 
 ```
 Clear-Content -LiteralPath <String[]> [-Filter <String>] [-Include <String[]>]
- [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf] [-Confirm] [-Stream <String>]
- [<CommonParameters>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [-Stream <String>] [<CommonParameters>]
+```
+
+### Path (Default) - All providers
+
+```
+Clear-Content [-Path] <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+### LiteralPath - All providers
+
+```
+Clear-Content -LiteralPath <String[]> [-Filter <String>] [-Include <String[]>]
+ [-Exclude <String[]>] [-Force] [-Credential <PSCredential>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -224,23 +241,22 @@ Accept wildcard characters: True
 
 ### -Stream
 
-> [!NOTE]
-> This Parameter is only available on Windows.
+This is a dynamic parameter made available by the **FileSystem** provider. This parameter is only
+available on Windows.
 
 Specifies an alternative data stream for content. If the stream does not exist, this cmdlet creates
 it. Wildcard characters are not supported.
 
-**Stream** is a dynamic parameter that the FileSystem provider adds to `Clear-Content`. This
-parameter works only in file system drives, and will clear the content of alternative data streams
-on both files and directories.
-
 You can use the `Clear-Content` cmdlet to change the content of any alternate data stream, such as
 `Zone.Identifier`. However, we do not recommend this as a way to eliminate security checks that
-block files that are downloaded from the internet. If you verify that a downloaded file is safe, use
-the `Unblock-File` cmdlet.
+block files that are downloaded from the internet. If you verify that a downloaded file is safe,
+use the `Unblock-File` cmdlet.
 
 This parameter was introduced in PowerShell 3.0. As of PowerShell 7.2, `Clear-Content` can clear the
 content of alternative data streams from directories as well as files.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.String

--- a/reference/7.4/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Copy-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/12/2022
+ms.date: 02/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/copy-item?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Copy-Item
@@ -15,20 +15,40 @@ Copies an item from one location to another.
 
 ## SYNTAX
 
-### Path (Default)
+### Path (Default) - FileSystem provider
 
 ```
-Copy-Item [-Path] <String[]> [[-Destination] <String>] [-Container] [-Force] [-Filter <String>]
- [-Include <String[]>] [-Exclude <String[]>] [-Recurse] [-PassThru] [-Credential <PSCredential>]
- [-WhatIf] [-Confirm] [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]
+Copy-Item [-Path] <String[]> [[-Destination] <String>] [-Container] [-Force]
+ [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-Recurse]
+ [-PassThru] [-Credential <PSCredential>] [-WhatIf] [-Confirm]
+ [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]
 ```
 
-### LiteralPath
+### LiteralPath - FileSystem provider
 
 ```
-Copy-Item -LiteralPath <String[]> [[-Destination] <String>] [-Container] [-Force] [-Filter <String>]
- [-Include <String[]>] [-Exclude <String[]>] [-Recurse] [-PassThru] [-Credential <PSCredential>]
- [-WhatIf] [-Confirm] [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]
+Copy-Item -LiteralPath <String[]> [[-Destination] <String>] [-Container]
+ [-Force] [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
+ [-Recurse] [-PassThru] [-Credential <PSCredential>] [-WhatIf] [-Confirm]
+ [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]
+```
+
+### Path (Default) - All providers
+
+```
+Copy-Item [-Path] <string[]> [[-Destination] <string>] [-Container] [-Force]
+ [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Recurse]
+ [-PassThru] [-Credential <pscredential>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### LiteralPath - All providers
+
+```
+Copy-Item [[-Destination] <string>] -LiteralPath <string[]> [-Container]
+ [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>]
+ [-Recurse] [-PassThru] [-Credential <pscredential>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -467,9 +487,14 @@ Accept wildcard characters: False
 
 ### -FromSession
 
-Specifies the **PSSession** object from which a remote file is being copied. When you use this
+This is a dynamic parameter made available by the **FileSystem** provider.
+
+Specify the **PSSession** object from which a remote file is being copied. When you use this
 parameter, the **Path** and **LiteralPath** parameters refer to the local path on the remote
 machine.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.Management.Automation.Runspaces.PSSession
@@ -576,8 +601,13 @@ Accept wildcard characters: False
 
 ### -ToSession
 
-Specifies the **PSSession** object to which a remote file is being copied. When you use this
+This is a dynamic parameter made available by the **FileSystem** provider.
+
+Specify the **PSSession** object to which a remote file is being copied. When you use this
 parameter, the **Destination** parameter refers to the local path on the remote machine.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.Management.Automation.Runspaces.PSSession

--- a/reference/7.4/Microsoft.PowerShell.Management/Get-Item.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Get-Item.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/13/2022
+ms.date: 02/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-item?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Item
@@ -14,18 +14,54 @@ Gets the item at the specified location.
 
 ## SYNTAX
 
-### Path (Default)
+### Path (Default) - FileSystem provider
 
 ```
-Get-Item [-Path] <String[]> [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-Force]
- [-Credential <PSCredential>] [-Stream <String[]>] [<CommonParameters>]
+Get-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [-Stream <string[]>] [<CommonParameters>]
 ```
 
-### LiteralPath
+### LiteralPath - FileSystem provider
 
 ```
-Get-Item -LiteralPath <String[]> [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
- [-Force] [-Credential <PSCredential>] [-Stream <String[]>] [<CommonParameters>]
+Get-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [-Stream <string[]>] [<CommonParameters>]
+```
+
+### Path (Default) - Certificate provider
+
+```
+Get-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-CodeSigningCert]
+ [-DocumentEncryptionCert] [-SSLServerAuthentication] [-DnsName <string>]
+ [-Eku <string[]>] [-ExpiringInDays <int>] [<CommonParameters>]
+```
+
+### LiteralPath - Certificate provider
+
+```
+Get-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-CodeSigningCert]
+ [-DocumentEncryptionCert] [-SSLServerAuthentication] [-DnsName <string>]
+ [-Eku <string[]>] [-ExpiringInDays <int>] [<CommonParameters>]
+```
+
+### Path (Default) - All providers
+
+```
+Get-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [<CommonParameters>]
+```
+
+### LiteralPath - All providers
+
+```
+Get-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>]
+ [-Exclude <string[]>] [-Force] [-Credential <pscredential>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -176,6 +212,29 @@ The new properties that are now part of the output are:
 
 ## PARAMETERS
 
+### -CodeSigningCert
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+To get certificates that have `Code Signing` in their **EnhancedKeyUsageList** property value, use
+the **CodeSigningCert** parameter.
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Credential
 
 > [!NOTE]
@@ -193,6 +252,81 @@ Position: Named
 Default value: Current user
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
+```
+
+### -DnsName
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+Specifies a domain name or name pattern to match with the **DNSNameList** property of certificates
+the cmdlet gets. The value of this parameter can either be `Unicode` or `ASCII`. Punycode values
+are converted to Unicode. Wildcard characters (`*`) are permitted.
+
+This parameter was reintroduced in PowerShell 7.1
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: Microsoft.PowerShell.Commands.DnsNameRepresentation
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -DocumentEncryptionCert
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+To get certificates that have `Document Encryption` in their **EnhancedKeyUsageList** property
+value, use the **DocumentEncryptionCert** parameter.
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Eku
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+Specifies text or a text pattern to match with the **EnhancedKeyUsageList** property of
+certificates the cmdlet gets. Wildcard characters (`*`) are permitted. The **EnhancedKeyUsageList**
+property contains the friendly name and the OID fields of the EKU.
+
+This parameter was reintroduced in PowerShell 7.1
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
 ```
 
 ### -Exclude
@@ -213,6 +347,31 @@ Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: True
+```
+
+### -ExpiringInDays
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+Specifies that the cmdlet should only return certificates that are expiring in or before the
+specified number of days. A value of zero (`0`) gets certificates that have expired.
+
+This parameter was reintroduced in PowerShell 7.1
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### -Filter
@@ -316,10 +475,33 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: True
 ```
 
+### -SSLServerAuthentication
+
+This is a dynamic parameter made available by the **Certificate** provider. This parameter and the
+**Certificate** provider are only available on Windows.
+
+To get certificates that have `Server Authentication` in their **EnhancedKeyUsageList** property
+value, use the **SSLServerAuthentication** parameter.
+
+For more information, see
+[about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Stream
 
-> [!NOTE]
-> This Parameter is only available on Windows.
+This is a dynamic parameter made available by the **FileSystem** provider. This parameter is only
+available on Windows.
 
 Gets the specified alternative data stream from the file. Enter the stream name. Wildcards are
 supported. To get all streams, use an asterisk (`*`). This parameter is valid on directories, but
@@ -327,6 +509,9 @@ note that directories do not have data streams by default.
 
 This parameter was introduced in PowerShell 3.0.  As of PowerShell 7.2, `Get-Item` can get
 alternative data streams from directories as well as files.
+
+For more information, see
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md).
 
 ```yaml
 Type: System.String[]


### PR DESCRIPTION


# PR Summary

Prior to this change, the reference documentation for the `Copy-Item`, `Get-ChildItem`, and `Get-Item` cmdlets only included dynamic parameters for the FileSystem provider.

This change updates the documentation to:

- clarify that some parameters are only for specific providers
- add provider-specific syntax information
- add notes to clarify which parameters are provider-specific
- document dynamic parameters for providers other than FileSystem

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
