### PR TITLE
Update about_Functions_Advanced_Methods.md to include clean block in example as well

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how functions that specify the `CmdletBinding` attribute can use the methods and properties that are available to compiled cmdlets.
 Locale: en-US
-ms.date: 03/12/2024
+ms.date: 10/16/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_methods?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_Advanced_Methods
@@ -54,7 +54,7 @@ processing, and an `end` block for one-time post-processing.
 Function Test-ScriptCmdlet
 {
 [CmdletBinding(SupportsShouldProcess=$True)]
-    Param ($Parameter1)
+    param ($Parameter1)
     begin{}
     process{}
     end{}

--- a/reference/7.2/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/7.2/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how functions that specify the `CmdletBinding` attribute can use the methods and properties that are available to compiled cmdlets.
 Locale: en-US
-ms.date: 03/12/2024
+ms.date: 10/16/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_methods?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_Advanced_Methods
@@ -54,7 +54,7 @@ processing, and an `end` block for one-time post-processing.
 Function Test-ScriptCmdlet
 {
 [CmdletBinding(SupportsShouldProcess=$True)]
-    Param ($Parameter1)
+    param ($Parameter1)
     begin{}
     process{}
     end{}

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -59,6 +59,7 @@ Function Test-ScriptCmdlet
     begin{}
     process{}
     end{}
+    clean{}
 }
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how functions that specify the `CmdletBinding` attribute can use the methods and properties that are available to compiled cmdlets.
 Locale: en-US
-ms.date: 05/20/2024
+ms.date: 10/16/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_methods?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_Advanced_Methods
@@ -55,7 +55,7 @@ processing, and an `end` block for one-time post-processing.
 Function Test-ScriptCmdlet
 {
 [CmdletBinding(SupportsShouldProcess=$True)]
-    Param ($Parameter1)
+    param ($Parameter1)
     begin{}
     process{}
     end{}

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how functions that specify the `CmdletBinding` attribute can use the methods and properties that are available to compiled cmdlets.
 Locale: en-US
-ms.date: 05/20/2024
+ms.date: 10/16/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_methods?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Functions_Advanced_Methods
@@ -55,10 +55,11 @@ processing, and an `end` block for one-time post-processing.
 Function Test-ScriptCmdlet
 {
 [CmdletBinding(SupportsShouldProcess=$True)]
-    Param ($Parameter1)
+    param ($Parameter1)
     begin{}
     process{}
     end{}
+    clean{}
 }
 ```
 


### PR DESCRIPTION
add clean block to first example

# PR Summary

As this is 7.4 doc, the clean block should be in the example as well

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
