### PR TITLE
Fix typo: `$MyInvocation.PSCommandPath` instead of `$MyInvocation.MyCommand.Path`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -9,6 +9,7 @@ title: about Command Precedence
 # about_Command_Precedence
 
 ## Short description
+
 Describes how PowerShell determines which command to run.
 
 ## Long description
@@ -51,7 +52,7 @@ For example, to run the FindDocs.ps1 file in the current directory, type:
 ### Using wildcards in execution
 
 You may use wildcards in command execution. Using wildcard characters is
-also known as *globbing*.
+also known as _globbing_.
 
 PowerShell executes a file that has a wildcard match, before a literal match.
 
@@ -70,7 +71,7 @@ Mode                LastWriteTime         Length Name
 -a----        5/20/2019   2:29 PM             28 [a1].ps1
 ```
 
-Both script files have the same content: `$MyInvocation.MyCommand.Path`.
+Both script files have the same content: `$MyInvocation.PSCommandPath`.
 This command displays the name of the script that is invoked.
 
 When you run `[a1].ps1`, the file `a.ps1` is executed even though the file
@@ -111,9 +112,9 @@ If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands for all items loaded in the current session:
 
 1. Alias
-2. Function
-3. Cmdlet
-4. External executable files (programs and non-PowerShell scripts)
+1. Function
+1. Cmdlet
+1. External executable files (programs and non-PowerShell scripts)
 
 Therefore, if you type "help", PowerShell first looks for an alias named
 `help`, then a function named `Help`, and finally a cmdlet named `Help`. It

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -9,6 +9,7 @@ title: about Debuggers
 # about_Debuggers
 
 ## Short description
+
 Describes the PowerShell debugger.
 
 ## Long description
@@ -161,7 +162,7 @@ In the example in this topic, the value of the `$MyInvocation` variable is
 reassigned as follows:
 
 ```powershell
-$scriptname = $MyInvocation.MyCommand.Path
+$scriptname = $MyInvocation.PSCommandPath
 ```
 
 ## The Debugger Environment
@@ -494,7 +495,7 @@ function psversion {
   }
 }
 
-$scriptName = $MyInvocation.MyCommand.Path
+$scriptName = $MyInvocation.PSCommandPath
 psversion
 "Done $scriptName."
 ```
@@ -559,7 +560,7 @@ and file name of the script file.
 
 ```powershell
 DBG> s
-test.ps1:11  $scriptName = $MyInvocation.MyCommand.Path
+test.ps1:11  $scriptName = $MyInvocation.PSCommandPath
 ```
 
 At this point, the `$scriptName` variable is not populated, but you can verify
@@ -665,7 +666,7 @@ PS C:\ps-test> .\test.ps1
 Hit Variable breakpoint on 'C:\ps-test\test.ps1:$scriptName'
 (Write access)
 
-test.ps1:11  $scriptName = $MyInvocation.MyCommand.Path
+test.ps1:11  $scriptName = $MyInvocation.PSCommandPath
 # DBG>
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -9,6 +9,7 @@ title: about Command Precedence
 # about_Command_Precedence
 
 ## Short description
+
 Describes how PowerShell determines which command to run.
 
 ## Long description
@@ -51,7 +52,7 @@ For example, to run the FindDocs.ps1 file in the current directory, type:
 ### Using wildcards in execution
 
 You may use wildcards in command execution. Using wildcard characters is
-also known as *globbing*.
+also known as _globbing_.
 
 PowerShell executes a file that has a wildcard match, before a literal match.
 
@@ -70,7 +71,7 @@ Mode                LastWriteTime         Length Name
 -a----        5/20/2019   2:29 PM             28 [a1].ps1
 ```
 
-Both script files have the same content: `$MyInvocation.MyCommand.Path`.
+Both script files have the same content: `$MyInvocation.PSCommandPath`.
 This command displays the name of the script that is invoked.
 
 When you run `[a1].ps1`, the file `a.ps1` is executed even though the file
@@ -111,9 +112,9 @@ If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands for all items loaded in the current session:
 
 1. Alias
-2. Function
-3. Cmdlet
-4. External executable files (programs and non-PowerShell scripts)
+1. Function
+1. Cmdlet
+1. External executable files (programs and non-PowerShell scripts)
 
 Therefore, if you type "help", PowerShell first looks for an alias named
 `help`, then a function named `Help`, and finally a cmdlet named `Help`. It

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -9,6 +9,7 @@ title: about Debuggers
 # about_Debuggers
 
 ## Short description
+
 Describes the PowerShell debugger.
 
 ## Long description
@@ -156,7 +157,7 @@ In the example in this topic, the value of the `$MyInvocation` variable is
 reassigned as follows:
 
 ```powershell
