### PR TITLE
Add Documentation for New PSReadLine Option ViClipboardMode

### DIFF
--- a/reference/7.4/PSReadLine/Get-PSReadLineOption.md
+++ b/reference/7.4/PSReadLine/Get-PSReadLineOption.md
@@ -56,6 +56,7 @@ CompletionQueryItems                   : 100
 MaximumKillRingCount                   : 10
 ShowToolTips                           : True
 ViModeIndicator                        : None
+ViClipboardMode                        : ViRegister
 WordDelimiters                         : ;:,.[]{}()/\|^&*-=+'"---
 AnsiEscapeTimeout                      : 100
 CommandColor                           : "`e[93m"

--- a/reference/7.4/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.4/PSReadLine/Set-PSReadLineOption.md
@@ -24,8 +24,9 @@ Set-PSReadLineOption [-EditMode <EditMode>] [-ContinuationPrompt <String>] [-His
  [-BellStyle <BellStyle>] [-CompletionQueryItems <Int32>] [-WordDelimiters <String>]
  [-HistorySearchCaseSensitive] [-HistorySaveStyle <HistorySaveStyle>] [-HistorySavePath <String>]
  [-AnsiEscapeTimeout <Int32>] [-PromptText <String[]>] [-ViModeIndicator <ViModeStyle>]
- [-ViModeChangeHandler <ScriptBlock>] [-PredictionSource <PredictionSource>]
- [-PredictionViewStyle <PredictionViewStyle>] [-Colors <Hashtable>] [<CommonParameters>]
+ [-ViModeChangeHandler <ScriptBlock>]  [-ViClipboardMode <ViClipboardMode>] 
+ [-PredictionSource <PredictionSource>] [-PredictionViewStyle <PredictionViewStyle>] 
+ [-Colors <Hashtable>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -744,6 +745,29 @@ Aliases:
 Required: False
 Position: Named
 Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ViClipboardMode
+
+This option determines whether the local clipboard or system clipboard is used for copy and paste
+operations while in the **Vi Edit Mode**.
+
+The valid values are as follows:
+- **ViRegister**: The default value. Copy and paste with **Vi** keys is isolated to the current prompt. 
+  Using **Vi** keys, text cannot be copied and pasted between windows, panes, or external applications.
+- **SystemClipboard**: Copy and paste with **Vi** keys uses the system clipboard. Using **Vi** keys, 
+  text can be copied and pasted between windows, panes, and external applications.
+
+```yaml
+Type: Microsoft.PowerShell.ViClipboardMode
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.4/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.4/PSReadLine/Set-PSReadLineOption.md
@@ -754,11 +754,14 @@ Accept wildcard characters: False
 This option determines whether the local clipboard or system clipboard is used for copy and paste
 operations while in the **Vi Edit Mode**.
 
-The valid values are as follows:
-- **ViRegister**: The default value. Copy and paste with **Vi** keys is isolated to the current prompt. 
-  Using **Vi** keys, text cannot be copied and pasted between windows, panes, or external applications.
-- **SystemClipboard**: Copy and paste with **Vi** keys uses the system clipboard. Using **Vi** keys, 
+The valid values are:
+
+- **ViRegister**: The default value. Copy and paste with **Vi** keys are isolated to the current
+  prompt. Using **Vi** keys, text cannot be copied and pasted between windows, panes, or external
+  applications.
+- **SystemClipboard**: Copy and paste with **Vi** keys use the system clipboard. Using **Vi** keys,
   text can be copied and pasted between windows, panes, and external applications.
+
 
 ```yaml
 Type: Microsoft.PowerShell.ViClipboardMode
@@ -767,7 +770,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: ViRegister
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

This change adds documentation for the **ViClipboardMode** option being added to PSReadLine. Specifically, it updates the **Get-PSReadLineOption.md** and **Set-PSReadLineOption.md** for version 7.4 of PSReadLine. In these files it documents the usage of the command parameter **-ViClipboardMode**.

This is the associated PR:

- https://github.com/PowerShell/PSReadLine/pull/3769

When **ViClipboardMode** is set to **SystemClipboard**, copying and pasting will utilize the system's clipboard instead of a local clipboard while in **Vi** mode in PSReadLine. Using the system clipboard allows text to be copied and pasted between applications, terminal windows, and panes while in **VI** mode.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
