### PR TITLE
Use relative path in a Get-ChildItem example

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 11/13/2023
+ms.date: 03/28/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-childitem?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-ChildItem
@@ -153,7 +153,7 @@ This example displays `.txt` files that are located in the current directory and
 subdirectories.
 
 ```powershell
-Get-ChildItem -Path C:\Test\*.txt -Recurse -Force
+Get-ChildItem -Path .\*.txt -Recurse -Force
 ```
 
 ```Output

--- a/reference/7.2/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/7.2/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/14/2023
+ms.date: 03/28/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-childitem?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-ChildItem
@@ -152,7 +152,7 @@ This example displays `.txt` files that are located in the current directory and
 subdirectories.
 
 ```powershell
-Get-ChildItem -Path C:\Test\*.txt -Recurse -Force
+Get-ChildItem -Path .\*.txt -Recurse -Force
 ```
 
 ```Output

--- a/reference/7.3/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/7.3/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/14/2023
+ms.date: 03/28/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-childitem?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-ChildItem
@@ -152,7 +152,7 @@ This example displays `.txt` files that are located in the current directory and
 subdirectories.
 
 ```powershell
-Get-ChildItem -Path C:\Test\*.txt -Recurse -Force
+Get-ChildItem -Path .\*.txt -Recurse -Force
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/14/2023
+ms.date: 03/28/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-childitem?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-ChildItem
@@ -152,7 +152,7 @@ This example displays `.txt` files that are located in the current directory and
 subdirectories.
 
 ```powershell
-Get-ChildItem -Path C:\Test\*.txt -Recurse -Force
+Get-ChildItem -Path .\*.txt -Recurse -Force
 ```
 
 ```Output

--- a/reference/7.5/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/14/2023
+ms.date: 03/28/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-childitem?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-ChildItem
@@ -152,7 +152,7 @@ This example displays `.txt` files that are located in the current directory and
 subdirectories.
 
 ```powershell
-Get-ChildItem -Path C:\Test\*.txt -Recurse -Force
+Get-ChildItem -Path .\*.txt -Recurse -Force
 ```
 
 ```Output


### PR DESCRIPTION
# PR Summary

Replace absolute path `C:\Test\*.txt` with relative path `.\*.txt` in the third `Get-ChildItem` example which "displays `.txt` files that are located in the current directory and its subdirectories."

Link to that example in docs of PowerShell 7.4: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-childitem?view=powershell-7.4#example-3-get-child-items-in-the-current-directory-and-subdirectories

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide