### PR TITLE
Fix `<maml:paragraph>` elements in cmdlet doc examples to `<maml:para>`

### DIFF
--- a/reference/docs-conceptual/developer/help/how-to-add-examples-to-a-cmdlet-help-topic.md
+++ b/reference/docs-conceptual/developer/help/how-to-add-examples-to-a-cmdlet-help-topic.md
@@ -63,9 +63,9 @@ the Windows PowerShell prompt: `C:\PS>`.
 <command:examples>
   <command:example>
     <maml:title>----------  EXAMPLE 1  ----------</maml:title>
-    <maml:Introduction>
-      <maml:paragraph>C:\PS></maml:paragraph>
-    </maml:Introduction>
+    <maml:introduction>
+      <maml:para>C:\PS></maml:para>
+    </maml:introduction>
 </command:example>
 </command:examples>
 ```
@@ -80,9 +80,9 @@ whenever possible.
 <command:examples>
   <command:example>
     <maml:title>----------  EXAMPLE 1  ----------</maml:title>
-    <maml:Introduction>
-      <maml:paragraph>C:\PS></maml:paragraph>
-    </maml:Introduction>
+    <maml:introduction>
+      <maml:para>C:\PS></maml:para>
+    </maml:introduction>
     <dev:code> command </dev:code>
 </command:example>
 </command:examples>
@@ -97,9 +97,9 @@ The following XML shows how to add a description for the example. PowerShell use
 <command:examples>
   <command:example>
     <maml:title>----------  EXAMPLE 1  ----------</maml:title>
-    <maml:Introduction>
-      <maml:paragraph>C:\PS></maml:paragraph>
-    </maml:Introduction>
+    <maml:introduction>
+      <maml:para>C:\PS></maml:para>
+    </maml:introduction>
     <dev:code> command </dev:code>
     <dev:remarks>
       <maml:para> command description </maml:para>
@@ -119,9 +119,9 @@ command.
 <command:examples>
   <command:example>
     <maml:title>----------  EXAMPLE 1  ----------</maml:title>
-    <maml:Introduction>
-      <maml:paragraph>C:\PS></maml:paragraph>
-    </maml:Introduction>
+    <maml:introduction>
+      <maml:para>C:\PS></maml:para>
+    </maml:introduction>
     <dev:code> command </dev:code>
     <dev:remarks>
       <maml:para> command description </maml:para>


### PR DESCRIPTION
# PR Summary

Discussed on PowerShell Discord server. The documentation for adding examples to XML cmdlet docs uses `paragraph` tags, `para` should be used instead. Also fixes casing for the `introduction` element in the same examples.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
