### PR TITLE
(GH-10219) Update RHEL 9 intall instructions

### DIFF
--- a/reference/docs-conceptual/install/install-rhel.md
+++ b/reference/docs-conceptual/install/install-rhel.md
@@ -24,19 +24,8 @@ updates.
 
 On RHEL 9:
 
-```sh
-# Register the Microsoft RedHat repository
-curl https://packages.microsoft.com/config/rhel/9.0/prod.repo | sudo tee /etc/yum.repos.d/microsoft.repo
-
-# Install PowerShell
-sudo dnf install --assumeyes powershell
-
-# Start PowerShell
-pwsh
-```
-
-As superuser, register the Microsoft repository once. After registration, you can update PowerShell
-with `sudo dnf upgrade powershell`.
+The PowerShell RPMs aren't published to the RHEL 9 repository yet. For RHEL 9, you need to
+[install PowerShell via direct download](#installation-via-direct-download).
 
 On RHEL 8:
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the install documentation for RHEL 9 directed users to add the Microsoft repository and install PowerShell from there. However, the PowerShell RPMs have not been published to that repo yet.

This change:

- Directs users to install PowerShell on RHEL 9 via direct download instead
- Resolves #10219

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