-$scriptname = $MyInvocation.MyCommand.Path
+$scriptname = $MyInvocation.PSCommandPath
 ```
 
 ## The Debugger Environment
@@ -381,7 +382,7 @@ function psversion {
   }
 }
 
-$scriptName = $MyInvocation.MyCommand.Path
+$scriptName = $MyInvocation.PSCommandPath
 psversion
 "Done $scriptName."
 ```
@@ -446,7 +447,7 @@ and file name of the script file.
 
 ```powershell
 DBG> s
-test.ps1:11  $scriptName = $MyInvocation.MyCommand.Path
+test.ps1:11  $scriptName = $MyInvocation.PSCommandPath
 ```
 
 At this point, the `$scriptName` variable is not populated, but you can verify
@@ -552,7 +553,7 @@ PS C:\ps-test> .\test.ps1
 Hit Variable breakpoint on 'C:\ps-test\test.ps1:$scriptName'
 (Write access)
 
-test.ps1:11  $scriptName = $MyInvocation.MyCommand.Path
+test.ps1:11  $scriptName = $MyInvocation.PSCommandPath
 # DBG>
 ```
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -9,6 +9,7 @@ title: about Command Precedence
 # about_Command_Precedence
 
 ## Short description
+
 Describes how PowerShell determines which command to run.
 
 ## Long description
@@ -51,7 +52,7 @@ For example, to run the FindDocs.ps1 file in the current directory, type:
 ### Using wildcards in execution
 
 You may use wildcards in command execution. Using wildcard characters is
-also known as *globbing*.
+also known as _globbing_.
 
 PowerShell executes a file that has a wildcard match, before a literal match.
 
@@ -70,7 +71,7 @@ Mode                LastWriteTime         Length Name
 -a----        5/20/2019   2:29 PM             28 [a1].ps1
 ```
 
-Both script files have the same content: `$MyInvocation.MyCommand.Path`.
+Both script files have the same content: `$MyInvocation.PSCommandPath`.
 This command displays the name of the script that is invoked.
 
 When you run `[a1].ps1`, the file `a.ps1` is executed even though the file
@@ -111,9 +112,9 @@ If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands for all items loaded in the current session:
 
 1. Alias
-2. Function
-3. Cmdlet
-4. External executable files (programs and non-PowerShell scripts)
+1. Function
+1. Cmdlet
+1. External executable files (programs and non-PowerShell scripts)
 
 Therefore, if you type "help", PowerShell first looks for an alias named
 `help`, then a function named `Help`, and finally a cmdlet named `Help`. It

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -9,6 +9,7 @@ title: about Debuggers
 # about_Debuggers
 
 ## Short description
+
 Describes the PowerShell debugger.
 
 ## Long description
@@ -156,7 +157,7 @@ In the example in this topic, the value of the `$MyInvocation` variable is
 reassigned as follows:
 
 ```powershell
-$scriptname = $MyInvocation.MyCommand.Path
+$scriptname = $MyInvocation.PSCommandPath
 ```
 
 ## The Debugger Environment
@@ -381,7 +382,7 @@ function psversion {
   }
 }
 
-$scriptName = $MyInvocation.MyCommand.Path
+$scriptName = $MyInvocation.PSCommandPath
 psversion
 "Done $scriptName."
 ```
@@ -446,7 +447,7 @@ and file name of the script file.
 
 ```powershell
 DBG> s
-test.ps1:11  $scriptName = $MyInvocation.MyCommand.Path
+test.ps1:11  $scriptName = $MyInvocation.PSCommandPath
 ```
 
 At this point, the `$scriptName` variable is not populated, but you can verify
@@ -552,7 +553,7 @@ PS C:\ps-test> .\test.ps1
 Hit Variable breakpoint on 'C:\ps-test\test.ps1:$scriptName'
 (Write access)
 
-test.ps1:11  $scriptName = $MyInvocation.MyCommand.Path
+test.ps1:11  $scriptName = $MyInvocation.PSCommandPath
 # DBG>
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -9,6 +9,7 @@ title: about Command Precedence
 # about_Command_Precedence
 
 ## Short description
+
 Describes how PowerShell determines which command to run.
 
 ## Long description
@@ -51,7 +52,7 @@ For example, to run the FindDocs.ps1 file in the current directory, type:
 ### Using wildcards in execution
 
 You may use wildcards in command execution. Using wildcard characters is
-also known as *globbing*.
+also known as _globbing_.
 
 PowerShell executes a file that has a wildcard match, before a literal match.
 
@@ -70,7 +71,7 @@ Mode                LastWriteTime         Length Name
 -a----        5/20/2019   2:29 PM             28 [a1].ps1
 ```
 
