### PR TITLE
(GH-10385) Indicate Path accepts wildcards for `Convert-Path`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Convert-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Convert-Path.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 11/22/2022
+ms.date: 09/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/convert-path?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Convert-Path
@@ -66,9 +66,12 @@ C:\Users\User01
 ### -LiteralPath
 
 Specifies, as a string array, the path to be converted. The value of the **LiteralPath** parameter
-is used exactly as it is typed. No characters are interpreted as wildcards. If the path includes
+is used exactly as it's typed. No characters are interpreted as wildcards. If the path includes
 escape characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not
 to interpret any characters as escape sequences.
+
+For more information, see
+[about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md).
 
 ```yaml
 Type: System.String[]
@@ -95,7 +98,7 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -UseTransaction
@@ -141,18 +144,18 @@ Windows PowerShell includes the following aliases for `Convert-Path`:
 - `cvpa`
 
 The cmdlets that contain the Path noun manipulate path names and return the names in a concise
-format that all PowerShell providers can interpret. They are designed for use in programs and
-scripts where you want to display all or part of a path name in a particular format. Use them like
-you would use **Dirname**, **Normpath**, **Realpath**, **Join**, or other path manipulators.
+format that all PowerShell providers can interpret. They're designed for use in programs and
+scripts where you want to display all or part of a path in a particular format. Use them like you
+would use **Dirname**, **Normpath**, **Realpath**, **Join**, or other path manipulators.
 
-You can use the path cmdlets with several providers, including the FileSystem, Registry, and
-Certificate providers.
+You can use the path cmdlets with several providers, including the **FileSystem**, **Registry**,
+and **Certificate** providers.
 
 This cmdlet is designed to work with the data exposed by any provider. To list the providers
 available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-`Convert-Path` only converts existing paths. It cannot be used to convert a location that does not
+`Convert-Path` only converts existing paths. It can't be used to convert a location that doesn't
 exist yet.
 
 ## RELATED LINKS

--- a/reference/7.2/Microsoft.PowerShell.Management/Convert-Path.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Convert-Path.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 11/22/2022
+ms.date: 09/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/convert-path?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Convert-Path
@@ -66,9 +66,12 @@ C:\Users\User01
 ### -LiteralPath
 
 Specifies, as a string array, the path to be converted. The value of the **LiteralPath** parameter
-is used exactly as it is typed. No characters are interpreted as wildcards. If the path includes
+is used exactly as it's typed. No characters are interpreted as wildcards. If the path includes
 escape characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not
 to interpret any characters as escape sequences.
+
+For more information, see
+[about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md).
 
 ```yaml
 Type: System.String[]
@@ -95,7 +98,7 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### CommonParameters
@@ -125,18 +128,18 @@ PowerShell includes the following aliases for `Convert-Path`:
   - `cvpa`
 
 The cmdlets that contain the Path noun manipulate path names and return the names in a concise
-format that all PowerShell providers can interpret. They are designed for use in programs and
-scripts where you want to display all or part of a path name in a particular format. Use them like
-you would use **Dirname**, **Normpath**, **Realpath**, **Join**, or other path manipulators.
+format that all PowerShell providers can interpret. They're designed for use in programs and
+scripts where you want to display all or part of a path in a particular format. Use them like you
+would use **Dirname**, **Normpath**, **Realpath**, **Join**, or other path manipulators.
 
-You can use the path cmdlets with several providers, including the FileSystem, Registry, and
-Certificate providers.
+You can use the path cmdlets with several providers, including the **FileSystem**, **Registry**,
+and **Certificate** providers.
 
 This cmdlet is designed to work with the data exposed by any provider. To list the providers
 available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-`Convert-Path` only converts existing paths. It cannot be used to convert a location that does not
+`Convert-Path` only converts existing paths. It can't be used to convert a location that doesn't
 exist yet.
 
 ## RELATED LINKS
@@ -150,4 +153,3 @@ exist yet.
 [Test-Path](Test-Path.md)
 
 [Get-PSProvider](Get-PSProvider.md)
-

--- a/reference/7.3/Microsoft.PowerShell.Management/Convert-Path.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Convert-Path.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 11/22/2022
+ms.date: 09/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/convert-path?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Convert-Path
@@ -66,9 +66,12 @@ C:\Users\User01
 ### -LiteralPath
 
 Specifies, as a string array, the path to be converted. The value of the **LiteralPath** parameter
