### PR TITLE
(GH-10779) Clarify Static param for `Get-Member`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 01/10/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-member?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Member
@@ -424,9 +424,9 @@ Indicates that this cmdlet gets only the static properties and methods of the ob
 properties and methods are defined on the class of objects, not on any particular instance of the
 class.
 
-If you use the **Static** parameter with the **View** parameter, the **View** parameter is ignored.
-If you use the **Static** parameter with the **MemberType** parameter, `Get-Member` gets only the
-members that belong to both sets.
+If you use the **Static** parameter with the **View** or **Force** parameters, the cmdlet ignores
+those parameters. If you use the **Static** parameter with the **MemberType** parameter,
+`Get-Member` gets only the members that belong to both sets.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.2/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Get-Member.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 01/10/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-member?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Member
@@ -428,9 +428,9 @@ Indicates that this cmdlet gets only the static properties and methods of the ob
 properties and methods are defined on the class of objects, not on any particular instance of the
 class.
 
-If you use the **Static** parameter with the **View** parameter, the **View** parameter is ignored.
-If you use the **Static** parameter with the **MemberType** parameter, `Get-Member` gets only the
-members that belong to both sets.
+If you use the **Static** parameter with the **View** or **Force** parameters, the cmdlet ignores
+those parameters. If you use the **Static** parameter with the **MemberType** parameter,
+`Get-Member` gets only the members that belong to both sets.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.3/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Get-Member.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 01/10/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-member?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Member
@@ -428,9 +428,9 @@ Indicates that this cmdlet gets only the static properties and methods of the ob
 properties and methods are defined on the class of objects, not on any particular instance of the
 class.
 
-If you use the **Static** parameter with the **View** parameter, the **View** parameter is ignored.
-If you use the **Static** parameter with the **MemberType** parameter, `Get-Member` gets only the
-members that belong to both sets.
+If you use the **Static** parameter with the **View** or **Force** parameters, the cmdlet ignores
+those parameters. If you use the **Static** parameter with the **MemberType** parameter,
+`Get-Member` gets only the members that belong to both sets.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-Member.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 01/10/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-member?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-Member
@@ -428,9 +428,9 @@ Indicates that this cmdlet gets only the static properties and methods of the ob
 properties and methods are defined on the class of objects, not on any particular instance of the
 class.
 
-If you use the **Static** parameter with the **View** parameter, the **View** parameter is ignored.
-If you use the **Static** parameter with the **MemberType** parameter, `Get-Member` gets only the
-members that belong to both sets.
+If you use the **Static** parameter with the **View** or **Force** parameters, the cmdlet ignores
+those parameters. If you use the **Static** parameter with the **MemberType** parameter,
+`Get-Member` gets only the members that belong to both sets.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter


### PR DESCRIPTION

# PR Summary

Prior to this change, the documentation for the **Static** parameter on the `Get-Member` cmdlet did not clarify that the cmdlet ignores the **Force** parameter when used with the **Static** parameter.

This change:

- Clarifies that the cmdlet ignores both the **View** and **Force** parameters when you use the **Static** parameter, not just **View**.
- Resolves #10779
- Fixes [AB#198702](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/198702)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
