### PR TITLE
(GH-10140) Document env vars in manifests

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -1,7 +1,7 @@
 ---
 description: Explains language modes and their effect on PowerShell sessions.
 Locale: en-US
-ms.date: 01/19/2023
+ms.date: 06/07/2023
 no-loc: [FullLanguage, ConstrainedLanguage, RestrictedLanguage, NoLanguage]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -175,6 +175,7 @@ additional variables:
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
+- Any environment variables, like `$ENV:TEMP`
 
 Only the following comparison operators are permitted:
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the settings and practices for writing module manifest files.
 Locale: en-US
-ms.date: 01/30/2023
+ms.date: 06/07/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_module_manifests?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Module Manifests
@@ -98,6 +98,7 @@ Allowed variables
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
+- Any environment variables, like `$ENV:TEMP`
 
 For more information, see [about_Language_Modes](about_Language_Modes.md).
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -1,7 +1,7 @@
 ---
 description: Explains language modes and their effect on PowerShell sessions.
 Locale: en-US
-ms.date: 01/19/2023
+ms.date: 06/07/2023
 no-loc: [FullLanguage, ConstrainedLanguage, RestrictedLanguage, NoLanguage]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -178,6 +178,7 @@ additional variables:
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
+- Any environment variables, like `$ENV:TEMP`
 
 Only the following comparison operators are permitted:
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the settings and practices for writing module manifest files.
 Locale: en-US
-ms.date: 01/30/2023
+ms.date: 06/07/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_module_manifests?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Module Manifests
@@ -98,6 +98,7 @@ Allowed variables
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
+- Any environment variables, like `$ENV:TEMP`
 
 For more information, see [about_Language_Modes](about_Language_Modes.md).
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -1,7 +1,7 @@
 ---
 description: Explains language modes and their effect on PowerShell sessions.
 Locale: en-US
-ms.date: 01/19/2023
+ms.date: 06/07/2023
 no-loc: [FullLanguage, ConstrainedLanguage, RestrictedLanguage, NoLanguage]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -181,6 +181,7 @@ additional variables:
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
+- Any environment variables, like `$ENV:TEMP`
 
 Only the following comparison operators are permitted:
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the settings and practices for writing module manifest files.
 Locale: en-US
-ms.date: 01/30/2023
+ms.date: 06/07/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_module_manifests?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Module Manifests
@@ -98,6 +98,7 @@ Allowed variables
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
+- Any environment variables, like `$ENV:TEMP`
 
 For more information, see [about_Language_Modes](about_Language_Modes.md).
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -1,7 +1,7 @@
 ---
 description: Explains language modes and their effect on PowerShell sessions.
 Locale: en-US
-ms.date: 01/19/2023
+ms.date: 06/07/2023
 no-loc: [FullLanguage, ConstrainedLanguage, RestrictedLanguage, NoLanguage]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -181,6 +181,7 @@ additional variables:
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
+- Any environment variables, like `$ENV:TEMP`
 
 Only the following comparison operators are permitted:
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the settings and practices for writing module manifest files.
 Locale: en-US
-ms.date: 01/30/2023
+ms.date: 06/07/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_module_manifests?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Module Manifests
@@ -98,6 +98,7 @@ Allowed variables
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
+- Any environment variables, like `$ENV:TEMP`
 
 For more information, see [about_Language_Modes](about_Language_Modes.md).
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation noted specific variables you can use in module manifests, but did not note that you can use environment variables, unlike in restricted language mode.

This change:

- Adds a note in the section on module manifest variables to both the `about_Module_Manifests` and `about_Language_Modes` articles.
- Resolves #10140
- Fixes [AB#98137](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/98137)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
