### PR TITLE
(GH-9887) Document `Ansi` value for Encoding parameter

### DIFF
--- a/reference/7.4/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Add-Content.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/12/2022
+ms.date: 03/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/add-content?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Add-Content
@@ -220,6 +220,8 @@ parameter works only in file system drives.
 The acceptable values for this parameter are as follows:
 
 - `ascii`: Uses the encoding for the ASCII (7-bit) character set.
+- `ansi`: Uses the encoding for the for the current culture's ANSI code page. This option was added
+  in PowerShell 7.4.
 - `bigendianunicode`: Encodes in UTF-16 format using the big-endian byte order.
 - `bigendianutf32`: Encodes in UTF-32 format using the big-endian byte order.
 - `oem`: Uses the default encoding for MS-DOS and console programs.
@@ -234,6 +236,9 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+Starting with PowerShell 7.4, you can use the `Ansi` value for the **Encoding** parameter to pass
+the numeric ID for the current culture's ANSI code page without having to specify it manually.
 
 > [!NOTE]
 > **UTF-7*** is no longer recommended to use. As of PowerShell 7.1, a warning is written if you

--- a/reference/7.4/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Get-Content.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/12/2022
+ms.date: 03/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-content?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Content
@@ -351,6 +351,8 @@ Specifies the type of encoding for the target file. The default value is `utf8No
 The acceptable values for this parameter are as follows:
 
 - `ascii`: Uses the encoding for the ASCII (7-bit) character set.
+- `ansi`: Uses the encoding for the for the current culture's ANSI code page. This option was added
+  in PowerShell 7.4.
 - `bigendianunicode`: Encodes in UTF-16 format using the big-endian byte order.
 - `bigendianutf32`: Encodes in UTF-32 format using the big-endian byte order.
 - `oem`: Uses the default encoding for MS-DOS and console programs.
@@ -374,6 +376,9 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+Starting with PowerShell 7.4, you can use the `Ansi` value for the **Encoding** parameter to pass
+the numeric ID for the current culture's ANSI code page without having to specify it manually.
 
 > [!NOTE]
 > **UTF-7*** is no longer recommended to use. As of PowerShell 7.1, a warning is written if you

--- a/reference/7.4/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Set-Content.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 02/16/2023
+ms.date: 03/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/set-content?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-Content
@@ -218,6 +218,8 @@ works only in file system drives.
 The acceptable values for this parameter are as follows:
 
 - `ascii`: Uses the encoding for the ASCII (7-bit) character set.
+- `ansi`: Uses the encoding for the for the current culture's ANSI code page. This option was added
+  in PowerShell 7.4.
 - `bigendianunicode`: Encodes in UTF-16 format using the big-endian byte order.
 - `bigendianutf32`: Encodes in UTF-32 format using the big-endian byte order.
 - `oem`: Uses the default encoding for MS-DOS and console programs.
@@ -232,6 +234,9 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+Starting with PowerShell 7.4, you can use the `Ansi` value for the **Encoding** parameter to pass
+the numeric ID for the current culture's ANSI code page without having to specify it manually.
 
 > [!NOTE]
 > **UTF-7*** is no longer recommended to use. As of PowerShell 7.1, a warning is written if you

--- a/reference/7.4/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 03/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/export-clixml?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Export-Clixml
@@ -177,6 +177,7 @@ Specifies the type of encoding for the target file. The default value is `utf8No
 The acceptable values for this parameter are as follows:
 
 - `ascii`: Uses the encoding for the ASCII (7-bit) character set.
+- `ansi`: Uses the encoding for the for the current culture's ANSI code page. This option was added
 - `bigendianunicode`: Encodes in UTF-16 format using the big-endian byte order.
 - `bigendianutf32`: Encodes in UTF-32 format using the big-endian byte order.
 - `oem`: Uses the default encoding for MS-DOS and console programs.
@@ -191,6 +192,9 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+Starting with PowerShell 7.4, you can use the `Ansi` value for the **Encoding** parameter to pass
+the numeric ID for the current culture's ANSI code page without having to specify it manually.
 
 > [!NOTE]
 > **UTF-7*** is no longer recommended to use. As of PowerShell 7.1, a warning is written if you

--- a/reference/7.4/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 03/14/2023
+ms.date: 03/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/export-csv?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Export-Csv
@@ -476,6 +476,7 @@ Specifies the encoding for the exported CSV file. The default value is `utf8NoBO
 The acceptable values for this parameter are as follows:
 
 - `ascii`: Uses the encoding for the ASCII (7-bit) character set.
+- `ansi`: Uses the encoding for the for the current culture's ANSI code page. This option was added
 - `bigendianunicode`: Encodes in UTF-16 format using the big-endian byte order.
 - `bigendianutf32`: Encodes in UTF-32 format using the big-endian byte order.
 - `oem`: Uses the default encoding for MS-DOS and console programs.
@@ -490,6 +491,9 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+Starting with PowerShell 7.4, you can use the `Ansi` value for the **Encoding** parameter to pass
+the numeric ID for the current culture's ANSI code page without having to specify it manually.
 
 > [!NOTE]
 > **UTF-7*** is no longer recommended to use. As of PowerShell 7.1, a warning is written if you

--- a/reference/7.4/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 03/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/export-pssession?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Export-PSSession
@@ -292,6 +292,8 @@ Specifies the type of encoding for the target file. The default value is `utf8No
 The acceptable values for this parameter are as follows:
 
 - `ascii`: Uses the encoding for the ASCII (7-bit) character set.
+- `ansi`: Uses the encoding for the for the current culture's ANSI code page. This option was added
+  in PowerShell 7.4.
 - `bigendianunicode`: Encodes in UTF-16 format using the big-endian byte order.
 - `bigendianutf32`: Encodes in UTF-32 format using the big-endian byte order.
 - `oem`: Uses the default encoding for MS-DOS and console programs.
@@ -306,6 +308,13 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+Starting with PowerShell 7.4, you can use the `Ansi` value for the **Encoding** parameter to pass
+the numeric ID for the current culture's ANSI code page without having to specify it manually.
+
+> [!NOTE]
+> **UTF-7*** is no longer recommended to use. As of PowerShell 7.1, a warning is written if you
+> specify `utf7` for the **Encoding** parameter.
 
 ```yaml
 Type: System.Text.Encoding

--- a/reference/7.4/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 11/11/2022
+ms.date: 03/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/format-hex?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Format-Hex
@@ -182,6 +182,8 @@ has no effect on numeric types. The output value is always `utf8NoBOM`.
 The acceptable values for this parameter are as follows:
 
 - `ascii`: Uses the encoding for the ASCII (7-bit) character set.
+- `ansi`: Uses the encoding for the for the current culture's ANSI code page. This option was added
+  in PowerShell 7.4.
 - `bigendianunicode`: Encodes in UTF-16 format using the big-endian byte order.
 - `bigendianutf32`: Encodes in UTF-32 format using the big-endian byte order.
 - `oem`: Uses the default encoding for MS-DOS and console programs.
@@ -196,6 +198,9 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+Starting with PowerShell 7.4, you can use the `Ansi` value for the **Encoding** parameter to pass
+the numeric ID for the current culture's ANSI code page without having to specify it manually.
 
 > [!NOTE]
 > **UTF-7*** is no longer recommended to use. As of PowerShell 7.1, a warning is written if you

--- a/reference/7.4/Microsoft.PowerShell.Utility/Import-Csv.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Import-Csv.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 03/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/import-csv?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Import-Csv
@@ -344,6 +344,8 @@ Specifies the encoding for the imported CSV file. The default value is `utf8NoBO
 The acceptable values for this parameter are as follows:
 
 - `ascii`: Uses the encoding for the ASCII (7-bit) character set.
+- `ansi`: Uses the encoding for the for the current culture's ANSI code page. This option was added
+  in PowerShell 7.4.
 - `bigendianunicode`: Encodes in UTF-16 format using the big-endian byte order.
 - `bigendianutf32`: Encodes in UTF-32 format using the big-endian byte order.
 - `oem`: Uses the default encoding for MS-DOS and console programs.
@@ -358,6 +360,9 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+Starting with PowerShell 7.4, you can use the `Ansi` value for the **Encoding** parameter to pass
+the numeric ID for the current culture's ANSI code page without having to specify it manually.
 
 > [!NOTE]
 > **UTF-7*** is no longer recommended to use. As of PowerShell 7.1, a warning is written if you

