### PR TITLE
Add missing comparsion operators, BNF grammar fixes, markdown formatting

### DIFF
--- a/reference/docs-conceptual/lang-spec/chapter-02.md
+++ b/reference/docs-conceptual/lang-spec/chapter-02.md
@@ -7,10 +7,10 @@ title: Lexical structure
 
 ## 2.1 Grammars
 
-This specification shows the syntax of the PowerShell language using two grammars. The *lexical
-grammar* ([§B.1][§B.1]) shows how Unicode characters are combined to form line terminators, comments,
-white space, and tokens. The *syntactic grammar* ([§B.2][§B.2]) shows how the tokens resulting from the
-lexical grammar are combined to form PowerShell scripts.
+This specification shows the syntax of the PowerShell language using two grammars. The _lexical
+grammar_ ([§B.1][§B.1]) shows how Unicode characters are combined to form line terminators,
+comments, white space, and tokens. The _syntactic grammar_ ([§B.2][§B.2]) shows how the tokens
+resulting from the lexical grammar are combined to form PowerShell scripts.
 
 For convenience, fragments of these grammars are replicated in appropriate places throughout this
 specification.
@@ -58,11 +58,11 @@ signature-end:
 
 Description:
 
-The input source stream to a PowerShell translator is the *input* in a script, which contains a
+The input source stream to a PowerShell translator is the _input_ in a script, which contains a
 sequence of Unicode characters. The lexical processing of this stream involves the reduction of
 those characters into a sequence of tokens, which go on to become the input of syntactic analysis.
 
-A script is a group of PowerShell commands stored in a *script-file*. The script itself has no name,
+A script is a group of PowerShell commands stored in a _script-file_. The script itself has no name,
 per se, and takes its name from its source file. The end of that file indicates the end of the
 script.
 
@@ -145,11 +145,11 @@ not-greater-than-or-hash:
 
 Description:
 
-Source code can be annotated by the use of *comments*.
+Source code can be annotated by the use of _comments_.
 
-A *single-line-comment* begins with the character `#` and ends with a *new-line-character*.
+A _single-line-comment_ begins with the character `#` and ends with a _new-line-character_.
 
-A *delimited-comment* begins with the character pair `<#` and ends with the character pair `#>`.
+A _delimited-comment_ begins with the character pair `<#` and ends with the character pair `#>`.
 It can occur as part of a source line, as a whole source line, or it can span any number of source
 lines.
 
@@ -166,15 +166,15 @@ The lexical grammar implies that comments cannot occur inside tokens.
 (See §A for information about creating script files that contain special-valued comments that are
 used to generate documentation from script files.)
 
-A *requires-comment* specifies the criteria that have to be met for its containing script to be
+A _requires-comment_ specifies the criteria that have to be met for its containing script to be
 allowed to run. The primary criterion is the version of PowerShell being used to run the script. The
 minimum version requirement is specified as follows:
 
 `#requires -Version N[.n]`
 
-Where *N* is the (required) major version and *n* is the (optional) minor version.
+Where _N_ is the (required) major version and _n_ is the (optional) minor version.
 
-A *requires-comment* can be present in any script file; however, it cannot be present inside a
+A _requires-comment_ can be present in any script file; however, it cannot be present inside a
 function or cmdlet. It must be the first item on a source line. A script can contain multiple
 *requires-comment*s.
 
@@ -184,9 +184,9 @@ followed by a single-line comment. As well as following white space, the comment
 also be preceded by any expression-terminating or statement-terminating character (such as `)`, `}`,
 `]`, `'`, `"`, or `;`).
 
-A *requires-comment* cannot be present inside a snap-in.
+A _requires-comment_ cannot be present inside a snap-in.
 
-There are four other forms of a *requires-comment*:
+There are four other forms of a _requires-comment_:
 
 ```Syntax
 #requires --Assembly AssemblyId
@@ -210,7 +210,7 @@ whitespace:
 
 Description:
 
-*White space* consists of any sequence of one or more *whitespace* characters.
+_White space_ consists of any sequence of one or more _whitespace_ characters.
 
 Except for the fact that white space may act as a separator for tokens, it is ignored.
 
@@ -258,9 +258,9 @@ token:
 
 Description:
 
-A *token* is the smallest lexical element within the PowerShell language.
+A _token_ is the smallest lexical element within the PowerShell language.
 
-Tokens can be separated by *new-lines*, comments, white space, or any combination thereof.
+Tokens can be separated by _new-lines_, comments, white space, or any combination thereof.
 
 ### 2.3.1 Keywords
 
@@ -281,10 +281,10 @@ keyword: one of
 
 Description:
 
-A *keyword* is a sequence of characters that has a special meaning when used in a context-dependent
-place. Most often, this is as the first token in a *statement*; however, there are other locations,
+A _keyword_ is a sequence of characters that has a special meaning when used in a context-dependent
+place. Most often, this is as the first token in a _statement_; however, there are other locations,
 as indicated by the grammar. (A token that looks like a keyword, but is not being used in a keyword
-context, is a *command-name* or a *command-argument*.)
+context, is a _command-name_ or a _command-argument_.)
 
 The keywords `class`, `define`, `from`, `using`, and `var` are reserved for future use.
 
@@ -353,9 +353,9 @@ discussed in [§3.5][§3.5].
 The variables `$$` and `$^` are reserved for use in an interactive environment, which is outside the
 scope of this specification.
 
-There are two ways of writing a variable name: A *braced variable name*, which begins with `$`,
+There are two ways of writing a variable name: A _braced variable name_, which begins with `$`,
 followed by a curly bracket-delimited set of one or more almost-arbitrary characters; and an
-*ordinary variable name*, which also begins with `$`, followed by a set of one or more characters
+_ordinary variable name_, which also begins with `$`, followed by a set of one or more characters
 from a more restrictive set than a braced variable name allows. Every ordinary variable name can be
 expressed using a corresponding braced variable name.
 
@@ -373,7 +373,7 @@ ${E:\\File.txt}
 ```
 
 There is no limit on the length of a variable name, all characters in a variable name are
-significant, and letter case is *not* distinct.
+significant, and letter case is _not_ distinct.
 
 There are several different kinds of variables: user-defined ([§2.3.2.1][§2.3.2.1]), automatic
 ([§2.3.2.2][§2.3.2.2]), and preference ([§2.3.2.3][§2.3.2.3]). They can all coexist in the same scope ([§3.5][§3.5]).
@@ -389,7 +389,7 @@ Get-Power -exponent 3 -base 5 # " " "
 
 Each argument is passed by position or name, one at a time. However, a set of arguments can be
 passed as a group with expansion into individual arguments being handled by the runtime environment.
-This automatic argument expansion is known as *splatting*. For example,
+This automatic argument expansion is known as _splatting_. For example,
 
 ```powershell
 $values = 5,3 # put arguments into an array
@@ -411,7 +411,7 @@ This notation can only be used in an argument to a command.
 Names are partitioned into various namespaces each of which is stored on a virtual drive
 ([§3.1][§3.1]). For example, variables are stored on `Variable:`, environment variables are stored on
 `Env:`, functions are stored on `Function:`, and aliases are stored on `Alias:`. All of these names
-can be accessed as variables using the *variable-namespace* production within *variable-scope*. For
+can be accessed as variables using the _variable-namespace_ production within _variable-scope_. For
 example,
 
 ```powershell
@@ -548,14 +548,14 @@ non-double-quote-char:
 
 Description:
 
-When a command is invoked, information may be passed to it via one or more *arguments* whose values
-are accessed from within the command through a set of corresponding *parameters*. The process of
-matching parameters to arguments is called *parameter binding*.
+When a command is invoked, information may be passed to it via one or more _arguments_ whose values
+are accessed from within the command through a set of corresponding _parameters_. The process of
+matching parameters to arguments is called _parameter binding_.
 
 There are three kinds of argument:
 
-- Switch parameter ([§8.10.5][§8.10.5]) -- This has the form *command-parameter* where
-  *first-parameter-char* and *parameter-chars* together make up the switch name, which corresponds
+- Switch parameter ([§8.10.5][§8.10.5]) -- This has the form _command-parameter_ where
+  _first-parameter-char_ and _parameter-chars_ together make up the switch name, which corresponds
   to the name of a parameter (without its leading `-`) in the command being invoked. If the trailing
   colon is omitted, the presence of this argument indicates that the corresponding parameter be set
   to `$true`. If the trailing colon is present, the argument immediately following must designate a
@@ -567,8 +567,8 @@ There are three kinds of argument:
   Set-MyProcess -Strict: $true
   ```
 
-- Parameter with argument ([§8.10.2][§8.10.2]) -- This has the form *command-parameter* where
-  *first-parameter-char* and *parameter-chars* together make up the parameter name, which
+- Parameter with argument ([§8.10.2][§8.10.2]) -- This has the form _command-parameter_ where
+  _first-parameter-char_ and _parameter-chars_ together make up the parameter name, which
   corresponds to the name of a parameter (without its leading -) in the command being invoked. There
   must be no trailing colon. The argument immediately following designates an associated value. For
   example, given a command `Get-Power`, which has parameters `$base` and `$exponent`, the following
@@ -657,16 +657,16 @@ numeric-multiplier: one of
 Description:
 
 The type of an integer literal is determined by its value, the presence or absence of
-*long-type-suffix*, and the presence of a *numeric-multiplier* ([§2.3.5.1.3][§2.3.5.1.3]).
+_long-type-suffix_, and the presence of a _numeric-multiplier_ ([§2.3.5.1.3][§2.3.5.1.3]).
 
-For an integer literal with no *long-type-suffix*
+For an integer literal with no _long-type-suffix_
 
 - If its value can be represented by type int ([§4.2.3][§4.2.3]), that is its type;
 - Otherwise, if its value can be represented by type long ([§4.2.3][§4.2.3]), that is its type.
 - Otherwise, if its value can be represented by type decimal ([§2.3.5.1.2][§2.3.5.1.2]), that is its type.
 - Otherwise, it is represented by type double ([§2.3.5.1.2][§2.3.5.1.2]).
 
-For an integer literal with *long-type-suffix*
+For an integer literal with _long-type-suffix_
 
 - If its value can be represented by type long ([§4.2.3][§4.2.3]), that is its type;
 - Otherwise, that literal is ill formed.
@@ -717,19 +717,19 @@ dash:
 
 Description:
 
-A real literal may contain a *numeric-multiplier* ([§2.3.5.1.3][§2.3.5.1.3]).
+A real literal may contain a _numeric-multiplier_ ([§2.3.5.1.3][§2.3.5.1.3]).
 
-There are two kinds of real literal: *double* and *decimal*. These are indicated by the absence or
-presence, respectively, of *decimal-type-suffix*. (There is no such thing as a *float real
-literal*.)
+There are two kinds of real literal: _double_ and _decimal_. These are indicated by the absence or
+presence, respectively, of _decimal-type-suffix_. (There is no such thing as a _float real
+literal_.)
 
 A double real literal has type double ([§4.2.4.1][§4.2.4.1]). A decimal real literal has type decimal
 ([§4.2.4.2][§4.2.4.2]). Trailing zeros in the fraction part of a decimal real literal are significant.
 
-If the value of *exponent-part*'s *decimal-digits* in a double real literal is less than the
-minimum supported, the value of that double real literal is 0. If the value of *exponent-part*'s
-*decimal-digits* in a decimal real literal is less than the minimum supported, that literal is ill
-formed. If the value of *exponent-part*'s *decimal-digits* in a double or decimal real literal is
+If the value of _exponent-part_'s _decimal-digits_ in a double real literal is less than the
+minimum supported, the value of that double real literal is 0. If the value of _exponent-part_'s
+_decimal-digits_ in a decimal real literal is less than the minimum supported, that literal is ill
+formed. If the value of _exponent-part_'s _decimal-digits_ in a double or decimal real literal is
 greater than the maximum supported, that literal is ill formed.
 
 Some examples of double real literals are 1., 1.23, .45e35, 32.e+12, and 123.456E-231.
@@ -768,8 +768,8 @@ numeric-multiplier: *one of*
 
 Description:
 
-For convenience, integer and real literals can contain a *numeric-multiplier*, which indicates one
-of a set of commonly used powers of 10. *numeric-multiplier* can be written in any combination of
+For convenience, integer and real literals can contain a _numeric-multiplier_, which indicates one
+of a set of commonly used powers of 10. _numeric-multiplier_ can be written in any combination of
 upper- or lowercase letters.
 
 | **Multiplier** | **Meaning**                                 | **Example**                    |
@@ -894,13 +894,13 @@ Description:
 
 There are four kinds of string literals:
 
-- *verbatim-string-literal* (single-line single-quoted), which is a sequence of zero or more
+- _verbatim-string-literal_ (single-line single-quoted), which is a sequence of zero or more
   characters delimited by a pair of *single-quote-character*s. Examples are '' and 'red'.
-- *expandable-string-literal* (single-line double-quoted), which is a sequence of zero or more
+- _expandable-string-literal_ (single-line double-quoted), which is a sequence of zero or more
   characters delimited by a pair of *double-quote-character*s. Examples are "" and "red".
-- *verbatim-here-string-literal* (multi-line single-quoted), which is a sequence of zero or more
-  characters delimited by the character pairs @*single-quote-character* and
-  *single-quote-character*@, respectively, all contained on two or more source lines. Examples are:
+- _verbatim-here-string-literal_ (multi-line single-quoted), which is a sequence of zero or more
+  characters delimited by the character pairs @_single-quote-character_ and
+  _single-quote-character_@, respectively, all contained on two or more source lines. Examples are:
 
   ```powershell
   @'
