### PR TITLE
(GH-10004) Use `Get-WinEvent` in v7+ examples

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Select-Object.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 04/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-object?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Select-Object
@@ -169,14 +169,14 @@ applied to `"a","a"` and returns `a` as the unique value.
 
 This example gets the first (newest) and last (oldest) events in the Windows PowerShell event log.
 
-`Get-EventLog` gets all events in the Windows PowerShell log and saves them in the `$a` variable.
+`Get-WinEvent` gets all events in the Windows PowerShell log and saves them in the `$a` variable.
 Then, `$a` is piped to the `Select-Object` cmdlet. The `Select-Object` command uses the **Index**
 parameter to select events from the array of events in the `$a` variable. The index of the first
 event is 0. The index of the last event is the number of items in `$a` minus 1.
 
 ```powershell
-$a = Get-EventLog -LogName "Windows PowerShell"
-$a | Select-Object -Index 0, ($A.count - 1)
+$a = Get-WinEvent -LogName "Windows PowerShell"
+$a | Select-Object -Index 0, ($a.count - 1)
 ```
 
 ### Example 7: Select all but the first object

--- a/reference/7.3/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Select-Object.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 03/16/2023
+ms.date: 04/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-object?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Select-Object
@@ -169,14 +169,14 @@ applied to `"a","a"` and returns `a` as the unique value.
 
 This example gets the first (newest) and last (oldest) events in the Windows PowerShell event log.
 
-`Get-EventLog` gets all events in the Windows PowerShell log and saves them in the `$a` variable.
+`Get-WinEvent` gets all events in the Windows PowerShell log and saves them in the `$a` variable.
 Then, `$a` is piped to the `Select-Object` cmdlet. The `Select-Object` command uses the **Index**
 parameter to select events from the array of events in the `$a` variable. The index of the first
 event is 0. The index of the last event is the number of items in `$a` minus 1.
 
 ```powershell
-$a = Get-EventLog -LogName "Windows PowerShell"
-$a | Select-Object -Index 0, ($A.count - 1)
+$a = Get-WinEvent -LogName "Windows PowerShell"
+$a | Select-Object -Index 0, ($a.count - 1)
 ```
 
 ### Example 7: Select all but the first object

--- a/reference/7.4/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Select-Object.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 03/16/2023
+ms.date: 04/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-object?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Select-Object
@@ -169,14 +169,14 @@ applied to `"a","a"` and returns `a` as the unique value.
 
 This example gets the first (newest) and last (oldest) events in the Windows PowerShell event log.
 
-`Get-EventLog` gets all events in the Windows PowerShell log and saves them in the `$a` variable.
+`Get-WinEvent` gets all events in the Windows PowerShell log and saves them in the `$a` variable.
 Then, `$a` is piped to the `Select-Object` cmdlet. The `Select-Object` command uses the **Index**
 parameter to select events from the array of events in the `$a` variable. The index of the first
 event is 0. The index of the last event is the number of items in `$a` minus 1.
 
 ```powershell
-$a = Get-EventLog -LogName "Windows PowerShell"
-$a | Select-Object -Index 0, ($A.count - 1)
+$a = Get-WinEvent -LogName "Windows PowerShell"
+$a | Select-Object -Index 0, ($a.count - 1)
 ```
 
 ### Example 7: Select all but the first object


### PR DESCRIPTION
# PR Summary

Prior to this change, an example in `Select-Object` used the `Get-EventLog` command across all versions. However, that command was removed from PowerShell and the examples should use `Get-WinEvent` instead for newer versions.

This change:

- Updates the command in the example for newer versions of PowerShell
- Resolves #10004
- Fixes [AB#85080](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/85080)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
