### PR TITLE
(GH-10057) Fix `Where-Object` example

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
@@ -364,11 +364,11 @@ Get-ChildItem | where { $_.PSIsContainer }
 ```
 
 ```powershell
-# Finally, use the Not operator (!) to get objects that are not containers.
+# Finally, use the -not operator (!) to get objects that are not containers.
 # This gets objects that do have the **PSIsContainer** property and those
 # that have a value of $False for the **PSIsContainer** property.
 Get-ChildItem | where { !$_.PSIsContainer }
-# You cannot use the Not operator (!) in the comparison statement format
+# You cannot use the -not operator (!) in the comparison statement format
 # of the command.
 Get-ChildItem | where PSIsContainer -eq $False
 ```
@@ -387,11 +387,11 @@ This command gets non-core modules that support the Updatable Help feature. The 
 **ListAvailable** parameter of the `Get-Module` cmdlet to get all modules on the computer. A
 pipeline operator (`|`) sends the modules to the `Where-Object` cmdlet, which gets modules whose
 names don't begin with `Microsoft` or `PS`, and have a value for the **HelpInfoURI** property,
-which tells PowerShell where to find updated help files for the module. The **And** logical operator
+which tells PowerShell where to find updated help files for the module. The `-and` logical operator
 connects the comparison statements.
 
-The example uses the script block command format. Logical operators, such as **And** and **Or**,
-are valid only in script blocks. You can't use them in the comparison statement format of a
+The example uses the script block command format. Logical operators, such as `-and`,`-or`, and
+`-not` are valid only in script blocks. You can't use them in the comparison statement format of a
 `Where-Object` command.
 
 - For more information about PowerShell logical operators, see
@@ -1120,7 +1120,7 @@ wildcard characters when used with the following comparison parameters:
 This parameter was introduced in Windows PowerShell 3.0.
 
 ```yaml
-Type: System.Object
+Type: System.Management.Automation.PSObject
 Parameter Sets: EqualSet, MatchSet, CaseSensitiveEqualSet, NotEqualSet, CaseSensitiveNotEqualSet, GreaterThanSet, CaseSensitiveGreaterThanSet, LessThanSet, CaseSensitiveLessThanSet, GreaterOrEqualSet, CaseSensitiveGreaterOrEqualSet, LessOrEqualSet, CaseSensitiveLessOrEqualSet, LikeSet, CaseSensitiveLikeSet, NotLikeSet, CaseSensitiveNotLikeSet, CaseSensitiveMatchSet, NotMatchSet, CaseSensitiveNotMatchSet, ContainsSet, CaseSensitiveContainsSet, NotContainsSet, CaseSensitiveNotContainsSet, InSet, CaseSensitiveInSet, NotInSet, CaseSensitiveNotInSet, IsSet, IsNotSet
 Aliases:
 
@@ -1146,7 +1146,7 @@ You can pipe any object to this cmdlet.
 
 ## OUTPUTS
 
-### Object
+### System.Object
 
 This cmdlet returns the selected items from the input object set.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/09/2022
+ms.date: 05/08/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/where-object?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Where-Object
@@ -317,27 +317,28 @@ for a specified property. Each example shows both the script block and compariso
 for the command.
 
 ```powershell
-# Use Where-Object to get commands that have any value for the OutputType property of the command.
-# This omits commands that do not have an OutputType property and those that have an OutputType
-# property, but no property value.
+# Use Where-Object to get commands that have any value for the OutputType
+# property of the command. This omits commands that do not have an OutputType
+# property and those that have an OutputType property, but no property value.
 Get-Command | where OutputType
-Get-Command | where {$_.OutputType}
+Get-Command | where { $_.OutputType }
 ```
 
 ```powershell
-# Use Where-Object to get objects that are containers.
-# This gets objects that have the **PSIsContainer** property with a value of $True and excludes all
+# Use Where-Object to get objects that are containers. This gets objects that
+# have the **PSIsContainer** property with a value of $True and excludes all
 # others.
 Get-ChildItem | where PSIsContainer
-Get-ChildItem | where {$_.PSIsContainer}
+Get-ChildItem | where { $_.PSIsContainer }
 ```
 
 ```powershell
 # Finally, use the Not operator (!) to get objects that are not containers.
-# This gets objects that do have the **PSIsContainer** property and those that have a value of
-# $False for the **PSIsContainer** property.
-Get-ChildItem | where {!$_.PSIsContainer}
-# You cannot use the Not operator (!) in the comparison statement format of the command.
+# This gets objects that do have the **PSIsContainer** property and those
+# that have a value of $False for the **PSIsContainer** property.
+Get-ChildItem | where { !$_.PSIsContainer }
+# You cannot use the Not operator (!) in the comparison statement format
+# of the command.
 Get-ChildItem | where PSIsContainer -eq $False
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
@@ -17,196 +17,218 @@ Selects objects from a collection based on their property values.
 ### EqualSet (Default)
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-EQ]
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ [-EQ] [<CommonParameters>]
 ```
 
 ### ScriptBlockSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-FilterScript] <ScriptBlock> [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-FilterScript] <ScriptBlock>
+ [<CommonParameters>]
 ```
 
 ### MatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-Match]
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Match [<CommonParameters>]
 ```
 
 ### CaseSensitiveEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CEQ] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CEQ [<CommonParameters>]
 ```
 
 ### NotEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-NE] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NE [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CNE] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNE [<CommonParameters>]
 ```
 
 ### GreaterThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-GT] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -GT [<CommonParameters>]
 ```
 
 ### CaseSensitiveGreaterThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CGT] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CGT [<CommonParameters>]
 ```
 
 ### LessThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-LT] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -LT [<CommonParameters>]
 ```
 
 ### CaseSensitiveLessThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CLT] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CLT [<CommonParameters>]
 ```
 
 ### GreaterOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-GE] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -GE [<CommonParameters>]
 ```
 
 ### CaseSensitiveGreaterOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CGE] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CGE [<CommonParameters>]
 ```
 
 ### LessOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-LE] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -LE [<CommonParameters>]
 ```
 
 ### CaseSensitiveLessOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CLE] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CLE [<CommonParameters>]
 ```
 
 ### LikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-Like] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Like [<CommonParameters>]
 ```
 
 ### CaseSensitiveLikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CLike] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CLike [<CommonParameters>]
 ```
 
 ### NotLikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-NotLike] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotLike [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotLikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CNotLike]
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotLike [<CommonParameters>]
 ```
 
 ### CaseSensitiveMatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CMatch] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CMatch [<CommonParameters>]
 ```
 
 ### NotMatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-NotMatch]
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotMatch [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotMatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CNotMatch]
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotMatch [<CommonParameters>]
 ```
 
 ### ContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-Contains]
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Contains [<CommonParameters>]
 ```
 
 ### CaseSensitiveContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CContains]
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CContains [<CommonParameters>]
 ```
 
 ### NotContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-NotContains]
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotContains [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CNotContains]
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotContains [<CommonParameters>]
 ```
 
 ### InSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-In] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -In [<CommonParameters>]
 ```
 
 ### CaseSensitiveInSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CIn] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CIn
+ [<CommonParameters>]
 ```
 
 ### NotInSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-NotIn] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotIn [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotInSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-CNotIn] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotIn [<CommonParameters>]
 ```
 
 ### IsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-Is] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Is [<CommonParameters>]
 ```
 
 ### IsNotSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-IsNot] [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -IsNot [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -235,52 +257,53 @@ command.
   natural language. Comparison statements were introduced in Windows PowerShell 3.0.
 
   For example, the following commands also get processes that have a priority class of `Normal`.
-  These commands are equivalent and can be used interchangeably.
+  These commands are equivalent and you can use them interchangeably.
 
   `Get-Process | Where-Object -Property PriorityClass -eq -Value "Normal"`
 
   `Get-Process | Where-Object PriorityClass -eq "Normal"`
 
   Starting in Windows PowerShell 3.0, `Where-Object` adds comparison operators as parameters in a
-  `Where-Object` command. Unless specified, all operators are case-insensitive. Prior to Windows
-  PowerShell 3.0, the comparison operators in the PowerShell language could be used only in script
+  `Where-Object` command. Unless specified, all operators are case-insensitive. Before Windows
+  PowerShell 3.0, the comparison operators in the PowerShell language were only usable in script
   blocks.
 
-When you provide a single **Property** to `Where-Object`, the value of the property is treated as
-a boolean expression. When the value of **Length** is not zero, the expression evaluates to
-`$true`. For example: `('hi', '', 'there') | Where-Object Length`
+When you provide a single **Property** to `Where-Object`, the cmdlet treats the value of the
+property as a boolean expression. When the value of the property's **Length** isn't zero, the
+expression evaluates to `$true`. For example: `('hi', '', 'there') | Where-Object Length`
 
 The previous example is functionally equivalent to:
 
 - `('hi', '', 'there') | Where-Object Length -GT 0`
-- `('hi', '', 'there') | Where-Object {$_.Length -gt 0}`
+- `('hi', '', 'there') | Where-Object { $_.Length -gt 0 }`
 
-For more information about how booleans are evaluated, see
+For more information about how PowerShell evaluates booleans, see
 [about_Booleans](about/about_Booleans.md).
 
 ## EXAMPLES
 
 ### Example 1: Get stopped services
 
-These commands get a list of all services that are currently stopped. The `$_` automatic variable
-represents each object that is passed to the `Where-Object` cmdlet.
+These commands get a list of all services that are stopped. The `$_` automatic variable represents
+each object that's passed to the `Where-Object` cmdlet.
 
 The first command uses the script block format, the second command uses the comparison statement
-format. The commands are equivalent and can be used interchangeably.
+format. The commands filter the services the same way and return the same output. Only the syntax
+is different.
 
 ```powershell
-Get-Service | Where-Object {$_.Status -eq "Stopped"}
+Get-Service | Where-Object { $_.Status -eq "Stopped" }
 Get-Service | where Status -eq "Stopped"
 ```
 
 ### Example 2: Get processes based on working set
 
-These commands list processes that have a working set greater than 250 megabytes (MB). The
-scriptblock and statement syntax are equivalent and can be used interchangeably.
+These commands list processes that have a working set greater than 250 megabytes (MB). The commands
+filter the processes the same way and return the same output. Only the syntax is different.
 
 ```powershell
-Get-Process | Where-Object {$_.WorkingSet -GT 250MB}
-Get-Process | Where-Object WorkingSet -GT (250MB)
+Get-Process | Where-Object { $_.WorkingSet -GT 250MB }
+Get-Process | Where-Object WorkingSet -GT 250MB
 ```
 
 ### Example 3: Get processes based on process name
@@ -288,10 +311,11 @@ Get-Process | Where-Object WorkingSet -GT (250MB)
 These commands get the processes that have a **ProcessName** property value that begins with the
 letter `p`. The **Match** operator lets you use regular expression matches.
 
