### PR TITLE
(GH-9995) Clarify whitespace regex usage

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -1,7 +1,7 @@
 ---
 description: Describes regular expressions in PowerShell.
 Locale: en-US
-ms.date: 08/29/2022
+ms.date: 04/10/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_regular_expressions?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Regular Expressions
@@ -113,13 +113,14 @@ any character except a newline (`\n`).
 
 ### Whitespace
 
-Whitespace is matched using the `\s` character class. Any non-whitespace
-character is matched using `\S`. Literal space characters `' '` can also be
-used.
+You can match any whitespace character with the `\s` character class. You can
+match any non-whitespace character with `\S`. You can match literal space
+characters with ` `.
 
 ```powershell
 # This expression returns true.
-# The pattern uses both methods to match the space.
+# The pattern uses the whitespace character class to match the leading
+# space and a literal space to matching the trailing space.
 ' - ' -match '\s- '
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -1,7 +1,7 @@
 ---
 description: Describes regular expressions in PowerShell.
 Locale: en-US
-ms.date: 08/29/2022
+ms.date: 04/10/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_regular_expressions?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Regular Expressions
@@ -113,13 +113,14 @@ any character except a newline (`\n`).
 
 ### Whitespace
 
-Whitespace is matched using the `\s` character class. Any non-whitespace
-character is matched using `\S`. Literal space characters `' '` can also be
-used.
+You can match any whitespace character with the `\s` character class. You can
+match any non-whitespace character with `\S`. You can match literal space
+characters with ` `.
 
 ```powershell
 # This expression returns true.
-# The pattern uses both methods to match the space.
+# The pattern uses the whitespace character class to match the leading
+# space and a literal space to matching the trailing space.
 ' - ' -match '\s- '
 ```
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -1,7 +1,7 @@
 ---
 description: Describes regular expressions in PowerShell.
 Locale: en-US
-ms.date: 08/29/2022
+ms.date: 04/10/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_regular_expressions?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Regular Expressions
@@ -113,13 +113,14 @@ any character except a newline (`\n`).
 
 ### Whitespace
 
-Whitespace is matched using the `\s` character class. Any non-whitespace
-character is matched using `\S`. Literal space characters `' '` can also be
-used.
+You can match any whitespace character with the `\s` character class. You can
+match any non-whitespace character with `\S`. You can match literal space
+characters with ` `.
 
 ```powershell
 # This expression returns true.
-# The pattern uses both methods to match the space.
+# The pattern uses the whitespace character class to match the leading
+# space and a literal space to matching the trailing space.
 ' - ' -match '\s- '
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -1,7 +1,7 @@
 ---
 description: Describes regular expressions in PowerShell.
 Locale: en-US
-ms.date: 08/29/2022
+ms.date: 04/10/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_regular_expressions?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Regular Expressions
@@ -113,13 +113,14 @@ any character except a newline (`\n`).
 
 ### Whitespace
 
-Whitespace is matched using the `\s` character class. Any non-whitespace
-character is matched using `\S`. Literal space characters `' '` can also be
-used.
+You can match any whitespace character with the `\s` character class. You can
+match any non-whitespace character with `\S`. You can match literal space
+characters with ` `.
 
 ```powershell
 # This expression returns true.
-# The pattern uses both methods to match the space.
+# The pattern uses the whitespace character class to match the leading
+# space and a literal space to matching the trailing space.
 ' - ' -match '\s- '
 ```
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the wording for matching whitespace in the `about_Regular_Expressions` about topic could be ambiguously interpreted.

This change:

- Rewrites the whitespace section for active voice and clarifies that you can match literal space characters with a space in the pattern, not that a literal space is the same as the whitespace character class.
- Resolves #9995
- Fixes AB#84204

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
