### PR TITLE
Update Installing-PowerShell-on-Windows.md - fixing typo

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-on-Windows.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-on-Windows.md
@@ -64,7 +64,7 @@ winget install --id Microsoft.Powershell.Preview --source winget
 
 > [!NOTE]
 > On Windows systems using X86 or X64 processor, `winget` installs the MSI package. On systems using
-> the Arm64 processor, `winget` install the Microsoft Store (MSIX) package. For more information,
+> the Arm64 processor, `winget` installs the Microsoft Store (MSIX) package. For more information,
 > see [Installing from the Microsoft Store][17].
 
 ## <a id="msi" />Installing the MSI package


### PR DESCRIPTION
Fixing a minor typo in the Note section describing the difference in winget behaviours on X86/64 and Arm64 machines.