@@ -916,9 +916,9 @@ There are four kinds of string literals:
   '@
   ```
 
-- *expandable-here-string-literal* (multi-line double-quoted), which is a sequence of zero or more
-  characters delimited by the character pairs @*double-quote-character* and
-  *double-quote-character*@, respectively, all contained on two or more source lines. Examples are:
+- _expandable-here-string-literal_ (multi-line double-quoted), which is a sequence of zero or more
+  characters delimited by the character pairs @_double-quote-character_ and
+  _double-quote-character_@, respectively, all contained on two or more source lines. Examples are:
 
   ```powershell
   @"
@@ -939,20 +939,20 @@ For *verbatim-here-string-literal*s and *expandable-here-string-literal*s, excep
 delimiter-character pair, and no characters may precede on the same source line as the closing
 delimiter character pair.
 
-The *body* of a *verbatim-here-string-literal* or an *expandable-here-string-literal* begins at the
+The _body_ of a _verbatim-here-string-literal_ or an _expandable-here-string-literal_ begins at the
 start of the first source line following the opening delimiter, and ends at the end of the last
 source line preceding the closing delimiter. The body may be empty. The line terminator on the last
 source line preceding the closing delimiter is not part of that literal's body.
 
 A literal of any of these kinds has type string ([§4.3.1][§4.3.1]).
 
-The character used to delimit a *verbatim-string-literal* or *expandable-string-literal* can be
+The character used to delimit a _verbatim-string-literal_ or _expandable-string-literal_ can be
 contained in such a string literal by writing that character twice, in succession. For example,
-`'What''s the time?'` and `"I said, ""Hello""."`. However, a *single-quote-character* has no
-special meaning inside an *expandable-string-literal*, and a *double-quote-character* has no special
-meaning inside a *verbatim-string-literal*.
+`'What''s the time?'` and `"I said, ""Hello""."`. However, a _single-quote-character_ has no
+special meaning inside an _expandable-string-literal_, and a _double-quote-character_ has no special
+meaning inside a _verbatim-string-literal_.
 
-An *expandable-string-literal* and an *expandable-here-string-literal* may contain
+An _expandable-string-literal_ and an _expandable-here-string-literal_ may contain
 *escaped-character*s ([§2.3.7][§2.3.7]). For example, when the following string literal is written to the
 pipeline, the result is as shown below:
 
@@ -965,9 +965,9 @@ column1<horizontal-tab>column2<new-line>
 second line, "Hello", `Q5!
 ```
 
-If an *expandable-string-literal* or *expandable-here-string-literal* contains the name of a
+If an _expandable-string-literal_ or _expandable-here-string-literal_ contains the name of a
 variable, unless that name is preceded immediately by an escape character, it is replaced by the
-string representation of that variable's value ([§6.7][§6.7]). This is known as *variable substitution*.
+string representation of that variable's value ([§6.7][§6.7]). This is known as _variable substitution_.
 
 > [!NOTE]
 > If the variable name is part of some larger expression, only the variable name is replaced. For
@@ -981,7 +981,7 @@ $count = 10
 "The value of `$count is $count"
 ```
 
-results in the *expandable-string-literal*
+results in the _expandable-string-literal_
 
 ```Output
 The value of $count is 10.
@@ -1001,10 +1001,10 @@ $a[0] is red blue[0], $a[0] is red
 ```
 
 *expandable-string-literal*s and *expandable-here-string-literal*s also support a kind of
-substitution called *sub-expression expansion*, by treating text of the form `$( ... )` as a
-*sub-expression* ([§7.1.6][§7.1.6]). Such text is replaced by the string representation of that
-expression's value ([§6.8][§6.8]). Any white space used to separate tokens within *sub-expression*'s
-*statement-list* is ignored as far as the result string's construction is concerned.
+substitution called _sub-expression expansion_, by treating text of the form `$( ... )` as a
+_sub-expression_ ([§7.1.6][§7.1.6]). Such text is replaced by the string representation of that
+expression's value ([§6.8][§6.8]). Any white space used to separate tokens within _sub-expression_'s
+_statement-list_ is ignored as far as the result string's construction is concerned.
 
 The examples,
 
@@ -1030,7 +1030,7 @@ $i = 5; $j = 10; $k = 15
 "`$i, `$j, and `$k have the values $( $i; $j; $k )"
 ```
 
-results in the following *expandable-string-literal*:
+results in the following _expandable-string-literal_:
 
 ```Output
 $i, $j, and $k have the values 5 10 15
@@ -1048,18 +1048,18 @@ In the following example,
 "First 10 squares: $(for ($i = 1; $i -le 10; ++$i) { "$i $($i*$i) " })"
 ```
 
-the resulting *expandable-string-literal* is as follows:
+the resulting _expandable-string-literal_ is as follows:
 
 ```Output
 First 10 squares: 1 1 2 4 3 9 4 16 5 25 6 36 7 49 8 64 9 81 10 100
 ```
 
-As shown, a *sub-expression* can contain string literals having both variable substitution and
-sub-expression expansion. Note also that the inner *expandable-string-literal*'s delimiters need
-not be escaped; the fact that they are inside a *sub-expression* means they cannot be terminators
-for the outer *expandable-string-literal*.
+As shown, a _sub-expression_ can contain string literals having both variable substitution and
+sub-expression expansion. Note also that the inner _expandable-string-literal_'s delimiters need
+not be escaped; the fact that they are inside a _sub-expression_ means they cannot be terminators
+for the outer _expandable-string-literal_.
 
-An *expandable-string-literal* or *expandable-here-string-literal* containing a variable
+An _expandable-string-literal_ or _expandable-here-string-literal_ containing a variable
 substitution or sub-expression expansion is evaluated each time that literal is used; for example,
 
 ```powershell
@@ -1080,7 +1080,7 @@ $s2 = >$a = 11<
 $s2 = >$a = 10<
 ```
 
-The contents of a *verbatim-here-string-literal* are taken verbatim, including any leading or
+The contents of a _verbatim-here-string-literal_ are taken verbatim, including any leading or
 trailing white space within the body. As such, embedded *single-quote-character*s need not be
 doubled-up, and there is no substitution or expansion. For example,
 
@@ -1098,7 +1098,7 @@ That's it!
 2 * 3 = $(2*3)
 ```
 
-The contents of an *expandable-here-string-literal* are subject to substitution and expansion, but
+The contents of an _expandable-here-string-literal_ are subject to substitution and expansion, but
 any leading or trailing white space within the body but outside any *sub-expression*s is taken
 verbatim, and embedded *double-quote-character*s need not be doubled-up. For example,
 
@@ -1128,7 +1128,7 @@ xyz
 ```
 
 the second line of the body has two leading spaces, and the first and second lines of the body have
-line terminators; however, the terminator for the second line of the body is *not* part of that
+line terminators; however, the terminator for the second line of the body is _not_ part of that
 body. The resulting literal is equivalent to:
 `"abc<implementation-defined character sequence>xyz"`.
 
@@ -1156,13 +1156,13 @@ See the automatic variables `$false` and `$true` ([§2.3.2.2][§2.3.2.2]).
 #### 2.3.5.5 Array literals
 
 PowerShell allows expressions of array type (§9) to be written using the unary comma operator
-([§7.2.1][§7.2.1]), *array-expression* ([§7.1.7][§7.1.7]), the binary comma operator ([§7.3][§7.3]), and the range
+([§7.2.1][§7.2.1]), _array-expression_ ([§7.1.7][§7.1.7]), the binary comma operator ([§7.3][§7.3]), and the range
 operator ([§7.4][§7.4]).
 
 #### 2.3.5.6 Hash literals
 
 PowerShell allows expressions of type Hashtable (§10) to be written using a
-*hash-literal-expression* ([§7.1.9][§7.1.9])
+_hash-literal-expression_ ([§7.1.9][§7.1.9])
 
 #### 2.3.5.7 Type names
 
@@ -1250,9 +1250,9 @@ Description:
 > Editor's Note: The pipeline chain operators `&&` and `||` were introduced in PowerShell 7. See
 > [about_Pipeline_Chain_Operators](/powershell/module/microsoft.powershell.core/about/about_pipeline_chain_operators).
 
-The name following *dash* in an operator is reserved for that purpose only in an operator context.
+The name following _dash_ in an operator is reserved for that purpose only in an operator context.
 
-An operator that begins with *dash* must not have any white space between that *dash* and the token
+An operator that begins with _dash_ must not have any white space between that _dash_ and the token
 that follows it.
 
 ### 2.3.7 Escaped characters
@@ -1266,9 +1266,9 @@ escaped-character:
 
 Description:
 
-An *escaped character* is a way to assign a special interpretation to a character by giving it a
+An _escaped character_ is a way to assign a special interpretation to a character by giving it a
 prefix Backtick character (U+0060). The following table shows the meaning of each
-*escaped-character*:
+_escaped-character_:
 
 | Escaped Character |                                                           Meaning                                                            |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------------- |
@@ -1313,7 +1313,7 @@ written as ``Test` Data.txt`` (as well as `'Test Data.txt'` or `"Test Data.txt"`
 [§7.2.1]: chapter-07.md#721-unary-comma-operator
 [§7.3]: chapter-07.md#73-binary-comma-operator
 [§7.4]: chapter-07.md#74-range-operator
-[§7.7.2]: chapter-07.md#772-string-concatentaion
+[§7.7.2]: chapter-07.md#772-string-concatenation
 [§8.10.2]: chapter-08.md#8102-workflow-functions
 [§8.10.5]: chapter-08.md#8105-the-switch-type-constraint
 [§8.14]: chapter-08.md#814-parameter-binding

--- a/reference/docs-conceptual/lang-spec/chapter-07.md
+++ b/reference/docs-conceptual/lang-spec/chapter-07.md
@@ -2286,7 +2286,7 @@ dir -Verbose 4>&2 2> error2.txt
 [§7.6.4]: chapter-07.md#764-division
 [§7.6.5]: chapter-07.md#765-remainder
 [§7.7.1]: chapter-07.md#771-addition
-[§7.7.2]: chapter-07.md#772-string-concatentaion
+[§7.7.2]: chapter-07.md#772-string-concatenation
 [§7.7.3]: chapter-07.md#773-array-concatenation
 [§7.7.5]: chapter-07.md#775-subtraction
 [§7.7]: chapter-07.md#77-additive-operators

--- a/reference/docs-conceptual/lang-spec/chapter-07.md
+++ b/reference/docs-conceptual/lang-spec/chapter-07.md
@@ -1,6 +1,6 @@
 ---
 description: An expression is a sequence of operators and operands that designates a method, a function, a writable location, or a value; specifies the computation of a value; produces one or more side effects; or performs some combination thereof.
-ms.date: 05/19/2021
+ms.date: 04/23/2024
 title: Expressions
 ---
 # 7. Expressions
@@ -28,7 +28,7 @@ dashdash:
 
 Description:
 
-An *expression* is a sequence of operators and operands that designates a method, a function, a
+An _expression_ is a sequence of operators and operands that designates a method, a function, a
 writable location, or a value; specifies the computation of a value; produces one or more side
 effects; or performs some combination thereof. For example,
 
@@ -45,11 +45,11 @@ include the following: `$i++ + $i`, `$i + --$i`, and `$w[$j++] = $v[$j]`.
 An implementation of PowerShell may provide support for user-defined types, and those types may have
 operations defined on them. All details of such types and operations are implementation defined.
 
-A *top-level expression* is one that is not part of some larger expression. If a top-level
+A _top-level expression_ is one that is not part of some larger expression. If a top-level
 expression contains a side-effect operator the value of that expression is not written to the
 pipeline; otherwise, it is. See [§7.1.1][§7.1.1] for a detailed discussion of this.
 
-Ordinarily, an expression that designates a collection (§4) is enumerated into its constituent
+Ordinarily, an expression that designates a collection ([§4[§4]]) is enumerated into its constituent
 elements when the value of that expression is used. However, this is not the case when the
 expression is a cmdlet invocation. For example,
 
@@ -110,7 +110,7 @@ parenthesized-expression:
 
 Description:
 
-A parenthesized expression is a *primary-expression* whose type and value are the same as those of
+A parenthesized expression is a _primary-expression_ whose type and value are the same as those of
 the expression without the parentheses. If the expression designates a variable then the
 parenthesized expression designates that same variable. For example, `$x.m` and `($x).m` are
 equivalent.
@@ -146,7 +146,7 @@ $a                # pipeline gets 4319
 
 In the first and third cases, the value of the result is written to the pipeline. However, although
 the expression in the second case is evaluated, the result is not written to the pipeline due to the
-presence of the side-effect operator = at the top level. (Removal of the `$a = ` part allows the
+presence of the side-effect operator `=` at the top level. (Removal of the `$a = ` part allows the
 value to be written, as `*` is not a side-effect operator.)
 
 To stop a value of any expression not containing top-level side effects from being written to the
@@ -169,16 +169,15 @@ expression in parentheses, as follows:
 
 As such, the grouping parentheses in this case are not redundant.
 
-In the following example, we have variable substitution ([§2.3.5.2][§2.3.5.2]) taking place in a string
-literal:
+In the following example, we have variable substitution ([§2.3.5.2][§2.3.5.2]) taking place in a
+string literal:
 
 ```powershell
-">$($a = -23)<"    # value not written to pipeline, get
-><
+">$($a = -23)<"    # value not written to pipeline, get ><
 ">$(($a = -23))<"  # pipeline gets >-23<
 ```
 
-In the first case, the parentheses represent a *sub-expression*'s delimiters *not* grouping
+In the first case, the parentheses represent a _sub-expression_'s delimiters _not_ grouping
 parentheses, and as the top-level expression contains a side-effect operator, the expression's value
 is not written to the pipeline. Of course, the `>` and `<` characters are still written.) If
 grouping parenthesis are added -- as shown in the second case -- writing is enabled.
@@ -219,11 +218,11 @@ Syntax:
 
 ```Syntax
 member-access:
-    primary-expression . member-name
-    primary-expression :: member-name
+    primary-expression . new-line~opt~ member-name
+    primary-expression :: new-line~opt~ member-name
 ```
 
-Note that no whitespace is allowed after *primary-expression*.
+Note that no whitespace is allowed after _primary-expression_.
 
 Description:
 
@@ -235,7 +234,7 @@ Either the right operand designates an accessible instance member within the typ
 designated by the left operand or, if the left operand designates an array, the right operand
 designates accessible instance members within each element of the array.
 
-White space is not permitted before the `.` operator.
+Whitespace is not permitted before the `.` operator.
 
 This operator is left associative.
 
@@ -243,7 +242,7 @@ The operator `::` is used to select a static member from a given type. The left 
 designate a type, and the right-hand operand must designate an accessible static member within that
 type.
 
-White space is not permitted before the `::` operator.
+Whitespace is not permitted before the `::` operator.
 
 This operator is left associative.
 
@@ -285,28 +284,28 @@ Syntax:
 
 ```Syntax
 invocation-expression:
-    primary-expression . member-name argument-list
-    primary-expression :: member-name argument-list
+    primary-expression . new-line~opt~ member-name argument-list
+    primary-expression :: new-line~opt~ member-name argument-list
 
 argument-list:
     ( argument-expression-list~opt~ new-lines~opt~ )
 ```
 
-Note that no whitespace is allowed after *primary-expression*.
+Note that no whitespace is allowed after _primary-expression_.
 
 Description:
 
-An *invocation-expression* calls the method designated by *primary-expression*.*member-name* or
-*primary-expression*::*member-name*. The parentheses in *argument-list* contain a possibly empty,
-comma-separated list of expressions, which designate the *arguments* whose values are passed to the
+An _invocation-expression_ calls the method designated by `primary-expression.member-name` or
+`primary-expression::member-name`. The parentheses in _argument-list_ contain a possibly empty,
+comma-separated list of expressions that designate the _arguments_ whose values are passed to the
 method. Before the method is called, the arguments are evaluated and converted according to the
-rules of §6, if necessary, to match the types expected by the method. The order of evaluation of
-*primary-expression*.*member-name*, *primary-expression*::*member-name*, and the arguments is
+rules of [§6][§6], if necessary, to match the types expected by the method. The order of evaluation
+of `primary-expression.member-name`, `primary-expression::member-name`, and the arguments is
 unspecified.
 
 This operator is left associative.
 
-The type of the result of an *invocation-expression* is a *method designator* ([§4.5.24][§4.5.24]).
+The type of the result of an _invocation-expression_ is a _method-designator_ ([§4.5.24][§4.5.24]).
 
 Examples:
 
@@ -340,27 +339,27 @@ element-access:
 
 Description:
 
-There must not be any white space between *primary-expression* and the left square bracket (`[`).
+There must not be any whitespace between _primary-expression_ and the left square bracket (`[`).
 
 #### 7.1.4.1 Subscripting an array
 
 Description:
 
-Arrays are discussed in detail in [§9.][§9.] If *expression* is a 1-dimensional array, see
+Arrays are discussed in detail in [§9.][§9.] If _expression_ is a 1-dimensional array, see
 [§7.1.4.5][§7.1.4.5].
 
-When *primary-expression* designates a 1-dimensional array *A*, the operator `[]` returns the
-element located at `A[0 + expression]` after the value of *expression* has been converted to `int`.
-The result has the element type of the array being subscripted. If *expression* is negative,
+When _primary-expression_ designates a 1-dimensional array _A_, the operator `[]` returns the
+element located at `A[0 + expression]` after the value of _expression_ has been converted to `int`.
+The result has the element type of the array being subscripted. If _expression_ is negative,
 `A[expression]` designates the element located at `A[A.Length + expression]`.
 
-When *primary-expression* designates a 2-dimensional array *B*, the operator `[]` returns the
-element located at `B[0 + row,0 + column]` after the value of the *row* and *column* components of
-*expression* (which are specified as a comma-separated list) have been converted to `int`. The
+When _primary-expression_ designates a 2-dimensional array _B_, the operator `[]` returns the
+element located at `B[0 + row,0 + column]` after the value of the _row_ and _column_ components of
+_expression_ (which are specified as a comma-separated list) have been converted to `int`. The
 result has the element type of the array being subscripted. Unlike for a 1-dimensional array,
 negative positions have no special meaning.
 
-When *primary-expression* designates an array of three or more dimensions, the rules for
+When _primary-expression_ designates an array of three or more dimensions, the rules for
 2-dimensional arrays apply and the dimension positions are specified as a comma-separated list of
 values.
 
@@ -371,7 +370,7 @@ For a multidimensional-array subscript expression, the order of evaluation of th
 expressions is unspecified. For example, given a 3-dimensional array `$a`, the behavior of
 `$a[$i++,$i,++$i]` is unspecified.
 
-If *expression* is an array, see [§7.1.4.5][§7.1.4.5].
+If _expression_ is an array, see [§7.1.4.5][§7.1.4.5].
 
 This operator is left associative.
 
@@ -406,9 +405,9 @@ raised.
 
 Description:
 
-When *primary-expression* designates a string *S*, the operator `[]` returns the character located
-in the zero-based position indicated by *expression*, as a char. If *expression* is greater than or
-equal to that string's length, the result is `$null`. If *expression* is negative,
+When _primary-expression_ designates a string _S_, the operator `[]` returns the character located
+in the zero-based position indicated by _expression_, as a char. If _expression_ is greater than or
+equal to that string's length, the result is `$null`. If _expression_ is negative,
 `S[expression]` designates the element located at `S[S.Length + expression]`.
 
 Examples:
@@ -424,14 +423,14 @@ $c = $s[-1]    # returns "o", i.e., $s[$s.Length-1]
 
 Description:
 
-When *primary-expression* designates a Hashtable, the operator `[]` returns the value(s) associated
-with the key(s) designated by *expression*. The type of *expression* is not restricted.
+When _primary-expression_ designates a Hashtable, the operator `[]` returns the value(s) associated
+with the key(s) designated by _expression_. The type of _expression_ is not restricted.
 
-When *expression* is a single key name, the result is the associated value and has that type, unless
+When _expression_ is a single key name, the result is the associated value and has that type, unless
 no such key exists, in which case, the result is `$null`. If `$null` is used as the key the behavior
-is implementation defined. If *expression* is an array of key names, see [§7.1.4.5][§7.1.4.5].
+is implementation defined. If _expression_ is an array of key names, see [§7.1.4.5][§7.1.4.5].
 
-If *expression* is an array, see [§7.1.4.5][§7.1.4.5].
+If _expression_ is an array, see [§7.1.4.5][§7.1.4.5].
 
 Examples:
 
@@ -446,18 +445,18 @@ $h1[20.5]            # returns value "Anderson" using key 20.5
 $h1[$true]           # returns value 123 using key $true
 ```
 
-When *expression* is a single key name, if `$null` is used as the only value to subscript a
+When _expression_ is a single key name, if `$null` is used as the only value to subscript a
 Hashtable, a **NullArrayIndex** exception is raised.
 
 #### 7.1.4.4 Subscripting an XML document
 
 Description:
 
-When *primary-expression* designates an object of type xml, *expression* is converted to string, if
+When _primary-expression_ designates an object of type xml, _expression_ is converted to string, if
 necessary, and the operator `[]` returns the first child element having the name specified by
-*expression*. The type of *expression* must be string. The type of the result is implementation
+_expression_. The type of _expression_ must be string. The type of the result is implementation
 defined. The result can be subscripted to return its first child element. If no child element exists
-with the name specified by *expression*, the result is `$null`. The result does not designate a
+with the name specified by _expression_, the result is `$null`. The result does not designate a
 writable location.
 
 Examples:
@@ -479,9 +478,9 @@ The type of the result is `System.Xml.XmlElement` or `System.String`.
 
 #### 7.1.4.5 Generating array slices
 
-When *primary-expression* designates an object of a type that is enumerable (§4) or a Hashtable, and
-*expression* is a 1-dimensional array, the result is an array slice ([§9.9][§9.9]) containing the
-elements of *primary-expression* designated by the elements of *expression*.
+When _primary-expression_ designates an object of a type that is enumerable (§4) or a Hashtable, and
+_expression_ is a 1-dimensional array, the result is an array slice ([§9.9][§9.9]) containing the
+elements of _primary-expression_ designated by the elements of _expression_.
 
 In the case of a Hashtable, the array slice contains the associated values to the keys provided,
 unless no such key exists, in which case, the corresponding element is `$null`. If `$null` is used
@@ -492,10 +491,9 @@ Examples:
 ```powershell
 $a = [int[]](30,40,50,60,70,80,90)
 $a[1,3,5]                 # slice has Length 3, value 40,60,80
-++$a[1,3,5][1]            # preincrement 60 in array 40,60,80
 $a[,5]                    # slice with Length 1
 $a[@()]                   # slice with Length 0
-$a[-1..-3]                # slice with Length 0, value 90,80,70
+$a[-1..-3]                # slice with Length 3, value 90,80,70
 $a = New-Object 'int[,]' 3,2
 $a[0,0] = 10; $a[0,1] = 20; $a[1,0] = 30
 $a[1,1] = 40; $a[2,0] = 50; $a[2,1] = 60
@@ -505,10 +503,10 @@ $h1['FirstName']          # the value associated with key FirstName
 $h1['BirthDate']          # no such key, returns $null
 $h1['FirstName','IDNum']  # returns [object[]], Length 2 (James/123)
 $h1['FirstName','xxx']    # returns [object[]], Length 2 (James/$null)
-$h1[$null,'IDNum']        # returns [object[]], Length 1 (123)
+$h1[$null,'IDNum']        # returns [object[]], Length 2 ($null/123)
 ```
 
-Windows PowerShell: When *expression* is a collection of two or more key names, if `$null` is used
+Windows PowerShell: When _expression_ is a collection of two or more key names, if `$null` is used
 as any key name that key is ignored and has no corresponding element in the resulting array.
 
 ### 7.1.5 Postfix increment and decrement operators
@@ -525,11 +523,11 @@ post-decrement-expression:
 
 Description:
 
-The *primary-expression* must designate a writable location having a value of numeric type (§4) or
+The _primary-expression_ must designate a writable location having a value of numeric type (§4) or
 the value `$null`. If the value designated by the operand is `$null`, that value is converted to
 type int and value zero before the operator is evaluated. The type of the value designated by
-*primary-expression* may change when the result is stored. See [§7.11][§7.11] for a discussion of type
-change via assignment.
+_primary-expression_ may change when the result is stored. See [§7.11][§7.11] for a discussion of
+type change via assignment.
 
 The result produced by the postfix `++` operator is the value designated by the operand. After that
 result is obtained, the value designated by the operand is incremented by 1 of the appropriate type.
@@ -580,7 +578,7 @@ sub-expression:
 
 Description:
 
-If *statement-list* is omitted, the result is `$null`. Otherwise, *statement-list* is evaluated. Any
+If _statement-list_ is omitted, the result is `$null`. Otherwise, _statement-list_ is evaluated. Any
 objects written to the pipeline as part of the evaluation are collected in an unconstrained
 1-dimensional array, in order. If the array of collected objects is empty, the result is `$null`. If
 the array of collected objects contains a single element, the result is that element; otherwise, the
@@ -611,8 +609,8 @@ array-expression:
 
 Description:
 
-If *statement-list* is omitted, the result is an unconstrained 1-dimensional array of length zero.
-Otherwise, *statement-list* is evaluated, and any objects written to the pipeline as part of the
+If _statement-list_ is omitted, the result is an unconstrained 1-dimensional array of length zero.
+Otherwise, _statement-list_ is evaluated, and any objects written to the pipeline as part of the
 evaluation are collected in an unconstrained 1-dimensional array, in order. The result is the
 (possibly empty) unconstrained 1-dimensional array.
 
@@ -651,18 +649,19 @@ script-block-body:
 
 Description:
 
-*param-block* is described in [§8.10.9][§8.10.9]. *named-block-list* is described in [§8.10.7][§8.10.7].
+_param-block_ is described in [§8.10.9][§8.10.9]. _named-block-list_ is described in
+[§8.10.7][§8.10.7].
 
 A script block is an unnamed block of statements that can be used as a single unit. Script blocks
 can be used to invoke a block of code as if it was a single command, or they can be assigned to
 variables that can be executed.
 
-The *named-block-list* or *statement-list* is executed and the type and value(s) of the result are
+The _named-block-list_ or _statement-list_ is executed and the type and value(s) of the result are
 the type and value(s) of the results of those statement sets.
 
-A *script-block-expression* has type scriptblock ([§4.3.7][§4.3.7]).
+A _script-block-expression_ has type scriptblock ([§4.3.7][§4.3.7]).
 
-If *param-block* is omitted, any arguments passed to the script block are available via `$args`
+If _param-block_ is omitted, any arguments passed to the script block are available via `$args`
 ([§8.10.1][§8.10.1]).
 
 During parameter binding, a script block can be passed either as a script block object or as the
@@ -698,7 +697,7 @@ statement-terminator:
 
 Description:
 
-A *hash-literal-expression* is used to create a Hashtable (§10) of zero or more elements each of
+A _hash-literal-expression_ is used to create a Hashtable (§10) of zero or more elements each of
 which is a key/value pair.
 
 The key may have any type except the null type. The associated values may have any type, including
@@ -750,7 +749,7 @@ generic-type-name:
 
 Description:
 
-A *type-literal* is represented in an implementation by some unspecified *underlying type*. As a
+A _type-literal_ is represented in an implementation by some unspecified _underlying type_. As a
 result, a type name is a synonym for its underlying type.
 
 Type literals are used in a number of contexts:
@@ -758,7 +757,8 @@ Type literals are used in a number of contexts:
 - Specifying an explicit conversion (§6, [§7.2.9][§7.2.9])
 - Creating a type-constrained array ([§9.4][§9.4])
 - Accessing the static members of an object ([§7.1.2][§7.1.2])
-- Specifying a type constraint on a variable ([§5.3][§5.3]) or a function parameter ([§8.10.2][§8.10.2])
+- Specifying a type constraint on a variable ([§5.3][§5.3]) or a function parameter
+  ([§8.10.2][§8.10.2])
 
 Examples:
 
@@ -772,7 +772,7 @@ A generic stack type ([§4.4][§4.4]) that is specialized to hold strings might 
 `[Stack[string]]`, and a generic dictionary type that is specialized to hold `int` keys with
 associated string values might be written as `[Dictionary[int,string]]`.
 
-The type of a *type-literal* is `System.Type`. The complete name for the type `Stack[string]`
+The type of a _type-literal_ is `System.Type`. The complete name for the type `Stack[string]`
 suggested above is `System.Collections.Generic.Stack[int]`. The complete name for the type
 `Dictionary[int,string]` suggested above is `System.Collections.Generic.Dictionary[int,string]`.
 
@@ -804,16 +804,25 @@ pre-increment-expression:
 pre-decrement-expression:
     dashdash new-lines~opt~ unary-expression
 
+dash: one of
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
+
 cast-expression:
     type-literal unary-expression
+
+dashdash:
+    dash dash
 ```
 
 ### 7.2.1 Unary comma operator
 
 Description:
 
-This operator creates an unconstrained 1-dimensional array having one element, whose type and value
-are that of *unary-expression*.
+The comma operator (`,`) creates an unconstrained 1-dimensional array having one element, whose type
+and value are that of _unary-expression_.
 
 This operator is right associative.
 
@@ -835,11 +844,24 @@ $a = ,,10        # create an unconstrained array of 1 element, which is
 
 ### 7.2.2 Logical NOT
 
+Syntax:
+
+```Syntax
+logical-not-operator:
+    dash not
+
+dash: one of
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
+```
+
 Description:
 
-The operator -not converts the value designated by *unary-expression* to type bool ([§6.2][§6.2]), if
-necessary, and produces a result of that type. If *unary-expression*'s value is True, the result is
-False, and vice versa. The operator ! is an alternate spelling for -not.
+The operator `-not` converts the value designated by _unary-expression_ to type bool
+([§6.2][§6.2]), if necessary, and produces a result of that type. If _unary-expression_'s value is
+True, the result is False, and vice versa. The operator `!` is an alternate spelling for `-not`.
 
 This operator is right associative.
 
@@ -855,13 +877,26 @@ Examples:
 
 ### 7.2.3 Bitwise NOT
 
+Syntax:
+
+```Syntax
+bitwise-not-operator:
+    dash bnot
+
+dash: one of
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
+```
+
 Description:
 
-The operator -bnot converts the value designated by *unary-expression* to an integer type
-([§6.4][§6.4]), if necessary. If the converted value can be represented in type int then that is the
-result type. Else, if the converted value can be represented in type long then that is the result
-type. Otherwise, the expression is ill formed. The resulting value is the ones-complement of the
-converted value.
+The operator `-bnot` converts the value designated by _unary-expression_ to an integer type
+([§6.4][§6.4]), if necessary. If the converted value can be represented in type **int** then that is
+the result type. Else, if the converted value can be represented in type **long** then that is the
+result type. Otherwise, the expression is ill-formed. The resulting value is the ones-complement of
+the converted value.
 
 This operator is right associative.
 
@@ -879,8 +914,8 @@ Examples:
 
 Description:
 
-An expression of the form +*unary-expression* is treated as if it were written as
-`0 + unary-expression` ([§7.7][§7.7]). The integer literal 0 has type `int`.
+An expression of the form `+ unary-expression` is treated as if it were written as
+`0 + unary-expression` ([§7.7][§7.7]). The integer literal `0` has type `int`.
 
 This operator is right associative.
 
@@ -896,8 +931,9 @@ Examples:
 
 Description:
 
-An expression of the form -*unary-expression* is treated as if it were written as
-`0 - unary-expression` ([§7.7][§7.7]). The integer literal 0 has type `int`.
+An expression of the form `- unary-expression` is treated as if it were written as
+`0 - unary-expression` ([§7.7][§7.7]). The integer literal 0 has type `int`. The minus operator can
+be any one of the _dash_ characters listed in [§7.2][§7.2].
 
 This operator is right associative.
 
@@ -913,21 +949,22 @@ Examples:
 
 Description:
 
-The *unary-expression* must designate a writable location having a value of numeric type (§4) or the
-value `$null`. If the value designated by its *unary-expression* is `$null`, *unary-expression*'s
-value is converted to type int and value zero before the operator is evaluated.
+The _unary-expression_ must designate a writable location having a value of numeric type ([§4][§4])
+or the value `$null`. If the value designated by its _unary-expression_ is `$null`,
+_unary-expression_'s value is converted to type int and value zero before the operator is evaluated.
 
 > [!NOTE]
-> The type of the value designated by *unary-expression* may change when the result is stored. See
+> The type of the value designated by _unary-expression_ may change when the result is stored. See
 > [§7.11][§7.11] for a discussion of type change via assignment.
 
-For the prefix `++` operator, the value of *unary-expression* is incremented by 1 of the appropriate
-type. The result is the new value after incrementing has taken place. The expression `++E` is
-equivalent to `E += 1` ([§7.11.2][§7.11.2]).
+For the prefix increment operator `++` , the value of _unary-expression_ is incremented by `1` of
+the appropriate type. The result is the new value after incrementing has taken place. The expression
+`++E` is equivalent to `E += 1` ([§7.11.2][§7.11.2]).
 
-For the prefix `--` operator, the value of *unary-expression* is decremented by 1 of the appropriate
-type. The result is the new value after decrementing has taken place. The expression `--E` is
-equivalent to `E -= 1` ([§7.11.2][§7.11.2]).
+For the prefix decrement operator `--` , the value of _unary-expression_ is decremented by `1` of
+the appropriate type. The result is the new value after decrementing has taken place. The expression
+`--E` is equivalent to `E -= 1` ([§7.11.2][§7.11.2]). The prefix decrement operator can be any of
+the patterns matching the _dashdash_ pattern in [§7.2][§7.2].
 
 These operators are right associative.
 
@@ -959,13 +996,26 @@ $--x                  # value treated as int, 0 becomes -1
 
 ### 7.2.7 The unary -join operator
 
+Syntax:
+
+```Syntax
+join-operator:
+    dash join
+
+dash: one of
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
+```
+
 Description:
 
 The unary `-join` operator produces a string that is the concatenation of the value of one or more
-objects designated by *unary-expression*. (A separator can be inserted by using the binary version
+objects designated by _unary-expression_. (A separator can be inserted by using the binary version
 of this operator ([§7.8.4.4][§7.8.4.4]).)
 
-*unary-expression* can be a scalar value or a collection.
+_unary-expression_ can be a scalar value or a collection.
 
 Examples:
 
@@ -978,19 +1028,32 @@ Examples:
 
 ### 7.2.8 The unary -split operator
 
+Syntax:
+
+```Syntax
+split-operator:
+    dash split
+
+dash: one of
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
+```
+
 Description:
 
-The unary `-split` operator splits one or more strings designated by *unary-expression*, returning
+The unary `-split` operator splits one or more strings designated by _unary-expression_, returning
 their subparts in a constrained 1-dimensional array of string. It treats any contiguous group of
-white space characters as the delimiter between successive subparts. (An explicit delimiter string
-can be specified by using the binary version of this operator ([§7.8.4.5][§7.8.4.5]).) This operator has two
-variants ([§7.8][§7.8]).
+whitespace characters as the delimiter between successive subparts. An explicit delimiter string can
+be specified by using the binary version of this operator ([§7.8.4.5][§7.8.4.5]) or its two variants
+([§7.8][§7.8]).
 
-The delimiter text is not included in the resulting strings. Leading and trailing white space in the
-input string is ignored. An input string that is empty or contains white space only results in an
-array of 1 string, which is empty.
+The delimiter text is not included in the resulting strings. Leading and trailing whitespace in the
+input string is ignored. An input string that is empty or contains whitespace only results in an
+array of one string, which is empty.
 
-*unary-expression* can designate a scalar value or an array of strings.
+_unary-expression_ can designate a scalar value or an array of strings.
 
 Examples:
 
@@ -1004,13 +1067,13 @@ Examples:
 
 Description:
 
-This operator converts explicitly (§6) the value designated by *unary-expression* to the type
-designated by *type-literal*. If *type-literal* is other than void, the type of the result is the
-named type, and the value is the value after conversion. If *type-literal* is void, no object is
-written to the pipeline and there is no result.
+This operator converts explicitly ([§6][§6]) the value designated by _unary-expression_ to the type
+designated by _type-literal_ ([§7.1.10][§7.1.10]). If _type-literal_ is other than void, the type of
+the result is the named type, and the value is the value after conversion. If _type-literal_ is
+void, no object is written to the pipeline and there is no result.
 
 When an expression of any type is cast to that same type, the resulting type and value is the
-*unary-expression*'s type and value.
+_unary-expression_'s type and value.
 
 This operator is right associative.
 
@@ -1030,7 +1093,6 @@ Syntax:
 
 ```Syntax
 array-literal-expression:
-    unary-expression
     unary-expression , new-lines~opt~ array-literal-expression
 ```
 
@@ -1057,32 +1119,31 @@ Syntax:
 
 ```Syntax
 range-expression:
-    array-literal-expression
-    range-expression *..* new-lines~opt~ array-literal-expression
+    unary-expression .. new-lines~opt~ unary-expression
 ```
 
 Description:
 
-A *range-expression* creates an unconstrained 1-dimensional array whose elements are the values of
-the int sequence specified by the range bounds. The values designated by the operands are converted
-to int, if necessary ([§6.4][§6.4]). The operand designating the lower value after conversion is the
-*lower bound*, while the operand designating the higher value after conversion is the *upper bound*.
-Both bounds may be the same, in which case, the resulting array has length 1. If the left operand
-designates the lower bound, the sequence is in ascending order. If the left operand designates the
-upper bound, the sequence is in descending order.
+A _range-expression_ creates an unconstrained 1-dimensional array whose elements are the values of
+the **int** sequence specified by the range bounds. The values designated by the operands are
+converted to **int**, if necessary ([§6.4][§6.4]). The operand designating the lower value after
+conversion is the _lower bound_, while the operand designating the higher value after conversion is
+the _upper bound_. Both bounds may be the same, in which case, the resulting array has length `1`.
+If the left operand designates the lower bound, the sequence is in ascending order. If the left
+operand designates the upper bound, the sequence is in descending order.
 
 Conceptually, this operator is a shortcut for the corresponding binary comma operator sequence. For
 example, the range `5..8` can also be generated using `5,6,7,8`. However, if an ascending or
 descending sequence is needed without having an array, an implementation may avoid generating an
 actual array. For example, in `foreach ($i in 1..5) { ... }`, no array need be created.
 
-A *range-expression* can be used to specify an array slice ([§9.9][§9.9]).
+A _range-expression_ can be used to specify an array slice ([§9.9][§9.9]).
 
 Examples:
 
 ```powershell
 1..10        # ascending range 1..10
--500..-495   # descending range -500..-495
+-495..-500   # descending range -495..-500
 16..16       # sequence of 1
 
 $x = 1.5
@@ -1090,7 +1151,7 @@ $x..5.40D    # ascending range 2..5
 
 $true..3     # ascending range 1..3
 -2..$null    # ascending range -2..0
-"0xf".."0xa" # descending range 15..10
+0xf..0xa     # descending range 15..10
 ```
 
 ## 7.5 Format operator
@@ -1099,15 +1160,23 @@ Syntax:
 
 ```Syntax
 format-expression:
-    range-expression
-    format-expression -f new-lines~opt~ range-expression
+    format-specification-string format-operator new-lines~opt~ range-expression
+
+format-operator:
+    dash f
+
+dash:
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
 ```
 
 Description:
 
-A format-expression formats one or more values designated by *range-expression* according to a
-*format specification string* designated by *format-expression*. The positions of the values
-designated by *range-expression* are numbered starting at zero and increasing in lexical order. The
+A _format-expression_ formats one or more values designated by _range-expression_ according to a
+_format-specification-string_ designated by _format-expression_. The positions of the values
+designated by _range-expression_ are numbered starting at zero and increasing in lexical order. The
 result has type `string`.
 
 A format specification string may contain zero or more format specifications each having the
@@ -1115,17 +1184,17 @@ following form:
 
 `{N [ ,M ][ : FormatString ]}`
 
-*N* represents a (required) *range-expression* value position, *M* represents the (optional) minimum
-display width, and *FormatString* indicates the (optional) format. If the width of a formatted value
+_N_ represents a (required) _range-expression_ value position, _M_ represents the (optional) minimum
+display width, and _FormatString_ indicates the (optional) format. If the width of a formatted value
 exceeds the specified width, the width is increased accordingly. Values whose positions are not
-referenced in *FormatString* are ignored after being evaluated for any side effects. If *N* refers
+referenced in _FormatString_ are ignored after being evaluated for any side effects. If _N_ refers
 to a non-existent position, the behavior is implementation defined. Value of type `$null` and void
-are formatted as empty strings. Arrays are formatted as for *sub-expression* ([§7.1.6][§7.1.6]). To
-include the characters "{" and "}" in a format specification without their being interpreted as
-format delimiters, write them as "{{" and "}}", respectively.
+are formatted as empty strings. Arrays are formatted as for _sub-expression_ ([§7.1.6][§7.1.6]). To
+include the characters `{` and `}` in a format specification without their being interpreted as
+format delimiters, write them as `{{` and `}}`, respectively.
 
-For a complete definition of format specifications, see the type `System.IFormattable` in Ecma
-Technical Report TR/84.
+For a complete definition of format specifications, see the type `System.IFormattable` in
+[Ecma Technical Report TR/84][TR84].
 
 Examples:
 
@@ -1146,7 +1215,7 @@ $format = "__0x{0:X8}__"
 $format -f 65535                         # __0x0000FFFF__
 ```
 
-In a format specification if *N* refers to a non-existent position, a **FormatError** is raised.
+In a format specification, if _N_ refers to a non-existent position, a **FormatError** is raised.
 
 ## 7.6 Multiplicative operators
 
@@ -1277,6 +1346,12 @@ Syntax:
 additive-expression:
     primary-expression + new-lines~opt~ expression
     primary-expression dash new-lines~opt~ expression
+
+dash: one of
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
 ```
 
 ### 7.7.1 Addition
@@ -1297,7 +1372,7 @@ Examples:
 12 + "0xabc"    # int result 2760
 ```
 
-### 7.7.2 String concatentaion
+### 7.7.2 String concatenation
 
 Description:
 
@@ -1366,14 +1441,15 @@ Description:
 
 The result of the subtraction operator `-` is the difference when the value designated by the right
 operand is subtracted from the value designated by the left operand after the usual arithmetic
-conversions ([§6.15][§6.15]) have been applied.
+conversions ([§6.15][§6.15]) have been applied. The subtraction operator can be any one of the
+_dash_ characters listed in [§7.7][§7.7].
 
 This operator is left associative.
 
 Examples:
 
 ```powershell
-12 - -10L      # long result 2c
+12 - -10L      # long result 22
 -10.300D - 12  # decimal result -22.300
 10.6 - 12      # double result -1.4
 12 - "0xabc"   # int result -2736
@@ -1391,6 +1467,7 @@ comparison-operator:
     equality-operator
     relational-operator
     containment-operator
+    type-operator
     like-operator
     match-operator
 ```
@@ -1398,12 +1475,12 @@ comparison-operator:
 Description:
 
 The type of the value designated by the left operand determines how the value designated by the
-right operand is converted (§6), if necessary, before the comparison is done.
+right operand is converted ([§6][§6]), if necessary, before the comparison is done.
 
-Some *comparison-operator*s (written here as -*op*) have two variants, one that is case sensitive
-(-c*op*), and one that is not (-i*op*). The -*op* version is equivalent to -i*op*. Case sensitivity
-is meaningful only with comparisons of values of type string. In non-string comparison contexts, the
-two variants behave the same.
+Some comparison operators have two variants, one that is case sensitive (`-c<operator>`), and one
+that isn't case sensitive (`-i<operator>`). The `-<operator>` version is equivalent to
+`-i<operator>`. Case sensitivity is meaningful only with comparisons of values of type string. In
+non-string comparison contexts, the two variants behave the same.
 
 These operators are left associative.
 
@@ -1413,20 +1490,26 @@ Syntax:
 
 ```Syntax
 equality-operator: one of
-    -eq         -ceq        -ieq
-    -ne         -cne        -ine
+    dash eq     dash ceq    dash ieq
+    dash ne     dash cne    dash ine
+
+dash:
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
 
 relational-operator: one of
-    -lt         -clt        -ilt
-    -le         -cle        -ile
-    -gt         -cgt        -igt
-    -ge         -cge        -ige
+    dash lt     dash clt    dash ilt
+    dash le     dash cle    dash ile
+    dash gt     dash cgt    dash igt
+    dash ge     dash cge    dash ige
 ```
 
 Description:
 
-There are two *equality-operator*s: equality (`-eq`) and inequality (`-ne`); and four *relational
-operator*s: less-than (`-lt`), less-than-or-equal-to (`-le`), greater-than (`-gt`), and
+There are two equality operators: equality (`-eq`) and inequality (`-ne`); and four
+relational operators: less-than (`-lt`), less-than-or-equal-to (`-le`), greater-than (`-gt`), and
 greater-than-or-equal-to (`-ge`). Each of these has two variants ([§7.8][§7.8]).
 
 For two strings to compare equal, they must have the same length and contents, and letter case, if
@@ -1459,15 +1542,21 @@ Syntax:
 
 ```Syntax
 containment-operator: one of
-    -contains       -ccontains      -icontains
-    -notcontains    -cnotcontains   -inotcontains
-    -in             -cin            -iin
-    -notin          -cnotin         -inotin
+    dash contains       dash ccontains      dash icontains
+    dash notcontains    dash cnotcontains   dash inotcontains
+    dash in             dash cin            dash iin
+    dash notin          dash cnotin         dash inotin
+
+dash:
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
 ```
 
 Description:
 
-There are four *containment-operator*s: contains (`-contains`), does-not-contain (`-notcontains`),
+There are four containment operators: contains (`-contains`), does-not-contain (`-notcontains`),
 in (`-in`) and not-in (`-notin`). Each of these has two variants ([§7.8][§7.8]).
 
 The containment operators return a result of type bool that indicates whether a value occurs (or
@@ -1485,12 +1574,27 @@ Examples:
 10,20,30,20,10 -contains 20     # True
 10,20,30,20,10 -contains 42.9   # False
 10,20,30 -contains "10"         # True
+"10",20,30 -contains 10         # True
 "010",20,30 -contains 10        # False
 10,20,30,20,10 -notcontains 15  # True
 "Red",20,30 -ccontains "RED"    # False
 ```
 
 ### 7.8.3 Type testing and conversion operators
+
+Syntax:
+
+```Syntax
+type-operator: one of
+    dash is
+    dash as
+
+dash:
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
+```
 
 Description:
 
@@ -1537,8 +1641,14 @@ Syntax:
 
 ```Syntax
 like-operator: one of
-    -like       -clike      -ilike
-    -notlike    -cnotlike   -inotlike
+    dash like       dash clike      dash ilike
+    dash notlike    dash cnotlike   dash inotlike
+
+dash:
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
 ```
 
 Description:
@@ -1546,8 +1656,8 @@ Description:
 If the left operand does not designate a collection, the result has type `bool`. Otherwise, the
 result is a possibly empty unconstrained 1-dimensional array containing the elements of the
 collection that test True when compared to the value designated by the right operand. The right
-operand may designate a string that contains wildcard expressions ([§3.15][§3.15]). These operators have
-two variants ([§7.8][§7.8]).
+operand may designate a string that contains wildcard expressions ([§3.15][§3.15]). These operators
+have two variants ([§7.8][§7.8]).
 
 Examples:
 
@@ -1573,8 +1683,14 @@ Syntax:
 
 ```Syntax
 match-operator: one of
-    -match      -cmatch     -imatch
-    -notmatch   -cnotmatch  -inotmatch
+    dash match      dash cmatch     dash imatch
+    dash notmatch   dash cnotmatch  dash inotmatch
+
+dash:
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
 ```
 
 Description:
@@ -1584,8 +1700,8 @@ is `$true`, the elements of the Hashtable `$matches` are set to the strings that
 do-not-match) the value designated by the right operand. Otherwise, the result is a possibly empty
 unconstrained 1-dimensional array containing the elements of the collection that test True when
 compared to the value designated by the right operand, and `$matches` is not set. The right operand
-may designate a string that contains regular expressions ([§3.16][§3.16]), in which case, it is referred
-to as a *pattern*. These operators have two variants ([§7.8][§7.8]).
+may designate a string that contains regular expressions ([§3.16][§3.16]), in which case, it is
+referred to as a _pattern_. These operators have two variants ([§7.8][§7.8]).
 
 These operators support submatches ([§7.8.4.6][§7.8.4.6]).
 
@@ -1610,7 +1726,13 @@ Syntax:
 
 ```Syntax
 binary-replace-operator: one of
-    -replace    -creplace   -ireplace
+    dash replace    dash creplace   dash ireplace
+
+dash:
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
 ```
 
 Description:
@@ -1619,8 +1741,8 @@ The `-replace` operator allows text replacement in one or more strings designate
 operand using the values designated by the right operand. This operator has two variants
 ([§7.8][§7.8]). The right operand has one of the following forms:
 
-- The string to be located, which may contain regular expressions ([§3.16][§3.16]). In this case, the
-  replacement string is implicitly "".
+- The string to be located, which may contain regular expressions ([§3.16][§3.16]). In this case,
+  the replacement string is implicitly "".
 - An array of 2 objects containing the string to be located, followed by the replacement string.
 
 If the left operand designates a string, the result has type string. If the left operand designates
@@ -1639,6 +1761,19 @@ Examples:
 ```
 
 #### 7.8.4.4 The binary -join operator
+
+Syntax:
+
+```Syntax
+binary-join-operator: one of
+    dash join
+
+dash:
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
+```
 
 Description:
 
@@ -1663,25 +1798,31 @@ Syntax:
 
 ```Syntax
 binary-split-operator: one of
-    -split      -csplit     -isplit
+    dash split      dash csplit     dash isplit
+
+dash:
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
 ```
 
 Description:
 
 The binary `-split` operator splits one or more strings designated by the left operand, returning
 their subparts in a constrained 1-dimensional array of string. This operator has two variants
-([§7.8][§7.8]). The left operand can designate a scalar value or an array of strings. The right operand
-has one of the following forms:
+([§7.8][§7.8]). The left operand can designate a scalar value or an array of strings. The right
+operand has one of the following forms:
 
-- A *delimiter string*
-- An array of 2 objects containing a delimiter string followed by a numeric *split count*
-- An array of 3 objects containing a delimiter string, a numeric split count, and an *options
-  string*
+- A _delimiter string_
+- An array of 2 objects containing a delimiter string followed by a numeric _split count_
+- An array of 3 objects containing a delimiter string, a numeric split count, and an _options
+  string_
 - A script block
 - An array of 2 objects containing a script block followed by a numeric split count
 
-The delimiter string may contain regular expressions ([§3.16][§3.16]). It is used to locate subparts with
-the input strings. The delimiter is not included in the resulting strings. If the left operand
+The delimiter string may contain regular expressions ([§3.16][§3.16]). It is used to locate subparts
+with the input strings. The delimiter is not included in the resulting strings. If the left operand
 designates an empty string, that results in an empty string element. If the delimiter string is an
 empty string, it is found at every character position in the input strings.
 
@@ -1692,8 +1833,8 @@ separate element. If that count is less than the number of subparts in the input
 count elements in the result, with the final element containing all of the subparts beyond the first
 **count - 1** subparts.
 
-An options string contains zero or more *option names* with each adjacent pair separated by a comma.
-Leading, trailing, and embedded white space is ignored. Option names may be in any order and are
+An options string contains zero or more _option names_ with each adjacent pair separated by a comma.
+Leading, trailing, and embedded whitespace is ignored. Option names may be in any order and are
 case-sensitive.
 
 If an options string contains the option name **SimpleMatch**, it may also contain the option name
@@ -1708,14 +1849,14 @@ Here is the set of option names:
 | CultureInvariant        | Ignores cultural differences in language when evaluating the delimiter.                              |
 | ExplicitCapture         | Ignores non-named match groups so that only explicit capture groups are returned in the result list. |
 | IgnoreCase              | Force case-insensitive matching, even if `-csplit` is used.                                          |
-| IgnorePatternWhitespace | Ignores unescaped white space and comments marked with the number sign (#).                          |
+| IgnorePatternWhitespace | Ignores unescaped whitespace and comments marked with the number sign (`#`).                         |
 | Multiline               | This mode recognizes the start and end of lines and strings. The default mode is **Singleline**.     |
 | RegexMatch              | Use regular expression matching to evaluate the delimiter. This is the default.                      |
 | SimpleMatch             | Use simple string comparison when evaluating the delimiter.                                          |
 | Singleline              | This mode recognizes only the start and end of strings. It is the default mode.                      |
 
-The script block ([§7.1.8][§7.1.8]) specifies the rules for determining the delimiter, and must evaluate
-to type bool.
+The script block ([§7.1.8][§7.1.8]) specifies the rules for determining the delimiter, and must
+evaluate to type bool.
 
 Examples:
 
@@ -1738,7 +1879,7 @@ Examples:
 #### 7.8.4.6 Submatches
 
 The pattern being matched by `-match`, `-notmatch`, and `-replace` may contain subparts (called
-*submatches*) delimited by parentheses. Consider the following example:
+_submatches_) delimited by parentheses. Consider the following example:
 
 `"red" -match "red"`
 
@@ -1756,7 +1897,7 @@ Consider the following, more complex, pattern:
 
 `"red" -match "((r)e)(d)"`
 
-This pattern allows submatches of "r", "re", "d", or "red".
+This pattern allows submatches of "re", "r", "d", or "red".
 
 Again, key 0 contains "red". Key 1 contains "re", key 2 contains "r", and key 3 contains "d". The
 key/value pairs are in matching order from left-to-right in the pattern, with longer string matches
@@ -1772,10 +1913,24 @@ In the case of `-replace`, the replacement text can access the submatches via na
 The resulting string is "the morning of Monday".
 
 Instead of having keys in `$matches` be zero-based indexes, submatches can be named using the form
-`?<*name*>`. For example, `"((r)e)(d)"` can be written with three named submatches, m1, m2, and m3,
-as follows: `"(?<m1>(?<m2>r)e)(?<m3>d)"`.
+`?<*name*>`. For example, `"((r)e)(d)"` can be written with three named submatches, `m1`, `m2`, and
+`m3`, as follows: `"(?<m1>(?<m2>r)e)(?<m3>d)"`.
 
 ### 7.8.5 Shift operators
+
+Syntax:
+
+```Syntax
+shift-operator: one of
+    dash shl
+    dash shr
+
+dash:
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
+```
 
 Description:
 
