### PR TITLE
Fix New-Service -BinaryPathName quotes

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-Service.md
@@ -34,7 +34,7 @@ dependencies of the service.
 ### Example 1: Create a service
 
 ```powershell
-New-Service -Name "TestService" -BinaryPathName '"C:\WINDOWS\System32\svchost.exe -k netsvcs"'
+New-Service -Name "TestService" -BinaryPathName 'C:\WINDOWS\System32\svchost.exe -k netsvcs'
 ```
 
 This command creates a service named TestService.
@@ -44,7 +44,7 @@ This command creates a service named TestService.
 ```powershell
 $params = @{
   Name = "TestService"
-  BinaryPathName = '"C:\WINDOWS\System32\svchost.exe -k netsvcs"'
+  BinaryPathName = 'C:\WINDOWS\System32\svchost.exe -k netsvcs'
   DependsOn = "NetLogon"
   DisplayName = "Test Service"
   StartupType = "Manual"
@@ -97,7 +97,7 @@ so that it is correctly interpreted. For example, `d:\my share\myservice.exe` sh
 `'"d:\my share\myservice.exe"'`.
 
 The path can also include arguments for an auto-start service. For example,
-`'"d:\myshare\myservice.exe arg1 arg2"'`. These arguments are passed to the service entry point.
+`'"d:\my share\myservice.exe" arg1 arg2'`. These arguments are passed to the service entry point.
 
 For more information, see the **lpBinaryPathName** parameter of
 [CreateServiceW](/windows/win32/api/winsvc/nf-winsvc-createservicew) API.

--- a/reference/7.2/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/New-Service.md
@@ -36,7 +36,7 @@ dependencies of the service.
 ### Example 1: Create a service
 
 ```powershell
