### PR TITLE
(GH-10658) Correct 7.4 end of support date

### DIFF
--- a/reference/docs-conceptual/install/PowerShell-Support-Lifecycle.md
+++ b/reference/docs-conceptual/install/PowerShell-Support-Lifecycle.md
@@ -106,11 +106,11 @@ support options.
 Based on these lifecycle policies, the following table lists the dates when support for the current
 versions of PowerShell end:
 
-|      Version       |   Release Date    |  End-of-support  |
-| ------------------ | ----------------- | ---------------- |
-| 7.4 (LTS-current)  | November 16, 2023 | May 15, 2025     |
-| 7.3 (Stable)       | November 9, 2022  | May 8, 2024      |
-| 7.2 (LTS-previous) | November 8, 2021  | November 8, 2024 |
+|      Version       |   Release Date    |  End-of-support   |
+| ------------------ | ----------------- | ----------------- |
+| 7.4 (LTS-current)  | November 16, 2023 | November 15, 2026 |
+| 7.3 (Stable)       | November 9, 2022  | May 8, 2024       |
+| 7.2 (LTS-previous) | November 8, 2021  | November 8, 2024  |
 
 Support for PowerShell on a specific platform is based on the support policy of the version of .NET
 used.


### PR DESCRIPTION
# PR Summary

Prior to this change, the PowerShell 7.4 end of support date was incorrectly listed as May 15, 2025.

PowerShell 7.4 is built on .NET 8 and follows the same LTS lifecycle.

This change:

- Corrects the end of support date for PowerShell 7.4
- Fixes #10658

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