-The scriptblock and statement syntax are equivalent and can be used interchangeably.
+The commands filter the processes the same way and return the same output. Only the syntax is
+different.
 
 ```powershell
-Get-Process | Where-Object {$_.ProcessName -Match "^p.*"}
+Get-Process | Where-Object { $_.ProcessName -Match "^p.*" }
 Get-Process | Where-Object ProcessName -Match "^p.*"
 ```
 
@@ -299,11 +323,15 @@ Get-Process | Where-Object ProcessName -Match "^p.*"
 
 This example shows how to use the new comparison statement format of the `Where-Object` cmdlet.
 
-The first command uses the comparison statement format. In this command, no aliases are used and all
-parameters include the parameter name.
+The first command uses the comparison statement format. It doesn't use any aliases and includes the
+name for every parameter.
 
-The second command is the more natural use of the comparison command format. The `where` alias is
-substituted for the `Where-Object` cmdlet name and all optional parameter names are omitted.
+The second command is the more natural use of the comparison command format. The command
+substitutes the `where` alias for the `Where-Object` cmdlet name and omits all optional parameter
+names.
+
+The commands filter the processes the same way and return the same output. Only the syntax is
+different.
 
 ```powershell
 Get-Process | Where-Object -Property Handles -GE -Value 1000
@@ -315,6 +343,9 @@ Get-Process | where Handles -GE 1000
 This example shows how to write commands that return items that are true or false or have any value
 for a specified property. Each example shows both the script block and comparison statement formats
 for the command.
+
+The commands filter their input the same way and return the same output. Only the syntax is
+different.
 
 ```powershell
 # Use Where-Object to get commands that have any value for the OutputType
@@ -355,12 +386,12 @@ This example shows how to create a `Where-Object` command with multiple conditio
 This command gets non-core modules that support the Updatable Help feature. The command uses the
 **ListAvailable** parameter of the `Get-Module` cmdlet to get all modules on the computer. A
 pipeline operator (`|`) sends the modules to the `Where-Object` cmdlet, which gets modules whose
-names do not begin with `Microsoft` or `PS`, and have a value for the **HelpInfoURI** property,
-which tells PowerShell where to find updated help files for the module. The comparison statements
-are connected by the **And** logical operator.
+names don't begin with `Microsoft` or `PS`, and have a value for the **HelpInfoURI** property,
+which tells PowerShell where to find updated help files for the module. The **And** logical operator
+connects the comparison statements.
 
-The example uses the script block command format. Logical operators, such as **And** and **Or**, are
-valid only in script blocks. You cannot use them in the comparison statement format of a
+The example uses the script block command format. Logical operators, such as **And** and **Or**,
+are valid only in script blocks. You can't use them in the comparison statement format of a
 `Where-Object` command.
 
 - For more information about PowerShell logical operators, see
@@ -542,8 +573,8 @@ Accept wildcard characters: False
 ### -CMatch
 
 Indicates that this cmdlet gets objects if the property value matches the specified regular
-expression. This operation is case-sensitive. When the input is scalar, the matched value is saved
-in `$Matches` automatic variable.
+expression. This operation is case-sensitive. When the input is a single object, the matched value
+is saved in the `$Matches` automatic variable.
 
 For example: `Get-Process | where ProcessName -CMatch "Shell"`
 
@@ -582,13 +613,13 @@ Accept wildcard characters: False
 
 ### -CNotContains
 
-Indicates that this cmdlet gets objects if the property value of the object is not an exact match
+Indicates that this cmdlet gets objects if the property value of the object isn't an exact match
 for the specified value. This operation is case-sensitive.
 
 For example: `Get-Process | where ProcessName -CNotContains "svchost"`
 
 **NotContains** and **CNotContains** refer to a collection of values and are true when the
-collection does not contains any items that are an exact match for the specified value. If the input
+collection doesn't contain any items that are an exact match for the specified value. If the input
 is a single object, PowerShell converts it to a collection of one object.
 
 This parameter was introduced in Windows PowerShell 3.0.
@@ -607,7 +638,7 @@ Accept wildcard characters: False
 
 ### -CNotIn
 
-Indicates that this cmdlet gets objects if the property value is not an exact match for the
+Indicates that this cmdlet gets objects if the property value isn't an exact match for the
 specified value. This operation is case-sensitive.
 
 For example: `Get-Process | where -Value "svchost" -CNotIn -Property ProcessName`
@@ -633,7 +664,7 @@ Accept wildcard characters: False
 
 ### -CNotLike
 
-Indicates that this cmdlet gets objects if the property value does not match a value that includes
+Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters. This operation is case-sensitive.
 
 For example: `Get-Process | where ProcessName -CNotLike "*host"`
@@ -654,9 +685,9 @@ Accept wildcard characters: False
 
 ### -CNotMatch
 
-Indicates that this cmdlet gets objects if the property value does not match the specified regular
-expression. This operation is case-sensitive. When the input is scalar, the matched value is saved
-in `$Matches` automatic variable.
+Indicates that this cmdlet gets objects if the property value doesn't match the specified regular
+expression. This operation is case-sensitive. When the input is a single object, the matched value
+is saved in the `$Matches` automatic variable.
 
 For example: `Get-Process | where ProcessName -CNotMatch "Shell"`
 
@@ -681,8 +712,7 @@ match for the specified value.
 
 For example: `Get-Process | where ProcessName -Contains "Svchost"`
 
-If the property value contains a single object, PowerShell converts it to a collection of one
-object.
+If the input is a single object, PowerShell converts it to a collection of one object.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -718,7 +748,7 @@ Accept wildcard characters: False
 
 ### -FilterScript
 
-Specifies the script block that is used to filter the objects. Enclose the script block in braces
+Specifies the script block that's used to filter the objects. Enclose the script block in braces
 (`{}`).
 
 The parameter name, **FilterScript**, is optional.
@@ -779,8 +809,7 @@ For example:
 
 `Get-Process | where -Property ProcessName -in -Value "Svchost", "TaskHost", "WsmProvHost"`
 
-If the value of the **Value** parameter is a single object, PowerShell converts it to a collection
-of one object.
+If the input is a single object, PowerShell converts it to a collection of one object.
 
 If the property value of an object is an array, PowerShell uses reference equality to determine a
 match. `Where-Object` returns the object only if the value of the **Property** parameter and any
@@ -802,15 +831,16 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the objects to be filtered. You can also pipe the objects to `Where-Object`.
+Specifies the objects to filter. You can also pipe the objects to `Where-Object`.
 
-When you use the **InputObject** parameter with `Where-Object`, instead of piping command results to
-`Where-Object`, the **InputObject** value is treated as a single object. This is true even if the
-value is a collection that is the result of a command, such as `-InputObject (Get-Process)`. Because
-**InputObject** cannot return individual properties from an array or collection of objects, we
-recommend that, if you use `Where-Object` to filter a collection of objects for those objects that
-have specific values in defined properties, you use `Where-Object` in the pipeline, as shown in the
-examples in this topic.
+When you use the **InputObject** parameter with `Where-Object`, instead of piping command results
+to `Where-Object`, the cmdlet treats the **InputObject** as a single object. This is true even if
+the value is a collection that's the result of a command, such as `-InputObject (Get-Process)`.
+
+Because **InputObject** can't return individual properties from an array or collection of objects,
+we recommend that, if you use `Where-Object` to filter a collection of objects for those objects
+that have specific values in defined properties, you use `Where-Object` in the pipeline, as shown
+in the examples in this topic.
 
 ```yaml
 Type: System.Management.Automation.PSObject
@@ -847,7 +877,7 @@ Accept wildcard characters: False
 
 ### -IsNot
 
-Indicates that this cmdlet gets objects if the property value is not an instance of the specified
+Indicates that this cmdlet gets objects if the property value isn't an instance of the specified
 .NET type.
 
 For example, `Get-Process | where StartTime -IsNot [DateTime]`
@@ -927,7 +957,8 @@ Accept wildcard characters: False
 ### -Match
 
 Indicates that this cmdlet gets objects if the property value matches the specified regular
-expression. When the input is scalar, the matched value is saved in `$Matches` automatic variable.
+expression. When the input is a single object, the matched value is saved in the `$Matches`
+automatic variable.
 
 For example: `Get-Process | where ProcessName -Match "shell"`
 
@@ -970,7 +1001,7 @@ for the specified value.
 
 For example: `Get-Process | where ProcessName -NotContains "Svchost"`
 
-**NotContains** refers to a collection of values and is true if the collection does not contain any
+**NotContains** refers to a collection of values and is true if the collection doesn't contain any
 items that are an exact match for the specified value. If the input is a single object, PowerShell
 converts it to a collection of one object.
 
@@ -990,7 +1021,7 @@ Accept wildcard characters: False
 
 ### -NotIn
 
-Indicates that this cmdlet gets objects if the property value is not an exact match for any of the
+Indicates that this cmdlet gets objects if the property value isn't an exact match for any of the
 specified values.
 
 For example: `Get-Process | where -Value "svchost" -NotIn -Property ProcessName`
@@ -999,7 +1030,7 @@ If the value of **Value** is a single object, PowerShell converts it to a collec
 
 If the property value of an object is an array, PowerShell uses reference equality to determine a
 match. `Where-Object` returns the object only if the value of **Property** and any value of
-**Value** are not the same instance of an object.
+**Value** aren't the same instance of an object.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -1017,7 +1048,7 @@ Accept wildcard characters: False
 
 ### -NotLike
 
-Indicates that this cmdlet gets objects if the property value does not match a value that includes
+Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters (`*`).
 
 For example: `Get-Process | where ProcessName -NotLike "*host"`
@@ -1038,8 +1069,9 @@ Accept wildcard characters: False
 
 ### -NotMatch
 
-Indicates that this cmdlet gets objects when the property value does not match the specified regular
-expression. When the input is scalar, the matched value is saved in `$Matches` automatic variable.
+Indicates that this cmdlet gets objects when the property value doesn't match the specified regular
+expression. When the input is a single object, the matched value is saved in the `$Matches`
+automatic variable.
 
 For example: `Get-Process | where ProcessName -NotMatch "PowerShell"`
 

--- a/reference/5.1/Microsoft.PowerShell.Diagnostics/Get-Counter.md
+++ b/reference/5.1/Microsoft.PowerShell.Diagnostics/Get-Counter.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Diagnostics
-ms.date: 12/12/2022
+ms.date: 05/08/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.diagnostics/get-counter?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Counter
@@ -475,7 +475,7 @@ Accept wildcard characters: False
 
 ### -Continuous
 
-When the **Continuous** is specified, `Get-Counter` gets samples until you press
+When **Continuous** is specified, `Get-Counter` gets samples until you press
 <kbd>CTRL</kbd>+<kbd>C</kbd>. Samples are obtained every second for each specified performance
 counter. Use the **SampleInterval** parameter to increase the interval between continuous samples.
 

--- a/reference/7.2/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Where-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/09/2022
+ms.date: 05/08/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/where-object?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Where-Object
@@ -344,28 +344,27 @@ for a specified property. Each example shows both the script block and compariso
 for the command.
 
 ```powershell
