### PR TITLE
(GH-10127) Document enums as function parameters

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -9,21 +9,23 @@ title: about Enum
 # about_Enum
 
 ## Short description
-The `enum` statement is used to declare an enumeration. An enumeration is a
+
+The `enum` statement declares an enumeration. An enumeration is a
 distinct type that consists of a set of named labels called the enumerator
 list.
 
 ## Long description
 
-The `enum` statement allows you to create a strongly typed set of labels. That
-enumeration can be used in the code without having to parse or check for
+The `enum` statement allows you to create a strongly typed set of labels. You
+can use that enumeration in the code without having to parse or check for
 spelling errors.
 
 Enumerations are internally represented as integers with a starting value of
-zero. The first label in the list is assigned the value zero. The remaining
-labels are assigned with consecutive numbers.
+zero. By default, PowerShell assigns the first label in the list the value
+zero. By default, PowerShell assigns the remaining labels with consecutive
+integers.
 
-In the definition, labels can be given any integer value. Labels with no value
+In the definition, you can give labels any integer value. Labels with no value
 assigned take the next integer value.
 
 ## Syntax (basic)
@@ -37,29 +39,29 @@ enum <enum-name> {
 
 ## Usage example
 
-The following example shows an enumeration of objects that can be seen as
-media files. The definition assigns explicit values to the underlying values
-of `music`, `picture`, `video`. Labels immediately following an explicit
-assignment get the next integer value. Synonyms can be created by assigning
-the same value to another label; see the constructed values for: `ogg`, `oga`,
+The following example shows an enumeration of objects that correlate to media
+files. The definition assigns explicit values to the underlying values of
+`music`, `picture`, `video`. Labels immediately following an explicit
+assignment get the next integer value. You can create synonyms by assigning the
+same value to another label; see the constructed values for: `ogg`, `oga`,
 `mogg`, or `jpg`, `jpeg`, or `mpg`, `mpeg`.
 
 ```powershell
 enum MediaTypes {
     unknown
-    music = 10
+    music   = 10
     mp3
     aac
-    ogg = 15
-    oga = 15
-    mogg = 15
+    ogg     = 15
+    oga     = 15
+    mogg    = 15
     picture = 20
     jpg
-    jpeg = 21
+    jpeg    = 21
     png
-    video = 40
+    video   = 40
     mpg
-    mpeg = 41
+    mpeg    = 41
     avi
     m4v
 }
@@ -90,7 +92,8 @@ avi
 m4v
 ```
 
-The `GetEnumValues()` method returns the list of the values for the enumeration.
+The `GetEnumValues()` method returns the list of the values for the
+enumeration.
 
 ```powershell
 [MediaTypes].GetEnumValues()
@@ -123,7 +126,7 @@ m4v
 > `GetEnumNames()`, but the output of `GetEnumValues()` only shows `oga`. The
 > same thing happens for `jpg`, `jpeg`, and `mpg`, `mpeg`.
 
-The `GetEnumName()` method can be used to get a name associated with a specific
+You can use the `GetEnumName()` method to get a name associated with a specific
 value. If there are multiple names associated with a value, the method returns
 the alphabetically-first name.
 
@@ -161,12 +164,13 @@ m4v        43
 
 ## Enumerations as flags
 
-Enumerations can be defined as a collection of bit flags.
+You can define enumerations as a collection of bit flags.
 Where, at any given point the enumeration represents one or more of
 those flags turned on.
 
-For enumerations as flags to work properly, each label should have a power of
-two value.
+For enumerations as flags to work properly, you must set each label's integer
+value to a power of two. If you don't specify a value for a label, PowerShell
+sets the value to one higher than the previous label.
 
 ## Syntax (flags)
 
@@ -182,21 +186,22 @@ two value.
 
 ## Flags usage example
 
-In the following example the *FileAttributes* enumeration is created.
+The following example creates the **FileAttributes** enumeration. The value for
+each label is double the value of the prior label.
 
 ```powershell
 [Flags()] enum FileAttributes {
-    Archive = 1
+    Archive    = 1
     Compressed = 2
-    Device = 4
-    Directory = 8
-    Encrypted = 16
-    Hidden = 32
+    Device     = 4
+    Directory  = 8
+    Encrypted  = 16
+    Hidden     = 32
 }
 
-[FileAttributes]$file1 = [FileAttributes]::Archive
-[FileAttributes]$file1 +=[FileAttributes]::Compressed
-[FileAttributes]$file1 +=  [FileAttributes]::Device
+[FileAttributes]$file1 =  [FileAttributes]::Archive
+[FileAttributes]$file1 += [FileAttributes]::Compressed
+[FileAttributes]$file1 += [FileAttributes]::Device
 "file1 attributes are: $file1"
 
 [FileAttributes]$file2 = [FileAttributes]28 ## => 16 + 8 + 4
@@ -208,8 +213,8 @@ file1 attributes are: Archive, Compressed, Device
 file2 attributes are: Device, Directory, Encrypted
 ```
 
-To test that a specific is set, you can use the binary comparison operator
-`-band`. In this example, we test for the **Device** and the **Archive**
+To test whether a specific flag is set, you can use the binary comparison
+operator `-band`. This example tests for the **Device** and the **Archive**
 attributes in the value of `$file2`.
 
 ```powershell
@@ -217,6 +222,18 @@ PS > ($file2 -band [FileAttributes]::Device) -eq [FileAttributes]::Device
 True
 
 PS > ($file2 -band [FileAttributes]::Archive) -eq [FileAttributes]::Archive
+False
+```
+
+You can also use the `HasFlag()` method to test whether a specific flag is set.
+This example tests for the **Device** and **Hidden** attributes in the value of
+`$file1`.
+
+```powershell
+PS > $file1.HasFlag([FileAttributes]::Device)
+True
+
+PS > $file1.HasFlag([FileAttributes]::Hidden)
 False
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,7 +1,7 @@
 ---
 description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 06/21/2021
+ms.date: 06/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -218,4 +218,79 @@ True
 
 PS > ($file2 -band [FileAttributes]::Archive) -eq [FileAttributes]::Archive
 False
+```
+
+## Enumerations as parameters
+
+You can define cmdlet parameters that use an enum as their type. When you
+specify an enum as the type for a parameter, users get automatic completion for
+and validation of the parameter's value. The argument completion suggests the
+list of valid labels for the enum.
+
+When a parameter has an enum as its type, you can specify any of:
+
+- An enumeration, like `[<EnumType>]::<Label>`
+- The label for an enumeration as a string
+- The numerical value of an enumeration
+
+## Enumeration parameter example
+
+In the following example, the function `ConvertTo-LineEndingRegex` defines the
+**InputObject** parameter with the type **EndOfLine**.
+
+```powershell
+enum EndOfLine {
+    CR   = 1
+    LF   = 2
+    CRLF = 3
+}
+
+function ConvertTo-LineEndingRegex {
+    [CmdletBinding()]
+    param (
+        [Parameter(ValueFromPipeline)]
+        [EndOfLine[]]$InputObject
+    )
+
+    process {
+        switch ($InputObject) {
+            CR   {  '\r'  }
+            LF   {  '\n'  }
+            CRLF { '\r\n' }
+        }
+    }
+}
+
+[EndOfLine]::CR | ConvertTo-LineEndingRegex
+
+'CRLF' | ConvertTo-LineEndingRegex
+
+ConvertTo-LineEndingRegex 2
+```
+
+In the example, the first statement calling `ConvertTo-LineEndingRegex` passes
+the enumeration value for `CR`. The second statement passes the string
+`'CRLF'`, which is cast to a **LineEnding**. The third statement specifies the
+value `2` for the parameter, which maps to the `LF` label.
+
+You can see the argument completion options by typing the following text into
+your PowerShell prompt:
+
+```powershell
+ConvertTo-LineEndingRegex -InputObject <Tab>
+```
+
+When you specify an invalid label name or numerical value for the parameter,
+the function raises an error.
+
+```powershell
+ConvertTo-LineEndingRegex -InputObject 0
+```
+
+```output
+ConvertTo-LineEndingRegex: Cannot process argument transformation on
+parameter 'InputObject'. Cannot convert value "0" to type "EndOfLine" due
+to enumeration values that are not valid. Specify one of the following
+enumeration values and try again. The possible enumeration values are
+"CR,LF,CRLF".
 ```

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -9,21 +9,23 @@ title: about Enum
 # about_Enum
 
 ## Short description
-The `enum` statement is used to declare an enumeration. An enumeration is a
+
+The `enum` statement declares an enumeration. An enumeration is a
 distinct type that consists of a set of named labels called the enumerator
 list.
 
 ## Long description
 
-The `enum` statement allows you to create a strongly typed set of labels. That
-enumeration can be used in the code without having to parse or check for
+The `enum` statement allows you to create a strongly typed set of labels. You
+can use that enumeration in the code without having to parse or check for
 spelling errors.
 
 Enumerations are internally represented as integers with a starting value of
-zero. The first label in the list is assigned the value zero. The remaining
-labels are assigned with consecutive numbers.
+zero. By default, PowerShell assigns the first label in the list the value
+zero. By default, PowerShell assigns the remaining labels with consecutive
+integers.
 
-In the definition, labels can be given any integer value. Labels with no value
+In the definition, you can give labels any integer value. Labels with no value
 assigned take the next integer value.
 
 ## Syntax (basic)
@@ -37,29 +39,29 @@ enum <enum-name> {
 
 ## Usage example
 
-The following example shows an enumeration of objects that can be seen as
-media files. The definition assigns explicit values to the underlying values
-of `music`, `picture`, `video`. Labels immediately following an explicit
-assignment get the next integer value. Synonyms can be created by assigning
-the same value to another label; see the constructed values for: `ogg`, `oga`,
+The following example shows an enumeration of objects that correlate to media
+files. The definition assigns explicit values to the underlying values of
+`music`, `picture`, `video`. Labels immediately following an explicit
+assignment get the next integer value. You can create synonyms by assigning the
+same value to another label; see the constructed values for: `ogg`, `oga`,
 `mogg`, or `jpg`, `jpeg`, or `mpg`, `mpeg`.
 
 ```powershell
 enum MediaTypes {
     unknown
-    music = 10
+    music   = 10
     mp3
     aac
-    ogg = 15
-    oga = 15
-    mogg = 15
+    ogg     = 15
+    oga     = 15
+    mogg    = 15
     picture = 20
     jpg
-    jpeg = 21
+    jpeg    = 21
     png
-    video = 40
+    video   = 40
     mpg
-    mpeg = 41
+    mpeg    = 41
     avi
     m4v
 }
@@ -90,7 +92,8 @@ avi
 m4v
 ```
 
-The `GetEnumValues()` method returns the list of the values for the enumeration.
+The `GetEnumValues()` method returns the list of the values for the
+enumeration.
 
 ```powershell
 [MediaTypes].GetEnumValues()
@@ -123,7 +126,7 @@ m4v
 > `GetEnumNames()`, but the output of `GetEnumValues()` only shows `oga`. The
 > same thing happens for `jpg`, `jpeg`, and `mpg`, `mpeg`.
 
-The `GetEnumName()` method can be used to get a name associated with a specific
+You can use the `GetEnumName()` method to get a name associated with a specific
 value. If there are multiple names associated with a value, the method returns
 the alphabetically-first name.
 
@@ -161,12 +164,13 @@ m4v        43
 
 ## Enumerations as flags
 
-Enumerations can be defined as a collection of bit flags.
+You can define enumerations as a collection of bit flags.
 Where, at any given point the enumeration represents one or more of
 those flags turned on.
 
-For enumerations as flags to work properly, each label should have a power of
-two value.
+For enumerations as flags to work properly, you must set each label's integer
+value to a power of two. If you don't specify a value for a label, PowerShell
+sets the value to one higher than the previous label.
 
 ## Syntax (flags)
 
@@ -182,21 +186,22 @@ two value.
 
 ## Flags usage example
 
-In the following example the *FileAttributes* enumeration is created.
+The following example creates the **FileAttributes** enumeration. The value for
+each label is double the value of the prior label.
 
 ```powershell
 [Flags()] enum FileAttributes {
-    Archive = 1
+    Archive    = 1
     Compressed = 2
-    Device = 4
-    Directory = 8
-    Encrypted = 16
-    Hidden = 32
+    Device     = 4
+    Directory  = 8
+    Encrypted  = 16
+    Hidden     = 32
 }
 
-[FileAttributes]$file1 = [FileAttributes]::Archive
-[FileAttributes]$file1 +=[FileAttributes]::Compressed
-[FileAttributes]$file1 +=  [FileAttributes]::Device
+[FileAttributes]$file1 =  [FileAttributes]::Archive
+[FileAttributes]$file1 += [FileAttributes]::Compressed
+[FileAttributes]$file1 += [FileAttributes]::Device
 "file1 attributes are: $file1"
 
 [FileAttributes]$file2 = [FileAttributes]28 ## => 16 + 8 + 4
@@ -208,8 +213,8 @@ file1 attributes are: Archive, Compressed, Device
 file2 attributes are: Device, Directory, Encrypted
 ```
 
-To test that a specific is set, you can use the binary comparison operator
-`-band`. In this example, we test for the **Device** and the **Archive**
+To test whether a specific flag is set, you can use the binary comparison
+operator `-band`. This example tests for the **Device** and the **Archive**
 attributes in the value of `$file2`.
 
 ```powershell
@@ -217,6 +222,18 @@ PS > ($file2 -band [FileAttributes]::Device) -eq [FileAttributes]::Device
 True
 
 PS > ($file2 -band [FileAttributes]::Archive) -eq [FileAttributes]::Archive
+False
+```
+
+You can also use the `HasFlag()` method to test whether a specific flag is set.
+This example tests for the **Device** and **Hidden** attributes in the value of
+`$file1`.
+
+```powershell
+PS > $file1.HasFlag([FileAttributes]::Device)
+True
+
+PS > $file1.HasFlag([FileAttributes]::Hidden)
 False
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,7 +1,7 @@
 ---
 description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 06/21/2021
+ms.date: 06/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -218,4 +218,79 @@ True
 
 PS > ($file2 -band [FileAttributes]::Archive) -eq [FileAttributes]::Archive
 False
+```
+
+## Enumerations as parameters
+
+You can define cmdlet parameters that use an enum as their type. When you
+specify an enum as the type for a parameter, users get automatic completion for
+and validation of the parameter's value. The argument completion suggests the
+list of valid labels for the enum.
+
+When a parameter has an enum as its type, you can specify any of:
+
+- An enumeration, like `[<EnumType>]::<Label>`
+- The label for an enumeration as a string
+- The numerical value of an enumeration
+
+## Enumeration parameter example
+
+In the following example, the function `ConvertTo-LineEndingRegex` defines the
+**InputObject** parameter with the type **EndOfLine**.
+
+```powershell
+enum EndOfLine {
+    CR   = 1
+    LF   = 2
+    CRLF = 3
+}
+
+function ConvertTo-LineEndingRegex {
+    [CmdletBinding()]
+    param (
+        [Parameter(ValueFromPipeline)]
+        [EndOfLine[]]$InputObject
+    )
+
+    process {
+        switch ($InputObject) {
+            CR   {  '\r'  }
+            LF   {  '\n'  }
+            CRLF { '\r\n' }
+        }
+    }
+}
+
+[EndOfLine]::CR | ConvertTo-LineEndingRegex
+
+'CRLF' | ConvertTo-LineEndingRegex
+
+ConvertTo-LineEndingRegex 2
+```
+
+In the example, the first statement calling `ConvertTo-LineEndingRegex` passes
+the enumeration value for `CR`. The second statement passes the string
+`'CRLF'`, which is cast to a **LineEnding**. The third statement specifies the
+value `2` for the parameter, which maps to the `LF` label.
+
+You can see the argument completion options by typing the following text into
+your PowerShell prompt:
+
+```powershell
+ConvertTo-LineEndingRegex -InputObject <Tab>
+```
+
+When you specify an invalid label name or numerical value for the parameter,
+the function raises an error.
+
+```powershell
+ConvertTo-LineEndingRegex -InputObject 0
+```
+
+```output
+ConvertTo-LineEndingRegex: Cannot process argument transformation on
+parameter 'InputObject'. Cannot convert value "0" to type "EndOfLine" due
+to enumeration values that are not valid. Specify one of the following
+enumeration values and try again. The possible enumeration values are
+"CR,LF,CRLF".
 ```

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -9,21 +9,23 @@ title: about Enum
 # about_Enum
 
 ## Short description
-The `enum` statement is used to declare an enumeration. An enumeration is a
+
+The `enum` statement declares an enumeration. An enumeration is a
 distinct type that consists of a set of named labels called the enumerator
 list.
 
 ## Long description
 
-The `enum` statement allows you to create a strongly typed set of labels. That
-enumeration can be used in the code without having to parse or check for
+The `enum` statement allows you to create a strongly typed set of labels. You
+can use that enumeration in the code without having to parse or check for
 spelling errors.
 
 Enumerations are internally represented as integers with a starting value of
-zero. The first label in the list is assigned the value zero. The remaining
-labels are assigned with consecutive numbers.
+zero. By default, PowerShell assigns the first label in the list the value
+zero. By default, PowerShell assigns the remaining labels with consecutive
+integers.
 
-In the definition, labels can be given any integer value. Labels with no value
+In the definition, you can give labels any integer value. Labels with no value
 assigned take the next integer value.
 
 ## Syntax (basic)
@@ -37,29 +39,29 @@ enum <enum-name> {
 
 ## Usage example
 
-The following example shows an enumeration of objects that can be seen as
-media files. The definition assigns explicit values to the underlying values
-of `music`, `picture`, `video`. Labels immediately following an explicit
-assignment get the next integer value. Synonyms can be created by assigning
-the same value to another label; see the constructed values for: `ogg`, `oga`,
+The following example shows an enumeration of objects that correlate to media
+files. The definition assigns explicit values to the underlying values of
+`music`, `picture`, `video`. Labels immediately following an explicit
+assignment get the next integer value. You can create synonyms by assigning the
+same value to another label; see the constructed values for: `ogg`, `oga`,
 `mogg`, or `jpg`, `jpeg`, or `mpg`, `mpeg`.
 
 ```powershell
 enum MediaTypes {
     unknown
-    music = 10
+    music   = 10
     mp3
     aac
-    ogg = 15
-    oga = 15
-    mogg = 15
+    ogg     = 15
+    oga     = 15
+    mogg    = 15
     picture = 20
     jpg
-    jpeg = 21
+    jpeg    = 21
     png
-    video = 40
+    video   = 40
     mpg
-    mpeg = 41
+    mpeg    = 41
     avi
     m4v
 }
@@ -90,7 +92,8 @@ avi
 m4v
 ```
 
-The `GetEnumValues()` method returns the list of the values for the enumeration.
+The `GetEnumValues()` method returns the list of the values for the
+enumeration.
 
 ```powershell
 [MediaTypes].GetEnumValues()
@@ -123,7 +126,7 @@ m4v
 > `GetEnumNames()`, but the output of `GetEnumValues()` only shows `oga`. The
 > same thing happens for `jpg`, `jpeg`, and `mpg`, `mpeg`.
 
-The `GetEnumName()` method can be used to get a name associated with a specific
+You can use the `GetEnumName()` method to get a name associated with a specific
 value. If there are multiple names associated with a value, the method returns
 the alphabetically-first name.
 
@@ -161,12 +164,13 @@ m4v        43
 
 ## Enumerations as flags
 
-Enumerations can be defined as a collection of bit flags.
+You can define enumerations as a collection of bit flags.
 Where, at any given point the enumeration represents one or more of
 those flags turned on.
 
-For enumerations as flags to work properly, each label should have a power of
-two value.
+For enumerations as flags to work properly, you must set each label's integer
+value to a power of two. If you don't specify a value for a label, PowerShell
+sets the value to one higher than the previous label.
 
 ## Syntax (flags)
 
@@ -182,21 +186,22 @@ two value.
 
 ## Flags usage example
 
-In the following example the *FileAttributes* enumeration is created.
+The following example creates the **FileAttributes** enumeration. The value for
+each label is double the value of the prior label.
 
 ```powershell
 [Flags()] enum FileAttributes {
-    Archive = 1
+    Archive    = 1
     Compressed = 2
-    Device = 4
-    Directory = 8
-    Encrypted = 16
-    Hidden = 32
+    Device     = 4
+    Directory  = 8
+    Encrypted  = 16
+    Hidden     = 32
 }
 
-[FileAttributes]$file1 = [FileAttributes]::Archive
-[FileAttributes]$file1 +=[FileAttributes]::Compressed
-[FileAttributes]$file1 +=  [FileAttributes]::Device
+[FileAttributes]$file1 =  [FileAttributes]::Archive
+[FileAttributes]$file1 += [FileAttributes]::Compressed
+[FileAttributes]$file1 += [FileAttributes]::Device
 "file1 attributes are: $file1"
 
 [FileAttributes]$file2 = [FileAttributes]28 ## => 16 + 8 + 4
@@ -208,8 +213,8 @@ file1 attributes are: Archive, Compressed, Device
 file2 attributes are: Device, Directory, Encrypted
 ```
 
-To test that a specific is set, you can use the binary comparison operator
-`-band`. In this example, we test for the **Device** and the **Archive**
+To test whether a specific flag is set, you can use the binary comparison
+operator `-band`. This example tests for the **Device** and the **Archive**
 attributes in the value of `$file2`.
 
 ```powershell
@@ -217,6 +222,18 @@ PS > ($file2 -band [FileAttributes]::Device) -eq [FileAttributes]::Device
 True
 
 PS > ($file2 -band [FileAttributes]::Archive) -eq [FileAttributes]::Archive
+False
+```
+
+You can also use the `HasFlag()` method to test whether a specific flag is set.
+This example tests for the **Device** and **Hidden** attributes in the value of
+`$file1`.
+
+```powershell
+PS > $file1.HasFlag([FileAttributes]::Device)
+True
+
+PS > $file1.HasFlag([FileAttributes]::Hidden)
 False
 ```
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,7 +1,7 @@
 ---
 description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 06/21/2021
+ms.date: 06/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -218,4 +218,79 @@ True
 
 PS > ($file2 -band [FileAttributes]::Archive) -eq [FileAttributes]::Archive
 False
+```
+
+## Enumerations as parameters
+
+You can define cmdlet parameters that use an enum as their type. When you
+specify an enum as the type for a parameter, users get automatic completion for
+and validation of the parameter's value. The argument completion suggests the
+list of valid labels for the enum.
+
+When a parameter has an enum as its type, you can specify any of:
+
+- An enumeration, like `[<EnumType>]::<Label>`
+- The label for an enumeration as a string
+- The numerical value of an enumeration
+
+## Enumeration parameter example
+
+In the following example, the function `ConvertTo-LineEndingRegex` defines the
+**InputObject** parameter with the type **EndOfLine**.
+
+```powershell
+enum EndOfLine {
+    CR   = 1
+    LF   = 2
+    CRLF = 3
+}
+
+function ConvertTo-LineEndingRegex {
+    [CmdletBinding()]
+    param (
+        [Parameter(ValueFromPipeline)]
+        [EndOfLine[]]$InputObject
+    )
+
+    process {
+        switch ($InputObject) {
+            CR   {  '\r'  }
+            LF   {  '\n'  }
+            CRLF { '\r\n' }
+        }
+    }
+}
+
+[EndOfLine]::CR | ConvertTo-LineEndingRegex
+
+'CRLF' | ConvertTo-LineEndingRegex
+
+ConvertTo-LineEndingRegex 2
+```
+
+In the example, the first statement calling `ConvertTo-LineEndingRegex` passes
+the enumeration value for `CR`. The second statement passes the string
+`'CRLF'`, which is cast to a **LineEnding**. The third statement specifies the
+value `2` for the parameter, which maps to the `LF` label.
+
+You can see the argument completion options by typing the following text into
+your PowerShell prompt:
+
+```powershell
+ConvertTo-LineEndingRegex -InputObject <Tab>
+```
+
+When you specify an invalid label name or numerical value for the parameter,
+the function raises an error.
+
+```powershell
+ConvertTo-LineEndingRegex -InputObject 0
+```
+
+```output
+ConvertTo-LineEndingRegex: Cannot process argument transformation on
+parameter 'InputObject'. Cannot convert value "0" to type "EndOfLine" due
+to enumeration values that are not valid. Specify one of the following
+enumeration values and try again. The possible enumeration values are
+"CR,LF,CRLF".
 ```

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -9,21 +9,23 @@ title: about Enum
 # about_Enum
 
 ## Short description
-The `enum` statement is used to declare an enumeration. An enumeration is a
+
+The `enum` statement declares an enumeration. An enumeration is a
 distinct type that consists of a set of named labels called the enumerator
 list.
 
 ## Long description
 
-The `enum` statement allows you to create a strongly typed set of labels. That
-enumeration can be used in the code without having to parse or check for
+The `enum` statement allows you to create a strongly typed set of labels. You
+can use that enumeration in the code without having to parse or check for
 spelling errors.
 
 Enumerations are internally represented as integers with a starting value of
-zero. The first label in the list is assigned the value zero. The remaining
-labels are assigned with consecutive numbers.
+zero. By default, PowerShell assigns the first label in the list the value
+zero. By default, PowerShell assigns the remaining labels with consecutive
+integers.
 
-In the definition, labels can be given any integer value. Labels with no value
+In the definition, you can give labels any integer value. Labels with no value
 assigned take the next integer value.
 
 ## Syntax (basic)
@@ -37,29 +39,29 @@ enum <enum-name> {
 
 ## Usage example
 
-The following example shows an enumeration of objects that can be seen as
-media files. The definition assigns explicit values to the underlying values
-of `music`, `picture`, `video`. Labels immediately following an explicit
-assignment get the next integer value. Synonyms can be created by assigning
-the same value to another label; see the constructed values for: `ogg`, `oga`,
+The following example shows an enumeration of objects that correlate to media
+files. The definition assigns explicit values to the underlying values of
+`music`, `picture`, `video`. Labels immediately following an explicit
+assignment get the next integer value. You can create synonyms by assigning the
+same value to another label; see the constructed values for: `ogg`, `oga`,
 `mogg`, or `jpg`, `jpeg`, or `mpg`, `mpeg`.
 
 ```powershell
 enum MediaTypes {
     unknown
-    music = 10
+    music   = 10
     mp3
     aac
-    ogg = 15
-    oga = 15
-    mogg = 15
+    ogg     = 15
+    oga     = 15
+    mogg    = 15
     picture = 20
     jpg
-    jpeg = 21
+    jpeg    = 21
     png
-    video = 40
+    video   = 40
     mpg
-    mpeg = 41
+    mpeg    = 41
     avi
     m4v
 }
@@ -90,7 +92,8 @@ avi
 m4v
 ```
 
-The `GetEnumValues()` method returns the list of the values for the enumeration.
+The `GetEnumValues()` method returns the list of the values for the
+enumeration.
 
 ```powershell
 [MediaTypes].GetEnumValues()
@@ -123,7 +126,7 @@ m4v
 > `GetEnumNames()`, but the output of `GetEnumValues()` only shows `oga`. The
 > same thing happens for `jpg`, `jpeg`, and `mpg`, `mpeg`.
 
-The `GetEnumName()` method can be used to get a name associated with a specific
+You can use the `GetEnumName()` method to get a name associated with a specific
 value. If there are multiple names associated with a value, the method returns
 the alphabetically-first name.
 
@@ -161,12 +164,13 @@ m4v        43
 
 ## Enumerations as flags
 
-Enumerations can be defined as a collection of bit flags.
+You can define enumerations as a collection of bit flags.
 Where, at any given point the enumeration represents one or more of
 those flags turned on.
 
-For enumerations as flags to work properly, each label should have a power of
-two value.
+For enumerations as flags to work properly, you must set each label's integer
+value to a power of two. If you don't specify a value for a label, PowerShell
+sets the value to one higher than the previous label.
 
 ## Syntax (flags)
 
@@ -182,21 +186,22 @@ two value.
 
 ## Flags usage example
 
-In the following example the *FileAttributes* enumeration is created.
+The following example creates the **FileAttributes** enumeration. The value for
+each label is double the value of the prior label.
 
 ```powershell
 [Flags()] enum FileAttributes {
-    Archive = 1
+    Archive    = 1
     Compressed = 2
-    Device = 4
-    Directory = 8
-    Encrypted = 16
-    Hidden = 32
+    Device     = 4
+    Directory  = 8
+    Encrypted  = 16
+    Hidden     = 32
 }
 
-[FileAttributes]$file1 = [FileAttributes]::Archive
-[FileAttributes]$file1 +=[FileAttributes]::Compressed
-[FileAttributes]$file1 +=  [FileAttributes]::Device
+[FileAttributes]$file1 =  [FileAttributes]::Archive
+[FileAttributes]$file1 += [FileAttributes]::Compressed
+[FileAttributes]$file1 += [FileAttributes]::Device
 "file1 attributes are: $file1"
 
 [FileAttributes]$file2 = [FileAttributes]28 ## => 16 + 8 + 4
@@ -208,8 +213,8 @@ file1 attributes are: Archive, Compressed, Device
 file2 attributes are: Device, Directory, Encrypted
 ```
 
-To test that a specific is set, you can use the binary comparison operator
-`-band`. In this example, we test for the **Device** and the **Archive**
+To test whether a specific flag is set, you can use the binary comparison
+operator `-band`. This example tests for the **Device** and the **Archive**
 attributes in the value of `$file2`.
 
 ```powershell
@@ -217,6 +222,18 @@ PS > ($file2 -band [FileAttributes]::Device) -eq [FileAttributes]::Device
 True
 
 PS > ($file2 -band [FileAttributes]::Archive) -eq [FileAttributes]::Archive
+False
+```
+
+You can also use the `HasFlag()` method to test whether a specific flag is set.
+This example tests for the **Device** and **Hidden** attributes in the value of
+`$file1`.
+
+```powershell
+PS > $file1.HasFlag([FileAttributes]::Device)
+True
+
+PS > $file1.HasFlag([FileAttributes]::Hidden)
 False
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,7 +1,7 @@
 ---
 description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 06/21/2021
+ms.date: 06/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -218,4 +218,79 @@ True
 
 PS > ($file2 -band [FileAttributes]::Archive) -eq [FileAttributes]::Archive
 False
+```
+
+## Enumerations as parameters
+
+You can define cmdlet parameters that use an enum as their type. When you
+specify an enum as the type for a parameter, users get automatic completion for
+and validation of the parameter's value. The argument completion suggests the
+list of valid labels for the enum.
+
+When a parameter has an enum as its type, you can specify any of:
+
+- An enumeration, like `[<EnumType>]::<Label>`
+- The label for an enumeration as a string
+- The numerical value of an enumeration
+
+## Enumeration parameter example
+
+In the following example, the function `ConvertTo-LineEndingRegex` defines the
+**InputObject** parameter with the type **EndOfLine**.
+
+```powershell
+enum EndOfLine {
+    CR   = 1
+    LF   = 2
+    CRLF = 3
+}
+
+function ConvertTo-LineEndingRegex {
+    [CmdletBinding()]
+    param (
+        [Parameter(ValueFromPipeline)]
+        [EndOfLine[]]$InputObject
+    )
+
+    process {
+        switch ($InputObject) {
+            CR   {  '\r'  }
+            LF   {  '\n'  }
+            CRLF { '\r\n' }
+        }
+    }
+}
+
+[EndOfLine]::CR | ConvertTo-LineEndingRegex
+
+'CRLF' | ConvertTo-LineEndingRegex
+
+ConvertTo-LineEndingRegex 2
+```
+
+In the example, the first statement calling `ConvertTo-LineEndingRegex` passes
+the enumeration value for `CR`. The second statement passes the string
+`'CRLF'`, which is cast to a **LineEnding**. The third statement specifies the
+value `2` for the parameter, which maps to the `LF` label.
+
+You can see the argument completion options by typing the following text into
+your PowerShell prompt:
+
+```powershell
+ConvertTo-LineEndingRegex -InputObject <Tab>
+```
+
+When you specify an invalid label name or numerical value for the parameter,
+the function raises an error.
+
+```powershell
+ConvertTo-LineEndingRegex -InputObject 0
+```
+
+```output
+ConvertTo-LineEndingRegex: Cannot process argument transformation on
+parameter 'InputObject'. Cannot convert value "0" to type "EndOfLine" due
+to enumeration values that are not valid. Specify one of the following
+enumeration values and try again. The possible enumeration values are
+"CR,LF,CRLF".
 ```


### PR DESCRIPTION
# PR Summary

Prior to this change, the `about_Enum` topic showed using enumerations in scripts but not as parameters.

This change:

- Adds a new section to the article, clarifying the benefits of using enumerations as parameter types and including an example.
- Cleans up the prose and formatting for the article.
- Documents using the `HasFlag()` method as an alternative to using the binary comparison operator.
- Resolves #10127
- Fixes [AB#97124](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/97124)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