--- a/reference/7.4/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Out-File.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 03/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/out-file?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Out-File
@@ -191,6 +191,8 @@ Specifies the type of encoding for the target file. The default value is `utf8No
 The acceptable values for this parameter are as follows:
 
 - `ascii`: Uses the encoding for the ASCII (7-bit) character set.
+- `ansi`: Uses the encoding for the for the current culture's ANSI code page. This option was added
+  in PowerShell 7.4.
 - `bigendianunicode`: Encodes in UTF-16 format using the big-endian byte order.
 - `bigendianutf32`: Encodes in UTF-32 format using the big-endian byte order.
 - `oem`: Uses the default encoding for MS-DOS and console programs.
@@ -205,6 +207,9 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+Starting with PowerShell 7.4, you can use the `Ansi` value for the **Encoding** parameter to pass
+the numeric ID for the current culture's ANSI code page without having to specify it manually.
 
 > [!NOTE]
 > **UTF-7*** is no longer recommended to use. As of PowerShell 7.1, a warning is written if you

--- a/reference/7.4/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Select-String.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 03/10/2023
+ms.date: 03/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Select-String
@@ -501,6 +501,8 @@ Specifies the type of encoding for the target file. The default value is `utf8No
 The acceptable values for this parameter are as follows:
 
 - `ascii`: Uses the encoding for the ASCII (7-bit) character set.
+- `ansi`: Uses the encoding for the for the current culture's ANSI code page. This option was added
+  in PowerShell 7.4.
 - `bigendianunicode`: Encodes in UTF-16 format using the big-endian byte order.
 - `bigendianutf32`: Encodes in UTF-32 format using the big-endian byte order.
 - `oem`: Uses the default encoding for MS-DOS and console programs.
@@ -515,6 +517,9 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+Starting with PowerShell 7.4, you can use the `Ansi` value for the **Encoding** parameter to pass
+the numeric ID for the current culture's ANSI code page without having to specify it manually.
 
 > [!NOTE]
 > **UTF-7*** is no longer recommended to use. As of PowerShell 7.1, a warning is written if you

--- a/reference/7.4/Microsoft.PowerShell.Utility/Send-MailMessage.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Send-MailMessage.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 03/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/send-mailmessage?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Send-MailMessage
@@ -247,6 +247,8 @@ Specifies the type of encoding for the target file. The default value is `utf8No
 The acceptable values for this parameter are as follows:
 
 - `ascii`: Uses the encoding for the ASCII (7-bit) character set.
+- `ansi`: Uses the encoding for the for the current culture's ANSI code page. This option was added
+  in PowerShell 7.4.
 - `bigendianunicode`: Encodes in UTF-16 format using the big-endian byte order.
 - `bigendianutf32`: Encodes in UTF-32 format using the big-endian byte order.
 - `oem`: Uses the default encoding for MS-DOS and console programs.
@@ -261,6 +263,13 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+Starting with PowerShell 7.4, you can use the `Ansi` value for the **Encoding** parameter to pass
+the numeric ID for the current culture's ANSI code page without having to specify it manually.
+
+> [!NOTE]
+> **UTF-7*** is no longer recommended to use. As of PowerShell 7.1, a warning is written if you
+> specify `utf7` for the **Encoding** parameter.
 
 ```yaml
 Type: System.Text.Encoding

--- a/reference/7.4/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 03/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/tee-object?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Tee-Object
@@ -125,6 +125,8 @@ Specifies the type of encoding for the target file. The default value is `utf8No
 The acceptable values for this parameter are as follows:
 
 - `ascii`: Uses the encoding for the ASCII (7-bit) character set.
+- `ansi`: Uses the encoding for the for the current culture's ANSI code page. This option was added
+  in PowerShell 7.4.
 - `bigendianunicode`: Encodes in UTF-16 format using the big-endian byte order.
 - `oem`: Uses the default encoding for MS-DOS and console programs.
 - `unicode`: Encodes in UTF-16 format using the little-endian byte order.
@@ -138,6 +140,9 @@ Beginning with PowerShell 6.2, the **Encoding** parameter also allows numeric ID
 pages (like `-Encoding 1251`) or string names of registered code pages (like
 `-Encoding "windows-1251"`). For more information, see the .NET documentation for
 [Encoding.CodePage](/dotnet/api/system.text.encoding.codepage?view=netcore-2.2).
+
+Starting with PowerShell 7.4, you can use the `Ansi` value for the **Encoding** parameter to pass
+the numeric ID for the current culture's ANSI code page without having to specify it manually.
 
 This parameter was introduced in PowerShell 7.2.
 


### PR DESCRIPTION


# PR Summary

This change updates the documentation for the **Encoding** paramter to clarify support for using the `Ansi` value.

- Fixes [AB#70385](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/70385)
- Resolves #9887

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
