### PR TITLE
Semi colon missing for hash table

### DIFF
--- a/reference/7.3/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/7.3/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -101,8 +101,8 @@ structure in the archive file because the **Path** only specifies file names.
 
 ```powershell
 $compress = @{
-LiteralPath= "C:\Reference\Draft Doc.docx", "C:\Reference\Images\diagram2.vsd"
-CompressionLevel = "Fastest"
+LiteralPath= "C:\Reference\Draft Doc.docx", "C:\Reference\Images\diagram2.vsd";
+CompressionLevel = "Fastest";
 DestinationPath = "C:\Archives\Draft.zip"
 }
 Compress-Archive @compress

--- a/reference/7.3/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/7.3/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -81,8 +81,8 @@ archive file because the **Path** only specifies file names.
 
 ```powershell
 $compress = @{
-  Path = "C:\Reference\Draftdoc.docx", "C:\Reference\Images\*.vsd"
-  CompressionLevel = "Fastest"
+  Path = "C:\Reference\Draftdoc.docx", "C:\Reference\Images\*.vsd";
+  CompressionLevel = "Fastest";
   DestinationPath = "C:\Archives\Draft.zip"
 }
 Compress-Archive @compress


### PR DESCRIPTION
# PR Summary

This PR adds semi-colons to the hash table so that there isn't an error thrown for DestinationPath not being recognized

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
