### PR TITLE
Remove unnecessarily misleading clauses w.r.t. environment variable emptiness (#10850)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -28,11 +28,11 @@ PowerShell can access and manage environment variables in any of the supported
 operating system platforms. The PowerShell environment provider lets you get,
 add, change, clear, and delete environment variables in the current console.
 
-Environment variables, unlike other types of variables in PowerShell, are
-always stored as a string and can't be empty. Also unlike other variables,
-they're inherited by child processes, such as local background jobs and the
-sessions in which module members run. This makes environment variables well
-suited to storing values that are needed in both parent and child processes.
+Environment variables, unlike other types of variables in PowerShell, are always
+stored as strings. Also unlike other variables, they're inherited by child
+processes, such as local background jobs and the sessions in which module
+members run. This makes environment variables well suited to storing values that
+are needed in both parent and child processes.
 
 On Windows, environment variables can be defined in three scopes:
 
@@ -113,7 +113,7 @@ The 'Foo' environment variable is set to: An example
 An example!
 ```
 
-Because an environment variable can't be an empty string, setting one to
+Because environment variables aren't usually empty strings, setting one to
 `$null` or an empty string removes it. For example:
 
 ```powershell

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to access and manage environment variables in PowerShell.
 Locale: en-US
-ms.date: 09/20/2023
+ms.date: 02/05/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Environment Variables
@@ -28,11 +28,11 @@ PowerShell can access and manage environment variables in any of the supported
 operating system platforms. The PowerShell environment provider lets you get,
 add, change, clear, and delete environment variables in the current console.
 
-Environment variables, unlike other types of variables in PowerShell, are always
-stored as strings. Also unlike other variables, they're inherited by child
-processes, such as local background jobs and the sessions in which module
-members run. This makes environment variables well suited to storing values that
-are needed in both parent and child processes.
+Environment variables, unlike other types of variables in PowerShell, are
+always stored as strings. Also unlike other variables, they're inherited by
+child processes, such as local background jobs and the sessions in which module
+members run. This makes environment variables well suited to storing values
+that are needed in both parent and child processes.
 
 On Windows, environment variables can be defined in three scopes:
 
@@ -46,8 +46,8 @@ parent process and is constructed from the variables in the _Machine_ and
 _User_ scopes.
 
 When you change environment variables in PowerShell, the change affects only
-the current session. This behavior resembles the behavior of the `Set` command
-in the Windows Command Shell and the `Setenv` command in UNIX-based
+the current session. This behavior resembles the behavior of the `set` command
+in the Windows Command Shell and the `setenv` command in UNIX-based
 environments. To change values in the Machine or User scopes, you must use the
 methods of the **System.Environment** class.
 
@@ -113,8 +113,9 @@ The 'Foo' environment variable is set to: An example
 An example!
 ```
 
-Because environment variables aren't usually empty strings, setting one to
-`$null` or an empty string removes it. For example:
+In PowerShell, an environment variable can't be set to an empty string. Setting
+an environment variable to `$null` or an empty string removes it from the
+current session. For example:
 
 ```powershell
 $Env:Foo = ''

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -36,11 +36,11 @@ add, change, clear, and delete environment variables in the current console.
 > case-sensitive. For example, `$env:Path` and `$env:PATH` are different
 > environment variables on non-Windows platforms.
 
-Environment variables, unlike other types of variables in PowerShell, are
-always stored as a string and can't be empty. Also unlike other variables,
-they're inherited by child processes, such as local background jobs and the
-sessions in which module members run. This makes environment variables well
-suited to storing values that are needed in both parent and child processes.
+Environment variables, unlike other types of variables in PowerShell, are always
+stored as strings. Also unlike other variables, they're inherited by child
+processes, such as local background jobs and the sessions in which module
+members run. This makes environment variables well suited to storing values that
+are needed in both parent and child processes.
 
 On Windows, environment variables can be defined in three scopes:
 
@@ -121,7 +121,7 @@ The 'Foo' environment variable is set to: An example
 An example!
 ```
 
-Because an environment variable can't be an empty string, setting one to
+Because environment variables aren't usually empty strings, setting one to
 `$null` or an empty string removes it. For example:
 
 ```powershell

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to access and manage environment variables in PowerShell.
 Locale: en-US
-ms.date: 09/20/2023
+ms.date: 02/05/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Environment Variables
@@ -36,11 +36,11 @@ add, change, clear, and delete environment variables in the current console.
 > case-sensitive. For example, `$env:Path` and `$env:PATH` are different
 > environment variables on non-Windows platforms.
 
-Environment variables, unlike other types of variables in PowerShell, are always
-stored as strings. Also unlike other variables, they're inherited by child
-processes, such as local background jobs and the sessions in which module
-members run. This makes environment variables well suited to storing values that
-are needed in both parent and child processes.
+Environment variables, unlike other types of variables in PowerShell, are
+always stored as strings. Also unlike other variables, they're inherited by
+child processes, such as local background jobs and the sessions in which module
+members run. This makes environment variables well suited to storing values
+that are needed in both parent and child processes.
 
 On Windows, environment variables can be defined in three scopes:
 
@@ -54,8 +54,8 @@ parent process and is constructed from the variables in the _Machine_ and
 _User_ scopes.
 
 When you change environment variables in PowerShell, the change affects only
-the current session. This behavior resembles the behavior of the `Set` command
-in the Windows Command Shell and the `Setenv` command in UNIX-based
+the current session. This behavior resembles the behavior of the `set` command
+in the Windows Command Shell and the `setenv` command in UNIX-based
 environments. To change values in the Machine or User scopes, you must use the
 methods of the **System.Environment** class.
 
@@ -121,8 +121,9 @@ The 'Foo' environment variable is set to: An example
 An example!
 ```
 
-Because environment variables aren't usually empty strings, setting one to
-`$null` or an empty string removes it. For example:
+In PowerShell, an environment variable can't be set to an empty string. Setting
+an environment variable to `$null` or an empty string removes it from the
+current session. For example:
 
 ```powershell
 $Env:Foo = ''

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -36,11 +36,11 @@ add, change, clear, and delete environment variables in the current console.
 > case-sensitive. For example, `$env:Path` and `$env:PATH` are different
 > environment variables on non-Windows platforms.
 
-Environment variables, unlike other types of variables in PowerShell, are
-always stored as a string and can't be empty. Also unlike other variables,
-they're inherited by child processes, such as local background jobs and the
-sessions in which module members run. This makes environment variables well
-suited to storing values that are needed in both parent and child processes.
+Environment variables, unlike other types of variables in PowerShell, are always
+stored as strings. Also unlike other variables, they're inherited by child
+processes, such as local background jobs and the sessions in which module
+members run. This makes environment variables well suited to storing values that
+are needed in both parent and child processes.
 
 On Windows, environment variables can be defined in three scopes:
 
@@ -121,7 +121,7 @@ The 'Foo' environment variable is set to: An example
 An example!
 ```
 
-Because an environment variable can't be an empty string, setting one to
+Because environment variables aren't usually empty strings, setting one to
 `$null` or an empty string removes it. For example:
 
 ```powershell

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to access and manage environment variables in PowerShell.
 Locale: en-US
-ms.date: 09/20/2023
+ms.date: 02/05/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Environment Variables
@@ -36,11 +36,11 @@ add, change, clear, and delete environment variables in the current console.
 > case-sensitive. For example, `$env:Path` and `$env:PATH` are different
 > environment variables on non-Windows platforms.
 
-Environment variables, unlike other types of variables in PowerShell, are always
-stored as strings. Also unlike other variables, they're inherited by child
-processes, such as local background jobs and the sessions in which module
-members run. This makes environment variables well suited to storing values that
-are needed in both parent and child processes.
+Environment variables, unlike other types of variables in PowerShell, are
+always stored as strings. Also unlike other variables, they're inherited by
+child processes, such as local background jobs and the sessions in which module
+members run. This makes environment variables well suited to storing values
+that are needed in both parent and child processes.
 
 On Windows, environment variables can be defined in three scopes:
 
@@ -54,8 +54,8 @@ parent process and is constructed from the variables in the _Machine_ and
 _User_ scopes.
 
 When you change environment variables in PowerShell, the change affects only
-the current session. This behavior resembles the behavior of the `Set` command
-in the Windows Command Shell and the `Setenv` command in UNIX-based
+the current session. This behavior resembles the behavior of the `set` command
+in the Windows Command Shell and the `setenv` command in UNIX-based
 environments. To change values in the Machine or User scopes, you must use the
 methods of the **System.Environment** class.
 
@@ -121,8 +121,9 @@ The 'Foo' environment variable is set to: An example
 An example!
 ```
 
-Because environment variables aren't usually empty strings, setting one to
-`$null` or an empty string removes it. For example:
+In PowerShell, an environment variable can't be set to an empty string. Setting
+an environment variable to `$null` or an empty string removes it from the
+current session. For example:
 
 ```powershell
 $Env:Foo = ''

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -36,11 +36,11 @@ add, change, clear, and delete environment variables in the current console.
 > case-sensitive. For example, `$env:Path` and `$env:PATH` are different
 > environment variables on non-Windows platforms.
 
-Environment variables, unlike other types of variables in PowerShell, are
-always stored as a string and can't be empty. Also unlike other variables,
-they're inherited by child processes, such as local background jobs and the
-sessions in which module members run. This makes environment variables well
-suited to storing values that are needed in both parent and child processes.
+Environment variables, unlike other types of variables in PowerShell, are always
+stored as strings. Also unlike other variables, they're inherited by child
+processes, such as local background jobs and the sessions in which module
+members run. This makes environment variables well suited to storing values that
+are needed in both parent and child processes.
 
 On Windows, environment variables can be defined in three scopes:
 
@@ -121,7 +121,7 @@ The 'Foo' environment variable is set to: An example
 An example!
 ```
 
-Because an environment variable can't be an empty string, setting one to
+Because environment variables aren't usually empty strings, setting one to
 `$null` or an empty string removes it. For example:
 
 ```powershell

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to access and manage environment variables in PowerShell.
 Locale: en-US
-ms.date: 09/20/2023
+ms.date: 02/05/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Environment Variables
@@ -36,11 +36,11 @@ add, change, clear, and delete environment variables in the current console.
 > case-sensitive. For example, `$env:Path` and `$env:PATH` are different
 > environment variables on non-Windows platforms.
 
-Environment variables, unlike other types of variables in PowerShell, are always
-stored as strings. Also unlike other variables, they're inherited by child
-processes, such as local background jobs and the sessions in which module
-members run. This makes environment variables well suited to storing values that
-are needed in both parent and child processes.
+Environment variables, unlike other types of variables in PowerShell, are
+always stored as strings. Also unlike other variables, they're inherited by
+child processes, such as local background jobs and the sessions in which module
+members run. This makes environment variables well suited to storing values
+that are needed in both parent and child processes.
 
 On Windows, environment variables can be defined in three scopes:
 
@@ -54,8 +54,8 @@ parent process and is constructed from the variables in the _Machine_ and
 _User_ scopes.
 
 When you change environment variables in PowerShell, the change affects only
-the current session. This behavior resembles the behavior of the `Set` command
-in the Windows Command Shell and the `Setenv` command in UNIX-based
+the current session. This behavior resembles the behavior of the `set` command
+in the Windows Command Shell and the `setenv` command in UNIX-based
 environments. To change values in the Machine or User scopes, you must use the
 methods of the **System.Environment** class.
 
@@ -121,8 +121,9 @@ The 'Foo' environment variable is set to: An example
 An example!
 ```
 
-Because environment variables aren't usually empty strings, setting one to
-`$null` or an empty string removes it. For example:
+In PowerShell, an environment variable can't be set to an empty string. Setting
+an environment variable to `$null` or an empty string removes it from the
+current session. For example:
 
 ```powershell
 $Env:Foo = ''

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -36,11 +36,11 @@ add, change, clear, and delete environment variables in the current console.
 > case-sensitive. For example, `$env:Path` and `$env:PATH` are different
 > environment variables on non-Windows platforms.
 
-Environment variables, unlike other types of variables in PowerShell, are
-always stored as a string and can't be empty. Also unlike other variables,
-they're inherited by child processes, such as local background jobs and the
-sessions in which module members run. This makes environment variables well
-suited to storing values that are needed in both parent and child processes.
+Environment variables, unlike other types of variables in PowerShell, are always
+stored as strings. Also unlike other variables, they're inherited by child
+processes, such as local background jobs and the sessions in which module
+members run. This makes environment variables well suited to storing values that
+are needed in both parent and child processes.
 
 On Windows, environment variables can be defined in three scopes:
 
@@ -121,7 +121,7 @@ The 'Foo' environment variable is set to: An example
 An example!
 ```
 
-Because an environment variable can't be an empty string, setting one to
+Because environment variables aren't usually empty strings, setting one to
 `$null` or an empty string removes it. For example:
 
 ```powershell

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to access and manage environment variables in PowerShell.
 Locale: en-US
-ms.date: 09/20/2023
+ms.date: 02/05/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Environment Variables
@@ -36,11 +36,11 @@ add, change, clear, and delete environment variables in the current console.
 > case-sensitive. For example, `$env:Path` and `$env:PATH` are different
 > environment variables on non-Windows platforms.
 
-Environment variables, unlike other types of variables in PowerShell, are always
-stored as strings. Also unlike other variables, they're inherited by child
-processes, such as local background jobs and the sessions in which module
-members run. This makes environment variables well suited to storing values that
-are needed in both parent and child processes.
+Environment variables, unlike other types of variables in PowerShell, are
+always stored as strings. Also unlike other variables, they're inherited by
+child processes, such as local background jobs and the sessions in which module
+members run. This makes environment variables well suited to storing values
+that are needed in both parent and child processes.
 
 On Windows, environment variables can be defined in three scopes:
 
@@ -54,8 +54,8 @@ parent process and is constructed from the variables in the _Machine_ and
 _User_ scopes.
 
 When you change environment variables in PowerShell, the change affects only
-the current session. This behavior resembles the behavior of the `Set` command
-in the Windows Command Shell and the `Setenv` command in UNIX-based
+the current session. This behavior resembles the behavior of the `set` command
+in the Windows Command Shell and the `setenv` command in UNIX-based
 environments. To change values in the Machine or User scopes, you must use the
 methods of the **System.Environment** class.
 
@@ -121,8 +121,9 @@ The 'Foo' environment variable is set to: An example
 An example!
 ```
 
-Because environment variables aren't usually empty strings, setting one to
-`$null` or an empty string removes it. For example:
+In PowerShell, an environment variable can't be set to an empty string. Setting
+an environment variable to `$null` or an empty string removes it from the
+current session. For example:
 
 ```powershell
 $Env:Foo = ''


### PR DESCRIPTION


# PR Summary

This adjusts some wording to not inappropriately state that environment variables cannot be empty strings when they _can_ be empty strings.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