@@ -1810,20 +1965,20 @@ Syntax:
 
 ```Syntax
 bitwise-expression:
-    primary-expression -band new-lines~opt~ expression
-    primary-expression -bor new-lines~opt~ expression
-    primary-expression -bxor new-lines~opt~ expression
+    unary-expression -band new-lines~opt~ unary-expression
+    unary-expression -bor new-lines~opt~ unary-expression
+    unary-expression -bxor new-lines~opt~ unary-expression
 ```
 
 Description:
 
-The bitwise AND operator `-band`, the bitwise OR operator `-bor`, and the bitwise XOR operator -bxor
-convert the values designated by their operands to integer types, if necessary, using the usual
-arithmetic conversions ([§6.15][§6.15]). After conversion, if both values have type int that is the type
-of the result. Otherwise, if both values have type long, that is the type of the result. If one
-value has type int and the other has type long, the type of the result is long. Otherwise, the
-expression is ill formed. The result is the bitwise AND, bitwise OR, or bitwise XOR, respectively,
-of the possibly converted operand values.
+The bitwise AND operator `-band`, the bitwise OR operator `-bor`, and the bitwise XOR operator
+`-bxor` convert the values designated by their operands to integer types, if necessary, using the
+usual arithmetic conversions ([§6.15][§6.15]). After conversion, if both values have type int that
+is the type of the result. Otherwise, if both values have type long, that is the type of the result.
+If one value has type **int** and the other has type long, the type of the result is long.
+Otherwise, the expression is ill formed. The result is the bitwise AND, bitwise OR, or bitwise XOR,
+respectively, of the possibly converted operand values.
 
 These operators are left associative. They are commutative if neither operand contains a side
 effect.