-New-Service -Name "TestService" -BinaryPathName '"C:\WINDOWS\System32\svchost.exe -k netsvcs"'
+New-Service -Name "TestService" -BinaryPathName 'C:\WINDOWS\System32\svchost.exe -k netsvcs'
 ```
 
 This command creates a service named TestService.
@@ -46,7 +46,7 @@ This command creates a service named TestService.
 ```powershell
 $params = @{
   Name = "TestService"
-  BinaryPathName = '"C:\WINDOWS\System32\svchost.exe -k netsvcs"'
+  BinaryPathName = 'C:\WINDOWS\System32\svchost.exe -k netsvcs'
   DependsOn = "NetLogon"
   DisplayName = "Test Service"
   StartupType = "Manual"
@@ -83,7 +83,7 @@ This example adds the **SecurityDescriptor** of the service being created.
 ```powershell
 $SDDL = "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;SU)"
 $params = @{
-  BinaryPathName = '"C:\WINDOWS\System32\svchost.exe -k netsvcs"'
+  BinaryPathName = 'C:\WINDOWS\System32\svchost.exe -k netsvcs'
   DependsOn = "NetLogon"
   DisplayName = "Test Service"
   StartupType = "Manual"
@@ -107,7 +107,7 @@ so that it is correctly interpreted. For example, `d:\my share\myservice.exe` sh
 `'"d:\my share\myservice.exe"'`.
 
 The path can also include arguments for an auto-start service. For example,
-`'"d:\myshare\myservice.exe arg1 arg2"'`. These arguments are passed to the service entry point.
+`'"d:\my share\myservice.exe" arg1 arg2'`. These arguments are passed to the service entry point.
 
 For more information, see the **lpBinaryPathName** parameter of
 [CreateServiceW](/windows/win32/api/winsvc/nf-winsvc-createservicew) API.

--- a/reference/7.3/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/New-Service.md
@@ -36,7 +36,7 @@ dependencies of the service.
 ### Example 1: Create a service
 
 ```powershell
-New-Service -Name "TestService" -BinaryPathName "C:\WINDOWS\System32\svchost.exe -k netsvcs"
+New-Service -Name "TestService" -BinaryPathName 'C:\WINDOWS\System32\svchost.exe -k netsvcs'
 ```
 
 This command creates a service named TestService.
@@ -46,7 +46,7 @@ This command creates a service named TestService.
 ```powershell
 $params = @{
   Name = "TestService"
-  BinaryPathName = "C:\WINDOWS\System32\svchost.exe -k netsvcs"
+  BinaryPathName = 'C:\WINDOWS\System32\svchost.exe -k netsvcs'
   DependsOn = "NetLogon"
   DisplayName = "Test Service"
   StartupType = "Manual"
@@ -83,7 +83,7 @@ This example adds the **SecurityDescriptor** of the service being created.
 ```powershell
 $SDDL = "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;SU)"
 $params = @{
-  BinaryPathName = "C:\WINDOWS\System32\svchost.exe -k netsvcs"
+  BinaryPathName = 'C:\WINDOWS\System32\svchost.exe -k netsvcs'
   DependsOn = "NetLogon"
   DisplayName = "Test Service"
   StartupType = "Manual"
@@ -107,7 +107,7 @@ so that it is correctly interpreted. For example, `d:\my share\myservice.exe` sh
 `'"d:\my share\myservice.exe"'`.
 
 The path can also include arguments for an auto-start service. For example,
-`'"d:\myshare\myservice.exe arg1 arg2"'`. These arguments are passed to the service entry point.
+`'"d:\my share\myservice.exe" arg1 arg2'`. These arguments are passed to the service entry point.
 
 For more information, see the **lpBinaryPathName** parameter of
 [CreateServiceW](/windows/win32/api/winsvc/nf-winsvc-createservicew) API.

--- a/reference/7.4/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/New-Service.md
@@ -36,7 +36,7 @@ dependencies of the service.
 ### Example 1: Create a service
 
 ```powershell
-New-Service -Name "TestService" -BinaryPathName '"C:\WINDOWS\System32\svchost.exe -k netsvcs"'
+New-Service -Name "TestService" -BinaryPathName 'C:\WINDOWS\System32\svchost.exe -k netsvcs'
 ```
 
 This command creates a service named TestService.
@@ -46,7 +46,7 @@ This command creates a service named TestService.
 ```powershell
 $params = @{
   Name = "TestService"
-  BinaryPathName = '"C:\WINDOWS\System32\svchost.exe -k netsvcs"'
+  BinaryPathName = 'C:\WINDOWS\System32\svchost.exe -k netsvcs'
   DependsOn = "NetLogon"
   DisplayName = "Test Service"
   StartupType = "Manual"
@@ -83,7 +83,7 @@ This example adds the **SecurityDescriptor** of the service being created.
 ```powershell
 $SDDL = "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;SU)"
 $params = @{
-  BinaryPathName = '"C:\WINDOWS\System32\svchost.exe -k netsvcs"'
+  BinaryPathName = 'C:\WINDOWS\System32\svchost.exe -k netsvcs'
   DependsOn = "NetLogon"
   DisplayName = "Test Service"
   StartupType = "Manual"
@@ -107,7 +107,7 @@ so that it is correctly interpreted. For example, `d:\my share\myservice.exe` sh
 `'"d:\my share\myservice.exe"'`.
 
 The path can also include arguments for an auto-start service. For example,
-`'"d:\myshare\myservice.exe arg1 arg2"'`. These arguments are passed to the service entry point.
+`'"d:\my share\myservice.exe" arg1 arg2'`. These arguments are passed to the service entry point.
 
 For more information, see the **lpBinaryPathName** parameter of
 [CreateServiceW](/windows/win32/api/winsvc/nf-winsvc-createservicew) API.


### PR DESCRIPTION
# PR Summary

In the documentation for the `New-Service` command, it states that it should be use like the following:

```powershell
New-Service -Name "TestService" -BinaryPathName '"C:\WINDOWS\System32\svchost.exe -k netsvcs"'
```

But the reality is that using this command, the created service will try to find a file with the name `'svchost.exe -k netsvcs'`, giving the message in the Services app `Error 2: The system cannot find the file specified`.

As the documentation says `If the path contains a space, it must be quoted so that it is correctly interpreted.`, but arguments are not part of the path so they should be outside of the double quotes.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
