### PR TITLE
(GH-9997) Recommend `List<T>` over array addition

### DIFF
--- a/reference/docs-conceptual/dev-cross-plat/performance/script-authoring-considerations.md
+++ b/reference/docs-conceptual/dev-cross-plat/performance/script-authoring-considerations.md
@@ -1,6 +1,6 @@
 ---
 description: Scripting for Performance in PowerShell
-ms.date: 03/21/2023
+ms.date: 04/11/2023
 title: PowerShell scripting performance considerations
 ---
 
@@ -89,23 +89,141 @@ $results += Do-SomethingElse
 $results
 ```
 
-Array addition is inefficient because arrays are immutable. Each addition to the array creates a new
-array big enough to hold all elements of both the left and right operands. The elements of both
-operands are copied into the new array. For small collections, this overhead may not matter.
+Array addition is inefficient because arrays have a fixed size. Each addition to the array creates
+a new array big enough to hold all elements of both the left and right operands. The elements of
+both operands are copied into the new array. For small collections, this overhead may not matter.
 Performance can suffer for large collections.
 
 There are a couple of alternatives. If you don't actually require an array, instead consider using
-an ArrayList:
+a typed generic list (**List\<T\>**):
 
 ```powershell
-$results = [System.Collections.ArrayList]::new()
+$results = [System.Collections.Generic.List[object]]::new()
 $results.AddRange((Do-Something))
 $results.AddRange((Do-SomethingElse))
 $results
 ```
 
-If you do require an array, you can call the `ToArray()` method or you can let PowerShell create the
-array for you:
+The performance impact of using array addition grows exponentially with the size of the collection
+and the number additions. This code compares explicitly assigning values to an array with using
+array addition and using the `Add()` method on a **List\<T\>**. It defines explicit assignment as
+the baseline for performance.
+
+```powershell
+$tests = @{
+    'PowerShell Explicit Assignment' = {
+        param($count)
+
+        $result = foreach($i in 1..$count) {
+            $i
+        }
+    }
+    '.Add(..) to List<T>' = {
+        param($count)
+
+        $result = [Collections.Generic.List[int]]::new()
+        foreach($i in 1..$count) {
+            $result.Add($i)
+        }
+    }
+    '+= Operator to Array' = {
+        param($count)
+
+        $result = @()
+        foreach($i in 1..$count) {
+            $result += $i
+        }
+    }
+}
+
+5000, 10000, 100000 | ForEach-Object {
+    $groupResult = foreach($test in $tests.GetEnumerator()) {
+        $ms = (Measure-Command { & $test.Value -Count $_ }).TotalMilliseconds
+
+        [pscustomobject]@{
+            CollectionSize    = $_
+            Test              = $test.Key
+            TotalMilliseconds = [math]::Round($ms, 2)
+        }
+
+        [GC]::Collect()
+        [GC]::WaitForPendingFinalizers()
+    }
+
+    $groupResult = $groupResult | Sort-Object TotalMilliseconds
+    $groupResult | Select-Object *, @{
+        Name       = 'RelativeSpeed'
+        Expression = {
+            $relativeSpeed = $_.TotalMilliseconds / $groupResult[0].TotalMilliseconds
+            [math]::Round($relativeSpeed, 2).ToString() + 'x'
+        }
+    }
+}
+```
+
+```Output
+CollectionSize Test                           TotalMilliseconds RelativeSpeed
+-------------- ----                           ----------------- -------------
+          5000 PowerShell Explicit Assignment              0.56 1x
+          5000 .Add(..) to List<T>                         7.56 13.5x
+          5000 += Operator to Array                     1357.74 2424.54x
+         10000 PowerShell Explicit Assignment              0.77 1x
+         10000 .Add(..) to List<T>                        18.20 23.64x
+         10000 += Operator to Array                     5411.23 7027.57x
+        100000 PowerShell Explicit Assignment             14.85 1x
+        100000 .Add(..) to List<T>                       177.13 11.93x
+        100000 += Operator to Array                   473824.71 31907.39x
+```
+
+When you're working with large collections, array addition is dramatically slower than adding to
+a **List\<T\>**.
+
+When using a **List\<T\>**, you need to create the list with a specific type, like **String** or
+**Int**. When you add objects of a different type to the list, they are cast to the specified type.
+If they can't be cast to the specified type, the method raises an exception.
+
+```powershell
+$intList = [System.Collections.Generic.List[int]]::new()
+$intList.Add(1)
+$intList.Add('2')
+$intList.Add(3.0)
+$intList.Add('Four')
+$intList
+```
+
+```Output
+MethodException:
+Line |
+   5 |  $intList.Add('Four')
+     |  ~~~~~~~~~~~~~~~~~~~~
+     | Cannot convert argument "item", with value: "Four", for "Add" to type
+     "System.Int32": "Cannot convert value "Four" to type "System.Int32".
+     Error: "The input string 'Four' was not in a correct format.""
+
+1
+2
+3
+```
+
+When you need the list to be a collection of different types of objects, create it with **Object**
+as the list type. You can enumerate the collection inspect the types of the objects in it.
+
+```powershell
+$objectList = [System.Collections.Generic.List[object]]::new()
+$objectList.Add(1)
+$objectList.Add('2')
+$objectList.Add(3.0)
+$objectList.GetEnumerator().ForEach({ "$_ is $($_.GetType())" })
+```
+
+```Output
+1 is int
+2 is string
+3 is double
+```
+
+If you do require an array, you can call the `ToArray()` method on the list or you can let
+PowerShell create the array for you:
 
 ```powershell
 $results = @(
@@ -114,16 +232,16 @@ $results = @(
 )
 ```
 
-In this example, PowerShell creates an `ArrayList` to hold the results written to the pipeline
+In this example, PowerShell creates an **ArrayList** to hold the results written to the pipeline
 inside the array expression. Just before assigning to `$results`, PowerShell converts the
-`ArrayList` to an `object[]`.
+**ArrayList** to an **object[]**.
 
 ## String addition
 
-Like arrays, strings are immutable. Each addition to the string actually creates a new string big
-enough to hold the contents of both the left and right operands, then copies the elements of both
-operands into the new string. For small strings, this overhead may not matter. For large strings,
-this can affect performance and memory consumption.
+Strings are immutable. Each addition to the string actually creates a new string big enough to hold
+the contents of both the left and right operands, then copies the elements of both operands into
+the new string. For small strings, this overhead may not matter. For large strings, this can affect
+performance and memory consumption.
 
 ```powershell
 $string = ''


### PR DESCRIPTION
# PR Summary

Prior to this change, the array addition section of the article _PowerShell scripting performance considerations_ recommended that script authors use the **ArrayList** type instead of using array addition to add new values to an array.

The use of **ArrayList** is discouraged in the [.NET documentation][01], recommending instead that developers use **List<T>** with a specific type for homogenous lists or **List<Object>** for heterogenous lists.

This change:

- Recommends using **List<T>** instead of array addition or **ArrayList**
- Adds performance comparisons to clarify the impact of array addition
- Resolves #9997
- Fixes [AB#84476](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/84476)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide

[01]: https://learn.microsoft.com/en-us/dotnet/api/system.collections.arraylist?view=net-8.0#remarks