### PR TITLE
(GH-9870) Add note for hidden files/folders to `Compress-Archive`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/5.1/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Archive-help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Archive
-ms.date: 12/09/2022
+ms.date: 03/03/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.archive/compress-archive?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Compress-Archive
@@ -67,6 +67,12 @@ the compression algorithm specified by the **CompressionLevel** parameter.
 The `Compress-Archive` cmdlet uses the Microsoft .NET API
 [System.IO.Compression.ZipArchive](/dotnet/api/system.io.compression.ziparchive) to compress files.
 The maximum file size is 2 GB because there's a limitation of the underlying API.
+
+> [!NOTE]
+> The `Compress-Archive` cmdlet ignores hidden files and folders when creating or updating the
+> archive file.
+>
+> To ensure hidden files and folders are compressed into the archive, use the .NET API instead.
 
 Some examples use splatting to reduce the line length of the code samples. For more information, see
 [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).

--- a/reference/7.2/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/7.2/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -71,7 +71,7 @@ The maximum file size is 2 GB because there's a limitation of the underlying API
 > [!NOTE]
 > The `Compress-Archive` cmdlet ignores hidden files and folders when creating or updating the
 > archive file. On non-Windows machines, this includes files and folders with name that begins with
-> the `.` character.
+> the period (`.`) character.
 >
 > To ensure hidden files and folders are compressed into the archive, use the .NET API instead.
 

--- a/reference/7.2/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/7.2/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Archive-help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Archive
-ms.date: 12/09/2022
+ms.date: 03/03/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.archive/compress-archive?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Compress-Archive
@@ -67,6 +67,13 @@ the compression algorithm specified by the **CompressionLevel** parameter.
 The `Compress-Archive` cmdlet uses the Microsoft .NET API
 [System.IO.Compression.ZipArchive](/dotnet/api/system.io.compression.ziparchive) to compress files.
 The maximum file size is 2 GB because there's a limitation of the underlying API.
+
+> [!NOTE]
+> The `Compress-Archive` cmdlet ignores hidden files and folders when creating or updating the
+> archive file. On non-Windows machines, this includes files and folders with name that begins with
+> the `.` character.
+>
+> To ensure hidden files and folders are compressed into the archive, use the .NET API instead.
 
 Some examples use splatting to reduce the line length of the code samples. For more information, see
 [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).

--- a/reference/7.3/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/7.3/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Archive-help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Archive
-ms.date: 12/09/2022
+ms.date: 03/03/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.archive/compress-archive?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Compress-Archive
@@ -67,6 +67,13 @@ the compression algorithm specified by the **CompressionLevel** parameter.
 The `Compress-Archive` cmdlet uses the Microsoft .NET API
 [System.IO.Compression.ZipArchive](/dotnet/api/system.io.compression.ziparchive) to compress files.
 The maximum file size is 2 GB because there's a limitation of the underlying API.
+
+> [!NOTE]
+> The `Compress-Archive` cmdlet ignores hidden files and folders when creating or updating the
+> archive file. On non-Windows machines, this includes files and folders with name that begins with
+> the `.` character.
+>
+> To ensure hidden files and folders are compressed into the archive, use the .NET API instead.
 
 Some examples use splatting to reduce the line length of the code samples. For more information, see
 [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).

--- a/reference/7.3/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/7.3/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -71,7 +71,7 @@ The maximum file size is 2 GB because there's a limitation of the underlying API
 > [!NOTE]
 > The `Compress-Archive` cmdlet ignores hidden files and folders when creating or updating the
 > archive file. On non-Windows machines, this includes files and folders with name that begins with
-> the `.` character.
+> the period (`.`) character.
 >
 > To ensure hidden files and folders are compressed into the archive, use the .NET API instead.
 

--- a/reference/7.4/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/7.4/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -71,7 +71,7 @@ The maximum file size is 2 GB because there's a limitation of the underlying API
 > [!NOTE]
 > The `Compress-Archive` cmdlet ignores hidden files and folders when creating or updating the
 > archive file. On non-Windows machines, this includes files and folders with name that begins with
-> the `.` character.
+> the period (`.`) character.
 >
 > To ensure hidden files and folders are compressed into the archive, use the .NET API instead.
 

--- a/reference/7.4/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/7.4/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Archive-help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Archive
-ms.date: 12/09/2022
+ms.date: 03/03/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.archive/compress-archive?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Compress-Archive
@@ -67,6 +67,13 @@ the compression algorithm specified by the **CompressionLevel** parameter.
 The `Compress-Archive` cmdlet uses the Microsoft .NET API
 [System.IO.Compression.ZipArchive](/dotnet/api/system.io.compression.ziparchive) to compress files.
 The maximum file size is 2 GB because there's a limitation of the underlying API.
+
+> [!NOTE]
+> The `Compress-Archive` cmdlet ignores hidden files and folders when creating or updating the
+> archive file. On non-Windows machines, this includes files and folders with name that begins with
+> the `.` character.
+>
+> To ensure hidden files and folders are compressed into the archive, use the .NET API instead.
 
 Some examples use splatting to reduce the line length of the code samples. For more information, see
 [about_Splatting](../Microsoft.PowerShell.Core/About/about_Splatting.md).


### PR DESCRIPTION


# PR Summary

Prior to this change, the documentation did not note that the `Compress-Archive` cmdlet ignores hidden files and folders.

This change:

- adds a note explaining the behavior and offering workaround guidance.
- Resolves #9870
- Fixes [AB#67512](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/67512)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
