### PR TITLE
(GH-9788) Document using folders with OutFile in web cmdlets

### DIFF
--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 03/16/2023
+ms.date: 04/21/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -856,6 +856,12 @@ Names that contain brackets (`[]`) must be enclosed in single quotes (`'`).
 
 By default, `Invoke-WebRequest` returns the results to the pipeline. To send the results to a file
 and to the pipeline, use the **Passthru** parameter.
+
+Starting in PowerShell 7.4, you can specify a folder path without the filename. When you do, the
+file's name is the taken from either the
+[Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition)
+of the response or the last segment of the resolved URI after any redirections. When you specify a
+folder path for **OutFile**, you can't use the **Resume** parameter.
 
 ```yaml
 Type: System.String


### PR DESCRIPTION
# PR Summary

This change documents the updated functionality for the **OutFile** parameter in the `Invoke-RestMethod` and `Invoke-WebRequest` cmdlets. It clarifies that you can specify the name of a folder path without a filename and how the cmdlet determines the filename to use.

- Resolves #9788
- Fixes [AB#86341](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/86341)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
