### PR TITLE
Remove the extra single quotes in New-Service example command

### DIFF
--- a/reference/7.3/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/New-Service.md
@@ -36,7 +36,7 @@ dependencies of the service.
 ### Example 1: Create a service
 
 ```powershell
-New-Service -Name "TestService" -BinaryPathName '"C:\WINDOWS\System32\svchost.exe -k netsvcs"'
+New-Service -Name "TestService" -BinaryPathName "C:\WINDOWS\System32\svchost.exe -k netsvcs"
 ```
 
 This command creates a service named TestService.
@@ -46,7 +46,7 @@ This command creates a service named TestService.
 ```powershell
 $params = @{
   Name = "TestService"
-  BinaryPathName = '"C:\WINDOWS\System32\svchost.exe -k netsvcs"'
+  BinaryPathName = "C:\WINDOWS\System32\svchost.exe -k netsvcs"
   DependsOn = "NetLogon"
   DisplayName = "Test Service"
   StartupType = "Manual"
@@ -83,7 +83,7 @@ This example adds the **SecurityDescriptor** of the service being created.
 ```powershell
 $SDDL = "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;SU)"
 $params = @{
-  BinaryPathName = '"C:\WINDOWS\System32\svchost.exe -k netsvcs"'
+  BinaryPathName = "C:\WINDOWS\System32\svchost.exe -k netsvcs"
   DependsOn = "NetLogon"
   DisplayName = "Test Service"
   StartupType = "Manual"


### PR DESCRIPTION
# PR Summary

Remove the extra single quotes in New-Service example command. An extra pair of quotes will cause the service to fail to start.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
