### PR TITLE
DefaultDisplayPropertySet takes a string[], update example

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -144,7 +144,7 @@ when no properties are specified. Because the type data is not specified in a `T
 is effective only in the current session.
 
 ```powershell
-Update-TypeData -TypeName "System.DateTime" -DefaultDisplayPropertySet "DateTime, DayOfYear, Quarter"
+Update-TypeData -TypeName "System.DateTime" -DefaultDisplayPropertySet "DateTime", "DayOfYear", "Quarter"
 Get-Date | Format-List
 ```
 

--- a/reference/7.2/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -144,7 +144,7 @@ when no properties are specified. Because the type data is not specified in a `T
 is effective only in the current session.
 
 ```powershell
-Update-TypeData -TypeName "System.DateTime" -DefaultDisplayPropertySet "DateTime, DayOfYear, Quarter"
+Update-TypeData -TypeName "System.DateTime" -DefaultDisplayPropertySet "DateTime", "DayOfYear", "Quarter"
 Get-Date | Format-List
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -144,7 +144,7 @@ when no properties are specified. Because the type data is not specified in a `T
 is effective only in the current session.
 
 ```powershell
-Update-TypeData -TypeName "System.DateTime" -DefaultDisplayPropertySet "DateTime, DayOfYear, Quarter"
+Update-TypeData -TypeName "System.DateTime" -DefaultDisplayPropertySet "DateTime", "DayOfYear", "Quarter"
 Get-Date | Format-List
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -144,7 +144,7 @@ when no properties are specified. Because the type data is not specified in a `T
 is effective only in the current session.
 
 ```powershell
-Update-TypeData -TypeName "System.DateTime" -DefaultDisplayPropertySet "DateTime, DayOfYear, Quarter"
+Update-TypeData -TypeName "System.DateTime" -DefaultDisplayPropertySet "DateTime", "DayOfYear", "Quarter"
 Get-Date | Format-List
 ```
 


### PR DESCRIPTION
# PR Summary

`DefaultDisplayPropertySet` takes a String array not a String.
```ps1
PS> Get-Help Update-TypeData -Parameter DefaultDisplayPropertySet
```
```ps1
# old example
PS> Update-TypeData -TypeName 'System.DateTime' -DefaultDisplayPropertySet "DateTime, DayOfYear, Quarter"
PS> Get-Date | fl
DateTime, DayOfYear, Quarter :
# empty

# fixed example:
PS> Update-TypeData -TypeName 'System.DateTime' -DefaultDisplayPropertySet "DateTime", "DayOfYear", "Quarter"
PS> Get-Date | fl

DateTime  : den 10 juni 2024 00:47:12
DayOfYear : 162
Quarter   : Q2
```
link to code [Update-TypeData.cs#L204-L215](https://github.com/PowerShell/PowerShell/blob/master/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs#L204-L215)

## PR Checklist

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
