### PR TITLE
Add section to Enum docs for how to import enums from modules

### DIFF
--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -339,8 +339,9 @@ more information about the `using` statement, see [about_Using][01].
 The `using module` statement imports enums from the root module
 (`ModuleToProcess`) of a script module or binary module. It doesn't
 consistently import enums defined in nested modules or enums defined in
-scripts that are dot-sourced into the module's .psm1 file. Enums that you want
-to be available to users outside of the module should be defined in the root
-module.
+scripts that are dot-sourced into the module. Enums that you want to be
+available to users outside of the module should be defined in the root module.
+For script modules, this means they should be defined directly in the psm1
+file.
 
 [01]: about_Using.md

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -327,3 +327,20 @@ to enumeration values that are not valid. Specify one of the following
 enumeration values and try again. The possible enumeration values are
 "CR,LF,CRLF".
 ```
+
+## Importing enums from a PowerShell module
+
+`Import-Module` and the `#requires` statement only import the module functions,
+aliases, and variables, as defined by the module. Enums aren't imported. The
+`using module` statement imports the enums defined in the module. If the
+module isn't loaded in the current session, the `using` statement fails. For
+more information about the `using` statement, see [about_Using][01].
+
+The `using module` statement imports enums from the root module
+(`ModuleToProcess`) of a script module or binary module. It doesn't
+consistently import enums defined in nested modules or enums defined in
+scripts that are dot-sourced into the module's .psm1 file. Enums that you want
+to be available to users outside of the module should be defined in the root
+module.
+
+[01]: about_Using.md


### PR DESCRIPTION
# PR Summary

Enums work similarly to classes in that the enum type is not imported when using `Import-Module`, and you must use `using module` if you want to reference the enum name in your scripts.

This PR adds a section to the Enum documentation that is similar to [the section in the Class documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_classes?view=powershell-7.3&source=docs#importing-classes-from-a-powershell-module) on how to import enums defined in modules into your scripts.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
