### PR TITLE
Fix format of "Accept pipeline input" metadata

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
@@ -264,7 +264,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -285,7 +285,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -307,7 +307,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -328,7 +328,7 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -452,7 +452,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -473,7 +473,7 @@ Aliases: OS
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -518,7 +518,7 @@ Aliases:
 Required: False False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (System.Object[]), ByName (System.Object[])
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -539,7 +539,7 @@ Aliases: SO
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Item.md
@@ -251,7 +251,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -315,7 +315,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (True)
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Test-Path.md
@@ -356,7 +356,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -387,7 +387,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/New-Item.md
@@ -264,7 +264,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -285,7 +285,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -307,7 +307,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -328,7 +328,7 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -454,7 +454,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -475,7 +475,7 @@ Aliases: OS
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -520,7 +520,7 @@ Aliases:
 Required: False False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (System.Object[]), ByName (System.Object[])
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -541,7 +541,7 @@ Aliases: SO
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -563,7 +563,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Set-Content.md
@@ -182,7 +182,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -246,7 +246,7 @@ Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UT
 Required: False
 Position: Named
 Default value: utf8NoBOM
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -369,7 +369,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -434,7 +434,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Set-Item.md
@@ -251,7 +251,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -315,7 +315,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (True)
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -389,7 +389,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (True)
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Test-Path.md
@@ -349,7 +349,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -380,7 +380,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Write-Information.md
@@ -194,7 +194,7 @@ Aliases: Msg, Message
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: ByValue (True), ByName (False)
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
@@ -212,7 +212,7 @@ Aliases:
 Required: False
 Position: 1
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.3/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/New-Item.md
@@ -264,7 +264,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -285,7 +285,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -307,7 +307,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -328,7 +328,7 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -454,7 +454,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -475,7 +475,7 @@ Aliases: OS
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -520,7 +520,7 @@ Aliases:
 Required: False False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (System.Object[]), ByName (System.Object[])
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -541,7 +541,7 @@ Aliases: SO
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -563,7 +563,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.3/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Set-Content.md
@@ -182,7 +182,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -246,7 +246,7 @@ Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UT
 Required: False
 Position: Named
 Default value: utf8NoBOM
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -369,7 +369,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -434,7 +434,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.3/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Set-Item.md
@@ -251,7 +251,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -315,7 +315,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (True)
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/reference/7.3/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -389,7 +389,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (True)
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/reference/7.3/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Test-Path.md
@@ -349,7 +349,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -380,7 +380,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.3/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/7.3/Microsoft.PowerShell.Utility/Write-Information.md
@@ -194,7 +194,7 @@ Aliases: Msg, Message
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: ByValue (True), ByName (False)
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
@@ -212,7 +212,7 @@ Aliases:
 Required: False
 Position: 1
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/New-Item.md
@@ -264,7 +264,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -285,7 +285,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -307,7 +307,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -328,7 +328,7 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -453,7 +453,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -474,7 +474,7 @@ Aliases: OS
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -519,7 +519,7 @@ Aliases:
 Required: False False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (System.Object[]), ByName (System.Object[])
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -540,7 +540,7 @@ Aliases: SO
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -562,7 +562,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -108,7 +108,7 @@ Aliases: ToLocalhost
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Set-Content.md
@@ -182,7 +182,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -251,7 +251,7 @@ Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UT
 Required: False
 Position: Named
 Default value: utf8NoBOM
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -374,7 +374,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -439,7 +439,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -515,7 +515,6 @@ By default, this cmdlet returns no output.
 When you use the **PassThru** parameter, this cmdlet returns a string representing the content.
 
 ## NOTES
-
 
 - `Set-Content` is designed for string processing. If you pipe non-string objects to `Set-Content`,
   it converts the object to a string before writing it. To write objects to files, use `Out-File`.

--- a/reference/7.4/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Set-Item.md
@@ -251,7 +251,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -315,7 +315,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (True)
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -389,7 +389,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (True)
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Start-Process.md
@@ -261,7 +261,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Test-Path.md
@@ -349,7 +349,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -380,7 +380,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Write-Information.md
@@ -194,7 +194,7 @@ Aliases: Msg, Message
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: ByValue (True), ByName (False)
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
@@ -212,7 +212,7 @@ Aliases:
 Required: False
 Position: 1
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/New-Item.md
@@ -264,7 +264,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -285,7 +285,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -307,7 +307,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -328,7 +328,7 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -453,7 +453,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -474,7 +474,7 @@ Aliases: OS
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -519,7 +519,7 @@ Aliases:
 Required: False False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (System.Object[]), ByName (System.Object[])
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -540,7 +540,7 @@ Aliases: SO
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -562,7 +562,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -108,7 +108,7 @@ Aliases: ToLocalhost
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Set-Content.md
@@ -182,7 +182,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -251,7 +251,7 @@ Accepted values: ASCII, BigEndianUnicode, BigEndianUTF32, OEM, Unicode, UTF7, UT
 Required: False
 Position: Named
 Default value: utf8NoBOM
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -374,7 +374,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -439,7 +439,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -515,7 +515,6 @@ By default, this cmdlet returns no output.
 When you use the **PassThru** parameter, this cmdlet returns a string representing the content.
 
 ## NOTES
-
 
 - `Set-Content` is designed for string processing. If you pipe non-string objects to `Set-Content`,
   it converts the object to a string before writing it. To write objects to files, use `Out-File`.

--- a/reference/7.5/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Set-Item.md
@@ -251,7 +251,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -315,7 +315,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (True)
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -389,7 +389,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (True)
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Start-Process.md
@@ -261,7 +261,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Test-Path.md
@@ -351,7 +351,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -382,7 +382,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Write-Information.md
@@ -194,7 +194,7 @@ Aliases: Msg, Message
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: ByValue (True), ByName (False)
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
@@ -212,7 +212,7 @@ Aliases:
 Required: False
 Position: 1
 Default value: None
-Accept pipeline input: ByValue (False), ByName (False)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
# PR Summary

Fix format of "Accept pipeline input" metadata

Before this PR, the formatting of "Accept pipeline input" metadata for parameters was inconsistent. This PR changes the formatting to be compliant with the work being done in PlatyPS.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide