### PR TITLE
(GH-10003) Clarify OutputType notes

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
@@ -1,7 +1,7 @@
 ---
 description: Describes an attribute that reports the type of object that the function returns.
 Locale: en-US
-ms.date: 10/27/2022
+ms.date: 04/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_outputtypeattribute?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Functions OutputTypeAttribute
@@ -14,24 +14,24 @@ returns.
 
 ## Long description
 
-The OutputType attribute lists the .NET types of objects that the functions
+The **OutputType** attribute lists the .NET types of objects that the functions
 returns. You can use its optional ParameterSetName parameter to list different
 output types for each parameter set.
 
-The OutputType attribute is supported on simple and advanced functions. It is
-independent of the CmdletBinding attribute.
+The **OutputType** attribute is supported on simple and advanced functions.
+It's independent of the **CmdletBinding** attribute.
 
-The OutputType attribute provides the value of the OutputType property of the
-**System.Management.Automation.FunctionInfo** object that the `Get-Command` cmdlet
-returns.
+The **OutputType** attribute provides the value of the **OutputType** property
+of the **System.Management.Automation.FunctionInfo** object that the
+`Get-Command` cmdlet returns.
 
-The OutputType attribute value is only a documentation note. It is not derived
-from the function code or compared to the actual function output. As such, the
-value might be inaccurate.
+The **OutputType** attribute value is only a documentation note. It's not
+derived from the function code or compared to the actual function output. As
+such, the value might be inaccurate.
 
 ## Syntax
 
-The OutputType attribute of functions has the following syntax:
+The **OutputType** attribute of functions has the following syntax:
 
 ```
 [OutputType([<TypeLiteral>], ParameterSetName="<Name>")]
@@ -40,7 +40,7 @@ The OutputType attribute of functions has the following syntax:
 
 The **ParameterSetName** parameter is optional.
 
-You can list multiple types in the OutputType attribute.
+You can list multiple types in the **OutputType** attribute.
 
 ```
 [OutputType([<Type1>],[<Type2>],[<Type3>])]
@@ -54,10 +54,10 @@ parameter sets return different types.
 [OutputType([<Type2>], ParameterSetName="<Set3>")]
 ```
 
-Place the OutputType attribute statements in the attributes list that precedes
-the `Param` statement.
+Place the **OutputType** attribute statements in the attributes list that
+precedes the `Param` statement.
 
-The following example shows the placement of the OutputType attribute in a
+The following example shows the placement of the **OutputType** attribute in a
 simple function.
 
 ```powershell
@@ -70,7 +70,7 @@ function SimpleFunction2
 }
 ```
 
-The following example shows the placement of the OutputType attribute in
+The following example shows the placement of the **OutputType** attribute in
 advanced functions.
 
 ```powershell
@@ -128,9 +128,9 @@ System.String                                      System.String
 
 ### Example 2: Use the OutputType attribute to indicate dynamic output types
 
-The following advanced function uses the OutputType attribute to indicate that
-the function returns different types depending on the parameter set used in the
-function command.
+The following advanced function uses the **OutputType** attribute to indicate
+that the function returns different types depending on the parameter set used
+in the function command.
 
 ```powershell
 function Get-User
@@ -157,10 +157,10 @@ function Get-User
 ### Example 3: Shows when an actual output differs from the OutputType
 
 The following example demonstrates that the output type property value
-displays the value of the OutputType attribute, even when it is inaccurate.
+displays the value of the **OutputType** attribute, even when it's inaccurate.
 
-The `Get-Time` function returns a string that contains the short form of
-the time in any DateTime object. However, the OutputType attribute reports
+The `Get-Time` function returns a string that contains the short form of the
+time in any **DateTime** object. However, the **OutputType** attribute reports
 that it returns a **System.DateTime** object.
 
 ```powershell
@@ -186,8 +186,9 @@ The `GetType()` method confirms that the function returns a string.
 System.String
 ```
 
-However, the OutputType property, which gets its value from the OutputType
-attribute, reports that the function returns a **DateTime** object.
+However, the **OutputType** property, which gets its value from the
+**OutputType** attribute, reports that the function returns a **DateTime**
+object.
 
 ```powershell
 (Get-Command Get-Time).OutputType
@@ -215,26 +216,26 @@ function Invoke-Notepad
 
 ## Notes
 
-The value of the OutputType property of a **FunctionInfo** object is an array of
-**System.Management.Automation.PSTypeName** objects, each of which have Name and
-Type properties.
+The value of the **OutputType** property of a **FunctionInfo** object is an
+array of **System.Management.Automation.PSTypeName** objects, which each have
+**Name** and **Type** properties.
 
 To get only the name of each output type, use a command with the following
 format.
 
 ```powershell
-(Get-Command Get-Time).OutputType | ForEach {$_.Name}
+(Get-Command Get-Date).OutputType | Select-Object -ExpandProperty Name
 ```
 
 Or its shorter version.
 
 ```powershell
-(Get-Command Get-Time).OutputType.Name
+(Get-Command Get-Date).OutputType.Name
 ```
 
-The value of the OutputType property can be null. Use a null value when
-the output is not a .NET type, such as a **WMI** object or a formatted view
-of an object.
+The value of the **OutputType** property can be null. Use a null value when the
+output isn't a .NET type, such as a **WMI** object or a formatted view of an
+object.
 
 ## See also
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
@@ -1,7 +1,7 @@
 ---
 description: Describes an attribute that reports the type of object that the function returns.
 Locale: en-US
-ms.date: 10/27/2022
+ms.date: 04/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_outputtypeattribute?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Functions OutputTypeAttribute
@@ -14,24 +14,24 @@ returns.
 
 ## Long description
 
-The OutputType attribute lists the .NET types of objects that the functions
+The **OutputType** attribute lists the .NET types of objects that the functions
 returns. You can use its optional ParameterSetName parameter to list different
 output types for each parameter set.
 
-The OutputType attribute is supported on simple and advanced functions. It is
-independent of the CmdletBinding attribute.
+The **OutputType** attribute is supported on simple and advanced functions.
+It's independent of the **CmdletBinding** attribute.
 
-The OutputType attribute provides the value of the OutputType property of the
-**System.Management.Automation.FunctionInfo** object that the `Get-Command` cmdlet
-returns.
+The **OutputType** attribute provides the value of the **OutputType** property
+of the **System.Management.Automation.FunctionInfo** object that the
+`Get-Command` cmdlet returns.
 
-The OutputType attribute value is only a documentation note. It is not derived
-from the function code or compared to the actual function output. As such, the
-value might be inaccurate.
+The **OutputType** attribute value is only a documentation note. It's not
+derived from the function code or compared to the actual function output. As
+such, the value might be inaccurate.
 
 ## Syntax
 
-The OutputType attribute of functions has the following syntax:
+The **OutputType** attribute of functions has the following syntax:
 
 ```
 [OutputType([<TypeLiteral>], ParameterSetName="<Name>")]
@@ -40,7 +40,7 @@ The OutputType attribute of functions has the following syntax:
 
 The **ParameterSetName** parameter is optional.
 
-You can list multiple types in the OutputType attribute.
+You can list multiple types in the **OutputType** attribute.
 
 ```
 [OutputType([<Type1>],[<Type2>],[<Type3>])]
@@ -54,10 +54,10 @@ parameter sets return different types.
 [OutputType([<Type2>], ParameterSetName="<Set3>")]
 ```
 
-Place the OutputType attribute statements in the attributes list that precedes
-the `Param` statement.
+Place the **OutputType** attribute statements in the attributes list that
+precedes the `Param` statement.
 
-The following example shows the placement of the OutputType attribute in a
+The following example shows the placement of the **OutputType** attribute in a
 simple function.
 
 ```powershell
@@ -70,7 +70,7 @@ function SimpleFunction2
 }
 ```
 
-The following example shows the placement of the OutputType attribute in
+The following example shows the placement of the **OutputType** attribute in
 advanced functions.
 
 ```powershell
@@ -128,9 +128,9 @@ System.String                                      System.String
 
 ### Example 2: Use the OutputType attribute to indicate dynamic output types
 
-The following advanced function uses the OutputType attribute to indicate that
-the function returns different types depending on the parameter set used in the
-function command.
+The following advanced function uses the **OutputType** attribute to indicate
+that the function returns different types depending on the parameter set used
+in the function command.
 
 ```powershell
 function Get-User
@@ -157,10 +157,10 @@ function Get-User
 ### Example 3: Shows when an actual output differs from the OutputType
 
 The following example demonstrates that the output type property value
-displays the value of the OutputType attribute, even when it is inaccurate.
+displays the value of the **OutputType** attribute, even when it's inaccurate.
 
-The `Get-Time` function returns a string that contains the short form of
-the time in any DateTime object. However, the OutputType attribute reports
+The `Get-Time` function returns a string that contains the short form of the
+time in any **DateTime** object. However, the **OutputType** attribute reports
 that it returns a **System.DateTime** object.
 
 ```powershell
