### PR TITLE
Fixes the embedded parameter name for Update-TypeData

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes_Constructors.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes_Constructors.md
@@ -484,7 +484,7 @@ text in angle brackets as needed.
 class <class-name> {
     static [hashtable[]] $MemberDefinitions = @(
         @{
-            Name       = '<member-name>'
+            MemberName = '<member-name>'
             MemberType = '<member-type>'
             Value      = <member-definition>
         }


### PR DESCRIPTION
# PR Summary

Fixes an error in the hashtable which is used to splat Update-TypeData. Incorrect parameter name, `Name` changed to `MemberName`.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
