### PR TITLE
Use a HashTable to lookup values or objects (added performance consideration section)

### DIFF
--- a/reference/docs-conceptual/dev-cross-plat/performance/script-authoring-considerations.md
+++ b/reference/docs-conceptual/dev-cross-plat/performance/script-authoring-considerations.md
@@ -207,13 +207,13 @@ finally
 ### Looking up entries by property in large collections
 
 It's common to need to use a shared property to identify the same record in different collections,
-like a user name from to retrieve an ID from one list and an email from another. Iterating over the
+like using a name to retrieve an ID from one list and an email from another. Iterating over the
 first list to find the matching record in the second collection is slow. In particular, the
 repeated filtering of the second collection has a large overhead.
 
-Given two collections, one with an **ID** and **Name**, the other with **Name** and **Email:
+Given two collections, one with an **ID** and **Name**, the other with **Name** and **Email**:
 
-```PowerShell
+```powershell
 $Employees = 1..10000 | ForEach-Object {
     [PSCustomObject]@{
         Id   = $_
@@ -232,7 +232,7 @@ $Accounts = 2500..7500 | ForEach-Object {
 The usual way to reconcile these collections to return a list of objects with the **ID**, **Name**,
 and **Email** properties might look like this:
 
-```PowerShell
+```powershell
 $Results = $Employees | ForEach-Object -Process {
     $Employee = $_
 


### PR DESCRIPTION
# PR Summary
The "Use a HashTable to lookup values or objects" section that I have added to the [PowerShell scripting performance considerations](https://learn.microsoft.com/powershell/scripting/dev-cross-plat/performance/script-authoring-considerations) document shows and explains the impact of using a hashtable to quickly lookup values or objects.

- Fixes #9899

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
