### PR TITLE
Document addition of wl-copy/wl-paste usage in Set/Get-Clipboard

### DIFF
--- a/reference/7.5/Microsoft.PowerShell.Management/Get-Clipboard.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Get-Clipboard.md
@@ -25,7 +25,7 @@ The `Get-Clipboard` cmdlet gets the contents of the clipboard as text. Multiple 
 returned as an array of strings similar to `Get-Content`.
 
 > [!NOTE]
-> On Linux, this cmdlet requires the `xclip` utility to be in the path.
+> On Linux, this cmdlet requires either the `xclip` (under X11) or `wl-paste` (under Wayland) utilities to be in the path.
 
 ## EXAMPLES
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -25,7 +25,7 @@ Set-Clipboard [-Value] <string[]> [-Append] [-PassThru] [-AsOSC52] [-WhatIf] [-C
 The `Set-Clipboard` cmdlet sets the contents of the clipboard.
 
 > [!NOTE]
-> On Linux, this cmdlet requires the `xclip` utility to be in the path.
+> On Linux, this cmdlet requires either the `xclip` (under X11) or `wl-copy` (under Wayland) utilities to be in the path.
 
 ## EXAMPLES
 


### PR DESCRIPTION
# PR Summary

Add note for `wl-copy`/`wl-paste` ([wl-clipboard](https://github.com/bugaevc/wl-clipboard)) dependency in Get/Set-Clipboard alongside existing `xclip` dependency for issue
- https://github.com/PowerShell/PowerShell/pull/24049

Note: In following the main Powershell [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md), I tried using `Update-MarkdownHelp` on the modified doc files, but it seemed to change far more lines than I had changed myself, so I haven't included it's changes. If I absolutely need to include those, I can.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
