### PR TITLE
(GH-10141) Clarify ternaries and enums

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,7 +1,7 @@
 ---
 description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 06/05/2023
+ms.date: 06/07/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -132,6 +132,9 @@ the alphabetically-first name.
 
 ```powershell
 [MediaTypes].GetEnumName(15)
+```
+
+```Output
 oga
 ```
 
@@ -160,6 +163,19 @@ mpg        41
 mpeg       41
 avi        42
 m4v        43
+```
+
+You can specify a single enum value by its label with the syntax
+`[<enum-name>]::<label>`.
+
+```powershell
+[MediaTypes]::png
+[MediaTypes]::png -eq 22
+```
+
+```Output
+png
+True
 ```
 
 ## Enumerations as flags

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_If.md
@@ -1,7 +1,7 @@
 ---
 description: Describes a language command you can use to run statement lists based on the results of one or more conditional tests.
 Locale: en-US
-ms.date: 06/10/2021
+ms.date: 06/07/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_if?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about If
@@ -14,15 +14,15 @@ results of one or more conditional tests.
 
 ## Long description
 
-You can use the `If` statement to run code blocks if a specified conditional
+You can use the `if` statement to run code blocks if a specified conditional
 test evaluates to true. You can also specify one or more additional conditional
 tests to run if all the prior tests evaluate to false. Finally, you can specify
-an additional code block that is run if no other prior conditional test
+an additional code block that's run if no other prior conditional test
 evaluates to true.
 
 ### Syntax
 
-The following example shows the `If` statement syntax:
+The following example shows the `if` statement syntax:
 
 ```powershell
 if (<test1>)
