### PR TITLE
(GH-9948) Fix AddToHistoryHandler in `Set-PSReadLineOption`

### DIFF
--- a/reference/5.1/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/5.1/PSReadLine/Set-PSReadLineOption.md
@@ -149,9 +149,9 @@ Specifies a **ScriptBlock** that controls which commands get added to **PSReadLi
 
 The **ScriptBlock** receives the command line as input.
 
-The output of the **ScripBlock** may be a member of the **AddToHistoryOption** enum, the string
-name of one of those members, or a boolean value. The list below describes the possible values and
-their effect.
+The  **ScripBlock** should return a member of the **AddToHistoryOption** enum, the string name of
+one of those members, or a boolean value. The list below describes the possible values and their
+effects.
 
 - `MemoryAndFile` - Add the command to the history file and the current session.
 - `MemoryOnly` - Add the command to history for the current session only.

--- a/reference/5.1/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/5.1/PSReadLine/Set-PSReadLineOption.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadline
-ms.date: 12/13/2022
+ms.date: 03/24/2023
 online version: https://learn.microsoft.com/powershell/module/psreadline/set-psreadlineoption?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineOption
@@ -147,8 +147,17 @@ For more information, see
 
 Specifies a **ScriptBlock** that controls which commands get added to **PSReadLine** history.
 
-The **ScriptBlock** receives the command line as input. If the **ScriptBlock** returns `$True`, the
-command line is added to the history.
+The **ScriptBlock** receives the command line as input.
+
+The output of the **ScripBlock** may be a member of the **AddToHistoryOption** enum, the string
+name of one of those members, or a boolean value. The list below describes the possible values and
+their effect.
+
+- `MemoryAndFile` - Add the command to the history file and the current session.
+- `MemoryOnly` - Add the command to history for the current session only.
+- `SkipAdding` - Don't add the command to the history file for current session.
+- `$false` - Same as if the value was `SkipAdding`.
+- `$true` - Same as if the value was `MemoryAndFile`.
 
 ```yaml
 Type: System.Func`2[System.String,System.Object]

--- a/reference/7.2/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.2/PSReadLine/Set-PSReadLineOption.md
@@ -150,9 +150,9 @@ Specifies a **ScriptBlock** that controls which commands get added to **PSReadLi
 
 The **ScriptBlock** receives the command line as input.
 
-The output of the **ScripBlock** may be a member of the **AddToHistoryOption** enum, the string
-name of one of those members, or a boolean value. The list below describes the possible values and
-their effect.
+The  **ScripBlock** should return a member of the **AddToHistoryOption** enum, the string name of
+one of those members, or a boolean value. The list below describes the possible values and their
+effects.
 
 - `MemoryAndFile` - Add the command to the history file and the current session.
 - `MemoryOnly` - Add the command to history for the current session only.

--- a/reference/7.2/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.2/PSReadLine/Set-PSReadLineOption.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/13/2022
+ms.date: 03/24/2023
 online version: https://learn.microsoft.com/powershell/module/psreadline/set-psreadlineoption?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineOption
@@ -148,8 +148,17 @@ For more information, see
 
 Specifies a **ScriptBlock** that controls which commands get added to **PSReadLine** history.
 
-The **ScriptBlock** receives the command line as input. If the **ScriptBlock** returns `$True`, the
-command line is added to the history.
+The **ScriptBlock** receives the command line as input.
+
+The output of the **ScripBlock** may be a member of the **AddToHistoryOption** enum, the string
+name of one of those members, or a boolean value. The list below describes the possible values and
+their effect.
+
+- `MemoryAndFile` - Add the command to the history file and the current session.
+- `MemoryOnly` - Add the command to history for the current session only.
+- `SkipAdding` - Don't add the command to the history file for current session.
+- `$false` - Same as if the value was `SkipAdding`.
+- `$true` - Same as if the value was `MemoryAndFile`.
 
 ```yaml
 Type: System.Func`2[System.String,System.Object]

--- a/reference/7.3/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.3/PSReadLine/Set-PSReadLineOption.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/13/2022
+ms.date: 03/24/2023
 online version: https://learn.microsoft.com/powershell/module/psreadline/set-psreadlineoption?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineOption
@@ -148,8 +148,17 @@ For more information, see
 
 Specifies a **ScriptBlock** that controls which commands get added to **PSReadLine** history.
 
-The **ScriptBlock** receives the command line as input. If the **ScriptBlock** returns `$True`, the
-command line is added to the history.
+The **ScriptBlock** receives the command line as input.
+
+The output of the **ScripBlock** may be a member of the **AddToHistoryOption** enum, the string
+name of one of those members, or a boolean value. The list below describes the possible values and
+their effect.
+
+- `MemoryAndFile` - Add the command to the history file and the current session.
+- `MemoryOnly` - Add the command to history for the current session only.
+- `SkipAdding` - Don't add the command to the history file for current session.
+- `$false` - Same as if the value was `SkipAdding`.
+- `$true` - Same as if the value was `MemoryAndFile`.
 
 ```yaml
 Type: System.Func`2[System.String,System.Object]

--- a/reference/7.3/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.3/PSReadLine/Set-PSReadLineOption.md
@@ -150,9 +150,9 @@ Specifies a **ScriptBlock** that controls which commands get added to **PSReadLi
 
 The **ScriptBlock** receives the command line as input.
 
-The output of the **ScripBlock** may be a member of the **AddToHistoryOption** enum, the string
-name of one of those members, or a boolean value. The list below describes the possible values and
-their effect.
+The  **ScripBlock** should return a member of the **AddToHistoryOption** enum, the string name of
+one of those members, or a boolean value. The list below describes the possible values and their
+effects.
 
 - `MemoryAndFile` - Add the command to the history file and the current session.
 - `MemoryOnly` - Add the command to history for the current session only.

--- a/reference/7.4/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.4/PSReadLine/Set-PSReadLineOption.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.PSReadLine2.dll-Help.xml
 Locale: en-US
 Module Name: PSReadLine
-ms.date: 12/13/2022
+ms.date: 03/24/2023
 online version: https://learn.microsoft.com/powershell/module/psreadline/set-psreadlineoption?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-PSReadLineOption
@@ -148,8 +148,17 @@ For more information, see
 
 Specifies a **ScriptBlock** that controls which commands get added to **PSReadLine** history.
 
-The **ScriptBlock** receives the command line as input. If the **ScriptBlock** returns `$True`, the
-command line is added to the history.
+The **ScriptBlock** receives the command line as input.
+
+The output of the **ScripBlock** may be a member of the **AddToHistoryOption** enum, the string
+name of one of those members, or a boolean value. The list below describes the possible values and
+their effect.
+
+- `MemoryAndFile` - Add the command to the history file and the current session.
+- `MemoryOnly` - Add the command to history for the current session only.
+- `SkipAdding` - Don't add the command to the history file for current session.
+- `$false` - Same as if the value was `SkipAdding`.
+- `$true` - Same as if the value was `MemoryAndFile`.
 
 ```yaml
 Type: System.Func`2[System.String,System.Object]

--- a/reference/7.4/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.4/PSReadLine/Set-PSReadLineOption.md
@@ -150,9 +150,9 @@ Specifies a **ScriptBlock** that controls which commands get added to **PSReadLi
 
 The **ScriptBlock** receives the command line as input.
 
-The output of the **ScripBlock** may be a member of the **AddToHistoryOption** enum, the string
-name of one of those members, or a boolean value. The list below describes the possible values and
-their effect.
+The  **ScripBlock** should return a member of the **AddToHistoryOption** enum, the string name of
+one of those members, or a boolean value. The list below describes the possible values and their
+effects.
 
 - `MemoryAndFile` - Add the command to the history file and the current session.
 - `MemoryOnly` - Add the command to history for the current session only.


### PR DESCRIPTION
# PR Summary

This change corrects the documentation for the **AddToHistoryHandler** parameter of the `Set-PSReadLineOption` cmdlet. Prior to this change, the documentation stated that the valid return values were true/false.

The valid return values also include the **AddToHistoryOption** enum and strings matching the names of those enums.

This change corrects the documentation and further explains how each value affects the history.

- Resolves #9948
- Fixes [AB#69559](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/69559)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
