### PR TITLE
docker run does not create a PowerShell 7.5 container

### DIFF
--- a/reference/docs-conceptual/install/PowerShell-in-Docker.md
+++ b/reference/docs-conceptual/install/PowerShell-in-Docker.md
@@ -27,12 +27,14 @@ GitHub.
 
 ## Using PowerShell in a container
 
-The following steps show the Docker commands required to download the image and start an interactive
+The following steps show the Docker commands required to download the latest PowerShell image and start an interactive
 PowerShell session.
 
 ```console
 docker run -it mcr.microsoft.com/powershell
 ```
+
+This version corresponding to the latest PowerShell image may differ from the version of PowerShell targetted by this documentation.  
 
 ### Remove the image when no longer needed
 


### PR DESCRIPTION
The command "docker run -it mcr.microsoft.com/powershell" downloads the latest PowerShell 7.4.1 but this article is on PowerShell 7.5. (preview). ACR is not setup to run each version on the documentation. For example "docker run -it mcr.microsoft.com/powershell:preview" runs PowerShell 7.4.0-rc.1.

Every article is incorrect 5.1, 7.1.7.2, 7.3 and technically 7.4 b/c once 7.5 is related, 7.4 will be incorrect.

All articles will have to updated

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [ ] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [ ] **Summary:** This PR's summary describes the scope and intent of the change.
- [ ] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [ ] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
