### PR TITLE
(AB-168933) Clarify Length and Count for PSCustomObject

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
@@ -1,7 +1,7 @@
 ---
 description: Explains the differences between the [psobject] and [pscustomobject] type accelerators.
 Locale: en-US
-ms.date: 12/05/2022
+ms.date: 10/11/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pscustomobject?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSCustomObject
@@ -219,7 +219,7 @@ have subtle side effects.
 ## Notes
 
 In Windows PowerShell, objects created by casting a **Hashtable** to
-`[pscustomobject]` do not have the **Length** or **Count** properties.
+`[pscustomobject]` don't have the **Length** or **Count** properties.
 Attempting to access these members returns `$null`.
 
 For example:
@@ -235,6 +235,10 @@ value
 PS> $object.Count
 PS> $object.Length
 ```
+
+Starting in PowerShell 6, objects created by casting a **Hashtable** to
+`[pscustomobject]` always have a value of `1` for the **Length** and **Count**
+properties.
 
 ## See also
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
@@ -1,7 +1,7 @@
 ---
 description: Explains the differences between the [psobject] and [pscustomobject] type accelerators.
 Locale: en-US
-ms.date: 12/05/2022
+ms.date: 10/11/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_PSCustomObject?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSCustomObject
@@ -214,7 +214,7 @@ have subtle side effects.
 ## Notes
 
 In Windows PowerShell, objects created by casting a **Hashtable** to
-`[pscustomobject]` do not have the **Length** or **Count** properties.
+`[pscustomobject]` don't have the **Length** or **Count** properties.
 Attempting to access these members returns `$null`.
 
 For example:
@@ -230,6 +230,10 @@ value
 PS> $object.Count
 PS> $object.Length
 ```
+
+Starting in PowerShell 6, objects created by casting a **Hashtable** to
+`[pscustomobject]` always have a value of `1` for the **Length** and **Count**
+properties.
 
 ## See also
 

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
@@ -1,7 +1,7 @@
 ---
 description: Explains the differences between the [psobject] and [pscustomobject] type accelerators.
 Locale: en-US
-ms.date: 12/05/2022
+ms.date: 10/11/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pscustomobject?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSCustomObject
@@ -214,7 +214,7 @@ have subtle side effects.
 ## Notes
 
 In Windows PowerShell, objects created by casting a **Hashtable** to
-`[pscustomobject]` do not have the **Length** or **Count** properties.
+`[pscustomobject]` don't have the **Length** or **Count** properties.
 Attempting to access these members returns `$null`.
 
 For example:
@@ -230,6 +230,10 @@ value
 PS> $object.Count
 PS> $object.Length
 ```
+
+Starting in PowerShell 6, objects created by casting a **Hashtable** to
+`[pscustomobject]` always have a value of `1` for the **Length** and **Count**
+properties.
 
 ## See also
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
@@ -1,7 +1,7 @@
 ---
 description: Explains the differences between the [psobject] and [pscustomobject] type accelerators.
 Locale: en-US
-ms.date: 12/05/2022
+ms.date: 10/11/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pscustomobject?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about PSCustomObject
@@ -214,7 +214,7 @@ have subtle side effects.
 ## Notes
 
 In Windows PowerShell, objects created by casting a **Hashtable** to
-`[pscustomobject]` do not have the **Length** or **Count** properties.
+`[pscustomobject]` don't have the **Length** or **Count** properties.
 Attempting to access these members returns `$null`.
 
 For example:
@@ -230,6 +230,10 @@ value
 PS> $object.Count
 PS> $object.Length
 ```
+
+Starting in PowerShell 6, objects created by casting a **Hashtable** to
+`[pscustomobject]` always have a value of `1` for the **Length** and **Count**
+properties.
 
 ## See also
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation note for the **Length** and **Count** properties of **PSCustomObjects** created by casting a hashtable indicated that, for Windows PowerShell, those properties don't exist on the object and accessing them returns `$null`.

However, in PowerShell, those members exist and return a value of `1`.

This change:

- Updates the note to indicate the changed behavior.
- Fixes [AB#168933](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/168933)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
