### PR TITLE
add hint about -InformationVariable for using tags

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Information.md
@@ -43,7 +43,7 @@ adding the **InformationAction** common parameter to your command. For more info
 [about_Preference_Variables](../Microsoft.PowerShell.Core/About/about_Preference_Variables.md) and
 [about_CommonParameters](../Microsoft.PowerShell.Core/About/about_CommonParameters.md).
 
-To make use of the `-Tag` parameter, you should also use the [common parameter](../Microsoft.PowerShell.Core/About/about_CommonParameters.md) `-InformationVariable`. 
+To make use of the `-Tag` parameter, you should also use the [common parameter](../Microsoft.PowerShell.Core/About/about_CommonParameters.md) `-InformationVariable`. Fore more information see [Information Stream](https://learn.microsoft.com/en-us/powershell/scripting/windows-powershell/wmf/whats-new/informationstream-overview).
 
 > [!NOTE]
 > Starting in Windows PowerShell 5.0, `Write-Host` is a wrapper for `Write-Information` This allows

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Information.md
@@ -43,6 +43,8 @@ adding the **InformationAction** common parameter to your command. For more info
 [about_Preference_Variables](../Microsoft.PowerShell.Core/About/about_Preference_Variables.md) and
 [about_CommonParameters](../Microsoft.PowerShell.Core/About/about_CommonParameters.md).
 
+To make use of the `-Tag` parameter, you should also use the [common parameter](../Microsoft.PowerShell.Core/About/about_CommonParameters.md) `-InformationVariable`. 
+
 > [!NOTE]
 > Starting in Windows PowerShell 5.0, `Write-Host` is a wrapper for `Write-Information` This allows
 > you to use `Write-Host` to emit output to the information stream. This enables the capture or


### PR DESCRIPTION
# PR Summary

Added a note regarding the usage of the common parameter `-InformationVariable` when using tagged `Write-Information`

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
