### PR TITLE
docs(get-counter): correct grammar for Continuous

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Diagnostics/Get-Counter.md
+++ b/reference/7.2/Microsoft.PowerShell.Diagnostics/Get-Counter.md
@@ -481,7 +481,7 @@ Accept wildcard characters: False
 
 ### -Continuous
 
-When the **Continuous** is specified, `Get-Counter` gets samples until you press
+When **Continuous** is specified, `Get-Counter` gets samples until you press
 <kbd>CTRL</kbd>+<kbd>C</kbd>. Samples are obtained every second for each specified performance
 counter. Use the **SampleInterval** parameter to increase the interval between continuous samples.
 


### PR DESCRIPTION
# PR Summary

'When the Continuous is specified...' reads awkwardly to me. I feel 'the Continuous switch,' or my edit, is more appropriate.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].