-# Use Where-Object to get commands that have any value for the OutputType property of the command.
-# This omits commands that do not have an OutputType property and those that have an OutputType
-# property, but no property value.
+# Use Where-Object to get commands that have any value for the OutputType
+# property of the command. This omits commands that do not have an OutputType
+# property and those that have an OutputType property, but no property value.
 Get-Command | where OutputType
-Get-Command | where {$_.OutputType}
+Get-Command | where { $_.OutputType }
 ```
 
 ```powershell
-# Use Where-Object to get objects that are containers.
-# This gets objects that have the **PSIsContainer** property with a value of $True and excludes all
+# Use Where-Object to get objects that are containers. This gets objects that
+# have the **PSIsContainer** property with a value of $True and excludes all
 # others.
 Get-ChildItem | where PSIsContainer
-Get-ChildItem | where {$_.PSIsContainer}
+Get-ChildItem | where { $_.PSIsContainer }
 ```
 
 ```powershell
 # Finally, use the Not operator (!) to get objects that are not containers.
-# This gets objects that do have the **PSIsContainer** property and those that have a value of
-# $False for the **PSIsContainer** property.
-Get-ChildItem | where {!$_.PSIsContainer}
-# You cannot use the Not operator (!) in the comparison statement format of the command.
-Get-ChildItem | where PSIsContainer -eq $False
+# This gets objects that do have the **PSIsContainer** property and those
+# that have a value of $False for the **PSIsContainer** property.
+Get-ChildItem | where -Not PSIsContainer
+Get-ChildItem | where { !$_.PSIsContainer }
 ```
 
 ### Example 6: Use multiple conditions

--- a/reference/7.2/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Where-Object.md
@@ -17,182 +17,183 @@ Selects objects from a collection based on their property values.
 ### EqualSet (Default)
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-EQ]
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ [-EQ] [<CommonParameters>]
 ```
 
 ### ScriptBlockSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-FilterScript] <ScriptBlock> [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-FilterScript] <ScriptBlock>
