### PR TITLE
Fixed typo Window Nano Server should be Windows Nano Server in about_Execution_Policies

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
@@ -362,7 +362,7 @@ For more information, see [about_Signing][04],
 > - `Invoke-RestMethod`
 > - `Invoke-WebRequest`
 
-## Execution policy on Windows Server Core and Window Nano Server
+## Execution policy on Windows Server Core and Windows Nano Server
 
 When PowerShell 6 is run on Windows Server Core or Windows Nano Server under
 certain conditions, execution policies can fail with the following error:

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
@@ -371,7 +371,7 @@ For more information, see [about_Signing][04],
 > - `Invoke-RestMethod`
 > - `Invoke-WebRequest`
 
-## Execution policy on Windows Server Core and Window Nano Server
+## Execution policy on Windows Server Core and Windows Nano Server
 
 When PowerShell 6 is run on Windows Server Core or Windows Nano Server under
 certain conditions, execution policies can fail with the following error:

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
@@ -371,7 +371,7 @@ For more information, see [about_Signing][04],
 > - `Invoke-RestMethod`
 > - `Invoke-WebRequest`
 
-## Execution policy on Windows Server Core and Window Nano Server
+## Execution policy on Windows Server Core and Windows Nano Server
 
 When PowerShell 6 is run on Windows Server Core or Windows Nano Server under
 certain conditions, execution policies can fail with the following error:

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
@@ -371,7 +371,7 @@ For more information, see [about_Signing][04],
 > - `Invoke-RestMethod`
 > - `Invoke-WebRequest`
 
-## Execution policy on Windows Server Core and Window Nano Server
+## Execution policy on Windows Server Core and Windows Nano Server
 
 When PowerShell 6 is run on Windows Server Core or Windows Nano Server under
 certain conditions, execution policies can fail with the following error:


### PR DESCRIPTION
# PR Summary

Added missing 's' so Window Nano Server became Windows Nano Server.
Change is made in documentations for PowerShell 7.5, 7.4, 7.2, 5.1.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
