### PR TITLE
(AB#156514) Remove reference to .NET Framework in about_Operators

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 05/30/2023
+ms.date: 09/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -88,8 +88,8 @@ For more information, see [about_Split][20] and [about_Join][11].
 
 ## Type Operators
 
-Use the type operators (`-is`, `-isnot`, `-as`) to find or change the .NET
-Framework type of an object.
+Use the type operators (`-is`, `-isnot`, `-as`) to find or change the .NET type
+of an object.
 
 For more information, see [about_Type_Operators][21].
 
@@ -687,8 +687,8 @@ see [about_Member-Access_Enumeration][13].
 
 ### Static member operator `::`
 
-Calls the static properties and methods of a .NET Framework class. To find the
-static properties and methods of an object, use the Static parameter of the
+Calls the static properties and methods of a .NET class. To find the static
+properties and methods of an object, use the Static parameter of the
 `Get-Member` cmdlet. The member name may be an expression.
 
 ```powershell

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 05/30/2023
+ms.date: 09/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -88,8 +88,8 @@ For more information, see [about_Split][20] and [about_Join][11].
 
 ## Type Operators
 
-Use the type operators (`-is`, `-isnot`, `-as`) to find or change the .NET
-Framework type of an object.
+Use the type operators (`-is`, `-isnot`, `-as`) to find or change the .NET type
+of an object.
 
 For more information, see [about_Type_Operators][21].
 
@@ -687,8 +687,8 @@ see [about_Member-Access_Enumeration][13].
 
 ### Static member operator `::`
 
-Calls the static properties and methods of a .NET Framework class. To find the
-static properties and methods of an object, use the Static parameter of the
+Calls the static properties and methods of a .NET class. To find the static
+properties and methods of an object, use the Static parameter of the
 `Get-Member` cmdlet. The member name may be an expression.
 
 ```powershell

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 05/30/2023
+ms.date: 09/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -88,8 +88,8 @@ For more information, see [about_Split][20] and [about_Join][11].
 
 ## Type Operators
 
-Use the type operators (`-is`, `-isnot`, `-as`) to find or change the .NET
-Framework type of an object.
+Use the type operators (`-is`, `-isnot`, `-as`) to find or change the .NET type
+of an object.
 
 For more information, see [about_Type_Operators][21].
 
@@ -687,8 +687,8 @@ see [about_Member-Access_Enumeration][13].
 
 ### Static member operator `::`
 
-Calls the static properties and methods of a .NET Framework class. To find the
-static properties and methods of an object, use the Static parameter of the
+Calls the static properties and methods of a .NET class. To find the static
+properties and methods of an object, use the Static parameter of the
 `Get-Member` cmdlet. The member name may be an expression.
 
 ```powershell


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation in `about_Operators` referenced .NET Framework types and classes instead of .NET types and classes.

This change:

- Removes the incorrect qualifier as 7+ is built on .NET, not the .NET Framework.
- Fixes [AB#156514](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/156514)
- Resolves #10382

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
