### PR TITLE
(GH-10487) Update `New-FileCatalog`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Security/New-FileCatalog.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/New-FileCatalog.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Security.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Security
-ms.date: 10/23/2023
+ms.date: 10/25/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.security/new-filecatalog?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-FileCatalog
@@ -36,7 +36,12 @@ create file hashes, and version 2 uses SHA256.
 ### Example 1: Create a file catalog for `Microsoft.PowerShell.Utility`
 
 ```powershell
-New-FileCatalog -Path $PSHOME\Modules\Microsoft.PowerShell.Utility -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -CatalogVersion 2.0
+$parameters = @{
+    Path            = "$PSHOME\Modules\Microsoft.PowerShell.Utility"
+    CatalogFilePath = "\temp\Microsoft.PowerShell.Utility.cat"
+    CatalogVersion  = 2
+}
+New-FileCatalog @parameters
 ```
 
 ```Output
@@ -66,9 +71,9 @@ Accept wildcard characters: False
 
 ### -CatalogVersion
 
-Accepts `1.0` or `2.0` as possible values for specifying the catalog version. `1.0` should be used
-avoided whenever possible, as it uses the insecure SHA-1 hash algorithm, while `2.0` uses the secure
-SHA-256 algorithm However, `1.0` is the only supported algorithm on Windows 7 and Server 2008R2.
+Accepts `1` or `2` as possible values for specifying the catalog version. `1` should be avoided
+whenever possible, as it uses the insecure SHA-1 hash algorithm, while `2` uses the secure SHA-256
+algorithm.
 
 ```yaml
 Type: System.Int32
@@ -84,8 +89,8 @@ Accept wildcard characters: False
 
 ### -Path
 
-Accepts a path or array of paths to files or folders that should be included in the catalog file. If
-a folder is specified, all the files in the folder will be included as well.
+Accepts a path or array of paths to files or folders to include in the catalog file. If
+this value is a folder, the catalog also includes all files in the folder.
 
 ```yaml
 Type: System.String[]
@@ -117,7 +122,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -142,7 +147,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-You can pipe a string that is used as the catalog filename to this cmdlet.
+You can pipe a string that's used as the catalog filename to this cmdlet.
 
 ## OUTPUTS
 

--- a/reference/7.2/Microsoft.PowerShell.Security/New-FileCatalog.md
+++ b/reference/7.2/Microsoft.PowerShell.Security/New-FileCatalog.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Security.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Security
-ms.date: 10/23/2023
+ms.date: 10/25/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.security/new-filecatalog?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-FileCatalog
@@ -38,7 +38,12 @@ create file hashes, and version 2 uses SHA256.
 ### Example 1: Create a file catalog for `Microsoft.PowerShell.Utility`
 
 ```powershell
-New-FileCatalog -Path $PSHOME\Modules\Microsoft.PowerShell.Utility -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -CatalogVersion 2.0
+$parameters = @{
+    Path            = "$PSHOME\Modules\Microsoft.PowerShell.Utility"
+    CatalogFilePath = "\temp\Microsoft.PowerShell.Utility.cat"
+    CatalogVersion  = 2
+}
+New-FileCatalog @parameters
 ```
 
 ```Output
@@ -51,8 +56,8 @@ Mode                LastWriteTime         Length Name
 
 ### -CatalogFilePath
 
-A path to a file or folder where the catalog file (.cat) should be placed. If a folder path is
-specified, the default filename `catalog.cat` will be used.
+A path to a file or folder where the catalog file (`.cat`) should be placed. If a folder path is
+specified, created catalog has the default filename `catalog.cat`.
 
 ```yaml
 Type: System.String
@@ -68,9 +73,9 @@ Accept wildcard characters: False
 
 ### -CatalogVersion
 
-Accepts `1.0` or `2.0` as possible values for specifying the catalog version. `1.0` should be used
-avoided whenever possible, as it uses the insecure SHA-1 hash algorithm, while `2.0` uses the secure
-SHA-256 algorithm However, `1.0` is the only supported algorithm on Windows 7 and Server 2008R2.
+Accepts `1` or `2` as possible values for specifying the catalog version. `1` should be avoided
+whenever possible, as it uses the insecure SHA-1 hash algorithm, while `2` uses the secure SHA-256
+algorithm.
 
 ```yaml
 Type: System.Int32
@@ -86,8 +91,8 @@ Accept wildcard characters: False
 
 ### -Path
 
-Accepts a path or array of paths to files or folders that should be included in the catalog file. If
-a folder is specified, all the files in the folder will be included as well.
+Accepts a path or array of paths to files or folders to include in the catalog file. If
+this value is a folder, the catalog also includes all files in the folder.
 
 ```yaml
 Type: System.String[]
@@ -119,7 +124,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -144,7 +149,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-You can pipe a string that is used as the catalog filename to this cmdlet.
+You can pipe a string that's used as the catalog filename to this cmdlet.
 
 ## OUTPUTS
 

--- a/reference/7.3/Microsoft.PowerShell.Security/New-FileCatalog.md
+++ b/reference/7.3/Microsoft.PowerShell.Security/New-FileCatalog.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Security.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Security
-ms.date: 10/23/2023
+ms.date: 10/25/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.security/new-filecatalog?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-FileCatalog
@@ -38,7 +38,12 @@ create file hashes, and version 2 uses SHA256.
 ### Example 1: Create a file catalog for `Microsoft.PowerShell.Utility`
 
 ```powershell
