### PR TITLE
Added note about -parallel Parameter when using 'foreach ($item in $array)'

### DIFF
--- a/reference/7.4/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -650,6 +650,12 @@ that describes the operation.
 
 This parameter was introduced in PowerShell 7.0.
 
+
+> [!NOTE]
+> The **-Parallel** Parameter is not supported in **Foreach ($item in $array)** scenarios
+> You have to directly pipe an array like **$array | foreach -parallel**
+
+
 ```yaml
 Type: System.Management.Automation.ScriptBlock
 Parameter Sets: ParallelParameterSet

--- a/reference/7.4/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -653,7 +653,7 @@ This parameter was introduced in PowerShell 7.0.
 
 > [!NOTE]
 > The **-Parallel** Parameter is not supported in **Foreach ($item in $array)** scenarios
-> You have to directly pipe an array like **$array | foreach -parallel**
+> You have to directly pipe an array like **$array | Foreach-Object -parallel**
 
 
 ```yaml


### PR DESCRIPTION
# PR Summary

Added note about not that often used "Foreach-Object ($item in $array)". Parameter "-parallel" is not supported in any way when using this scenario. (Not applying when pipeing array)

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