-Both script files have the same content: `$MyInvocation.MyCommand.Path`.
+Both script files have the same content: `$MyInvocation.PSCommandPath`.
 This command displays the name of the script that is invoked.
 
 When you run `[a1].ps1`, the file `a.ps1` is executed even though the file
@@ -111,9 +112,9 @@ If you do not specify a path, PowerShell uses the following precedence order
 when it runs commands for all items loaded in the current session:
 
 1. Alias
-2. Function
-3. Cmdlet
-4. External executable files (programs and non-PowerShell scripts)
+1. Function
+1. Cmdlet
+1. External executable files (programs and non-PowerShell scripts)
 
 Therefore, if you type "help", PowerShell first looks for an alias named
 `help`, then a function named `Help`, and finally a cmdlet named `Help`. It

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -9,6 +9,7 @@ title: about Debuggers
 # about_Debuggers
 
 ## Short description
+
 Describes the PowerShell debugger.
 
 ## Long description
@@ -156,7 +157,7 @@ In the example in this topic, the value of the `$MyInvocation` variable is
 reassigned as follows:
 
 ```powershell
-$scriptname = $MyInvocation.MyCommand.Path
+$scriptname = $MyInvocation.PSCommandPath
 ```
 
 ## The Debugger Environment
@@ -381,7 +382,7 @@ function psversion {
   }
 }
 
-$scriptName = $MyInvocation.MyCommand.Path
+$scriptName = $MyInvocation.PSCommandPath
 psversion
 "Done $scriptName."
 ```
@@ -446,7 +447,7 @@ and file name of the script file.
 
 ```powershell
 DBG> s
-test.ps1:11  $scriptName = $MyInvocation.MyCommand.Path
+test.ps1:11  $scriptName = $MyInvocation.PSCommandPath
 ```
 
 At this point, the `$scriptName` variable is not populated, but you can verify
@@ -552,7 +553,7 @@ PS C:\ps-test> .\test.ps1
 Hit Variable breakpoint on 'C:\ps-test\test.ps1:$scriptName'
 (Write access)
 
-test.ps1:11  $scriptName = $MyInvocation.MyCommand.Path
+test.ps1:11  $scriptName = $MyInvocation.PSCommandPath
 # DBG>
 ```
 

--- a/reference/docs-conceptual/windows-powershell/ise/How-to-Debug-Scripts-in-Windows-PowerShell-ISE.md
+++ b/reference/docs-conceptual/windows-powershell/ise/How-to-Debug-Scripts-in-Windows-PowerShell-ISE.md
@@ -251,7 +251,7 @@ display its value.
 
 ```powershell
 # In C:\ps-test\MyScript.ps1
-$scriptName = $MyInvocation.MyCommand.Path
+$scriptName = $MyInvocation.PSCommandPath
 ```
 
 ```PowerShell


### PR DESCRIPTION
# PR Summary

**Primary change:** This PR fixes a prevalent typo in the entire repo. It replaces `$MyInvocation.MyCommand.Path` (a typo) with `$MyInvocation.PSCommandPath` (correct.)

To eliminate all doubt, I've checked the following sources:

- PowerShell object browser running in VSCode debugger.
- [PowerShell SDK documentations for the `CommandInfo` class](https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.commandinfo?view=powershellsdk-1.1.0) (`MyCommand` is an object of `CommandInfo` type.)
- [Source code of the `CommandInfo` class](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/CommandInfo.cs#L92-L747)

Now I have to fix this repo on the rest of the Internet... 😔 This typo is quite prevalent.

**Secondary changes:** In compliance with the fourth checkbox below, the Microsoft Learn Authoring Pack extension set performed many style changes while politely pretending that I had a say in accepting them. 😉

## PR Checklist

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
