### PR TITLE
WIP: Update Write-Information.md with example for colored output

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Information.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 05/31/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/write-information?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Information
@@ -131,6 +131,28 @@ function Test-Info
 }
 Test-Info 6> Info.txt
 ```
+
+### Example 4: Write in color
+Because `Write-Host` was rewritten as a wrapper for `Write-Information`, you too can do
+what it does by passing a **System.Management.Automation.HostInformationMessage** object to it
+to get colored output or no new line.
+```powershell
+$colorMsg = [System.Management.Automation.HostInformationMessage]@{
+    Message         = "I'm Blue"
+    NoNewLine       = $false
+    ForegroundColor = [ConsoleColor]::Blue
+    BackgroundColor = [ConsoleColor]::DarkBlue
+}
+Write-Information -MessageData $colorMsg -InformationAction Continue
+```
+
+One benefit of this approach is that `Write-Host` still outputs when **InformationAction** is
+**SilentlyContinue** (default) and only stops when set to **Ignore**.
+
+> [!NOTE]
+> Since PowerShell 6.0 you can also use the escape (`` `e ``) character to color the output,
+> which can also change the color mid-line among other things, see
+> [about_Special_Characters](../Microsoft.PowerShell.Core/About/about_Special_Characters.md#escape-e)
 
 ## PARAMETERS
 

--- a/reference/7.2/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Write-Information.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 05/31/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/write-information?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Information
@@ -154,6 +154,28 @@ Get-Process | Sort-Object CPU -Descending |
 @{Id=6900; ProcessName=chrome; CPU=2546.9375}
 @{Id=9044; ProcessName=explorer; CPU=2358.765625}
 ```
+
+### Example 5: Write in color
+Because `Write-Host` was rewritten as a wrapper for `Write-Information`, you too can do
+what it does by passing a **System.Management.Automation.HostInformationMessage** object to it
+to get colored output or no new line.
+```powershell
+$colorMsg = [System.Management.Automation.HostInformationMessage]@{
+    Message         = "I'm Blue"
+    NoNewLine       = $false
+    ForegroundColor = [ConsoleColor]::Blue
+    BackgroundColor = [ConsoleColor]::DarkBlue
+}
+Write-Information -MessageData $colorMsg -InformationAction Continue
+```
+
+One benefit of this approach is that `Write-Host` still outputs when **InformationAction** is
+**SilentlyContinue** (default) and only stops when set to **Ignore**.
+
+> [!NOTE]
+> Since PowerShell 6.0 you can also use the escape (`` `e ``) character to color the output,
+> which can also change the color mid-line among other things, see
+> [about_Special_Characters](../Microsoft.PowerShell.Core/About/about_Special_Characters.md#escape-e)
 
 ## PARAMETERS
 

--- a/reference/7.3/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Write-Information.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 05/31/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/write-information?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Information
@@ -156,6 +156,28 @@ Get-Process | Sort-Object CPU -Descending |
 @{Id=6900; ProcessName=chrome; CPU=2546.9375}
 @{Id=9044; ProcessName=explorer; CPU=2358.765625}
 ```
+
+### Example 5: Write in color
+Because `Write-Host` was rewritten as a wrapper for `Write-Information`, you too can do
+what it does by passing a **System.Management.Automation.HostInformationMessage** object to it
+to get colored output or no new line.
+```powershell
+$colorMsg = [System.Management.Automation.HostInformationMessage]@{
+    Message         = "I'm Blue"
+    NoNewLine       = $false
+    ForegroundColor = [ConsoleColor]::Blue
+    BackgroundColor = [ConsoleColor]::DarkBlue
+}
+Write-Information -MessageData $colorMsg -InformationAction Continue
+```
+
+One benefit of this approach is that `Write-Host` still outputs when **InformationAction** is
+**SilentlyContinue** (default) and only stops when set to **Ignore**.
+
+> [!NOTE]
+> Since PowerShell 6.0 you can also use the escape (`` `e ``) character to color the output,
+> which can also change the color mid-line among other things, see
+> [about_Special_Characters](../Microsoft.PowerShell.Core/About/about_Special_Characters.md#escape-e)
 
 ## PARAMETERS
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Write-Information.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 05/31/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/write-information?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Write-Information
@@ -156,6 +156,28 @@ Get-Process | Sort-Object CPU -Descending |
 @{Id=6900; ProcessName=chrome; CPU=2546.9375}
 @{Id=9044; ProcessName=explorer; CPU=2358.765625}
 ```
+
+### Example 5: Write in color
+Because `Write-Host` was rewritten as a wrapper for `Write-Information`, you too can do
+what it does by passing a **System.Management.Automation.HostInformationMessage** object to it
+to get colored output or no new line.
+```powershell
+$colorMsg = [System.Management.Automation.HostInformationMessage]@{
+    Message         = "I'm Blue"
+    NoNewLine       = $false
+    ForegroundColor = [ConsoleColor]::Blue
+    BackgroundColor = [ConsoleColor]::DarkBlue
+}
+Write-Information -MessageData $colorMsg -InformationAction Continue
+```
+
+One benefit of this approach is that `Write-Host` still outputs when **InformationAction** is
+**SilentlyContinue** (default) and only stops when set to **Ignore**.
+
+> [!NOTE]
+> Since PowerShell 6.0 you can also use the escape (`` `e ``) character to color the output,
+> which can also change the color mid-line among other things, see
+> [about_Special_Characters](../Microsoft.PowerShell.Core/About/about_Special_Characters.md#escape-e)
 
 ## PARAMETERS
 


### PR DESCRIPTION
# PR Summary

Added an example to Write-Information.md on how to get colored output via **HostInformationMessage**.

Should we also update the **MessageData** parameter section with the accepted object types?
Namely that **String** as is, **HostInformationMessage** as `Write-Host` and object as some logic I'm not sure (seems to be either **ToString** or turn the NoteProperties to hash).

Also in 5.1 the Example 4 from the others could be migrated by replacing the piping with a single object or `Foreach-Object`.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
