### PR TITLE
Use literal hexadecimal notation with upper case

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -522,7 +522,7 @@ The bitwise NOT operator is a unary operator that produces the binary
 complement of the value. A bit of 1 is set to 0 and a bit of 0 is set to 1.
 
 For example, the binary complement of 0 is -1, the maximum unsigned integer
-(0xffffffff), and the binary complement of -1 is 0.
+(0xFFFFFFFF), and the binary complement of -1 is 0.
 
 ```powershell
 -bNot 10
@@ -535,7 +535,7 @@ For example, the binary complement of 0 is -1, the maximum unsigned integer
 ```
 0000 0000 0000 1010  (10)
 ------------------------- bNOT
-1111 1111 1111 0101  (-11, xfffffff5)
+1111 1111 1111 0101  (-11, 0xFFFFFFF5)
 ```
 
 In a bitwise shift-left operation, all bits are moved "n" places to the left,

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -522,7 +522,7 @@ The bitwise NOT operator is a unary operator that produces the binary
 complement of the value. A bit of 1 is set to 0 and a bit of 0 is set to 1.
 
 For example, the binary complement of 0 is -1, the maximum unsigned integer
-(0xffffffff), and the binary complement of -1 is 0.
+(0xFFFFFFFF), and the binary complement of -1 is 0.
 
 ```powershell
 -bNot 10
@@ -535,7 +535,7 @@ For example, the binary complement of 0 is -1, the maximum unsigned integer
 ```
 0000 0000 0000 1010  (10)
 ------------------------- bNOT
-1111 1111 1111 0101  (-11, xfffffff5)
+1111 1111 1111 0101  (-11, 0xFFFFFFF5)
 ```
 
 In a bitwise shift-left operation, all bits are moved "n" places to the left,

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -522,7 +522,7 @@ The bitwise NOT operator is a unary operator that produces the binary
 complement of the value. A bit of 1 is set to 0 and a bit of 0 is set to 1.
 
 For example, the binary complement of 0 is -1, the maximum unsigned integer
-(0xffffffff), and the binary complement of -1 is 0.
+(0xFFFFFFFF), and the binary complement of -1 is 0.
 
 ```powershell
 -bNot 10
@@ -535,7 +535,7 @@ For example, the binary complement of 0 is -1, the maximum unsigned integer
 ```
 0000 0000 0000 1010  (10)
 ------------------------- bNOT
-1111 1111 1111 0101  (-11, xfffffff5)
+1111 1111 1111 0101  (-11, 0xFFFFFFF5)
 ```
 
 In a bitwise shift-left operation, all bits are moved "n" places to the left,

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -522,7 +522,7 @@ The bitwise NOT operator is a unary operator that produces the binary
 complement of the value. A bit of 1 is set to 0 and a bit of 0 is set to 1.
 
 For example, the binary complement of 0 is -1, the maximum unsigned integer
-(0xffffffff), and the binary complement of -1 is 0.
+(0xFFFFFFFF), and the binary complement of -1 is 0.
 
 ```powershell
 -bNot 10
@@ -535,7 +535,7 @@ For example, the binary complement of 0 is -1, the maximum unsigned integer
 ```
 0000 0000 0000 1010  (10)
 ------------------------- bNOT
-1111 1111 1111 0101  (-11, xfffffff5)
+1111 1111 1111 0101  (-11, 0xFFFFFFF5)
 ```
 
 In a bitwise shift-left operation, all bits are moved "n" places to the left,


### PR DESCRIPTION
# PR Summary

Changes nonstandard hexadecimal notation to use numeric literal format with upper case

Fixes #10314

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
