### PR TITLE
Stop-Process syntax needs fixup with app name change

### DIFF
--- a/reference/docs-conceptual/developer/cmdlet/strongly-encouraged-development-guidelines.md
+++ b/reference/docs-conceptual/developer/cmdlet/strongly-encouraged-development-guidelines.md
@@ -135,11 +135,11 @@ By default, many cmdlets that modify the system, such as the
 parameter to force the cmdlet to return an object. When the `PassThru` parameter is specified, the
 cmdlet returns an object by using a call to the
 [System.Management.Automation.Cmdlet.WriteObject](/dotnet/api/System.Management.Automation.Cmdlet.WriteObject)
-method. For example, the following command stops the Calc process and passes the resultant process
+method. For example, the following command stops the Calc (CalculatorApp.exe) and passes the resultant process
 to the pipeline.
 
 ```powershell
-Stop-Process calc -passthru
+Stop-Process -Name CalculatorApp -PassThru
 ```
 
 In most cases, Add, Set, and New cmdlets should support a `PassThru` parameter.


### PR DESCRIPTION
# PR Summary

Changing 'calc' to 'calculatorapp' to fix non-working command line. Feel free to reach out to me directly on Teams if you have any questions.


## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

 
[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
