### PR TITLE
Get-Date DST Grammar Correction

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -146,9 +146,9 @@ The Gregorian calendar has 365 days, except for leap years that have 366 days. F
 `Get-Date` uses three parameters to specify the date: **Year**, **Month**, and **Day**. The command
 is wrapped with parentheses so that the result is evaluated by the **DayofYear** property.
 
-### Example 6: Check if a date is adjusted for daylight savings time
+### Example 6: Check if a date is adjusted for daylight saving time
 
-This example uses a boolean method to verify if a date is adjusted by daylight savings time.
+This example uses a boolean method to verify if a date is adjusted by daylight saving time.
 
 ```powershell
 $DST = Get-Date
@@ -160,7 +160,7 @@ True
 ```
 
 A variable, `$DST` stores the result of `Get-Date`. `$DST` uses the **IsDaylightSavingTime** method
-to test if the date is adjusted for daylight savings time.
+to test if the date is adjusted for daylight saving time.
 
 ### Example 7: Convert the current time to UTC time
 

--- a/reference/7.2/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Get-Date.md
@@ -162,9 +162,9 @@ The Gregorian calendar has 365 days, except for leap years that have 366 days. F
 `Get-Date` uses three parameters to specify the date: **Year**, **Month**, and **Day**. The command
 is wrapped with parentheses so that the result is evaluated by the **DayofYear** property.
 
-### Example 6: Check if a date is adjusted for daylight savings time
+### Example 6: Check if a date is adjusted for daylight saving time
 
-This example uses a boolean method to verify if a date is adjusted by daylight savings time.
+This example uses a boolean method to verify if a date is adjusted by daylight saving time.
 
 ```powershell
 $DST = Get-Date
@@ -176,7 +176,7 @@ True
 ```
 
 A variable, `$DST` stores the result of `Get-Date`. `$DST` uses the **IsDaylightSavingTime** method
-to test if the date is adjusted for daylight savings time.
+to test if the date is adjusted for daylight saving time.
 
 ### Example 7: Convert the current time to UTC time
 

--- a/reference/7.3/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Get-Date.md
@@ -162,9 +162,9 @@ The Gregorian calendar has 365 days, except for leap years that have 366 days. F
 `Get-Date` uses three parameters to specify the date: **Year**, **Month**, and **Day**. The command
 is wrapped with parentheses so that the result is evaluated by the **DayofYear** property.
 
-### Example 6: Check if a date is adjusted for daylight savings time
+### Example 6: Check if a date is adjusted for daylight saving time
 
-This example uses a boolean method to verify if a date is adjusted by daylight savings time.
+This example uses a boolean method to verify if a date is adjusted by daylight saving time.
 
 ```powershell
 $DST = Get-Date
@@ -176,7 +176,7 @@ True
 ```
 
 A variable, `$DST` stores the result of `Get-Date`. `$DST` uses the **IsDaylightSavingTime** method
-to test if the date is adjusted for daylight savings time.
+to test if the date is adjusted for daylight saving time.
 
 ### Example 7: Convert the current time to UTC time
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-Date.md
@@ -162,9 +162,9 @@ The Gregorian calendar has 365 days, except for leap years that have 366 days. F
 `Get-Date` uses three parameters to specify the date: **Year**, **Month**, and **Day**. The command
 is wrapped with parentheses so that the result is evaluated by the **DayofYear** property.
 
-### Example 6: Check if a date is adjusted for daylight savings time
+### Example 6: Check if a date is adjusted for daylight saving time
 
-This example uses a boolean method to verify if a date is adjusted by daylight savings time.
+This example uses a boolean method to verify if a date is adjusted by daylight saving time.
 
 ```powershell
 $DST = Get-Date
@@ -176,7 +176,7 @@ True
 ```
 
 A variable, `$DST` stores the result of `Get-Date`. `$DST` uses the **IsDaylightSavingTime** method
-to test if the date is adjusted for daylight savings time.
+to test if the date is adjusted for daylight saving time.
 
 ### Example 7: Convert the current time to UTC time
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-Date.md
@@ -162,9 +162,9 @@ The Gregorian calendar has 365 days, except for leap years that have 366 days. F
 `Get-Date` uses three parameters to specify the date: **Year**, **Month**, and **Day**. The command
 is wrapped with parentheses so that the result is evaluated by the **DayofYear** property.
 
-### Example 6: Check if a date is adjusted for daylight savings time
+### Example 6: Check if a date is adjusted for daylight saving time
 
-This example uses a boolean method to verify if a date is adjusted by daylight savings time.
+This example uses a boolean method to verify if a date is adjusted by daylight saving time.
 
 ```powershell
 $DST = Get-Date
@@ -176,7 +176,7 @@ True
 ```
 
 A variable, `$DST` stores the result of `Get-Date`. `$DST` uses the **IsDaylightSavingTime** method
-to test if the date is adjusted for daylight savings time.
+to test if the date is adjusted for daylight saving time.
 
 ### Example 7: Convert the current time to UTC time
 


### PR DESCRIPTION
# PR Summary
Corrects the references in Get-Date documentation from `daylight savings time` to `daylight saving time` 

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
