### PR TITLE
(GH-10822) Clarify UUID version for `New-Guid`

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Guid.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Guid.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Utility-help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/04/2021
+ms.date: 01/24/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/new-guid?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-Guid
@@ -52,5 +52,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 This cmdlet returns a GUID.
 
 ## NOTES
+
+The cmdlet creates a Version 4 Universally Unique Identifier (UUID). For more information, see
+[System.Guid.NewGuid](xref:System.Guid.NewGuid).
 
 ## RELATED LINKS

--- a/reference/7.2/Microsoft.PowerShell.Utility/New-Guid.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/New-Guid.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/04/2021
+ms.date: 01/24/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/new-guid?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-Guid
@@ -51,5 +51,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 This cmdlet returns a GUID.
 
 ## NOTES
+
+The cmdlet creates a Version 4 Universally Unique Identifier (UUID). For more information, see
+[System.Guid.NewGuid](xref:System.Guid.NewGuid).
 
 ## RELATED LINKS

--- a/reference/7.3/Microsoft.PowerShell.Utility/New-Guid.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/New-Guid.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 10/04/2021
+ms.date: 01/24/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/new-guid?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-Guid
@@ -51,5 +51,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 This cmdlet returns a GUID.
 
 ## NOTES
+
+The cmdlet creates a Version 4 Universally Unique Identifier (UUID). For more information, see
+[System.Guid.NewGuid](xref:System.Guid.NewGuid).
 
 ## RELATED LINKS

--- a/reference/7.4/Microsoft.PowerShell.Utility/New-Guid.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/New-Guid.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 08/28/2023
+ms.date: 01/24/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/new-guid?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-Guid
@@ -53,5 +53,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 This cmdlet returns a GUID.
 
 ## NOTES
+
+The cmdlet creates a Version 4 Universally Unique Identifier (UUID). For more information, see
+[System.Guid.NewGuid](xref:System.Guid.NewGuid).
 
 ## RELATED LINKS

--- a/reference/7.5/Microsoft.PowerShell.Utility/New-Guid.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/New-Guid.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 01/18/2024
+ms.date: 01/24/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/new-guid?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: New-Guid
@@ -146,5 +146,9 @@ This cmdlet returns a GUID.
 The cmdlet passes string input to the constructor of the **System.Guid** class. The constructor
 support strings in several formats. For more information, see
 [System.Guid(String)](/dotnet/api/system.guid.-ctor#system-guid-ctor(system-string)).
+
+When used without string input or the **Empty** parameter, the cmdlet creates a Version 4
+Universally Unique Identifier (UUID). For more information, see
+[System.Guid.NewGuid](xref:System.Guid.NewGuid).
 
 ## RELATED LINKS


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for the `New-Guid` cmdlet did not specify which GUID version the cmdlet creates. This change:

- Adds a note clarifying the cmdlet creates v4 UUIDs.
- Resolves #10822
- Fixes [AB#203150](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/203150)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