-New-FileCatalog -Path $PSHOME\Modules\Microsoft.PowerShell.Utility -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -CatalogVersion 2.0
+$parameters = @{
+    Path            = "$PSHOME\Modules\Microsoft.PowerShell.Utility"
+    CatalogFilePath = "\temp\Microsoft.PowerShell.Utility.cat"
+    CatalogVersion  = 2
+}
+New-FileCatalog @parameters
 ```
 
 ```Output
@@ -51,8 +56,8 @@ Mode                LastWriteTime         Length Name
 
 ### -CatalogFilePath
 
-A path to a file or folder where the catalog file (.cat) should be placed. If a folder path is
-specified, the default filename `catalog.cat` will be used.
+A path to a file or folder where the catalog file (`.cat`) should be placed. If a folder path is
+specified, created catalog has the default filename `catalog.cat`.
 
 ```yaml
 Type: System.String
@@ -68,9 +73,9 @@ Accept wildcard characters: False
 
 ### -CatalogVersion
 
-Accepts `1.0` or `2.0` as possible values for specifying the catalog version. `1.0` should be used
-avoided whenever possible, as it uses the insecure SHA-1 hash algorithm, while `2.0` uses the secure
-SHA-256 algorithm However, `1.0` is the only supported algorithm on Windows 7 and Server 2008R2.
+Accepts `1` or `2` as possible values for specifying the catalog version. `1` should be avoided
+whenever possible, as it uses the insecure SHA-1 hash algorithm, while `2` uses the secure SHA-256
+algorithm.
 
 ```yaml
 Type: System.Int32
@@ -86,8 +91,8 @@ Accept wildcard characters: False
 
 ### -Path
 
-Accepts a path or array of paths to files or folders that should be included in the catalog file. If
-a folder is specified, all the files in the folder will be included as well.
+Accepts a path or array of paths to files or folders to include in the catalog file. If
+this value is a folder, the catalog also includes all files in the folder.
 
 ```yaml
 Type: System.String[]
@@ -119,7 +124,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -144,7 +149,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-You can pipe a string that is used as the catalog filename to this cmdlet.
+You can pipe a string that's used as the catalog filename to this cmdlet.
 
 ## OUTPUTS
 

--- a/reference/7.4/Microsoft.PowerShell.Security/New-FileCatalog.md
+++ b/reference/7.4/Microsoft.PowerShell.Security/New-FileCatalog.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Security.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Security
-ms.date: 10/23/2023
+ms.date: 10/25/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.security/new-filecatalog?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-FileCatalog
@@ -38,7 +38,12 @@ create file hashes, and version 2 uses SHA256.
 ### Example 1: Create a file catalog for `Microsoft.PowerShell.Utility`
 
 ```powershell
-New-FileCatalog -Path $PSHOME\Modules\Microsoft.PowerShell.Utility -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -CatalogVersion 2.0
+$parameters = @{
+    Path            = "$PSHOME\Modules\Microsoft.PowerShell.Utility"
+    CatalogFilePath = "\temp\Microsoft.PowerShell.Utility.cat"
+    CatalogVersion  = 2
+}
+New-FileCatalog @parameters
 ```
 
 ```Output
@@ -51,8 +56,8 @@ Mode                LastWriteTime         Length Name
 
 ### -CatalogFilePath
 
-A path to a file or folder where the catalog file (.cat) should be placed. If a folder path is
-specified, the default filename `catalog.cat` will be used.
+A path to a file or folder where the catalog file (`.cat`) should be placed. If a folder path is
+specified, created catalog has the default filename `catalog.cat`.
 
 ```yaml
 Type: System.String
@@ -68,9 +73,9 @@ Accept wildcard characters: False
 
 ### -CatalogVersion
 
-Accepts `1.0` or `2.0` as possible values for specifying the catalog version. `1.0` should be used
-avoided whenever possible, as it uses the insecure SHA-1 hash algorithm, while `2.0` uses the secure
-SHA-256 algorithm However, `1.0` is the only supported algorithm on Windows 7 and Server 2008R2.
+Accepts `1` or `2` as possible values for specifying the catalog version. `1` should be avoided
+whenever possible, as it uses the insecure SHA-1 hash algorithm, while `2` uses the secure SHA-256
+algorithm. Starting in PowerShell 7.4, `2` is the default value.
 
 ```yaml
 Type: System.Int32
@@ -79,15 +84,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 2
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Path
 
-Accepts a path or array of paths to files or folders that should be included in the catalog file. If
-a folder is specified, all the files in the folder will be included as well.
+Accepts a path or array of paths to files or folders to include in the catalog file. If
+this value is a folder, the catalog also includes all files in the folder.
 
 ```yaml
 Type: System.String[]
@@ -119,7 +124,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet isn't run.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -144,7 +149,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-You can pipe a string that is used as the catalog filename to this cmdlet.
+You can pipe a string that's used as the catalog filename to this cmdlet.
 
 ## OUTPUTS
 


### PR DESCRIPTION
# PR Summary

This change:

- Updates the reference documentation for the `New-FileCatalog` cmdlet to reflect the new default value for **CatalogVersion** in 7.4.
- Makes minor fixes to grammar, syntax, and style across the versions.
- Resolves #10487

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
