### PR TITLE
use libssl3 to avoid "unable to select packages" error

### DIFF
--- a/reference/docs-conceptual/install/install-alpine.md
+++ b/reference/docs-conceptual/install/install-alpine.md
@@ -35,7 +35,7 @@ sudo apk add --no-cache \
     krb5-libs \
     libgcc \
     libintl \
-    libssl1.1 \
+    libssl3 \
     libstdc++ \
     tzdata \
     userspace-rcu \


### PR DESCRIPTION
# PR Summary

use libssl3 to avoid "unable to select packages" error.  This occurs building a docker image `FROM alpine`:

```
0.899 ERROR: unable to select packages:
0.899   libssl1.1 (no such package):
0.899     required by: world[libssl1.1]
```

the build is successful after updating the apk command to use libssl3.  additionally, my Azure DevOps Self-Hosted agent is then able to successfully run pwsh Tasks.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
