### PR TITLE
(AB#263705) Fix description for example using `[ValidateScript()]`

### DIFF
--- a/reference/docs-conceptual/developer/cmdlet/how-to-validate-an-argument-using-script.md
+++ b/reference/docs-conceptual/developer/cmdlet/how-to-validate-an-argument-using-script.md
@@ -1,6 +1,6 @@
 ---
 description: How to validate an argument using a script
-ms.date: 09/16/2021
+ms.date: 06/11/2024
 ms.topic: reference
 title: How to validate an argument using a script
 ---
@@ -16,8 +16,8 @@ must return `$true` for every value piped to it.
 
 ## To validate an argument using a script
 
-- Add the ValidateScript attribute as shown in the following code. This example specifies a set of
-  three possible values for the `UserName` parameter.
+- Add the ValidateScript attribute as shown in the following code. This example specifies a script
+  to validate that the input value is an odd number.
 
    ```csharp
    [ValidateScript("$_ % 2", ErrorMessage = "The item '{0}' did not pass validation of script '{1}'")]


### PR DESCRIPTION
# PR Summary

Prior to this change, the example description in the article _How to validate an argument using a script_ declared that the example validates that the input belongs to a set of possible values. That description belongs to a different example, using `[ValidateSet()]`.

This change:

- Corrects the example description to match the code.
- Fixes [AB#263705](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/263705)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
