### PR TITLE
(GH-10076) Remove incorrect info from `New-LocalUser`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
@@ -35,8 +35,7 @@ New-LocalUser [-AccountExpires <DateTime>] [-AccountNeverExpires] [-Description 
 
 ## DESCRIPTION
 
-The `New-LocalUser` cmdlet creates a local user account. This cmdlet creates a local user account
-or a local user account that's connected to a Microsoft account.
+The `New-LocalUser` cmdlet creates a local user account. This cmdlet creates a local user account.
 
 > [!NOTE]
 > The Microsoft.PowerShell.LocalAccounts module isn't available in 32-bit PowerShell on a 64-bit
@@ -173,8 +172,8 @@ Accept wildcard characters: False
 
 Specifies the user name for the user account.
 
-If you create a local user account for the local system, the user name can contain up to 20
-uppercase characters or lowercase characters. A user name can't contain the following characters:
+A user name can contain up to 20 uppercase characters or lowercase characters. A user name can't
+contain the following characters:
 
 `"`, `/`, `\`, `[`, `]`, `:`, `;`, `|`, `=`, `,`, `+`, `*`, `?`, `<`, `>`, `@`
 

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.LocalAccounts
-ms.date: 12/13/2022
+ms.date: 05/18/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.localaccounts/new-localuser?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-LocalUser
@@ -19,64 +19,78 @@ Creates a local user account.
 ### Password (Default)
 
 ```
-New-LocalUser [-AccountExpires <DateTime>] [-AccountNeverExpires] [-Description <String>] [-Disabled]
- [-FullName <String>] [-Name] <String> -Password <SecureString> [-PasswordNeverExpires]
- [-UserMayNotChangePassword] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-LocalUser [-AccountExpires <DateTime>] [-AccountNeverExpires] [-Description <String>]
+ [-Disabled] [-FullName <String>] [-Name] <String> -Password <SecureString>
+ [-PasswordNeverExpires] [-UserMayNotChangePassword] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### NoPassword
 
 ```
-New-LocalUser [-AccountExpires <DateTime>] [-AccountNeverExpires] [-Description <String>] [-Disabled]
- [-FullName <String>] [-Name] <String> [-NoPassword] [-UserMayNotChangePassword] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+New-LocalUser [-AccountExpires <DateTime>] [-AccountNeverExpires] [-Description <String>]
+ [-Disabled] [-FullName <String>] [-Name] <String> [-NoPassword]
+ [-UserMayNotChangePassword] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 The `New-LocalUser` cmdlet creates a local user account. This cmdlet creates a local user account
-or a local user account that is connected to a Microsoft account.
+or a local user account that's connected to a Microsoft account.
 
 > [!NOTE]
-> The Microsoft.PowerShell.LocalAccounts module is not available in 32-bit PowerShell on a 64-bit
+> The Microsoft.PowerShell.LocalAccounts module isn't available in 32-bit PowerShell on a 64-bit
 > system.
 
 ## EXAMPLES
 
 ### Example 1: Create a user account
 
+```powershell
+New-LocalUser -Name 'User02' -Description 'Description of this account.' -NoPassword
 ```
-PS C:\> New-LocalUser -Name "User02" -Description "Description of this account." -NoPassword
+
+```output
 Name    Enabled  Description
 ----    -------  -----------
 User02  True     Description of this account.
 ```
 
-This command creates a local user account and does not specify the **AccountExpires** or **Password**
-parameters. Therefore, the account doesn't expire or have a password by default.
+This command creates a local user account and doesn't specify the **AccountExpires** or
+**Password** parameters. The account doesn't expire or have a password.
 
 ### Example 2: Create a user account that has a password
 
+```powershell
+$Password = Read-Host -AsSecureString
+$params = @{
+    Name        = 'User03'
+    Password    = $Password
+    FullName    = 'Third User'
+    Description = 'Description of this account.'
+}
+New-LocalUser @params
 ```
-PS C:\> $Password = Read-Host -AsSecureString
-PS C:\> New-LocalUser "User03" -Password $Password -FullName "Third User" -Description "Description of this account."
+
+```output
 Name    Enabled  Description
 ----    -------  -----------
 User03  True     Description of this account.
 ```
 
-The first command prompts you for a password by using the `Read-Host` cmdlet. The command stores the
+The first command uses the `Read-Host` cmdlet to prompts you for a password. The command stores the
 password as a secure string in the `$Password` variable.
 
-The second command creates a local user account by using the password stored in `$Password`. The
-command specifies a user name, full name, and description for the user account.
+The second command creates a local user account and sets the new account's password to the secure
+string stored in `$Password`. The command specifies a user name, full name, and description for the
+user account.
 
 ## PARAMETERS
 
 ### -AccountExpires
 
-Specifies when the user account expires. To obtain a **DateTime** object, use the `Get-Date` cmdlet.
-If you do not specify this parameter, the account does not expire.
+Specifies when the user account expires. You can use the `Get-Date` cmdlet to get a **DateTime**
+object. If you don't specify this parameter, the account doesn't expire.
 
 ```yaml
 Type: System.DateTime
@@ -92,7 +106,7 @@ Accept wildcard characters: False
 
 ### -AccountNeverExpires
 
-Indicates that the account does not expire.
+Indicates that the account doesn't expire.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -108,8 +122,7 @@ Accept wildcard characters: False
 
 ### -Description
 
-Specifies a comment for the user account.
-The maximum length is 48 characters.
+Specifies a comment for the user account. The maximum length is 48 characters.
 
 ```yaml
 Type: System.String
@@ -161,11 +174,11 @@ Accept wildcard characters: False
 Specifies the user name for the user account.
 
 If you create a local user account for the local system, the user name can contain up to 20
-uppercase characters or lowercase characters. A user name cannot contain the following characters:
+uppercase characters or lowercase characters. A user name can't contain the following characters:
 
 `"`, `/`, `\`, `[`, `]`, `:`, `;`, `|`, `=`, `,`, `+`, `*`, `?`, `<`, `>`, `@`
 
-A user name cannot consist only of periods `.` or spaces.
+A user name can't consist only of periods `.` or spaces.
 
 ```yaml
 Type: System.String
@@ -181,7 +194,7 @@ Accept wildcard characters: False
 
 ### -NoPassword
 
-Indicates that the user account does not have a password.
+Indicates that the user account doesn't have a password.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -197,8 +210,8 @@ Accept wildcard characters: False
 
 ### -Password
 
-Specifies a password for the user account. You can use `Read-Host -AsSecureString`, `Get-Credential`,
-or `ConvertTo-SecureString` to create a **SecureString** object for the password.
+Specifies a password for the user account. You can use `Read-Host -AsSecureString`,
+`Get-Credential`, or `ConvertTo-SecureString` to create a **SecureString** object for the password.
 
 If you omit the **Password** and **NoPassword** parameters, `New-LocalUser` prompts you for the new
 user's password.
@@ -217,7 +230,7 @@ Accept wildcard characters: False
 
 ### -PasswordNeverExpires
 
-Indicates whether the password expires.
+Indicates whether the new user's password expires.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -233,7 +246,7 @@ Accept wildcard characters: False
 
 ### -UserMayNotChangePassword
 
-Indicates that the user cannot change the password on the user account.
+Indicates that the user can't change the password on the user account.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -265,8 +278,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -313,9 +325,9 @@ This cmdlet returns a **LocalUser** object representing the created user account
 
 ## NOTES
 
-- A user name cannot be identical to any other user name or group name on the computer. A user name
-  cannot consist only of periods `.` or spaces. A user name can contain up to 20 uppercase
-  characters or lowercase characters. A user name cannot contain the following characters:
+- A user name can't be identical to any other user name or group name on the computer. A user name
+  can't consist only of periods `.` or spaces. A user name can contain up to 20 uppercase
+  characters or lowercase characters. A user name can't contain the following characters:
 
 `"`, `/`, `\`, `[`, `]`, `:`, `;`, `|`, `=`, `,`, `+`, `*`, `?`, `<`, `>`, `@`
 
@@ -324,14 +336,14 @@ This cmdlet returns a **LocalUser** object representing the created user account
   **LocalPrincipal** objects that describes the source of the object. The possible sources are as
   follows:
 
-  - Local
-  - Active Directory
-  - Azure Active Directory group
-  - Microsoft Account
+  - `Local`
+  - `Active Directory`
+  - `Azure Active Directory group`
+  - `Microsoft Account`
 
 > [!NOTE]
-> **PrincipalSource** is supported only by Windows 10, Windows Server 2016, and later versions of the
-> Windows operating system. For earlier versions, the property is blank.
+> **PrincipalSource** is supported only by Windows 10, Windows Server 2016, and later versions of
+> the Windows operating system. For earlier versions, the property is blank.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the reference documentation for the `New-LocalUser` cmdlet incorrectly stated that it can be used to create a local account that is connected to a Microsoft account.

However, SAM account names, and any API call for creating user accounts, is [limited to 20 characters][01]. This problem was identified in #997 and partially addressed by removing an incorrect example.

With the 20 character limit, a user can't specify a valid email after the `MicrosoftAccount\` prefix - the smallest user name, `MicrosoftAccount\a@outlook.com`, is 30 characters long.

This change:

- Removes the statement about the cmdlet being able to create local accounts connected to a Microsoft account.
- Resolves #10076 
- Fixes [AB#91025](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/91025)

[01]: https://learn.microsoft.com/en-us/windows/win32/adschema/a-samaccountname

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
