### PR TITLE
call operator: reference changes since v7.3 with PSnativeCommandArgumentPassing becoming mainstream

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 02/26/2024
+ms.date: 05/07/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -262,9 +262,13 @@ table. For more information, see [about_Hash_Tables][09].
 ### Call operator `&`
 
 Runs a command, script, or script block. The call operator, also known as the
-"invocation operator", lets you run commands that are stored in variables and
+_invocation operator_, lets you run commands that are stored in variables and
 represented by strings or script blocks. The call operator executes in a child
-scope. For more about scopes, see [about_Scopes][19].
+scope. For more about scopes, see [about_Scopes][19]. You can use this to build
+strings containing the command, parameters, and arguments you need, and then
+invoke the string as if it were a command. The strings that you create must
+follow the same parsing rules as a command that you type at the command line.
+For more information, see [about_Parsing][08].
 
 This example stores a command in a string and executes it using the call
 operator.
@@ -603,6 +607,7 @@ properties and methods of an object, use the Static parameter of the
 [05]: about_Arithmetic_Operators.md
 [06]: about_Assignment_Operators.md
 [07]: about_Comparison_Operators.md
+[08]: about_Parsing.md
 [09]: about_Hash_Tables.md
 [12]: about_Join.md
 [13]: about_logical_operators.md

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 02/26/2024
+ms.date: 05/07/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -239,9 +239,13 @@ table. For more information, see [about_Hash_Tables][09].
 ### Call operator `&`
 
 Runs a command, script, or script block. The call operator, also known as the
-"invocation operator", lets you run commands that are stored in variables and
+_invocation operator_, lets you run commands that are stored in variables and
 represented by strings or script blocks. The call operator executes in a child
-scope. For more about scopes, see [about_Scopes][19].
+scope. For more about scopes, see [about_Scopes][19]. You can use this to build
+strings containing the command, parameters, and arguments you need, and then
+invoke the string as if it were a command. The strings that you create must
+follow the same parsing rules as a command that you type at the command line.
+For more information, see [about_Parsing][08].
 
 This example stores a command in a string and executes it using the call
 operator.
@@ -851,6 +855,7 @@ ${a}?[0]
 [05]: about_Arithmetic_Operators.md
 [06]: about_Assignment_Operators.md
 [07]: about_Comparison_Operators.md
+[08]: about_Parsing.md
 [09]: about_Hash_Tables.md
 [10]: about_If.md
 [11]: about_Jobs.md

--- a/reference/7.3/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.3/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 02/26/2024
+ms.date: 05/07/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.3&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -239,9 +239,13 @@ table. For more information, see [about_Hash_Tables][09].
 ### Call operator `&`
 
 Runs a command, script, or script block. The call operator, also known as the
-"invocation operator", lets you run commands that are stored in variables and
+_invocation operator_, lets you run commands that are stored in variables and
 represented by strings or script blocks. The call operator executes in a child
-scope. For more about scopes, see [about_Scopes][19].
+scope. For more about scopes, see [about_Scopes][19]. You can use this to build
+strings containing the command, parameters, and arguments you need, and then
+invoke the string as if it were a command. The strings that you create must
+follow the same parsing rules as a command that you type at the command line.
+For more information, see [about_Parsing][08].
 
 This example stores a command in a string and executes it using the call
 operator.
@@ -851,6 +855,7 @@ ${a}?[0]
 [05]: about_Arithmetic_Operators.md
 [06]: about_Assignment_Operators.md
 [07]: about_Comparison_Operators.md
+[08]: about_Parsing.md
 [09]: about_Hash_Tables.md
 [10]: about_If.md
 [11]: about_Jobs.md

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -243,6 +243,12 @@ Runs a command, script, or script block. The call operator, also known as the
 represented by strings or script blocks. The call operator executes in a child
 scope. For more about scopes, see [about_Scopes][19].
 
+> [!CAUTION]
+> The default argument passing behavior has changed since version 7.3.
+> For a detailed description of the change and its impact see the description of
+> preference variable `$PSNativeCommandArgumentPassing` in
+> [Using Experimental Features in PowerShell][26].
+
 This example stores a command in a string and executes it using the call
 operator.
 
@@ -868,3 +874,4 @@ ${a}?[0]
 [23]: about_Variables.md
 [24]: about_Variables.md#variable-names-that-include-special-characters
 [25]: xref:Microsoft.PowerShell.Utility.Invoke-Expression
+[26]: /reference/docs-conceptual/learn/experimental-features.md#psnativecommandargumentpassing

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -246,7 +246,7 @@ scope. For more about scopes, see [about_Scopes][19].
 > [!CAUTION]
 > The default argument passing behavior has changed since version 7.3.
 > For a detailed description of the change and its impact see the description of
-> preference variable `$PSNativeCommandArgumentPassing` in
+> preference variable `PSNativeCommandArgumentPassing` in
 > [Using Experimental Features in PowerShell][26].
 
 This example stores a command in a string and executes it using the call
@@ -874,4 +874,4 @@ ${a}?[0]
 [23]: about_Variables.md
 [24]: about_Variables.md#variable-names-that-include-special-characters
 [25]: xref:Microsoft.PowerShell.Utility.Invoke-Expression
-[26]: /reference/docs-conceptual/learn/experimental-features.md#psnativecommandargumentpassing
+[26]: ../../../docs-conceptual/learn/experimental-features.md#psnativecommandargumentpassing

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 02/26/2024
+ms.date: 05/07/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -239,15 +239,13 @@ table. For more information, see [about_Hash_Tables][09].
 ### Call operator `&`
 
 Runs a command, script, or script block. The call operator, also known as the
