### PR TITLE
about_Automatic_Variables.md — delete a misleading typo

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -270,8 +270,7 @@ invoked, such as the name of the script that called the current command.
 
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
-object that `$MyInvocation` returns in the current script, such as the path and
-filename of the script (`$MyInvocation.MyCommand.Path`) or the name of a
+object that `$MyInvocation` returns in the current script, such as the name of a
 function (`$MyInvocation.MyCommand.Name`) to identify the current command. This
 is useful for finding the name of the current script.
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -301,8 +301,7 @@ invoked, such as the name of the script that called the current command.
 
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
-object that `$MyInvocation` returns in the current script, such as the path and
-filename of the script (`$MyInvocation.MyCommand.Path`) or the name of a
+object that `$MyInvocation` returns in the current script, such as the name of a
 function (`$MyInvocation.MyCommand.Name`) to identify the current command. This
 is useful for finding the name of the current script.
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -301,8 +301,7 @@ invoked, such as the name of the script that called the current command.
 
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
-object that `$MyInvocation` returns in the current script, such as the path and
-filename of the script (`$MyInvocation.MyCommand.Path`) or the name of a
+object that `$MyInvocation` returns in the current script, such as the name of a
 function (`$MyInvocation.MyCommand.Name`) to identify the current command. This
 is useful for finding the name of the current script.
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -301,8 +301,7 @@ invoked, such as the name of the script that called the current command.
 
 `$MyInvocation` is populated only for scripts, function, and script blocks. You
 can use the information in the **System.Management.Automation.InvocationInfo**
-object that `$MyInvocation` returns in the current script, such as the path and
-filename of the script (`$MyInvocation.MyCommand.Path`) or the name of a
+object that `$MyInvocation` returns in the current script, such as the name of a
 function (`$MyInvocation.MyCommand.Name`) to identify the current command. This
 is useful for finding the name of the current script.
 


### PR DESCRIPTION
# PR Summary

This PR deletes a bad example from the documentation page. There is no `$MyInvocation.MyCommand.Path`. ([PowerShell SDK doesn't mention it either](https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.commandinfo?view=powershellsdk-1.1.0).) Hence, this PR removes the erroneous mention of `$MyInvocation.MyCommand.Path` from `about_Automatic_Variables.md`.

## PR Checklist

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
    - Checked only in the area that I changed.
- [X] **Style:** This PR adheres to the [style guide][style].
    - At least my changes do.

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
