### PR TITLE
Update clone instructions in README and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug.yml
+++ b/.github/ISSUE_TEMPLATE/00-bug.yml
@@ -1,6 +1,7 @@
 name: "🐛 Report a documentation issue"
 description: >-
   Report an issue with current documentation.
+  Note: You can clone the repository using `gh repo clone MicrosoftDocs/PowerShell-Docs`.
 labels:
   - issue-doc-bug
   - needs-triage

--- a/.github/ISSUE_TEMPLATE/01-article.yml
+++ b/.github/ISSUE_TEMPLATE/01-article.yml
@@ -1,6 +1,7 @@
 name: "💡 Suggest a new document or idea"
 description: >-
   Suggest a new document or major rewrite of an existing one.
+  Note: You can clone the repository using `gh repo clone MicrosoftDocs/PowerShell-Docs`.
 labels:
   - issue-doc-idea
   - needs-triage

--- a/.github/ISSUE_TEMPLATE/02-quality.yml
+++ b/.github/ISSUE_TEMPLATE/02-quality.yml
@@ -1,6 +1,7 @@
 name: "🦾 Commit to a Quality Contribution"
 description: >-
   File an issue to take part in the PowerShell Docs Quality Contributions project.
+  Note: You can clone the repository using `gh repo clone MicrosoftDocs/PowerShell-Docs`.
 title: "Quality: "
 labels:
   - project-quality

--- a/.github/ISSUE_TEMPLATE/03-change.yml
+++ b/.github/ISSUE_TEMPLATE/03-change.yml
@@ -1,6 +1,7 @@
 name: "🛠 Document a product change"
 description: >-
   Request documentation for a new or updated feature, cmdlet, parameter, or behavior.
+  Note: You can clone the repository using `gh repo clone MicrosoftDocs/PowerShell-Docs`.
 labels:
   - issue-doc-idea
   - needs-triage

--- a/.github/ISSUE_TEMPLATE/04-customer-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/04-customer-feedback.yml
@@ -3,6 +3,7 @@ title: "Feedback"
 description: >-
   ⛔ This template is intended for use by the feedback control on the bottom of every page on the
   live site. If you aren't using the feedback control, choose one of the other templates.⛔
+  Note: You can clone the repository using `gh repo clone MicrosoftDocs/PowerShell-Docs`.
 labels:
   - "needs-triage"
 body:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][04].
 The following list describes the main folders in this repository.
 
 - `.github` - contains configuration settings used by GitHub for this repository
+- `.github/ISSUE_TEMPLATE` - contains multiple issue templates
 - `.vscode` - contains configuration settings and recommended extensions for Visual Studio Code (VS
   Code)
 - `assets` - contains downloadable files linked in the documentation
@@ -56,6 +57,14 @@ The following list describes the main folders in this repository.
 > NOTE: The reference content (in the numbered folders) is used to create the webpages on the Docs
 > site as well as the updateable help used by PowerShell. The articles in the `docs-conceptual`
 > folder are only published to the Docs website.
+
+## Cloning the Repository
+
+To clone the repository, use the following command:
+
+```sh
+gh repo clone MicrosoftDocs/PowerShell-Docs
+```
 
 ## Contributing
 


### PR DESCRIPTION
Add instructions for cloning the repository using `gh repo clone MicrosoftDocs/PowerShell-Docs` to the `README.md` file.

* **README.md**
  - Add a section for cloning the repository with the `gh repo clone` command.
  - Update the repository structure section to include the `.github/ISSUE_TEMPLATE` directory.

* **Issue Templates**
  - Add a note to the description section of `.github/ISSUE_TEMPLATE/00-bug.yml`, `.github/ISSUE_TEMPLATE/01-article.yml`, `.github/ISSUE_TEMPLATE/02-quality.yml`, `.github/ISSUE_TEMPLATE/03-change.yml`, and `.github/ISSUE_TEMPLATE/04-customer-feedback.yml` to mention the new cloning instructions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MicrosoftDocs/PowerShell-Docs?shareId=be9c0115-76c2-47ed-8313-61791fcc00a9).