### PR TITLE
align type info from Set-ItemProperty and New-ItemProperty

### DIFF
--- a/reference/7.3/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -285,8 +285,10 @@ Accept wildcard characters: True
 
 ### -PropertyType
 
-Specifies the type of property that this cmdlet adds.
-The acceptable values for this parameter are:
+This is a dynamic parameter made available by the **Registry** provider. The **Registry** provider
+and this parameter are only available on Windows.
+
+Specifies the type of property that this cmdlet adds. The acceptable values for this parameter are:
 
 - `String`: Specifies a null-terminated string. Used for **REG_SZ** values.
 - `ExpandString`: Specifies a null-terminated string that contains unexpanded references to
@@ -300,7 +302,7 @@ The acceptable values for this parameter are:
 - `Unknown`: Indicates an unsupported registry data type, such as **REG_RESOURCE_LIST** values.
 
 ```yaml
-Type: System.String
+Type: Microsoft.Win32.RegistryValueKind
 Parameter Sets: (All)
 Aliases: Type
 


### PR DESCRIPTION
# PR Summary

Uses the parameter description from [Set-ItemProperty -Type](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-itemproperty?view=powershell-7.3#-type) and applies to [New-ItemProperty -PropertyType](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/new-itemproperty?view=powershell-7.3#-propertytype) (aliased `-Type`) as well.

This is largely to be able to reference the fact that all values come from [`RegistryValueKind` Enum](https://learn.microsoft.com/en-us/dotnet/api/microsoft.win32.registryvaluekind?view=net-7.0)

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

