### PR TITLE
(GH-10780) Fix example in about_Intrinsic_Members

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
@@ -1,7 +1,7 @@
 ---
 description: Describes automatic members in all PowerShell objects
 Locale: en-US
-ms.date: 08/21/2023
+ms.date: 01/10/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_Inrinsic_Members?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Intrinsic_Members
@@ -59,7 +59,12 @@ The **Force** parameter of `Get-Member` shows us the intrinsic members of the
 object.
 
 ```powershell
-$hash | Get-Member -Force -Type MemberSet, CodeProperty
+$hash = @{
+    Age  = 33
+    Name = 'Bob'
+}
+
+$hash | Get-Member -Force -MemberType MemberSet, CodeProperty
 ```
 
 ```Output
@@ -114,7 +119,7 @@ the **PSCustomObject**. The new properties are now part of the `psextended`
 **MemberSet**.
 
 ```powershell
-$user | Get-Member -Force -Type MemberSet, CodeProperty
+$user | Get-Member -Force -MemberType MemberSet, CodeProperty
 ```
 
 ```Output

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
@@ -1,7 +1,7 @@
 ---
 description: Describes automatic members in all PowerShell objects
 Locale: en-US
-ms.date: 08/21/2023
+ms.date: 01/10/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_Inrinsic_Members?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Intrinsic_Members
@@ -59,7 +59,12 @@ The **Force** parameter of `Get-Member` shows us the intrinsic members of the
 object.
 
 ```powershell
-$hash | Get-Member -Force -Type MemberSet, CodeProperty
+$hash = @{
+    Age  = 33
+    Name = 'Bob'
+}
+
+$hash | Get-Member -Force -MemberType MemberSet, CodeProperty
 ```
 
 ```Output
@@ -114,7 +119,7 @@ the **PSCustomObject**. The new properties are now part of the `psextended`
 **MemberSet**.
 
 ```powershell
-$user | Get-Member -Force -Type MemberSet, CodeProperty
+$user | Get-Member -Force -MemberType MemberSet, CodeProperty
 ```
 
 ```Output

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
@@ -1,7 +1,7 @@
 ---
 description: Describes automatic members in all PowerShell objects
 Locale: en-US
-ms.date: 08/21/2023
+ms.date: 01/10/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_Inrinsic_Members?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Intrinsic_Members
@@ -59,7 +59,12 @@ The **Force** parameter of `Get-Member` shows us the intrinsic members of the
 object.
 
 ```powershell
-$hash | Get-Member -Force -Type MemberSet, CodeProperty
+$hash = @{
+    Age  = 33
+    Name = 'Bob'
+}
+
+$hash | Get-Member -Force -MemberType MemberSet, CodeProperty
 ```
 
 ```Output
@@ -114,7 +119,7 @@ the **PSCustomObject**. The new properties are now part of the `psextended`
 **MemberSet**.
 
 ```powershell
-$user | Get-Member -Force -Type MemberSet, CodeProperty
+$user | Get-Member -Force -MemberType MemberSet, CodeProperty
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
@@ -1,7 +1,7 @@
 ---
 description: Describes automatic members in all PowerShell objects
 Locale: en-US
-ms.date: 08/21/2023
+ms.date: 01/10/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_Inrinsic_Members?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Intrinsic_Members
@@ -59,7 +59,12 @@ The **Force** parameter of `Get-Member` shows us the intrinsic members of the
 object.
 
 ```powershell
-$hash | Get-Member -Force -Type MemberSet, CodeProperty
+$hash = @{
+    Age  = 33
+    Name = 'Bob'
+}
+
+$hash | Get-Member -Force -MemberType MemberSet, CodeProperty
 ```
 
 ```Output
@@ -114,7 +119,7 @@ the **PSCustomObject**. The new properties are now part of the `psextended`
 **MemberSet**.
 
 ```powershell
-$user | Get-Member -Force -Type MemberSet, CodeProperty
+$user | Get-Member -Force -MemberType MemberSet, CodeProperty
 ```
 
 ```Output


### PR DESCRIPTION
# PR Summary

Prior to this change, `about_Intrinsic_Members` defines examples that describe a hashtable and interacts with a variable containing the hashtable but doesn't define the hashtable itself in the code blocks. The examples also use `-Type` with the `Get-Member` cmdlet, which is an alias for the paramter canonically named **MemberType**.

This change:

- Defines the `$hash` variable in the first code block for the example, ensuring readers can follow along without needing to intuit the definition from the output.
- Replaces usage of the `-Type` alias parameter with the canonical parameter name **MemberType**, making it easier for readers to look up the parameter. This also adheres to the docs style guide.
- Resolves #10780
- Fixes [AB#198703](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/198703)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
