### PR TITLE
Set-TraceSource parameter -Option has default value 'None' and not 'All'.

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -193,7 +193,7 @@ Specifies the type of events that are traced. The acceptable values for this par
 - `Assert`
 - `All`
 
-`All` is the default.
+`None` is the default.
 
 The following values are combinations of other values:
 

--- a/reference/7.2/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/7.2/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -193,7 +193,7 @@ Specifies the type of events that are traced. The acceptable values for this par
 - `Assert`
 - `All`
 
-`All` is the default.
+`None` is the default.
 
 The following values are combinations of other values:
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -193,7 +193,7 @@ Specifies the type of events that are traced. The acceptable values for this par
 - `Assert`
 - `All`
 
-`All` is the default.
+`None` is the default.
 
 The following values are combinations of other values:
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -193,7 +193,7 @@ Specifies the type of events that are traced. The acceptable values for this par
 - `Assert`
 - `All`
 
-`All` is the default.
+`None` is the default.
 
 The following values are combinations of other values:
 


### PR DESCRIPTION
# PR Summary

In all versions (**5.1**, **7.2**, **7.4**, **7.5**) i changed mentioned `Set-TraceSource` default value for parameter `-Option`. In current documentation is stated that the default value is `All` but is actually `None`. 

I found this when i executed cmdlet `Set-TraceSource -Name * -PSHost` without explicit value for parameter `-Option` (expected it will be `All` by default as stated in documentation) but no tracing information was shown when i executed further commands. If i explicitly set the `-Option` parameter everything is fine.

Here is link for **7.4** where doc says that the default value is `All` https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-tracesource?view=powershell-7.4#-option.

**I went to explore the source code to be sure and it seems to me that one of these things should happen:**
1. Accept this commit that changes the documentation and voluntarily change the [line](https://github.com/PowerShell/PowerShell/blob/2f4f585e7fe075f5c1669397ae738c554fa18391/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceListenerCommandBase.cs#L47) `private PSTraceSourceOptions _options = PSTraceSourceOptions.All;` to `private PSTraceSourceOptions _options = PSTraceSourceOptions.None;` because the initially set value `PSTraceSourceOptions.All` is actually never used. You have to explicitly set `-Option` parameter otherwise `_options` variable is not used thanks to the `if (optionsSpecified)` [condition](https://github.com/PowerShell/PowerShell/blob/2f4f585e7fe075f5c1669397ae738c554fa18391/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceListenerCommandBase.cs#L129). But in that case you overwrite the initially set value `PSTraceSourceOptions.All` so there is no reason to set it as initial value for variable `_options`. It makes more sense to set it to `PSTraceSourceOptions.None`. 
2. Don't accept this commit and remove the condition from this [block of code](https://github.com/PowerShell/PowerShell/blob/2f4f585e7fe075f5c1669397ae738c554fa18391/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceListenerCommandBase.cs#L129) `if (optionsSpecified) { SetFlags(matchingSources); }` so it is not necessary to explicitly set `-Option` parameter and the default value for this parameter will be trully `PSTraceSourceOptions.All`. But this may theoretically lead to problems if anybody uses the `Set-TraceSource` cmdlet without `-Option` parameter (don't know if it makes sense) because then tracing will magically start to appear.
 
https://github.com/PowerShell/PowerShell/blob/2f4f585e7fe075f5c1669397ae738c554fa18391/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceListenerCommandBase.cs#L47

```csharp
  /// <summary>
  /// The flags to be set on the TraceSource.
  /// </summary>
  /// <value></value>
  internal PSTraceSourceOptions OptionsInternal
  {
      get
      {
          return _options;
      }

      set
      {
          _options = value;
          optionsSpecified = true;
      }
  }

  private PSTraceSourceOptions _options = PSTraceSourceOptions.All;
```
Somewhere later in the file we can see that the initial value `PSTraceSourceOptions.All` from variable `_options` is actually never used if it is not explictly specified via cmdlet `-Option` parameter. 

```csharp

        if (preConfigure)
        {
            // Set the flags if they were specified
            if (optionsSpecified)
            {
                SetFlags(matchingSources);
            }

            AddTraceListenersToSources(matchingSources);
            SetTraceListenerOptions(matchingSources);
        }

        /// <summary>
        /// Sets the flags for all the specified TraceSources.
        /// </summary>
        internal void SetFlags(Collection<PSTraceSource> matchingSources)
        {
            foreach (PSTraceSource structuredSource in matchingSources)
            {
                structuredSource.Options = this.OptionsInternal;
            }
        }
```

## PR Checklist

- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