@@ -1851,16 +2006,16 @@ Syntax:
 
 ```Syntax
 logical-expression:
-    primary-expression -and new-lines~opt~ expression
-    primary-expression -or new-lines~opt~ expression
-    primary-expression -xor new-lines~opt~ expression
+    unary-expression -and new-lines~opt~ unary-expression
+    unary-expression -or new-lines~opt~ unary-expression
+    unary-expression -xor new-lines~opt~ unary-expression
 ```
 
 Description:
 
 The logical AND operator `-and` converts the values designated by its operands to `bool`, if
-necessary ([§6.2][§6.2]). The result is the logical AND of the possibly converted operand values, and
-has type `bool`. If the left operand evaluates to False the right operand is not evaluated.
+necessary ([§6.2][§6.2]). The result is the logical AND of the possibly converted operand values,
+and has type `bool`. If the left operand evaluates to False the right operand is not evaluated.
 
 The logical OR operator `-or` converts the values designated by its operands to `bool`, if necessary
 ([§6.2][§6.2]). The result is the logical OR of the possibly converted operand values, and has type
@@ -1909,13 +2064,13 @@ assignment-operator: *one of
 
 Description:
 
-An assignment operator stores a value in the writable location designated by *expression*. For a
-discussion of *assignment-operator* `=` see [§7.11.1][§7.11.1]. For a discussion of all other
-*assignment-operator*s see [§7.11.2][§7.11.2].
+An assignment operator stores a value in the writable location designated by _expression_. For a
+discussion of _assignment-operator_ `=` see [§7.11.1][§7.11.1]. For a discussion of all other
+assignment operators see [§7.11.2][§7.11.2].
 
-An assignment expression has the value designated by *expression* after the assignment has taken
+An assignment expression has the value designated by _expression_ after the assignment has taken
 place; however, that assignment expression does not itself designate a writable location. If
-*expression* is type-constrained ([§5.3][§5.3]), the type used in that constraint is the type of the
+_expression_ is type-constrained ([§5.3][§5.3]), the type used in that constraint is the type of the
 result; otherwise, the type of the result is the type after the usual arithmetic conversions
 ([§6.15][§6.15]) have been applied.
 
@@ -1925,23 +2080,23 @@ This operator is right associative.
 
 Description:
 
-In *simple assignment* (`=`), the value designated by *statement* replaces the value stored in the
-writable location designated by *expression*. However, if *expression* designates a non-existent key
+In _simple assignment_ (`=`), the value designated by _statement_ replaces the value stored in the
+writable location designated by _expression_. However, if _expression_ designates a non-existent key
 in a Hashtable, that key is added to the Hashtable with an associated value of the value designated
