### PR TITLE
Clarify `using` statement and class/enum definition requirements

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how you can use classes to create your own custom types.
 Locale: en-US
-ms.date: 07/05/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_classes?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Classes
@@ -841,29 +841,27 @@ class MyComparableBar : bar, System.IComparable
 ## Importing classes from a PowerShell module
 
 `Import-Module` and the `#requires` statement only import the module functions,
-aliases, and variables, as defined by the module. Classes aren't imported. The
-`using module` statement imports the classes defined in the module. If the
-module isn't loaded in the current session, the `using` statement fails. For
-more information about the `using` statement, see [about_Using][07].
+aliases, and variables, as defined by the module. Classes aren't imported.
 
-The `using module` statement imports classes from the root module
-(`ModuleToProcess`) of a script module or binary module. It doesn't
+The `using module` statement imports classes and enumerations from the root
+module (`ModuleToProcess`) of a script module or binary module. It doesn't
 consistently import classes defined in nested modules or classes defined in
-scripts that are dot-sourced into the module. Classes that you want to be
-available to users outside of the module should be defined in the root module.
+scripts that are dot-sourced into the root module. Define classes that you want
+to be available to users outside of the module directly in the root module.
+
+For more information about the `using` statement, see [about_Using][07].
 
 ## Loading newly changed code during development
 
 During development of a script module, it's common to make changes to the code
 then load the new version of the module using `Import-Module` with the
 **Force** parameter. This works for changes to functions in the root module
-only. `Import-Module` doesn't reload any nested modules. Also, there is no way
+only. `Import-Module` doesn't reload any nested modules. Also, there's no way
 to load any updated classes.
 
-To ensure that you are running the latest version, you must unload the module
-using the `Remove-Module` cmdlet. `Remove-Module` removes the root module, all
-nested modules, and any classes defined in the modules. Then you can reload the
-module and the classes using `Import-Module` and the `using module` statement.
+To ensure that you're running the latest version, you must start a new session.
+Classes and enumerations defined in PowerShell and imported with a `using`
+statement can't be unloaded.
 
 Another common development practice is to separate your code into different
 files. If you have function in one file that use classes defined in another

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,7 +1,7 @@
 ---
 description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 06/07/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -327,3 +327,35 @@ to enumeration values that are not valid. Specify one of the following
 enumeration values and try again. The possible enumeration values are
 "CR,LF,CRLF".
 ```
+
+## Importing enumerations from a PowerShell module
+
+`Import-Module` and the `#requires` statement only import the module functions,
+aliases, and variables, as defined by the module. Enumerations aren't imported.
+
+The `using module` statement imports classes and enumerations from the root
+module (`ModuleToProcess`) of a script module or binary module. It doesn't
+consistently import classes defined in nested modules or classes defined in
+scripts that are dot-sourced into the root module. Define classes that you want
+to be available to users outside of the module directly in the root module.
+
+For more information about the `using` statement, see [about_Using][01].
+
+## Loading newly changed code during development
+
+During development of a script module, it's common to make changes to the code
+then load the new version of the module using `Import-Module` with the
+**Force** parameter. This works for changes to functions in the root module
+only. `Import-Module` doesn't reload any nested modules. Also, there's no way
+to load any updated classes.
+
+To ensure that you're running the latest version, you must start a new session.
+Classes and enumerations defined in PowerShell and imported with a `using`
+statement can't be unloaded.
+
+Another common development practice is to separate your code into different
+files. If you have function in one file that use enumerations defined in
+another module, you should using the `using module` statement to ensure that
+the functions have the enumeration definitions that are needed.
+
+[01]: about_Using.md

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -1,7 +1,7 @@
 ---
 description: Prevents a script from running without the required elements.
 Locale: en-US
-ms.date: 08/18/2022
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Requires
@@ -10,6 +10,7 @@ title: about Requires
 # about_Requires
 
 ## Short description
+
 Prevents a script from running without the required elements.
 
 ## Long description
@@ -38,13 +39,13 @@ For more information about the syntax, see
 A script can include more than one `#Requires` statement. The `#Requires`
 statements can appear on any line in a script.
 
-Placing a `#Requires` statement inside a function does NOT limit its scope. All
+Placing a `#Requires` statement inside a function doesn't limit its scope. All
 `#Requires` statements are always applied globally, and must be met, before the
 script can execute.
 
 > [!WARNING]
 > Even though a `#Requires` statement can appear on any line in a script, its
-> position in a script does not affect the sequence of its application. The
+> position in a script doesn't affect the sequence of its application. The
 > global state the `#Requires` statement presents must be met before script
 > execution.
 
@@ -113,6 +114,11 @@ and an optional version number.
 
 If the required modules aren't in the current session, PowerShell imports them.
 If the modules can't be imported, PowerShell throws a terminating error.
+
+The `#Requires` statement doesn't load class and enumeration definitions in the
+module. Use the `using module` statement at the beginning of your script to
+import the module, including the class and enumeration definitions. For more
+information, see [about_Using](about_Using.md).
 
 For each module, type the module name (\<String\>) or a hashtable. The value
 can be a combination of strings and hashtables. The hashtable has the

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Using.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Using.md
@@ -1,7 +1,7 @@
 ---
-description: Allows you to indicate which namespaces are used in the session.
+description: Allows you to specify namespaces to use in the session.
 Locale: en-US
-ms.date: 01/25/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_using?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Using
@@ -9,26 +9,27 @@ title: about Using
 # about_Using
 
 ## Short description
-Allows you to indicate which namespaces are used in the session.
+
+Allows you to specify namespaces to use in the session.
 
 ## Long description
 
-The `using` statement allows you to specify which namespaces are used in the
-session. Adding namespaces simplifies usage of .NET classes and member and
-allows you to import classes from script modules and assemblies.
+The `using` statement allows you to specify namespaces to use in the session.
+Adding namespaces simplifies usage of .NET classes and members and allows you
+to import classes from script modules and assemblies.
 
 The `using` statements must come before any other statements in a script or
 module. No uncommented statement can precede it, including parameters.
 
 The `using` statement must not contain any variables.
 
-The `using` statement should not be confused with the `using:` scope modifier
-for variables. For more information, see
+The `using` statement isn't the same as the `using:` scope modifier for
+variables. For more information, see
 [about_Remote_Variables](about_Remote_Variables.md).
 
 ## Namespace syntax
 
-To specify .NET namespaces from which to resolve types:
+To resolve types from a .NET namespace:
 
 ```
 using namespace <.NET-namespace>
@@ -38,7 +39,7 @@ Specifying a namespace makes it easier to reference types by their short names.
 
 ## Module syntax
 
-To load classes from a PowerShell module:
+To load classes and enumerations from a PowerShell module:
 
 ```
 using module <module-name>
@@ -48,8 +49,7 @@ The value of `<module-name>` can be a module name, a full module specification,
 or a path to a module file.
 
 When `<module-name>` is a path, the path can be fully qualified or relative. A
-relative path is resolved relative to the script that contains the using
-statement.
+relative path resolves relative to the script that has the `using` statement.
 
 When `<module-name>` is a name or module specification, PowerShell searches the
 **PSModulePath** for the specified module.
@@ -64,22 +64,26 @@ A module specification is a hashtable that has the following keys.
   - `RequiredVersion` - Specifies an exact, required version of the module.
     This can't be used with the other Version keys.
 
-The `using module` statement imports classes from the root module
-(`ModuleToProcess`) of a script module or binary module. It does not
-consistently import classes defined in nested modules or classes defined in
-scripts that are dot-sourced into the module. Classes that you want to be
-available to users outside of the module should be defined in the root module.
+`Import-Module` and the `#requires` statement only import the module functions,
+aliases, and variables, as defined by the module. Classes and enumerations
+aren't imported.
 
-During development of a script module, it is common to make changes to the code
+The `using module` statement imports classes and enumerations from the root
+module (`ModuleToProcess`) of a script module or binary module. It doesn't
+consistently import classes or enumerations defined in nested modules or in
+scripts that are dot-sourced into the root module. Define classes and
+enumerations that you want to be available to users outside of the module
+directly in the root module.
+
+During development of a script module, it's common to make changes to the code
 then load the new version of the module using `Import-Module` with the
 **Force** parameter. This works for changes to functions in the root module
-only. `Import-Module` does not reload any nested modules. Also, there is no way
-to load any updated classes.
+only. `Import-Module` doesn't reload any nested modules. Also, there's no way
+to load any updated classes or enumerations.
 
-To ensure that you are running the latest version, you must unload the module
-using the `Remove-Module` cmdlet. `Remove-Module` removes the root module, all
-nested modules, and any classes defined in the modules. Then you can reload the
-module and the classes using `Import-Module` and the `using module` statement.
+To ensure that you're running the latest version, you must start a new session.
+Classes and enumerations defined in PowerShell and imported with a `using`
+statement can't be unloaded.
 
 ## Assembly syntax
 
@@ -98,7 +102,7 @@ In Windows PowerShell 5.1 you can load the assembly by path name or by
 name. When you use the name, PowerShell searches the .NET Global Assembly
 Cache (GAC) for the associated assembly.
 
-If you are not creating new PowerShell classes, use the `Add-Type` cmdlet
+If you aren't creating new PowerShell classes, use the `Add-Type` cmdlet
 instead. For more information, see
 [Add-Type](xref:Microsoft.PowerShell.Utility.Add-Type).
 
@@ -110,7 +114,7 @@ The following script gets the cryptographic hash for the "Hello World" string.
 
 Note how the `using namespace System.Text` and `using namespace System.IO`
 simplify the references to `[UnicodeEncoding]` in `System.Text` and `[Stream]`
-and to `[MemoryStream]` in `System.IO`.
+and `[MemoryStream]` in `System.IO`.
 
 ```powershell
 using namespace System.Text
@@ -130,14 +134,14 @@ $hashfromstream.Hash.ToString()
 
 ### Example 2 - Load classes from a script module
 
-In this example, we have a PowerShell script module named **CardGames** that
-defines the following classes:
+In this example, a PowerShell script module named **CardGames** defines the
+following classes:
 
 - **Deck**
 - **Card**
 
 `Import-Module` and the `#requires` statement only import the module functions,
-aliases, and variables, as defined by the module. Classes are not imported. The
+aliases, and variables, as defined by the module. Classes aren't imported. The
 `using module` command imports the module and also loads the class definitions.
 
 ```powershell

--- a/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/12/2022
+ms.date: 08/17/2023
 no-loc: [Import-Module, -Scope]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/import-module?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -92,9 +92,9 @@ You can disable automatic module importing using the `$PSModuleAutoloadingPrefer
 variable. For more information about the `$PSModuleAutoloadingPreference` variable, see
 [about_Preference_Variables](About/about_Preference_Variables.md).
 
-A module is a package that contains members that can be used in PowerShell. Members include cmdlets,
-providers, scripts, functions, variables, and other tools and files. After a module is imported, you
-can use the module members in your session. For more information about modules, see
+A module is a package that contains members that can be used in PowerShell. Members include
+cmdlets, providers, scripts, functions, variables, and other tools and files. After a module is
+imported, you can use the module members in your session. For more information about modules, see
 [about_Modules](About/about_Modules.md).
 
 By default, `Import-Module` imports all members that the module exports, but you can use the
@@ -116,10 +116,10 @@ Starting in Windows PowerShell 3.0, you can use `Import-Module` to import Common
 you use cmdlets that are implemented in non-managed code assemblies, such as those written in C++.
 
 For remote computers that don't have PowerShell remoting enabled, including computers that aren't
-running the Windows operating system, you can use the **CIMSession** parameter of `Import-Module` to
-import CIM modules from the remote computer. The imported commands run implicitly on the remote
-computer. A **CIMSession** is a connection to Windows Management Instrumentation (WMI) on the remote
-computer.
+running the Windows operating system, you can use the **CIMSession** parameter of `Import-Module`
+to import CIM modules from the remote computer. The imported commands run implicitly on the remote
+computer. A **CIMSession** is a connection to Windows Management Instrumentation (WMI) on the
+remote computer.
 
 ## EXAMPLES
 
@@ -174,15 +174,15 @@ VERBOSE: Exporting function 'Get-SpecDetails'.
 ```
 
 Using the **Verbose** parameter causes `Import-Module` to report progress as it loads the module.
-Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, `Import-Module` does not
+Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, `Import-Module` doesn't
 generate any output when it imports a module.
 
 ### Example 5: Restrict module members imported into a session
 
-This example shows how to restrict which module members are imported into the session and the effect
-of this command on the session. The **Function** parameter limits the members that are imported from
-the module. You can also use the **Alias**, **Variable**, and **Cmdlet** parameters to restrict
-other members that a module imports.
+This example shows how to restrict which module members are imported into the session and the
+effect of this command on the session. The **Function** parameter limits the members that are
+imported from the module. You can also use the **Alias**, **Variable**, and **Cmdlet** parameters
+to restrict other members that a module imports.
 
 The `Get-Module` cmdlet gets the object that represents the **PSDiagnostics** module. The
 **ExportedCmdlets** property lists all the cmdlets that the module exports, even though they were
@@ -227,8 +227,8 @@ from the **PSDiagnostics** module. The results confirm that only the `Disable-PS
 
 This example imports the **PSDiagnostics** module into the current session, adds a prefix to the
 member names, and then displays the prefixed member names. The **Prefix** parameter of
-`Import-Module` adds the **x** prefix to all members that are imported from the module. The prefix
-applies only to the members in the current session. It does not change the module. The **PassThru**
+`Import-Module` adds the `x` prefix to all members that are imported from the module. The prefix
+applies only to the members in the current session. It doesn't change the module. The **PassThru**
 parameter returns a module object that represents the imported module.
 
 ```powershell
@@ -270,12 +270,12 @@ This example demonstrates how to get and use the custom object returned by `Impo
 Custom objects include synthetic members that represent each of the imported module members. For
 example, the cmdlets and functions in a module are converted to script methods of the custom object.
 
-Custom objects are useful in scripting. They are also useful when several imported objects have
+Custom objects are useful in scripting. They're also useful when several imported objects have
 the same names. Using the script method of an object is equivalent to specifying the fully qualified
 name of an imported member, including its module name.
 
-The **AsCustomObject** parameter can be used only when importing a script module. Use `Get-Module`
-to determine which of the available modules is a script module.
+The **AsCustomObject** parameter is only usable when importing a script module. Use `Get-Module` to
+determine which of the available modules is a script module.
 
 ```powershell
 Get-Module -List | Format-Table -Property Name, ModuleType -AutoSize
@@ -391,12 +391,13 @@ Because functions take precedence over cmdlets, the `Get-Date` function from the
 module runs, instead of the `Get-Date` cmdlet. To run the original version of `Get-Date`, you must
 qualify the command name with the module name.
 
-For more information about command precedence in PowerShell, see [about_Command_Precedence](about/about_Command_Precedence.md).
+For more information about command precedence in PowerShell, see
+[about_Command_Precedence](about/about_Command_Precedence.md).
 
 ### Example 10: Import a minimum version of a module
 
 This example imports the **PowerShellGet** module. It uses the **MinimumVersion** parameter of
-`Import-Module` to import only version 2.0.0 or greater of the module.
+`Import-Module` to import only version `2.0.0` or greater of the module.
 
 ```powershell
 Import-Module -Name PowerShellGet -MinimumVersion 2.0.0
@@ -408,7 +409,7 @@ version of a module in a script.
 
 ### Example 11: Import using a fully qualified name
 
-This example imports a specific version of a module using the FullyQualifiedName.
+This example imports a specific version of a module using the **FullyQualifiedName**.
 
 ```powershell
 PS> Get-Module -ListAvailable PowerShellGet | Select-Object Name, Version
@@ -492,22 +493,23 @@ Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP-PUBLI
 Windows Remote Management - Compatibility Mode (HTTP-In) WINRM-HTTP-Compat-In-TCP
 ```
 
