### PR TITLE
(GH-10088) Add example for normalizing `Read-Host` input

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Read-Host.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Read-Host.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 05/22/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/read-host?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Read-Host
@@ -48,6 +48,55 @@ value is stored as a **SecureString** object in the `$pwd_secure_string` variabl
 ```powershell
 $pwd_secure_string = Read-Host "Enter a Password" -AsSecureString
 ```
+
+### Example 3: Normalizing input
+
+This example prompts the user to input a list of cities separated by semi-colons. It shows the
+string's value as typed by the user. In the example, the user added spaces between some of
+the entries. This could lead to an error later in the script where the code expects an exact
+name.
+
+The example shows how you can convert an input string into an array of entries without any
+extra spaces.
+
+```powershell
+$prompt = @(
+    'List the cities you want weather information for.'
+    'When specifying multiple cities, separate them with a semi-colon, like:'
+    "'New York; Osan; Koforidua'"
+) -join ' '
+
+$cities = Read-Host $prompt
+
+"Input cities string: `n`t'$cities'"
+
+$splitCities = $cities -split ';'
+
+"Split cities array:"
+$splitCities | ForEach-Object -Process { "`t'$_'" }
+
+$normalizedCities = $splitCities  | ForEach-Object -Process { $_.Trim() }
+
+"Normalized split cities array:"
+$normalizedCities | ForEach-Object -Process { "`t'$_'" }
+```
+
+```output
+Input cities string:
+        '    New York;  Osan   ;Koforidua   '
+Split cities array:
+        '    New York'
+        '  Osan   '
+        'Koforidua   '
+Normalized split cities array:
+        'New York'
+        'Osan'
+        'Koforidua'
+```
+
+The example uses the `-split` operator to convert the input string into an array of strings. Each
+string in the array includes the name of a different city. However, the split strings include extra
+spaces. The `Trim()` method removes the leading and trailing spaces from each string.
 
 ## PARAMETERS
 

--- a/reference/7.2/Microsoft.PowerShell.Utility/Read-Host.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Read-Host.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 05/22/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/read-host?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Read-Host
@@ -66,6 +66,55 @@ value is stored as a plaintext **String** object in the `$pwd_string` variable.
 ```powershell
 $pwd_string = Read-Host "Enter a Password" -MaskInput
 ```
+
+### Example 4: Normalizing input
+
+This example prompts the user to input a list of cities separated by semi-colons. It shows the
+string's value as typed by the user. In the example, the user added spaces between some of
+the entries. This could lead to an error later in the script where the code expects an exact
+name.
+
+The example shows how you can convert an input string into an array of entries without any
+extra spaces.
+
+```powershell
+$prompt = @(
+    'List the cities you want weather information for.'
+    'When specifying multiple cities, separate them with a semi-colon, like:'
+    "'New York; Osan; Koforidua'"
+) -join ' '
+
+$cities = Read-Host $prompt
+
+"Input cities string: `n`t'$cities'"
+
+$splitCities = $cities -split ';'
+
+"Split cities array:"
+$splitCities | ForEach-Object -Process { "`t'$_'" }
+
+$normalizedCities = $splitCities  | ForEach-Object -Process { $_.Trim() }
+
+"Normalized split cities array:"
+$normalizedCities | ForEach-Object -Process { "`t'$_'" }
+```
+
+```output
+Input cities string:
+        '    New York;  Osan   ;Koforidua   '
+Split cities array:
+        '    New York'
+        '  Osan   '
+        'Koforidua   '
+Normalized split cities array:
+        'New York'
+        'Osan'
+        'Koforidua'
+```
+
+The example uses the `-split` operator to convert the input string into an array of strings. Each
+string in the array includes the name of a different city. However, the split strings include extra
+spaces. The `Trim()` method removes the leading and trailing spaces from each string.
 
 ## PARAMETERS
 

--- a/reference/7.3/Microsoft.PowerShell.Utility/Read-Host.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Read-Host.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 05/22/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/read-host?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Read-Host
@@ -66,6 +66,55 @@ value is stored as a plaintext **String** object in the `$pwd_string` variable.
 ```powershell
 $pwd_string = Read-Host "Enter a Password" -MaskInput
 ```
+
+### Example 4: Normalizing input
+
+This example prompts the user to input a list of cities separated by semi-colons. It shows the
+string's value as typed by the user. In the example, the user added spaces between some of
+the entries. This could lead to an error later in the script where the code expects an exact
+name.
+
+The example shows how you can convert an input string into an array of entries without any
+extra spaces.
+
+```powershell
+$prompt = @(
+    'List the cities you want weather information for.'
+    'When specifying multiple cities, separate them with a semi-colon, like:'
+    "'New York; Osan; Koforidua'"
+) -join ' '
+
+$cities = Read-Host $prompt
+
+"Input cities string: `n`t'$cities'"
+
+$splitCities = $cities -split ';'
+
+"Split cities array:"
+$splitCities | ForEach-Object -Process { "`t'$_'" }
+
+$normalizedCities = $splitCities  | ForEach-Object -Process { $_.Trim() }
+
+"Normalized split cities array:"
+$normalizedCities | ForEach-Object -Process { "`t'$_'" }
+```
+
+```output
+Input cities string:
+        '    New York;  Osan   ;Koforidua   '
+Split cities array:
+        '    New York'
+        '  Osan   '
+        'Koforidua   '
+Normalized split cities array:
+        'New York'
+        'Osan'
+        'Koforidua'
+```
+
+The example uses the `-split` operator to convert the input string into an array of strings. Each
+string in the array includes the name of a different city. However, the split strings include extra
+spaces. The `Trim()` method removes the leading and trailing spaces from each string.
 
 ## PARAMETERS
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Read-Host.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Read-Host.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 05/22/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/read-host?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Read-Host
@@ -66,6 +66,55 @@ value is stored as a plaintext **String** object in the `$pwd_string` variable.
 ```powershell
 $pwd_string = Read-Host "Enter a Password" -MaskInput
 ```
+
+### Example 4: Normalizing input
+
+This example prompts the user to input a list of cities separated by semi-colons. It shows the
+string's value as typed by the user. In the example, the user added spaces between some of
+the entries. This could lead to an error later in the script where the code expects an exact
+name.
+
+The example shows how you can convert an input string into an array of entries without any
+extra spaces.
+
+```powershell
+$prompt = @(
+    'List the cities you want weather information for.'
+    'When specifying multiple cities, separate them with a semi-colon, like:'
+    "'New York; Osan; Koforidua'"
+) -join ' '
+
+$cities = Read-Host $prompt
+
+"Input cities string: `n`t'$cities'"
+
+$splitCities = $cities -split ';'
+
+"Split cities array:"
+$splitCities | ForEach-Object -Process { "`t'$_'" }
+
+$normalizedCities = $splitCities  | ForEach-Object -Process { $_.Trim() }
+
+"Normalized split cities array:"
+$normalizedCities | ForEach-Object -Process { "`t'$_'" }
+```
+
+```output
+Input cities string:
+        '    New York;  Osan   ;Koforidua   '
+Split cities array:
+        '    New York'
+        '  Osan   '
+        'Koforidua   '
+Normalized split cities array:
+        'New York'
+        'Osan'
+        'Koforidua'
+```
+
+The example uses the `-split` operator to convert the input string into an array of strings. Each
+string in the array includes the name of a different city. However, the split strings include extra
+spaces. The `Trim()` method removes the leading and trailing spaces from each string.
 
 ## PARAMETERS
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for the `Read-Host` cmdlet didn't include information about trimming the input. The cmdlet doesn't have a built-in way to trim extra spaces from the input value, which is an arbitrary string.

This change:

- Adds an example to `Read-Host` showing how user input may need to normalized before it can be used. It also shows how a reader can apply some simple normalizing techniques to clean up the input.
- Resolves #10088
- Fixes [AB#91532](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/91532)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
