### PR TITLE
(GH-10698) Update `-Content` parameter for `Get-Authenticode` in 7.4

### DIFF
--- a/reference/7.4/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
+++ b/reference/7.4/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Security.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Security
-ms.date: 12/12/2022
+ms.date: 12/01/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.security/get-authenticodesignature?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-AuthenticodeSignature
@@ -97,9 +97,9 @@ example, the file extension is specified along with the content of the file.
 
 ### -Content
 
-Contents of a file as a byte array for which the Authenticode signature is retrieved. This parameter
-must be used with **SourcePathOrExtension** parameter. The contents of the file must be in Unicode
-(UTF-16LE) format.
+Contents of a file as a byte array for which the Authenticode signature is retrieved. This
+parameter must be used with **SourcePathOrExtension** parameter. Prior to PowerShell 7.4, the
+contents of the file must be in Unicode (UTF-16LE) format.
 
 ```yaml
 Type: System.Byte[]


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for the `-Content` parameter of the `Get-Authenticode` cmdlet in version 7.4 incorrectly stated that the contents must be encoded as UTF-16LE. This was true in prior versions, but in 7.4 the cmdlet works with content of any valid and readable encoding.

This change:

- Updates the description for the `-Content` parameter to indicate that the encoding limitation is removed in PowerShell 7.4.
- Resolves #10698
- Fixes [AB#187542](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/187542)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
