### PR TITLE
(GH-10661) Fix `$PSNativeCommandUseErrorActionPreference` default

### DIFF
--- a/reference/docs-conceptual/learn/experimental-features.md
+++ b/reference/docs-conceptual/learn/experimental-features.md
@@ -1,6 +1,6 @@
 ---
 description: Lists the currently available experimental features and how to use them.
-ms.date: 11/14/2023
+ms.date: 11/20/2023
 title: Using Experimental Features in PowerShell
 ---
 # Using Experimental Features in PowerShell
@@ -317,9 +317,9 @@ To enable this feature, run the following commands:
 Enable-ExperimentalFeature PSNativeCommandErrorActionPreference
 ```
 
-You must start a new PowerShell session for this change to be in effect. Beginning in PowerShell
-7.4, `$PSNativeCommandUseErrorActionPreference` is set to `$true` by default. With the preference
-set to `$true` you get the following behavior:
+You must start a new PowerShell session for this change to be in effect.
+`$PSNativeCommandUseErrorActionPreference` is set to `$true` by default. With the preference set to
+`$true` you get the following behavior:
 
 - When `$ErrorActionPreference = 'Stop'`, scripts will break when a native command returns a
   non-zero exit code.


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for the `$PSNativeCommandUseErrorActionPreference` variable noted that it defaults to `$true` starting in PowerShell 7.4.

The different default value was temporary for gathering feedback while 7.4 was in preview. When 7.4 was released as stable, the default value was reverted to `$false` in PowerShell/PowerShell#20285.

This change:

- Replaces the misleading sentence with one that states the default value as `$true`.
- Fixes #10661

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
