### PR TITLE
(MAINT) Add Vale config to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ updatablehelp/
 xhtml/
 **/settings.json
 StaleContentReport.*.csv
+.vscode/styles
+.vale/

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,10 @@
+StylesPath    = .vscode/styles
+Packages      = https://microsoft.github.io/Documentarian/packages/vale/PowerShell-Docs.zip
+MinAlertLevel = suggestion
+
+[*]
+BasedOnStyles = PowerShell-Docs
+Vale.Spelling = NO              # We use cspell
+
+[*.md]
+BasedOnStyles = PowerShell-Docs


### PR DESCRIPTION
# PR Summary

Prior to this change, using Vale to lint the docs required knowledge of the tool and where to retrieve the configuration and rules.

This change adds a new `.vale.ini` file to the repository root and configures it to use our own published prose style package.

It also ensures the `.vale` and `.vscode/styles` folders are ignored by git for contributors who use `Install-WorkspaceVale` and sync the style packages respectively.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
