### PR TITLE
Added missing parenthesis in about_Arithmetic_Operators.md

### DIFF
--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -178,7 +178,7 @@ PS> [int]( 7 / 2 )  # Result is rounded up
 You can use the `[Math]` class to get different rounding behavior.
 
 ```powershell
-PS> [int][Math]::Round(5 / 2,[MidpointRounding]::AwayFromZero
+PS> [int][Math]::Round(5 / 2,[MidpointRounding]::AwayFromZero)
 3
 
 PS> [int][Math]::Ceiling(5 / 2)


### PR DESCRIPTION
# PR Summary

This change fixes the missing parenthesis at the end of the first line in the [Math] class example in the **Division and rounding** section.


## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