-is used exactly as it is typed. No characters are interpreted as wildcards. If the path includes
+is used exactly as it's typed. No characters are interpreted as wildcards. If the path includes
 escape characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not
 to interpret any characters as escape sequences.
+
+For more information, see
+[about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md).
 
 ```yaml
 Type: System.String[]
@@ -95,7 +98,7 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### CommonParameters
@@ -125,18 +128,18 @@ PowerShell includes the following aliases for `Convert-Path`:
   - `cvpa`
 
 The cmdlets that contain the Path noun manipulate path names and return the names in a concise
-format that all PowerShell providers can interpret. They are designed for use in programs and
-scripts where you want to display all or part of a path name in a particular format. Use them like
-you would use **Dirname**, **Normpath**, **Realpath**, **Join**, or other path manipulators.
+format that all PowerShell providers can interpret. They're designed for use in programs and
+scripts where you want to display all or part of a path in a particular format. Use them like you
+would use **Dirname**, **Normpath**, **Realpath**, **Join**, or other path manipulators.
 
-You can use the path cmdlets with several providers, including the FileSystem, Registry, and
-Certificate providers.
+You can use the path cmdlets with several providers, including the **FileSystem**, **Registry**,
+and **Certificate** providers.
 
 This cmdlet is designed to work with the data exposed by any provider. To list the providers
 available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-`Convert-Path` only converts existing paths. It cannot be used to convert a location that does not
+`Convert-Path` only converts existing paths. It can't be used to convert a location that doesn't
 exist yet.
 
 ## RELATED LINKS
@@ -150,4 +153,3 @@ exist yet.
 [Test-Path](Test-Path.md)
 
 [Get-PSProvider](Get-PSProvider.md)
-

--- a/reference/7.4/Microsoft.PowerShell.Management/Convert-Path.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Convert-Path.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 11/22/2022
+ms.date: 09/05/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/convert-path?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Convert-Path
@@ -66,9 +66,12 @@ C:\Users\User01
 ### -LiteralPath
 
 Specifies, as a string array, the path to be converted. The value of the **LiteralPath** parameter
-is used exactly as it is typed. No characters are interpreted as wildcards. If the path includes
+is used exactly as it's typed. No characters are interpreted as wildcards. If the path includes
 escape characters, enclose it in single quotation marks. Single quotation marks tell PowerShell not
 to interpret any characters as escape sequences.
+
+For more information, see
+[about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md).
 
 ```yaml
 Type: System.String[]
@@ -95,7 +98,7 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### CommonParameters
@@ -125,18 +128,18 @@ PowerShell includes the following aliases for `Convert-Path`:
   - `cvpa`
 
 The cmdlets that contain the Path noun manipulate path names and return the names in a concise
-format that all PowerShell providers can interpret. They are designed for use in programs and
-scripts where you want to display all or part of a path name in a particular format. Use them like
-you would use **Dirname**, **Normpath**, **Realpath**, **Join**, or other path manipulators.
+format that all PowerShell providers can interpret. They're designed for use in programs and
+scripts where you want to display all or part of a path in a particular format. Use them like you
+would use **Dirname**, **Normpath**, **Realpath**, **Join**, or other path manipulators.
 
-You can use the path cmdlets with several providers, including the FileSystem, Registry, and
-Certificate providers.
+You can use the path cmdlets with several providers, including the **FileSystem**, **Registry**,
+and **Certificate** providers.
 
 This cmdlet is designed to work with the data exposed by any provider. To list the providers
 available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-`Convert-Path` only converts existing paths. It cannot be used to convert a location that does not
+`Convert-Path` only converts existing paths. It can't be used to convert a location that doesn't
 exist yet.
 
 ## RELATED LINKS
@@ -150,4 +153,3 @@ exist yet.
 [Test-Path](Test-Path.md)
 
 [Get-PSProvider](Get-PSProvider.md)
-


### PR DESCRIPTION
# PR Summary

Prior to this change, the **Path** parameter for the `Convert-Path` cmdlet indicated that it does not accept wildcard values, even though it does.

This change:

- Updates the metadata to accurately reflect the cmdlet behavior
- Fixes [AB#156610](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/156610)
- Resolves #10385

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