@@ -186,8 +186,9 @@ The `GetType()` method confirms that the function returns a string.
 System.String
 ```
 
-However, the OutputType property, which gets its value from the OutputType
-attribute, reports that the function returns a **DateTime** object.
+However, the **OutputType** property, which gets its value from the
+**OutputType** attribute, reports that the function returns a **DateTime**
+object.
 
 ```powershell
 (Get-Command Get-Time).OutputType
@@ -215,26 +216,26 @@ function Invoke-Notepad
 
 ## Notes
 
-The value of the OutputType property of a **FunctionInfo** object is an array of
-**System.Management.Automation.PSTypeName** objects, each of which have Name and
-Type properties.
+The value of the **OutputType** property of a **FunctionInfo** object is an
+array of **System.Management.Automation.PSTypeName** objects, which each have
+**Name** and **Type** properties.
 
 To get only the name of each output type, use a command with the following
 format.
 
 ```powershell
-(Get-Command Get-Time).OutputType | ForEach {$_.Name}
+(Get-Command Get-Date).OutputType | Select-Object -ExpandProperty Name
 ```
 
 Or its shorter version.
 
 ```powershell
-(Get-Command Get-Time).OutputType.Name
+(Get-Command Get-Date).OutputType.Name
 ```
 
-The value of the OutputType property can be null. Use a null value when
-the output is not a .NET type, such as a **WMI** object or a formatted view
-of an object.
+The value of the **OutputType** property can be null. Use a null value when the
+output isn't a .NET type, such as a **WMI** object or a formatted view of an
+object.
 
 ## See also
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
@@ -1,7 +1,7 @@
 ---
 description: Describes an attribute that reports the type of object that the function returns.
 Locale: en-US
-ms.date: 10/27/2022
+ms.date: 04/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_outputtypeattribute?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Functions OutputTypeAttribute
@@ -14,24 +14,24 @@ returns.
 
 ## Long description
 
-The OutputType attribute lists the .NET types of objects that the functions
+The **OutputType** attribute lists the .NET types of objects that the functions
 returns. You can use its optional ParameterSetName parameter to list different
 output types for each parameter set.
 
-The OutputType attribute is supported on simple and advanced functions. It is
-independent of the CmdletBinding attribute.
+The **OutputType** attribute is supported on simple and advanced functions.
+It's independent of the **CmdletBinding** attribute.
 
-The OutputType attribute provides the value of the OutputType property of the
-**System.Management.Automation.FunctionInfo** object that the `Get-Command` cmdlet
-returns.
+The **OutputType** attribute provides the value of the **OutputType** property
+of the **System.Management.Automation.FunctionInfo** object that the
+`Get-Command` cmdlet returns.
 
-The OutputType attribute value is only a documentation note. It is not derived
-from the function code or compared to the actual function output. As such, the
-value might be inaccurate.
+The **OutputType** attribute value is only a documentation note. It's not
+derived from the function code or compared to the actual function output. As
+such, the value might be inaccurate.
 
 ## Syntax
 
-The OutputType attribute of functions has the following syntax:
+The **OutputType** attribute of functions has the following syntax:
 
 ```
 [OutputType([<TypeLiteral>], ParameterSetName="<Name>")]
@@ -40,7 +40,7 @@ The OutputType attribute of functions has the following syntax:
 
 The **ParameterSetName** parameter is optional.
 
-You can list multiple types in the OutputType attribute.
+You can list multiple types in the **OutputType** attribute.
 
 ```
 [OutputType([<Type1>],[<Type2>],[<Type3>])]
@@ -54,10 +54,10 @@ parameter sets return different types.
 [OutputType([<Type2>], ParameterSetName="<Set3>")]
 ```
 
-Place the OutputType attribute statements in the attributes list that precedes
-the `Param` statement.
+Place the **OutputType** attribute statements in the attributes list that
+precedes the `Param` statement.
 
-The following example shows the placement of the OutputType attribute in a
+The following example shows the placement of the **OutputType** attribute in a
 simple function.
 
 ```powershell
