### PR TITLE
(GH-9987) Clarify return behavior for collections with `-like`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 04/03/2023
+ms.date: 04/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -354,9 +354,14 @@ The syntax is:
 ```
 
 When the input of these operators is a scalar value, they return a **Boolean**
-value. When the input is a collection of values, the operators return any
-matching members. If there are no matches in a collection, the operators return
-an empty array.
+value.
+
+When the input is a collection of values, each item in the collection is
+converted to a string for comparison. The `-match` and `-notmatch` operators
+return any matching and non-matching members respectively. However, the `-like`
+and `-notlike` operators return the members as strings. The string returned for
+a member of the collection by `-like` and `-notlike` is the string the operator
+used for the comparison and is obtained by casting the member to a string.
 
 ### -like and -notlike
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 04/03/2023
+ms.date: 04/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -354,9 +354,14 @@ The syntax is:
 ```
 
 When the input of these operators is a scalar value, they return a **Boolean**
-value. When the input is a collection of values, the operators return any
-matching members. If there are no matches in a collection, the operators return
-an empty array.
+value.
+
+When the input is a collection of values, each item in the collection is
+converted to a string for comparison. The `-match` and `-notmatch` operators
+return any matching and non-matching members respectively. However, the `-like`
+and `-notlike` operators return the members as strings. The string returned for
+a member of the collection by `-like` and `-notlike` is the string the operator
+used for the comparison and is obtained by casting the member to a string.
 
 ### -like and -notlike
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 04/03/2023
+ms.date: 04/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -354,9 +354,14 @@ The syntax is:
 ```
 
 When the input of these operators is a scalar value, they return a **Boolean**
-value. When the input is a collection of values, the operators return any
-matching members. If there are no matches in a collection, the operators return
-an empty array.
+value.
+
+When the input is a collection of values, each item in the collection is
+converted to a string for comparison. The `-match` and `-notmatch` operators
+return any matching and non-matching members respectively. However, the `-like`
+and `-notlike` operators return the members as strings. The string returned for
+a member of the collection by `-like` and `-notlike` is the string the operator
+used for the comparison and is obtained by casting the member to a string.
 
 ### -like and -notlike
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 04/03/2023
+ms.date: 04/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -354,9 +354,14 @@ The syntax is:
 ```
 
 When the input of these operators is a scalar value, they return a **Boolean**
-value. When the input is a collection of values, the operators return any
-matching members. If there are no matches in a collection, the operators return
-an empty array.
+value.
+
+When the input is a collection of values, each item in the collection is
+converted to a string for comparison. The `-match` and `-notmatch` operators
+return any matching and non-matching members respectively. However, the `-like`
+and `-notlike` operators return the members as strings. The string returned for
+a member of the collection by `-like` and `-notlike` is the string the operator
+used for the comparison and is obtained by casting the member to a string.
 
 ### -like and -notlike
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for the `-like` and `-notlike` operator did not cover the (potentially surprising) behavior when called for a collection where the members of the collection are not strings.

In this case, the operators return the matching items from the collection cast to `[string]`, unlike the `-match` and `-notmatch` operators, which return the input object.

This change:

- Clarifies the behavior for these operators
- Resolves #9987
- Fixes [AB#83269](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/83269)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
