### PR TITLE
Corrects note about use of named blocks

### DIFF
--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -61,12 +61,11 @@ Function Test-ScriptCmdlet
 }
 ```
 
-> [!NOTE]
-> Using either a `begin` or `end` block requires that you define all three
-> blocks. When using any block, all PowerShell code must be inside one
-> of the blocks.
-
 PowerShell 7.3 adds a `clean` block process method.
+
+> [!NOTE]
+> Using any of the three named block above, or `dynamicparam` and `clean`,
+> requires that all code in a function must reside in a named block.
 
 ### `begin`
 


### PR DESCRIPTION
Removes incorrect assertion that functions must use `begin`, `process`, and `end` if any named block is used. 

This implies these blocks are required even if they are empty. Assertion is contradicted later in the document when discussing `process`.

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