@@ -70,7 +70,7 @@ function SimpleFunction2
 }
 ```
 
-The following example shows the placement of the OutputType attribute in
+The following example shows the placement of the **OutputType** attribute in
 advanced functions.
 
 ```powershell
@@ -128,9 +128,9 @@ System.String                                      System.String
 
 ### Example 2: Use the OutputType attribute to indicate dynamic output types
 
-The following advanced function uses the OutputType attribute to indicate that
-the function returns different types depending on the parameter set used in the
-function command.
+The following advanced function uses the **OutputType** attribute to indicate
+that the function returns different types depending on the parameter set used
+in the function command.
 
 ```powershell
 function Get-User
@@ -157,10 +157,10 @@ function Get-User
 ### Example 3: Shows when an actual output differs from the OutputType
 
 The following example demonstrates that the output type property value
-displays the value of the OutputType attribute, even when it is inaccurate.
+displays the value of the **OutputType** attribute, even when it's inaccurate.
 
-The `Get-Time` function returns a string that contains the short form of
-the time in any DateTime object. However, the OutputType attribute reports
+The `Get-Time` function returns a string that contains the short form of the
+time in any **DateTime** object. However, the **OutputType** attribute reports
 that it returns a **System.DateTime** object.
 
 ```powershell
@@ -186,8 +186,9 @@ The `GetType()` method confirms that the function returns a string.
 System.String
 ```
 
-However, the OutputType property, which gets its value from the OutputType
-attribute, reports that the function returns a **DateTime** object.
+However, the **OutputType** property, which gets its value from the
+**OutputType** attribute, reports that the function returns a **DateTime**
+object.
 
 ```powershell
 (Get-Command Get-Time).OutputType
@@ -215,26 +216,26 @@ function Invoke-Notepad
 
 ## Notes
 
-The value of the OutputType property of a **FunctionInfo** object is an array of
-**System.Management.Automation.PSTypeName** objects, each of which have Name and
-Type properties.
+The value of the **OutputType** property of a **FunctionInfo** object is an
+array of **System.Management.Automation.PSTypeName** objects, which each have
+**Name** and **Type** properties.
 
 To get only the name of each output type, use a command with the following
 format.
 
 ```powershell
-(Get-Command Get-Time).OutputType | ForEach {$_.Name}
+(Get-Command Get-Date).OutputType | Select-Object -ExpandProperty Name
 ```
 
 Or its shorter version.
 
 ```powershell
-(Get-Command Get-Time).OutputType.Name
+(Get-Command Get-Date).OutputType.Name
 ```
 
-The value of the OutputType property can be null. Use a null value when
-the output is not a .NET type, such as a **WMI** object or a formatted view
-of an object.
+The value of the **OutputType** property can be null. Use a null value when the
+output isn't a .NET type, such as a **WMI** object or a formatted view of an
+object.
 
 ## See also
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
@@ -1,7 +1,7 @@
 ---
 description: Describes an attribute that reports the type of object that the function returns.
 Locale: en-US
-ms.date: 10/27/2022
+ms.date: 04/14/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_outputtypeattribute?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Functions OutputTypeAttribute
@@ -14,24 +14,24 @@ returns.
 
 ## Long description
 
-The OutputType attribute lists the .NET types of objects that the functions
+The **OutputType** attribute lists the .NET types of objects that the functions
 returns. You can use its optional ParameterSetName parameter to list different
 output types for each parameter set.
 
-The OutputType attribute is supported on simple and advanced functions. It is
-independent of the CmdletBinding attribute.
+The **OutputType** attribute is supported on simple and advanced functions.
+It's independent of the **CmdletBinding** attribute.
 
-The OutputType attribute provides the value of the OutputType property of the
-**System.Management.Automation.FunctionInfo** object that the `Get-Command` cmdlet
-returns.
+The **OutputType** attribute provides the value of the **OutputType** property
+of the **System.Management.Automation.FunctionInfo** object that the
+`Get-Command` cmdlet returns.
 
-The OutputType attribute value is only a documentation note. It is not derived
-from the function code or compared to the actual function output. As such, the
-value might be inaccurate.
+The **OutputType** attribute value is only a documentation note. It's not
+derived from the function code or compared to the actual function output. As
+such, the value might be inaccurate.
 
 ## Syntax
 
