### PR TITLE
Added libssl1.1 from testing repository

### DIFF
--- a/reference/docs-conceptual/install/install-alpine.md
+++ b/reference/docs-conceptual/install/install-alpine.md
@@ -35,7 +35,6 @@ sudo apk add --no-cache \
     krb5-libs \
     libgcc \
     libintl \
-    libssl1.1 \
     libstdc++ \
     tzdata \
     userspace-rcu \
@@ -45,6 +44,9 @@ sudo apk add --no-cache \
 
 sudo apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
     lttng-ust
+
+sudo apk -X https://dl-cdn.alpinelinux.org/alpine/edge/testing add --no-cache \
+    libssl1.1
 
 # Download the powershell '.tar.gz' archive
 curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.4.2/powershell-7.4.2-linux-musl-x64.tar.gz -o /tmp/powershell.tar.gz


### PR DESCRIPTION
# PR Summary

libssl1.1 is not available from the main repository and must be fetched from testing.  Fixes #11068 


## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].


[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
