### PR TITLE
(GH-10002) Fix broken link in about_Profiles

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to create and use a PowerShell profile.
 Locale: en-US
-ms.date: 03/24/2023
+ms.date: 04/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Profiles
@@ -231,7 +231,7 @@ $env:COMPUTERNAME + "\" + (Get-Location) + "> "
 }
 ```
 
-For more information about the PowerShell prompt, see [about_Prompts][07].
+For more information about the PowerShell prompt, see [about_Prompts][04].
 
 For other profile examples, see [Customizing your shell environment][10].
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to create and use a PowerShell profile.
 Locale: en-US
-ms.date: 03/24/2023
+ms.date: 04/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Profiles
@@ -242,7 +242,7 @@ $env:COMPUTERNAME + "\" + (Get-Location) + "> "
 }
 ```
 
-For more information about the PowerShell prompt, see [about_Prompts][07].
+For more information about the PowerShell prompt, see [about_Prompts][04].
 
 For other profile examples, see [Customizing your shell environment][10].
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to create and use a PowerShell profile.
 Locale: en-US
-ms.date: 03/24/2023
+ms.date: 04/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Profiles
@@ -242,7 +242,7 @@ $env:COMPUTERNAME + "\" + (Get-Location) + "> "
 }
 ```
 
-For more information about the PowerShell prompt, see [about_Prompts][07].
+For more information about the PowerShell prompt, see [about_Prompts][04].
 
 For other profile examples, see [Customizing your shell environment][10].
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to create and use a PowerShell profile.
 Locale: en-US
-ms.date: 03/24/2023
+ms.date: 04/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Profiles
@@ -242,7 +242,7 @@ $env:COMPUTERNAME + "\" + (Get-Location) + "> "
 }
 ```
 
-For more information about the PowerShell prompt, see [about_Prompts][07].
+For more information about the PowerShell prompt, see [about_Prompts][04].
 
 For other profile examples, see [Customizing your shell environment][10].
 


### PR DESCRIPTION


# PR Summary

This change correctly points the link to about_Prompts in the about_Profiles articule.

- Resolves #10002
- Fixes [AB#85079](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/85079)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
