### PR TITLE
6/3/2024 PM Publish

### DIFF
--- a/reference/7.2/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/04/2024
+ms.date: 06/03/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -352,7 +352,9 @@ Specifies the body of the request. The body is the content of the request that f
 You can also pipe a body value to `Invoke-RestMethod`.
 
 The **Body** parameter can be used to specify a list of query parameters or specify the content of
-the response.
+the response. For query parameters, the cmdlet uses the **System.Net.WebUtility.UrlEncode** method
+method to encode the key-value pairs. For more information about encoding strings for URLs, see
+[the UrlEncode() method reference](xref:System.Net.WebUtility.UrlEncode).
 
 When the input is a POST request and the body is a **String**, the value to the left of the first
 equals sign (`=`) is set as a key in the form data and the remaining text is set as the value. To

--- a/reference/7.2/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/04/2024
+ms.date: 06/03/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -435,7 +435,9 @@ Specifies the body of the request. The body is the content of the request that f
 You can also pipe a body value to `Invoke-WebRequest`.
 
 The **Body** parameter can be used to specify a list of query parameters or specify the content of
-the response.
+the response. For query parameters, the cmdlet uses the **System.Net.WebUtility.UrlEncode** method
+method to encode the key-value pairs. For more information about encoding strings for URLs, see
+[the UrlEncode() method reference](xref:System.Net.WebUtility.UrlEncode).
 
 When the input is a POST request and the body is a **String**, the value to the left of the first
 equals sign (`=`) is set as a key in the form data and the remaining text is set as the value. To

--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/04/2024
+ms.date: 06/03/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -406,7 +406,9 @@ Specifies the body of the request. The body is the content of the request that f
 You can also pipe a body value to `Invoke-RestMethod`.
 
 The **Body** parameter can be used to specify a list of query parameters or specify the content of
-the response.
+the response. For query parameters, the cmdlet uses the **System.Net.WebUtility.UrlEncode** method
+method to encode the key-value pairs. For more information about encoding strings for URLs, see
+[the UrlEncode() method reference](xref:System.Net.WebUtility.UrlEncode).
 
 When the input is a POST request and the body is a **String**, the value to the left of the first
 equals sign (`=`) is set as a key in the form data and the remaining text is set as the value. To

--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/04/2024
+ms.date: 06/03/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -487,7 +487,9 @@ Specifies the body of the request. The body is the content of the request that f
 You can also pipe a body value to `Invoke-WebRequest`.
 
 The **Body** parameter can be used to specify a list of query parameters or specify the content of
-the response.
+the response. For query parameters, the cmdlet uses the **System.Net.WebUtility.UrlEncode** method
+method to encode the key-value pairs. For more information about encoding strings for URLs, see
+[the UrlEncode() method reference](xref:System.Net.WebUtility.UrlEncode).
 
 When the input is a POST request and the body is a **String**, the value to the left of the first
 equals sign (`=`) is set as a key in the form data and the remaining text is set as the value. To

--- a/reference/7.5/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/04/2024
+ms.date: 06/03/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-restmethod?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-RestMethod
@@ -406,7 +406,9 @@ Specifies the body of the request. The body is the content of the request that f
 You can also pipe a body value to `Invoke-RestMethod`.
 
 The **Body** parameter can be used to specify a list of query parameters or specify the content of
-the response.
+the response. For query parameters, the cmdlet uses the **System.Net.WebUtility.UrlEncode** method
+method to encode the key-value pairs. For more information about encoding strings for URLs, see
+[the UrlEncode() method reference](xref:System.Net.WebUtility.UrlEncode).
 
 When the input is a POST request and the body is a **String**, the value to the left of the first
 equals sign (`=`) is set as a key in the form data and the remaining text is set as the value. To

--- a/reference/7.5/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 04/04/2024
+ms.date: 06/03/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-WebRequest
@@ -487,7 +487,9 @@ Specifies the body of the request. The body is the content of the request that f
 You can also pipe a body value to `Invoke-WebRequest`.
 
 The **Body** parameter can be used to specify a list of query parameters or specify the content of
-the response.
+the response. For query parameters, the cmdlet uses the **System.Net.WebUtility.UrlEncode** method
+method to encode the key-value pairs. For more information about encoding strings for URLs, see
+[the UrlEncode() method reference](xref:System.Net.WebUtility.UrlEncode).
 
 When the input is a POST request and the body is a **String**, the value to the left of the first
 equals sign (`=`) is set as a key in the form data and the remaining text is set as the value. To


### PR DESCRIPTION
Prior to this change, the documentation didn't clearly indicate that the converted key-value pairs for requests from the **Body** parameter were URL encoded or point users to how those strings are encoded.

This change:

- Adds a brief note indicating that the cmdlet uses the `WebUtility.UrlEncode()` method and points to that method reference for more information about the encoding behavior.
- Resolves #11155
- Fixes [AB#260889](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/260889)

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [ ] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [ ] **Summary:** This PR's summary describes the scope and intent of the change.
- [ ] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [ ] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
