### PR TITLE
(AB-168938) Update Windows upgrade info

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-on-Windows.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-on-Windows.md
@@ -1,6 +1,6 @@
 ---
 description: Information about installing PowerShell on Windows
-ms.date: 09/26/2023
+ms.date: 10/11/2023
 title: Installing PowerShell on Windows
 ---
 # Installing PowerShell on Windows
@@ -227,10 +227,27 @@ release.
 ## Upgrading an existing installation
 
 For best results when upgrading, you should use the same install method you used when you first
-installed PowerShell. Each installation method installs PowerShell in a different location. If you
-aren't sure how PowerShell was installed, you can compare the installed location with the package
-information in this article. If you installed via the MSI package, that information appears in the
+installed PowerShell. If you aren't sure how PowerShell was installed, you can check the value of
+the `$PSHOME` variable, which always points to the directory containing PowerShell that the current
+session is running.
+
+- If the value is `$HOME\.dotnet\tools`, PowerShell was installed with the [.NET Global tool][15].
+- If the value is `$Env:ProgramFiles\PowerShell\7`, PowerShell was installed as an
+  [MSI package][16] or with [Winget][19] on a computer with an X86 or x64 processor.
+- If the value starts with `$Env:ProgramFiles\WindowsApps\`, PowerShell was installed as a
+  [Microsoft Store package][17] or with [Winget][19] on computer with an ARM processor.
+- If the value is anything else, it's likely that PowerShell was installed as a [ZIP package][20].
+
+If you installed via the MSI package, that information also appears in the
 **Programs and Features** Control Panel.
+
+To determine whether PowerShell may be upgraded with Winget, run the following command:
+
+```powershell
+winget list --name PowerShell --upgrade-available
+```
+
+If there is an available upgrade, the output indicates the latest available version.
 
 > [!NOTE]
 > When upgrading, PowerShell won't upgrade from an LTS version to a non-LTS version. It only


### PR DESCRIPTION
# PR Summary

Prior to this change, the upgrade instructions for Windows didn't help a user understand how to find where their install was located to determine which upgrade method to use.

This change:

- Adds information to help users understand which method  was used to install PowerShell
- Adds a note for how to determine if PowerShell may be upgraded with Winget
- Resolves [AB#168938](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/168938)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
