### PR TITLE
(MAINT) Clarify line length for about topics

### DIFF
--- a/reference/docs-conceptual/community/contributing/general-markdown.md
+++ b/reference/docs-conceptual/community/contributing/general-markdown.md
@@ -1,6 +1,6 @@
 ---
 description: This article provides specific guidance for using Markdown in our documentation.
-ms.date: 04/23/2024
+ms.date: 08/01/2024
 title: Markdown best practices
 ---
 # Markdown best practices
@@ -50,9 +50,9 @@ Only use [ATX headings][07] (`#` style, as opposed to `=` or `-` style headers).
 
 ## Limit line length to 100 characters
 
-This applies to conceptual articles and cmdlet reference. Limiting the line length improves the
-readability of `git` diffs and history. It also makes it easier for other writers to make
-contributions.
+This applies to conceptual articles and cmdlet reference. For `about_` topics, limit the line
+length to 80 characters. Limiting the line length improves the readability of `git` diffs and
+history. It also makes it easier for other writers to make contributions.
 
 Use the [Reflow Markdown][09] extension in VS Code to reflow paragraphs to fit the prescribed line
 length.

--- a/reference/docs-conceptual/community/contributing/general-markdown.md
+++ b/reference/docs-conceptual/community/contributing/general-markdown.md
@@ -51,7 +51,7 @@ Only use [ATX headings][07] (`#` style, as opposed to `=` or `-` style headers).
 ## Limit line length to 100 characters
 
 This applies to conceptual articles and cmdlet reference. For `about_` topics, limit the line
-length to 80 characters. Limiting the line length improves the readability of `git` diffs and
+length to 79 characters. Limiting the line length improves the readability of `git` diffs and
 history. It also makes it easier for other writers to make contributions.
 
 Use the [Reflow Markdown][09] extension in VS Code to reflow paragraphs to fit the prescribed line


### PR DESCRIPTION
# PR Summary

Prior to this change, the contributing guide indicated that the line length should be limited to 100 characters. It clarified that this guideline applies to conceptual articles and cmdlet reference, but didn't indicate that the line length in `about_` topics should be limited to 80 characters.

This change clarifies the guidance.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
