### PR TITLE
(GH-10697) Clarify behavior of `-Repeat` for `Test-Connection`

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Test-Connection.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/12/2022
+ms.date: 12/01/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/test-connection?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Test-Connection
@@ -382,8 +382,9 @@ Accept wildcard characters: False
 
 ### -Repeat
 
-Causes the cmdlet to send ping requests continuously. This parameter can't be used with the
-**Count** parameter.
+Causes the cmdlet to send ping requests continuously. When the value of **TargetName** is an array
+of targets, the cmdlet repeats the ping requests for the first target only. It ignores the
+remaining targets. This parameter can't be used with the **Count** parameter.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.3/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Test-Connection.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 12/12/2022
+ms.date: 12/01/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/test-connection?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Test-Connection
@@ -382,8 +382,9 @@ Accept wildcard characters: False
 
 ### -Repeat
 
-Causes the cmdlet to send ping requests continuously. This parameter can't be used with the
-**Count** parameter.
+Causes the cmdlet to send ping requests continuously. When the value of **TargetName** is an array
+of targets, the cmdlet repeats the ping requests for the first target only. It ignores the
+remaining targets. This parameter can't be used with the **Count** parameter.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.4/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Test-Connection.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 10/25/2023
+ms.date: 12/01/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/test-connection?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Test-Connection
@@ -422,8 +422,9 @@ Accept wildcard characters: False
 
 ### -Repeat
 
-Causes the cmdlet to send ping requests continuously. This parameter can't be used with the
-**Count** parameter.
+Causes the cmdlet to send ping requests continuously. When the value of **TargetName** is an array
+of targets, the cmdlet repeats the ping requests for the first target only. It ignores the
+remaining targets. This parameter can't be used with the **Count** parameter.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for the `-Repeat` parameter of the `Test-Connection` cmdlet did not indicate that the cmdlet continuously pings only the _first_ value for the `-TargetValue` parameter.

This change:

- Clarifies the behavior.
- Resolves #10697
- Fixes [AB#187541](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/187541)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
