### PR TITLE
Add backtick escape

### DIFF
--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -41,6 +41,7 @@ PowerShell recognizes these escape sequences:
 |  `` `t ``   | Horizontal tab                                  |
 | `` `u{x} `` | Unicode escape sequence (added in PowerShell 6) |
 |  `` `v ``   | Vertical tab                                    |
+| ``` `` ```  | Backtick                                        |
 
 PowerShell also has a special token to mark where you want parsing to stop. All
 characters that follow this token are used as literal values that aren't


### PR DESCRIPTION
# PR Summary

It seems that PowerShell accepts escaping single quotes in double quoted strings but this is not documented

```
PS /Users> "``"
`
```


## PR Checklist


- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
