### PR TITLE
fixes #11234 add terms to no-loc and new cmd example 

### DIFF
--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to use the `pwsh` command-line interface. Displays the command-line parameters and describes the syntax.
 Locale: en-US
-ms.date: 01/10/2024
+ms.date: 07/05/2024
 no-loc: [-File, -f, -Command, -c, -CommandWithArgs, -cwa, -ConfigurationName, -config, -CustomPipeName, -EncodedCommand, -e, -ec, -ExecutionPolicy, -ex, -ep, -InputFormat, -inp, -if, -Interactive, -i, -Login, -l, -MTA, -NoExit, -noe, -NoLogo, -nol, -NonInteractive, -noni, -NoProfile, -nop, -OutputFormat, -o, -of, -SettingsFile, -settings, -SSHServerMode, -sshs, -STA, -Version, -v, -WindowStyle, -w, -WorkingDirectory, -wd, -Help]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -222,22 +222,17 @@ arg: arg2
 ```
 
 > [!NOTE]
-> [Argument parsing with quotes][05] causes the example to fail if ran from 
+> [Argument parsing with quotes][05] causes the example to fail if run from
 > `cmd.exe` or `powershell.exe`. To run from those, you can use
 
-```powershell
-# When ran from cmd.exe
+```Cmd
+REM Quoting required when run from cmd.exe
 pwsh -CommandWithArgs "$args | % { ""arg: $_"" }" arg1 arg2
+```
 
-# when ran from pwsh.exe
-pwsh -CommandWithArgs '$args | % { "arg: $_" }' arg1 arg2
-
-# when ran from powershell.exe
+```powershell
+# Quoting required when run from powershell.exe
 pwsh -CommandWithArgs '"$args | % { ""arg: $_"" }"' arg1 arg2
-
-# when ran from pwsh.exe with legacy argument passing
-$PSNativeCommandArgumentPassing = 'Legacy'
-pwsh -CommandWithArgs '$args | % { ""arg: $_"" }' arg1 arg2
 ```
 
 ### -ConfigurationName | -config

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -2,7 +2,7 @@
 description: Explains how to use the `pwsh` command-line interface. Displays the command-line parameters and describes the syntax.
 Locale: en-US
 ms.date: 01/10/2024
-no-loc: [-File, -f, -Command, -c, -ConfigurationName, -config, -CustomPipeName, -EncodedCommand, -e, -ec, -ExecutionPolicy, -ex, -ep, -InputFormat, -inp, -if, -Interactive, -i, -Login, -l, -MTA, -NoExit, -noe, -NoLogo, -nol, -NonInteractive, -noni, -NoProfile, -nop, -OutputFormat, -o, -of, -SettingsFile, -settings, -SSHServerMode, -sshs, -STA, -Version, -v, -WindowStyle, -w, -WorkingDirectory, -wd, -Help]
+no-loc: [-File, -f, -Command, -c, -CommandWithArgs, -cwa, -ConfigurationName, -config, -CustomPipeName, -EncodedCommand, -e, -ec, -ExecutionPolicy, -ex, -ep, -InputFormat, -inp, -if, -Interactive, -i, -Login, -l, -MTA, -NoExit, -noe, -NoLogo, -nol, -NonInteractive, -noni, -NoProfile, -nop, -OutputFormat, -o, -of, -SettingsFile, -settings, -SSHServerMode, -sshs, -STA, -Version, -v, -WindowStyle, -w, -WorkingDirectory, -wd, -Help]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Pwsh
@@ -221,6 +221,25 @@ arg: arg1
 arg: arg2
 ```
 
+> [!NOTE]
+> [Argument parsing with quotes][05] causes the example to fail if ran from 
+> `cmd.exe` or `powershell.exe`. To run from those, you can use
+
+```powershell
+# When ran from cmd.exe
+pwsh -CommandWithArgs "$args | % { ""arg: $_"" }" arg1 arg2
+
+# when ran from pwsh.exe
+pwsh -CommandWithArgs '$args | % { "arg: $_" }' arg1 arg2
+
+# when ran from powershell.exe
+pwsh -CommandWithArgs '"$args | % { ""arg: $_"" }"' arg1 arg2
+
+# when ran from pwsh.exe with legacy argument passing
+$PSNativeCommandArgumentPassing = 'Legacy'
+pwsh -CommandWithArgs '$args | % { ""arg: $_"" }' arg1 arg2
+```
+
 ### -ConfigurationName | -config
 
 Specifies a configuration endpoint in which PowerShell is run. This can be any
@@ -410,3 +429,4 @@ prepend the command parameters with a hyphen (`-`), not a forward slash (`/`).
 [02]: about_Automatic_Variables.md#lastexitcode
 [03]: about_operators.md#special-operators
 [04]: https://linux.die.net/man/1/chsh
+[05]: about_Parsing.md#passing-arguments-that-contain-quote-characters

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -2,7 +2,7 @@
 description: Explains how to use the `pwsh` command-line interface. Displays the command-line parameters and describes the syntax.
 Locale: en-US
 ms.date: 01/10/2024
-no-loc: [-File, -f, -Command, -c, -ConfigurationName, -config, -CustomPipeName, -EncodedCommand, -e, -ec, -ExecutionPolicy, -ex, -ep, -InputFormat, -inp, -if, -Interactive, -i, -Login, -l, -MTA, -NoExit, -noe, -NoLogo, -nol, -NonInteractive, -noni, -NoProfile, -nop, -OutputFormat, -o, -of, -SettingsFile, -settings, -SSHServerMode, -sshs, -STA, -Version, -v, -WindowStyle, -w, -WorkingDirectory, -wd, -Help]
+no-loc: [-File, -f, -Command, -c, -CommandWithArgs, -cwa, -ConfigurationName, -config, -CustomPipeName, -EncodedCommand, -e, -ec, -ExecutionPolicy, -ex, -ep, -InputFormat, -inp, -if, -Interactive, -i, -Login, -l, -MTA, -NoExit, -noe, -NoLogo, -nol, -NonInteractive, -noni, -NoProfile, -nop, -OutputFormat, -o, -of, -SettingsFile, -settings, -SSHServerMode, -sshs, -STA, -Version, -v, -WindowStyle, -w, -WorkingDirectory, -wd, -Help]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Pwsh
@@ -221,6 +221,25 @@ arg: arg1
 arg: arg2
 ```
 
