### PR TITLE
Quality: Fix formatting for code blocks for `Connect-PSSession` 

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/02/2022
+ms.date: 09/09/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/connect-pssession?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Connect-PSSession
@@ -203,7 +203,7 @@ session. The command saves the results in the `$BackupSpecs` variable.The eighth
 
 ```powershell
 $s = New-PSSession -ComputerName Server01 -Name ITTask -ConfigurationName ITTasks
-Invoke-Command -Session $s {Start-Job -FilePath \\Server30\Scripts\Backup-SQLDatabase.ps1}
+Invoke-Command -Session $s -ScriptBlock {Start-Job -FilePath \\Server30\Scripts\Backup-SQLDatabase.ps1}
 ```
 
 ```Output
@@ -243,7 +243,7 @@ Id Name            ComputerName    State         ConfigurationName     Availabil
 ```
 
 ```powershell
-Invoke-Command -Session $s {Get-Job}
+Invoke-Command -Session $s -ScriptBlock {Get-Job}
 ```
 
 ```Output
@@ -253,8 +253,8 @@ Id     Name            State         HasMoreData     Location             Comman
 ```
 
 ```powershell
-Invoke-Command -Session $s {$BackupSpecs = Receive-Job -JobName Job2}
-Invoke-Command -Session $s {\\Server30\Scripts\New-SQLDatabase.ps1 -InitData $BackupSpecs.Initialization}
+Invoke-Command -Session $s -ScriptBlock {$BackupSpecs = Receive-Job -JobName Job2}
+Invoke-Command -Session $s -ScriptBlock {\\Server30\Scripts\New-SQLDatabase.ps1 -InitData $BackupSpecs.Initialization}
 Disconnect-PSSession -Session $s -OutputBufferingMode Drop -IdleTimeoutSec 60*60*15
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/02/2022
+ms.date: 09/09/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/connect-pssession?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Connect-PSSession
@@ -208,7 +208,7 @@ session. The command saves the results in the `$BackupSpecs` variable.The eighth
 
 ```powershell
 $s = New-PSSession -ComputerName Server01 -Name ITTask -ConfigurationName ITTasks
-Invoke-Command -Session $s {Start-Job -FilePath \\Server30\Scripts\Backup-SQLDatabase.ps1}
+Invoke-Command -Session $s -ScriptBlock {Start-Job -FilePath \\Server30\Scripts\Backup-SQLDatabase.ps1}
 ```
 
 ```Output
@@ -248,7 +248,7 @@ Id Name            ComputerName    State         ConfigurationName     Availabil
 ```
 
 ```powershell
-Invoke-Command -Session $s {Get-Job}
+Invoke-Command -Session $s -ScriptBlock {Get-Job}
 ```
 
 ```Output
@@ -258,8 +258,8 @@ Id     Name            State         HasMoreData     Location             Comman
 ```
 
 ```powershell
-Invoke-Command -Session $s {$BackupSpecs = Receive-Job -JobName Job2}
-Invoke-Command -Session $s {\\Server30\Scripts\New-SQLDatabase.ps1 -InitData $BackupSpecs.Initialization}
+Invoke-Command -Session $s -ScriptBlock {$BackupSpecs = Receive-Job -JobName Job2}
+Invoke-Command -Session $s -ScriptBlock {\\Server30\Scripts\New-SQLDatabase.ps1 -InitData $BackupSpecs.Initialization}
 Disconnect-PSSession -Session $s -OutputBufferingMode Drop -IdleTimeoutSec 60*60*15
 ```
 

--- a/reference/7.3/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/02/2022
+ms.date: 09/09/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/connect-pssession?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Connect-PSSession
@@ -208,7 +208,7 @@ session. The command saves the results in the `$BackupSpecs` variable.The eighth
 
 ```powershell
 $s = New-PSSession -ComputerName Server01 -Name ITTask -ConfigurationName ITTasks
-Invoke-Command -Session $s {Start-Job -FilePath \\Server30\Scripts\Backup-SQLDatabase.ps1}
+Invoke-Command -Session $s -ScriptBlock {Start-Job -FilePath \\Server30\Scripts\Backup-SQLDatabase.ps1}
 ```
 
 ```Output
@@ -248,7 +248,7 @@ Id Name            ComputerName    State         ConfigurationName     Availabil
 ```
 
 ```powershell
-Invoke-Command -Session $s {Get-Job}
+Invoke-Command -Session $s -ScriptBlock {Get-Job}
 ```
 
 ```Output
@@ -258,8 +258,8 @@ Id     Name            State         HasMoreData     Location             Comman
 ```
 
 ```powershell
-Invoke-Command -Session $s {$BackupSpecs = Receive-Job -JobName Job2}
-Invoke-Command -Session $s {\\Server30\Scripts\New-SQLDatabase.ps1 -InitData $BackupSpecs.Initialization}
+Invoke-Command -Session $s -ScriptBlock {$BackupSpecs = Receive-Job -JobName Job2}
+Invoke-Command -Session $s -ScriptBlock {\\Server30\Scripts\New-SQLDatabase.ps1 -InitData $BackupSpecs.Initialization}
 Disconnect-PSSession -Session $s -OutputBufferingMode Drop -IdleTimeoutSec 60*60*15
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -208,7 +208,7 @@ session. The command saves the results in the `$BackupSpecs` variable.The eighth
 
 ```powershell
 $s = New-PSSession -ComputerName Server01 -Name ITTask -ConfigurationName ITTasks
-Invoke-Command -Session $s {Start-Job -FilePath \\Server30\Scripts\Backup-SQLDatabase.ps1}
+Invoke-Command -Session $s -ScriptBlock {Start-Job -FilePath \\Server30\Scripts\Backup-SQLDatabase.ps1}
 ```
 
 ```Output
@@ -248,7 +248,7 @@ Id Name            ComputerName    State         ConfigurationName     Availabil
 ```
 
 ```powershell
-Invoke-Command -Session $s {Get-Job}
+Invoke-Command -Session $s -ScriptBlock {Get-Job}
 ```
 
 ```Output
@@ -258,8 +258,8 @@ Id     Name            State         HasMoreData     Location             Comman
 ```
 
 ```powershell
-Invoke-Command -Session $s {$BackupSpecs = Receive-Job -JobName Job2}
-Invoke-Command -Session $s {\\Server30\Scripts\New-SQLDatabase.ps1 -InitData $BackupSpecs.Initialization}
+Invoke-Command -Session $s -ScriptBlock {$BackupSpecs = Receive-Job -JobName Job2}
+Invoke-Command -Session $s -ScriptBlock {\\Server30\Scripts\New-SQLDatabase.ps1 -InitData $BackupSpecs.Initialization}
 Disconnect-PSSession -Session $s -OutputBufferingMode Drop -IdleTimeoutSec 60*60*15
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 12/02/2022
+ms.date: 09/09/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/connect-pssession?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Connect-PSSession


### PR DESCRIPTION
# PR Summary

Prior to this PR, `Connect-PSSession` has examples that does not type out the parameter names.

To clarify and align with the style guideline, the parameter names should be added.

- Fixes #10398

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
