### PR TITLE
Fix small typo in ConvertFrom-Json.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 11/29/2022
+ms.date: 11/29/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/convertfrom-json?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertFrom-Json
@@ -26,7 +26,7 @@ custom **PSObject** or **Hashtable** object that has a property for each field i
 JSON is commonly used by web sites to provide a textual representation of objects. The cmdlet adds
 the properties to the new object as it processes each line of the JSON string.
 
-The JSON standard allows duplicate key names, which are prohibited in **PSObject** end **Hashtable**
+The JSON standard allows duplicate key names, which are prohibited in **PSObject** and **Hashtable**
 types. For example, if the JSON string contains duplicate keys, only the last key is used by this
 cmdlet. See other examples below.
 

--- a/reference/7.2/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 11/29/2022
+ms.date: 11/29/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/convertfrom-json?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertFrom-Json
@@ -26,7 +26,7 @@ custom **PSObject** or **Hashtable** object that has a property for each field i
 JSON is commonly used by web sites to provide a textual representation of objects. The cmdlet adds
 the properties to the new object as it processes each line of the JSON string.
 
-The JSON standard allows duplicate key names, which are prohibited in **PSObject** end **Hashtable**
+The JSON standard allows duplicate key names, which are prohibited in **PSObject** and **Hashtable**
 types. For example, if the JSON string contains duplicate keys, only the last key is used by this
 cmdlet. See other examples below.
 

--- a/reference/7.3/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 11/29/2022
+ms.date: 11/29/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/convertfrom-json?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertFrom-Json
@@ -26,7 +26,7 @@ custom **PSObject** or **Hashtable** object that has a property for each field i
 JSON is commonly used by web sites to provide a textual representation of objects. The cmdlet adds
 the properties to the new object as it processes each line of the JSON string.
 
-The JSON standard allows duplicate key names, which are prohibited in **PSObject** end **Hashtable**
+The JSON standard allows duplicate key names, which are prohibited in **PSObject** and **Hashtable**
 types. For example, if the JSON string contains duplicate keys, only the last key is used by this
 cmdlet. See other examples below.
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 11/29/2022
+ms.date: 11/29/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/convertfrom-json?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: ConvertFrom-Json
@@ -26,7 +26,7 @@ custom **PSObject** or **Hashtable** object that has a property for each field i
 JSON is commonly used by web sites to provide a textual representation of objects. The cmdlet adds
 the properties to the new object as it processes each line of the JSON string.
 
-The JSON standard allows duplicate key names, which are prohibited in **PSObject** end **Hashtable**
+The JSON standard allows duplicate key names, which are prohibited in **PSObject** and **Hashtable**
 types. For example, if the JSON string contains duplicate keys, only the last key is used by this
 cmdlet. See other examples below.
 


### PR DESCRIPTION
# PR Summary

"end"/"and" typo was introduced a year ago in #9496
Searched rest of repo and the PR diff and didn't see any more of this typo! :)

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].


[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
