### PR TITLE
Update `chapter-02.md`: Whitespace fix for readability and accuracy

### DIFF
--- a/reference/docs-conceptual/lang-spec/chapter-02.md
+++ b/reference/docs-conceptual/lang-spec/chapter-02.md
@@ -98,7 +98,7 @@ Syntax:
 
 ```Syntax
 comment:
-single-line-comment
+    single-line-comment
     requires-comment
     delimited-comment
 


### PR DESCRIPTION
Fixing indentation in `comment:` section

# PR Summary

The lack of whitespace before `single-line-comment` in the `comment:` section of this language spec was confusing as a user.

## Before

![image](https://github.com/MicrosoftDocs/PowerShell-Docs/assets/76000251/48c63047-a889-4673-87c6-c0946220175f)

## After

![image](https://github.com/MicrosoftDocs/PowerShell-Docs/assets/76000251/db8e2b20-67af-4d91-b842-1b59f295f1e2)


## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
