### PR TITLE
(GH-10592) Clarify culture impact for comparison operators

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 08/17/2023
+ms.date: 10/30/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -61,7 +61,9 @@ To make the case-insensitivity explicit, add an `i` after `-`. For example,
 `-ieq` is the explicitly case-insensitive version of `-eq`.
 
 String comparisons use the [InvariantCulture][01] for both case-sensitive and
-case-insensitive comparisons.
+case-insensitive comparisons. The comparisons are between unicode code points
+and don't use culture-specific collation ordering. The results are the same
+regardless of the current culture.
 
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 08/17/2023
+ms.date: 10/30/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -61,7 +61,9 @@ To make the case-insensitivity explicit, add an `i` after `-`. For example,
 `-ieq` is the explicitly case-insensitive version of `-eq`.
 
 String comparisons use the [InvariantCulture][01] for both case-sensitive and
-case-insensitive comparisons.
+case-insensitive comparisons. The comparisons are between unicode code points
+and don't use culture-specific collation ordering. The results are the same
+regardless of the current culture.
 
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 08/17/2023
+ms.date: 10/30/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -61,7 +61,9 @@ To make the case-insensitivity explicit, add an `i` after `-`. For example,
 `-ieq` is the explicitly case-insensitive version of `-eq`.
 
 String comparisons use the [InvariantCulture][01] for both case-sensitive and
-case-insensitive comparisons.
+case-insensitive comparisons. The comparisons are between unicode code points
+and don't use culture-specific collation ordering. The results are the same
+regardless of the current culture.
 
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 08/17/2023
+ms.date: 10/30/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Comparison Operators
@@ -61,7 +61,9 @@ To make the case-insensitivity explicit, add an `i` after `-`. For example,
 `-ieq` is the explicitly case-insensitive version of `-eq`.
 
 String comparisons use the [InvariantCulture][01] for both case-sensitive and
-case-insensitive comparisons.
+case-insensitive comparisons. The comparisons are between unicode code points
+and don't use culture-specific collation ordering. The results are the same
+regardless of the current culture.
 
 When the input of an operator is a scalar value, the operator returns a
 **Boolean** value. When the input is a collection, the operator returns the


### PR DESCRIPTION
# PR Summary
Prior to this change, the _about_Comparison_Operators_ article noted that the comparisons use InvariantCulture, but not how that affects the expected output for the comparisons.

This change:

- Extends the explanation, clarifying that the results are the same regardless of current culture
- Resolves #10592
- Fixes AB#176660

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