-by *statement*.
+by _statement_.
 
-As shown by the grammar, *expression* may designate a comma-separated list of writable locations.
-This is known as *multiple assignment*. *statement* designates a list of one or more comma-separated
-values. The commas in either operand list are part of the multiple-assignment syntax and do *not*
-represent the binary comma operator. Values are taken from the list designated by *statement*, in
-lexical order, and stored in the corresponding writable location designated by *expression*. If the
-list designated by *statement* has fewer values than there are *expression* writable locations, the
-excess locations take on the value `$null`. If the list designated by *statement* has more values
-than there are *expression* writable locations, all but the right-most *expression* location take on
-the corresponding *statement* value and the right-most *expression* location becomes an
-unconstrained 1-dimensional array with all the remaining *statement* values as elements.
+As shown by the grammar, _expression_ may designate a comma-separated list of writable locations.
+This is known as _multiple assignment_. _statement_ designates a list of one or more comma-separated
+values. The commas in either operand list are part of the multiple-assignment syntax and do _not_
+represent the binary comma operator. Values are taken from the list designated by _statement_, in
+lexical order, and stored in the corresponding writable location designated by _expression_. If the
+list designated by _statement_ has fewer values than there are _expression_ writable locations, the
+excess locations take on the value `$null`. If the list designated by _statement_ has more values
+than there are _expression_ writable locations, all but the right-most _expression_ location take on
+the corresponding _statement_ value and the right-most _expression_ location becomes an
+unconstrained 1-dimensional array with all the remaining _statement_ values as elements.
 
-For statements that have values ([§8.1.2][§8.1.2]), *statement* can be a statement.
+For statements that have values ([§8.1.2][§8.1.2]), _statement_ can be a statement.
 
 Examples:
 
@@ -1979,12 +2134,13 @@ A                                  # invoke function Demo via the alias
 
 Description:
 
-A *compound assignment* has the form `E1 op= E2`, and is equivalent to the simple assignment
-expression `E1 = E1 op (E2)` except that in the compound assignment case the expression *E1* is
-evaluated only once. If *expression* is type-constrained ([§5.3][§5.3]), the type used in that
-constraint is the type of the result; otherwise, the type of the result is determined by *op*. For
-`*=`, see [§7.6.1][§7.6.1], [§7.6.2][§7.6.2], [§7.6.3][§7.6.3]; for `/=`, see [§7.6.4][§7.6.4]; for `%=`, see [§7.6.5][§7.6.5];
-for `+=`, see [§7.7.1][§7.7.1], [§7.7.2][§7.7.2], [§7.7.3][§7.7.3]; for `-=`, see [§7.7.5][§7.7.5].
+A _compound assignment_ has the form `E1 op= E2`, and is equivalent to the simple assignment
+expression `E1 = E1 op (E2)` except that in the compound assignment case the expression _E1_ is
+evaluated only once. If _expression_ is type-constrained ([§5.3][§5.3]), the type used in that
+constraint is the type of the result; otherwise, the type of the result is determined by _op_. For
+`*=`, see [§7.6.1][§7.6.1], [§7.6.2][§7.6.2], [§7.6.3][§7.6.3]; for `/=`, see [§7.6.4][§7.6.4]; for
+`%=`, see [§7.6.5][§7.6.5]; for `+=`, see [§7.7.1][§7.7.1], [§7.7.2][§7.7.2], [§7.7.3][§7.7.3]; for
+`-=`, see [§7.7.5][§7.7.5].
 
 > [!NOTE]
 > An operand designating an unconstrained value of numeric type may have its type changed by an
@@ -2015,7 +2171,6 @@ Syntax:
 
 ```Syntax
 pipeline:
-    assignment-expression
     expression redirections~opt~ pipeline-tail~opt~
     command verbatim-command-argument~opt~ pipeline-tail~opt~
 
@@ -2043,22 +2198,22 @@ merging-redirection-operator: one of
 Description:
 
 The redirection operator `>` takes the standard output from the pipeline and redirects it to the
-location designated by *redirected-file-name*, overwriting that location's current contents.
+location designated by _redirected-file-name_, overwriting that location's current contents.
 
 The redirection operator `>>` takes the standard output from the pipeline and redirects it to the
-location designated by *redirected-file-name*, appending to that location's current contents, if
+location designated by _redirected-file-name_, appending to that location's current contents, if
 any. If that location does not exist, it is created.
 
-The redirection operator with the form `n>` takes the output of stream *n* from the pipeline and
-redirects it to the location designated by *redirected-file-name*, overwriting that location's
+The redirection operator with the form `n>` takes the output of stream _n_ from the pipeline and
+redirects it to the location designated by _redirected-file-name_, overwriting that location's
 current contents.
 
-The redirection operator with the form `n>>` takes the output of stream *n* from the pipeline and
-redirects it to the location designated by *redirected-file-name*, appending to that location's
+The redirection operator with the form `n>>` takes the output of stream _n_ from the pipeline and
+redirects it to the location designated by _redirected-file-name_, appending to that location's
 current contents, if any. If that location does not exist, it is created.
 
-The redirection operator with the form `m>&n` writes output from stream *m* to the same location as
-stream *n*.
+The redirection operator with the form `m>&n` writes output from stream _m_ to the same location as
+stream _n_.
 
 The following are the valid streams:
 
@@ -2073,7 +2228,7 @@ The following are the valid streams:
 
 The redirection operators `1>&2`, `6>`, `6>>` and `<` are reserved for future use.
 
-If on output the value of *redirected-file-name* is `$null`, the output is discarded.
+If on output the value of _redirected-file-name_ is `$null`, the output is discarded.
 
 Ordinarily, the value of an expression containing a top-level side effect is not written to the
 pipeline unless that expression is enclosed in a pair of parentheses. However, if such an expression
@@ -2102,10 +2257,12 @@ dir -Verbose 4>&2 2> error2.txt
 [§2.3.5.2]: chapter-02.md#2352-string-literals
 [§3.15]: chapter-03.md#315-wildcard-expressions
 [§3.16]: chapter-03.md#316-regular-expressions
+[§4]: chapter-04.md
 [§4.3.7]: chapter-04.md#437-the-scriptblock-type
 [§4.4]: chapter-04.md#44-generic-types
 [§4.5.24]: chapter-04.md#4524-method-designator-type
 [§5.3]: chapter-05.md#53-constrained-variables
+[§6]: chapter-06.md
 [§6.15]: chapter-06.md#615-usual-arithmetic-conversions
 [§6.17]: chapter-06.md#617-conversion-during-parameter-binding
 [§6.2]: chapter-06.md#62-conversion-to-bool
@@ -2117,9 +2274,11 @@ dir -Verbose 4>&2 2> error2.txt
 [§7.1.4.5]: chapter-07.md#7145-generating-array-slices
 [§7.1.6]: chapter-07.md#716--operator
 [§7.1.8]: chapter-07.md#718-script-block-expression
+[§7.1.10]: chapter-07.md#7110-type-literal-expression
 [§7.11.1]: chapter-07.md#7111-simple-assignment
 [§7.11.2]: chapter-07.md#7112-compound-assignment
 [§7.11]: chapter-07.md#711-assignment-operators
+[§7.2]: chapter-07.md#72-unary-operators
 [§7.2.9]: chapter-07.md#729-cast-operator
 [§7.6.1]: chapter-07.md#761-multiplication
 [§7.6.2]: chapter-07.md#762-string-replication
@@ -2144,3 +2303,4 @@ dir -Verbose 4>&2 2> error2.txt
 [§9.12]: chapter-09.md#912-multidimensional-array-flattening
 [§9.4]: chapter-09.md#94-constraining-element-types
 [§9.9]: chapter-09.md#99-array-slices
+[TR84]: https://ecma-international.org/publications-and-standards/technical-reports/ecma-tr-84/

--- a/reference/docs-conceptual/lang-spec/chapter-07.md
+++ b/reference/docs-conceptual/lang-spec/chapter-07.md
@@ -995,7 +995,7 @@ array of 1 string, which is empty.
 Examples:
 
 ```powershell
--split " red&#96;tblue&#96;ngreen " # 3 strings: "red", "blue", "green"
+-split " red`tblue`ngreen " # 3 strings: "red", "blue", "green"
 -split ("yes no", "up down") # 4 strings: "yes", "no", "up", "down"
 -split " " # 1 (empty) string
 ```

--- a/reference/docs-conceptual/lang-spec/chapter-07.md
+++ b/reference/docs-conceptual/lang-spec/chapter-07.md
@@ -9,7 +9,21 @@ Syntax:
 
 ```Syntax
 expression:
+    primary-expression
+    bitwise-expression
     logical-expression
+    comparison-expression
+    additive-expression
+    multiplicative-expression
+
+dash: one of
+    - (U+002D)
+    EnDash character (U+2013)
+    EmDash character (U+2014)
+    Horizontal bar character (U+2015)
+
+dashdash:
+    dash dash
 ```
 
 Description:
@@ -204,10 +218,12 @@ The result is written to the pipeline, as the top-level expression has no side e
 Syntax:
 
 ```Syntax
-member-access: Note no whitespace is allowed after primary-expression. 
+member-access:
     primary-expression . member-name
     primary-expression :: member-name
 ```
+
+Note that no whitespace is allowed after *primary-expression*.
 
 Description:
 
@@ -268,13 +284,15 @@ $a.ID                        # get ID from each element in the array
 Syntax:
 
 ```Syntax
-invocation-expression: Note no whitespace is allowed after primary-expression. 
+invocation-expression:
     primary-expression . member-name argument-list
     primary-expression :: member-name argument-list
 
 argument-list:
     ( argument-expression-list~opt~ new-lines~opt~ )
 ```
+
+Note that no whitespace is allowed after *primary-expression*.
 
 Description:
 
@@ -316,7 +334,7 @@ $a.Invoke("X")               # call ToLower via the descriptor
 Syntax:
 
 ```Syntax