@@ -33,28 +33,28 @@ if (<test1>)
     {<statement list 3>}]
 ```
 
-When you run an `If` statement, PowerShell evaluates the `<test1>` conditional
+When you run an `if` statement, PowerShell evaluates the `<test1>` conditional
 expression as true or false. If `<test1>` is true, `<statement list 1>` runs,
-and PowerShell exits the `If` statement. If `<test1>` is false, PowerShell
+and PowerShell exits the `if` statement. If `<test1>` is false, PowerShell
 evaluates the condition specified by the `<test2>` conditional statement.
 
 For more information about boolean evaluation, see
 [about_Booleans](about_Booleans.md).
 
-If `<test2>` is true, `<statement list 2>` runs, and PowerShell exits the `If`
+If `<test2>` is true, `<statement list 2>` runs, and PowerShell exits the `if`
 statement. If both `<test1>` and `<test2>` evaluate to false, the
-`<statement list 3`> code block runs, and PowerShell exits the If statement.
+`<statement list 3`> code block runs, and PowerShell exits the `if` statement.
 
-You can use multiple `Elseif` statements to chain a series of conditional
-tests. So, that each test is run only if all the previous tests are false. If
-you need to create an `If` statement that contains many `Elseif` statements,
-consider using a Switch statement instead.
+You can use multiple `elseif` statements to chain a series of conditional
+tests. Each test is run only if all the previous tests are false. If you need
+to create an `if` statement that contains many `elseif` statements, consider
+using a Switch statement instead.
 
 Examples:
 
-The simplest `If` statement contains a single command and does not contain
-any Elseif statements or any Else statements. The following example shows
-the simplest form of the `If` statement:
+The simplest `if` statement contains a single command and doesn't contain
+any `elseif` statements or any `else` statements. The following example shows
+the simplest form of the `if` statement:
 
 ```powershell
 if ($a -gt 2) {
@@ -62,9 +62,10 @@ if ($a -gt 2) {
 }
 ```
 
-In this example, if the $a variable is greater than 2, the condition evaluates
-to true, and the statement list runs. However, if $a is less than or equal to 2
-or is not an existing variable, the `If` statement does not display a message.
+In this example, if the `$a` variable is greater than `2`, the condition
+evaluates to true, and the statement list runs. However, if `$a` is less than
+or equal to `2` or isn't an existing variable, the `if` statement doesn't
+display a message.
 
 By adding an Else statement, a message is displayed when $a is less than or
 equal to 2. As the next example shows:
@@ -79,8 +80,8 @@ else {
 }
 ```
 
-To further refine this example, you can use the Elseif statement to display a
-message when the value of $a is equal to 2. As the next example shows:
+To further refine this example, you can use the `elseif` statement to display a
+message when the value of `$a` is equal to `2`. As the next example shows:
 
 ```powershell
 if ($a -gt 2) {

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,7 +1,7 @@
 ---
 description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 06/05/2023
+ms.date: 06/07/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -132,6 +132,9 @@ the alphabetically-first name.
 
 ```powershell
 [MediaTypes].GetEnumName(15)
+```
+
+```Output
 oga
 ```
 
@@ -160,6 +163,19 @@ mpg        41
 mpeg       41
 avi        42
 m4v        43
+```
+
+You can specify a single enum value by its label with the syntax
+`[<enum-name>]::<label>`.
+
+```powershell
+[MediaTypes]::png
+[MediaTypes]::png -eq 22
+```
+
+```Output
+png
+True
 ```
 
 ## Enumerations as flags

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_If.md
@@ -1,7 +1,7 @@
 ---
 description: Describes a language command you can use to run statement lists based on the results of one or more conditional tests.
 Locale: en-US
-ms.date: 06/10/2021
+ms.date: 06/07/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_if?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about If
@@ -14,15 +14,15 @@ results of one or more conditional tests.
 
 ## Long description
 
-You can use the `If` statement to run code blocks if a specified conditional
+You can use the `if` statement to run code blocks if a specified conditional
 test evaluates to true. You can also specify one or more additional conditional
 tests to run if all the prior tests evaluate to false. Finally, you can specify
-an additional code block that is run if no other prior conditional test
+an additional code block that's run if no other prior conditional test
 evaluates to true.
 
 ### Syntax
 
-The following example shows the `If` statement syntax:
+The following example shows the `if` statement syntax:
 
 ```powershell
 if (<test1>)
@@ -33,28 +33,28 @@ if (<test1>)
     {<statement list 3>}]
 ```
 
-When you run an `If` statement, PowerShell evaluates the `<test1>` conditional
+When you run an `if` statement, PowerShell evaluates the `<test1>` conditional
 expression as true or false. If `<test1>` is true, `<statement list 1>` runs,
-and PowerShell exits the `If` statement. If `<test1>` is false, PowerShell
+and PowerShell exits the `if` statement. If `<test1>` is false, PowerShell
 evaluates the condition specified by the `<test2>` conditional statement.
 
 For more information about boolean evaluation, see
 [about_Booleans](about_Booleans.md).
 
-If `<test2>` is true, `<statement list 2>` runs, and PowerShell exits the `If`
+If `<test2>` is true, `<statement list 2>` runs, and PowerShell exits the `if`
 statement. If both `<test1>` and `<test2>` evaluate to false, the
-`<statement list 3`> code block runs, and PowerShell exits the If statement.
+`<statement list 3`> code block runs, and PowerShell exits the `if` statement.
 
-You can use multiple `Elseif` statements to chain a series of conditional
-tests. So, that each test is run only if all the previous tests are false. If
-you need to create an `If` statement that contains many `Elseif` statements,
-consider using a Switch statement instead.
+You can use multiple `elseif` statements to chain a series of conditional
+tests. Each test is run only if all the previous tests are false. If you need
+to create an `if` statement that contains many `elseif` statements, consider
+using a Switch statement instead.
 
 Examples:
 
-The simplest `If` statement contains a single command and does not contain
-any Elseif statements or any Else statements. The following example shows
-the simplest form of the `If` statement:
+The simplest `if` statement contains a single command and doesn't contain
+any `elseif` statements or any `else` statements. The following example shows
+the simplest form of the `if` statement:
 
 ```powershell
 if ($a -gt 2) {
@@ -62,9 +62,10 @@ if ($a -gt 2) {
 }
 ```
 
-In this example, if the $a variable is greater than 2, the condition evaluates
-to true, and the statement list runs. However, if $a is less than or equal to 2
-or is not an existing variable, the `If` statement does not display a message.
+In this example, if the `$a` variable is greater than `2`, the condition
+evaluates to true, and the statement list runs. However, if `$a` is less than
+or equal to `2` or isn't an existing variable, the `if` statement doesn't
+display a message.
 
 By adding an Else statement, a message is displayed when $a is less than or
 equal to 2. As the next example shows:
@@ -79,8 +80,8 @@ else {
 }
 ```
 
-To further refine this example, you can use the Elseif statement to display a
-message when the value of $a is equal to 2. As the next example shows:
+To further refine this example, you can use the `elseif` statement to display a
+message when the value of `$a` is equal to `2`. As the next example shows:
 
 ```powershell
 if ($a -gt 2) {
@@ -119,17 +120,55 @@ For example:
 $message = (Test-Path $path) ? "Path exists" : "Path not found"
 ```
 
-In this example, the value of `$message` is "Path exists" when `Test-Path`
+In this example, the value of `$message` is `Path exists` when `Test-Path`
 returns `$true`. When `Test-Path` returns `$false`, the value of `$message` is
-"Path not found".
+`Path not found`.
 
 ```powershell
 $service = Get-Service BITS
 $service.Status -eq 'Running' ? (Stop-Service $service) : (Start-Service $service)
 ```
 
-In this example, if the service is running, it is stopped, and if its status is
-not **Running**, it is started.
+In this example, if the service is running, it's stopped, and if its status is
+not **Running**, it's started.
+
+
+If a `<condition>`, `<if-true>`, or `<if-false>` expression calls a command,
+you must wrap it in parentheses. If you don't, PowerShell raises an argument
+exception for the command in the `<condition>` expression and parsing
+exceptions for the `<if-true>` and `<if-false>` expressions.
+
+For example, PowerShell raises exceptions for these ternaries:
+
+```powershell
+Test-Path .vscode   ? Write-Host 'exists'   : Write-Host 'not found'
+(Test-Path .vscode) ? Write-Host 'exists'   : Write-Host 'not found'
+(Test-Path .vscode) ? (Write-Host 'exists') : Write-Host 'not found'
+```
+
+```Output
+Test-Path: A positional parameter cannot be found that accepts argument '?'.
+ParserError:
+Line |
+   1 |  (Test-Path .vscode) ? Write-Host 'exists'   : Write-Host 'not found'
+     |                       ~
+     | You must provide a value expression following the '?' operator.
+ParserError:
+Line |
+   1 |  (Test-Path .vscode) ? (Write-Host 'exists') : Write-Host 'not found'
+     |                                               ~
+     | You must provide a value expression following the ':' operator.
+```
+
+And this example parses:
+
+```powershell
+(Test-Path .vscode) ? (Write-Host 'exists') : (Write-Host 'not found')
+```
+
+```Output
+exists
+```
 
 ## See also
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,7 +1,7 @@
 ---
 description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 06/05/2023
+ms.date: 06/07/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -132,6 +132,9 @@ the alphabetically-first name.
 
 ```powershell
 [MediaTypes].GetEnumName(15)
+```
+
+```Output
 oga
 ```
 
@@ -160,6 +163,19 @@ mpg        41
 mpeg       41
 avi        42
 m4v        43
+```
+
+You can specify a single enum value by its label with the syntax
+`[<enum-name>]::<label>`.
+
+```powershell
+[MediaTypes]::png
+[MediaTypes]::png -eq 22
+```
+
+```Output
+png
+True
 ```
 
 ## Enumerations as flags

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_If.md
@@ -1,7 +1,7 @@
 ---
 description: Describes a language command you can use to run statement lists based on the results of one or more conditional tests.
 Locale: en-US
-ms.date: 06/10/2021
+ms.date: 06/07/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_if?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about If
@@ -14,15 +14,15 @@ results of one or more conditional tests.
 
 ## Long description
 
-You can use the `If` statement to run code blocks if a specified conditional
+You can use the `if` statement to run code blocks if a specified conditional
 test evaluates to true. You can also specify one or more additional conditional
 tests to run if all the prior tests evaluate to false. Finally, you can specify
-an additional code block that is run if no other prior conditional test
+an additional code block that's run if no other prior conditional test
 evaluates to true.
 
 ### Syntax
 
-The following example shows the `If` statement syntax:
+The following example shows the `if` statement syntax:
 
 ```powershell
 if (<test1>)
@@ -33,28 +33,28 @@ if (<test1>)
     {<statement list 3>}]
 ```
 
-When you run an `If` statement, PowerShell evaluates the `<test1>` conditional
+When you run an `if` statement, PowerShell evaluates the `<test1>` conditional
 expression as true or false. If `<test1>` is true, `<statement list 1>` runs,
-and PowerShell exits the `If` statement. If `<test1>` is false, PowerShell
+and PowerShell exits the `if` statement. If `<test1>` is false, PowerShell
 evaluates the condition specified by the `<test2>` conditional statement.
 
 For more information about boolean evaluation, see
 [about_Booleans](about_Booleans.md).
 
-If `<test2>` is true, `<statement list 2>` runs, and PowerShell exits the `If`
+If `<test2>` is true, `<statement list 2>` runs, and PowerShell exits the `if`
 statement. If both `<test1>` and `<test2>` evaluate to false, the
-`<statement list 3`> code block runs, and PowerShell exits the If statement.
+`<statement list 3`> code block runs, and PowerShell exits the `if` statement.
 
-You can use multiple `Elseif` statements to chain a series of conditional
-tests. So, that each test is run only if all the previous tests are false. If
-you need to create an `If` statement that contains many `Elseif` statements,
-consider using a Switch statement instead.
+You can use multiple `elseif` statements to chain a series of conditional
+tests. Each test is run only if all the previous tests are false. If you need
+to create an `if` statement that contains many `elseif` statements, consider
+using a Switch statement instead.
 
 Examples:
 
-The simplest `If` statement contains a single command and does not contain
-any Elseif statements or any Else statements. The following example shows
-the simplest form of the `If` statement:
+The simplest `if` statement contains a single command and doesn't contain
+any `elseif` statements or any `else` statements. The following example shows
+the simplest form of the `if` statement:
 
 ```powershell
 if ($a -gt 2) {
@@ -62,9 +62,10 @@ if ($a -gt 2) {
 }
 ```
 
-In this example, if the $a variable is greater than 2, the condition evaluates
-to true, and the statement list runs. However, if $a is less than or equal to 2
-or is not an existing variable, the `If` statement does not display a message.
+In this example, if the `$a` variable is greater than `2`, the condition
+evaluates to true, and the statement list runs. However, if `$a` is less than
+or equal to `2` or isn't an existing variable, the `if` statement doesn't
+display a message.
 
 By adding an Else statement, a message is displayed when $a is less than or
 equal to 2. As the next example shows:
@@ -79,8 +80,8 @@ else {
 }
 ```
 
-To further refine this example, you can use the Elseif statement to display a
-message when the value of $a is equal to 2. As the next example shows:
+To further refine this example, you can use the `elseif` statement to display a
+message when the value of `$a` is equal to `2`. As the next example shows:
 
 ```powershell
 if ($a -gt 2) {
@@ -119,17 +120,55 @@ For example:
 $message = (Test-Path $path) ? "Path exists" : "Path not found"
 ```
 
-In this example, the value of `$message` is "Path exists" when `Test-Path`
+In this example, the value of `$message` is `Path exists` when `Test-Path`
 returns `$true`. When `Test-Path` returns `$false`, the value of `$message` is
-"Path not found".
+`Path not found`.
 
 ```powershell
 $service = Get-Service BITS
 $service.Status -eq 'Running' ? (Stop-Service $service) : (Start-Service $service)
 ```
 
-In this example, if the service is running, it is stopped, and if its status is
-not **Running**, it is started.
+In this example, if the service is running, it's stopped, and if its status is
+not **Running**, it's started.
+
+
+If a `<condition>`, `<if-true>`, or `<if-false>` expression calls a command,
+you must wrap it in parentheses. If you don't, PowerShell raises an argument
+exception for the command in the `<condition>` expression and parsing
+exceptions for the `<if-true>` and `<if-false>` expressions.
+
+For example, PowerShell raises exceptions for these ternaries:
+
+```powershell
+Test-Path .vscode   ? Write-Host 'exists'   : Write-Host 'not found'
+(Test-Path .vscode) ? Write-Host 'exists'   : Write-Host 'not found'
+(Test-Path .vscode) ? (Write-Host 'exists') : Write-Host 'not found'
+```
+
+```Output
+Test-Path: A positional parameter cannot be found that accepts argument '?'.
+ParserError:
+Line |
+   1 |  (Test-Path .vscode) ? Write-Host 'exists'   : Write-Host 'not found'
+     |                       ~
+     | You must provide a value expression following the '?' operator.
+ParserError:
+Line |
+   1 |  (Test-Path .vscode) ? (Write-Host 'exists') : Write-Host 'not found'
+     |                                               ~
+     | You must provide a value expression following the ':' operator.
+```
+
+And this example parses:
+
+```powershell
+(Test-Path .vscode) ? (Write-Host 'exists') : (Write-Host 'not found')
+```
+
+```Output
+exists
+```
 
 ## See also
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,7 +1,7 @@
 ---
 description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 06/05/2023
+ms.date: 06/07/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -132,6 +132,9 @@ the alphabetically-first name.
 
 ```powershell
 [MediaTypes].GetEnumName(15)
+```
+
+```Output
 oga
 ```
 
@@ -160,6 +163,19 @@ mpg        41
 mpeg       41
 avi        42
 m4v        43
+```
+
+You can specify a single enum value by its label with the syntax
+`[<enum-name>]::<label>`.
+
+```powershell
+[MediaTypes]::png
+[MediaTypes]::png -eq 22
+```
+
+```Output
+png
+True
 ```
 
 ## Enumerations as flags

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_If.md
@@ -1,7 +1,7 @@
 ---
 description: Describes a language command you can use to run statement lists based on the results of one or more conditional tests.
 Locale: en-US
-ms.date: 06/10/2021
+ms.date: 06/07/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_if?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about If
@@ -14,15 +14,15 @@ results of one or more conditional tests.
 
 ## Long description
 
-You can use the `If` statement to run code blocks if a specified conditional
+You can use the `if` statement to run code blocks if a specified conditional
 test evaluates to true. You can also specify one or more additional conditional
 tests to run if all the prior tests evaluate to false. Finally, you can specify
-an additional code block that is run if no other prior conditional test
+an additional code block that's run if no other prior conditional test
 evaluates to true.
 
 ### Syntax
 
-The following example shows the `If` statement syntax:
+The following example shows the `if` statement syntax:
 
 ```powershell
 if (<test1>)
@@ -33,28 +33,28 @@ if (<test1>)
     {<statement list 3>}]
 ```
 
-When you run an `If` statement, PowerShell evaluates the `<test1>` conditional
+When you run an `if` statement, PowerShell evaluates the `<test1>` conditional
 expression as true or false. If `<test1>` is true, `<statement list 1>` runs,
-and PowerShell exits the `If` statement. If `<test1>` is false, PowerShell
+and PowerShell exits the `if` statement. If `<test1>` is false, PowerShell
 evaluates the condition specified by the `<test2>` conditional statement.
 
 For more information about boolean evaluation, see
 [about_Booleans](about_Booleans.md).
 
-If `<test2>` is true, `<statement list 2>` runs, and PowerShell exits the `If`
+If `<test2>` is true, `<statement list 2>` runs, and PowerShell exits the `if`
 statement. If both `<test1>` and `<test2>` evaluate to false, the
-`<statement list 3`> code block runs, and PowerShell exits the If statement.
+`<statement list 3`> code block runs, and PowerShell exits the `if` statement.
 
-You can use multiple `Elseif` statements to chain a series of conditional
-tests. So, that each test is run only if all the previous tests are false. If
-you need to create an `If` statement that contains many `Elseif` statements,
-consider using a Switch statement instead.
+You can use multiple `elseif` statements to chain a series of conditional
+tests. Each test is run only if all the previous tests are false. If you need
+to create an `if` statement that contains many `elseif` statements, consider
+using a Switch statement instead.
 
 Examples:
 
-The simplest `If` statement contains a single command and does not contain
-any Elseif statements or any Else statements. The following example shows
-the simplest form of the `If` statement:
+The simplest `if` statement contains a single command and doesn't contain
+any `elseif` statements or any `else` statements. The following example shows
+the simplest form of the `if` statement:
 
 ```powershell
 if ($a -gt 2) {
@@ -62,9 +62,10 @@ if ($a -gt 2) {
 }
 ```
 
-In this example, if the $a variable is greater than 2, the condition evaluates
-to true, and the statement list runs. However, if $a is less than or equal to 2
-or is not an existing variable, the `If` statement does not display a message.
+In this example, if the `$a` variable is greater than `2`, the condition
+evaluates to true, and the statement list runs. However, if `$a` is less than
+or equal to `2` or isn't an existing variable, the `if` statement doesn't
+display a message.
 
 By adding an Else statement, a message is displayed when $a is less than or
 equal to 2. As the next example shows:
@@ -79,8 +80,8 @@ else {
 }
 ```
 
-To further refine this example, you can use the Elseif statement to display a
-message when the value of $a is equal to 2. As the next example shows:
+To further refine this example, you can use the `elseif` statement to display a
+message when the value of `$a` is equal to `2`. As the next example shows:
 
 ```powershell
 if ($a -gt 2) {
@@ -119,17 +120,55 @@ For example:
 $message = (Test-Path $path) ? "Path exists" : "Path not found"
 ```
 
-In this example, the value of `$message` is "Path exists" when `Test-Path`
+In this example, the value of `$message` is `Path exists` when `Test-Path`
 returns `$true`. When `Test-Path` returns `$false`, the value of `$message` is
-"Path not found".
+`Path not found`.
 
 ```powershell
 $service = Get-Service BITS
 $service.Status -eq 'Running' ? (Stop-Service $service) : (Start-Service $service)
 ```
 
-In this example, if the service is running, it is stopped, and if its status is
-not **Running**, it is started.
+In this example, if the service is running, it's stopped, and if its status is
+not **Running**, it's started.
+
+
+If a `<condition>`, `<if-true>`, or `<if-false>` expression calls a command,
+you must wrap it in parentheses. If you don't, PowerShell raises an argument
+exception for the command in the `<condition>` expression and parsing
+exceptions for the `<if-true>` and `<if-false>` expressions.
+
+For example, PowerShell raises exceptions for these ternaries:
+
+```powershell
+Test-Path .vscode   ? Write-Host 'exists'   : Write-Host 'not found'
+(Test-Path .vscode) ? Write-Host 'exists'   : Write-Host 'not found'
+(Test-Path .vscode) ? (Write-Host 'exists') : Write-Host 'not found'
+```
+
+```Output
+Test-Path: A positional parameter cannot be found that accepts argument '?'.
+ParserError:
+Line |
+   1 |  (Test-Path .vscode) ? Write-Host 'exists'   : Write-Host 'not found'
+     |                       ~
+     | You must provide a value expression following the '?' operator.
+ParserError:
+Line |
+   1 |  (Test-Path .vscode) ? (Write-Host 'exists') : Write-Host 'not found'
+     |                                               ~
+     | You must provide a value expression following the ':' operator.
+```
+
+And this example parses:
+
+```powershell
+(Test-Path .vscode) ? (Write-Host 'exists') : (Write-Host 'not found')
+```
+
+```Output
+exists
+```
 
 ## See also
 


### PR DESCRIPTION
# PR Summary

Prior to this change, there was some confusion around the syntax for both ternaries and enums. This change:

- Clarifies that non-value expressions, which are expressions that call commands, in a ternary must be wrapped in parentheses to avoid exceptions.
- Clarifies that you can get an enumeration value with the syntax `[<enum-name>]::<label>`.
- Resolves #10141
- Fixes [AB#98123](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/98123)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