-The OutputType attribute of functions has the following syntax:
+The **OutputType** attribute of functions has the following syntax:
 
 ```
 [OutputType([<TypeLiteral>], ParameterSetName="<Name>")]
@@ -40,7 +40,7 @@ The OutputType attribute of functions has the following syntax:
 
 The **ParameterSetName** parameter is optional.
 
-You can list multiple types in the OutputType attribute.
+You can list multiple types in the **OutputType** attribute.
 
 ```
 [OutputType([<Type1>],[<Type2>],[<Type3>])]
@@ -54,10 +54,10 @@ parameter sets return different types.
 [OutputType([<Type2>], ParameterSetName="<Set3>")]
 ```
 
-Place the OutputType attribute statements in the attributes list that precedes
-the `Param` statement.
+Place the **OutputType** attribute statements in the attributes list that
+precedes the `Param` statement.
 
-The following example shows the placement of the OutputType attribute in a
+The following example shows the placement of the **OutputType** attribute in a
 simple function.
 
 ```powershell
@@ -70,7 +70,7 @@ function SimpleFunction2
 }
 ```
 
-The following example shows the placement of the OutputType attribute in
+The following example shows the placement of the **OutputType** attribute in
 advanced functions.
 
 ```powershell
@@ -128,9 +128,9 @@ System.String                                      System.String
 
 ### Example 2: Use the OutputType attribute to indicate dynamic output types
 
-The following advanced function uses the OutputType attribute to indicate that
-the function returns different types depending on the parameter set used in the
-function command.
+The following advanced function uses the **OutputType** attribute to indicate
+that the function returns different types depending on the parameter set used
+in the function command.
 
 ```powershell
 function Get-User
@@ -157,10 +157,10 @@ function Get-User
 ### Example 3: Shows when an actual output differs from the OutputType
 
 The following example demonstrates that the output type property value
-displays the value of the OutputType attribute, even when it is inaccurate.
+displays the value of the **OutputType** attribute, even when it's inaccurate.
 
-The `Get-Time` function returns a string that contains the short form of
-the time in any DateTime object. However, the OutputType attribute reports
+The `Get-Time` function returns a string that contains the short form of the
+time in any **DateTime** object. However, the **OutputType** attribute reports
 that it returns a **System.DateTime** object.
 
 ```powershell
@@ -186,8 +186,9 @@ The `GetType()` method confirms that the function returns a string.
 System.String
 ```
 
-However, the OutputType property, which gets its value from the OutputType
-attribute, reports that the function returns a **DateTime** object.
+However, the **OutputType** property, which gets its value from the
+**OutputType** attribute, reports that the function returns a **DateTime**
+object.
 
 ```powershell
 (Get-Command Get-Time).OutputType
@@ -215,26 +216,26 @@ function Invoke-Notepad
 
 ## Notes
 
-The value of the OutputType property of a **FunctionInfo** object is an array of
-**System.Management.Automation.PSTypeName** objects, each of which have Name and
-Type properties.
+The value of the **OutputType** property of a **FunctionInfo** object is an
+array of **System.Management.Automation.PSTypeName** objects, which each have
+**Name** and **Type** properties.
 
 To get only the name of each output type, use a command with the following
 format.
 
 ```powershell
-(Get-Command Get-Time).OutputType | ForEach {$_.Name}
+(Get-Command Get-Date).OutputType | Select-Object -ExpandProperty Name
 ```
 
 Or its shorter version.
 
 ```powershell
-(Get-Command Get-Time).OutputType.Name
+(Get-Command Get-Date).OutputType.Name
 ```
 
-The value of the OutputType property can be null. Use a null value when
-the output is not a .NET type, such as a **WMI** object or a formatted view
-of an object.
+The value of the **OutputType** property can be null. Use a null value when the
+output isn't a .NET type, such as a **WMI** object or a formatted view of an
+object.
 
 ## See also
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the notes section of the `about_Functions_OutputTypeAttribute` topic referenced the `Get-Time` function from a prior example without connecting the note to the example. The example could instead use the `Get-Date` cmdlet, which is available and will work regardless of whether the user has run prior examples in their terminal.

This change:

- Updates the notes section to use `Get-Date` instead of `Get-Time`.
- Cleans up linting errors and warnings.
- Ensures correct formatting for types and attributes.
- Resolves #10003
- Fixes [AB#85082](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/85082)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
