### PR TITLE
(GH-9982) Clarify equivalence for comparison operators

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 01/20/2023
+ms.date: 04/03/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -60,6 +60,9 @@ case-sensitive operator. To make a comparison operator case-sensitive, add a
 To make the case-insensitivity explicit, add an `i` after `-`. For example,
 `-ieq` is the explicitly case-insensitive version of `-eq`.
 
+String comparisons use the [InvariantCulture][01] for both case-sensitive and
+case-insensitive comparisons.
+
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the
 elements of the collection that match the right-hand value of the expression.
@@ -89,9 +92,9 @@ There are a few exceptions:
 ### -eq and -ne
 
 When the left-hand side is scalar, `-eq` returns **True** if the right-hand
-side is an exact match, otherwise, `-eq` returns **False**. `-ne` does the
-opposite; it returns **False** when both sides match; otherwise, `-ne` returns
-**True**.
+side is equivalent, otherwise, `-eq` returns **False**. `-ne` does the
+opposite; it returns **False** when both sides are equivalent; otherwise, `-ne`
+returns **True**.
 
 Example:
 
@@ -702,6 +705,7 @@ $a -isnot $b.GetType() # Output: True
 - [Where-Object][13]
 
 <!-- link references -->
+[01]: /dotnet/api/system.globalization.cultureinfo.invariantculture
 [02]: /dotnet/api/system.icomparable
 [03]: /dotnet/api/system.iequatable-1
 [04]: /dotnet/api/system.text.regularexpressions.match

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 01/20/2023
+ms.date: 04/03/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -60,6 +60,9 @@ case-sensitive operator. To make a comparison operator case-sensitive, add a
 To make the case-insensitivity explicit, add an `i` after `-`. For example,
 `-ieq` is the explicitly case-insensitive version of `-eq`.
 
+String comparisons use the [InvariantCulture][01] for both case-sensitive and
+case-insensitive comparisons.
+
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the
 elements of the collection that match the right-hand value of the expression.
@@ -89,9 +92,9 @@ There are a few exceptions:
 ### -eq and -ne
 
 When the left-hand side is scalar, `-eq` returns **True** if the right-hand
-side is an exact match, otherwise, `-eq` returns **False**. `-ne` does the
-opposite; it returns **False** when both sides match; otherwise, `-ne` returns
-**True**.
+side is equivalent, otherwise, `-eq` returns **False**. `-ne` does the
+opposite; it returns **False** when both sides are equivalent; otherwise, `-ne`
+returns **True**.
 
 Example:
 
@@ -752,6 +755,7 @@ $a -isnot $b.GetType() # Output: True
 - [Where-Object][13]
 
 <!-- link references -->
+[01]: /dotnet/api/system.globalization.cultureinfo.invariantculture
 [02]: /dotnet/api/system.icomparable
 [03]: /dotnet/api/system.iequatable-1
 [04]: /dotnet/api/system.text.regularexpressions.match

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 01/20/2023
+ms.date: 04/03/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -60,6 +60,9 @@ case-sensitive operator. To make a comparison operator case-sensitive, add a
 To make the case-insensitivity explicit, add an `i` after `-`. For example,
 `-ieq` is the explicitly case-insensitive version of `-eq`.
 
+String comparisons use the [InvariantCulture][01] for both case-sensitive and
+case-insensitive comparisons.
+
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the
 elements of the collection that match the right-hand value of the expression.
@@ -89,9 +92,9 @@ There are a few exceptions:
 ### -eq and -ne
 
 When the left-hand side is scalar, `-eq` returns **True** if the right-hand
-side is an exact match, otherwise, `-eq` returns **False**. `-ne` does the
-opposite; it returns **False** when both sides match; otherwise, `-ne` returns
-**True**.
+side is equivalent, otherwise, `-eq` returns **False**. `-ne` does the
+opposite; it returns **False** when both sides are equivalent; otherwise, `-ne`
+returns **True**.
 
 Example:
 
@@ -752,6 +755,7 @@ $a -isnot $b.GetType() # Output: True
 - [Where-Object][13]
 
 <!-- link references -->
+[01]: /dotnet/api/system.globalization.cultureinfo.invariantculture
 [02]: /dotnet/api/system.icomparable
 [03]: /dotnet/api/system.iequatable-1
 [04]: /dotnet/api/system.text.regularexpressions.match

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 01/20/2023
+ms.date: 04/03/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -60,6 +60,9 @@ case-sensitive operator. To make a comparison operator case-sensitive, add a
 To make the case-insensitivity explicit, add an `i` after `-`. For example,
 `-ieq` is the explicitly case-insensitive version of `-eq`.
 
+String comparisons use the [InvariantCulture][01] for both case-sensitive and
+case-insensitive comparisons.
+
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the
 elements of the collection that match the right-hand value of the expression.
@@ -89,9 +92,9 @@ There are a few exceptions:
 ### -eq and -ne
 
 When the left-hand side is scalar, `-eq` returns **True** if the right-hand
-side is an exact match, otherwise, `-eq` returns **False**. `-ne` does the
-opposite; it returns **False** when both sides match; otherwise, `-ne` returns
-**True**.
+side is equivalent, otherwise, `-eq` returns **False**. `-ne` does the
+opposite; it returns **False** when both sides are equivalent; otherwise, `-ne`
+returns **True**.
 
 Example:
 
@@ -752,6 +755,7 @@ $a -isnot $b.GetType() # Output: True
 - [Where-Object][13]
 
 <!-- link references -->
+[01]: /dotnet/api/system.globalization.cultureinfo.invariantculture
 [02]: /dotnet/api/system.icomparable
 [03]: /dotnet/api/system.iequatable-1
 [04]: /dotnet/api/system.text.regularexpressions.match


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for string comparisons in `about_Comparison_Operators` did not note in the common features section that the comparisons use the `InvariantCulture`. The section for the `eq` and `ne` operator used the phrase `exact match` to describe the comparison, which is inaccurate.

This change:

- Adds a note to the common features about the use of `InvariantCulture`.
- Corrects the description for the equality operators to say that they are equivalent, rather than an exact match.
- Fixes [AB#82412](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/82412)
- Resolves #9982

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
