### PR TITLE
Update about_Operators.md

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 03/31/2023
+ms.date: 05/30/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -752,6 +752,7 @@ In the following example, the right-hand operand won't be evaluated.
 ```powershell
 [string] $todaysDate = '1/10/2020'
 $todaysDate ??= (Get-Date).ToShortDateString()
+$todaysDate
 ```
 
 ```Output

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 03/31/2023
+ms.date: 05/30/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -752,6 +752,7 @@ In the following example, the right-hand operand won't be evaluated.
 ```powershell
 [string] $todaysDate = '1/10/2020'
 $todaysDate ??= (Get-Date).ToShortDateString()
+$todaysDate
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 03/31/2023
+ms.date: 05/30/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -752,6 +752,7 @@ In the following example, the right-hand operand won't be evaluated.
 ```powershell
 [string] $todaysDate = '1/10/2020'
 $todaysDate ??= (Get-Date).ToShortDateString()
+$todaysDate
 ```
 
 ```Output


### PR DESCRIPTION
there's a typo or omission in `??=` sample. It assumes that output is produced by default (like in `??`) but it's not. Note that the first sample is correct (`$x` is called out explicitly for output in the end) but the second sample is not (`$todaysDate` is missing and therefore no output is generated.)