### PR TITLE
(GH-10801) Fix `-OutFile` for web request cmdlets

### DIFF
--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 01/03/2024
+ms.date: 01/17/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -888,11 +888,15 @@ Accept wildcard characters: False
 
 ### -OutFile
 
-Saves the response body in the specified output file. Enter a path and file name. If you omit the
+Saves the response body in the specified output file. Enter a path and filename. If you omit the
 path, the default is the current location. The name is treated as a literal path. Names that contain
 brackets (`[]`) must be enclosed in single quotes (`'`).
 
 By default, `Invoke-RestMethod` returns the results to the pipeline.
+
+Starting in PowerShell 7.4, you can specify a folder path without the filename. When you do, the
+file's name is the taken from the last segment of the resolved URI after any redirections. When you
+specify a folder path for **OutFile**, you can't use the **Resume** parameter.
 
 ```yaml
 Type: System.String

--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 01/03/2024
+ms.date: 01/17/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -921,10 +921,8 @@ By default, `Invoke-WebRequest` returns the results to the pipeline. To send the
 and to the pipeline, use the **Passthru** parameter.
 
 Starting in PowerShell 7.4, you can specify a folder path without the filename. When you do, the
-file's name is the taken from either the
-[Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition)
-of the response or the last segment of the resolved URI after any redirections. When you specify a
-folder path for **OutFile**, you can't use the **Resume** parameter.
+file's name is the taken from the last segment of the resolved URI after any redirections. When you
+specify a folder path for **OutFile**, you can't use the **Resume** parameter.
 
 ```yaml
 Type: System.String


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for the `-OutFile` parameter of the `Invoke-WebRequest` cmdlet incorrectly mentioned retrieving the filename from the Content-Disposition. This functionality isn't implemented. Further, the `-OutFile` parameter for `Invoke-RestMethod` is missing any version-specific note, even though the behavior is the same.

This change:

- Fixes the wording for the `-OutFile` parameter in `Invoke-WebRequest` to remove the non-implemented detail.
- Adds a note to the documentation for `Invoke-RestMethod` about the automatic naming.
- Resolves #10801
- Fixes [AB#200725](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/200725)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
