### PR TITLE
Changing Disable the Debugger Console to Using the Debugger Console

### DIFF
--- a/reference/docs-conceptual/dev-cross-plat/vscode/How-To-Replicate-the-ISE-Experience-In-VSCode.md
+++ b/reference/docs-conceptual/dev-cross-plat/vscode/How-To-Replicate-the-ISE-Experience-In-VSCode.md
@@ -140,11 +140,12 @@ ISE Mode makes the following changes to VS Code settings.
 
   For more information, see [the VS Code documentation][03].
 
-- Disable the Debug Console
+- Using the Debug Console
 
-  If you only plan on using VS Code for PowerShell scripting, you can hide the **Debug Console**
-  since it'sn't used by the PowerShell extension. To do so, right click on **Debug Console** then
-  click on the check mark to hide it.
+  The PowerShell extension uses the built-in debugging interface of VS Code to allow for debugging
+  of PowerShell scripts and modules.
+  
+  For more information about debugging PowerShell with Visual Studio Code, see [Using VS Code][10].
 
 ## More settings
 
@@ -164,4 +165,4 @@ We're always happy to accept PRs and contributions as well!
 [07]: media/How-To-Replicate-the-ISE-Experience-In-VSCode/1-highlighted-sidebar.png
 [08]: media/How-To-Replicate-the-ISE-Experience-In-VSCode/2-simplified-ui.png
 [09]: media/How-To-Replicate-the-ISE-Experience-In-VSCode/3-ise-mode.png
-
+[10]: ./using-vscode.md#debugging-with-visual-studio-code


### PR DESCRIPTION
Link to the issue:
https://github.com/MicrosoftDocs/PowerShell-Docs/issues/10250

# PR Summary


By directing the reader to the debugger section in using-vscode.md, these changes resolve the previous conflicting information that the powershell extension does not use the debig console in vs code.

These changes resolve the problem of conflicting information regarding the debugger with PowerShell in VSCode in the documentation for [how-to-replicate-the-ise-experience-in-vscode#vs-code-tips.](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/docs-conceptual/dev-cross-plat/vscode/How-To-Replicate-the-ISE-Experience-In-VSCode.md)

    - Fixes MicrosoftDocs/PowerShell-Docs#10250
    - Resolves MicrosoftDocs/PowerShell-Docs#10250


## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
