### PR TITLE
WIP: Add missing word to description of -AsOsc52 flag for Set-Clipboard

### DIFF
--- a/reference/7.4/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 ### -AsOSC52
 
 When connected to a remote session over SSH, `Set-Clipboard` sets the clipboard of the remote
-machine, not the local host. When you use this parameter, `Set-Clipboard` the OSC52 ANSI escape
+machine, not the local host. When you use this parameter, `Set-Clipboard` uses the OSC52 ANSI escape
 sequence to set the clipboard of the local machine.
 
 For this feature to work, your terminal application must support the OSC52 ANSI escape sequence. The

--- a/reference/7.4/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 09/11/2023
+ms.date: 05/31/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/set-clipboard?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-Clipboard

--- a/reference/7.5/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 09/11/2023
+ms.date: 05/31/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/set-clipboard?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Set-Clipboard
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 ### -AsOSC52
 
 When connected to a remote session over SSH, `Set-Clipboard` sets the clipboard of the remote
-machine, not the local host. When you use this parameter, `Set-Clipboard` the OSC52 ANSI escape
+machine, not the local host. When you use this parameter, `Set-Clipboard` uses the OSC52 ANSI escape
 sequence to set the clipboard of the local machine.
 
 For this feature to work, your terminal application must support the OSC52 ANSI escape sequence. The


### PR DESCRIPTION
# PR Summary

Adds a word that was omitted as a typo to the description of a flag for the `Set-Clipboard` command.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [ ] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [ ] **Style:** This PR adheres to the [style guide][style].

Marking as draft as I have not verified that this PR adheres to the style guide.