### PR TITLE
Fix dead link to Quick Edits

### DIFF
--- a/reference/docs-conceptual/community/contributing/get-started-writing.md
+++ b/reference/docs-conceptual/community/contributing/get-started-writing.md
@@ -95,7 +95,7 @@ more information and best practices.
 [2]: https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference
 [3]: https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference/docs-conceptual
 [4]: https://github.com/PowerShell/powershell-rfc/blob/master/RFC0000-RFC-Process.md
-[5]: /contribute/#quick-edits-to-existing-documents
+[5]: /contribute/content/how-to-write-quick-edits
 [6]: /contribute/how-to-write-workflows-major#making-your-changes
 [7]: /contribute/get-started-setup-local#fork-the-repository
 [8]: pull-requests.md

--- a/reference/docs-conceptual/community/contributing/overview.md
+++ b/reference/docs-conceptual/community/contributing/overview.md
@@ -96,7 +96,7 @@ Additional resources
 [7]: https://www.powershellgallery.com/packages/posh-git
 [8]: /contribute/get-started-setup-local
 [9]: /contribute/git-github-fundamentals
-[10]: /contribute/#quick-edits-to-existing-documents
+[10]: /contribute/content/how-to-write-quick-edits
 [11]: /contribute/how-to-write-workflows-major
 [12]: /contribute/style-quick-start
 [13]: /style-guide/welcome/


### PR DESCRIPTION
Linked fragment doesn't exist anymore.

Same link was fixed in https://github.com/MicrosoftDocs/Contribute/pull/946

Note: Figuring out the cause of the problem was a bit confusing.

- Before [this change](https://github.com/MicrosoftDocs/Contribute/pull/775/files#diff-3fa6f2a8672a06f5c881c8621af9e49f935e65eb99e06ec73d42afe0b1323d7a) that link was to `index.md` but the current page is built from [`index.yml`](https://github.com/MicrosoftDocs/Contribute/blob/main/Contribute/index.yml).
- [This edit to index.md](https://github.com/MicrosoftDocs/Contribute/pull/823/files#diff-ffd9be212c6bbe6590c4f303f94fc153ba3e2e2b4432f0c603d65929774ec70b) moved the linked resource to a new page.

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
