### PR TITLE
Fix remaining invalid prefix increment unary operator usage in `chapter-07.md`

### DIFF
--- a/reference/docs-conceptual/lang-spec/chapter-07.md
+++ b/reference/docs-conceptual/lang-spec/chapter-07.md
@@ -988,10 +988,10 @@ $i = 2147483647       # $i holds a value of type int
 
 [int]$k = 0           # $k is constrained to int
 $k = [int]::MinValue  # $k is set to -2147483648
-$--k                  # -2147483649 is too small to fit, imp-def behavior
+--$k                  # -2147483649 is too small to fit, imp-def behavior
 
 $x = $null            # target is unconstrained, $null goes to [int]0
-$--x                  # value treated as int, 0 becomes -1
+--$x                  # value treated as int, 0 becomes -1
 ```
 
 ### 7.2.7 The unary -join operator


### PR DESCRIPTION
# PR Summary

Please note:
I've only searched inside of `reference/docs-conceptual/lang-spec/chapter-07.md`

Therefore, there might theoretically be other instances of this unary operator use in other chapters.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
