### PR TITLE
(GH-10458) Add note about `sudo` for `Test-Connection`

### DIFF
--- a/reference/7.4/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Test-Connection.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/01/2023
+ms.date: 10/25/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/test-connection?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Test-Connection
@@ -591,6 +591,11 @@ When you use the **Detailed** parameter, this cmdlet returns a
 **TestConnectionCommand+TcpPortStatus** object that shows the status of the TCP connection.
 
 ## NOTES
+
+On Linux, using the **BufferSize** parameter or any combination of parameters with the
+**MtuSizeDetect** parameter set that results in a non-default buffer size of 32 bytes may require
+`sudo`. In those cases, `Test-Command` raises an exception with a message indicating that `sudo` is
+required.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
# PR Summary

This change adds a note to the `Test-Connection` reference documentation about requiring `sudo` for non-standard buffer sizes.

- Resolves #10458

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
