### PR TITLE
One syntax token format, lists to split versions

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -23,7 +23,7 @@ assignment.
 
 The syntax of the assignment operators is as follows:
 
-`<assignable-expression>` `<assignment-operator>` `<value>`
+- `<assignable-expression><assignment-operator><value>`
 
 Assignable expressions include variables and properties. The value can be a
 single value, an array of values, or a command, expression, or statement.
@@ -31,8 +31,8 @@ single value, an array of values, or a command, expression, or statement.
 The increment and decrement operators are unary operators. Each has prefix and
 postfix versions.
 
-`<assignable-expression><operator>`
-`<operator><assignable-expression>`
+- `<assignable-expression><operator>`
+- `<operator><assignable-expression>`
 
 The assignable expression must be a number or it must be convertible to a
 number.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to use operators to assign values to variables.
 Locale: en-US
-ms.date: 08/24/2022
+ms.date: 08/01/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_assignment_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Assignment Operators
@@ -23,7 +23,7 @@ assignment.
 
 The syntax of the assignment operators is as follows:
 
-- `<assignable-expression><assignment-operator><value>`
+- `<assignable-expression>` `<assignment-operator>` `<value>`
 
 Assignable expressions include variables and properties. The value can be a
 single value, an array of values, or a command, expression, or statement.
@@ -34,8 +34,8 @@ postfix versions.
 - `<assignable-expression><operator>`
 - `<operator><assignable-expression>`
 
-The assignable expression must be a number or it must be convertible to a
-number.
+The value of the assignable expression must be a number or it must be
+convertible to a number.
 
 ## Using the assignment operator
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -23,7 +23,7 @@ assignment.
 
 The syntax of the assignment operators is as follows:
 
-`<assignable-expression>` `<assignment-operator>` `<value>`
+- `<assignable-expression><assignment-operator><value>`
 
 Assignable expressions include variables and properties. The value can be a
 single value, an array of values, or a command, expression, or statement.
@@ -31,8 +31,8 @@ single value, an array of values, or a command, expression, or statement.
 The increment and decrement operators are unary operators. Each has prefix and
 postfix versions.
 
-`<assignable-expression><operator>`
-`<operator><assignable-expression>`
+- `<assignable-expression><operator>`
+- `<operator><assignable-expression>`
 
 The assignable expression must be a number or it must be convertible to a
 number.

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to use operators to assign values to variables.
 Locale: en-US
-ms.date: 08/24/2022
+ms.date: 08/01/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_assignment_operators?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Assignment Operators
@@ -23,7 +23,7 @@ assignment.
 
 The syntax of the assignment operators is as follows:
 
-- `<assignable-expression><assignment-operator><value>`
+- `<assignable-expression>` `<assignment-operator>` `<value>`
 
 Assignable expressions include variables and properties. The value can be a
 single value, an array of values, or a command, expression, or statement.
@@ -34,8 +34,8 @@ postfix versions.
 - `<assignable-expression><operator>`
 - `<operator><assignable-expression>`
 
-The assignable expression must be a number or it must be convertible to a
-number.
+The value of the assignable expression must be a number or it must be
+convertible to a number.
 
 ## Using the assignment operator
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -23,7 +23,7 @@ assignment.
 
 The syntax of the assignment operators is as follows:
 
-`<assignable-expression>` `<assignment-operator>` `<value>`
+- `<assignable-expression><assignment-operator><value>`
 
 Assignable expressions include variables and properties. The value can be a
 single value, an array of values, or a command, expression, or statement.
@@ -31,8 +31,8 @@ single value, an array of values, or a command, expression, or statement.
 The increment and decrement operators are unary operators. Each has prefix and
 postfix versions.
 
-`<assignable-expression><operator>`
-`<operator><assignable-expression>`
+- `<assignable-expression><operator>`
+- `<operator><assignable-expression>`
 
 The assignable expression must be a number or it must be convertible to a
 number.

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to use operators to assign values to variables.
 Locale: en-US
-ms.date: 08/24/2022
+ms.date: 08/01/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_assignment_operators?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Assignment Operators
@@ -23,7 +23,7 @@ assignment.
 
 The syntax of the assignment operators is as follows:
 
-- `<assignable-expression><assignment-operator><value>`
+- `<assignable-expression>` `<assignment-operator>` `<value>`
 
 Assignable expressions include variables and properties. The value can be a
 single value, an array of values, or a command, expression, or statement.
@@ -34,8 +34,8 @@ postfix versions.
 - `<assignable-expression><operator>`
 - `<operator><assignable-expression>`
 
-The assignable expression must be a number or it must be convertible to a
-number.
+The value of the assignable expression must be a number or it must be
+convertible to a number.
 
 ## Using the assignment operator
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -23,7 +23,7 @@ assignment.
 
 The syntax of the assignment operators is as follows:
 
-`<assignable-expression>` `<assignment-operator>` `<value>`
+- `<assignable-expression><assignment-operator><value>`
 
 Assignable expressions include variables and properties. The value can be a
 single value, an array of values, or a command, expression, or statement.
@@ -31,8 +31,8 @@ single value, an array of values, or a command, expression, or statement.
 The increment and decrement operators are unary operators. Each has prefix and
 postfix versions.
 
-`<assignable-expression><operator>`
-`<operator><assignable-expression>`
+- `<assignable-expression><operator>`
+- `<operator><assignable-expression>`
 
 The assignable expression must be a number or it must be convertible to a
 number.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to use operators to assign values to variables.
 Locale: en-US
-ms.date: 08/24/2022
+ms.date: 08/01/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_assignment_operators?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Assignment Operators
@@ -23,7 +23,7 @@ assignment.
 
 The syntax of the assignment operators is as follows:
 
-- `<assignable-expression><assignment-operator><value>`
+- `<assignable-expression>` `<assignment-operator>` `<value>`
 
 Assignable expressions include variables and properties. The value can be a
 single value, an array of values, or a command, expression, or statement.
@@ -34,8 +34,8 @@ postfix versions.
 - `<assignable-expression><operator>`
 - `<operator><assignable-expression>`
 
-The assignable expression must be a number or it must be convertible to a
-number.
+The value of the assignable expression must be a number or it must be
+convertible to a number.
 
 ## Using the assignment operator
 


### PR DESCRIPTION

# PR Summary

Use only one syntax token spacing format and use lists to clearly show two syntax versions.

Fixes #10322

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
