### PR TITLE
Added Break to $WarningPreference

### DIFF
--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -1375,6 +1375,8 @@ The valid values are as follows:
 
 - **Stop**: Displays the warning message and an error message and then stops
   executing.
+- **Break** - Enter the debugger when an error occurs or when an exception is
+  raised.
 - **Inquire**: Displays the warning message and then prompts for permission to
   continue.
 - **Continue**: (Default) Displays the warning message and then continues


### PR DESCRIPTION
# PR Summary
$WarningPreference also supports 'Break' but that was not clearly specified in the documentation. This PR fixes that by replicating the 'Break' documentation line to $WarningPreference.

## PR Checklist
- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
