### PR TITLE
(AB-69106) Update docs for `$?`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 03/02/2023
+ms.date: 03/07/2023
 no-loc: [Reset, Current, Background, Blink, Bold, Foreground, Formatting, Hidden, Italic, Reset, Reverse, Underline]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -45,11 +45,23 @@ executed, but won't set `$?` to **False** for a function calling it:
 function Test-WriteError
 {
     Write-Error "Bad"
-    $? # $false
+    "The `$? variable is: $?"
 }
 
 Test-WriteError
-$? # $true
+"Now the `$? variable is: $?"
+```
+
+```Output
+Test-WriteError : Bad
+At line:7 char:1
++ Test-WriteError
++ ~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
+    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Test-WriteError
+
+The $? variable is: False
+Now the $? variable is: True
 ```
 
 For the latter purpose, `$PSCmdlet.WriteError()` should be used instead.

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 03/02/2023
+ms.date: 03/07/2023
 no-loc: [Reset, Current, Background, Blink, Bold, Foreground, Formatting, Hidden, Italic, Reset, Reverse, Underline]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -45,11 +45,21 @@ executed, but won't set `$?` to **False** for a function calling it:
 function Test-WriteError
 {
     Write-Error "Bad"
-    $? # $false
+    "The `$? variable is: $?"
 }
 
 Test-WriteError
-$? # $true
+"Now the `$? variable is: $?"
+```
+
+```Output
+Test-WriteError: 
+Line |
+   7 |  Test-WriteError
+     |  ~~~~~~~~~~~~~~~
+     | Bad
+The $? variable is: False
+Now the $? variable is: True
 ```
 
 For the latter purpose, `$PSCmdlet.WriteError()` should be used instead.

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 03/02/2023
+ms.date: 03/07/2023
 no-loc: [Reset, Current, Background, Blink, Bold, Foreground, Formatting, Hidden, Italic, Reset, Reverse, Underline]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -45,11 +45,21 @@ executed, but won't set `$?` to **False** for a function calling it:
 function Test-WriteError
 {
     Write-Error "Bad"
-    $? # $false
+    "The `$? variable is: $?"
 }
 
 Test-WriteError
-$? # $true
+"Now the `$? variable is: $?"
+```
+
+```Output
+Test-WriteError: 
+Line |
+   7 |  Test-WriteError
+     |  ~~~~~~~~~~~~~~~
+     | Bad
+The $? variable is: False
+Now the $? variable is: True
 ```
 
 For the latter purpose, `$PSCmdlet.WriteError()` should be used instead.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 Locale: en-US
-ms.date: 03/02/2023
+ms.date: 03/07/2023
 no-loc: [Reset, Current, Background, Blink, Bold, Foreground, Formatting, Hidden, Italic, Reset, Reverse, Underline]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -45,11 +45,21 @@ executed, but won't set `$?` to **False** for a function calling it:
 function Test-WriteError
 {
     Write-Error "Bad"
-    $? # $false
+    "The `$? variable is: $?"
 }
 
 Test-WriteError
-$? # $true
+"Now the `$? variable is: $?"
+```
+
+```Output
+Test-WriteError: 
+Line |
+   7 |  Test-WriteError
+     |  ~~~~~~~~~~~~~~~
+     | Bad
+The $? variable is: False
+Now the $? variable is: True
 ```
 
 For the latter purpose, `$PSCmdlet.WriteError()` should be used instead.


### PR DESCRIPTION


# PR Summary

This change updates the example for the `$?` to clarify when the value is set and impacted.

- Resolves #9877
- Fixes [AB#69106](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/69106)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