-`New-PSSession` creates a remote session (**PSSession**) to the Server01 computer. The **PSSession**
-is saved in the `$s` variable.
+`New-PSSession` creates a remote session (**PSSession**) to the `Server01` computer. The
+**PSSession** is saved in the `$s` variable.
 
 Running `Get-Module` with the **PSSession** parameter shows that the **NetSecurity** module is
 installed and available on the remote computer. This command is equivalent to using the
 `Invoke-Command` cmdlet to run `Get-Module` command in the remote session. For example:
- (`Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity`
 
-Running `Import-Module` with the **PSSession** parameter imports the **NetSecurity** module from the
-remote computer into the current session. The `Get-Command` cmdlet is used to get commands that
-begin with **Get** and include **Firewall** from the **NetSecurity** module. The output confirms
-that the module and its cmdlets were imported into the current session.
+`Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity`
 
-Next, the `Get-NetFirewallRule` cmdlet gets Windows Remote Management firewall rules on the Server01
-computer. This is equivalent to using the `Invoke-Command` cmdlet to run `Get-NetFirewallRule`
-on the remote session.
+Running `Import-Module` with the **PSSession** parameter imports the **NetSecurity** module from
+the remote computer into the current session. The `Get-Command` cmdlet retrieves commands that
+begin with `Get` and include `Firewall` from the **NetSecurity** module. The output confirms that
+the module and its cmdlets were imported into the current session.
+
+Next, the `Get-NetFirewallRule` cmdlet gets Windows Remote Management firewall rules on the
+`Server01` computer. This is equivalent to using the `Invoke-Command` cmdlet to run
+`Get-NetFirewallRule` on the remote session.
 
 ### Example 14: Manage storage on a remote computer without the Windows operating system
 
@@ -517,7 +519,7 @@ provider, which allows you to use CIM commands that are designed for the provide
 The `New-CimSession` cmdlet creates a session on the remote computer named RSDGF03. The session
 connects to the WMI service on the remote computer. The CIM session is saved in the `$cs` variable.
 `Import-Module` uses the **CimSession** in `$cs` to import the **Storage** CIM module from the
-RSDGF03 computer.
+`RSDGF03` computer.
 
 The `Get-Command` cmdlet shows the `Get-Disk` command in the **Storage** module. When you import a
 CIM module into the local session, PowerShell converts the CDXML files for each command into
@@ -530,8 +532,8 @@ session.
 ```powershell
 $cs = New-CimSession -ComputerName RSDGF03
 Import-Module -CimSession $cs -Name Storage
-# Importing a CIM module, converts the CDXML files for each command into PowerShell scripts.
-# These appear as functions in the local session.
+# Importing a CIM module, converts the CDXML files for each command into
+# PowerShell scripts. These appear as functions in the local session.
 Get-Command Get-Disk
 ```
 
@@ -542,7 +544,8 @@ Function        Get-Disk              Storage
 ```
 
 ```powershell
-# Use implicit remoting to query disks on the remote computer from which the module was imported.
+# Use implicit remoting to query disks on the remote computer from which the
+# module was imported.
 Get-Disk
 ```
 
@@ -580,7 +583,8 @@ Specifies an array of arguments, or parameter values, that are passed to a scrip
 `Import-Module` command. This parameter is valid only when you're importing a script module.
 
 You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information
-about the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
+about the behavior of **ArgumentList**, see
+[about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: System.Object[]
@@ -601,7 +605,7 @@ members. This parameter is valid only for script modules.
 
 When you use the **AsCustomObject** parameter, `Import-Module` imports the module members into the
 session and then returns a **PSCustomObject** object instead of a **PSModuleInfo** object. You can
-save the custom object in a variable and use dot notation to invoke the members.
+save the custom object in a variable and use member-access enumeration to invoke the members.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -735,8 +739,8 @@ Accept wildcard characters: True
 Indicates that this cmdlet suppresses the message that warns you when you import a cmdlet or
 function whose name includes an unapproved verb or a prohibited character.
 
-By default, when a module that you import exports cmdlets or functions that have unapproved verbs in
-their names, PowerShell displays the following warning message:
+By default, when a module that you import exports cmdlets or functions that have unapproved verbs
+in their names, PowerShell displays the following warning message:
 
 > WARNING: Some imported command names include unapproved verbs which might make them less
 > discoverable. Use the Verbose parameter for more detail or type Get-Verb to see the list of
@@ -827,7 +831,7 @@ Accept wildcard characters: True
 
 ### -Global
 
-Indicates that this cmdlet imports modules into the global session state so they are available to
+Indicates that this cmdlet imports modules into the global session state so they're available to
 all commands in the session.
 
 By default, when `Import-Module` cmdlet is called from the command prompt, script file, or
@@ -860,7 +864,7 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies a maximum version. This cmdlet imports only a version of the module that is less than or
+Specifies a maximum version. This cmdlet imports only a version of the module that's less than or
 equal to the specified value. If no version qualifies, `Import-Module` returns an error.
 
 ```yaml
@@ -877,7 +881,7 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies a minimum version. This cmdlet imports only a version of the module that is greater than
+Specifies a minimum version. This cmdlet imports only a version of the module that's greater than
 or equal to the specified value. Use the **MinimumVersion** parameter name or its alias,
 **Version**. If no version qualifies, `Import-Module` generates an error.
 
@@ -926,14 +930,14 @@ characters aren't permitted. You can also pipe module names and filenames to `Im
 If you omit a path, `Import-Module` looks for the module in the paths saved in the
 `$env:PSModulePath` environment variable.
 
-Specify only the module name whenever possible. When you specify a file name, only the members that
+Specify only the module name whenever possible. When you specify a filename, only the members that
 are implemented in that file are imported. If the module contains other files, they aren't
 imported, and you might be missing important members of the module.
 
 > [!NOTE]
-> While it is possible to import a script (`.ps1`) file as a module, script files are usually not
-> structured like script modules file (`.psm1`) file. Importing a script file does not guarantee
-> that it is usable as a module. For more information, see [about_Modules](about/about_Modules.md).
+> While it's possible to import a script (`.ps1`) file as a module, script files are usually not
+> structured like script modules file (`.psm1`) file. Importing a script file doesn't guarantee
+> that it's usable as a module. For more information, see [about_Modules](about/about_Modules.md).
 
 ```yaml
 Type: System.String[]
@@ -974,8 +978,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you're working. By default, this cmdlet does not
-generate any output.
+Returns an object representing the imported module. By default, this cmdlet doesn't generate any
+output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -994,12 +998,12 @@ Accept wildcard characters: False
 Specifies a prefix that this cmdlet adds to the nouns in the names of imported module members.
 
 Use this parameter to avoid name conflicts that might occur when different members in the session
-have the same name. This parameter does not change the module, and it does not affect files that the
+have the same name. This parameter doesn't change the module, and it doesn't affect files that the
 module imports for its own use. These are known as nested modules. This cmdlet affects only the
 names of members in the current session.
 
 For example, if you specify the prefix UTC and then import a `Get-Date` cmdlet, the cmdlet is known
-in the session as `Get-UTCDate`, and it is not confused with the original `Get-Date` cmdlet.
+in the session as `Get-UTCDate`, and it's not confused with the original `Get-Date` cmdlet.
 
 The value of this parameter takes precedence over the **DefaultCommandPrefix** property of the
 module, which specifies the default prefix.
@@ -1024,13 +1028,13 @@ into the current session. Enter a variable that contains a **PSSession** or a co
 
 When you import a module from a different session into the current session, you can use the cmdlets
 from the module in the current session, just as you would use cmdlets from a local module. Commands
-that use the remote cmdlets run in the remote session, but the remoting details are managed
-in the background by PowerShell.
+that use the remote cmdlets run in the remote session, but the remoting details are managed in the
+background by PowerShell.
 
-This parameter uses the Implicit Remoting feature of PowerShell. It is equivalent to using the
+This parameter uses the Implicit Remoting feature of PowerShell. It's equivalent to using the
 `Import-PSSession` cmdlet to import particular modules from a session.
 
-`Import-Module` cannot import core PowerShell modules from another session. The core PowerShell
+`Import-Module` can't import core PowerShell modules from another session. The core PowerShell
 modules have names that begin with Microsoft.PowerShell.
 
 This parameter was introduced in Windows PowerShell 3.0.
@@ -1049,7 +1053,7 @@ Accept wildcard characters: False
 
 ### -RequiredVersion
 
-Specifies a version of the module that this cmdlet imports. If the version is not installed,
+Specifies a version of the module that this cmdlet imports. If the version isn't installed,
 `Import-Module` generates an error.
 
 By default, `Import-Module` imports the module without checking the version number.
@@ -1080,7 +1084,7 @@ Accept wildcard characters: False
 
 ### -Scope
 
-Specifies a scope into which this cmdlet imports the module.
+Specifies a scope to import the module in.
 
 The acceptable values for this parameter are:
 
@@ -1091,9 +1095,9 @@ By default, when `Import-Module` cmdlet is called from the command prompt, scrip
 scriptblock, all the commands are imported into the global session state. You can use the
 `-Scope Local` parameter to import module content into the script or scriptblock scope.
 
-When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
-commands from nested modules, into the caller's session state. Specifying `-Scope Global` or
-`-Global` indicates that this cmdlet imports modules into the global session state so they are
+When invoked from another module, `Import-Module` cmdlet imports the commands in a module,
+including commands from nested modules, into the caller's session state. Specifying `-Scope Global`
+or `-Global` indicates that this cmdlet imports modules into the global session state so they're
 available to all commands in the session.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of **Global**.
@@ -1134,6 +1138,7 @@ Accept wildcard characters: True
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see
@@ -1162,7 +1167,7 @@ By default, this cmdlet returns no output.
 ### System.Management.Automation.PSModuleInfo
 
 If you specify the **PassThru** parameter, the cmdlet generates a
-**System.Management.Automation.PSModuleInfo** object that represents the module.
+**System.Management.Automation.PSModuleInfo** object that represents the imported module.
 
 ### System.Management.Automation.PSCustomObject
 
@@ -1175,9 +1180,9 @@ Windows PowerShell includes the following aliases for `Import-Module`:
 
 - `ipmo`
 
-- Before you can import a module, the module must be installed on the local computer. That is, the
-  module directory must be copied to a directory that is accessible to your local computer. For more
-  information, see [about_Modules](About/about_Modules.md).
+- Before you can import a module, the module must be accessible to your local computer and included
+  in the `PSModulePath` environmental variable. For more information, see
+  [about_Modules](About/about_Modules.md).
 
   You can also use the **PSSession** and **CIMSession** parameters to import modules that are
   installed on remote computers. However, commands that use the cmdlets in these modules run in the
@@ -1188,24 +1193,23 @@ Windows PowerShell includes the following aliases for `Import-Module`:
   accessible. Functions, cmdlets, and providers are merely shadowed by the new members. They can be
   accessed by qualifying the command name with the name of its snap-in, module, or function path.
 
-- To update the formatting data for commands that have been imported from a module, use the
-  `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in
-  the session that were imported from modules. If the formatting file for a module changes, you can
-  run an `Update-FormatData` command to update the formatting data for imported commands. You don't
-  need to import the module again.
+- To update the formatting data for commands imported from a module, use the `Update-FormatData`
+  cmdlet. If the formatting file for a module changes, use the `Update-FormatData` cmdlet to update
+  the formatting data for imported commands. You don't need to import the module again.
 
-- Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are
-  packaged in modules. In Windows PowerShell 2.0, and in host programs that create older-style
-  sessions in later versions of PowerShell, the core commands are packaged in snap-ins
-  (**PSSnapins**). The exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also,
-  remote sessions, such as those started by the `New-PSSession` cmdlet, are older-style sessions
-  that include core snap-ins.
+- Starting in Windows PowerShell 3.0, the core commands installed with PowerShell are packaged in
+  modules. In Windows PowerShell 2.0, and in host programs that create older-style sessions in
+  later versions of PowerShell, the core commands are packaged in snap-ins (**PSSnapins**). The
+  exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also, remote sessions,
+  such as those started by the `New-PSSession` cmdlet, are older-style sessions that include core
+  snap-ins.
 
   For information about the **CreateDefault2** method that creates newer-style sessions with core
-  modules, see the [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2).
+  modules, see the
+  [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2).
 
-- In Windows PowerShell 2.0, some of the property values of the module object, such as the
-  **ExportedCmdlets** and **NestedModules** property values, were not populated until the module was
+- In Windows PowerShell 2.0, some property values of the module object, such as the
+  **ExportedCmdlets** and **NestedModules** property values, weren't populated until the module was
   imported.
 
 - If you attempt to import a module that contains mixed-mode assemblies that aren't compatible with
@@ -1214,7 +1218,7 @@ Windows PowerShell includes the following aliases for `Import-Module`:
   > Import-Module : Mixed mode assembly is built against version 'v2.0.50727' of the runtime and
   > cannot be loaded in the 4.0 runtime without additional configuration information.
 
-  This error occurs when a module that is designed for Windows PowerShell 2.0 contains at least one
+  This error occurs when a module that's designed for Windows PowerShell 2.0 contains at least one
   mixed-module assembly. A mixed-module assembly that includes both managed and non-managed code,
   such as C++ and C#.
 
@@ -1240,16 +1244,28 @@ Windows PowerShell includes the following aliases for `Import-Module`:
   exported elements.
 
   In a descendant scope, `-Scope Local` limits the import to that scope and all its descendant
-  scopes. Parent scopes then do not see the imported members.
+  scopes. Parent scopes then don't see the imported members.
 
   > [!NOTE]
   > `Get-Module` shows all modules loaded in the current session. This includes modules loaded
   > locally in a descendant scope. Use `Get-Command -Module modulename` to see which members are
   > loaded in the current scope.
 
-  `Import-Module` does not load class and enum definitions in the module. Use the `using module`
-  statement at the beginning of your script. This imports the module, including the class and enum
-  definitions. For more information, see [about_Using](About/about_Using.md).
+- `Import-Module` doesn't load class and enumeration definitions in the module. Use the
+  `using module` statement at the beginning of your script. This imports the module, including the
+  class and enumeration definitions. For more information, see [about_Using](About/about_Using.md).
+
+- During development of a script module, it's common to make changes to the code then load the new
+  version of the module using `Import-Module` with the **Force** parameter. This works for changes
+  to functions in the root module only. `Import-Module` doesn't reload any nested modules. Also,
+  there's no way to load any updated classes or enumerations.
+
+  To get updated module members defined in nested modules, remove the module with `Remove-Module`,
+  then import the module again.
+
+  If the module was loaded with a `using` statement, you must start a new session to import updated
+  definitions for the classes and enumerations. Classes and enumerations defined in PowerShell and
+  imported with a `using` statement can't be unloaded.
 
 ## RELATED LINKS
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how you can use classes to create your own custom types.
 Locale: en-US
-ms.date: 07/05/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_classes?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Classes
@@ -841,29 +841,27 @@ class MyComparableBar : bar, System.IComparable
 ## Importing classes from a PowerShell module
 
 `Import-Module` and the `#requires` statement only import the module functions,
-aliases, and variables, as defined by the module. Classes aren't imported. The
-`using module` statement imports the classes defined in the module. If the
-module isn't loaded in the current session, the `using` statement fails. For
-more information about the `using` statement, see [about_Using][07].
+aliases, and variables, as defined by the module. Classes aren't imported.
 
-The `using module` statement imports classes from the root module
-(`ModuleToProcess`) of a script module or binary module. It doesn't
+The `using module` statement imports classes and enumerations from the root
+module (`ModuleToProcess`) of a script module or binary module. It doesn't
 consistently import classes defined in nested modules or classes defined in
-scripts that are dot-sourced into the module. Classes that you want to be
-available to users outside of the module should be defined in the root module.
+scripts that are dot-sourced into the root module. Define classes that you want
+to be available to users outside of the module directly in the root module.
+
+For more information about the `using` statement, see [about_Using][07].
 
 ## Loading newly changed code during development
 
 During development of a script module, it's common to make changes to the code
 then load the new version of the module using `Import-Module` with the
 **Force** parameter. This works for changes to functions in the root module
-only. `Import-Module` doesn't reload any nested modules. Also, there is no way
+only. `Import-Module` doesn't reload any nested modules. Also, there's no way
 to load any updated classes.
 
-To ensure that you are running the latest version, you must unload the module
-using the `Remove-Module` cmdlet. `Remove-Module` removes the root module, all
-nested modules, and any classes defined in the modules. Then you can reload the
-module and the classes using `Import-Module` and the `using module` statement.
+To ensure that you're running the latest version, you must start a new session.
+Classes and enumerations defined in PowerShell and imported with a `using`
+statement can't be unloaded.
 
 Another common development practice is to separate your code into different
 files. If you have function in one file that use classes defined in another

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,7 +1,7 @@
 ---
 description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 06/07/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -327,3 +327,35 @@ to enumeration values that are not valid. Specify one of the following
 enumeration values and try again. The possible enumeration values are
 "CR,LF,CRLF".
 ```
+
+## Importing enumerations from a PowerShell module
+
+`Import-Module` and the `#requires` statement only import the module functions,
+aliases, and variables, as defined by the module. Enumerations aren't imported.
+
+The `using module` statement imports classes and enumerations from the root
+module (`ModuleToProcess`) of a script module or binary module. It doesn't
+consistently import classes defined in nested modules or classes defined in
+scripts that are dot-sourced into the root module. Define classes that you want
+to be available to users outside of the module directly in the root module.
+
+For more information about the `using` statement, see [about_Using][01].
+
+## Loading newly changed code during development
+
+During development of a script module, it's common to make changes to the code
+then load the new version of the module using `Import-Module` with the
+**Force** parameter. This works for changes to functions in the root module
+only. `Import-Module` doesn't reload any nested modules. Also, there's no way
+to load any updated classes.
+
+To ensure that you're running the latest version, you must start a new session.
+Classes and enumerations defined in PowerShell and imported with a `using`
+statement can't be unloaded.
+
+Another common development practice is to separate your code into different
+files. If you have function in one file that use enumerations defined in
+another module, you should using the `using module` statement to ensure that
+the functions have the enumeration definitions that are needed.
+
+[01]: about_Using.md

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -1,7 +1,7 @@
 ---
 description: Prevents a script from running without the required elements.
 Locale: en-US
-ms.date: 03/14/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Requires
@@ -10,6 +10,7 @@ title: about Requires
 # about_Requires
 
 ## Short description
+
 Prevents a script from running without the required elements.
 
 ## Long description
@@ -36,13 +37,13 @@ For more information about the syntax, see
 A script can include more than one `#Requires` statement. The `#Requires`
 statements can appear on any line in a script.
 
-Placing a `#Requires` statement inside a function does NOT limit its scope. All
+Placing a `#Requires` statement inside a function doesn't limit its scope. All
 `#Requires` statements are always applied globally, and must be met, before the
 script can execute.
 
 > [!WARNING]
 > Even though a `#Requires` statement can appear on any line in a script, its
-> position in a script does not affect the sequence of its application. The
+> position in a script doesn't affect the sequence of its application. The
 > global state the `#Requires` statement presents must be met before script
 > execution.
 
@@ -100,6 +101,11 @@ and an optional version number.
 
 If the required modules aren't in the current session, PowerShell imports them.
 If the modules can't be imported, PowerShell throws a terminating error.
+
+The `#Requires` statement doesn't load class and enumeration definitions in the
+module. Use the `using module` statement at the beginning of your script to
+import the module, including the class and enumeration definitions. For more
+information, see [about_Using](about_Using.md).
 
 For each module, type the module name (\<String\>) or a hashtable. The value
 can be a combination of strings and hashtables. The hashtable has the

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Using.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Using.md
@@ -1,7 +1,7 @@
 ---
-description: Allows you to indicate which namespaces are used in the session.
+description: Allows you to specify namespaces to use in the session.
 Locale: en-US
-ms.date: 01/25/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_using?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Using
@@ -9,26 +9,27 @@ title: about Using
 # about_Using
 
 ## Short description
-Allows you to indicate which namespaces are used in the session.
+
+Allows you to specify namespaces to use in the session.
 
 ## Long description
 
-The `using` statement allows you to specify which namespaces are used in the
-session. Adding namespaces simplifies usage of .NET classes and member and
-allows you to import classes from script modules and assemblies.
+The `using` statement allows you to specify namespaces to use in the session.
+Adding namespaces simplifies usage of .NET classes and members and allows you
+to import classes from script modules and assemblies.
 
 The `using` statements must come before any other statements in a script or
 module. No uncommented statement can precede it, including parameters.
 
 The `using` statement must not contain any variables.
 
-The `using` statement should not be confused with the `using:` scope modifier
-for variables. For more information, see
+The `using` statement isn't the same as the `using:` scope modifier for
+variables. For more information, see
 [about_Remote_Variables](about_Remote_Variables.md).
 
 ## Namespace syntax
 
-To specify .NET namespaces from which to resolve types:
+To resolve types from a .NET namespace:
 
 ```
 using namespace <.NET-namespace>
@@ -38,7 +39,7 @@ Specifying a namespace makes it easier to reference types by their short names.
 
 ## Module syntax
 
-To load classes from a PowerShell module:
+To load classes and enumerations from a PowerShell module:
 
 ```
 using module <module-name>
@@ -48,8 +49,7 @@ The value of `<module-name>` can be a module name, a full module specification,
 or a path to a module file.
 
 When `<module-name>` is a path, the path can be fully qualified or relative. A
-relative path is resolved relative to the script that contains the using
-statement.
+relative path resolves relative to the script that has the `using` statement.
 
 When `<module-name>` is a name or module specification, PowerShell searches the
 **PSModulePath** for the specified module.
@@ -64,22 +64,26 @@ A module specification is a hashtable that has the following keys.
   - `RequiredVersion` - Specifies an exact, required version of the module.
     This can't be used with the other Version keys.
 
-The `using module` statement imports classes from the root module
-(`ModuleToProcess`) of a script module or binary module. It does not
-consistently import classes defined in nested modules or classes defined in
-scripts that are dot-sourced into the module. Classes that you want to be
-available to users outside of the module should be defined in the root module.
+`Import-Module` and the `#requires` statement only import the module functions,
+aliases, and variables, as defined by the module. Classes and enumerations
+aren't imported.
 
-During development of a script module, it is common to make changes to the code
+The `using module` statement imports classes and enumerations from the root
+module (`ModuleToProcess`) of a script module or binary module. It doesn't
+consistently import classes or enumerations defined in nested modules or in
+scripts that are dot-sourced into the root module. Define classes and
+enumerations that you want to be available to users outside of the module
+directly in the root module.
+
+During development of a script module, it's common to make changes to the code
 then load the new version of the module using `Import-Module` with the
 **Force** parameter. This works for changes to functions in the root module
-only. `Import-Module` does not reload any nested modules. Also, there is no way
-to load any updated classes.
+only. `Import-Module` doesn't reload any nested modules. Also, there's no way
+to load any updated classes or enumerations.
 
-To ensure that you are running the latest version, you must unload the module
-using the `Remove-Module` cmdlet. `Remove-Module` removes the root module, all
-nested modules, and any classes defined in the modules. Then you can reload the
-module and the classes using `Import-Module` and the `using module` statement.
+To ensure that you're running the latest version, you must start a new session.
+Classes and enumerations defined in PowerShell and imported with a `using`
+statement can't be unloaded.
 
 ## Assembly syntax
 
@@ -93,7 +97,7 @@ Loading an assembly preloads .NET types from that assembly into a script at
 parse time. This allows you to create new PowerShell classes that use types
 from the preloaded assembly.
 
-If you are not creating new PowerShell classes, use the `Add-Type` cmdlet
+If you aren't creating new PowerShell classes, use the `Add-Type` cmdlet
 instead. For more information, see
 [Add-Type](xref:Microsoft.PowerShell.Utility.Add-Type).
 
@@ -105,7 +109,7 @@ The following script gets the cryptographic hash for the "Hello World" string.
 
 Note how the `using namespace System.Text` and `using namespace System.IO`
 simplify the references to `[UnicodeEncoding]` in `System.Text` and `[Stream]`
-and to `[MemoryStream]` in `System.IO`.
+and `[MemoryStream]` in `System.IO`.
 
 ```powershell
 using namespace System.Text
@@ -125,14 +129,14 @@ $hashfromstream.Hash.ToString()
 
 ### Example 2 - Load classes from a script module
 
-In this example, we have a PowerShell script module named **CardGames** that
-defines the following classes:
+In this example, a PowerShell script module named **CardGames** defines the
+following classes:
 
 - **Deck**
 - **Card**
 
 `Import-Module` and the `#requires` statement only import the module functions,
-aliases, and variables, as defined by the module. Classes are not imported. The
+aliases, and variables, as defined by the module. Classes aren't imported. The
 `using module` command imports the module and also loads the class definitions.
 
 ```powershell
@@ -161,7 +165,7 @@ $info = [ordered]@{
     @{ Name = 'Apples' ; Count = 1234 }
     @{ Name = 'Bagels' ; Count = 5678 }
   )
-    CheckedAt = [datetime]'2023-01-01T01:01:01'
+  CheckedAt = [datetime]'2023-01-01T01:01:01'
 }
 
 $yamlSerializer.Serialize($info)

--- a/reference/7.2/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Import-Module.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/12/2022
+ms.date: 08/17/2023
 no-loc: [Import-Module, -Scope]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/import-module?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -111,9 +111,9 @@ You can disable automatic module importing using the `$PSModuleAutoloadingPrefer
 variable. For more information about the `$PSModuleAutoloadingPreference` variable, see
 [about_Preference_Variables](About/about_Preference_Variables.md).
 
-A module is a package that contains members that can be used in PowerShell. Members include cmdlets,
-providers, scripts, functions, variables, and other tools and files. After a module is imported, you
-can use the module members in your session. For more information about modules, see
+A module is a package that contains members that can be used in PowerShell. Members include
+cmdlets, providers, scripts, functions, variables, and other tools and files. After a module is
+imported, you can use the module members in your session. For more information about modules, see
 [about_Modules](About/about_Modules.md).
 
 By default, `Import-Module` imports all members that the module exports, but you can use the
@@ -135,10 +135,10 @@ Starting in Windows PowerShell 3.0, you can use `Import-Module` to import Common
 you use cmdlets that are implemented in non-managed code assemblies, such as those written in C++.
 
 For remote computers that don't have PowerShell remoting enabled, including computers that aren't
-running the Windows operating system, you can use the **CIMSession** parameter of `Import-Module` to
-import CIM modules from the remote computer. The imported commands run implicitly on the remote
-computer. A **CIMSession** is a connection to Windows Management Instrumentation (WMI) on the remote
-computer.
+running the Windows operating system, you can use the **CIMSession** parameter of `Import-Module`
+to import CIM modules from the remote computer. The imported commands run implicitly on the remote
+computer. A **CIMSession** is a connection to Windows Management Instrumentation (WMI) on the
+remote computer.
 
 ## EXAMPLES
 
@@ -193,15 +193,15 @@ VERBOSE: Exporting function 'Get-SpecDetails'.
 ```
 
 Using the **Verbose** parameter causes `Import-Module` to report progress as it loads the module.
-Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, `Import-Module` does not
+Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, `Import-Module` doesn't
 generate any output when it imports a module.
 
 ### Example 5: Restrict module members imported into a session
 
-This example shows how to restrict which module members are imported into the session and the effect
-of this command on the session. The **Function** parameter limits the members that are imported from
-the module. You can also use the **Alias**, **Variable**, and **Cmdlet** parameters to restrict
-other members that a module imports.
+This example shows how to restrict which module members are imported into the session and the
+effect of this command on the session. The **Function** parameter limits the members that are
+imported from the module. You can also use the **Alias**, **Variable**, and **Cmdlet** parameters
+to restrict other members that a module imports.
 
 The `Get-Module` cmdlet gets the object that represents the **PSDiagnostics** module. The
 **ExportedCmdlets** property lists all the cmdlets that the module exports, even though they were
@@ -246,8 +246,8 @@ from the **PSDiagnostics** module. The results confirm that only the `Disable-PS
 
 This example imports the **PSDiagnostics** module into the current session, adds a prefix to the
 member names, and then displays the prefixed member names. The **Prefix** parameter of
-`Import-Module` adds the **x** prefix to all members that are imported from the module. The prefix
-applies only to the members in the current session. It does not change the module. The **PassThru**
+`Import-Module` adds the `x` prefix to all members that are imported from the module. The prefix
+applies only to the members in the current session. It doesn't change the module. The **PassThru**
 parameter returns a module object that represents the imported module.
 
 ```powershell
@@ -289,12 +289,12 @@ This example demonstrates how to get and use the custom object returned by `Impo
 Custom objects include synthetic members that represent each of the imported module members. For
 example, the cmdlets and functions in a module are converted to script methods of the custom object.
 
-Custom objects are useful in scripting. They are also useful when several imported objects have
+Custom objects are useful in scripting. They're also useful when several imported objects have
 the same names. Using the script method of an object is equivalent to specifying the fully qualified
 name of an imported member, including its module name.
 
-The **AsCustomObject** parameter can be used only when importing a script module. Use `Get-Module`
-to determine which of the available modules is a script module.
+The **AsCustomObject** parameter is only usable when importing a script module. Use `Get-Module` to
+determine which of the available modules is a script module.
 
 ```powershell
 Get-Module -List | Format-Table -Property Name, ModuleType -AutoSize
@@ -410,12 +410,13 @@ Because functions take precedence over cmdlets, the `Get-Date` function from the
 module runs, instead of the `Get-Date` cmdlet. To run the original version of `Get-Date`, you must
 qualify the command name with the module name.
 
-For more information about command precedence in PowerShell, see [about_Command_Precedence](about/about_Command_Precedence.md).
+For more information about command precedence in PowerShell, see
+[about_Command_Precedence](about/about_Command_Precedence.md).
 
 ### Example 10: Import a minimum version of a module
 
 This example imports the **PowerShellGet** module. It uses the **MinimumVersion** parameter of
-`Import-Module` to import only version 2.0.0 or greater of the module.
+`Import-Module` to import only version `2.0.0` or greater of the module.
 
 ```powershell
 Import-Module -Name PowerShellGet -MinimumVersion 2.0.0
@@ -427,7 +428,7 @@ version of a module in a script.
 
 ### Example 11: Import using a fully qualified name
 
-This example imports a specific version of a module using the FullyQualifiedName.
+This example imports a specific version of a module using the **FullyQualifiedName**.
 
 ```powershell
 PS> Get-Module -ListAvailable PowerShellGet | Select-Object Name, Version
@@ -511,22 +512,23 @@ Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP-PUBLI
 Windows Remote Management - Compatibility Mode (HTTP-In) WINRM-HTTP-Compat-In-TCP
 ```
 
-`New-PSSession` creates a remote session (**PSSession**) to the Server01 computer. The **PSSession**
-is saved in the `$s` variable.
+`New-PSSession` creates a remote session (**PSSession**) to the `Server01` computer. The
+**PSSession** is saved in the `$s` variable.
 
 Running `Get-Module` with the **PSSession** parameter shows that the **NetSecurity** module is
 installed and available on the remote computer. This command is equivalent to using the
 `Invoke-Command` cmdlet to run `Get-Module` command in the remote session. For example:
- (`Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity`
 
-Running `Import-Module` with the **PSSession** parameter imports the **NetSecurity** module from the
-remote computer into the current session. The `Get-Command` cmdlet is used to get commands that
-begin with **Get** and include **Firewall** from the **NetSecurity** module. The output confirms
-that the module and its cmdlets were imported into the current session.
+`Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity`
 
-Next, the `Get-NetFirewallRule` cmdlet gets Windows Remote Management firewall rules on the Server01
-computer. This is equivalent to using the `Invoke-Command` cmdlet to run `Get-NetFirewallRule`
-on the remote session.
+Running `Import-Module` with the **PSSession** parameter imports the **NetSecurity** module from
+the remote computer into the current session. The `Get-Command` cmdlet retrieves commands that
+begin with `Get` and include `Firewall` from the **NetSecurity** module. The output confirms that
+the module and its cmdlets were imported into the current session.
+
+Next, the `Get-NetFirewallRule` cmdlet gets Windows Remote Management firewall rules on the
+`Server01` computer. This is equivalent to using the `Invoke-Command` cmdlet to run
+`Get-NetFirewallRule` on the remote session.
 
 ### Example 14: Manage storage on a remote computer without the Windows operating system
 
@@ -536,7 +538,7 @@ provider, which allows you to use CIM commands that are designed for the provide
 The `New-CimSession` cmdlet creates a session on the remote computer named RSDGF03. The session
 connects to the WMI service on the remote computer. The CIM session is saved in the `$cs` variable.
 `Import-Module` uses the **CimSession** in `$cs` to import the **Storage** CIM module from the
-RSDGF03 computer.
+`RSDGF03` computer.
 
 The `Get-Command` cmdlet shows the `Get-Disk` command in the **Storage** module. When you import a
 CIM module into the local session, PowerShell converts the CDXML files for each command into
@@ -549,8 +551,8 @@ session.
 ```powershell
 $cs = New-CimSession -ComputerName RSDGF03
 Import-Module -CimSession $cs -Name Storage
-# Importing a CIM module, converts the CDXML files for each command into PowerShell scripts.
-# These appear as functions in the local session.
+# Importing a CIM module, converts the CDXML files for each command into
+# PowerShell scripts. These appear as functions in the local session.
 Get-Command Get-Disk
 ```
 
@@ -561,7 +563,8 @@ Function        Get-Disk              Storage
 ```
 
 ```powershell
-# Use implicit remoting to query disks on the remote computer from which the module was imported.
+# Use implicit remoting to query disks on the remote computer from which the
+# module was imported.
 Get-Disk
 ```
 
@@ -599,7 +602,8 @@ Specifies an array of arguments, or parameter values, that are passed to a scrip
 `Import-Module` command. This parameter is valid only when you're importing a script module.
 
 You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information
-about the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
+about the behavior of **ArgumentList**, see
+[about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: System.Object[]
@@ -620,7 +624,7 @@ members. This parameter is valid only for script modules.
 
 When you use the **AsCustomObject** parameter, `Import-Module` imports the module members into the
 session and then returns a **PSCustomObject** object instead of a **PSModuleInfo** object. You can
-save the custom object in a variable and use dot notation to invoke the members.
+save the custom object in a variable and use member-access enumeration to invoke the members.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -754,8 +758,8 @@ Accept wildcard characters: True
 Indicates that this cmdlet suppresses the message that warns you when you import a cmdlet or
 function whose name includes an unapproved verb or a prohibited character.
 
-By default, when a module that you import exports cmdlets or functions that have unapproved verbs in
-their names, PowerShell displays the following warning message:
+By default, when a module that you import exports cmdlets or functions that have unapproved verbs
+in their names, PowerShell displays the following warning message:
 
 > WARNING: Some imported command names include unapproved verbs which might make them less
 > discoverable. Use the Verbose parameter for more detail or type Get-Verb to see the list of
@@ -846,7 +850,7 @@ Accept wildcard characters: True
 
 ### -Global
 
-Indicates that this cmdlet imports modules into the global session state so they are available to
+Indicates that this cmdlet imports modules into the global session state so they're available to
 all commands in the session.
 
 By default, when `Import-Module` cmdlet is called from the command prompt, script file, or
@@ -879,7 +883,7 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies a maximum version. This cmdlet imports only a version of the module that is less than or
+Specifies a maximum version. This cmdlet imports only a version of the module that's less than or
 equal to the specified value. If no version qualifies, `Import-Module` returns an error.
 
 ```yaml
@@ -896,7 +900,7 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies a minimum version. This cmdlet imports only a version of the module that is greater than
+Specifies a minimum version. This cmdlet imports only a version of the module that's greater than
 or equal to the specified value. Use the **MinimumVersion** parameter name or its alias,
 **Version**. If no version qualifies, `Import-Module` generates an error.
 
@@ -945,14 +949,14 @@ characters aren't permitted. You can also pipe module names and filenames to `Im
 If you omit a path, `Import-Module` looks for the module in the paths saved in the
 `$env:PSModulePath` environment variable.
 
-Specify only the module name whenever possible. When you specify a file name, only the members that
+Specify only the module name whenever possible. When you specify a filename, only the members that
 are implemented in that file are imported. If the module contains other files, they aren't
 imported, and you might be missing important members of the module.
 
 > [!NOTE]
-> While it is possible to import a script (`.ps1`) file as a module, script files are usually not
-> structured like script modules file (`.psm1`) file. Importing a script file does not guarantee
-> that it is usable as a module. For more information, see [about_Modules](about/about_Modules.md).
+> While it's possible to import a script (`.ps1`) file as a module, script files are usually not
+> structured like script modules file (`.psm1`) file. Importing a script file doesn't guarantee
+> that it's usable as a module. For more information, see [about_Modules](about/about_Modules.md).
 
 ```yaml
 Type: System.String[]
@@ -993,8 +997,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you're working. By default, this cmdlet does not
-generate any output.
+Returns an object representing the imported module. By default, this cmdlet doesn't generate any
+output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -1013,12 +1017,12 @@ Accept wildcard characters: False
 Specifies a prefix that this cmdlet adds to the nouns in the names of imported module members.
 
 Use this parameter to avoid name conflicts that might occur when different members in the session
-have the same name. This parameter does not change the module, and it does not affect files that the
+have the same name. This parameter doesn't change the module, and it doesn't affect files that the
 module imports for its own use. These are known as nested modules. This cmdlet affects only the
 names of members in the current session.
 
 For example, if you specify the prefix UTC and then import a `Get-Date` cmdlet, the cmdlet is known
-in the session as `Get-UTCDate`, and it is not confused with the original `Get-Date` cmdlet.
+in the session as `Get-UTCDate`, and it's not confused with the original `Get-Date` cmdlet.
 
 The value of this parameter takes precedence over the **DefaultCommandPrefix** property of the
 module, which specifies the default prefix.
@@ -1043,13 +1047,13 @@ into the current session. Enter a variable that contains a **PSSession** or a co
 
 When you import a module from a different session into the current session, you can use the cmdlets
 from the module in the current session, just as you would use cmdlets from a local module. Commands
-that use the remote cmdlets run in the remote session, but the remoting details are managed
-in the background by PowerShell.
+that use the remote cmdlets run in the remote session, but the remoting details are managed in the
+background by PowerShell.
 
-This parameter uses the Implicit Remoting feature of PowerShell. It is equivalent to using the
+This parameter uses the Implicit Remoting feature of PowerShell. It's equivalent to using the
 `Import-PSSession` cmdlet to import particular modules from a session.
 
-`Import-Module` cannot import core PowerShell modules from another session. The core PowerShell
+`Import-Module` can't import core PowerShell modules from another session. The core PowerShell
 modules have names that begin with Microsoft.PowerShell.
 
 This parameter was introduced in Windows PowerShell 3.0.
@@ -1068,7 +1072,7 @@ Accept wildcard characters: False
 
 ### -RequiredVersion
 
-Specifies a version of the module that this cmdlet imports. If the version is not installed,
+Specifies a version of the module that this cmdlet imports. If the version isn't installed,
 `Import-Module` generates an error.
 
 By default, `Import-Module` imports the module without checking the version number.
@@ -1099,7 +1103,7 @@ Accept wildcard characters: False
 
 ### -Scope
 
-Specifies a scope into which this cmdlet imports the module.
+Specifies a scope to import the module in.
 
 The acceptable values for this parameter are:
 
@@ -1110,9 +1114,9 @@ By default, when `Import-Module` cmdlet is called from the command prompt, scrip
 scriptblock, all the commands are imported into the global session state. You can use the
 `-Scope Local` parameter to import module content into the script or scriptblock scope.
 
-When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
-commands from nested modules, into the caller's session state. Specifying `-Scope Global` or
-`-Global` indicates that this cmdlet imports modules into the global session state so they are
+When invoked from another module, `Import-Module` cmdlet imports the commands in a module,
+including commands from nested modules, into the caller's session state. Specifying `-Scope Global`
+or `-Global` indicates that this cmdlet imports modules into the global session state so they're
 available to all commands in the session.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of **Global**.
@@ -1137,10 +1141,10 @@ Accept wildcard characters: False
 Skips the check on the `CompatiblePSEditions` field.
 
 Allows loading a module from the `"$($env:windir)\System32\WindowsPowerShell\v1.0\Modules"` module
-directory into PowerShell Core when that module does not specify `Core` in the
+directory into PowerShell Core when that module doesn't specify `Core` in the
 `CompatiblePSEditions` manifest field.
 
-When importing a module from another path, this switch does nothing, since the check is not
+When importing a module from another path, this switch does nothing, since the check isn't
 performed. On Linux and macOS, this switch does nothing.
 
 For more information, see [about_PowerShell_Editions](About/about_PowerShell_Editions.md).
@@ -1219,7 +1223,7 @@ You can pipe a module object to this cmdlet.
 
 ### System.Reflection.Assembly
 
- You can pipe an assembly object to this cmdlet.
+You can pipe an assembly object to this cmdlet.
 
 ## OUTPUTS
 
@@ -1230,7 +1234,7 @@ By default, this cmdlet returns no output.
 ### System.Management.Automation.PSModuleInfo
 
 If you specify the **PassThru** parameter, the cmdlet generates a
-**System.Management.Automation.PSModuleInfo** object that represents the module.
+**System.Management.Automation.PSModuleInfo** object that represents the imported module.
 
 ### System.Management.Automation.PSCustomObject
 
@@ -1244,9 +1248,9 @@ PowerShell includes the following aliases for `Import-Module`:
 - All platforms:
   - `ipmo`
 
-- Before you can import a module, the module must be installed on the local computer. That is, the
-  module directory must be copied to a directory that is accessible to your local computer. For more
-  information, see [about_Modules](About/about_Modules.md).
+- Before you can import a module, the module must be accessible to your local computer and included
+  in the `PSModulePath` environmental variable. For more information, see
+  [about_Modules](About/about_Modules.md).
 
   You can also use the **PSSession** and **CIMSession** parameters to import modules that are
   installed on remote computers. However, commands that use the cmdlets in these modules run in the
@@ -1257,24 +1261,23 @@ PowerShell includes the following aliases for `Import-Module`:
   accessible. Functions, cmdlets, and providers are merely shadowed by the new members. They can be
   accessed by qualifying the command name with the name of its snap-in, module, or function path.
 
-- To update the formatting data for commands that have been imported from a module, use the
-  `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in
-  the session that were imported from modules. If the formatting file for a module changes, you can
-  run an `Update-FormatData` command to update the formatting data for imported commands. You don't
-  need to import the module again.
+- To update the formatting data for commands imported from a module, use the `Update-FormatData`
+  cmdlet. If the formatting file for a module changes, use the `Update-FormatData` cmdlet to update
+  the formatting data for imported commands. You don't need to import the module again.
 
-- Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are
-  packaged in modules. In Windows PowerShell 2.0, and in host programs that create older-style
-  sessions in later versions of PowerShell, the core commands are packaged in snap-ins
-  (**PSSnapins**). The exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also,
-  remote sessions, such as those started by the `New-PSSession` cmdlet, are older-style sessions
-  that include core snap-ins.
+- Starting in Windows PowerShell 3.0, the core commands installed with PowerShell are packaged in
+  modules. In Windows PowerShell 2.0, and in host programs that create older-style sessions in
+  later versions of PowerShell, the core commands are packaged in snap-ins (**PSSnapins**). The
+  exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also, remote sessions,
+  such as those started by the `New-PSSession` cmdlet, are older-style sessions that include core
+  snap-ins.
 
   For information about the **CreateDefault2** method that creates newer-style sessions with core
-  modules, see the [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2).
+  modules, see the
+  [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2).
 
-- In Windows PowerShell 2.0, some of the property values of the module object, such as the
-  **ExportedCmdlets** and **NestedModules** property values, were not populated until the module was
+- In Windows PowerShell 2.0, some property values of the module object, such as the
+  **ExportedCmdlets** and **NestedModules** property values, weren't populated until the module was
   imported.
 
 - If you attempt to import a module that contains mixed-mode assemblies that aren't compatible with
@@ -1283,7 +1286,7 @@ PowerShell includes the following aliases for `Import-Module`:
   > Import-Module : Mixed mode assembly is built against version 'v2.0.50727' of the runtime and
   > cannot be loaded in the 4.0 runtime without additional configuration information.
 
-  This error occurs when a module that is designed for Windows PowerShell 2.0 contains at least one
+  This error occurs when a module that's designed for Windows PowerShell 2.0 contains at least one
   mixed-module assembly. A mixed-module assembly that includes both managed and non-managed code,
   such as C++ and C#.
 
@@ -1309,16 +1312,28 @@ PowerShell includes the following aliases for `Import-Module`:
   exported elements.
 
   In a descendant scope, `-Scope Local` limits the import to that scope and all its descendant
-  scopes. Parent scopes then do not see the imported members.
+  scopes. Parent scopes then don't see the imported members.
 
   > [!NOTE]
   > `Get-Module` shows all modules loaded in the current session. This includes modules loaded
   > locally in a descendant scope. Use `Get-Command -Module modulename` to see which members are
   > loaded in the current scope.
 
-  `Import-Module` does not load class and enum definitions in the module. Use the `using module`
-  statement at the beginning of your script. This imports the module, including the class and enum
-  definitions. For more information, see [about_Using](About/about_Using.md).
+- `Import-Module` doesn't load class and enumeration definitions in the module. Use the
+  `using module` statement at the beginning of your script. This imports the module, including the
+  class and enumeration definitions. For more information, see [about_Using](About/about_Using.md).
+
+- During development of a script module, it's common to make changes to the code then load the new
+  version of the module using `Import-Module` with the **Force** parameter. This works for changes
+  to functions in the root module only. `Import-Module` doesn't reload any nested modules. Also,
+  there's no way to load any updated classes or enumerations.
+
+  To get updated module members defined in nested modules, remove the module with `Remove-Module`,
+  then import the module again.
+
+  If the module was loaded with a `using` statement, you must start a new session to import updated
+  definitions for the classes and enumerations. Classes and enumerations defined in PowerShell and
+  imported with a `using` statement can't be unloaded.
 
 ## RELATED LINKS
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how you can use classes to create your own custom types.
 Locale: en-US
-ms.date: 07/05/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_classes?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Classes
@@ -841,29 +841,27 @@ class MyComparableBar : bar, System.IComparable
 ## Importing classes from a PowerShell module
 
 `Import-Module` and the `#requires` statement only import the module functions,
-aliases, and variables, as defined by the module. Classes aren't imported. The
-`using module` statement imports the classes defined in the module. If the
-module isn't loaded in the current session, the `using` statement fails. For
-more information about the `using` statement, see [about_Using][07].
+aliases, and variables, as defined by the module. Classes aren't imported.
 
-The `using module` statement imports classes from the root module
-(`ModuleToProcess`) of a script module or binary module. It doesn't
+The `using module` statement imports classes and enumerations from the root
+module (`ModuleToProcess`) of a script module or binary module. It doesn't
 consistently import classes defined in nested modules or classes defined in
-scripts that are dot-sourced into the module. Classes that you want to be
-available to users outside of the module should be defined in the root module.
+scripts that are dot-sourced into the root module. Define classes that you want
+to be available to users outside of the module directly in the root module.
+
+For more information about the `using` statement, see [about_Using][07].
 
 ## Loading newly changed code during development
 
 During development of a script module, it's common to make changes to the code
 then load the new version of the module using `Import-Module` with the
 **Force** parameter. This works for changes to functions in the root module
-only. `Import-Module` doesn't reload any nested modules. Also, there is no way
+only. `Import-Module` doesn't reload any nested modules. Also, there's no way
 to load any updated classes.
 
-To ensure that you are running the latest version, you must unload the module
-using the `Remove-Module` cmdlet. `Remove-Module` removes the root module, all
-nested modules, and any classes defined in the modules. Then you can reload the
-module and the classes using `Import-Module` and the `using module` statement.
+To ensure that you're running the latest version, you must start a new session.
+Classes and enumerations defined in PowerShell and imported with a `using`
+statement can't be unloaded.
 
 Another common development practice is to separate your code into different
 files. If you have function in one file that use classes defined in another

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,7 +1,7 @@
 ---
 description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 06/07/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -327,3 +327,35 @@ to enumeration values that are not valid. Specify one of the following
 enumeration values and try again. The possible enumeration values are
 "CR,LF,CRLF".
 ```
+
+## Importing enumerations from a PowerShell module
+
+`Import-Module` and the `#requires` statement only import the module functions,
+aliases, and variables, as defined by the module. Enumerations aren't imported.
+
+The `using module` statement imports classes and enumerations from the root
+module (`ModuleToProcess`) of a script module or binary module. It doesn't
+consistently import classes defined in nested modules or classes defined in
+scripts that are dot-sourced into the root module. Define classes that you want
+to be available to users outside of the module directly in the root module.
+
+For more information about the `using` statement, see [about_Using][01].
+
+## Loading newly changed code during development
+
+During development of a script module, it's common to make changes to the code
+then load the new version of the module using `Import-Module` with the
+**Force** parameter. This works for changes to functions in the root module
+only. `Import-Module` doesn't reload any nested modules. Also, there's no way
+to load any updated classes.
+
+To ensure that you're running the latest version, you must start a new session.
+Classes and enumerations defined in PowerShell and imported with a `using`
+statement can't be unloaded.
+
+Another common development practice is to separate your code into different
+files. If you have function in one file that use enumerations defined in
+another module, you should using the `using module` statement to ensure that
+the functions have the enumeration definitions that are needed.
+
+[01]: about_Using.md

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -1,7 +1,7 @@
 ---
 description: Prevents a script from running without the required elements.
 Locale: en-US
-ms.date: 03/14/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Requires
@@ -10,6 +10,7 @@ title: about Requires
 # about_Requires
 
 ## Short description
+
 Prevents a script from running without the required elements.
 
 ## Long description
@@ -36,13 +37,13 @@ For more information about the syntax, see
 A script can include more than one `#Requires` statement. The `#Requires`
 statements can appear on any line in a script.
 
-Placing a `#Requires` statement inside a function does NOT limit its scope. All
+Placing a `#Requires` statement inside a function doesn't limit its scope. All
 `#Requires` statements are always applied globally, and must be met, before the
 script can execute.
 
 > [!WARNING]
 > Even though a `#Requires` statement can appear on any line in a script, its
-> position in a script does not affect the sequence of its application. The
+> position in a script doesn't affect the sequence of its application. The
 > global state the `#Requires` statement presents must be met before script
 > execution.
 
@@ -100,6 +101,11 @@ and an optional version number.
 
 If the required modules aren't in the current session, PowerShell imports them.
 If the modules can't be imported, PowerShell throws a terminating error.
+
+The `#Requires` statement doesn't load class and enumeration definitions in the
+module. Use the `using module` statement at the beginning of your script to
+import the module, including the class and enumeration definitions. For more
+information, see [about_Using](about_Using.md).
 
 For each module, type the module name (\<String\>) or a hashtable. The value
 can be a combination of strings and hashtables. The hashtable has the

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Using.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Using.md
@@ -1,7 +1,7 @@
 ---
-description: Allows you to indicate which namespaces are used in the session.
+description: Allows you to specify namespaces to use in the session.
 Locale: en-US
-ms.date: 01/25/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_using?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Using
@@ -9,26 +9,27 @@ title: about Using
 # about_Using
 
 ## Short description
-Allows you to indicate which namespaces are used in the session.
+
+Allows you to specify namespaces to use in the session.
 
 ## Long description
 
-The `using` statement allows you to specify which namespaces are used in the
-session. Adding namespaces simplifies usage of .NET classes and member and
-allows you to import classes from script modules and assemblies.
+The `using` statement allows you to specify namespaces to use in the session.
+Adding namespaces simplifies usage of .NET classes and members and allows you
+to import classes from script modules and assemblies.
 
 The `using` statements must come before any other statements in a script or
 module. No uncommented statement can precede it, including parameters.
 
 The `using` statement must not contain any variables.
 
-The `using` statement should not be confused with the `using:` scope modifier
-for variables. For more information, see
+The `using` statement isn't the same as the `using:` scope modifier for
+variables. For more information, see
 [about_Remote_Variables](about_Remote_Variables.md).
 
 ## Namespace syntax
 
-To specify .NET namespaces from which to resolve types:
+To resolve types from a .NET namespace:
 
 ```
 using namespace <.NET-namespace>
@@ -38,7 +39,7 @@ Specifying a namespace makes it easier to reference types by their short names.
 
 ## Module syntax
 
-To load classes from a PowerShell module:
+To load classes and enumerations from a PowerShell module:
 
 ```
 using module <module-name>
@@ -48,8 +49,7 @@ The value of `<module-name>` can be a module name, a full module specification,
 or a path to a module file.
 
 When `<module-name>` is a path, the path can be fully qualified or relative. A
-relative path is resolved relative to the script that contains the using
-statement.
+relative path resolves relative to the script that has the `using` statement.
 
 When `<module-name>` is a name or module specification, PowerShell searches the
 **PSModulePath** for the specified module.
@@ -64,22 +64,26 @@ A module specification is a hashtable that has the following keys.
   - `RequiredVersion` - Specifies an exact, required version of the module.
     This can't be used with the other Version keys.
 
-The `using module` statement imports classes from the root module
-(`ModuleToProcess`) of a script module or binary module. It does not
-consistently import classes defined in nested modules or classes defined in
-scripts that are dot-sourced into the module. Classes that you want to be
-available to users outside of the module should be defined in the root module.
+`Import-Module` and the `#requires` statement only import the module functions,
+aliases, and variables, as defined by the module. Classes and enumerations
+aren't imported.
 
-During development of a script module, it is common to make changes to the code
+The `using module` statement imports classes and enumerations from the root
+module (`ModuleToProcess`) of a script module or binary module. It doesn't
+consistently import classes or enumerations defined in nested modules or in
+scripts that are dot-sourced into the root module. Define classes and
+enumerations that you want to be available to users outside of the module
+directly in the root module.
+
+During development of a script module, it's common to make changes to the code
 then load the new version of the module using `Import-Module` with the
 **Force** parameter. This works for changes to functions in the root module
-only. `Import-Module` does not reload any nested modules. Also, there is no way
-to load any updated classes.
+only. `Import-Module` doesn't reload any nested modules. Also, there's no way
+to load any updated classes or enumerations.
 
-To ensure that you are running the latest version, you must unload the module
-using the `Remove-Module` cmdlet. `Remove-Module` removes the root module, all
-nested modules, and any classes defined in the modules. Then you can reload the
-module and the classes using `Import-Module` and the `using module` statement.
+To ensure that you're running the latest version, you must start a new session.
+Classes and enumerations defined in PowerShell and imported with a `using`
+statement can't be unloaded.
 
 ## Assembly syntax
 
@@ -93,7 +97,7 @@ Loading an assembly preloads .NET types from that assembly into a script at
 parse time. This allows you to create new PowerShell classes that use types
 from the preloaded assembly.
 
-If you are not creating new PowerShell classes, use the `Add-Type` cmdlet
+If you aren't creating new PowerShell classes, use the `Add-Type` cmdlet
 instead. For more information, see
 [Add-Type](xref:Microsoft.PowerShell.Utility.Add-Type).
 
@@ -105,7 +109,7 @@ The following script gets the cryptographic hash for the "Hello World" string.
 
 Note how the `using namespace System.Text` and `using namespace System.IO`
 simplify the references to `[UnicodeEncoding]` in `System.Text` and `[Stream]`
-and to `[MemoryStream]` in `System.IO`.
+and `[MemoryStream]` in `System.IO`.
 
 ```powershell
 using namespace System.Text
@@ -125,14 +129,14 @@ $hashfromstream.Hash.ToString()
 
 ### Example 2 - Load classes from a script module
 
-In this example, we have a PowerShell script module named **CardGames** that
-defines the following classes:
+In this example, a PowerShell script module named **CardGames** defines the
+following classes:
 
 - **Deck**
 - **Card**
 
 `Import-Module` and the `#requires` statement only import the module functions,
-aliases, and variables, as defined by the module. Classes are not imported. The
+aliases, and variables, as defined by the module. Classes aren't imported. The
 `using module` command imports the module and also loads the class definitions.
 
 ```powershell
@@ -161,7 +165,7 @@ $info = [ordered]@{
     @{ Name = 'Apples' ; Count = 1234 }
     @{ Name = 'Bagels' ; Count = 5678 }
   )
-    CheckedAt = [datetime]'2023-01-01T01:01:01'
+  CheckedAt = [datetime]'2023-01-01T01:01:01'
 }
 
 $yamlSerializer.Serialize($info)

--- a/reference/7.3/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/Import-Module.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/12/2022
+ms.date: 08/17/2023
 no-loc: [Import-Module, -Scope]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/import-module?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -111,9 +111,9 @@ You can disable automatic module importing using the `$PSModuleAutoloadingPrefer
 variable. For more information about the `$PSModuleAutoloadingPreference` variable, see
 [about_Preference_Variables](About/about_Preference_Variables.md).
 
-A module is a package that contains members that can be used in PowerShell. Members include cmdlets,
-providers, scripts, functions, variables, and other tools and files. After a module is imported, you
-can use the module members in your session. For more information about modules, see
+A module is a package that contains members that can be used in PowerShell. Members include
+cmdlets, providers, scripts, functions, variables, and other tools and files. After a module is
+imported, you can use the module members in your session. For more information about modules, see
 [about_Modules](About/about_Modules.md).
 
 By default, `Import-Module` imports all members that the module exports, but you can use the
@@ -135,10 +135,10 @@ Starting in Windows PowerShell 3.0, you can use `Import-Module` to import Common
 you use cmdlets that are implemented in non-managed code assemblies, such as those written in C++.
 
 For remote computers that don't have PowerShell remoting enabled, including computers that aren't
-running the Windows operating system, you can use the **CIMSession** parameter of `Import-Module` to
-import CIM modules from the remote computer. The imported commands run implicitly on the remote
-computer. A **CIMSession** is a connection to Windows Management Instrumentation (WMI) on the remote
-computer.
+running the Windows operating system, you can use the **CIMSession** parameter of `Import-Module`
+to import CIM modules from the remote computer. The imported commands run implicitly on the remote
+computer. A **CIMSession** is a connection to Windows Management Instrumentation (WMI) on the
+remote computer.
 
 ## EXAMPLES
 
@@ -193,15 +193,15 @@ VERBOSE: Exporting function 'Get-SpecDetails'.
 ```
 
 Using the **Verbose** parameter causes `Import-Module` to report progress as it loads the module.
-Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, `Import-Module` does not
+Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, `Import-Module` doesn't
 generate any output when it imports a module.
 
 ### Example 5: Restrict module members imported into a session
 
-This example shows how to restrict which module members are imported into the session and the effect
-of this command on the session. The **Function** parameter limits the members that are imported from
-the module. You can also use the **Alias**, **Variable**, and **Cmdlet** parameters to restrict
-other members that a module imports.
+This example shows how to restrict which module members are imported into the session and the
+effect of this command on the session. The **Function** parameter limits the members that are
+imported from the module. You can also use the **Alias**, **Variable**, and **Cmdlet** parameters
+to restrict other members that a module imports.
 
 The `Get-Module` cmdlet gets the object that represents the **PSDiagnostics** module. The
 **ExportedCmdlets** property lists all the cmdlets that the module exports, even though they were
@@ -246,8 +246,8 @@ from the **PSDiagnostics** module. The results confirm that only the `Disable-PS
 
 This example imports the **PSDiagnostics** module into the current session, adds a prefix to the
 member names, and then displays the prefixed member names. The **Prefix** parameter of
-`Import-Module` adds the **x** prefix to all members that are imported from the module. The prefix
-applies only to the members in the current session. It does not change the module. The **PassThru**
+`Import-Module` adds the `x` prefix to all members that are imported from the module. The prefix
+applies only to the members in the current session. It doesn't change the module. The **PassThru**
 parameter returns a module object that represents the imported module.
 
 ```powershell
@@ -289,12 +289,12 @@ This example demonstrates how to get and use the custom object returned by `Impo
 Custom objects include synthetic members that represent each of the imported module members. For
 example, the cmdlets and functions in a module are converted to script methods of the custom object.
 
-Custom objects are useful in scripting. They are also useful when several imported objects have
+Custom objects are useful in scripting. They're also useful when several imported objects have
 the same names. Using the script method of an object is equivalent to specifying the fully qualified
 name of an imported member, including its module name.
 
-The **AsCustomObject** parameter can be used only when importing a script module. Use `Get-Module`
-to determine which of the available modules is a script module.
+The **AsCustomObject** parameter is only usable when importing a script module. Use `Get-Module` to
+determine which of the available modules is a script module.
 
 ```powershell
 Get-Module -List | Format-Table -Property Name, ModuleType -AutoSize
@@ -410,12 +410,13 @@ Because functions take precedence over cmdlets, the `Get-Date` function from the
 module runs, instead of the `Get-Date` cmdlet. To run the original version of `Get-Date`, you must
 qualify the command name with the module name.
 
-For more information about command precedence in PowerShell, see [about_Command_Precedence](about/about_Command_Precedence.md).
+For more information about command precedence in PowerShell, see
+[about_Command_Precedence](about/about_Command_Precedence.md).
 
 ### Example 10: Import a minimum version of a module
 
 This example imports the **PowerShellGet** module. It uses the **MinimumVersion** parameter of
-`Import-Module` to import only version 2.0.0 or greater of the module.
+`Import-Module` to import only version `2.0.0` or greater of the module.
 
 ```powershell
 Import-Module -Name PowerShellGet -MinimumVersion 2.0.0
@@ -427,7 +428,7 @@ version of a module in a script.
 
 ### Example 11: Import using a fully qualified name
 
-This example imports a specific version of a module using the FullyQualifiedName.
+This example imports a specific version of a module using the **FullyQualifiedName**.
 
 ```powershell
 PS> Get-Module -ListAvailable PowerShellGet | Select-Object Name, Version
@@ -511,22 +512,23 @@ Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP-PUBLI
 Windows Remote Management - Compatibility Mode (HTTP-In) WINRM-HTTP-Compat-In-TCP
 ```
 
-`New-PSSession` creates a remote session (**PSSession**) to the Server01 computer. The **PSSession**
-is saved in the `$s` variable.
+`New-PSSession` creates a remote session (**PSSession**) to the `Server01` computer. The
+**PSSession** is saved in the `$s` variable.
 
 Running `Get-Module` with the **PSSession** parameter shows that the **NetSecurity** module is
 installed and available on the remote computer. This command is equivalent to using the
 `Invoke-Command` cmdlet to run `Get-Module` command in the remote session. For example:
- (`Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity`
 
-Running `Import-Module` with the **PSSession** parameter imports the **NetSecurity** module from the
-remote computer into the current session. The `Get-Command` cmdlet is used to get commands that
-begin with **Get** and include **Firewall** from the **NetSecurity** module. The output confirms
-that the module and its cmdlets were imported into the current session.
+`Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity`
 
-Next, the `Get-NetFirewallRule` cmdlet gets Windows Remote Management firewall rules on the Server01
-computer. This is equivalent to using the `Invoke-Command` cmdlet to run `Get-NetFirewallRule`
-on the remote session.
+Running `Import-Module` with the **PSSession** parameter imports the **NetSecurity** module from
+the remote computer into the current session. The `Get-Command` cmdlet retrieves commands that
+begin with `Get` and include `Firewall` from the **NetSecurity** module. The output confirms that
+the module and its cmdlets were imported into the current session.
+
+Next, the `Get-NetFirewallRule` cmdlet gets Windows Remote Management firewall rules on the
+`Server01` computer. This is equivalent to using the `Invoke-Command` cmdlet to run
+`Get-NetFirewallRule` on the remote session.
 
 ### Example 14: Manage storage on a remote computer without the Windows operating system
 
@@ -536,7 +538,7 @@ provider, which allows you to use CIM commands that are designed for the provide
 The `New-CimSession` cmdlet creates a session on the remote computer named RSDGF03. The session
 connects to the WMI service on the remote computer. The CIM session is saved in the `$cs` variable.
 `Import-Module` uses the **CimSession** in `$cs` to import the **Storage** CIM module from the
-RSDGF03 computer.
+`RSDGF03` computer.
 
 The `Get-Command` cmdlet shows the `Get-Disk` command in the **Storage** module. When you import a
 CIM module into the local session, PowerShell converts the CDXML files for each command into
@@ -549,8 +551,8 @@ session.
 ```powershell
 $cs = New-CimSession -ComputerName RSDGF03
 Import-Module -CimSession $cs -Name Storage
-# Importing a CIM module, converts the CDXML files for each command into PowerShell scripts.
-# These appear as functions in the local session.
+# Importing a CIM module, converts the CDXML files for each command into
+# PowerShell scripts. These appear as functions in the local session.
 Get-Command Get-Disk
 ```
 
@@ -561,7 +563,8 @@ Function        Get-Disk              Storage
 ```
 
 ```powershell
-# Use implicit remoting to query disks on the remote computer from which the module was imported.
+# Use implicit remoting to query disks on the remote computer from which the
+# module was imported.
 Get-Disk
 ```
 
@@ -599,7 +602,8 @@ Specifies an array of arguments, or parameter values, that are passed to a scrip
 `Import-Module` command. This parameter is valid only when you're importing a script module.
 
 You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information
-about the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
+about the behavior of **ArgumentList**, see
+[about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: System.Object[]
@@ -620,7 +624,7 @@ members. This parameter is valid only for script modules.
 
 When you use the **AsCustomObject** parameter, `Import-Module` imports the module members into the
 session and then returns a **PSCustomObject** object instead of a **PSModuleInfo** object. You can
-save the custom object in a variable and use dot notation to invoke the members.
+save the custom object in a variable and use member-access enumeration to invoke the members.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -754,8 +758,8 @@ Accept wildcard characters: True
 Indicates that this cmdlet suppresses the message that warns you when you import a cmdlet or
 function whose name includes an unapproved verb or a prohibited character.
 
-By default, when a module that you import exports cmdlets or functions that have unapproved verbs in
-their names, PowerShell displays the following warning message:
+By default, when a module that you import exports cmdlets or functions that have unapproved verbs
+in their names, PowerShell displays the following warning message:
 
 > WARNING: Some imported command names include unapproved verbs which might make them less
 > discoverable. Use the Verbose parameter for more detail or type Get-Verb to see the list of
@@ -846,7 +850,7 @@ Accept wildcard characters: True
 
 ### -Global
 
-Indicates that this cmdlet imports modules into the global session state so they are available to
+Indicates that this cmdlet imports modules into the global session state so they're available to
 all commands in the session.
 
 By default, when `Import-Module` cmdlet is called from the command prompt, script file, or
@@ -879,7 +883,7 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies a maximum version. This cmdlet imports only a version of the module that is less than or
+Specifies a maximum version. This cmdlet imports only a version of the module that's less than or
 equal to the specified value. If no version qualifies, `Import-Module` returns an error.
 
 ```yaml
@@ -896,7 +900,7 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies a minimum version. This cmdlet imports only a version of the module that is greater than
+Specifies a minimum version. This cmdlet imports only a version of the module that's greater than
 or equal to the specified value. Use the **MinimumVersion** parameter name or its alias,
 **Version**. If no version qualifies, `Import-Module` generates an error.
 
@@ -945,14 +949,14 @@ characters aren't permitted. You can also pipe module names and filenames to `Im
 If you omit a path, `Import-Module` looks for the module in the paths saved in the
 `$env:PSModulePath` environment variable.
 
-Specify only the module name whenever possible. When you specify a file name, only the members that
+Specify only the module name whenever possible. When you specify a filename, only the members that
 are implemented in that file are imported. If the module contains other files, they aren't
 imported, and you might be missing important members of the module.
 
 > [!NOTE]
-> While it is possible to import a script (`.ps1`) file as a module, script files are usually not
-> structured like script modules file (`.psm1`) file. Importing a script file does not guarantee
-> that it is usable as a module. For more information, see [about_Modules](about/about_Modules.md).
+> While it's possible to import a script (`.ps1`) file as a module, script files are usually not
+> structured like script modules file (`.psm1`) file. Importing a script file doesn't guarantee
+> that it's usable as a module. For more information, see [about_Modules](about/about_Modules.md).
 
 ```yaml
 Type: System.String[]
@@ -993,8 +997,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you're working. By default, this cmdlet does not
-generate any output.
+Returns an object representing the imported module. By default, this cmdlet doesn't generate any
+output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -1013,12 +1017,12 @@ Accept wildcard characters: False
 Specifies a prefix that this cmdlet adds to the nouns in the names of imported module members.
 
 Use this parameter to avoid name conflicts that might occur when different members in the session
-have the same name. This parameter does not change the module, and it does not affect files that the
+have the same name. This parameter doesn't change the module, and it doesn't affect files that the
 module imports for its own use. These are known as nested modules. This cmdlet affects only the
 names of members in the current session.
 
 For example, if you specify the prefix UTC and then import a `Get-Date` cmdlet, the cmdlet is known
-in the session as `Get-UTCDate`, and it is not confused with the original `Get-Date` cmdlet.
+in the session as `Get-UTCDate`, and it's not confused with the original `Get-Date` cmdlet.
 
 The value of this parameter takes precedence over the **DefaultCommandPrefix** property of the
 module, which specifies the default prefix.
@@ -1043,13 +1047,13 @@ into the current session. Enter a variable that contains a **PSSession** or a co
 
 When you import a module from a different session into the current session, you can use the cmdlets
 from the module in the current session, just as you would use cmdlets from a local module. Commands
-that use the remote cmdlets run in the remote session, but the remoting details are managed
-in the background by PowerShell.
+that use the remote cmdlets run in the remote session, but the remoting details are managed in the
+background by PowerShell.
 
-This parameter uses the Implicit Remoting feature of PowerShell. It is equivalent to using the
+This parameter uses the Implicit Remoting feature of PowerShell. It's equivalent to using the
 `Import-PSSession` cmdlet to import particular modules from a session.
 
-`Import-Module` cannot import core PowerShell modules from another session. The core PowerShell
+`Import-Module` can't import core PowerShell modules from another session. The core PowerShell
 modules have names that begin with Microsoft.PowerShell.
 
 This parameter was introduced in Windows PowerShell 3.0.
@@ -1068,7 +1072,7 @@ Accept wildcard characters: False
 
 ### -RequiredVersion
 
-Specifies a version of the module that this cmdlet imports. If the version is not installed,
+Specifies a version of the module that this cmdlet imports. If the version isn't installed,
 `Import-Module` generates an error.
 
 By default, `Import-Module` imports the module without checking the version number.
@@ -1099,7 +1103,7 @@ Accept wildcard characters: False
 
 ### -Scope
 
-Specifies a scope into which this cmdlet imports the module.
+Specifies a scope to import the module in.
 
 The acceptable values for this parameter are:
 
@@ -1110,9 +1114,9 @@ By default, when `Import-Module` cmdlet is called from the command prompt, scrip
 scriptblock, all the commands are imported into the global session state. You can use the
 `-Scope Local` parameter to import module content into the script or scriptblock scope.
 
-When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
-commands from nested modules, into the caller's session state. Specifying `-Scope Global` or
-`-Global` indicates that this cmdlet imports modules into the global session state so they are
+When invoked from another module, `Import-Module` cmdlet imports the commands in a module,
+including commands from nested modules, into the caller's session state. Specifying `-Scope Global`
+or `-Global` indicates that this cmdlet imports modules into the global session state so they're
 available to all commands in the session.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of **Global**.
@@ -1137,10 +1141,10 @@ Accept wildcard characters: False
 Skips the check on the `CompatiblePSEditions` field.
 
 Allows loading a module from the `"$($env:windir)\System32\WindowsPowerShell\v1.0\Modules"` module
-directory into PowerShell Core when that module does not specify `Core` in the
+directory into PowerShell Core when that module doesn't specify `Core` in the
 `CompatiblePSEditions` manifest field.
 
-When importing a module from another path, this switch does nothing, since the check is not
+When importing a module from another path, this switch does nothing, since the check isn't
 performed. On Linux and macOS, this switch does nothing.
 
 For more information, see [about_PowerShell_Editions](About/about_PowerShell_Editions.md).
@@ -1230,7 +1234,7 @@ By default, this cmdlet returns no output.
 ### System.Management.Automation.PSModuleInfo
 
 If you specify the **PassThru** parameter, the cmdlet generates a
-**System.Management.Automation.PSModuleInfo** object that represents the module.
+**System.Management.Automation.PSModuleInfo** object that represents the imported module.
 
 ### System.Management.Automation.PSCustomObject
 
@@ -1244,9 +1248,9 @@ PowerShell includes the following aliases for `Import-Module`:
 - All platforms:
   - `ipmo`
 
-- Before you can import a module, the module must be installed on the local computer. That is, the
-  module directory must be copied to a directory that is accessible to your local computer. For more
-  information, see [about_Modules](About/about_Modules.md).
+- Before you can import a module, the module must be accessible to your local computer and included
+  in the `PSModulePath` environmental variable. For more information, see
+  [about_Modules](About/about_Modules.md).
 
   You can also use the **PSSession** and **CIMSession** parameters to import modules that are
   installed on remote computers. However, commands that use the cmdlets in these modules run in the
@@ -1257,24 +1261,23 @@ PowerShell includes the following aliases for `Import-Module`:
   accessible. Functions, cmdlets, and providers are merely shadowed by the new members. They can be
   accessed by qualifying the command name with the name of its snap-in, module, or function path.
 
-- To update the formatting data for commands that have been imported from a module, use the
-  `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in
-  the session that were imported from modules. If the formatting file for a module changes, you can
-  run an `Update-FormatData` command to update the formatting data for imported commands. You don't
-  need to import the module again.
+- To update the formatting data for commands imported from a module, use the `Update-FormatData`
+  cmdlet. If the formatting file for a module changes, use the `Update-FormatData` cmdlet to update
+  the formatting data for imported commands. You don't need to import the module again.
 
-- Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are
-  packaged in modules. In Windows PowerShell 2.0, and in host programs that create older-style
-  sessions in later versions of PowerShell, the core commands are packaged in snap-ins
-  (**PSSnapins**). The exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also,
-  remote sessions, such as those started by the `New-PSSession` cmdlet, are older-style sessions
-  that include core snap-ins.
+- Starting in Windows PowerShell 3.0, the core commands installed with PowerShell are packaged in
+  modules. In Windows PowerShell 2.0, and in host programs that create older-style sessions in
+  later versions of PowerShell, the core commands are packaged in snap-ins (**PSSnapins**). The
+  exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also, remote sessions,
+  such as those started by the `New-PSSession` cmdlet, are older-style sessions that include core
+  snap-ins.
 
   For information about the **CreateDefault2** method that creates newer-style sessions with core
-  modules, see the [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2).
+  modules, see the
+  [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2).
 
-- In Windows PowerShell 2.0, some of the property values of the module object, such as the
-  **ExportedCmdlets** and **NestedModules** property values, were not populated until the module was
+- In Windows PowerShell 2.0, some property values of the module object, such as the
+  **ExportedCmdlets** and **NestedModules** property values, weren't populated until the module was
   imported.
 
 - If you attempt to import a module that contains mixed-mode assemblies that aren't compatible with
@@ -1283,7 +1286,7 @@ PowerShell includes the following aliases for `Import-Module`:
   > Import-Module : Mixed mode assembly is built against version 'v2.0.50727' of the runtime and
   > cannot be loaded in the 4.0 runtime without additional configuration information.
 
-  This error occurs when a module that is designed for Windows PowerShell 2.0 contains at least one
+  This error occurs when a module that's designed for Windows PowerShell 2.0 contains at least one
   mixed-module assembly. A mixed-module assembly that includes both managed and non-managed code,
   such as C++ and C#.
 
@@ -1309,16 +1312,28 @@ PowerShell includes the following aliases for `Import-Module`:
   exported elements.
 
   In a descendant scope, `-Scope Local` limits the import to that scope and all its descendant
-  scopes. Parent scopes then do not see the imported members.
+  scopes. Parent scopes then don't see the imported members.
 
   > [!NOTE]
   > `Get-Module` shows all modules loaded in the current session. This includes modules loaded
   > locally in a descendant scope. Use `Get-Command -Module modulename` to see which members are
   > loaded in the current scope.
 
-  `Import-Module` does not load class and enum definitions in the module. Use the `using module`
-  statement at the beginning of your script. This imports the module, including the class and enum
-  definitions. For more information, see [about_Using](About/about_Using.md).
+- `Import-Module` doesn't load class and enumeration definitions in the module. Use the
+  `using module` statement at the beginning of your script. This imports the module, including the
+  class and enumeration definitions. For more information, see [about_Using](About/about_Using.md).
+
+- During development of a script module, it's common to make changes to the code then load the new
+  version of the module using `Import-Module` with the **Force** parameter. This works for changes
+  to functions in the root module only. `Import-Module` doesn't reload any nested modules. Also,
+  there's no way to load any updated classes or enumerations.
+
+  To get updated module members defined in nested modules, remove the module with `Remove-Module`,
+  then import the module again.
+
+  If the module was loaded with a `using` statement, you must start a new session to import updated
+  definitions for the classes and enumerations. Classes and enumerations defined in PowerShell and
+  imported with a `using` statement can't be unloaded.
 
 ## RELATED LINKS
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how you can use classes to create your own custom types.
 Locale: en-US
-ms.date: 07/13/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_classes?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Classes
@@ -918,29 +918,27 @@ while ($true) {
 ## Importing classes from a PowerShell module
 
 `Import-Module` and the `#requires` statement only import the module functions,
-aliases, and variables, as defined by the module. Classes aren't imported. The
-`using module` statement imports the classes defined in the module. If the
-module isn't loaded in the current session, the `using` statement fails. For
-more information about the `using` statement, see [about_Using][07].
+aliases, and variables, as defined by the module. Classes aren't imported.
 
-The `using module` statement imports classes from the root module
-(`ModuleToProcess`) of a script module or binary module. It doesn't
+The `using module` statement imports classes and enumerations from the root
+module (`ModuleToProcess`) of a script module or binary module. It doesn't
 consistently import classes defined in nested modules or classes defined in
-scripts that are dot-sourced into the module. Classes that you want to be
-available to users outside of the module should be defined in the root module.
+scripts that are dot-sourced into the root module. Define classes that you want
+to be available to users outside of the module directly in the root module.
+
+For more information about the `using` statement, see [about_Using][07].
 
 ## Loading newly changed code during development
 
 During development of a script module, it's common to make changes to the code
 then load the new version of the module using `Import-Module` with the
 **Force** parameter. This works for changes to functions in the root module
-only. `Import-Module` doesn't reload any nested modules. Also, there is no way
+only. `Import-Module` doesn't reload any nested modules. Also, there's no way
 to load any updated classes.
 
-To ensure that you are running the latest version, you must unload the module
-using the `Remove-Module` cmdlet. `Remove-Module` removes the root module, all
-nested modules, and any classes defined in the modules. Then you can reload the
-module and the classes using `Import-Module` and the `using module` statement.
+To ensure that you're running the latest version, you must start a new session.
+Classes and enumerations defined in PowerShell and imported with a `using`
+statement can't be unloaded.
 
 Another common development practice is to separate your code into different
 files. If you have function in one file that use classes defined in another

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -1,7 +1,7 @@
 ---
 description: The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 Locale: en-US
-ms.date: 06/07/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Enum
@@ -327,3 +327,35 @@ to enumeration values that are not valid. Specify one of the following
 enumeration values and try again. The possible enumeration values are
 "CR,LF,CRLF".
 ```
+
+## Importing enumerations from a PowerShell module
+
+`Import-Module` and the `#requires` statement only import the module functions,
+aliases, and variables, as defined by the module. Enumerations aren't imported.
+
+The `using module` statement imports classes and enumerations from the root
+module (`ModuleToProcess`) of a script module or binary module. It doesn't
+consistently import classes defined in nested modules or classes defined in
+scripts that are dot-sourced into the root module. Define classes that you want
+to be available to users outside of the module directly in the root module.
+
+For more information about the `using` statement, see [about_Using][01].
+
+## Loading newly changed code during development
+
+During development of a script module, it's common to make changes to the code
+then load the new version of the module using `Import-Module` with the
+**Force** parameter. This works for changes to functions in the root module
+only. `Import-Module` doesn't reload any nested modules. Also, there's no way
+to load any updated classes.
+
+To ensure that you're running the latest version, you must start a new session.
+Classes and enumerations defined in PowerShell and imported with a `using`
+statement can't be unloaded.
+
+Another common development practice is to separate your code into different
+files. If you have function in one file that use enumerations defined in
+another module, you should using the `using module` statement to ensure that
+the functions have the enumeration definitions that are needed.
+
+[01]: about_Using.md

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -1,7 +1,7 @@
 ---
 description: Prevents a script from running without the required elements.
 Locale: en-US
-ms.date: 03/14/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Requires
@@ -10,6 +10,7 @@ title: about Requires
 # about_Requires
 
 ## Short description
+
 Prevents a script from running without the required elements.
 
 ## Long description
@@ -36,13 +37,13 @@ For more information about the syntax, see
 A script can include more than one `#Requires` statement. The `#Requires`
 statements can appear on any line in a script.
 
-Placing a `#Requires` statement inside a function does NOT limit its scope. All
+Placing a `#Requires` statement inside a function doesn't limit its scope. All
 `#Requires` statements are always applied globally, and must be met, before the
 script can execute.
 
 > [!WARNING]
 > Even though a `#Requires` statement can appear on any line in a script, its
-> position in a script does not affect the sequence of its application. The
+> position in a script doesn't affect the sequence of its application. The
 > global state the `#Requires` statement presents must be met before script
 > execution.
 
@@ -100,6 +101,11 @@ and an optional version number.
 
 If the required modules aren't in the current session, PowerShell imports them.
 If the modules can't be imported, PowerShell throws a terminating error.
+
+The `#Requires` statement doesn't load class and enumeration definitions in the
+module. Use the `using module` statement at the beginning of your script to
+import the module, including the class and enumeration definitions. For more
+information, see [about_Using](about_Using.md).
 
 For each module, type the module name (\<String\>) or a hashtable. The value
 can be a combination of strings and hashtables. The hashtable has the

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Using.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Using.md
@@ -1,7 +1,7 @@
 ---
-description: Allows you to indicate which namespaces are used in the session.
+description: Allows you to specify namespaces to use in the session.
 Locale: en-US
-ms.date: 01/25/2023
+ms.date: 08/17/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_using?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Using
@@ -9,26 +9,27 @@ title: about Using
 # about_Using
 
 ## Short description
-Allows you to indicate which namespaces are used in the session.
+
+Allows you to specify namespaces to use in the session.
 
 ## Long description
 
-The `using` statement allows you to specify which namespaces are used in the
-session. Adding namespaces simplifies usage of .NET classes and member and
-allows you to import classes from script modules and assemblies.
+The `using` statement allows you to specify namespaces to use in the session.
+Adding namespaces simplifies usage of .NET classes and members and allows you
+to import classes from script modules and assemblies.
 
 The `using` statements must come before any other statements in a script or
 module. No uncommented statement can precede it, including parameters.
 
 The `using` statement must not contain any variables.
 
-The `using` statement should not be confused with the `using:` scope modifier
-for variables. For more information, see
+The `using` statement isn't the same as the `using:` scope modifier for
+variables. For more information, see
 [about_Remote_Variables](about_Remote_Variables.md).
 
 ## Namespace syntax
 
-To specify .NET namespaces from which to resolve types:
+To resolve types from a .NET namespace:
 
 ```
 using namespace <.NET-namespace>
@@ -38,7 +39,7 @@ Specifying a namespace makes it easier to reference types by their short names.
 
 ## Module syntax
 
-To load classes from a PowerShell module:
+To load classes and enumerations from a PowerShell module:
 
 ```
 using module <module-name>
@@ -48,8 +49,7 @@ The value of `<module-name>` can be a module name, a full module specification,
 or a path to a module file.
 
 When `<module-name>` is a path, the path can be fully qualified or relative. A
-relative path is resolved relative to the script that contains the using
-statement.
+relative path resolves relative to the script that has the `using` statement.
 
 When `<module-name>` is a name or module specification, PowerShell searches the
 **PSModulePath** for the specified module.
@@ -64,22 +64,26 @@ A module specification is a hashtable that has the following keys.
   - `RequiredVersion` - Specifies an exact, required version of the module.
     This can't be used with the other Version keys.
 
-The `using module` statement imports classes from the root module
-(`ModuleToProcess`) of a script module or binary module. It does not
-consistently import classes defined in nested modules or classes defined in
-scripts that are dot-sourced into the module. Classes that you want to be
-available to users outside of the module should be defined in the root module.
+`Import-Module` and the `#requires` statement only import the module functions,
+aliases, and variables, as defined by the module. Classes and enumerations
+aren't imported.
 
-During development of a script module, it is common to make changes to the code
+The `using module` statement imports classes and enumerations from the root
+module (`ModuleToProcess`) of a script module or binary module. It doesn't
+consistently import classes or enumerations defined in nested modules or in
+scripts that are dot-sourced into the root module. Define classes and
+enumerations that you want to be available to users outside of the module
+directly in the root module.
+
+During development of a script module, it's common to make changes to the code
 then load the new version of the module using `Import-Module` with the
 **Force** parameter. This works for changes to functions in the root module
-only. `Import-Module` does not reload any nested modules. Also, there is no way
-to load any updated classes.
+only. `Import-Module` doesn't reload any nested modules. Also, there's no way
+to load any updated classes or enumerations.
 
-To ensure that you are running the latest version, you must unload the module
-using the `Remove-Module` cmdlet. `Remove-Module` removes the root module, all
-nested modules, and any classes defined in the modules. Then you can reload the
-module and the classes using `Import-Module` and the `using module` statement.
+To ensure that you're running the latest version, you must start a new session.
+Classes and enumerations defined in PowerShell and imported with a `using`
+statement can't be unloaded.
 
 ## Assembly syntax
 
@@ -93,7 +97,7 @@ Loading an assembly preloads .NET types from that assembly into a script at
 parse time. This allows you to create new PowerShell classes that use types
 from the preloaded assembly.
 
-If you are not creating new PowerShell classes, use the `Add-Type` cmdlet
+If you aren't creating new PowerShell classes, use the `Add-Type` cmdlet
 instead. For more information, see
 [Add-Type](xref:Microsoft.PowerShell.Utility.Add-Type).
 
@@ -105,7 +109,7 @@ The following script gets the cryptographic hash for the "Hello World" string.
 
 Note how the `using namespace System.Text` and `using namespace System.IO`
 simplify the references to `[UnicodeEncoding]` in `System.Text` and `[Stream]`
-and to `[MemoryStream]` in `System.IO`.
+and `[MemoryStream]` in `System.IO`.
 
 ```powershell
 using namespace System.Text
@@ -125,14 +129,14 @@ $hashfromstream.Hash.ToString()
 
 ### Example 2 - Load classes from a script module
 
-In this example, we have a PowerShell script module named **CardGames** that
-defines the following classes:
+In this example, a PowerShell script module named **CardGames** defines the
+following classes:
 
 - **Deck**
 - **Card**
 
 `Import-Module` and the `#requires` statement only import the module functions,
-aliases, and variables, as defined by the module. Classes are not imported. The
+aliases, and variables, as defined by the module. Classes aren't imported. The
 `using module` command imports the module and also loads the class definitions.
 
 ```powershell
@@ -161,7 +165,7 @@ $info = [ordered]@{
     @{ Name = 'Apples' ; Count = 1234 }
     @{ Name = 'Bagels' ; Count = 5678 }
   )
-    CheckedAt = [datetime]'2023-01-01T01:01:01'
+  CheckedAt = [datetime]'2023-01-01T01:01:01'
 }
 
 $yamlSerializer.Serialize($info)

--- a/reference/7.4/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Import-Module.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/12/2022
+ms.date: 08/17/2023
 no-loc: [Import-Module, -Scope]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/import-module?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -111,9 +111,9 @@ You can disable automatic module importing using the `$PSModuleAutoloadingPrefer
 variable. For more information about the `$PSModuleAutoloadingPreference` variable, see
 [about_Preference_Variables](About/about_Preference_Variables.md).
 
-A module is a package that contains members that can be used in PowerShell. Members include cmdlets,
-providers, scripts, functions, variables, and other tools and files. After a module is imported, you
-can use the module members in your session. For more information about modules, see
+A module is a package that contains members that can be used in PowerShell. Members include
+cmdlets, providers, scripts, functions, variables, and other tools and files. After a module is
+imported, you can use the module members in your session. For more information about modules, see
 [about_Modules](About/about_Modules.md).
 
 By default, `Import-Module` imports all members that the module exports, but you can use the
@@ -135,10 +135,10 @@ Starting in Windows PowerShell 3.0, you can use `Import-Module` to import Common
 you use cmdlets that are implemented in non-managed code assemblies, such as those written in C++.
 
 For remote computers that don't have PowerShell remoting enabled, including computers that aren't
-running the Windows operating system, you can use the **CIMSession** parameter of `Import-Module` to
-import CIM modules from the remote computer. The imported commands run implicitly on the remote
-computer. A **CIMSession** is a connection to Windows Management Instrumentation (WMI) on the remote
-computer.
+running the Windows operating system, you can use the **CIMSession** parameter of `Import-Module`
+to import CIM modules from the remote computer. The imported commands run implicitly on the remote
+computer. A **CIMSession** is a connection to Windows Management Instrumentation (WMI) on the
+remote computer.
 
 ## EXAMPLES
 
@@ -193,15 +193,15 @@ VERBOSE: Exporting function 'Get-SpecDetails'.
 ```
 
 Using the **Verbose** parameter causes `Import-Module` to report progress as it loads the module.
-Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, `Import-Module` does not
+Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, `Import-Module` doesn't
 generate any output when it imports a module.
 
 ### Example 5: Restrict module members imported into a session
 
-This example shows how to restrict which module members are imported into the session and the effect
-of this command on the session. The **Function** parameter limits the members that are imported from
-the module. You can also use the **Alias**, **Variable**, and **Cmdlet** parameters to restrict
-other members that a module imports.
+This example shows how to restrict which module members are imported into the session and the
+effect of this command on the session. The **Function** parameter limits the members that are
+imported from the module. You can also use the **Alias**, **Variable**, and **Cmdlet** parameters
+to restrict other members that a module imports.
 
 The `Get-Module` cmdlet gets the object that represents the **PSDiagnostics** module. The
 **ExportedCmdlets** property lists all the cmdlets that the module exports, even though they were
@@ -246,8 +246,8 @@ from the **PSDiagnostics** module. The results confirm that only the `Disable-PS
 
 This example imports the **PSDiagnostics** module into the current session, adds a prefix to the
 member names, and then displays the prefixed member names. The **Prefix** parameter of
-`Import-Module` adds the **x** prefix to all members that are imported from the module. The prefix
-applies only to the members in the current session. It does not change the module. The **PassThru**
+`Import-Module` adds the `x` prefix to all members that are imported from the module. The prefix
+applies only to the members in the current session. It doesn't change the module. The **PassThru**
 parameter returns a module object that represents the imported module.
 
 ```powershell
@@ -289,12 +289,12 @@ This example demonstrates how to get and use the custom object returned by `Impo
 Custom objects include synthetic members that represent each of the imported module members. For
 example, the cmdlets and functions in a module are converted to script methods of the custom object.
 
-Custom objects are useful in scripting. They are also useful when several imported objects have
+Custom objects are useful in scripting. They're also useful when several imported objects have
 the same names. Using the script method of an object is equivalent to specifying the fully qualified
 name of an imported member, including its module name.
 
-The **AsCustomObject** parameter can be used only when importing a script module. Use `Get-Module`
-to determine which of the available modules is a script module.
+The **AsCustomObject** parameter is only usable when importing a script module. Use `Get-Module` to
+determine which of the available modules is a script module.
 
 ```powershell
 Get-Module -List | Format-Table -Property Name, ModuleType -AutoSize
@@ -410,12 +410,13 @@ Because functions take precedence over cmdlets, the `Get-Date` function from the
 module runs, instead of the `Get-Date` cmdlet. To run the original version of `Get-Date`, you must
 qualify the command name with the module name.
 
-For more information about command precedence in PowerShell, see [about_Command_Precedence](about/about_Command_Precedence.md).
+For more information about command precedence in PowerShell, see
+[about_Command_Precedence](about/about_Command_Precedence.md).
 
 ### Example 10: Import a minimum version of a module
 
 This example imports the **PowerShellGet** module. It uses the **MinimumVersion** parameter of
-`Import-Module` to import only version 2.0.0 or greater of the module.
+`Import-Module` to import only version `2.0.0` or greater of the module.
 
 ```powershell
 Import-Module -Name PowerShellGet -MinimumVersion 2.0.0
@@ -427,7 +428,7 @@ version of a module in a script.
 
 ### Example 11: Import using a fully qualified name
 
-This example imports a specific version of a module using the FullyQualifiedName.
+This example imports a specific version of a module using the **FullyQualifiedName**.
 
 ```powershell
 PS> Get-Module -ListAvailable PowerShellGet | Select-Object Name, Version
@@ -511,22 +512,23 @@ Windows Remote Management (HTTP-In)                      WINRM-HTTP-In-TCP-PUBLI
 Windows Remote Management - Compatibility Mode (HTTP-In) WINRM-HTTP-Compat-In-TCP
 ```
 
-`New-PSSession` creates a remote session (**PSSession**) to the Server01 computer. The **PSSession**
-is saved in the `$s` variable.
+`New-PSSession` creates a remote session (**PSSession**) to the `Server01` computer. The
+**PSSession** is saved in the `$s` variable.
 
 Running `Get-Module` with the **PSSession** parameter shows that the **NetSecurity** module is
 installed and available on the remote computer. This command is equivalent to using the
 `Invoke-Command` cmdlet to run `Get-Module` command in the remote session. For example:
- (`Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity`
 
-Running `Import-Module` with the **PSSession** parameter imports the **NetSecurity** module from the
-remote computer into the current session. The `Get-Command` cmdlet is used to get commands that
-begin with **Get** and include **Firewall** from the **NetSecurity** module. The output confirms
-that the module and its cmdlets were imported into the current session.
+`Invoke-Command $s {Get-Module -ListAvailable -Name NetSecurity`
 
-Next, the `Get-NetFirewallRule` cmdlet gets Windows Remote Management firewall rules on the Server01
-computer. This is equivalent to using the `Invoke-Command` cmdlet to run `Get-NetFirewallRule`
-on the remote session.
+Running `Import-Module` with the **PSSession** parameter imports the **NetSecurity** module from
+the remote computer into the current session. The `Get-Command` cmdlet retrieves commands that
+begin with `Get` and include `Firewall` from the **NetSecurity** module. The output confirms that
+the module and its cmdlets were imported into the current session.
+
+Next, the `Get-NetFirewallRule` cmdlet gets Windows Remote Management firewall rules on the
+`Server01` computer. This is equivalent to using the `Invoke-Command` cmdlet to run
+`Get-NetFirewallRule` on the remote session.
 
 ### Example 14: Manage storage on a remote computer without the Windows operating system
 
@@ -536,7 +538,7 @@ provider, which allows you to use CIM commands that are designed for the provide
 The `New-CimSession` cmdlet creates a session on the remote computer named RSDGF03. The session
 connects to the WMI service on the remote computer. The CIM session is saved in the `$cs` variable.
 `Import-Module` uses the **CimSession** in `$cs` to import the **Storage** CIM module from the
-RSDGF03 computer.
+`RSDGF03` computer.
 
 The `Get-Command` cmdlet shows the `Get-Disk` command in the **Storage** module. When you import a
 CIM module into the local session, PowerShell converts the CDXML files for each command into
@@ -549,8 +551,8 @@ session.
 ```powershell
 $cs = New-CimSession -ComputerName RSDGF03
 Import-Module -CimSession $cs -Name Storage
-# Importing a CIM module, converts the CDXML files for each command into PowerShell scripts.
-# These appear as functions in the local session.
+# Importing a CIM module, converts the CDXML files for each command into
+# PowerShell scripts. These appear as functions in the local session.
 Get-Command Get-Disk
 ```
 
@@ -561,7 +563,8 @@ Function        Get-Disk              Storage
 ```
 
 ```powershell
-# Use implicit remoting to query disks on the remote computer from which the module was imported.
+# Use implicit remoting to query disks on the remote computer from which the
+# module was imported.
 Get-Disk
 ```
 
@@ -599,7 +602,8 @@ Specifies an array of arguments, or parameter values, that are passed to a scrip
 `Import-Module` command. This parameter is valid only when you're importing a script module.
 
 You can also refer to the **ArgumentList** parameter by its alias, **args**. For more information
-about the behavior of **ArgumentList**, see [about_Splatting](about/about_Splatting.md#splatting-with-arrays).
+about the behavior of **ArgumentList**, see
+[about_Splatting](about/about_Splatting.md#splatting-with-arrays).
 
 ```yaml
 Type: System.Object[]
@@ -620,7 +624,7 @@ members. This parameter is valid only for script modules.
 
 When you use the **AsCustomObject** parameter, `Import-Module` imports the module members into the
 session and then returns a **PSCustomObject** object instead of a **PSModuleInfo** object. You can
-save the custom object in a variable and use dot notation to invoke the members.
+save the custom object in a variable and use member-access enumeration to invoke the members.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -754,8 +758,8 @@ Accept wildcard characters: True
 Indicates that this cmdlet suppresses the message that warns you when you import a cmdlet or
 function whose name includes an unapproved verb or a prohibited character.
 
-By default, when a module that you import exports cmdlets or functions that have unapproved verbs in
-their names, PowerShell displays the following warning message:
+By default, when a module that you import exports cmdlets or functions that have unapproved verbs
+in their names, PowerShell displays the following warning message:
 
 > WARNING: Some imported command names include unapproved verbs which might make them less
 > discoverable. Use the Verbose parameter for more detail or type Get-Verb to see the list of
@@ -846,7 +850,7 @@ Accept wildcard characters: True
 
 ### -Global
 
-Indicates that this cmdlet imports modules into the global session state so they are available to
+Indicates that this cmdlet imports modules into the global session state so they're available to
 all commands in the session.
 
 By default, when `Import-Module` cmdlet is called from the command prompt, script file, or
@@ -879,7 +883,7 @@ Accept wildcard characters: False
 
 ### -MaximumVersion
 
-Specifies a maximum version. This cmdlet imports only a version of the module that is less than or
+Specifies a maximum version. This cmdlet imports only a version of the module that's less than or
 equal to the specified value. If no version qualifies, `Import-Module` returns an error.
 
 ```yaml
@@ -896,7 +900,7 @@ Accept wildcard characters: False
 
 ### -MinimumVersion
 
-Specifies a minimum version. This cmdlet imports only a version of the module that is greater than
+Specifies a minimum version. This cmdlet imports only a version of the module that's greater than
 or equal to the specified value. Use the **MinimumVersion** parameter name or its alias,
 **Version**. If no version qualifies, `Import-Module` generates an error.
 
@@ -945,14 +949,14 @@ characters aren't permitted. You can also pipe module names and filenames to `Im
 If you omit a path, `Import-Module` looks for the module in the paths saved in the
 `$env:PSModulePath` environment variable.
 
-Specify only the module name whenever possible. When you specify a file name, only the members that
+Specify only the module name whenever possible. When you specify a filename, only the members that
 are implemented in that file are imported. If the module contains other files, they aren't
 imported, and you might be missing important members of the module.
 
 > [!NOTE]
-> While it is possible to import a script (`.ps1`) file as a module, script files are usually not
-> structured like script modules file (`.psm1`) file. Importing a script file does not guarantee
-> that it is usable as a module. For more information, see [about_Modules](about/about_Modules.md).
+> While it's possible to import a script (`.ps1`) file as a module, script files are usually not
+> structured like script modules file (`.psm1`) file. Importing a script file doesn't guarantee
+> that it's usable as a module. For more information, see [about_Modules](about/about_Modules.md).
 
 ```yaml
 Type: System.String[]
@@ -993,8 +997,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Returns an object representing the item with which you're working. By default, this cmdlet does not
-generate any output.
+Returns an object representing the imported module. By default, this cmdlet doesn't generate any
+output.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -1013,12 +1017,12 @@ Accept wildcard characters: False
 Specifies a prefix that this cmdlet adds to the nouns in the names of imported module members.
 
 Use this parameter to avoid name conflicts that might occur when different members in the session
-have the same name. This parameter does not change the module, and it does not affect files that the
+have the same name. This parameter doesn't change the module, and it doesn't affect files that the
 module imports for its own use. These are known as nested modules. This cmdlet affects only the
 names of members in the current session.
 
 For example, if you specify the prefix UTC and then import a `Get-Date` cmdlet, the cmdlet is known
-in the session as `Get-UTCDate`, and it is not confused with the original `Get-Date` cmdlet.
+in the session as `Get-UTCDate`, and it's not confused with the original `Get-Date` cmdlet.
 
 The value of this parameter takes precedence over the **DefaultCommandPrefix** property of the
 module, which specifies the default prefix.
@@ -1043,13 +1047,13 @@ into the current session. Enter a variable that contains a **PSSession** or a co
 
 When you import a module from a different session into the current session, you can use the cmdlets
 from the module in the current session, just as you would use cmdlets from a local module. Commands
-that use the remote cmdlets run in the remote session, but the remoting details are managed
-in the background by PowerShell.
+that use the remote cmdlets run in the remote session, but the remoting details are managed in the
+background by PowerShell.
 
-This parameter uses the Implicit Remoting feature of PowerShell. It is equivalent to using the
+This parameter uses the Implicit Remoting feature of PowerShell. It's equivalent to using the
 `Import-PSSession` cmdlet to import particular modules from a session.
 
-`Import-Module` cannot import core PowerShell modules from another session. The core PowerShell
+`Import-Module` can't import core PowerShell modules from another session. The core PowerShell
 modules have names that begin with Microsoft.PowerShell.
 
 This parameter was introduced in Windows PowerShell 3.0.
@@ -1068,7 +1072,7 @@ Accept wildcard characters: False
 
 ### -RequiredVersion
 
-Specifies a version of the module that this cmdlet imports. If the version is not installed,
+Specifies a version of the module that this cmdlet imports. If the version isn't installed,
 `Import-Module` generates an error.
 
 By default, `Import-Module` imports the module without checking the version number.
@@ -1099,7 +1103,7 @@ Accept wildcard characters: False
 
 ### -Scope
 
-Specifies a scope into which this cmdlet imports the module.
+Specifies a scope to import the module in.
 
 The acceptable values for this parameter are:
 
@@ -1110,9 +1114,9 @@ By default, when `Import-Module` cmdlet is called from the command prompt, scrip
 scriptblock, all the commands are imported into the global session state. You can use the
 `-Scope Local` parameter to import module content into the script or scriptblock scope.
 
-When invoked from another module, `Import-Module` cmdlet imports the commands in a module, including
-commands from nested modules, into the caller's session state. Specifying `-Scope Global` or
-`-Global` indicates that this cmdlet imports modules into the global session state so they are
+When invoked from another module, `Import-Module` cmdlet imports the commands in a module,
+including commands from nested modules, into the caller's session state. Specifying `-Scope Global`
+or `-Global` indicates that this cmdlet imports modules into the global session state so they're
 available to all commands in the session.
 
 The **Global** parameter is equivalent to the **Scope** parameter with a value of **Global**.
@@ -1137,10 +1141,10 @@ Accept wildcard characters: False
 Skips the check on the `CompatiblePSEditions` field.
 
 Allows loading a module from the `"$($env:windir)\System32\WindowsPowerShell\v1.0\Modules"` module
-directory into PowerShell Core when that module does not specify `Core` in the
+directory into PowerShell Core when that module doesn't specify `Core` in the
 `CompatiblePSEditions` manifest field.
 
-When importing a module from another path, this switch does nothing, since the check is not
+When importing a module from another path, this switch does nothing, since the check isn't
 performed. On Linux and macOS, this switch does nothing.
 
 For more information, see [about_PowerShell_Editions](About/about_PowerShell_Editions.md).
@@ -1230,7 +1234,7 @@ By default, this cmdlet returns no output.
 ### System.Management.Automation.PSModuleInfo
 
 If you specify the **PassThru** parameter, the cmdlet generates a
-**System.Management.Automation.PSModuleInfo** object that represents the module.
+**System.Management.Automation.PSModuleInfo** object that represents the imported module.
 
 ### System.Management.Automation.PSCustomObject
 
@@ -1244,9 +1248,9 @@ PowerShell includes the following aliases for `Import-Module`:
 - All platforms:
   - `ipmo`
 
-- Before you can import a module, the module must be installed on the local computer. That is, the
-  module directory must be copied to a directory that is accessible to your local computer. For more
-  information, see [about_Modules](About/about_Modules.md).
+- Before you can import a module, the module must be accessible to your local computer and included
+  in the `PSModulePath` environmental variable. For more information, see
+  [about_Modules](About/about_Modules.md).
 
   You can also use the **PSSession** and **CIMSession** parameters to import modules that are
   installed on remote computers. However, commands that use the cmdlets in these modules run in the
@@ -1257,24 +1261,23 @@ PowerShell includes the following aliases for `Import-Module`:
   accessible. Functions, cmdlets, and providers are merely shadowed by the new members. They can be
   accessed by qualifying the command name with the name of its snap-in, module, or function path.
 
-- To update the formatting data for commands that have been imported from a module, use the
-  `Update-FormatData` cmdlet. `Update-FormatData` also updates the formatting data for commands in
-  the session that were imported from modules. If the formatting file for a module changes, you can
-  run an `Update-FormatData` command to update the formatting data for imported commands. You don't
-  need to import the module again.
+- To update the formatting data for commands imported from a module, use the `Update-FormatData`
+  cmdlet. If the formatting file for a module changes, use the `Update-FormatData` cmdlet to update
+  the formatting data for imported commands. You don't need to import the module again.
 
-- Starting in Windows PowerShell 3.0, the core commands that are installed with PowerShell are
-  packaged in modules. In Windows PowerShell 2.0, and in host programs that create older-style
-  sessions in later versions of PowerShell, the core commands are packaged in snap-ins
-  (**PSSnapins**). The exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also,
-  remote sessions, such as those started by the `New-PSSession` cmdlet, are older-style sessions
-  that include core snap-ins.
+- Starting in Windows PowerShell 3.0, the core commands installed with PowerShell are packaged in
+  modules. In Windows PowerShell 2.0, and in host programs that create older-style sessions in
+  later versions of PowerShell, the core commands are packaged in snap-ins (**PSSnapins**). The
+  exception is **Microsoft.PowerShell.Core**, which is always a snap-in. Also, remote sessions,
+  such as those started by the `New-PSSession` cmdlet, are older-style sessions that include core
+  snap-ins.
 
   For information about the **CreateDefault2** method that creates newer-style sessions with core
-  modules, see the [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2).
+  modules, see the
+  [CreateDefault2 Method](/dotnet/api/system.management.automation.runspaces.initialsessionstate.createdefault2).
 
-- In Windows PowerShell 2.0, some of the property values of the module object, such as the
-  **ExportedCmdlets** and **NestedModules** property values, were not populated until the module was
+- In Windows PowerShell 2.0, some property values of the module object, such as the
+  **ExportedCmdlets** and **NestedModules** property values, weren't populated until the module was
   imported.
 
 - If you attempt to import a module that contains mixed-mode assemblies that aren't compatible with
@@ -1283,7 +1286,7 @@ PowerShell includes the following aliases for `Import-Module`:
   > Import-Module : Mixed mode assembly is built against version 'v2.0.50727' of the runtime and
   > cannot be loaded in the 4.0 runtime without additional configuration information.
 
-  This error occurs when a module that is designed for Windows PowerShell 2.0 contains at least one
+  This error occurs when a module that's designed for Windows PowerShell 2.0 contains at least one
   mixed-module assembly. A mixed-module assembly that includes both managed and non-managed code,
   such as C++ and C#.
 
@@ -1309,16 +1312,28 @@ PowerShell includes the following aliases for `Import-Module`:
   exported elements.
 
   In a descendant scope, `-Scope Local` limits the import to that scope and all its descendant
-  scopes. Parent scopes then do not see the imported members.
+  scopes. Parent scopes then don't see the imported members.
 
   > [!NOTE]
   > `Get-Module` shows all modules loaded in the current session. This includes modules loaded
   > locally in a descendant scope. Use `Get-Command -Module modulename` to see which members are
   > loaded in the current scope.
 
-  `Import-Module` does not load class and enum definitions in the module. Use the `using module`
-  statement at the beginning of your script. This imports the module, including the class and enum
-  definitions. For more information, see [about_Using](About/about_Using.md).
+- `Import-Module` doesn't load class and enumeration definitions in the module. Use the
+  `using module` statement at the beginning of your script. This imports the module, including the
+  class and enumeration definitions. For more information, see [about_Using](About/about_Using.md).
+
+- During development of a script module, it's common to make changes to the code then load the new
+  version of the module using `Import-Module` with the **Force** parameter. This works for changes
+  to functions in the root module only. `Import-Module` doesn't reload any nested modules. Also,
+  there's no way to load any updated classes or enumerations.
+
+  To get updated module members defined in nested modules, remove the module with `Remove-Module`,
+  then import the module again.
+
+  If the module was loaded with a `using` statement, you must start a new session to import updated
+  definitions for the classes and enumerations. Classes and enumerations defined in PowerShell and
+  imported with a `using` statement can't be unloaded.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
# PR Summary

Classes need to be defined directly in the module's psm1 file in order to be imported into the script using the module, but this wasn't obvious from the previous wording.

This PR adds wording to explicitly mention that classes should be placed in the module's psm1 file.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
