### PR TITLE
Fix issues in `*-Object` documentation

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 05/08/2023
+ms.date: 11/16/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/where-object?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Where-Object
@@ -259,9 +259,9 @@ command.
   For example, the following commands also get processes that have a priority class of `Normal`.
   These commands are equivalent and you can use them interchangeably.
 
-  `Get-Process | Where-Object -Property PriorityClass -eq -Value "Normal"`
+  `Get-Process | Where-Object -Property PriorityClass -EQ -Value "Normal"`
 
-  `Get-Process | Where-Object PriorityClass -eq "Normal"`
+  `Get-Process | Where-Object PriorityClass -EQ "Normal"`
 
   Starting in Windows PowerShell 3.0, `Where-Object` adds comparison operators as parameters in a
   `Where-Object` command. Unless specified, all operators are case-insensitive. Before Windows
@@ -293,7 +293,7 @@ is different.
 
 ```powershell
 Get-Service | Where-Object { $_.Status -eq "Stopped" }
-Get-Service | where Status -eq "Stopped"
+Get-Service | Where-Object Status -EQ "Stopped"
 ```
 
 ### Example 2: Get processes based on working set
@@ -351,32 +351,32 @@ different.
 # Use Where-Object to get commands that have any value for the OutputType
 # property of the command. This omits commands that do not have an OutputType
 # property and those that have an OutputType property, but no property value.
-Get-Command | where OutputType
-Get-Command | where { $_.OutputType }
+Get-Command | Where-Object OutputType
+Get-Command | Where-Object { $_.OutputType }
 ```
 
 ```powershell
 # Use Where-Object to get objects that are containers. This gets objects that
 # have the **PSIsContainer** property with a value of $True and excludes all
 # others.
-Get-ChildItem | where PSIsContainer
-Get-ChildItem | where { $_.PSIsContainer }
+Get-ChildItem | Where-Object PSIsContainer
+Get-ChildItem | Where-Object { $_.PSIsContainer }
 ```
 
 ```powershell
 # Finally, use the -not operator (!) to get objects that are not containers.
 # This gets objects that do have the **PSIsContainer** property and those
 # that have a value of $False for the **PSIsContainer** property.
-Get-ChildItem | where { !$_.PSIsContainer }
+Get-ChildItem | Where-Object { !$_.PSIsContainer }
 # You cannot use the -not operator (!) in the comparison statement format
 # of the command.
-Get-ChildItem | where PSIsContainer -eq $False
+Get-ChildItem | Where-Object PSIsContainer -eq $False
 ```
 
 ### Example 6: Use multiple conditions
 
 ```powershell
