### PR TITLE
Adding note about creating predictors that there needs to be a 20ms time out

### DIFF
--- a/reference/docs-conceptual/dev-cross-plat/create-cmdline-predictor.md
+++ b/reference/docs-conceptual/dev-cross-plat/create-cmdline-predictor.md
@@ -211,7 +211,7 @@ Create a new PowerShell module project by following these steps:
    `bin/Debug/net6.0` location of your project folder.
 
    > [!NOTE]
-   > To ensure a responsive user experience, the ICommandPredictor interface  has a 20ms time out
+   > To ensure a responsive user experience, the ICommandPredictor interface has a 20ms time out
    > for responses from the Predictors. Your predictor code must return results in less than 20ms
    > to be displayed.
 

--- a/reference/docs-conceptual/dev-cross-plat/create-cmdline-predictor.md
+++ b/reference/docs-conceptual/dev-cross-plat/create-cmdline-predictor.md
@@ -211,9 +211,9 @@ Create a new PowerShell module project by following these steps:
    `bin/Debug/net6.0` location of your project folder.
 
    > [!NOTE]
-   > In order to not add any sort of lag to the user experience, the ICommandPredictor interface
-   > has a 20ms time out for responses from the Predictors. This means any predictor results must
-   > return in less than 20ms to get displayed.
+   > To ensure a responsive user experience, the ICommandPredictor interface  has a 20ms time out
+   > for responses from the Predictors. Your predictor code must return results in less than 20ms
+   > to be displayed.
 
 ## Using your predictor plugin
 

--- a/reference/docs-conceptual/dev-cross-plat/create-cmdline-predictor.md
+++ b/reference/docs-conceptual/dev-cross-plat/create-cmdline-predictor.md
@@ -210,6 +210,11 @@ Create a new PowerShell module project by following these steps:
 1. Run `dotnet build` to produce the assembly. You can find the compiled assembly in the
    `bin/Debug/net6.0` location of your project folder.
 
+   > [!NOTE]
+   > In order to not add any sort of lag to the user experience, the ICommandPredictor interface
+   > has a 20ms time out for responses from the Predictors. This means any predictor results must
+   > return in less than 20ms to get displayed.
+
 ## Using your predictor plugin
 
 To try out your new predictor, open a new PowerShell 7.2 session and run the following commands:


### PR DESCRIPTION
# PR Summary

Adding details for why a predictor results may be silently failing for users. This gives more details about the requirements for predictors to meet the timeout in order to be displayed.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
