### PR TITLE
(GH-10459) Reorganize grouping expression docs

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -128,8 +128,7 @@ True
 > Wrapping a command in parentheses causes the automatic variable `$?` to be
 > set to `$true`, even when the enclosed command itself set `$?` to `$false`.
 > For example, `(Get-Item /Nosuch); $?` unexpectedly yields **True**. For
-> more information about `$?`, see
-> [about_Automatic_Variables][06].
+> more information about `$?`, see [about_Automatic_Variables][06].
 
 #### Piping grouped expressions
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 09/25/2023
+ms.date: 09/26/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -114,6 +114,8 @@ expressions. For example: `(1 + 2) / 3`
 
 However, in PowerShell, there are additional behaviors.
 
+#### Grouping result expressions
+
 `(...)` allows you to let output from a _command_ participate in an expression.
 For example:
 
@@ -128,6 +130,34 @@ True
 > For example, `(Get-Item /Nosuch); $?` unexpectedly yields **True**. For
 > more information about `$?`, see
 > [about_Automatic_Variables][06].
+
+#### Piping grouped expressions
+
+When used as the first segment of a pipeline, wrapping a command or expression
+in parentheses invariably causes _enumeration_ of the expression result. If the
+parentheses wrap a _command_, it's run to completion with all output _collected
+in memory_ before the results are sent through the pipeline.
+
+For example, the outputs for these statements are different:
+
+```powershell
+PS> ConvertFrom-Json '["a", "b"]'   | ForEach-Object { "The value is '$_'" }
+
+The value is 'a b'
+
+PS> (ConvertFrom-Json '["a", "b"]') | ForEach-Object { "The value is '$_'" }
+
+The value is 'a'
+The value is 'b'
+```
+
+Grouping an expression before piping also ensures that subsequent
+object-by-object processing can't interfere with the enumeration the command
+uses to produce its output.
+
+For example, piping the output from `Get-ChildItem` to `Rename-Item` can have
+unexpected effects where an item is renamed, then discovered again and renamed
+a second time.
 
 #### Grouping assignment statements
 
@@ -183,34 +213,6 @@ in the body of the `if` statement.
 > While this technique is convenient and concise, it can lead to confusion
 > between the assignment operator (`=`) and the equality-comparison operator
 > (`-eq`).
-
-#### Piping grouped expressions
-
-When used as the first segment of a pipeline, wrapping a command or expression
-in parentheses invariably causes _enumeration_ of the expression result. If the
-parentheses wrap a _command_, it's run to completion with all output _collected
-in memory_ before the results are sent through the pipeline.
-
-For example, the outputs for these statements are different:
-
-```powershell
-PS> ConvertFrom-Json '["a", "b"]'   | ForEach-Object { "The value is '$_'" }
-
-The value is 'a b'
-
-PS> (ConvertFrom-Json '["a", "b"]') | ForEach-Object { "The value is '$_'" }
-
-The value is 'a'
-The value is 'b'
-```
-
-Grouping an expression before piping also ensures that subsequent
-object-by-object processing can't interfere with the enumeration the command
-uses to produce its output.
-
-For example, piping the output from `Get-ChildItem` to `Rename-Item` can have
-unexpected effects where an item is renamed, then discovered again and renamed
-a second time.
 
 ### Subexpression operator `$( )`
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 09/25/2023
+ms.date: 09/26/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -114,6 +114,8 @@ expressions. For example: `(1 + 2) / 3`
 
 However, in PowerShell, there are additional behaviors.
 
+#### Grouping result expressions
+
 `(...)` allows you to let output from a _command_ participate in an expression.
 For example:
 
