### PR TITLE
8/15/2024 PM Publish

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the built-in functions in PowerShell.
 Locale: en-US
-ms.date: 06/13/2024
+ms.date: 08/14/2024
 online version: https://learn.microsoft.com/powershell/module/Microsoft.PowerShell.Core/about/about_built-in_functions?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Built-in Functions
@@ -46,7 +46,7 @@ more information, see [Get-Verb](xref:Microsoft.PowerShell.Core.Get-Verb)
 ## `help`
 
 This function invokes `Get-Help` with your parameters and passes the output to
-the systems pager command, `more.com`.
+the system's pager command, `more.com`.
 
 ## `ImportSystemModules`
 

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the built-in functions in PowerShell.
 Locale: en-US
-ms.date: 06/13/2024
+ms.date: 08/14/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_built-in_functions?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Built-in Functions
@@ -41,9 +41,12 @@ The script pauses execution and prompts the user to hit a key to continue.
 ## `help`
 
 This function invokes `Get-Help` with your parameters and passes the output to
-the systems pager command. On Windows systems, the pager is `more.com`. On
-non-Windows systems, `help` uses the pager defined by the `$env:PAGER`
-environment variable.
+the system's pager command. PowerShell uses a different default pager for
+Windows and non-Windows systems. On Windows systems, the default pager is
+`more.com`. On non-Windows systems, the default pager is `less`.
+
+If the `$env:PAGER` environment variable is defined, PowerShell uses the
+specified program instead of the system default.
 
 ## `prompt`
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the built-in functions in PowerShell.
 Locale: en-US
-ms.date: 06/13/2024
+ms.date: 08/14/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_built-in_functions?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Built-in Functions
@@ -49,9 +49,12 @@ The script pauses execution and prompts the user to hit a key to continue.
 ## `help`
 
 This function invokes `Get-Help` with your parameters and passes the output to
-the systems pager command. On Windows systems, the pager is `more.com`. On
-non-Windows systems, `help` uses the pager defined by the `$env:PAGER`
-environment variable.
+the system's pager command. PowerShell uses a different default pager for
+Windows and non-Windows systems. On Windows systems, the default pager is
+`more.com`. On non-Windows systems, the default pager is `less`.
+
+If the `$env:PAGER` environment variable is defined, PowerShell uses the
+specified program instead of the system default.
 
 ## `prompt`
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Built-in_Functions.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the built-in functions in PowerShell.
 Locale: en-US
-ms.date: 06/13/2024
+ms.date: 08/14/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_built-in_functions?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about Built-in Functions
@@ -49,9 +49,12 @@ The script pauses execution and prompts the user to hit a key to continue.
 ## `help`
 
 This function invokes `Get-Help` with your parameters and passes the output to
-the systems pager command. On Windows systems, the pager is `more.com`. On
-non-Windows systems, `help` uses the pager defined by the `$env:PAGER`
-environment variable.
+the system's pager command. PowerShell uses a different default pager for
+Windows and non-Windows systems. On Windows systems, the default pager is
+`more.com`. On non-Windows systems, the default pager is `less`.
+
+If the `$env:PAGER` environment variable is defined, PowerShell uses the
+specified program instead of the system default.
 
 ## `prompt`
 


### PR DESCRIPTION
Prior to this change, the documentation for the built-in `help` function in `about_Built-in_Functions` incorrectly stated that PowerShell always uses `more` for the pager on Windows and the `PAGER` environment variable on non-Windows systems.

This change:

- Clarifies that PowerShell uses a default pager for both Windows (`more`) and non-Windows (`less`) systems.
- Clarifies that when the `PAGER` environment variable is defined, PowerShell uses that command instead of the default pager on both Windows and non-Windows systems.
- Fixes [AB#297346](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/297346)
- Resolves #11332

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [ ] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [ ] **Summary:** This PR's summary describes the scope and intent of the change.
- [ ] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [ ] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