-Get-Module -ListAvailable | where {
+Get-Module -ListAvailable | Where-Object {
     ($_.Name -notlike "Microsoft*" -and $_.Name -notlike "PS*") -and $_.HelpInfoUri
 }
 ```
@@ -406,7 +406,7 @@ The example uses the script block command format. Logical operators, such as `-a
 Indicates that this cmdlet gets objects from a collection if the property value of the object is an
 exact match for the specified value. This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CContains "svchost"`
+For example: `Get-Process | Where-Object ProcessName -CContains "svchost"`
 
 **CContains** refers to a collection of values and is true if the collection contains an item that
 is an exact match for the specified value. If the input is a single object, PowerShell converts it
@@ -488,7 +488,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value includes the specified value. This
 operation is case-sensitive.
 
-For example: `Get-Process | where -Value "svchost" -CIn ProcessName`
+For example: `Get-Process | Where-Object -Value "svchost" -CIn ProcessName`
 
 **CIn** resembles **CContains**, except that the property and value positions are reversed. For
 example, the following statements are both true.
@@ -535,7 +535,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value matches a value that includes wildcard
 characters (`*`). This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CLike "*host"`
+For example: `Get-Process | Where-Object ProcessName -CLike "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -576,7 +576,7 @@ Indicates that this cmdlet gets objects if the property value matches the specif
 expression. This operation is case-sensitive. When the input is a single object, the matched value
 is saved in the `$Matches` automatic variable.
 
-For example: `Get-Process | where ProcessName -CMatch "Shell"`
+For example: `Get-Process | Where-Object ProcessName -CMatch "Shell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -616,7 +616,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value of the object isn't an exact match
 for the specified value. This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CNotContains "svchost"`
+For example: `Get-Process | Where-Object ProcessName -CNotContains "svchost"`
 
 **NotContains** and **CNotContains** refer to a collection of values and are true when the
 collection doesn't contain any items that are an exact match for the specified value. If the input
@@ -641,7 +641,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value isn't an exact match for the
 specified value. This operation is case-sensitive.
 
-For example: `Get-Process | where -Value "svchost" -CNotIn -Property ProcessName`
+For example: `Get-Process | Where-Object -Value "svchost" -CNotIn -Property ProcessName`
 
 **NotIn** and **CNotIn** operators resemble **NotContains** and **CNotContains**, except that the
 property and value positions are reversed. For example, the following statements are true.
@@ -667,7 +667,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters. This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CNotLike "*host"`
+For example: `Get-Process | Where-Object ProcessName -CNotLike "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -689,7 +689,7 @@ Indicates that this cmdlet gets objects if the property value doesn't match the 
 expression. This operation is case-sensitive. When the input is a single object, the matched value
 is saved in the `$Matches` automatic variable.
 
-For example: `Get-Process | where ProcessName -CNotMatch "Shell"`
+For example: `Get-Process | Where-Object ProcessName -CNotMatch "Shell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -710,7 +710,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if any item in the property value of the object is an exact
 match for the specified value.
 
-For example: `Get-Process | where ProcessName -Contains "Svchost"`
+For example: `Get-Process | Where-Object ProcessName -Contains "Svchost"`
 
 If the input is a single object, PowerShell converts it to a collection of one object.
 
@@ -807,7 +807,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value matches any of the specified values.
 For example:
 
-`Get-Process | where -Property ProcessName -in -Value "Svchost", "TaskHost", "WsmProvHost"`
+`Get-Process | Where-Object -Property ProcessName -in -Value "Svchost", "TaskHost", "WsmProvHost"`
 
 If the input is a single object, PowerShell converts it to a collection of one object.
 
@@ -859,7 +859,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value is an instance of the specified .NET
 type. Enclose the type name in square brackets.
 
-For example, `Get-Process | where StartTime -Is [DateTime]`
+For example, `Get-Process | Where-Object StartTime -Is [DateTime]`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -920,7 +920,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value matches a value that includes wildcard
 characters (`*`).
 
-For example: `Get-Process | where ProcessName -Like "*host"`
+For example: `Get-Process | Where-Object ProcessName -Like "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -960,7 +960,7 @@ Indicates that this cmdlet gets objects if the property value matches the specif
 expression. When the input is a single object, the matched value is saved in the `$Matches`
 automatic variable.
 
-For example: `Get-Process | where ProcessName -Match "shell"`
+For example: `Get-Process | Where-Object ProcessName -Match "shell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -999,7 +999,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if none of the items in the property value is an exact match
 for the specified value.
 
-For example: `Get-Process | where ProcessName -NotContains "Svchost"`
+For example: `Get-Process | Where-Object ProcessName -NotContains "Svchost"`
 
 **NotContains** refers to a collection of values and is true if the collection doesn't contain any
 items that are an exact match for the specified value. If the input is a single object, PowerShell
@@ -1024,7 +1024,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value isn't an exact match for any of the
 specified values.
 
-For example: `Get-Process | where -Value "svchost" -NotIn -Property ProcessName`
+For example: `Get-Process | Where-Object -Value "svchost" -NotIn -Property ProcessName`
 
 If the value of **Value** is a single object, PowerShell converts it to a collection of one object.
 
@@ -1051,7 +1051,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters (`*`).
 
-For example: `Get-Process | where ProcessName -NotLike "*host"`
+For example: `Get-Process | Where-Object ProcessName -NotLike "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -1073,7 +1073,7 @@ Indicates that this cmdlet gets objects when the property value doesn't match th
 expression. When the input is a single object, the matched value is saved in the `$Matches`
 automatic variable.
 
-For example: `Get-Process | where ProcessName -NotMatch "PowerShell"`
+For example: `Get-Process | Where-Object ProcessName -NotMatch "PowerShell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/7.2/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 04/21/2023
+ms.date: 11/16/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -31,8 +31,8 @@ ForEach-Object [-InputObject <PSObject>] [-MemberName] <String> [-ArgumentList <
 ### ParallelParameterSet
 
 ```
-ForEach-Object [-InputObject <PSObject>] -Parallel <ScriptBlock> [-ThrottleLimit <Int32>]
- [-TimeoutSeconds <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+ForEach-Object -Parallel <scriptblock> [-InputObject <psobject>] [-ThrottleLimit <int>]
+ [-TimeoutSeconds <int>] [-AsJob] [-UseNewRunspace] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -867,7 +867,7 @@ Using `ForEach-Object -Parallel`:
   > thread to each running script block thread. Since the script blocks run in different threads,
   > the object variables passed by reference must be used safely. Generally it's safe to read from
   > referenced objects that don't change. But if the object state is being modified then you must
-  > used thread safe objects, such as .NET **System.Collection.Concurrent** types (See Example 11).
+  > used thread safe objects, such as .NET **System.Collection.Concurrent** types (See Example 14).
 
 ## RELATED LINKS
 

--- a/reference/7.2/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/Where-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 05/08/2023
+ms.date: 11/16/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/where-object?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Where-Object
@@ -266,9 +266,9 @@ command.
   For example, the following commands also get processes that have a priority class of `Normal`.
   These commands are equivalent and you can use them interchangeably.
 
-  `Get-Process | Where-Object -Property PriorityClass -eq -Value "Normal"`
+  `Get-Process | Where-Object -Property PriorityClass -EQ -Value "Normal"`
 
-  `Get-Process | Where-Object PriorityClass -eq "Normal"`
+  `Get-Process | Where-Object PriorityClass -EQ "Normal"`
 
   Starting in Windows PowerShell 3.0, `Where-Object` adds comparison operators as parameters in a
   `Where-Object` command. Unless specified, all operators are case-insensitive. Before Windows
@@ -300,7 +300,7 @@ is different.
 
 ```powershell
 Get-Service | Where-Object { $_.Status -eq "Stopped" }
-Get-Service | where Status -eq "Stopped"
+Get-Service | Where-Object Status -EQ "Stopped"
 ```
 
 ### Example 2: Get processes based on working set
@@ -358,30 +358,30 @@ different.
 # Use Where-Object to get commands that have any value for the OutputType
 # property of the command. This omits commands that do not have an OutputType
 # property and those that have an OutputType property, but no property value.
-Get-Command | where OutputType
-Get-Command | where { $_.OutputType }
+Get-Command | Where-Object OutputType
+Get-Command | Where-Object { $_.OutputType }
 ```
 
 ```powershell
 # Use Where-Object to get objects that are containers. This gets objects that
 # have the **PSIsContainer** property with a value of $True and excludes all
 # others.
-Get-ChildItem | where PSIsContainer
-Get-ChildItem | where { $_.PSIsContainer }
+Get-ChildItem | Where-Object PSIsContainer
+Get-ChildItem | Where-Object { $_.PSIsContainer }
 ```
 
 ```powershell
 # Finally, use the -not operator (!) to get objects that are not containers.
 # This gets objects that do have the **PSIsContainer** property and those
 # that have a value of $False for the **PSIsContainer** property.
-Get-ChildItem | where -Not PSIsContainer
-Get-ChildItem | where { !$_.PSIsContainer }
+Get-ChildItem | Where-Object -Not PSIsContainer
+Get-ChildItem | Where-Object { !$_.PSIsContainer }
 ```
 
 ### Example 6: Use multiple conditions
 
 ```powershell
-Get-Module -ListAvailable | where {
+Get-Module -ListAvailable | Where-Object {
     ($_.Name -notlike "Microsoft*" -and $_.Name -notlike "PS*") -and $_.HelpInfoUri
 }
 ```
@@ -411,7 +411,7 @@ The example uses the script block command format. Logical operators, such as `-a
 Indicates that this cmdlet gets objects from a collection if the property value of the object is an
 exact match for the specified value. This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CContains "svchost"`
+For example: `Get-Process | Where-Object ProcessName -CContains "svchost"`
 
 **CContains** refers to a collection of values and is true if the collection contains an item that
 is an exact match for the specified value. If the input is a single object, PowerShell converts it
@@ -493,7 +493,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value includes the specified value. This
 operation is case-sensitive.
 
-For example: `Get-Process | where -Value "svchost" -CIn ProcessName`
+For example: `Get-Process | Where-Object -Value "svchost" -CIn ProcessName`
 
 **CIn** resembles **CContains**, except that the property and value positions are reversed. For
 example, the following statements are both true.
@@ -540,7 +540,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value matches a value that includes wildcard
 characters (`*`). This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CLike "*host"`
+For example: `Get-Process | Where-Object ProcessName -CLike "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -581,7 +581,7 @@ Indicates that this cmdlet gets objects if the property value matches the specif
 expression. This operation is case-sensitive. When the input is a single object, the matched value
 is saved in the `$Matches` automatic variable.
 
-For example: `Get-Process | where ProcessName -CMatch "Shell"`
+For example: `Get-Process | Where-Object ProcessName -CMatch "Shell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -621,7 +621,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value of the object isn't an exact match
 for the specified value. This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CNotContains "svchost"`
+For example: `Get-Process | Where-Object ProcessName -CNotContains "svchost"`
 
 **NotContains** and **CNotContains** refer to a collection of values and are true when the
 collection doesn't contain any items that are an exact match for the specified value. If the input
@@ -646,7 +646,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value isn't an exact match for the
 specified value. This operation is case-sensitive.
 
-For example: `Get-Process | where -Value "svchost" -CNotIn -Property ProcessName`
+For example: `Get-Process | Where-Object -Value "svchost" -CNotIn -Property ProcessName`
 
 **NotIn** and **CNotIn** operators resemble **NotContains** and **CNotContains**, except that the
 property and value positions are reversed. For example, the following statements are true.
@@ -672,7 +672,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters. This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CNotLike "*host"`
+For example: `Get-Process | Where-Object ProcessName -CNotLike "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -694,7 +694,7 @@ Indicates that this cmdlet gets objects if the property value doesn't match the 
 expression. This operation is case-sensitive. When the input is a single object, the matched value
 is saved in the `$Matches` automatic variable.
 
-For example: `Get-Process | where ProcessName -CNotMatch "Shell"`
+For example: `Get-Process | Where-Object ProcessName -CNotMatch "Shell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -715,7 +715,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if any item in the property value of the object is an exact
 match for the specified value.
 
-For example: `Get-Process | where ProcessName -Contains "Svchost"`
+For example: `Get-Process | Where-Object ProcessName -Contains "Svchost"`
 
 If the input is a single object, PowerShell converts it to a collection of one object.
 
@@ -812,7 +812,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value matches any of the specified values.
 For example:
 
-`Get-Process | where -Property ProcessName -in -Value "Svchost", "TaskHost", "WsmProvHost"`
+`Get-Process | Where-Object -Property ProcessName -in -Value "Svchost", "TaskHost", "WsmProvHost"`
 
 If the input is a single object, PowerShell converts it to a collection of one object.
 
@@ -864,7 +864,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value is an instance of the specified .NET
 type. Enclose the type name in square brackets.
 
-For example, `Get-Process | where StartTime -Is [DateTime]`
+For example, `Get-Process | Where-Object StartTime -Is [DateTime]`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -925,7 +925,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value matches a value that includes wildcard
 characters (`*`).
 
-For example: `Get-Process | where ProcessName -Like "*host"`
+For example: `Get-Process | Where-Object ProcessName -Like "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -965,7 +965,7 @@ Indicates that this cmdlet gets objects if the property value matches the specif
 expression. When the input is a single object, the matched value is saved in the `$Matches`
 automatic variable.
 
-For example: `Get-Process | where ProcessName -Match "shell"`
+For example: `Get-Process | Where-Object ProcessName -Match "shell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -1004,7 +1004,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property doesn't exist or has a value of `$null` or
 `$false`.
 
-For example: `Get-Service | where -Not "DependentServices"`
+For example: `Get-Service | Where-Object -Not "DependentServices"`
 
 This parameter was introduced in Windows PowerShell 6.1.
 
@@ -1025,7 +1025,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if none of the items in the property value is an exact match
 for the specified value.
 
-For example: `Get-Process | where ProcessName -NotContains "Svchost"`
+For example: `Get-Process | Where-Object ProcessName -NotContains "Svchost"`
 
 **NotContains** refers to a collection of values and is true if the collection doesn't contain any
 items that are an exact match for the specified value. If the input is a single object, PowerShell
@@ -1050,7 +1050,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value isn't an exact match for any of the
 specified values.
 
-For example: `Get-Process | where -Value "svchost" -NotIn -Property ProcessName`
+For example: `Get-Process | Where-Object -Value "svchost" -NotIn -Property ProcessName`
 
 If the value of **Value** is a single object, PowerShell converts it to a collection of one object.
 
@@ -1077,7 +1077,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters (`*`).
 
-For example: `Get-Process | where ProcessName -NotLike "*host"`
+For example: `Get-Process | Where-Object ProcessName -NotLike "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -1099,7 +1099,7 @@ Indicates that this cmdlet gets objects when the property value doesn't match th
 expression. When the input is a single object, the matched value is saved in the `$Matches`
 automatic variable.
 
-For example: `Get-Process | where ProcessName -NotMatch "PowerShell"`
+For example: `Get-Process | Where-Object ProcessName -NotMatch "PowerShell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/7.2/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Select-Object.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/14/2023
+ms.date: 11/16/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-object?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Select-Object
@@ -528,6 +528,12 @@ Accept wildcard characters: False
 ```
 
 ### -SkipIndex
+
+Skips (doesn't select) the objects from an array based on their index values. Enter the indexes in
+a comma-separated list. Indexes in an array begin with 0, where 0 represents the first value and
+(n-1) represents the last value.
+
+This parameter was introduced in Windows PowerShell 6.0.
 
 ```yaml
 Type: System.Int32[]

--- a/reference/7.3/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 04/21/2023
+ms.date: 11/16/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -31,8 +31,8 @@ ForEach-Object [-InputObject <PSObject>] [-MemberName] <String> [-ArgumentList <
 ### ParallelParameterSet
 
 ```
-ForEach-Object [-InputObject <PSObject>] -Parallel <ScriptBlock> [-ThrottleLimit <Int32>]
- [-TimeoutSeconds <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+ForEach-Object -Parallel <scriptblock> [-InputObject <psobject>] [-ThrottleLimit <int>]
+ [-TimeoutSeconds <int>] [-AsJob] [-UseNewRunspace] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -867,7 +867,7 @@ Using `ForEach-Object -Parallel`:
   > thread to each running script block thread. Since the script blocks run in different threads,
   > the object variables passed by reference must be used safely. Generally it's safe to read from
   > referenced objects that don't change. But if the object state is being modified then you must
-  > used thread safe objects, such as .NET **System.Collection.Concurrent** types (See Example 11).
+  > used thread safe objects, such as .NET **System.Collection.Concurrent** types (See Example 14).
 
 ## RELATED LINKS
 

--- a/reference/7.3/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/Where-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 05/08/2023
+ms.date: 11/16/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/where-object?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Where-Object
@@ -266,9 +266,9 @@ command.
   For example, the following commands also get processes that have a priority class of `Normal`.
   These commands are equivalent and you can use them interchangeably.
 
-  `Get-Process | Where-Object -Property PriorityClass -eq -Value "Normal"`
+  `Get-Process | Where-Object -Property PriorityClass -EQ -Value "Normal"`
 
-  `Get-Process | Where-Object PriorityClass -eq "Normal"`
+  `Get-Process | Where-Object PriorityClass -EQ "Normal"`
 
   Starting in Windows PowerShell 3.0, `Where-Object` adds comparison operators as parameters in a
   `Where-Object` command. Unless specified, all operators are case-insensitive. Before Windows
@@ -300,7 +300,7 @@ is different.
 
 ```powershell
 Get-Service | Where-Object { $_.Status -eq "Stopped" }
-Get-Service | where Status -eq "Stopped"
+Get-Service | Where-Object Status -EQ "Stopped"
 ```
 
 ### Example 2: Get processes based on working set
@@ -358,30 +358,30 @@ different.
 # Use Where-Object to get commands that have any value for the OutputType
 # property of the command. This omits commands that do not have an OutputType
 # property and those that have an OutputType property, but no property value.
-Get-Command | where OutputType
-Get-Command | where { $_.OutputType }
+Get-Command | Where-Object OutputType
+Get-Command | Where-Object { $_.OutputType }
 ```
 
 ```powershell
 # Use Where-Object to get objects that are containers. This gets objects that
 # have the **PSIsContainer** property with a value of $True and excludes all
 # others.
-Get-ChildItem | where PSIsContainer
-Get-ChildItem | where { $_.PSIsContainer }
+Get-ChildItem | Where-Object PSIsContainer
+Get-ChildItem | Where-Object { $_.PSIsContainer }
 ```
 
 ```powershell
 # Finally, use the -not operator (!) to get objects that are not containers.
 # This gets objects that do have the **PSIsContainer** property and those
 # that have a value of $False for the **PSIsContainer** property.
-Get-ChildItem | where -Not PSIsContainer
-Get-ChildItem | where { !$_.PSIsContainer }
+Get-ChildItem | Where-Object -Not PSIsContainer
+Get-ChildItem | Where-Object { !$_.PSIsContainer }
 ```
 
 ### Example 6: Use multiple conditions
 
 ```powershell
-Get-Module -ListAvailable | where {
+Get-Module -ListAvailable | Where-Object {
     ($_.Name -notlike "Microsoft*" -and $_.Name -notlike "PS*") -and $_.HelpInfoUri
 }
 ```
@@ -411,7 +411,7 @@ The example uses the script block command format. Logical operators, such as `-a
 Indicates that this cmdlet gets objects from a collection if the property value of the object is an
 exact match for the specified value. This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CContains "svchost"`
+For example: `Get-Process | Where-Object ProcessName -CContains "svchost"`
 
 **CContains** refers to a collection of values and is true if the collection contains an item that
 is an exact match for the specified value. If the input is a single object, PowerShell converts it
@@ -493,7 +493,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value includes the specified value. This
 operation is case-sensitive.
 
-For example: `Get-Process | where -Value "svchost" -CIn ProcessName`
+For example: `Get-Process | Where-Object -Value "svchost" -CIn ProcessName`
 
 **CIn** resembles **CContains**, except that the property and value positions are reversed. For
 example, the following statements are both true.
@@ -540,7 +540,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value matches a value that includes wildcard
 characters (`*`). This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CLike "*host"`
+For example: `Get-Process | Where-Object ProcessName -CLike "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -581,7 +581,7 @@ Indicates that this cmdlet gets objects if the property value matches the specif
 expression. This operation is case-sensitive. When the input is a single object, the matched value
 is saved in the `$Matches` automatic variable.
 
-For example: `Get-Process | where ProcessName -CMatch "Shell"`
+For example: `Get-Process | Where-Object ProcessName -CMatch "Shell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -621,7 +621,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value of the object isn't an exact match
 for the specified value. This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CNotContains "svchost"`
+For example: `Get-Process | Where-Object ProcessName -CNotContains "svchost"`
 
 **NotContains** and **CNotContains** refer to a collection of values and are true when the
 collection doesn't contain any items that are an exact match for the specified value. If the input
@@ -646,7 +646,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value isn't an exact match for the
 specified value. This operation is case-sensitive.
 
-For example: `Get-Process | where -Value "svchost" -CNotIn -Property ProcessName`
+For example: `Get-Process | Where-Object -Value "svchost" -CNotIn -Property ProcessName`
 
 **NotIn** and **CNotIn** operators resemble **NotContains** and **CNotContains**, except that the
 property and value positions are reversed. For example, the following statements are true.
@@ -672,7 +672,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters. This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CNotLike "*host"`
+For example: `Get-Process | Where-Object ProcessName -CNotLike "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -694,7 +694,7 @@ Indicates that this cmdlet gets objects if the property value doesn't match the 
 expression. This operation is case-sensitive. When the input is a single object, the matched value
 is saved in the `$Matches` automatic variable.
 
-For example: `Get-Process | where ProcessName -CNotMatch "Shell"`
+For example: `Get-Process | Where-Object ProcessName -CNotMatch "Shell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -715,7 +715,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if any item in the property value of the object is an exact
 match for the specified value.
 
-For example: `Get-Process | where ProcessName -Contains "Svchost"`
+For example: `Get-Process | Where-Object ProcessName -Contains "Svchost"`
 
 If the input is a single object, PowerShell converts it to a collection of one object.
 
@@ -812,7 +812,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value matches any of the specified values.
 For example:
 
-`Get-Process | where -Property ProcessName -in -Value "Svchost", "TaskHost", "WsmProvHost"`
+`Get-Process | Where-Object -Property ProcessName -in -Value "Svchost", "TaskHost", "WsmProvHost"`
 
 If the input is a single object, PowerShell converts it to a collection of one object.
 
@@ -864,7 +864,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value is an instance of the specified .NET
 type. Enclose the type name in square brackets.
 
-For example, `Get-Process | where StartTime -Is [DateTime]`
+For example, `Get-Process | Where-Object StartTime -Is [DateTime]`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -925,7 +925,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value matches a value that includes wildcard
 characters (`*`).
 
-For example: `Get-Process | where ProcessName -Like "*host"`
+For example: `Get-Process | Where-Object ProcessName -Like "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -965,7 +965,7 @@ Indicates that this cmdlet gets objects if the property value matches the specif
 expression. When the input is a single object, the matched value is saved in the `$Matches`
 automatic variable.
 
-For example: `Get-Process | where ProcessName -Match "shell"`
+For example: `Get-Process | Where-Object ProcessName -Match "shell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -1004,7 +1004,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property doesn't exist or has a value of `$null` or
 `$false`.
 
-For example: `Get-Service | where -Not "DependentServices"`
+For example: `Get-Service | Where-Object -Not "DependentServices"`
 
 This parameter was introduced in Windows PowerShell 6.1.
 
@@ -1025,7 +1025,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if none of the items in the property value is an exact match
 for the specified value.
 
-For example: `Get-Process | where ProcessName -NotContains "Svchost"`
+For example: `Get-Process | Where-Object ProcessName -NotContains "Svchost"`
 
 **NotContains** refers to a collection of values and is true if the collection doesn't contain any
 items that are an exact match for the specified value. If the input is a single object, PowerShell
@@ -1050,7 +1050,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value isn't an exact match for any of the
 specified values.
 
-For example: `Get-Process | where -Value "svchost" -NotIn -Property ProcessName`
+For example: `Get-Process | Where-Object -Value "svchost" -NotIn -Property ProcessName`
 
 If the value of **Value** is a single object, PowerShell converts it to a collection of one object.
 
@@ -1077,7 +1077,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters (`*`).
 
-For example: `Get-Process | where ProcessName -NotLike "*host"`
+For example: `Get-Process | Where-Object ProcessName -NotLike "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -1099,7 +1099,7 @@ Indicates that this cmdlet gets objects when the property value doesn't match th
 expression. When the input is a single object, the matched value is saved in the `$Matches`
 automatic variable.
 
-For example: `Get-Process | where ProcessName -NotMatch "PowerShell"`
+For example: `Get-Process | Where-Object ProcessName -NotMatch "PowerShell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/7.3/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Select-Object.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/14/2023
+ms.date: 11/16/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-object?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Select-Object
@@ -528,6 +528,12 @@ Accept wildcard characters: False
 ```
 
 ### -SkipIndex
+
+Skips (doesn't select) the objects from an array based on their index values. Enter the indexes in
+a comma-separated list. Indexes in an array begin with 0, where 0 represents the first value and
+(n-1) represents the last value.
+
+This parameter was introduced in Windows PowerShell 6.0.
 
 ```yaml
 Type: System.Int32[]

--- a/reference/7.4/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 04/21/2023
+ms.date: 11/16/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/foreach-object?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ForEach-Object
@@ -31,8 +31,8 @@ ForEach-Object [-InputObject <PSObject>] [-MemberName] <String> [-ArgumentList <
 ### ParallelParameterSet
 
 ```
-ForEach-Object [-InputObject <PSObject>] -Parallel <ScriptBlock> [-ThrottleLimit <Int32>]
- [-TimeoutSeconds <Int32>] [-AsJob] [-WhatIf] [-Confirm] [<CommonParameters>]
+ForEach-Object -Parallel <scriptblock> [-InputObject <psobject>] [-ThrottleLimit <int>]
+ [-TimeoutSeconds <int>] [-AsJob] [-UseNewRunspace] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -867,7 +867,7 @@ Using `ForEach-Object -Parallel`:
   > thread to each running script block thread. Since the script blocks run in different threads,
   > the object variables passed by reference must be used safely. Generally it's safe to read from
   > referenced objects that don't change. But if the object state is being modified then you must
-  > used thread safe objects, such as .NET **System.Collection.Concurrent** types (See Example 11).
+  > used thread safe objects, such as .NET **System.Collection.Concurrent** types (See Example 14).
 
 ## RELATED LINKS
 

--- a/reference/7.4/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Where-Object.md
@@ -2,7 +2,7 @@
 external help file: System.Management.Automation.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Core
-ms.date: 05/08/2023
+ms.date: 11/16/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/where-object?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Where-Object
@@ -266,9 +266,9 @@ command.
   For example, the following commands also get processes that have a priority class of `Normal`.
   These commands are equivalent and you can use them interchangeably.
 
-  `Get-Process | Where-Object -Property PriorityClass -eq -Value "Normal"`
+  `Get-Process | Where-Object -Property PriorityClass -EQ -Value "Normal"`
 
-  `Get-Process | Where-Object PriorityClass -eq "Normal"`
+  `Get-Process | Where-Object PriorityClass -EQ "Normal"`
 
   Starting in Windows PowerShell 3.0, `Where-Object` adds comparison operators as parameters in a
   `Where-Object` command. Unless specified, all operators are case-insensitive. Before Windows
@@ -300,7 +300,7 @@ is different.
 
 ```powershell
 Get-Service | Where-Object { $_.Status -eq "Stopped" }
-Get-Service | where Status -eq "Stopped"
+Get-Service | Where-Object Status -EQ "Stopped"
 ```
 
 ### Example 2: Get processes based on working set
@@ -358,30 +358,30 @@ different.
 # Use Where-Object to get commands that have any value for the OutputType
 # property of the command. This omits commands that do not have an OutputType
 # property and those that have an OutputType property, but no property value.
-Get-Command | where OutputType
-Get-Command | where { $_.OutputType }
+Get-Command | Where-Object OutputType
+Get-Command | Where-Object { $_.OutputType }
 ```
 
 ```powershell
 # Use Where-Object to get objects that are containers. This gets objects that
 # have the **PSIsContainer** property with a value of $True and excludes all
 # others.
-Get-ChildItem | where PSIsContainer
-Get-ChildItem | where { $_.PSIsContainer }
+Get-ChildItem | Where-Object PSIsContainer
+Get-ChildItem | Where-Object { $_.PSIsContainer }
 ```
 
 ```powershell
 # Finally, use the -not operator (!) to get objects that are not containers.
 # This gets objects that do have the **PSIsContainer** property and those
 # that have a value of $False for the **PSIsContainer** property.
-Get-ChildItem | where -Not PSIsContainer
-Get-ChildItem | where { !$_.PSIsContainer }
+Get-ChildItem | Where-Object -Not PSIsContainer
+Get-ChildItem | Where-Object { !$_.PSIsContainer }
 ```
 
 ### Example 6: Use multiple conditions
 
 ```powershell
-Get-Module -ListAvailable | where {
+Get-Module -ListAvailable | Where-Object {
     ($_.Name -notlike "Microsoft*" -and $_.Name -notlike "PS*") -and $_.HelpInfoUri
 }
 ```
@@ -411,7 +411,7 @@ The example uses the script block command format. Logical operators, such as `-a
 Indicates that this cmdlet gets objects from a collection if the property value of the object is an
 exact match for the specified value. This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CContains "svchost"`
+For example: `Get-Process | Where-Object ProcessName -CContains "svchost"`
 
 **CContains** refers to a collection of values and is true if the collection contains an item that
 is an exact match for the specified value. If the input is a single object, PowerShell converts it
@@ -493,7 +493,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value includes the specified value. This
 operation is case-sensitive.
 
-For example: `Get-Process | where -Value "svchost" -CIn ProcessName`
+For example: `Get-Process | Where-Object -Value "svchost" -CIn ProcessName`
 
 **CIn** resembles **CContains**, except that the property and value positions are reversed. For
 example, the following statements are both true.
@@ -540,7 +540,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value matches a value that includes wildcard
 characters (`*`). This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CLike "*host"`
+For example: `Get-Process | Where-Object ProcessName -CLike "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -581,7 +581,7 @@ Indicates that this cmdlet gets objects if the property value matches the specif
 expression. This operation is case-sensitive. When the input is a single object, the matched value
 is saved in the `$Matches` automatic variable.
 
-For example: `Get-Process | where ProcessName -CMatch "Shell"`
+For example: `Get-Process | Where-Object ProcessName -CMatch "Shell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -621,7 +621,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value of the object isn't an exact match
 for the specified value. This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CNotContains "svchost"`
+For example: `Get-Process | Where-Object ProcessName -CNotContains "svchost"`
 
 **NotContains** and **CNotContains** refer to a collection of values and are true when the
 collection doesn't contain any items that are an exact match for the specified value. If the input
@@ -646,7 +646,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value isn't an exact match for the
 specified value. This operation is case-sensitive.
 
-For example: `Get-Process | where -Value "svchost" -CNotIn -Property ProcessName`
+For example: `Get-Process | Where-Object -Value "svchost" -CNotIn -Property ProcessName`
 
 **NotIn** and **CNotIn** operators resemble **NotContains** and **CNotContains**, except that the
 property and value positions are reversed. For example, the following statements are true.
@@ -672,7 +672,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters. This operation is case-sensitive.
 
-For example: `Get-Process | where ProcessName -CNotLike "*host"`
+For example: `Get-Process | Where-Object ProcessName -CNotLike "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -694,7 +694,7 @@ Indicates that this cmdlet gets objects if the property value doesn't match the 
 expression. This operation is case-sensitive. When the input is a single object, the matched value
 is saved in the `$Matches` automatic variable.
 
-For example: `Get-Process | where ProcessName -CNotMatch "Shell"`
+For example: `Get-Process | Where-Object ProcessName -CNotMatch "Shell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -715,7 +715,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if any item in the property value of the object is an exact
 match for the specified value.
 
-For example: `Get-Process | where ProcessName -Contains "Svchost"`
+For example: `Get-Process | Where-Object ProcessName -Contains "Svchost"`
 
 If the input is a single object, PowerShell converts it to a collection of one object.
 
@@ -812,7 +812,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value matches any of the specified values.
 For example:
 
-`Get-Process | where -Property ProcessName -in -Value "Svchost", "TaskHost", "WsmProvHost"`
+`Get-Process | Where-Object -Property ProcessName -in -Value "Svchost", "TaskHost", "WsmProvHost"`
 
 If the input is a single object, PowerShell converts it to a collection of one object.
 
@@ -864,7 +864,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value is an instance of the specified .NET
 type. Enclose the type name in square brackets.
 
-For example, `Get-Process | where StartTime -Is [DateTime]`
+For example, `Get-Process | Where-Object StartTime -Is [DateTime]`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -925,7 +925,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value matches a value that includes wildcard
 characters (`*`).
 
-For example: `Get-Process | where ProcessName -Like "*host"`
+For example: `Get-Process | Where-Object ProcessName -Like "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -965,7 +965,7 @@ Indicates that this cmdlet gets objects if the property value matches the specif
 expression. When the input is a single object, the matched value is saved in the `$Matches`
 automatic variable.
 
-For example: `Get-Process | where ProcessName -Match "shell"`
+For example: `Get-Process | Where-Object ProcessName -Match "shell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -1004,7 +1004,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property doesn't exist or has a value of `$null` or
 `$false`.
 
-For example: `Get-Service | where -Not "DependentServices"`
+For example: `Get-Service | Where-Object -Not "DependentServices"`
 
 This parameter was introduced in Windows PowerShell 6.1.
 
@@ -1025,7 +1025,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if none of the items in the property value is an exact match
 for the specified value.
 
-For example: `Get-Process | where ProcessName -NotContains "Svchost"`
+For example: `Get-Process | Where-Object ProcessName -NotContains "Svchost"`
 
 **NotContains** refers to a collection of values and is true if the collection doesn't contain any
 items that are an exact match for the specified value. If the input is a single object, PowerShell
@@ -1050,7 +1050,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value isn't an exact match for any of the
 specified values.
 
-For example: `Get-Process | where -Value "svchost" -NotIn -Property ProcessName`
+For example: `Get-Process | Where-Object -Value "svchost" -NotIn -Property ProcessName`
 
 If the value of **Value** is a single object, PowerShell converts it to a collection of one object.
 
@@ -1077,7 +1077,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value doesn't match a value that includes
 wildcard characters (`*`).
 
-For example: `Get-Process | where ProcessName -NotLike "*host"`
+For example: `Get-Process | Where-Object ProcessName -NotLike "*host"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -1099,7 +1099,7 @@ Indicates that this cmdlet gets objects when the property value doesn't match th
 expression. When the input is a single object, the matched value is saved in the `$Matches`
 automatic variable.
 
-For example: `Get-Process | where ProcessName -NotMatch "PowerShell"`
+For example: `Get-Process | Where-Object ProcessName -NotMatch "PowerShell"`
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Select-Object.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/18/2023
+ms.date: 11/16/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-object?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Select-Object
@@ -567,6 +567,12 @@ Accept wildcard characters: False
 ```
 
 ### -SkipIndex
+
+Skips (doesn't select) the objects from an array based on their index values. Enter the indexes in
+a comma-separated list. Indexes in an array begin with 0, where 0 represents the first value and
+(n-1) represents the last value.
+
+This parameter was introduced in Windows PowerShell 6.0.
 
 ```yaml
 Type: System.Int32[]


### PR DESCRIPTION
# PR Summary

Prior to this change:

- The **UseNewRunspace** parameter of the `ForEach-Object` cmdlet wasn't included in the cmdlet syntax for any parameter set.
- The "Notes" section of `ForEach-Object` directed users to the wrong example for thread safety.
- The `Where-Object` reference documentation used the `where` alias throughout the article, not just when discussing the alias specifically.
- The **SkipIndex** parameter of the `Select-Object` cmdlet was missing a description entirely and didn't indicate the version of PowerShell it was added in.

This change:

- Adds the **UseNewRunspace** parameter to the `ParallelParameterSet` syntax of the `ForEach-Object` cmdlet reference.

  - Fixes #10642
  - Fixes [AB#183543](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/183543)
- Ensures that the notes section of `ForEach-Object` points to the correct example.

  - Fixes #10643
  - Fixes [AB#183544](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/183544)
- Replaces all instances of `where` with `Where-Object` in the `Where-Object` reference documentation except where discussing the `where` alias specifically.

  - Fixes #10644
  - Fixes [AB#183545](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/183545)
- Documents the **SkipIndex** parameter of the `Select-Object` cmdlet and indicates that it was added in PowerShell 6.0.

  - Fixes #10645
  - Fixes [AB#183546](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/183546)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