-"invocation operator", lets you run commands that are stored in variables and
+_invocation operator_, lets you run commands that are stored in variables and
 represented by strings or script blocks. The call operator executes in a child
-scope. For more about scopes, see [about_Scopes][19].
-
-> [!CAUTION]
-> The default argument passing behavior has changed since version 7.3.
-> For a detailed description of the change and its impact see the description of
-> preference variable `PSNativeCommandArgumentPassing` in
-> [Using Experimental Features in PowerShell][26].
+scope. For more about scopes, see [about_Scopes][19]. You can use this to build
+strings containing the command, parameters, and arguments you need, and then
+invoke the string as if it were a command. The strings that you create must
+follow the same parsing rules as a command that you type at the command line.
+For more information, see [about_Parsing][08].
 
 This example stores a command in a string and executes it using the call
 operator.
@@ -857,6 +855,7 @@ ${a}?[0]
 [05]: about_Arithmetic_Operators.md
 [06]: about_Assignment_Operators.md
 [07]: about_Comparison_Operators.md
+[08]: about_Parsing.md
 [09]: about_Hash_Tables.md
 [10]: about_If.md
 [11]: about_Jobs.md
@@ -874,4 +873,3 @@ ${a}?[0]
 [23]: about_Variables.md
 [24]: about_Variables.md#variable-names-that-include-special-characters
 [25]: xref:Microsoft.PowerShell.Utility.Invoke-Expression
-[26]: ../../../docs-conceptual/learn/experimental-features.md#psnativecommandargumentpassing

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -243,6 +243,12 @@ Runs a command, script, or script block. The call operator, also known as the
 represented by strings or script blocks. The call operator executes in a child
 scope. For more about scopes, see [about_Scopes][19].
 
+> [!CAUTION]
+> The default argument passing behavior has changed since version 7.3.
+> For a detailed description of the change and its impact see the description of
+> preference variable `PSNativeCommandArgumentPassing` in
+> [Using Experimental Features in PowerShell][26].
+
 This example stores a command in a string and executes it using the call
 operator.
 
@@ -868,3 +874,4 @@ ${a}?[0]
 [23]: about_Variables.md
 [24]: about_Variables.md#variable-names-that-include-special-characters
 [25]: xref:Microsoft.PowerShell.Utility.Invoke-Expression
+[26]: ../../../docs-conceptual/learn/experimental-features.md#psnativecommandargumentpassing

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that are supported by PowerShell.
 Locale: en-US
-ms.date: 02/26/2024
+ms.date: 05/07/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Operators
@@ -239,15 +239,13 @@ table. For more information, see [about_Hash_Tables][09].
 ### Call operator `&`
 
 Runs a command, script, or script block. The call operator, also known as the
-"invocation operator", lets you run commands that are stored in variables and
+_invocation operator_, lets you run commands that are stored in variables and
 represented by strings or script blocks. The call operator executes in a child
-scope. For more about scopes, see [about_Scopes][19].
-
-> [!CAUTION]
-> The default argument passing behavior has changed since version 7.3.
-> For a detailed description of the change and its impact see the description of
-> preference variable `PSNativeCommandArgumentPassing` in
-> [Using Experimental Features in PowerShell][26].
+scope. For more about scopes, see [about_Scopes][19]. You can use this to build
+strings containing the command, parameters, and arguments you need, and then
+invoke the string as if it were a command. The strings that you create must
+follow the same parsing rules as a command that you type at the command line.
+For more information, see [about_Parsing][08].
 
 This example stores a command in a string and executes it using the call
 operator.
@@ -857,6 +855,7 @@ ${a}?[0]
 [05]: about_Arithmetic_Operators.md
 [06]: about_Assignment_Operators.md
 [07]: about_Comparison_Operators.md
+[08]: about_Parsing.md
 [09]: about_Hash_Tables.md
 [10]: about_If.md
 [11]: about_Jobs.md
@@ -874,4 +873,3 @@ ${a}?[0]
 [23]: about_Variables.md
 [24]: about_Variables.md#variable-names-that-include-special-characters
 [25]: xref:Microsoft.PowerShell.Utility.Invoke-Expression
-[26]: ../../../docs-conceptual/learn/experimental-features.md#psnativecommandargumentpassing


### PR DESCRIPTION
Version 7.3 made an experimental change mainstream that significantly changes how arguments are encapsulated and passed to native commands. While this normally doesn't make a difference there are enough subtle breakages documented on the Web that warrant that this change should be documented in the reference documentation and not just in files describing experimental features.

# PR Summary

The change adds a paragraph similar to the one in https://learn.microsoft.com/en-us/powershell/scripting/learn/experimental-features?view=powershell-7.4#psnativecommandargumentpassing. There are numerous issu reports on the Web where poepe are describing odd behaviors when invoking native commands. For example https://github.com/Azure/azure-storage-azcopy/issues/796.
This change would make it more obvious to discover, in addition to the already existing references in

* https://github.com/MicrosoftDocs/PowerShell-Docs/blob/872c5339096bd94a2264980953dd736e11239722/reference/docs-conceptual/learn/shell/running-commands.md
* https://github.com/MicrosoftDocs/PowerShell-Docs/blob/872c5339096bd94a2264980953dd736e11239722/reference/docs-conceptual/learn/experimental-features.md#psnativecommandargumentpassing

Oddly enough both pages still reference to `PSnativeCommandArgumentPassing` as being experimental.

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
