### PR TITLE
Fix `Add-Member` examples

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Add-Member.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/14/2023
+ms.date: 11/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/add-member?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Add-Member
@@ -165,11 +165,12 @@ $A.SizeInMB()
 
 This example creates an **Asset** custom object.
 
-The `New-Object` cmdlet creates a **PSObject** that is saved in the `$Asset` variable. Piping
-`$Asset` to `Add-Member` adds the key-value pair to the object as a **NoteProperty** member. The
-**TypeName** parameter assigns the type `Asset` to the **PSObject**. The `Get-Member` cmdlet shows
-the type and properties of the object. However, the properties are listed in alphabetical order, not
-in the order that they were added.
+The `New-Object` cmdlet creates a **PSObject** that's saved in the `$Asset` variable. The
+`[ordered]` type accelerator creates an ordered dictionary that's stored in the `$d` variable.
+Piping `$Asset` to `Add-Member` adds the key-value pairs in the dictionary to the object as
+**NoteProperty** members. **TypeName** parameter assigns the type `Asset` to the **PSObject**. The
+`Get-Member` cmdlet shows the type and properties of the object. However, the properties are listed
+in alphabetical order, not in the order that they were added.
 
 ```powershell
 $Asset = New-Object -TypeName PSObject
@@ -201,7 +202,7 @@ System    NoteProperty System.String   Server Core
 PSVersion NoteProperty System.String   4.0
 ```
 
-Inspecting the the raw list of properties shows the properties in the order that they were added to
+Inspecting the raw list of properties shows the properties in the order that they were added to
 the object. `Format-Table` is used in this example to create output similar to `Get-Member`.
 
 ### Example 6: Add an AliasProperty to an object
@@ -211,16 +212,13 @@ In this example we create a custom object that contains two **NoteProperty** mem
 property is a string.
 
 ```powershell
-$obj = [pscustomobject]@{
+PS> $obj = [pscustomobject]@{
       Name = 'Doris'
       Age = '20'
 }
-$obj | Add-Member -MemberType AliasProperty -Name 'intAge' -Value age -SecondValue uint32
-$obj | Get-Member
-$obj
-```
+PS> $obj | Add-Member -MemberType AliasProperty -Name 'intAge' -Value age -SecondValue uint32
+PS> $obj | Get-Member
 
-```Output
    TypeName: System.Management.Automation.PSCustomObject
 
 Name        MemberType    Definition
@@ -233,18 +231,18 @@ ToString    Method        string ToString()
 Age         NoteProperty  string Age=20
 Name        NoteProperty  string Name=Doris
 
+PS> $obj
+
 Name   : Doris
 Age    : 20
 intAge : 20
-```
 
-```powershell
-$obj.Age + 1
-$obj.intAge + 1
-```
+PS> $obj.Age + 1
 
-```Output
 201
+
+PS> $obj.intAge + 1
+
 21
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Add-Member.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/14/2023
+ms.date: 11/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/add-member?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Add-Member
@@ -130,7 +130,7 @@ note property value, **Display**.
 
 ```powershell
 $A = "A string"
-$A | Add-Member -NotePropertyMembers @{StringUse="Display"}
+$A = $A | Add-Member -NotePropertyMembers @{StringUse="Display"} -PassThru
 $A.StringUse
 ```
 
@@ -165,8 +165,8 @@ $A.SizeInMB()
 
 This example creates an **Asset** custom object.
 
-The `New-Object` cmdlet creates a **PSObject** that is saved in the `$Asset` variable. The
-`[ordered]` type accelerator creates an ordered dictionary that is stored in the `$d` variable.
+The `New-Object` cmdlet creates a **PSObject** that's saved in the `$Asset` variable. The
+`[ordered]` type accelerator creates an ordered dictionary that's stored in the `$d` variable.
 Piping `$Asset` to `Add-Member` adds the key-value pairs in the dictionary to the object as
 **NoteProperty** members. **TypeName** parameter assigns the type `Asset` to the **PSObject**. The
 `Get-Member` cmdlet shows the type and properties of the object. However, the properties are listed
@@ -201,7 +201,7 @@ System    NoteProperty System.String   Server Core
 PSVersion NoteProperty System.String   4.0
 ```
 