@@ -121,6 +123,17 @@ For example:
 PS> (Get-Item *.txt).Count -gt 10
 True
 ```
+
+#### Piping grouped expressions
+
+When used as the first segment of a pipeline, wrapping a command or expression
+in parentheses invariably causes _enumeration_ of the expression result. If the
+parentheses wrap a _command_, it's run to completion with all output _collected
+in memory_ before the results are sent through the pipeline.
+
+Grouping an expression before piping also ensures that subsequent
+object-by-object processing can't interfere with the enumeration the command
+uses to produce its output.
 
 #### Grouping assignment statements
 
@@ -176,17 +189,6 @@ in the body of the `if` statement.
 > While this technique is convenient and concise, it can lead to confusion
 > between the assignment operator (`=`) and the equality-comparison operator
 > (`-eq`).
-
-#### Piping grouped expressions
-
-When used as the first segment of a pipeline, wrapping a command or expression
-in parentheses invariably causes _enumeration_ of the expression result. If the
-parentheses wrap a _command_, it's run to completion with all output _collected
-in memory_ before the results are sent through the pipeline.
-
-Grouping an expression before piping also ensures that subsequent
-object-by-object processing can't interfere with the enumeration the command
-uses to produce its output.
 
 ### Subexpression operator `$( )`
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 09/25/2023
+ms.date: 09/26/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -114,6 +114,8 @@ expressions. For example: `(1 + 2) / 3`
 
 However, in PowerShell, there are additional behaviors.
 
+#### Grouping result expressions
+
 `(...)` allows you to let output from a _command_ participate in an expression.
 For example:
 
@@ -121,6 +123,17 @@ For example:
 PS> (Get-Item *.txt).Count -gt 10
 True
 ```
+
+#### Piping grouped expressions
+
+When used as the first segment of a pipeline, wrapping a command or expression
+in parentheses invariably causes _enumeration_ of the expression result. If the
+parentheses wrap a _command_, it's run to completion with all output _collected
+in memory_ before the results are sent through the pipeline.
+
+Grouping an expression before piping also ensures that subsequent
+object-by-object processing can't interfere with the enumeration the command
+uses to produce its output.
 
 #### Grouping assignment statements
 
@@ -176,17 +189,6 @@ in the body of the `if` statement.
 > While this technique is convenient and concise, it can lead to confusion
 > between the assignment operator (`=`) and the equality-comparison operator
 > (`-eq`).
-
-#### Piping grouped expressions
-
-When used as the first segment of a pipeline, wrapping a command or expression
-in parentheses invariably causes _enumeration_ of the expression result. If the
-parentheses wrap a _command_, it's run to completion with all output _collected
-in memory_ before the results are sent through the pipeline.
-
-Grouping an expression before piping also ensures that subsequent
-object-by-object processing can't interfere with the enumeration the command
-uses to produce its output.
 
 ### Subexpression operator `$( )`
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 09/25/2023
+ms.date: 09/26/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -114,6 +114,8 @@ expressions. For example: `(1 + 2) / 3`
 
 However, in PowerShell, there are additional behaviors.
 
+#### Grouping result expressions
+
 `(...)` allows you to let output from a _command_ participate in an expression.
 For example:
 
@@ -121,6 +123,17 @@ For example:
 PS> (Get-Item *.txt).Count -gt 10
 True
 ```
+
+#### Piping grouped expressions
+
+When used as the first segment of a pipeline, wrapping a command or expression
+in parentheses invariably causes _enumeration_ of the expression result. If the
+parentheses wrap a _command_, it's run to completion with all output _collected
+in memory_ before the results are sent through the pipeline.
+
+Grouping an expression before piping also ensures that subsequent
+object-by-object processing can't interfere with the enumeration the command
+uses to produce its output.
 
 #### Grouping assignment statements
 
@@ -176,17 +189,6 @@ in the body of the `if` statement.
 > While this technique is convenient and concise, it can lead to confusion
 > between the assignment operator (`=`) and the equality-comparison operator
 > (`-eq`).
-
-#### Piping grouped expressions
-
-When used as the first segment of a pipeline, wrapping a command or expression
-in parentheses invariably causes _enumeration_ of the expression result. If the
-parentheses wrap a _command_, it's run to completion with all output _collected
-in memory_ before the results are sent through the pipeline.
-
-Grouping an expression before piping also ensures that subsequent
-object-by-object processing can't interfere with the enumeration the command
-uses to produce its output.
 
 ### Subexpression operator `$( )`
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for using grouped expressions in _about_Operators_ included two subheadings:

1. Grouping assignment statements
1. Piping grouped expressions

However, it also defined a third use-case for grouping, which showed how to use the grouping operator to use the output of a command in an expression. This use case was documented before the subheadings and after a sentence indicating there's ways to use the grouping operator beyond overriding operator precedence.

Further, the section for grouping assignment statements was very long compared to the other use-cases and placed in the middle, despite being less commonly used than the others.

This change:

- Adds a subheading for the first use case to make it equivalent to the others in the information hierarchy.
- Moves the section for piping grouped expressions to before the section for grouping assignment statements.
- Resolves #10459
- Fixes [AB#163845](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/163845)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
