### PR TITLE
(AB#263698) Fix broken anchor in `Compare-Object` docs

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 06/11/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/compare-object?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Compare-Object
@@ -90,9 +90,9 @@ InputObject SideIndicator
 bird        ==
 ```
 
-<a id="ex3" />
-
 ### Example 3 - Show the difference when using the PassThru parameter
+
+<a id="ex3" ></a>
 
 Normally, `Compare-Object` returns a **PSCustomObject** type with the following properties:
 

--- a/reference/7.2/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 06/11/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/compare-object?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Compare-Object
@@ -91,9 +91,9 @@ InputObject SideIndicator
 bird        ==
 ```
 
-<a id="ex3" />
-
 ### Example 3 - Show the difference when using the PassThru parameter
+
+<a id="ex3" ></a>
 
 Normally, `Compare-Object` returns a **PSCustomObject** type with the following properties:
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 06/11/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/compare-object?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Compare-Object
@@ -91,9 +91,9 @@ InputObject SideIndicator
 bird        ==
 ```
 
-<a id="ex3" />
-
 ### Example 3 - Show the difference when using the PassThru parameter
+
+<a id="ex3" ></a>
 
 Normally, `Compare-Object` returns a **PSCustomObject** type with the following properties:
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 12/12/2022
+ms.date: 06/11/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/compare-object?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Compare-Object
@@ -91,9 +91,9 @@ InputObject SideIndicator
 bird        ==
 ```
 
-<a id="ex3" />
-
 ### Example 3 - Show the difference when using the PassThru parameter
+
+<a id="ex3" ></a>
 
 Normally, `Compare-Object` returns a **PSCustomObject** type with the following properties:
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the document used a self-closing anchor tag to enable quick-linking to the third example.

This change updates the anchor to wrap the text `Example 3` in the heading, per guidance for the platform. This ensures that the remainder of the page isn't a link to the anchor.

- Fixes [AB#263698](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/263698)
## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
