### PR TITLE
Update Remove-Module.md to format code block

### DIFF
--- a/reference/7.3/Microsoft.PowerShell.Core/Remove-Module.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/Remove-Module.md
@@ -255,19 +255,20 @@ PowerShell includes the following aliases for `Remove-Module`:
 When removing a module, there is an event on the module that will execute.
 This event allows a module to react to being removed and perform some cleanup such as freeing up resources. Example:
 
+```powershell
 $OnRemoveScript = {
-
-  \# perform cleanup
-
+  # perform cleanup
   $cachedSessions | Remove-PSSession
-
 }
 
 $ExecutionContext.SessionState.Module.OnRemove += $OnRemoveScript
+```
 
 For full consistency, it might be also useful to react to the closing of the PowerShell process:
 
+```powershell
 Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PsEngineEvent]::Exiting) -Action $OnRemoveScript
+```
 
 ## RELATED LINKS
 


### PR DESCRIPTION
# PR Summary

The bottom of the Remove-Module docs has a couple code snippets that aren't formatted as code blocks. This adds the markdown to format them a PowerShell code blocks.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style]

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