-Inspecting the the raw list of properties shows the properties in the order that they were added to
+Inspecting the raw list of properties shows the properties in the order that they were added to
 the object. `Format-Table` is used in this example to create output similar to `Get-Member`.
 
 ### Example 6: Add an AliasProperty to an object
@@ -211,16 +211,13 @@ In this example we create a custom object that contains two **NoteProperty** mem
 property is a string.
 
 ```powershell
-$obj = [pscustomobject]@{
+PS> $obj = [pscustomobject]@{
       Name = 'Doris'
       Age = '20'
 }
-$obj | Add-Member -MemberType AliasProperty -Name 'intAge' -Value age -SecondValue uint32
-$obj | Get-Member
-$obj
-```
+PS> $obj | Add-Member -MemberType AliasProperty -Name 'intAge' -Value age -SecondValue uint32
+PS> $obj | Get-Member
 
-```Output
    TypeName: System.Management.Automation.PSCustomObject
 
 Name        MemberType    Definition
@@ -233,18 +230,18 @@ ToString    Method        string ToString()
 Age         NoteProperty  string Age=20
 Name        NoteProperty  string Name=Doris
 
-Name   : Doris
-Age    : 20
-intAge : 20
-```
+PS> $obj
 
-```powershell
-$obj.Age + 1
-$obj.intAge + 1
-```
+Name  Age intAge
+----  --- ------
+Doris 20      20
 
-```Output
+PS> $obj.Age + 1
+
 201
+
+PS> $obj.intAge + 1
+
 21
 ```
 

--- a/reference/7.3/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Add-Member.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/14/2023
+ms.date: 11/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/add-member?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Add-Member
@@ -130,7 +130,7 @@ note property value, **Display**.
 
 ```powershell
 $A = "A string"
-$A | Add-Member -NotePropertyMembers @{StringUse="Display"}
+$A = $A | Add-Member -NotePropertyMembers @{StringUse="Display"} -PassThru
 $A.StringUse
 ```
 
@@ -165,8 +165,8 @@ $A.SizeInMB()
 
 This example creates an **Asset** custom object.
 
-The `New-Object` cmdlet creates a **PSObject** that is saved in the `$Asset` variable. The
-`[ordered]` type accelerator creates an ordered dictionary that is stored in the `$d` variable.
+The `New-Object` cmdlet creates a **PSObject** that's saved in the `$Asset` variable. The
+`[ordered]` type accelerator creates an ordered dictionary that's stored in the `$d` variable.
 Piping `$Asset` to `Add-Member` adds the key-value pairs in the dictionary to the object as
 **NoteProperty** members. **TypeName** parameter assigns the type `Asset` to the **PSObject**. The
 `Get-Member` cmdlet shows the type and properties of the object. However, the properties are listed
@@ -201,7 +201,7 @@ System    NoteProperty System.String   Server Core
 PSVersion NoteProperty System.String   4.0
 ```
 
-Inspecting the the raw list of properties shows the properties in the order that they were added to
+Inspecting the raw list of properties shows the properties in the order that they were added to
 the object. `Format-Table` is used in this example to create output similar to `Get-Member`.
 
 ### Example 6: Add an AliasProperty to an object
@@ -211,16 +211,13 @@ In this example we create a custom object that contains two **NoteProperty** mem
 property is a string.
 
 ```powershell
