### PR TITLE
Set-PSReadLineOption.md: Corrected Default value row of HistoryNoDuplicates's yaml block

### DIFF
--- a/reference/7.4/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.4/PSReadLine/Set-PSReadLineOption.md
@@ -518,7 +518,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: False
+Default value: True
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
# PR Summary

### _Incorrect:_

![image](https://github.com/MicrosoftDocs/PowerShell-Docs/assets/157975415/b277fe77-2042-4c9d-bb80-28e1163d5832)

### _Default value should be **True**. This PR amends that._

- - -

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
