### PR TITLE
Fix unix-support: Get-Clipboard now works on macOS

### DIFF
--- a/reference/docs-conceptual/whats-new/unix-support.md
+++ b/reference/docs-conceptual/whats-new/unix-support.md
@@ -225,10 +225,10 @@ The following cmdlets aren't available on Linux and macOS:
 
 The following cmdlets are available with limitations:
 
-`Get-Clipboard` - available on Linux but not supported on macOS
-`Set-Clipboard` - available in PowerShell 7.0+
-`Restart-Computer` - available for Linux and macOS in PowerShell 7.1+
-`Stop-Computer` - available for Linux and macOS in PowerShell 7.1+
+- `Get-Clipboard` - available in PowerShell 7.0+
+- `Set-Clipboard` - available in PowerShell 7.0+
+- `Restart-Computer` - available for Linux and macOS in PowerShell 7.1+
+- `Stop-Computer` - available for Linux and macOS in PowerShell 7.1+
 
 ### Microsoft.PowerShell.Utility cmdlets
 


### PR DESCRIPTION
# PR Summary

#11242 clarified that `Get-Clipboard` support for macOS was added in 7.0.
unix-support.md had out-of-date info.

(Locally i've been using it on my macbook.)

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
