### PR TITLE
Include step to delete file in Ubuntu install instructions

### DIFF
--- a/reference/docs-conceptual/install/install-ubuntu.md
+++ b/reference/docs-conceptual/install/install-ubuntu.md
@@ -40,6 +40,8 @@ sudo apt-get install -y wget apt-transport-https software-properties-common
 wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb"
 # Register the Microsoft repository GPG keys
 sudo dpkg -i packages-microsoft-prod.deb
+# Delete the the Microsoft repository GPG keys file 
+rm packages-microsoft-prod.deb
 # Update the list of packages after we added packages.microsoft.com
 sudo apt-get update
 # Install PowerShell


### PR DESCRIPTION
# PR Summary

Add a step to the installation instructions for Ubuntu to delete the downloaded `.deb` file.

It makes sense to me that as the script provided is otherwise an "all-in-one" that it should include the step to tidy up after itself.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [ ] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