+ [<CommonParameters>]
 ```
 
 ### MatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -Match
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Match [<CommonParameters>]
 ```
 
 ### CaseSensitiveEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CEQ
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CEQ [<CommonParameters>]
 ```
 
 ### NotEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NE [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNE [<CommonParameters>]
 ```
 
 ### GreaterThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -GT
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -GT [<CommonParameters>]
 ```
 
 ### CaseSensitiveGreaterThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CGT
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CGT [<CommonParameters>]
 ```
 
 ### LessThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -LT
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -LT [<CommonParameters>]
 ```
 
 ### CaseSensitiveLessThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CLT
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CLT [<CommonParameters>]
 ```
 
 ### GreaterOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -GE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -GE [<CommonParameters>]
 ```
 
 ### CaseSensitiveGreaterOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CGE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CGE [<CommonParameters>]
 ```
 
 ### LessOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -LE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -LE [<CommonParameters>]
 ```
 
 ### CaseSensitiveLessOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CLE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CLE [<CommonParameters>]
 ```
 
 ### LikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -Like
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Like [<CommonParameters>]
 ```
 
 ### CaseSensitiveLikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CLike
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CLike [<CommonParameters>]
 ```
 
 ### NotLikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NotLike
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotLike [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotLikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNotLike
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotLike [<CommonParameters>]
 ```
 
 ### CaseSensitiveMatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CMatch
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CMatch [<CommonParameters>]
 ```
 
 ### NotMatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NotMatch
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotMatch [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotMatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNotMatch
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotMatch [<CommonParameters>]
 ```
 
 ### ContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -Contains
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Contains [<CommonParameters>]
 ```
 
 ### CaseSensitiveContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CContains
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CContains [<CommonParameters>]
 ```
 
 ### NotContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NotContains
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotContains [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNotContains
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotContains [<CommonParameters>]
 ```
 
 ### InSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -In
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -In [<CommonParameters>]
 ```
 
 ### CaseSensitiveInSet
@@ -205,35 +206,36 @@ Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] 
 ### NotInSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NotIn
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotIn [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotInSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNotIn
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotIn [<CommonParameters>]
 ```
 
 ### IsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -Is
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Is [<CommonParameters>]
 ```
 
 ### IsNotSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -IsNot
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -IsNot [<CommonParameters>]
 ```
 
 ### Not
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> -Not [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> -Not
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -262,52 +264,53 @@ command.
   natural language. Comparison statements were introduced in Windows PowerShell 3.0.
 
   For example, the following commands also get processes that have a priority class of `Normal`.
-  These commands are equivalent and can be used interchangeably.
+  These commands are equivalent and you can use them interchangeably.
 
   `Get-Process | Where-Object -Property PriorityClass -eq -Value "Normal"`
 
   `Get-Process | Where-Object PriorityClass -eq "Normal"`
 
   Starting in Windows PowerShell 3.0, `Where-Object` adds comparison operators as parameters in a
-  `Where-Object` command. Unless specified, all operators are case-insensitive. Prior to Windows
-  PowerShell 3.0, the comparison operators in the PowerShell language could be used only in script
+  `Where-Object` command. Unless specified, all operators are case-insensitive. Before Windows
+  PowerShell 3.0, the comparison operators in the PowerShell language were only usable in script
   blocks.
 
-When you provide a single **Property** to `Where-Object`, the value of the property is treated as
-a boolean expression. When the value of **Length** is not zero, the expression evaluates to
-`$true`. For example: `('hi', '', 'there') | Where-Object Length`
+When you provide a single **Property** to `Where-Object`, the cmdlet treats the value of the
+property as a boolean expression. When the value of the property's **Length** isn't zero, the
+expression evaluates to `$true`. For example: `('hi', '', 'there') | Where-Object Length`
 
 The previous example is functionally equivalent to:
 
 - `('hi', '', 'there') | Where-Object Length -GT 0`
-- `('hi', '', 'there') | Where-Object {$_.Length -gt 0}`
+- `('hi', '', 'there') | Where-Object { $_.Length -gt 0 }`
 
-For more information about how booleans are evaluated, see
+For more information about how PowerShell evaluates booleans, see
 [about_Booleans](about/about_Booleans.md).
 
 ## EXAMPLES
 
 ### Example 1: Get stopped services
 
-These commands get a list of all services that are currently stopped. The `$_` automatic variable
-represents each object that is passed to the `Where-Object` cmdlet.
+These commands get a list of all services that are stopped. The `$_` automatic variable represents
+each object that's passed to the `Where-Object` cmdlet.
 
 The first command uses the script block format, the second command uses the comparison statement
-format. The commands are equivalent and can be used interchangeably.
+format. The commands filter the services the same way and return the same output. Only the syntax
+is different.
 
 ```powershell
-Get-Service | Where-Object {$_.Status -eq "Stopped"}
+Get-Service | Where-Object { $_.Status -eq "Stopped" }
 Get-Service | where Status -eq "Stopped"
 ```
 
 ### Example 2: Get processes based on working set
 
-These commands list processes that have a working set greater than 250 megabytes (MB). The
-scriptblock and statement syntax are equivalent and can be used interchangeably.
+These commands list processes that have a working set greater than 250 megabytes (MB). The commands
+filter the processes the same way and return the same output. Only the syntax is different.
 
 ```powershell
-Get-Process | Where-Object {$_.WorkingSet -GT 250MB}
-Get-Process | Where-Object WorkingSet -GT (250MB)
+Get-Process | Where-Object { $_.WorkingSet -GT 250MB }
+Get-Process | Where-Object WorkingSet -GT 250MB
 ```
 
 ### Example 3: Get processes based on process name
@@ -315,10 +318,11 @@ Get-Process | Where-Object WorkingSet -GT (250MB)
 These commands get the processes that have a **ProcessName** property value that begins with the
 letter `p`. The **Match** operator lets you use regular expression matches.
 
-The scriptblock and statement syntax are equivalent and can be used interchangeably.
+The commands filter the processes the same way and return the same output. Only the syntax is
+different.
 
 ```powershell
-Get-Process | Where-Object {$_.ProcessName -Match "^p.*"}
+Get-Process | Where-Object { $_.ProcessName -Match "^p.*" }
 Get-Process | Where-Object ProcessName -Match "^p.*"
 ```
 
@@ -326,11 +330,15 @@ Get-Process | Where-Object ProcessName -Match "^p.*"
 
 This example shows how to use the new comparison statement format of the `Where-Object` cmdlet.
 
-The first command uses the comparison statement format. In this command, no aliases are used and all
-parameters include the parameter name.
+The first command uses the comparison statement format. It doesn't use any aliases and includes the
+name for every parameter.
 
-The second command is the more natural use of the comparison command format. The `where` alias is
-substituted for the `Where-Object` cmdlet name and all optional parameter names are omitted.
+The second command is the more natural use of the comparison command format. The command
+substitutes the `where` alias for the `Where-Object` cmdlet name and omits all optional parameter
+names.
+
+The commands filter the processes the same way and return the same output. Only the syntax is
+different.
 
 ```powershell
 Get-Process | Where-Object -Property Handles -GE -Value 1000
@@ -342,6 +350,9 @@ Get-Process | where Handles -GE 1000
 This example shows how to write commands that return items that are true or false or have any value
 for a specified property. Each example shows both the script block and comparison statement formats
 for the command.
+
+The commands filter their input the same way and return the same output. Only the syntax is
+different.
 
 ```powershell
 # Use Where-Object to get commands that have any value for the OutputType
@@ -380,12 +391,12 @@ This example shows how to create a `Where-Object` command with multiple conditio
 This command gets non-core modules that support the Updatable Help feature. The command uses the
 **ListAvailable** parameter of the `Get-Module` cmdlet to get all modules on the computer. A
 pipeline operator (`|`) sends the modules to the `Where-Object` cmdlet, which gets modules whose
-names do not begin with `Microsoft` or `PS`, and have a value for the **HelpInfoURI** property,
-which tells PowerShell where to find updated help files for the module. The comparison statements
-are connected by the **And** logical operator.
+names don't begin with `Microsoft` or `PS`, and have a value for the **HelpInfoURI** property,
+which tells PowerShell where to find updated help files for the module. The **And** logical operator
+connects the comparison statements.
 
-The example uses the script block command format. Logical operators, such as **And** and **Or**, are
-valid only in script blocks. You cannot use them in the comparison statement format of a
+The example uses the script block command format. Logical operators, such as **And** and **Or**,
+are valid only in script blocks. You can't use them in the comparison statement format of a
 `Where-Object` command.
 
 - For more information about PowerShell logical operators, see
@@ -567,8 +578,8 @@ Accept wildcard characters: False
 ### -CMatch
 
 Indicates that this cmdlet gets objects if the property value matches the specified regular
-expression. This operation is case-sensitive. When the input is scalar, the matched value is saved
-in `$Matches` automatic variable.
+expression. This operation is case-sensitive. When the input is a single object, the matched value
+is saved in the `$Matches` automatic variable.
 
 For example: `Get-Process | where ProcessName -CMatch "Shell"`
 
@@ -607,13 +618,13 @@ Accept wildcard characters: False
 
 ### -CNotContains
 
-Indicates that this cmdlet gets objects if the property value of the object is not an exact match
+Indicates that this cmdlet gets objects if the property value of the object isn't an exact match
 for the specified value. This operation is case-sensitive.
 
 For example: `Get-Process | where ProcessName -CNotContains "svchost"`
 
 **NotContains** and **CNotContains** refer to a collection of values and are true when the
-collection does not contains any items that are an exact match for the specified value. If the input
+collection doesn't contain any items that are an exact match for the specified value. If the input
 is a single object, PowerShell converts it to a collection of one object.
 
 This parameter was introduced in Windows PowerShell 3.0.
@@ -632,7 +643,7 @@ Accept wildcard characters: False
 
 ### -CNotIn
 
-Indicates that this cmdlet gets objects if the property value is not an exact match for the
+Indicates that this cmdlet gets objects if the property value isn't an exact match for the
 specified value. This operation is case-sensitive.
 
 For example: `Get-Process | where -Value "svchost" -CNotIn -Property ProcessName`
@@ -658,7 +669,7 @@ Accept wildcard characters: False
 
 ### -CNotLike
 
-Indicates that this cmdlet gets objects if the property value does not match a value that includes
+Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters. This operation is case-sensitive.
 
 For example: `Get-Process | where ProcessName -CNotLike "*host"`
@@ -679,9 +690,9 @@ Accept wildcard characters: False
 
 ### -CNotMatch
 
-Indicates that this cmdlet gets objects if the property value does not match the specified regular
-expression. This operation is case-sensitive. When the input is scalar, the matched value is saved
-in `$Matches` automatic variable.
+Indicates that this cmdlet gets objects if the property value doesn't match the specified regular
+expression. This operation is case-sensitive. When the input is a single object, the matched value
+is saved in the `$Matches` automatic variable.
 
 For example: `Get-Process | where ProcessName -CNotMatch "Shell"`
 
@@ -706,8 +717,7 @@ match for the specified value.
 
 For example: `Get-Process | where ProcessName -Contains "Svchost"`
 
-If the property value contains a single object, PowerShell converts it to a collection of one
-object.
+If the input is a single object, PowerShell converts it to a collection of one object.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -743,7 +753,7 @@ Accept wildcard characters: False
 
 ### -FilterScript
 
-Specifies the script block that is used to filter the objects. Enclose the script block in braces
+Specifies the script block that's used to filter the objects. Enclose the script block in braces
 (`{}`).
 
 The parameter name, **FilterScript**, is optional.
@@ -804,8 +814,7 @@ For example:
 
 `Get-Process | where -Property ProcessName -in -Value "Svchost", "TaskHost", "WsmProvHost"`
 
-If the value of the **Value** parameter is a single object, PowerShell converts it to a collection
-of one object.
+If the input is a single object, PowerShell converts it to a collection of one object.
 
 If the property value of an object is an array, PowerShell uses reference equality to determine a
 match. `Where-Object` returns the object only if the value of the **Property** parameter and any
@@ -827,15 +836,16 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the objects to be filtered. You can also pipe the objects to `Where-Object`.
+Specifies the objects to filter. You can also pipe the objects to `Where-Object`.
 
-When you use the **InputObject** parameter with `Where-Object`, instead of piping command results to
-`Where-Object`, the **InputObject** value is treated as a single object. This is true even if the
-value is a collection that is the result of a command, such as `-InputObject (Get-Process)`. Because
-**InputObject** cannot return individual properties from an array or collection of objects, we
-recommend that, if you use `Where-Object` to filter a collection of objects for those objects that
-have specific values in defined properties, you use `Where-Object` in the pipeline, as shown in the
-examples in this topic.
+When you use the **InputObject** parameter with `Where-Object`, instead of piping command results
+to `Where-Object`, the cmdlet treats the **InputObject** as a single object. This is true even if
+the value is a collection that's the result of a command, such as `-InputObject (Get-Process)`.
+
+Because **InputObject** can't return individual properties from an array or collection of objects,
+we recommend that, if you use `Where-Object` to filter a collection of objects for those objects
+that have specific values in defined properties, you use `Where-Object` in the pipeline, as shown
+in the examples in this topic.
 
 ```yaml
 Type: System.Management.Automation.PSObject
@@ -872,7 +882,7 @@ Accept wildcard characters: False
 
 ### -IsNot
 
-Indicates that this cmdlet gets objects if the property value is not an instance of the specified
+Indicates that this cmdlet gets objects if the property value isn't an instance of the specified
 .NET type.
 
 For example, `Get-Process | where StartTime -IsNot [DateTime]`
@@ -952,7 +962,8 @@ Accept wildcard characters: False
 ### -Match
 
 Indicates that this cmdlet gets objects if the property value matches the specified regular
-expression. When the input is scalar, the matched value is saved in `$Matches` automatic variable.
+expression. When the input is a single object, the matched value is saved in the `$Matches`
+automatic variable.
 
 For example: `Get-Process | where ProcessName -Match "shell"`
 
@@ -990,7 +1001,7 @@ Accept wildcard characters: False
 
 ### -Not
 
-Indicates that this cmdlet gets objects if the property does not exist or has a value of `$null` or
+Indicates that this cmdlet gets objects if the property doesn't exist or has a value of `$null` or
 `$false`.
 
 For example: `Get-Service | where -Not "DependentServices"`
@@ -1016,7 +1027,7 @@ for the specified value.
 
 For example: `Get-Process | where ProcessName -NotContains "Svchost"`
 
-**NotContains** refers to a collection of values and is true if the collection does not contain any
+**NotContains** refers to a collection of values and is true if the collection doesn't contain any
 items that are an exact match for the specified value. If the input is a single object, PowerShell
 converts it to a collection of one object.
 
@@ -1036,7 +1047,7 @@ Accept wildcard characters: False
 
 ### -NotIn
 
-Indicates that this cmdlet gets objects if the property value is not an exact match for any of the
+Indicates that this cmdlet gets objects if the property value isn't an exact match for any of the
 specified values.
 
 For example: `Get-Process | where -Value "svchost" -NotIn -Property ProcessName`
@@ -1045,7 +1056,7 @@ If the value of **Value** is a single object, PowerShell converts it to a collec
 
 If the property value of an object is an array, PowerShell uses reference equality to determine a
 match. `Where-Object` returns the object only if the value of **Property** and any value of
-**Value** are not the same instance of an object.
+**Value** aren't the same instance of an object.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -1063,7 +1074,7 @@ Accept wildcard characters: False
 
 ### -NotLike
 
-Indicates that this cmdlet gets objects if the property value does not match a value that includes
+Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters (`*`).
 
 For example: `Get-Process | where ProcessName -NotLike "*host"`
@@ -1084,8 +1095,9 @@ Accept wildcard characters: False
 
 ### -NotMatch
 
-Indicates that this cmdlet gets objects when the property value does not match the specified regular
-expression. When the input is scalar, the matched value is saved in `$Matches` automatic variable.
+Indicates that this cmdlet gets objects when the property value doesn't match the specified regular
+expression. When the input is a single object, the matched value is saved in the `$Matches`
+automatic variable.
 
 For example: `Get-Process | where ProcessName -NotMatch "PowerShell"`
 

--- a/reference/7.2/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Where-Object.md
@@ -371,7 +371,7 @@ Get-ChildItem | where { $_.PSIsContainer }
 ```
 
 ```powershell
-# Finally, use the Not operator (!) to get objects that are not containers.
+# Finally, use the -not operator (!) to get objects that are not containers.
 # This gets objects that do have the **PSIsContainer** property and those
 # that have a value of $False for the **PSIsContainer** property.
 Get-ChildItem | where -Not PSIsContainer
@@ -392,11 +392,11 @@ This command gets non-core modules that support the Updatable Help feature. The 
 **ListAvailable** parameter of the `Get-Module` cmdlet to get all modules on the computer. A
 pipeline operator (`|`) sends the modules to the `Where-Object` cmdlet, which gets modules whose
 names don't begin with `Microsoft` or `PS`, and have a value for the **HelpInfoURI** property,
-which tells PowerShell where to find updated help files for the module. The **And** logical operator
+which tells PowerShell where to find updated help files for the module. The `-and` logical operator
 connects the comparison statements.
 
-The example uses the script block command format. Logical operators, such as **And** and **Or**,
-are valid only in script blocks. You can't use them in the comparison statement format of a
+The example uses the script block command format. Logical operators, such as `-and`,`-or`, and
+`-not` are valid only in script blocks. You can't use them in the comparison statement format of a
 `Where-Object` command.
 
 - For more information about PowerShell logical operators, see
@@ -1146,7 +1146,7 @@ wildcard characters when used with the following comparison parameters:
 This parameter was introduced in Windows PowerShell 3.0.
 
 ```yaml
-Type: Object
+Type: System.Management.Automation.PSObject
 Parameter Sets: EqualSet, CaseSensitiveGreaterOrEqualSet, CaseSensitiveEqualSet, NotEqualSet, CaseSensitiveNotEqualSet, GreaterThanSet, CaseSensitiveGreaterThanSet, LessThanSet, CaseSensitiveLessThanSet, GreaterOrEqualSet, LessOrEqualSet, CaseSensitiveLessOrEqualSet, LikeSet, CaseSensitiveLikeSet, NotLikeSet, CaseSensitiveNotLikeSet, MatchSet, CaseSensitiveMatchSet, NotMatchSet, CaseSensitiveNotMatchSet, ContainsSet, CaseSensitiveContainsSet, NotContainsSet, CaseSensitiveNotContainsSet, InSet, CaseSensitiveInSet, NotInSet, CaseSensitiveNotInSet, IsSet, IsNotSet
 Aliases:
 
@@ -1172,7 +1172,7 @@ You can pipe any object to this cmdlet.
 
 ## OUTPUTS
 
-### Object
+### System.Object
 
 This cmdlet returns the selected items from the input object set.
 

--- a/reference/7.2/Microsoft.PowerShell.Diagnostics/Get-Counter.md
+++ b/reference/7.2/Microsoft.PowerShell.Diagnostics/Get-Counter.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Diagnostics
-ms.date: 12/12/2022
+ms.date: 05/08/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.diagnostics/get-counter?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Counter

--- a/reference/7.3/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/Where-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/09/2022
+ms.date: 05/08/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/where-object?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Where-Object
@@ -344,28 +344,27 @@ for a specified property. Each example shows both the script block and compariso
 for the command.
 
 ```powershell
-# Use Where-Object to get commands that have any value for the OutputType property of the command.
-# This omits commands that do not have an OutputType property and those that have an OutputType
-# property, but no property value.
+# Use Where-Object to get commands that have any value for the OutputType
+# property of the command. This omits commands that do not have an OutputType
+# property and those that have an OutputType property, but no property value.
 Get-Command | where OutputType
-Get-Command | where {$_.OutputType}
+Get-Command | where { $_.OutputType }
 ```
 
 ```powershell
-# Use Where-Object to get objects that are containers.
-# This gets objects that have the **PSIsContainer** property with a value of $True and excludes all
+# Use Where-Object to get objects that are containers. This gets objects that
+# have the **PSIsContainer** property with a value of $True and excludes all
 # others.
 Get-ChildItem | where PSIsContainer
-Get-ChildItem | where {$_.PSIsContainer}
+Get-ChildItem | where { $_.PSIsContainer }
 ```
 
 ```powershell
 # Finally, use the Not operator (!) to get objects that are not containers.
-# This gets objects that do have the **PSIsContainer** property and those that have a value of
-# $False for the **PSIsContainer** property.
-Get-ChildItem | where {!$_.PSIsContainer}
-# You cannot use the Not operator (!) in the comparison statement format of the command.
-Get-ChildItem | where PSIsContainer -eq $False
+# This gets objects that do have the **PSIsContainer** property and those
+# that have a value of $False for the **PSIsContainer** property.
+Get-ChildItem | where -Not PSIsContainer
+Get-ChildItem | where { !$_.PSIsContainer }
 ```
 
 ### Example 6: Use multiple conditions

--- a/reference/7.3/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/Where-Object.md
@@ -17,182 +17,183 @@ Selects objects from a collection based on their property values.
 ### EqualSet (Default)
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-EQ]
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ [-EQ] [<CommonParameters>]
 ```
 
 ### ScriptBlockSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-FilterScript] <ScriptBlock> [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-FilterScript] <ScriptBlock>
+ [<CommonParameters>]
 ```
 
 ### MatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -Match
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Match [<CommonParameters>]
 ```
 
 ### CaseSensitiveEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CEQ
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CEQ [<CommonParameters>]
 ```
 
 ### NotEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NE [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNE [<CommonParameters>]
 ```
 
 ### GreaterThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -GT
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -GT [<CommonParameters>]
 ```
 
 ### CaseSensitiveGreaterThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CGT
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CGT [<CommonParameters>]
 ```
 
 ### LessThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -LT
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -LT [<CommonParameters>]
 ```
 
 ### CaseSensitiveLessThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CLT
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CLT [<CommonParameters>]
 ```
 
 ### GreaterOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -GE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -GE [<CommonParameters>]
 ```
 
 ### CaseSensitiveGreaterOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CGE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CGE [<CommonParameters>]
 ```
 
 ### LessOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -LE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -LE [<CommonParameters>]
 ```
 
 ### CaseSensitiveLessOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CLE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CLE [<CommonParameters>]
 ```
 
 ### LikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -Like
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Like [<CommonParameters>]
 ```
 
 ### CaseSensitiveLikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CLike
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CLike [<CommonParameters>]
 ```
 
 ### NotLikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NotLike
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotLike [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotLikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNotLike
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotLike [<CommonParameters>]
 ```
 
 ### CaseSensitiveMatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CMatch
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CMatch [<CommonParameters>]
 ```
 
 ### NotMatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NotMatch
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotMatch [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotMatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNotMatch
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotMatch [<CommonParameters>]
 ```
 
 ### ContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -Contains
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Contains [<CommonParameters>]
 ```
 
 ### CaseSensitiveContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CContains
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CContains [<CommonParameters>]
 ```
 
 ### NotContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NotContains
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotContains [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNotContains
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotContains [<CommonParameters>]
 ```
 
 ### InSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -In
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -In [<CommonParameters>]
 ```
 
 ### CaseSensitiveInSet
@@ -205,35 +206,36 @@ Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] 
 ### NotInSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NotIn
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotIn [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotInSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNotIn
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotIn [<CommonParameters>]
 ```
 
 ### IsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -Is
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Is [<CommonParameters>]
 ```
 
 ### IsNotSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -IsNot
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -IsNot [<CommonParameters>]
 ```
 
 ### Not
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> -Not [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> -Not
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -262,38 +264,39 @@ command.
   natural language. Comparison statements were introduced in Windows PowerShell 3.0.
 
   For example, the following commands also get processes that have a priority class of `Normal`.
-  These commands are equivalent and can be used interchangeably.
+  These commands are equivalent and you can use them interchangeably.
 
   `Get-Process | Where-Object -Property PriorityClass -eq -Value "Normal"`
 
   `Get-Process | Where-Object PriorityClass -eq "Normal"`
 
   Starting in Windows PowerShell 3.0, `Where-Object` adds comparison operators as parameters in a
-  `Where-Object` command. Unless specified, all operators are case-insensitive. Prior to Windows
-  PowerShell 3.0, the comparison operators in the PowerShell language could be used only in script
+  `Where-Object` command. Unless specified, all operators are case-insensitive. Before Windows
+  PowerShell 3.0, the comparison operators in the PowerShell language were only usable in script
   blocks.
 
-When you provide a single **Property** to `Where-Object`, the value of the property is treated as
-a boolean expression. When the value of **Length** is not zero, the expression evaluates to
-`$true`. For example: `('hi', '', 'there') | Where-Object Length`
+When you provide a single **Property** to `Where-Object`, the cmdlet treats the value of the
+property as a boolean expression. When the value of the property's **Length** isn't zero, the
+expression evaluates to `$true`. For example: `('hi', '', 'there') | Where-Object Length`
 
 The previous example is functionally equivalent to:
 
 - `('hi', '', 'there') | Where-Object Length -GT 0`
-- `('hi', '', 'there') | Where-Object {$_.Length -gt 0}`
+- `('hi', '', 'there') | Where-Object { $_.Length -gt 0 }`
 
-For more information about how booleans are evaluated, see
+For more information about how PowerShell evaluates booleans, see
 [about_Booleans](about/about_Booleans.md).
 
 ## EXAMPLES
 
 ### Example 1: Get stopped services
 
-These commands get a list of all services that are currently stopped. The `$_` automatic variable
-represents each object that is passed to the `Where-Object` cmdlet.
+These commands get a list of all services that are stopped. The `$_` automatic variable represents
+each object that's passed to the `Where-Object` cmdlet.
 
 The first command uses the script block format, the second command uses the comparison statement
-format. The commands are equivalent and can be used interchangeably.
+format. The commands filter the services the same way and return the same output. Only the syntax
+is different.
 
 ```powershell
 Get-Service | Where-Object {$_.Status -eq "Stopped"}
@@ -302,12 +305,12 @@ Get-Service | where Status -eq "Stopped"
 
 ### Example 2: Get processes based on working set
 
-These commands list processes that have a working set greater than 250 megabytes (MB). The
-scriptblock and statement syntax are equivalent and can be used interchangeably.
+These commands list processes that have a working set greater than 250 megabytes (MB). The commands
+filter the processes the same way and return the same output. Only the syntax is different.
 
 ```powershell
-Get-Process | Where-Object {$_.WorkingSet -GT 250MB}
-Get-Process | Where-Object WorkingSet -GT (250MB)
+Get-Process | Where-Object { $_.WorkingSet -GT 250MB }
+Get-Process | Where-Object WorkingSet -GT 250MB
 ```
 
 ### Example 3: Get processes based on process name
@@ -315,10 +318,11 @@ Get-Process | Where-Object WorkingSet -GT (250MB)
 These commands get the processes that have a **ProcessName** property value that begins with the
 letter `p`. The **Match** operator lets you use regular expression matches.
 
-The scriptblock and statement syntax are equivalent and can be used interchangeably.
+The commands filter the processes the same way and return the same output. Only the syntax is
+different.
 
 ```powershell
-Get-Process | Where-Object {$_.ProcessName -Match "^p.*"}
+Get-Process | Where-Object { $_.ProcessName -Match "^p.*" }
 Get-Process | Where-Object ProcessName -Match "^p.*"
 ```
 
@@ -326,11 +330,15 @@ Get-Process | Where-Object ProcessName -Match "^p.*"
 
 This example shows how to use the new comparison statement format of the `Where-Object` cmdlet.
 
-The first command uses the comparison statement format. In this command, no aliases are used and all
-parameters include the parameter name.
+The first command uses the comparison statement format. It doesn't use any aliases and includes the
+name for every parameter.
 
-The second command is the more natural use of the comparison command format. The `where` alias is
-substituted for the `Where-Object` cmdlet name and all optional parameter names are omitted.
+The second command is the more natural use of the comparison command format. The command
+substitutes the `where` alias for the `Where-Object` cmdlet name and omits all optional parameter
+names.
+
+The commands filter the processes the same way and return the same output. Only the syntax is
+different.
 
 ```powershell
 Get-Process | Where-Object -Property Handles -GE -Value 1000
@@ -342,6 +350,9 @@ Get-Process | where Handles -GE 1000
 This example shows how to write commands that return items that are true or false or have any value
 for a specified property. Each example shows both the script block and comparison statement formats
 for the command.
+
+The commands filter their input the same way and return the same output. Only the syntax is
+different.
 
 ```powershell
 # Use Where-Object to get commands that have any value for the OutputType
@@ -380,12 +391,12 @@ This example shows how to create a `Where-Object` command with multiple conditio
 This command gets non-core modules that support the Updatable Help feature. The command uses the
 **ListAvailable** parameter of the `Get-Module` cmdlet to get all modules on the computer. A
 pipeline operator (`|`) sends the modules to the `Where-Object` cmdlet, which gets modules whose
-names do not begin with `Microsoft` or `PS`, and have a value for the **HelpInfoURI** property,
-which tells PowerShell where to find updated help files for the module. The comparison statements
-are connected by the **And** logical operator.
+names don't begin with `Microsoft` or `PS`, and have a value for the **HelpInfoURI** property,
+which tells PowerShell where to find updated help files for the module. The **And** logical operator
+connects the comparison statements.
 
-The example uses the script block command format. Logical operators, such as **And** and **Or**, are
-valid only in script blocks. You cannot use them in the comparison statement format of a
+The example uses the script block command format. Logical operators, such as **And** and **Or**,
+are valid only in script blocks. You can't use them in the comparison statement format of a
 `Where-Object` command.
 
 - For more information about PowerShell logical operators, see
@@ -567,8 +578,8 @@ Accept wildcard characters: False
 ### -CMatch
 
 Indicates that this cmdlet gets objects if the property value matches the specified regular
-expression. This operation is case-sensitive. When the input is scalar, the matched value is saved
-in `$Matches` automatic variable.
+expression. This operation is case-sensitive. When the input is a single object, the matched value
+is saved in the `$Matches` automatic variable.
 
 For example: `Get-Process | where ProcessName -CMatch "Shell"`
 
@@ -607,13 +618,13 @@ Accept wildcard characters: False
 
 ### -CNotContains
 
-Indicates that this cmdlet gets objects if the property value of the object is not an exact match
+Indicates that this cmdlet gets objects if the property value of the object isn't an exact match
 for the specified value. This operation is case-sensitive.
 
 For example: `Get-Process | where ProcessName -CNotContains "svchost"`
 
 **NotContains** and **CNotContains** refer to a collection of values and are true when the
-collection does not contains any items that are an exact match for the specified value. If the input
+collection doesn't contain any items that are an exact match for the specified value. If the input
 is a single object, PowerShell converts it to a collection of one object.
 
 This parameter was introduced in Windows PowerShell 3.0.
@@ -632,7 +643,7 @@ Accept wildcard characters: False
 
 ### -CNotIn
 
-Indicates that this cmdlet gets objects if the property value is not an exact match for the
+Indicates that this cmdlet gets objects if the property value isn't an exact match for the
 specified value. This operation is case-sensitive.
 
 For example: `Get-Process | where -Value "svchost" -CNotIn -Property ProcessName`
@@ -658,7 +669,7 @@ Accept wildcard characters: False
 
 ### -CNotLike
 
-Indicates that this cmdlet gets objects if the property value does not match a value that includes
+Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters. This operation is case-sensitive.
 
 For example: `Get-Process | where ProcessName -CNotLike "*host"`
@@ -679,9 +690,9 @@ Accept wildcard characters: False
 
 ### -CNotMatch
 
-Indicates that this cmdlet gets objects if the property value does not match the specified regular
-expression. This operation is case-sensitive. When the input is scalar, the matched value is saved
-in `$Matches` automatic variable.
+Indicates that this cmdlet gets objects if the property value doesn't match the specified regular
+expression. This operation is case-sensitive. When the input is a single object, the matched value
+is saved in the `$Matches` automatic variable.
 
 For example: `Get-Process | where ProcessName -CNotMatch "Shell"`
 
@@ -706,8 +717,7 @@ match for the specified value.
 
 For example: `Get-Process | where ProcessName -Contains "Svchost"`
 
-If the property value contains a single object, PowerShell converts it to a collection of one
-object.
+If the input is a single object, PowerShell converts it to a collection of one object.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -743,7 +753,7 @@ Accept wildcard characters: False
 
 ### -FilterScript
 
-Specifies the script block that is used to filter the objects. Enclose the script block in braces
+Specifies the script block that's used to filter the objects. Enclose the script block in braces
 (`{}`).
 
 The parameter name, **FilterScript**, is optional.
@@ -804,8 +814,7 @@ For example:
 
 `Get-Process | where -Property ProcessName -in -Value "Svchost", "TaskHost", "WsmProvHost"`
 
-If the value of the **Value** parameter is a single object, PowerShell converts it to a collection
-of one object.
+If the input is a single object, PowerShell converts it to a collection of one object.
 
 If the property value of an object is an array, PowerShell uses reference equality to determine a
 match. `Where-Object` returns the object only if the value of the **Property** parameter and any
@@ -827,15 +836,16 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the objects to be filtered. You can also pipe the objects to `Where-Object`.
+Specifies the objects to filter. You can also pipe the objects to `Where-Object`.
 
-When you use the **InputObject** parameter with `Where-Object`, instead of piping command results to
-`Where-Object`, the **InputObject** value is treated as a single object. This is true even if the
-value is a collection that is the result of a command, such as `-InputObject (Get-Process)`. Because
-**InputObject** cannot return individual properties from an array or collection of objects, we
-recommend that, if you use `Where-Object` to filter a collection of objects for those objects that
-have specific values in defined properties, you use `Where-Object` in the pipeline, as shown in the
-examples in this topic.
+When you use the **InputObject** parameter with `Where-Object`, instead of piping command results
+to `Where-Object`, the cmdlet treats the **InputObject** as a single object. This is true even if
+the value is a collection that's the result of a command, such as `-InputObject (Get-Process)`.
+
+Because **InputObject** can't return individual properties from an array or collection of objects,
+we recommend that, if you use `Where-Object` to filter a collection of objects for those objects
+that have specific values in defined properties, you use `Where-Object` in the pipeline, as shown
+in the examples in this topic.
 
 ```yaml
 Type: System.Management.Automation.PSObject
@@ -872,7 +882,7 @@ Accept wildcard characters: False
 
 ### -IsNot
 
-Indicates that this cmdlet gets objects if the property value is not an instance of the specified
+Indicates that this cmdlet gets objects if the property value isn't an instance of the specified
 .NET type.
 
 For example, `Get-Process | where StartTime -IsNot [DateTime]`
@@ -952,7 +962,8 @@ Accept wildcard characters: False
 ### -Match
 
 Indicates that this cmdlet gets objects if the property value matches the specified regular
-expression. When the input is scalar, the matched value is saved in `$Matches` automatic variable.
+expression. When the input is a single object, the matched value is saved in the `$Matches`
+automatic variable.
 
 For example: `Get-Process | where ProcessName -Match "shell"`
 
@@ -990,7 +1001,7 @@ Accept wildcard characters: False
 
 ### -Not
 
-Indicates that this cmdlet gets objects if the property does not exist or has a value of `$null` or
+Indicates that this cmdlet gets objects if the property doesn't exist or has a value of `$null` or
 `$false`.
 
 For example: `Get-Service | where -Not "DependentServices"`
@@ -1016,7 +1027,7 @@ for the specified value.
 
 For example: `Get-Process | where ProcessName -NotContains "Svchost"`
 
-**NotContains** refers to a collection of values and is true if the collection does not contain any
+**NotContains** refers to a collection of values and is true if the collection doesn't contain any
 items that are an exact match for the specified value. If the input is a single object, PowerShell
 converts it to a collection of one object.
 
@@ -1036,7 +1047,7 @@ Accept wildcard characters: False
 
 ### -NotIn
 
-Indicates that this cmdlet gets objects if the property value is not an exact match for any of the
+Indicates that this cmdlet gets objects if the property value isn't an exact match for any of the
 specified values.
 
 For example: `Get-Process | where -Value "svchost" -NotIn -Property ProcessName`
@@ -1045,7 +1056,7 @@ If the value of **Value** is a single object, PowerShell converts it to a collec
 
 If the property value of an object is an array, PowerShell uses reference equality to determine a
 match. `Where-Object` returns the object only if the value of **Property** and any value of
-**Value** are not the same instance of an object.
+**Value** aren't the same instance of an object.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -1063,7 +1074,7 @@ Accept wildcard characters: False
 
 ### -NotLike
 
-Indicates that this cmdlet gets objects if the property value does not match a value that includes
+Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters (`*`).
 
 For example: `Get-Process | where ProcessName -NotLike "*host"`
@@ -1084,8 +1095,9 @@ Accept wildcard characters: False
 
 ### -NotMatch
 
-Indicates that this cmdlet gets objects when the property value does not match the specified regular
-expression. When the input is scalar, the matched value is saved in `$Matches` automatic variable.
+Indicates that this cmdlet gets objects when the property value doesn't match the specified regular
+expression. When the input is a single object, the matched value is saved in the `$Matches`
+automatic variable.
 
 For example: `Get-Process | where ProcessName -NotMatch "PowerShell"`
 

--- a/reference/7.3/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/Where-Object.md
@@ -299,7 +299,7 @@ format. The commands filter the services the same way and return the same output
 is different.
 
 ```powershell
-Get-Service | Where-Object {$_.Status -eq "Stopped"}
+Get-Service | Where-Object { $_.Status -eq "Stopped" }
 Get-Service | where Status -eq "Stopped"
 ```
 
@@ -371,7 +371,7 @@ Get-ChildItem | where { $_.PSIsContainer }
 ```
 
 ```powershell
-# Finally, use the Not operator (!) to get objects that are not containers.
+# Finally, use the -not operator (!) to get objects that are not containers.
 # This gets objects that do have the **PSIsContainer** property and those
 # that have a value of $False for the **PSIsContainer** property.
 Get-ChildItem | where -Not PSIsContainer
@@ -392,11 +392,11 @@ This command gets non-core modules that support the Updatable Help feature. The 
 **ListAvailable** parameter of the `Get-Module` cmdlet to get all modules on the computer. A
 pipeline operator (`|`) sends the modules to the `Where-Object` cmdlet, which gets modules whose
 names don't begin with `Microsoft` or `PS`, and have a value for the **HelpInfoURI** property,
-which tells PowerShell where to find updated help files for the module. The **And** logical operator
+which tells PowerShell where to find updated help files for the module. The `-and` logical operator
 connects the comparison statements.
 
-The example uses the script block command format. Logical operators, such as **And** and **Or**,
-are valid only in script blocks. You can't use them in the comparison statement format of a
+The example uses the script block command format. Logical operators, such as `-and`,`-or`, and
+`-not` are valid only in script blocks. You can't use them in the comparison statement format of a
 `Where-Object` command.
 
 - For more information about PowerShell logical operators, see
@@ -1146,7 +1146,7 @@ wildcard characters when used with the following comparison parameters:
 This parameter was introduced in Windows PowerShell 3.0.
 
 ```yaml
-Type: Object
+Type: System.Management.Automation.PSObject
 Parameter Sets: EqualSet, CaseSensitiveGreaterOrEqualSet, CaseSensitiveEqualSet, NotEqualSet, CaseSensitiveNotEqualSet, GreaterThanSet, CaseSensitiveGreaterThanSet, LessThanSet, CaseSensitiveLessThanSet, GreaterOrEqualSet, LessOrEqualSet, CaseSensitiveLessOrEqualSet, LikeSet, CaseSensitiveLikeSet, NotLikeSet, CaseSensitiveNotLikeSet, MatchSet, CaseSensitiveMatchSet, NotMatchSet, CaseSensitiveNotMatchSet, ContainsSet, CaseSensitiveContainsSet, NotContainsSet, CaseSensitiveNotContainsSet, InSet, CaseSensitiveInSet, NotInSet, CaseSensitiveNotInSet, IsSet, IsNotSet
 Aliases:
 
@@ -1172,7 +1172,7 @@ You can pipe any object to this cmdlet.
 
 ## OUTPUTS
 
-### System.Management.Automation.PSObject
+### System.Object
 
 This cmdlet returns the selected items from the input object set.
 

--- a/reference/7.3/Microsoft.PowerShell.Diagnostics/Get-Counter.md
+++ b/reference/7.3/Microsoft.PowerShell.Diagnostics/Get-Counter.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Diagnostics
-ms.date: 12/12/2022
+ms.date: 05/08/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.diagnostics/get-counter?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Counter
@@ -481,7 +481,7 @@ Accept wildcard characters: False
 
 ### -Continuous
 
-When the **Continuous** is specified, `Get-Counter` gets samples until you press
+When **Continuous** is specified, `Get-Counter` gets samples until you press
 <kbd>CTRL</kbd>+<kbd>C</kbd>. Samples are obtained every second for each specified performance
 counter. Use the **SampleInterval** parameter to increase the interval between continuous samples.
 

--- a/reference/7.4/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Where-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/09/2022
+ms.date: 05/08/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/where-object?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Where-Object
@@ -344,28 +344,27 @@ for a specified property. Each example shows both the script block and compariso
 for the command.
 
 ```powershell
-# Use Where-Object to get commands that have any value for the OutputType property of the command.
-# This omits commands that do not have an OutputType property and those that have an OutputType
-# property, but no property value.
+# Use Where-Object to get commands that have any value for the OutputType
+# property of the command. This omits commands that do not have an OutputType
+# property and those that have an OutputType property, but no property value.
 Get-Command | where OutputType
-Get-Command | where {$_.OutputType}
+Get-Command | where { $_.OutputType }
 ```
 
 ```powershell
-# Use Where-Object to get objects that are containers.
-# This gets objects that have the **PSIsContainer** property with a value of $True and excludes all
+# Use Where-Object to get objects that are containers. This gets objects that
+# have the **PSIsContainer** property with a value of $True and excludes all
 # others.
 Get-ChildItem | where PSIsContainer
-Get-ChildItem | where {$_.PSIsContainer}
+Get-ChildItem | where { $_.PSIsContainer }
 ```
 
 ```powershell
 # Finally, use the Not operator (!) to get objects that are not containers.
-# This gets objects that do have the **PSIsContainer** property and those that have a value of
-# $False for the **PSIsContainer** property.
-Get-ChildItem | where {!$_.PSIsContainer}
-# You cannot use the Not operator (!) in the comparison statement format of the command.
-Get-ChildItem | where PSIsContainer -eq $False
+# This gets objects that do have the **PSIsContainer** property and those
+# that have a value of $False for the **PSIsContainer** property.
+Get-ChildItem | where -Not PSIsContainer
+Get-ChildItem | where { !$_.PSIsContainer }
 ```
 
 ### Example 6: Use multiple conditions

--- a/reference/7.4/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Where-Object.md
@@ -17,182 +17,183 @@ Selects objects from a collection based on their property values.
 ### EqualSet (Default)
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-EQ]
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ [-EQ] [<CommonParameters>]
 ```
 
 ### ScriptBlockSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-FilterScript] <ScriptBlock> [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-FilterScript] <ScriptBlock>
+ [<CommonParameters>]
 ```
 
 ### MatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -Match
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Match [<CommonParameters>]
 ```
 
 ### CaseSensitiveEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CEQ
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CEQ [<CommonParameters>]
 ```
 
 ### NotEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NE [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNE [<CommonParameters>]
 ```
 
 ### GreaterThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -GT
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -GT [<CommonParameters>]
 ```
 
 ### CaseSensitiveGreaterThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CGT
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CGT [<CommonParameters>]
 ```
 
 ### LessThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -LT
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -LT [<CommonParameters>]
 ```
 
 ### CaseSensitiveLessThanSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CLT
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CLT [<CommonParameters>]
 ```
 
 ### GreaterOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -GE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -GE [<CommonParameters>]
 ```
 
 ### CaseSensitiveGreaterOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CGE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CGE [<CommonParameters>]
 ```
 
 ### LessOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -LE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -LE [<CommonParameters>]
 ```
 
 ### CaseSensitiveLessOrEqualSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CLE
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CLE [<CommonParameters>]
 ```
 
 ### LikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -Like
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Like [<CommonParameters>]
 ```
 
 ### CaseSensitiveLikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CLike
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CLike [<CommonParameters>]
 ```
 
 ### NotLikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NotLike
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotLike [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotLikeSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNotLike
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotLike [<CommonParameters>]
 ```
 
 ### CaseSensitiveMatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CMatch
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CMatch [<CommonParameters>]
 ```
 
 ### NotMatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NotMatch
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotMatch [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotMatchSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNotMatch
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotMatch [<CommonParameters>]
 ```
 
 ### ContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -Contains
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Contains [<CommonParameters>]
 ```
 
 ### CaseSensitiveContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CContains
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CContains [<CommonParameters>]
 ```
 
 ### NotContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NotContains
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotContains [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotContainsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNotContains
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotContains [<CommonParameters>]
 ```
 
 ### InSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -In
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -In [<CommonParameters>]
 ```
 
 ### CaseSensitiveInSet
@@ -205,35 +206,36 @@ Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] 
 ### NotInSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -NotIn
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -NotIn [<CommonParameters>]
 ```
 
 ### CaseSensitiveNotInSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -CNotIn
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -CNotIn [<CommonParameters>]
 ```
 
 ### IsSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -Is
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -Is [<CommonParameters>]
 ```
 
 ### IsNotSet
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] -IsNot
- [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>]
+ -IsNot [<CommonParameters>]
 ```
 
 ### Not
 
 ```
-Where-Object [-InputObject <PSObject>] [-Property] <String> -Not [<CommonParameters>]
+Where-Object [-InputObject <PSObject>] [-Property] <String> -Not
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -262,52 +264,53 @@ command.
   natural language. Comparison statements were introduced in Windows PowerShell 3.0.
 
   For example, the following commands also get processes that have a priority class of `Normal`.
-  These commands are equivalent and can be used interchangeably.
+  These commands are equivalent and you can use them interchangeably.
 
   `Get-Process | Where-Object -Property PriorityClass -eq -Value "Normal"`
 
   `Get-Process | Where-Object PriorityClass -eq "Normal"`
 
   Starting in Windows PowerShell 3.0, `Where-Object` adds comparison operators as parameters in a
-  `Where-Object` command. Unless specified, all operators are case-insensitive. Prior to Windows
-  PowerShell 3.0, the comparison operators in the PowerShell language could be used only in script
+  `Where-Object` command. Unless specified, all operators are case-insensitive. Before Windows
+  PowerShell 3.0, the comparison operators in the PowerShell language were only usable in script
   blocks.
 
-When you provide a single **Property** to `Where-Object`, the value of the property is treated as
-a boolean expression. When the value of **Length** is not zero, the expression evaluates to
-`$true`. For example: `('hi', '', 'there') | Where-Object Length`
+When you provide a single **Property** to `Where-Object`, the cmdlet treats the value of the
+property as a boolean expression. When the value of the property's **Length** isn't zero, the
+expression evaluates to `$true`. For example: `('hi', '', 'there') | Where-Object Length`
 
 The previous example is functionally equivalent to:
 
 - `('hi', '', 'there') | Where-Object Length -GT 0`
-- `('hi', '', 'there') | Where-Object {$_.Length -gt 0}`
+- `('hi', '', 'there') | Where-Object { $_.Length -gt 0 }`
 
-For more information about how booleans are evaluated, see
+For more information about how PowerShell evaluates booleans, see
 [about_Booleans](about/about_Booleans.md).
 
 ## EXAMPLES
 
 ### Example 1: Get stopped services
 
-These commands get a list of all services that are currently stopped. The `$_` automatic variable
-represents each object that is passed to the `Where-Object` cmdlet.
+These commands get a list of all services that are stopped. The `$_` automatic variable represents
+each object that's passed to the `Where-Object` cmdlet.
 
 The first command uses the script block format, the second command uses the comparison statement
-format. The commands are equivalent and can be used interchangeably.
+format. The commands filter the services the same way and return the same output. Only the syntax
+is different.
 
 ```powershell
-Get-Service | Where-Object {$_.Status -eq "Stopped"}
+Get-Service | Where-Object { $_.Status -eq "Stopped" }
 Get-Service | where Status -eq "Stopped"
 ```
 
 ### Example 2: Get processes based on working set
 
-These commands list processes that have a working set greater than 250 megabytes (MB). The
-scriptblock and statement syntax are equivalent and can be used interchangeably.
+These commands list processes that have a working set greater than 250 megabytes (MB). The commands
+filter the processes the same way and return the same output. Only the syntax is different.
 
 ```powershell
-Get-Process | Where-Object {$_.WorkingSet -GT 250MB}
-Get-Process | Where-Object WorkingSet -GT (250MB)
+Get-Process | Where-Object { $_.WorkingSet -GT 250MB }
+Get-Process | Where-Object WorkingSet -GT 250MB
 ```
 
 ### Example 3: Get processes based on process name
@@ -315,10 +318,11 @@ Get-Process | Where-Object WorkingSet -GT (250MB)
 These commands get the processes that have a **ProcessName** property value that begins with the
 letter `p`. The **Match** operator lets you use regular expression matches.
 
-The scriptblock and statement syntax are equivalent and can be used interchangeably.
+The commands filter the processes the same way and return the same output. Only the syntax is
+different.
 
 ```powershell
-Get-Process | Where-Object {$_.ProcessName -Match "^p.*"}
+Get-Process | Where-Object { $_.ProcessName -Match "^p.*" }
 Get-Process | Where-Object ProcessName -Match "^p.*"
 ```
 
@@ -326,11 +330,15 @@ Get-Process | Where-Object ProcessName -Match "^p.*"
 
 This example shows how to use the new comparison statement format of the `Where-Object` cmdlet.
 
-The first command uses the comparison statement format. In this command, no aliases are used and all
-parameters include the parameter name.
+The first command uses the comparison statement format. It doesn't use any aliases and includes the
+name for every parameter.
 
-The second command is the more natural use of the comparison command format. The `where` alias is
-substituted for the `Where-Object` cmdlet name and all optional parameter names are omitted.
+The second command is the more natural use of the comparison command format. The command
+substitutes the `where` alias for the `Where-Object` cmdlet name and omits all optional parameter
+names.
+
+The commands filter the processes the same way and return the same output. Only the syntax is
+different.
 
 ```powershell
 Get-Process | Where-Object -Property Handles -GE -Value 1000
@@ -342,6 +350,9 @@ Get-Process | where Handles -GE 1000
 This example shows how to write commands that return items that are true or false or have any value
 for a specified property. Each example shows both the script block and comparison statement formats
 for the command.
+
+The commands filter their input the same way and return the same output. Only the syntax is
+different.
 
 ```powershell
 # Use Where-Object to get commands that have any value for the OutputType
@@ -380,12 +391,12 @@ This example shows how to create a `Where-Object` command with multiple conditio
 This command gets non-core modules that support the Updatable Help feature. The command uses the
 **ListAvailable** parameter of the `Get-Module` cmdlet to get all modules on the computer. A
 pipeline operator (`|`) sends the modules to the `Where-Object` cmdlet, which gets modules whose
-names do not begin with `Microsoft` or `PS`, and have a value for the **HelpInfoURI** property,
-which tells PowerShell where to find updated help files for the module. The comparison statements
-are connected by the **And** logical operator.
+names don't begin with `Microsoft` or `PS`, and have a value for the **HelpInfoURI** property,
+which tells PowerShell where to find updated help files for the module. The **And** logical operator
+connects the comparison statements.
 
-The example uses the script block command format. Logical operators, such as **And** and **Or**, are
-valid only in script blocks. You cannot use them in the comparison statement format of a
+The example uses the script block command format. Logical operators, such as **And** and **Or**,
+are valid only in script blocks. You can't use them in the comparison statement format of a
 `Where-Object` command.
 
 - For more information about PowerShell logical operators, see
@@ -567,8 +578,8 @@ Accept wildcard characters: False
 ### -CMatch
 
 Indicates that this cmdlet gets objects if the property value matches the specified regular
-expression. This operation is case-sensitive. When the input is scalar, the matched value is saved
-in `$Matches` automatic variable.
+expression. This operation is case-sensitive. When the input is a single object, the matched value
+is saved in the `$Matches` automatic variable.
 
 For example: `Get-Process | where ProcessName -CMatch "Shell"`
 
@@ -607,13 +618,13 @@ Accept wildcard characters: False
 
 ### -CNotContains
 
-Indicates that this cmdlet gets objects if the property value of the object is not an exact match
+Indicates that this cmdlet gets objects if the property value of the object isn't an exact match
 for the specified value. This operation is case-sensitive.
 
 For example: `Get-Process | where ProcessName -CNotContains "svchost"`
 
 **NotContains** and **CNotContains** refer to a collection of values and are true when the
-collection does not contains any items that are an exact match for the specified value. If the input
+collection doesn't contain any items that are an exact match for the specified value. If the input
 is a single object, PowerShell converts it to a collection of one object.
 
 This parameter was introduced in Windows PowerShell 3.0.
@@ -632,7 +643,7 @@ Accept wildcard characters: False
 
 ### -CNotIn
 
-Indicates that this cmdlet gets objects if the property value is not an exact match for the
+Indicates that this cmdlet gets objects if the property value isn't an exact match for the
 specified value. This operation is case-sensitive.
 
 For example: `Get-Process | where -Value "svchost" -CNotIn -Property ProcessName`
@@ -658,7 +669,7 @@ Accept wildcard characters: False
 
 ### -CNotLike
 
-Indicates that this cmdlet gets objects if the property value does not match a value that includes
+Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters. This operation is case-sensitive.
 
 For example: `Get-Process | where ProcessName -CNotLike "*host"`
@@ -679,9 +690,9 @@ Accept wildcard characters: False
 
 ### -CNotMatch
 
-Indicates that this cmdlet gets objects if the property value does not match the specified regular
-expression. This operation is case-sensitive. When the input is scalar, the matched value is saved
-in `$Matches` automatic variable.
+Indicates that this cmdlet gets objects if the property value doesn't match the specified regular
+expression. This operation is case-sensitive. When the input is a single object, the matched value
+is saved in the `$Matches` automatic variable.
 
 For example: `Get-Process | where ProcessName -CNotMatch "Shell"`
 
@@ -706,8 +717,7 @@ match for the specified value.
 
 For example: `Get-Process | where ProcessName -Contains "Svchost"`
 
-If the property value contains a single object, PowerShell converts it to a collection of one
-object.
+If the input is a single object, PowerShell converts it to a collection of one object.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -743,7 +753,7 @@ Accept wildcard characters: False
 
 ### -FilterScript
 
-Specifies the script block that is used to filter the objects. Enclose the script block in braces
+Specifies the script block that's used to filter the objects. Enclose the script block in braces
 (`{}`).
 
 The parameter name, **FilterScript**, is optional.
@@ -804,8 +814,7 @@ For example:
 
 `Get-Process | where -Property ProcessName -in -Value "Svchost", "TaskHost", "WsmProvHost"`
 
-If the value of the **Value** parameter is a single object, PowerShell converts it to a collection
-of one object.
+If the input is a single object, PowerShell converts it to a collection of one object.
 
 If the property value of an object is an array, PowerShell uses reference equality to determine a
 match. `Where-Object` returns the object only if the value of the **Property** parameter and any
@@ -827,15 +836,16 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the objects to be filtered. You can also pipe the objects to `Where-Object`.
+Specifies the objects to filter. You can also pipe the objects to `Where-Object`.
 
-When you use the **InputObject** parameter with `Where-Object`, instead of piping command results to
-`Where-Object`, the **InputObject** value is treated as a single object. This is true even if the
-value is a collection that is the result of a command, such as `-InputObject (Get-Process)`. Because
-**InputObject** cannot return individual properties from an array or collection of objects, we
-recommend that, if you use `Where-Object` to filter a collection of objects for those objects that
-have specific values in defined properties, you use `Where-Object` in the pipeline, as shown in the
-examples in this topic.
+When you use the **InputObject** parameter with `Where-Object`, instead of piping command results
+to `Where-Object`, the cmdlet treats the **InputObject** as a single object. This is true even if
+the value is a collection that's the result of a command, such as `-InputObject (Get-Process)`.
+
+Because **InputObject** can't return individual properties from an array or collection of objects,
+we recommend that, if you use `Where-Object` to filter a collection of objects for those objects
+that have specific values in defined properties, you use `Where-Object` in the pipeline, as shown
+in the examples in this topic.
 
 ```yaml
 Type: System.Management.Automation.PSObject
@@ -872,7 +882,7 @@ Accept wildcard characters: False
 
 ### -IsNot
 
-Indicates that this cmdlet gets objects if the property value is not an instance of the specified
+Indicates that this cmdlet gets objects if the property value isn't an instance of the specified
 .NET type.
 
 For example, `Get-Process | where StartTime -IsNot [DateTime]`
@@ -952,7 +962,8 @@ Accept wildcard characters: False
 ### -Match
 
 Indicates that this cmdlet gets objects if the property value matches the specified regular
-expression. When the input is scalar, the matched value is saved in `$Matches` automatic variable.
+expression. When the input is a single object, the matched value is saved in the `$Matches`
+automatic variable.
 
 For example: `Get-Process | where ProcessName -Match "shell"`
 
@@ -990,7 +1001,7 @@ Accept wildcard characters: False
 
 ### -Not
 
-Indicates that this cmdlet gets objects if the property does not exist or has a value of `$null` or
+Indicates that this cmdlet gets objects if the property doesn't exist or has a value of `$null` or
 `$false`.
 
 For example: `Get-Service | where -Not "DependentServices"`
@@ -1016,7 +1027,7 @@ for the specified value.
 
 For example: `Get-Process | where ProcessName -NotContains "Svchost"`
 
-**NotContains** refers to a collection of values and is true if the collection does not contain any
+**NotContains** refers to a collection of values and is true if the collection doesn't contain any
 items that are an exact match for the specified value. If the input is a single object, PowerShell
 converts it to a collection of one object.
 
@@ -1036,7 +1047,7 @@ Accept wildcard characters: False
 
 ### -NotIn
 
-Indicates that this cmdlet gets objects if the property value is not an exact match for any of the
+Indicates that this cmdlet gets objects if the property value isn't an exact match for any of the
 specified values.
 
 For example: `Get-Process | where -Value "svchost" -NotIn -Property ProcessName`
@@ -1045,7 +1056,7 @@ If the value of **Value** is a single object, PowerShell converts it to a collec
 
 If the property value of an object is an array, PowerShell uses reference equality to determine a
 match. `Where-Object` returns the object only if the value of **Property** and any value of
-**Value** are not the same instance of an object.
+**Value** aren't the same instance of an object.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -1063,7 +1074,7 @@ Accept wildcard characters: False
 
 ### -NotLike
 
-Indicates that this cmdlet gets objects if the property value does not match a value that includes
+Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters (`*`).
 
 For example: `Get-Process | where ProcessName -NotLike "*host"`
@@ -1084,8 +1095,9 @@ Accept wildcard characters: False
 
 ### -NotMatch
 
-Indicates that this cmdlet gets objects when the property value does not match the specified regular
-expression. When the input is scalar, the matched value is saved in `$Matches` automatic variable.
+Indicates that this cmdlet gets objects when the property value doesn't match the specified regular
+expression. When the input is a single object, the matched value is saved in the `$Matches`
+automatic variable.
 
 For example: `Get-Process | where ProcessName -NotMatch "PowerShell"`
 

--- a/reference/7.4/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Where-Object.md
@@ -371,7 +371,7 @@ Get-ChildItem | where { $_.PSIsContainer }
 ```
 
 ```powershell
-# Finally, use the Not operator (!) to get objects that are not containers.
+# Finally, use the -not operator (!) to get objects that are not containers.
 # This gets objects that do have the **PSIsContainer** property and those
 # that have a value of $False for the **PSIsContainer** property.
 Get-ChildItem | where -Not PSIsContainer
@@ -392,11 +392,11 @@ This command gets non-core modules that support the Updatable Help feature. The 
 **ListAvailable** parameter of the `Get-Module` cmdlet to get all modules on the computer. A
 pipeline operator (`|`) sends the modules to the `Where-Object` cmdlet, which gets modules whose
 names don't begin with `Microsoft` or `PS`, and have a value for the **HelpInfoURI** property,
-which tells PowerShell where to find updated help files for the module. The **And** logical operator
+which tells PowerShell where to find updated help files for the module. The `-and` logical operator
 connects the comparison statements.
 
-The example uses the script block command format. Logical operators, such as **And** and **Or**,
-are valid only in script blocks. You can't use them in the comparison statement format of a
+The example uses the script block command format. Logical operators, such as `-and`,`-or`, and
+`-not` are valid only in script blocks. You can't use them in the comparison statement format of a
 `Where-Object` command.
 
 - For more information about PowerShell logical operators, see
@@ -1146,7 +1146,7 @@ wildcard characters when used with the following comparison parameters:
 This parameter was introduced in Windows PowerShell 3.0.
 
 ```yaml
-Type: Object
+Type: System.Management.Automation.PSObject
 Parameter Sets: EqualSet, CaseSensitiveGreaterOrEqualSet, CaseSensitiveEqualSet, NotEqualSet, CaseSensitiveNotEqualSet, GreaterThanSet, CaseSensitiveGreaterThanSet, LessThanSet, CaseSensitiveLessThanSet, GreaterOrEqualSet, LessOrEqualSet, CaseSensitiveLessOrEqualSet, LikeSet, CaseSensitiveLikeSet, NotLikeSet, CaseSensitiveNotLikeSet, MatchSet, CaseSensitiveMatchSet, NotMatchSet, CaseSensitiveNotMatchSet, ContainsSet, CaseSensitiveContainsSet, NotContainsSet, CaseSensitiveNotContainsSet, InSet, CaseSensitiveInSet, NotInSet, CaseSensitiveNotInSet, IsSet, IsNotSet
 Aliases:
 
@@ -1172,7 +1172,7 @@ You can pipe any object to this cmdlet.
 
 ## OUTPUTS
 
-### System.Management.Automation.PSObject
+### System.Object
 
 This cmdlet returns the selected items from the input object set.
 

--- a/reference/7.4/Microsoft.PowerShell.Diagnostics/Get-Counter.md
+++ b/reference/7.4/Microsoft.PowerShell.Diagnostics/Get-Counter.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Diagnostics
-ms.date: 12/12/2022
+ms.date: 05/08/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.diagnostics/get-counter?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Counter
@@ -481,7 +481,7 @@ Accept wildcard characters: False
 
 ### -Continuous
 
-When the **Continuous** is specified, `Get-Counter` gets samples until you press
+When **Continuous** is specified, `Get-Counter` gets samples until you press
 <kbd>CTRL</kbd>+<kbd>C</kbd>. Samples are obtained every second for each specified performance
 counter. Use the **SampleInterval** parameter to increase the interval between continuous samples.
 


### PR DESCRIPTION
# PR Summary

Prior to this change, example 5 for `Where-Object` incorrectly noted that the `-Not` parameter is unavailable for the cmdlet. That was true in Windows PowerShell, but not later versions.

This change:

- Updates the example
- Resolves #10057
- Fixes [AB#88602](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/88602)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