+> [!NOTE]
+> [Argument parsing with quotes][05] causes the example to fail if ran from 
+> `cmd.exe` or `powershell.exe`. To run from those, you can use
+
+```powershell
+# When ran from cmd.exe
+pwsh -CommandWithArgs "$args | % { ""arg: $_"" }" arg1 arg2
+
+# when ran from pwsh.exe
+pwsh -CommandWithArgs '$args | % { "arg: $_" }' arg1 arg2
+
+# when ran from powershell.exe
+pwsh -CommandWithArgs '"$args | % { ""arg: $_"" }"' arg1 arg2
+
+# when ran from pwsh.exe with legacy argument passing
+$PSNativeCommandArgumentPassing = 'Legacy'
+pwsh -CommandWithArgs '$args | % { ""arg: $_"" }' arg1 arg2
+```
+
 ### -ConfigurationName | -config
 
 Specifies a configuration endpoint in which PowerShell is run. This can be any
@@ -410,3 +429,4 @@ prepend the command parameters with a hyphen (`-`), not a forward slash (`/`).
 [02]: about_Automatic_Variables.md#lastexitcode
 [03]: about_operators.md#special-operators
 [04]: https://linux.die.net/man/1/chsh
+[05]: about_Parsing.md#passing-arguments-that-contain-quote-characters

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -1,7 +1,7 @@
 ---
 description: Explains how to use the `pwsh` command-line interface. Displays the command-line parameters and describes the syntax.
 Locale: en-US
-ms.date: 01/10/2024
+ms.date: 07/05/2024
 no-loc: [-File, -f, -Command, -c, -CommandWithArgs, -cwa, -ConfigurationName, -config, -CustomPipeName, -EncodedCommand, -e, -ec, -ExecutionPolicy, -ex, -ep, -InputFormat, -inp, -if, -Interactive, -i, -Login, -l, -MTA, -NoExit, -noe, -NoLogo, -nol, -NonInteractive, -noni, -NoProfile, -nop, -OutputFormat, -o, -of, -SettingsFile, -settings, -SSHServerMode, -sshs, -STA, -Version, -v, -WindowStyle, -w, -WorkingDirectory, -wd, -Help]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
@@ -222,22 +222,17 @@ arg: arg2
 ```
 
 > [!NOTE]
-> [Argument parsing with quotes][05] causes the example to fail if ran from 
+> [Argument parsing with quotes][05] causes the example to fail if run from
 > `cmd.exe` or `powershell.exe`. To run from those, you can use
 
-```powershell
-# When ran from cmd.exe
+```Cmd
+REM Quoting required when run from cmd.exe
 pwsh -CommandWithArgs "$args | % { ""arg: $_"" }" arg1 arg2
+```
 
-# when ran from pwsh.exe
-pwsh -CommandWithArgs '$args | % { "arg: $_" }' arg1 arg2
-
-# when ran from powershell.exe
+```powershell
+# Quoting required when run from powershell.exe
 pwsh -CommandWithArgs '"$args | % { ""arg: $_"" }"' arg1 arg2
-
-# when ran from pwsh.exe with legacy argument passing
-$PSNativeCommandArgumentPassing = 'Legacy'
-pwsh -CommandWithArgs '$args | % { ""arg: $_"" }' arg1 arg2
 ```
 
 ### -ConfigurationName | -config


### PR DESCRIPTION
# PR Summary

Added terms to `no-loc` for `CommandWithArgs`
Clarifies example's quoting error when running from `cmd.exe` or `powershell.exe`

- Fixes #11234

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