-element-access: Note no whitespace is allowed between primary-expression and [.
+element-access:
     primary-expression [ new-lines~opt~ expression new-lines~opt~ ]
 ```
 
@@ -454,7 +472,7 @@ $x = [xml]@"
 
 $x['Name']                # refers to the element Name
 $x['Name']['FirstName']   # refers to the element FirstName within Name
-$x['FirstName']           # No such child element at the top level, result is `$null`
+$x['FirstName']           # No such child element at the top level, result is $null
 ```
 
 The type of the result is `System.Xml.XmlElement` or `System.String`.
@@ -503,9 +521,6 @@ post-increment-expression:
 
 post-decrement-expression:
     primary-expression dashdash
-
-dashdash:
-    --
 ```
 
 Description:
@@ -747,10 +762,15 @@ Type literals are used in a number of contexts:
 
 Examples:
 
-Examples of type literals are `[int]`, `[object[]`, and `[int[,,]]`. A generic stack type ([§4.4][§4.4])
-that is specialized to hold strings might be written as `[Stack[string]]`, and a generic dictionary
-type that is specialized to hold `int` keys with associated string values might be written as
-`[Dictionary[int,string]]`.
+```powershell
+[int].IsPrimitive        # $true
+[Object[]].FullName      # "System.Object[]"
+[int[,,]].GetArrayRank() # 3
+```
+
+A generic stack type ([§4.4][§4.4]) that is specialized to hold strings might be written as
+`[Stack[string]]`, and a generic dictionary type that is specialized to hold `int` keys with
+associated string values might be written as `[Dictionary[int,string]]`.
 
 The type of a *type-literal* is `System.Type`. The complete name for the type `Stack[string]`
 suggested above is `System.Collections.Generic.Stack[int]`. The complete name for the type
@@ -778,12 +798,6 @@ expression-with-unary-operator:
     -split new-lines~opt~ unary-expression
     -join new-lines~opt~ unary-expression
 
-dash:*
-    - (U+002D)
-    EnDash character (U+2013)
-    EmDash character (U+2014)
-    Horizontal bar character (U+2015)
-
 pre-increment-expression:
     ++ new-lines~opt~ unary-expression
 
@@ -792,9 +806,6 @@ pre-decrement-expression:
 
 cast-expression:
     type-literal unary-expression
-
-dashdash:
-    dash dash
 ```
 
 ### 7.2.1 Unary comma operator
@@ -892,9 +903,11 @@ This operator is right associative.
 
 Examples:
 
--$true # type int, value -1
--123L # type long, value -123
--0.12340D # type decimal, value -0.12340
+```powershell
+-$true     # type int, value -1
+-123L      # type long, value -123
+-0.12340D  # type decimal, value -0.12340
+```
 
 ### 7.2.6 Prefix increment and decrement operators
 
@@ -941,7 +954,7 @@ $k = [int]::MinValue  # $k is set to -2147483648
 $--k                  # -2147483649 is too small to fit, imp-def behavior
 
 $x = $null            # target is unconstrained, $null goes to [int]0
-$--x                  # value treated as int, 0->-1
+$--x                  # value treated as int, 0 becomes -1
 ```
 
 ### 7.2.7 The unary -join operator
@@ -982,7 +995,7 @@ array of 1 string, which is empty.
 Examples:
 
 ```powershell
--split " red\`tblue\`ngreen " # 3 strings: "red", "blue", "green"
+-split " red&#96;tblue&#96;ngreen " # 3 strings: "red", "blue", "green"
 -split ("yes no", "up down") # 4 strings: "yes", "no", "up", "down"
 -split " " # 1 (empty) string
 ```
@@ -1044,9 +1057,8 @@ Syntax:
 
 ```Syntax
 range-expression:
-array-literal-expression
-range-expression *..* new-lines~opt~
-array-literal-expression
+    array-literal-expression
+    range-expression *..* new-lines~opt~ array-literal-expression
 ```
 
 Description:
@@ -1088,16 +1100,7 @@ Syntax:
 ```Syntax
 format-expression:
     range-expression
-    format-expression format-operator new-lines~opt~ range-expression
-
-format-operator:
-    dash f
-
-dash:
-    - (U+002D)
-    EnDash character (U+2013)
-    EmDash character (U+2014)
-    Horizontal bar character (U+2015)
+    format-expression -f new-lines~opt~ range-expression
 ```
 
 Description:
@@ -1127,18 +1130,20 @@ Technical Report TR/84.
 Examples:
 
 ```powershell
-`$i` = 10; $j = 12
-"{2} <= {0} + {1}\`n" -f $i,$j,($i+$j)  # 22 <= 10 + 12
-">{0,3}<" -f 5                          # > 5<
-">{0,-3}<" -f 5                         # >5 <
-">{0,3:000}<" -f 5                      # >005<
-">{0,5:0.00}<" -f 5.0                   # > 5.00<
-">{0:C}<" -f 1234567.888                # >$1,234,567.89<
-">{0:C}<" -f -1234.56                   # >($1,234.56)<
-">{0,12:e2}<" -f 123.456e2              # > 1.23e+004<
-">{0,-12:p}<" -f -0.252                 # >-25.20 % <
-$format = ">{0:x8}<"
-$format -f 123455                       # >0001e23f<
+"__{0,3}__" -f 5                         # __ 5__
+"__{0,-3}__" -f 5                        # __5 __
+"__{0,3:000}__" -f 5                     # __005__
+"__{0,5:0.00}__" -f 5.0                  # __ 5.00__
+"__{0:C}__" -f 1234567.888               # __$1,234,567.89__
+"__{0:C}__" -f -1234.56                  # __($1,234.56)__
+"__{0,12:e2}__" -f 123.456e2             # __ 1.23e+004__
+"__{0,-12:p}__" -f -0.252                # __-25.20 % __
+
+$i = 5; $j = 3
+"__{0} + {1} <= {2}__" -f $i,$j,($i+$j)  # __5 + 3 <= 8__
+
+$format = "__0x{0:X8}__"
+$format -f 65535                         # __0x0000FFFF__
 ```
 
 In a format specification if *N* refers to a non-existent position, a **FormatError** is raised.
@@ -1149,7 +1154,6 @@ Syntax:
 
 ```Syntax
 multiplicative-expression:
-    format-expression
     multiplicative-expression * new-lines~opt~ format-expression
     multiplicative-expression / new-lines~opt~ format-expression
     multiplicative-expression % new-lines~opt~ format-expression
@@ -1198,7 +1202,7 @@ Examples:
 Description:
 
 When the left operand designates an array the binary `*` operator creates a new unconstrained
-1‑dimensional array that contains the value designated by the left operand replicated the number of
+1-dimensional array that contains the value designated by the left operand replicated the number of
 times designated by the value of the right operand as converted to integer type ([§6.4][§6.4]). A
 replication count of zero results in an array of length 1. If the left operand designates a
 multidimensional array, it is flattened ([§9.12][§9.12]) before being used.
@@ -1271,9 +1275,8 @@ Syntax:
 
 ```Syntax
 additive-expression:
-    multiplicative-expression
-    additive-expression + new-lines~opt~ multiplicative-expression
-    additive-expression dash new-lines~opt~ multiplicative-expression
+    primary-expression + new-lines~opt~ expression
+    primary-expression dash new-lines~opt~ expression
 ```
 
 ### 7.7.1 Addition
@@ -1319,7 +1322,7 @@ Examples:
 Description:
 
 When the left operand designates an array the binary `+` operator creates a new unconstrained
-1‑dimensional array that contains the elements designated by the left operand followed immediately
+1-dimensional array that contains the elements designated by the left operand followed immediately
 by the value(s) designated by the right operand. Multidimensional arrays present in either operand
 are flattened ([§9.12][§9.12]) before being used.
 
@@ -1381,30 +1384,15 @@ Examples:
 Syntax:
 
 ```Syntax
-comparison-operator: one of
-    dash as           dash ccontains     dash ceq
-    dash cge          dash cgt           dash cle
-    dash clike        dash clt           dash cmatch
-    dash cne          dash cnotcontains  dash cnotlike
-    dash cnotmatch    dash contains      dash creplace
-    dash csplit       dash eq            dash ge
-    dash gt           dash icontains     dash ieq
-    dash ige          dash igt           dash ile
-    dash ilike        dash ilt           dash imatch
-    dash in           dash ine           dash inotcontains
-    dash inotlike     dash inotmatch     dash ireplace
-    dash is           dash isnot         dash isplit
-    dash join         dash le            dash like
-    dash lt           dash match         dash ne
-    dash notcontains  dash notin         dash notlike
-    dash notmatch     dash replace       dash shl
-    dash shr          dash split
+comparison-expression:
+    primary-expression comparison-operator new-lines~opt~ expression
 
-dash:
-    - (U+002D)
-    EnDash character (U+2013)
-    EmDash character (U+2014)
-    Horizontal bar character (U+2015)
+comparison-operator:
+    equality-operator
+    relational-operator
+    containment-operator
+    like-operator
+    match-operator
 ```
 
 Description:
@@ -1421,10 +1409,24 @@ These operators are left associative.
 
 ### 7.8.1 Equality and relational operators
 
+Syntax:
+
+```Syntax
+equality-operator: one of
+    -eq         -ceq        -ieq
+    -ne         -cne        -ine
+
+relational-operator: one of
+    -lt         -clt        -ilt
+    -le         -cle        -ile
+    -gt         -cgt        -igt
+    -ge         -cge        -ige
+```
+
 Description:
 
-There are two *equality* *operators*: equality (`-eq`) and inequality (`-ne`); and four *relational
-operators*: less-than (`-lt`), less-than-or-equal-to (`-le`), greater-than (`-gt`), and
+There are two *equality-operator*s: equality (`-eq`) and inequality (`-ne`); and four *relational
+operator*s: less-than (`-lt`), less-than-or-equal-to (`-le`), greater-than (`-gt`), and
 greater-than-or-equal-to (`-ge`). Each of these has two variants ([§7.8][§7.8]).
 
 For two strings to compare equal, they must have the same length and contents, and letter case, if
@@ -1453,13 +1455,23 @@ Examples:
 
 ### 7.8.2 Containment operators
 
+Syntax:
+
+```Syntax
+containment-operator: one of
+    -contains       -ccontains      -icontains
+    -notcontains    -cnotcontains   -inotcontains
+    -in             -cin            -iin
+    -notin          -cnotin         -inotin
+```
+
 Description:
 
-There are four *containment* *operators*: contains (`-contains`), does-not-contain (`‑notcontains`),
+There are four *containment-operator*s: contains (`-contains`), does-not-contain (`-notcontains`),
 in (`-in`) and not-in (`-notin`). Each of these has two variants ([§7.8][§7.8]).
 
 The containment operators return a result of type bool that indicates whether a value occurs (or
-does not occur) at least once in the elements of an array. With `-contains` and `‑notcontains`, the
+does not occur) at least once in the elements of an array. With `-contains` and `-notcontains`, the
 value is designated by the right operand and the array is designated by the left operand. With -in
 and `-notin`, the operands are reversed. The value is designated by the left operand and the array
 is designated by the right operand.
@@ -1521,6 +1533,14 @@ foreach ($t in [int],$x,[decimal],"string") {
 
 #### 7.8.4.1 The -like and -notlike operators
 
+Syntax:
+
+```Syntax
+like-operator: one of
+    -like       -clike      -ilike
+    -notlike    -cnotlike   -inotlike
+```
+
 Description:
 
 If the left operand does not designate a collection, the result has type `bool`. Otherwise, the
@@ -1548,6 +1568,14 @@ Examples:
 ```
 
 #### 7.8.4.2 The -match and -notmatch operators
+
+Syntax:
+
+```Syntax
+match-operator: one of
+    -match      -cmatch     -imatch
+    -notmatch   -cnotmatch  -inotmatch
+```
 
 Description:
 
@@ -1578,6 +1606,13 @@ Examples:
 
 #### 7.8.4.3 The -replace operator
 
+Syntax:
+
+```Syntax
+binary-replace-operator: one of
+    -replace    -creplace   -ireplace
+```
+
 Description:
 
 The `-replace` operator allows text replacement in one or more strings designated by the left
@@ -1589,7 +1624,7 @@ operand using the values designated by the right operand. This operator has two 
 - An array of 2 objects containing the string to be located, followed by the replacement string.
 
 If the left operand designates a string, the result has type string. If the left operand designates
-a 1‑dimensional array of string, the result is an unconstrained 1-dimensional array, whose length is
+a 1-dimensional array of string, the result is an unconstrained 1-dimensional array, whose length is
 the same as for left operand's array, containing the input strings after replacement has completed.
 
 This operator supports submatches ([§7.8.4.6][§7.8.4.6]).
@@ -1623,6 +1658,13 @@ Examples:
 ```
 
 #### 7.8.4.5 The binary -split operator
+
+Syntax:
+
+```Syntax
+binary-split-operator: one of
+    -split      -csplit     -isplit
+```
 
 Description:
 
@@ -1768,10 +1810,9 @@ Syntax:
 
 ```Syntax
 bitwise-expression:
-    comparison-expression
-    bitwise-expression -band new-lines~opt~ comparison-expression
-    bitwise-expression -bor new-lines~opt~ comparison-expression
-    bitwise-expression -bxor new-lines~opt~ comparison-expression
+    primary-expression -band new-lines~opt~ expression
+    primary-expression -bor new-lines~opt~ expression
+    primary-expression -bxor new-lines~opt~ expression
 ```
 
 Description:
@@ -1810,10 +1851,9 @@ Syntax:
 
 ```Syntax
 logical-expression:
-    bitwise-expression
-    logical-expression -and new-lines~opt~ bitwise-expression
-    logical-expression -or new-lines~opt~ bitwise-expression
-    logical-expression -xor new-lines~opt~ bitwise-expression
+    primary-expression -and new-lines~opt~ expression
+    primary-expression -or new-lines~opt~ expression
+    primary-expression -xor new-lines~opt~ expression
 ```
 
 Description:


### PR DESCRIPTION
# PR Summary

1. The BNF grammar is totally broken. This moves forward with a few fixes.
2. Many of the comparison operators were missing
3. Added a few missing`Syntax:` sections 

Please consider this PR on an 'as-is' basis; I believe the changes are a positive contribution which you can use or modify any way you like without my further participation.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
