### PR TITLE
(GH-10505) Add note on property name ordering

### DIFF
--- a/reference/docs-conceptual/learn/deep-dives/everything-about-pscustomobject.md
+++ b/reference/docs-conceptual/learn/deep-dives/everything-about-pscustomobject.md
@@ -1,7 +1,7 @@
 ---
 description: PSCustomObject is a simple way to create structured data.
 ms.custom: contributor-KevinMarquette
-ms.date: 06/07/2023
+ms.date: 10/11/2023
 title: Everything you wanted to know about PSCustomObject
 ---
 # Everything you wanted to know about PSCustomObject
@@ -128,6 +128,10 @@ We can get this same list off of the `psobject` property too.
 ```powershell
 $myobject.psobject.properties.name
 ```
+
+> [!NOTE]
+> `Get-Member` returns the properties in alphabetical order. Using the member-access operator to
+> enumerate the property names returns the properties in the order they were defined on the object.
 
 ### Dynamically accessing properties
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the "Enumerating property names" section in _Everything you wanted to know about PSCustomObject_ didn't clarify that the results from using `Get-Member` and the member-access operator to enumerate property names differs.

`Get-Member` returns the properties in alphabetical order while member-access returns them in the order they were defined on the object.

This change:

- adds a note to clarify this difference.
- Resolves #10505
- Fixes [AB#169145](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/169145)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