-$obj = [pscustomobject]@{
+PS> $obj = [pscustomobject]@{
       Name = 'Doris'
       Age = '20'
 }
-$obj | Add-Member -MemberType AliasProperty -Name 'intAge' -Value age -SecondValue uint32
-$obj | Get-Member
-$obj
-```
+PS> $obj | Add-Member -MemberType AliasProperty -Name 'intAge' -Value age -SecondValue uint32
+PS> $obj | Get-Member
 
-```Output
    TypeName: System.Management.Automation.PSCustomObject
 
 Name        MemberType    Definition
@@ -233,18 +230,18 @@ ToString    Method        string ToString()
 Age         NoteProperty  string Age=20
 Name        NoteProperty  string Name=Doris
 
-Name   : Doris
-Age    : 20
-intAge : 20
-```
+PS> $obj
 
-```powershell
-$obj.Age + 1
-$obj.intAge + 1
-```
+Name  Age intAge
+----  --- ------
+Doris 20      20
 
-```Output
+PS> $obj.Age + 1
+
 201
+
+PS> $obj.intAge + 1
+
 21
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Add-Member.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/14/2023
+ms.date: 11/15/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/add-member?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Add-Member
@@ -130,7 +130,7 @@ note property value, **Display**.
 
 ```powershell
 $A = "A string"
-$A | Add-Member -NotePropertyMembers @{StringUse="Display"}
+$A = $A | Add-Member -NotePropertyMembers @{StringUse="Display"} -PassThru
 $A.StringUse
 ```
 
@@ -165,8 +165,8 @@ $A.SizeInMB()
 
 This example creates an **Asset** custom object.
 
-The `New-Object` cmdlet creates a **PSObject** that is saved in the `$Asset` variable. The
-`[ordered]` type accelerator creates an ordered dictionary that is stored in the `$d` variable.
+The `New-Object` cmdlet creates a **PSObject** that's saved in the `$Asset` variable. The
+`[ordered]` type accelerator creates an ordered dictionary that's stored in the `$d` variable.
 Piping `$Asset` to `Add-Member` adds the key-value pairs in the dictionary to the object as
 **NoteProperty** members. **TypeName** parameter assigns the type `Asset` to the **PSObject**. The
 `Get-Member` cmdlet shows the type and properties of the object. However, the properties are listed
@@ -201,7 +201,7 @@ System    NoteProperty System.String   Server Core
 PSVersion NoteProperty System.String   4.0
 ```
 
-Inspecting the the raw list of properties shows the properties in the order that they were added to
+Inspecting the raw list of properties shows the properties in the order that they were added to
 the object. `Format-Table` is used in this example to create output similar to `Get-Member`.
 
 ### Example 6: Add an AliasProperty to an object
@@ -211,16 +211,13 @@ In this example we create a custom object that contains two **NoteProperty** mem
 property is a string.
 
 ```powershell
-$obj = [pscustomobject]@{
+PS> $obj = [pscustomobject]@{
       Name = 'Doris'
       Age = '20'
 }
-$obj | Add-Member -MemberType AliasProperty -Name 'intAge' -Value age -SecondValue uint32
-$obj | Get-Member
-$obj
-```
+PS> $obj | Add-Member -MemberType AliasProperty -Name 'intAge' -Value age -SecondValue uint32
+PS> $obj | Get-Member
 
-```Output
    TypeName: System.Management.Automation.PSCustomObject
 
 Name        MemberType    Definition
@@ -233,18 +230,18 @@ ToString    Method        string ToString()
 Age         NoteProperty  string Age=20
 Name        NoteProperty  string Name=Doris
 
-Name   : Doris
-Age    : 20
-intAge : 20
-```
+PS> $obj
 
-```powershell
-$obj.Age + 1
-$obj.intAge + 1
-```
+Name  Age intAge
+----  --- ------
+Doris 20      20
 
-```Output
+PS> $obj.Age + 1
+
 201
+
+PS> $obj.intAge + 1
+
 21
 ```
 


### PR DESCRIPTION
# PR Summary

Prior to this change, Example 3 in the 7x documentation for `Add-Member` was incorrect. Example 6 across all versions rendered incorrectly.

This change:

- Fixes #10633 by correcting the example
- Fixes #10634 by turning the example code blocks into a single demonstrative block.
- Fixes Vale linting errors.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
