### PR TITLE
Markdown Fixes to 7.5

### DIFF
--- a/reference/7.5/CimCmdlets/CimCmdlets.md
+++ b/reference/7.5/CimCmdlets/CimCmdlets.md
@@ -20,43 +20,57 @@ This module is only available on the Windows platform.
 ## CimCmdlets Cmdlets
 
 ### [Export-BinaryMiLog](Export-BinaryMiLog.md)
+
 Creates a binary encoded representation of an object or objects and stores it in a file.
 
 ### [Get-CimAssociatedInstance](Get-CimAssociatedInstance.md)
+
 Retrieves the CIM instances that are connected to a specific CIM instance by an association.
 
 ### [Get-CimClass](Get-CimClass.md)
+
 Gets a list of CIM classes in a specific namespace.
 
 ### [Get-CimInstance](Get-CimInstance.md)
+
 Gets the CIM instances of a class from a CIM server.
 
 ### [Get-CimSession](Get-CimSession.md)
+
 Gets the CIM session objects from the current session.
 
 ### [Import-BinaryMiLog](Import-BinaryMiLog.md)
+
 Used to re-create the saved objects based on the contents of an export file.
 
 ### [Invoke-CimMethod](Invoke-CimMethod.md)
+
 Invokes a method of a CIM class.
 
 ### [New-CimInstance](New-CimInstance.md)
+
 Creates a CIM instance.
 
 ### [New-CimSession](New-CimSession.md)
+
 Creates a CIM session.
 
 ### [New-CimSessionOption](New-CimSessionOption.md)
+
 Specifies advanced options for the `New-CimSession` cmdlet.
 
 ### [Register-CimIndicationEvent](Register-CimIndicationEvent.md)
+
 Subscribes to indications using a filter expression or a query expression.
 
 ### [Remove-CimInstance](Remove-CimInstance.md)
+
 Removes a CIM instance from a computer.
 
 ### [Remove-CimSession](Remove-CimSession.md)
+
 Removes one or more CIM sessions.
 
 ### [Set-CimInstance](Set-CimInstance.md)
+
 Modifies a CIM instance on a CIM server by calling the **ModifyInstance** method of the CIM class.

--- a/reference/7.5/CimCmdlets/Get-CimSession.md
+++ b/reference/7.5/CimCmdlets/Get-CimSession.md
@@ -225,6 +225,7 @@ Accept wildcard characters: True
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
 -WarningAction, and -WarningVariable. For more information, see

--- a/reference/7.5/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.md
+++ b/reference/7.5/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.md
@@ -18,8 +18,9 @@ This section contains the help topics for the cmdlets that are installed with th
 ## Microsoft.PowerShell.Archive Cmdlets
 
 ### [Compress-Archive](Compress-Archive.md)
+
 Creates a compressed archive, or zipped file, from specified files and directories.
 
 ### [Expand-Archive](Expand-Archive.md)
-Extracts files from a specified archive (zipped) file.
 
+Extracts files from a specified archive (zipped) file.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/About.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/About.md
@@ -14,424 +14,565 @@ About topics cover a range of concepts about PowerShell.
 ## About Topics
 
 ### [about_Alias_Provider](about_Alias_Provider.md)
+
 Provides access to the PowerShell aliases and the values that they represent.
 
 ### [about_Aliases](about_Aliases.md)
+
 Describes how to use alternate names for cmdlets and commands in PowerShell.
 
 ### [about_ANSI_Terminals](about_ANSI_Terminals.md)
+
 Describes the support available for ANSI escape sequences in Windows PowerShell.
 
 ### [about_Arithmetic_Operators](about_Arithmetic_Operators.md)
+
 Describes the operators that perform arithmetic in PowerShell.
 
 ### [about_Arrays](about_Arrays.md)
+
 Describes arrays, which are data structures designed to store collections of items.
 
 ### [about_Assignment_Operators](about_Assignment_Operators.md)
+
 Describes how to use operators to assign values to variables.
 
 ### [about_Automatic_Variables](about_Automatic_Variables.md)
+
 Describes variables that store state information for PowerShell. These variables are created and maintained by PowerShell.
 
 ### [about_Booleans](about_Booleans.md)
+
 Describes how boolean expressions are evaluated.
 
 ### [about_Break](about_Break.md)
+
 Describes the `break` statement, which provides a way to exit the current control block.
 
 ### [about_Built-in_Functions](about_Built-in_Functions.md)
+
 Describes the built-in functions in PowerShell.
 
 ### [about_Calculated_Properties](about_Calculated_Properties.md)
+
 PowerShell provides the ability to dynamically add new properties and alter the formatting of objects output to the pipeline.
 
 ### [about_Calling_Generic_Methods](about_Calling_Generic_Methods.md)
+
 A generic method is a method with two parameter lists: a list of generic types and a list of method arguments.  The following examples show the new PowerShell syntax for accessing a generic method:  ```Syntax # static generic methods [type_name]::MethodName[generic_type_arguments](method_arguments)  # instance generic methods $object.MethodName[generic_type_arguments](method_arguments) ```  The `generic_type_arguments` can be a single type or comma-separated list of types, like `[string, int]`, including other generic types like `$obj.MethodName[string, System.Collections.Generic.Dictionary[string, int]]()`  The `method_arguments` can be zero or more items.  For more information, see [Generics in .NET](/dotnet/standard/generics/).
 
 ### [about_Case-Sensitivity](about_Case-Sensitivity.md)
+
 PowerShell is as case-insensitive as possible while preserving case.
 
 ### [about_Character_Encoding](about_Character_Encoding.md)
+
 Describes how PowerShell uses character encoding for input and output of string data.
 
 ### [about_CimSession](about_CimSession.md)
+
 Describes a **CimSession** object and the difference between CIM sessions and PowerShell sessions.
 
 ### [about_Classes](about_Classes.md)
+
 Describes how you can use classes to create your own custom types.
 
 ### [about_Classes_Constructors](about_Classes_Constructors.md)
+
 Describes how to define constructors for PowerShell classes.
 
 ### [about_Classes_Inheritance](about_Classes_Inheritance.md)
+
 Describes how you can define classes that extend other types.
 
 ### [about_Classes_Methods](about_Classes_Methods.md)
+
 Describes how to define methods for PowerShell classes.
 
 ### [about_Classes_Properties](about_Classes_Properties.md)
+
 Describes how to define properties for PowerShell classes.
 
 ### [about_Command_Precedence](about_Command_Precedence.md)
+
 Describes how PowerShell determines which command to run.
 
 ### [about_Command_Syntax](about_Command_Syntax.md)
+
 Describes the syntax diagrams that are used in PowerShell.
 
 ### [about_Comment_Based_Help](about_Comment_Based_Help.md)
+
 Describes how to write comment-based help topics for functions and scripts.
 
 ### [about_CommonParameters](about_CommonParameters.md)
+
 Describes the parameters that can be used with any cmdlet.
 
 ### [about_Comparison_Operators](about_Comparison_Operators.md)
+
 The comparison operators in PowerShell can either compare two values or filter elements of a collection against an input value.
 
 ### [about_Continue](about_Continue.md)
+
 Describes how the `continue` statement immediately returns the program flow to the top of a program loop, a `switch` statement, or a `trap` statement.
 
 ### [about_Core_Commands](about_Core_Commands.md)
+
 Lists the cmdlets that are designed for use with PowerShell providers.
 
 ### [about_Data_Files](about_Data_Files.md)
+
 PowerShell data files are used to store arbitrary data using PowerShell syntax.
 
 ### [about_Data_Sections](about_Data_Sections.md)
+
 Explains Data sections, which isolate text strings and other read-only data from script logic.
 
 ### [about_Debuggers](about_Debuggers.md)
+
 Describes the PowerShell debugger.
 
 ### [about_Do](about_Do.md)
+
 Runs a statement list one or more times, subject to a `While` or `Until` condition.
 
 ### [about_Enum](about_Enum.md)
+
 The `enum` statement is used to declare an enumeration. An enumeration is a distinct type that consists of a set of named labels called the enumerator list.
 
 ### [about_Environment_Provider](about_Environment_Provider.md)
+
 Provides access to the Windows environment variables.
 
 ### [about_Environment_Variables](about_Environment_Variables.md)
+
 Describes how to access and manage environment variables in PowerShell.
 
 ### [about_Execution_Policies](about_Execution_Policies.md)
+
 Describes the PowerShell execution policies and explains how to manage them.
 
 ### [about_Experimental_Features](about_Experimental_Features.md)
+
 Use the `Experimental` attribute to declare some code as experimental.  Use the following syntax to declare the `Experimental` attribute providing the name of the experimental feature and the action to take if the experimental feature is enabled:  ```csharp [Experimental(NameOfExperimentalFeature, ExperimentAction)] ```  For modules, the `NameOfExperimentalFeature` must follow the form of `<modulename>.<experimentname>`. The `ExperimentAction` parameter must be specified and the only valid values are:  - `Show` means to show this experimental feature if the feature is enabled - `Hide` means to hide this experimental feature if the feature is enabled
 
 ### [about_FileSystem_Provider](about_FileSystem_Provider.md)
+
 Provides access to files and directories.
 
 ### [about_For](about_For.md)
+
 Describes a language command you can use to run statements based on a conditional test.
 
 ### [about_Foreach](about_Foreach.md)
+
 Describes a language command you can use to traverse all the items in a collection of items.
 
 ### [about_Format.ps1xml](about_Format.ps1xml.md)
+
 The `Format.ps1xml` files in PowerShell define the default display of objects in the PowerShell console.
 
 ### [about_Function_Provider](about_Function_Provider.md)
+
 Provides access to the functions defined in PowerShell.
 
 ### [about_Functions_Advanced_Methods](about_Functions_Advanced_Methods.md)
+
 Describes how functions that specify the `CmdletBinding` attribute can use the methods and properties that are available to compiled cmdlets.
 
 ### [about_Functions_Advanced_Parameters](about_Functions_Advanced_Parameters.md)
+
 Explains how to add parameters to advanced functions.
 
 ### [about_Functions_Advanced](about_Functions_Advanced.md)
+
 Introduces advanced functions that are a way to create cmdlets using scripts.
 
 ### [about_Functions_Argument_Completion](about_Functions_Argument_Completion.md)
+
 Argument completion is a feature of PowerShell that provide hints, enables discovery, and speeds up input entry of argument values.
 
 ### [about_Functions_CmdletBindingAttribute](about_Functions_CmdletBindingAttribute.md)
+
 Describes the attribute that makes a function work like a compiled cmdlet.
 
 ### [about_Functions_OutputTypeAttribute](about_Functions_OutputTypeAttribute.md)
+
 Describes an attribute that reports the type of object that the function returns.
 
 ### [about_Functions](about_Functions.md)
+
 Describes how to create and use functions in PowerShell.
 
 ### [about_Group_Policy_Settings](about_Group_Policy_Settings.md)
+
 Describes the Group Policy settings for PowerShell
 
 ### [about_Hash_Tables](about_Hash_Tables.md)
+
 Describes how to create, use, and sort hashtables in PowerShell.
 
 ### [about_Hidden](about_Hidden.md)
+
 Describes the `hidden` keyword, which hides class members from default `Get-Member` results.
 
 ### [about_History](about_History.md)
+
 Describes how to get and run commands in the command history.
 
 ### [about_If](about_If.md)
+
 Describes a language command you can use to run statement lists based on the results of one or more conditional tests.
 
 ### [about_Intrinsic_Members](about_Intrinsic_Members.md)
+
 Provides information about PowerShell's intrinsic members that are available to all PowerShell objects.
 
 ### [about_Job_Details](about_Job_Details.md)
+
 Provides details about background jobs on local and remote computers.
 
 ### [about_Jobs](about_Jobs.md)
+
 Provides information about how PowerShell background jobs run a command or expression in the background without interacting with the current session.
 
 ### [about_Join](about_Join.md)
+
 Describes how the join operator (-join) combines multiple strings into a single string.
 
 ### [about_Language_Keywords](about_Language_Keywords.md)
+
 Describes the keywords in the PowerShell scripting language.
 
 ### [about_Language_Modes](about_Language_Modes.md)
+
 Explains language modes and their effect on PowerShell sessions.
 
 ### [about_Line_Editing](about_Line_Editing.md)
+
 Describes how to edit commands at the PowerShell command prompt.
 
 ### [about_Locations](about_Locations.md)
+
 Describes how to access items from the working location in PowerShell.
 
 ### [about_Logging_Non-Windows](about_Logging_Non-Windows.md)
+
 PowerShell logs internal operations from the engine, providers, and cmdlets.
 
 ### [about_Logging_Windows](about_Logging_Windows.md)
+
 PowerShell logs internal operations from the engine, providers, and cmdlets to the Windows event log.
 
 ### [about_Logical_Operators](about_Logical_Operators.md)
+
 Describes the operators that connect statements in PowerShell.
 
 ### [about_Member-Access_Enumeration](about_Member-Access_Enumeration.md)
+
 Describes the automatic enumeration of list collection items when using the member-access operator.
 
 ### [about_Methods](about_Methods.md)
+
 Describes how to use methods to perform actions on objects in PowerShell.
 
 ### [about_Module_Manifests](about_Module_Manifests.md)
+
 Describes the settings and practices for writing module manifest files.
 
 ### [about_Modules](about_Modules.md)
+
 Explains how to install, import, and use PowerShell modules.
 
 ### [about_Numeric_Literals](about_Numeric_Literals.md)
+
 This article describes the syntax and usage of numeric values in PowerShell.
 
 ### [about_Object_Creation](about_Object_Creation.md)
+
 Explains how to create objects in PowerShell.
 
 ### [about_Objects](about_Objects.md)
+
 Provides essential information about objects in PowerShell.
 
 ### [about_Operator_Precedence](about_Operator_Precedence.md)
+
 Lists the PowerShell operators in precedence order.
 
 ### [about_Operators](about_Operators.md)
+
 Describes the operators that are supported by PowerShell.
 
 ### [about_Output_Streams](about_Output_Streams.md)
+
 Explains the availability and purpose of output streams in PowerShell.
 
 ### [about_PackageManagement](about_PackageManagement.md)
+
 PackageManagement is an aggregator for software package managers.
 
 ### [about_Parameter_Sets](about_Parameter_Sets.md)
+
 Describes how to define and use parameter sets in advanced functions.
 
 ### [about_Parameters_Default_Values](about_Parameters_Default_Values.md)
+
 Describes how to set custom default values for cmdlet parameters and advanced functions.
 
 ### [about_Parameters](about_Parameters.md)
+
 Describes how to work with command parameters in PowerShell.
 
 ### [about_Parsing](about_Parsing.md)
+
 Describes how PowerShell parses commands.
 
 ### [about_Path_Syntax](about_Path_Syntax.md)
+
 Describes the full and relative path formats in  PowerShell.
 
 ### [about_Pipeline_Chain_Operators](about_Pipeline_Chain_Operators.md)
+
 Describes chaining pipelines with the `&&` and `||` operators in PowerShell.
 
 ### [about_Pipelines](about_Pipelines.md)
+
 Combining commands into pipelines in the PowerShell
 
 ### [about_PowerShell_Config](about_PowerShell_Config.md)
+
 Configuration files for PowerShell, replacing Registry configuration.
 
 ### [about_PowerShell_Editions](about_PowerShell_Editions.md)
+
 Different editions of PowerShell run on different underlying runtimes.
 
 ### [about_Preference_Variables](about_Preference_Variables.md)
+
 Variables that customize the behavior of PowerShell.
 
 ### [about_Profiles](about_Profiles.md)
+
 Describes how to create and use a PowerShell profile.
 
 ### [about_Prompts](about_Prompts.md)
+
 Describes the `Prompt` function and demonstrates how to create a custom `Prompt` function.
 
 ### [about_Properties](about_Properties.md)
+
 Describes how to use object properties in PowerShell.
 
 ### [about_Providers](about_Providers.md)
+
 Describes how PowerShell providers provide access to data and components that wouldn't otherwise be easily accessible at the command line. The data is presented in a consistent format that resembles a file system drive.
 
 ### [about_PSConsoleHostReadLine](about_PSConsoleHostReadLine.md)
+
 Explains how to create a customize how PowerShell reads input at the console prompt.
 
 ### [about_PSCustomObject](about_PSCustomObject.md)
+
 Explains the differences between the `[psobject]` and `[pscustomobject]` type accelerators.
 
 ### [about_PSItem](about_PSItem.md)
+
 The automatic variable that contains the current object in the pipeline object.
 
 ### [about_PSModulePath](about_PSModulePath.md)
+
 This article the purpose and usage of the `$env:PSModulePath` environment variable.
 
 ### [about_PSSession_Details](about_PSSession_Details.md)
+
 Provides detailed information about PowerShell sessions and the role they play in remote commands.
 
 ### [about_PSSessions](about_PSSessions.md)
+
 Describes PowerShell sessions (PSSessions) and explains how to establish a persistent connection to a remote computer.
 
 ### [about_Pwsh](about_Pwsh.md)
+
 Explains how to use the `pwsh` command-line interface. Displays the command-line parameters and describes the syntax.
 
 ### [about_Quoting_Rules](about_Quoting_Rules.md)
+
 Describes rules for using single and double quotation marks in PowerShell.
 
 ### [about_Redirection](about_Redirection.md)
+
 Explains how to redirect output from PowerShell to text files.
 
 ### [about_Ref](about_Ref.md)
+
 Describes how to create and use a reference type variable. You can use reference type variables to permit a function to change the value of a variable that is passed to it.
 
 ### [about_Registry_Provider](about_Registry_Provider.md)
+
 Registry
 
 ### [about_Regular_Expressions](about_Regular_Expressions.md)
+
 Describes regular expressions in PowerShell.
 
 ### [about_Remote_Disconnected_Sessions](about_Remote_Disconnected_Sessions.md)
+
 Explains how to disconnect and reconnect to a PowerShell Session (PSSession).
 
 ### [about_Remote_Jobs](about_Remote_Jobs.md)
+
 Describes how to run jobs on remote computers.
 
 ### [about_Remote_Output](about_Remote_Output.md)
+
 Describes how to interpret and format the output of remote commands.
 
 ### [about_Remote_Requirements](about_Remote_Requirements.md)
+
 Describes the system requirements and configuration requirements for running remote commands in PowerShell.
 
 ### [about_Remote_Troubleshooting](about_Remote_Troubleshooting.md)
+
 Describes how to troubleshoot remote operations in PowerShell.
 
 ### [about_Remote_Variables](about_Remote_Variables.md)
+
 Explains how to use local and remote variables in remote commands.
 
 ### [about_Remote](about_Remote.md)
+
 Describes how to run remote commands in PowerShell.
 
 ### [about_Requires](about_Requires.md)
+
 Prevents a script from running without the required elements.
 
 ### [about_Reserved_Words](about_Reserved_Words.md)
+
 Lists the reserved words that cannot be used as identifiers because they have a special meaning in PowerShell.
 
 ### [about_Return](about_Return.md)
+
 Exits the current scope, which can be a function, script, or script block.
 
 ### [about_Run_With_PowerShell](about_Run_With_PowerShell.md)
+
 Explains how to use the "Run with PowerShell" feature to run a script from a file system drive.
 
 ### [about_Scopes](about_Scopes.md)
+
 Explains the concept of scope in PowerShell and shows how to set and change the scope of elements.
 
 ### [about_Script_Blocks](about_Script_Blocks.md)
+
 Defines what a script block is and explains how to use script blocks in the PowerShell programming language.
 
 ### [about_Script_Internationalization](about_Script_Internationalization.md)
+
 Describes the script internationalization features that make it easy for scripts to display messages and instructions to users in their user interface (UI) language.
 
 ### [about_Scripts](about_Scripts.md)
+
 Describes how to run and write scripts in PowerShell.
 
 ### [about_Session_Configuration_Files](about_Session_Configuration_Files.md)
+
 Describes session configuration files, which are used in a session configuration (also known as an "endpoint") to define the environment of sessions that use the session configuration.
 
 ### [about_Session_Configurations](about_Session_Configurations.md)
+
 Describes session configurations, which determine the users who can connect to the computer remotely and the commands they can run.
 
 ### [about_Signing](about_Signing.md)
+
 Explains how to sign scripts so that they comply with the PowerShell execution policies.
 
 ### [about_Simplified_Syntax](about_Simplified_Syntax.md)
+
 Describes easier, more natural-language ways of scripting filters for collections of objects.
 
 ### [about_Special_Characters](about_Special_Characters.md)
+
 Describes the special character sequences that control how PowerShell interprets the next characters in the sequence.
 
 ### [about_Splatting](about_Splatting.md)
+
 Describes how to use splatting to pass parameters to commands in PowerShell.
 
 ### [about_Split](about_Split.md)
+
 Explains how to use the Split operator to split one or more strings into substrings.
 
 ### [about_Switch](about_Switch.md)
+
 Explains how to use a switch to handle multiple `if` statements.
 
 ### [about_Tab_Expansion](about_Tab_Expansion.md)
+
 PowerShell provides completions on input to provide hints, enable discovery, and speed up input entry. Command names, parameter names, argument values and file paths can all be completed by pressing the <kbd>Tab</kbd> key.
 
 ### [about_Telemetry](about_Telemetry.md)
+
 Describes the telemetry collected in PowerShell and how to opt-out.
 
 ### [about_Thread_Jobs](about_Thread_Jobs.md)
+
 Provides information about PowerShell thread-based jobs. A thread job is a type of background job that runs a command or expression in a separate thread within the current session process.
 
 ### [about_Throw](about_Throw.md)
+
 Describes the `throw` keyword that generates a terminating error.
 
 ### [about_Trap](about_Trap.md)
+
 Describes a keyword that handles a terminating error.
 
 ### [about_Try_Catch_Finally](about_Try_Catch_Finally.md)
+
 Describes how to use the `try`, `catch`, and `finally` blocks to handle terminating errors.
 
 ### [about_Type_Accelerators](about_Type_Accelerators.md)
+
 Describes the Type accelerators available for .NET framework classes
 
 ### [about_Type_Operators](about_Type_Operators.md)
+
 Describes the operators that work with Microsoft .NET types.
 
 ### [about_Types.ps1xml](about_Types.ps1xml.md)
+
 Explains how to use `Types.ps1xml` files to extend the types of objects that are used in PowerShell.
 
 ### [about_Updatable_Help](about_Updatable_Help.md)
+
 Describes the updatable help system in PowerShell.
 
 ### [about_Update_Notifications](about_Update_Notifications.md)
+
 Notifies users on startup of PowerShell that a new version of PowerShell has been released.
 
 ### [about_Using](about_Using.md)
+
 Allows you to indicate which namespaces are used in the session.
 
 ### [about_Variable_Provider](about_Variable_Provider.md)
+
 Variable
 
 ### [about_Variables](about_Variables.md)
+
 Describes how variables store values that can be used in PowerShell.
 
 ### [about_While](about_While.md)
+
 Describes a language statement that you can use to run a command block based on the results of a conditional test.
 
 ### [about_Wildcards](about_Wildcards.md)
+
 Describes how to use wildcard characters in PowerShell.
 
 ### [about_Windows_PowerShell_Compatibility](about_Windows_PowerShell_Compatibility.md)
+
 Describes the Windows PowerShell Compatibility functionality for PowerShell 7.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_ANSI_Terminals.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_ANSI_Terminals.md
@@ -8,6 +8,7 @@ title: about_ANSI_terminals
 # about_ANSI_Terminals
 
 ## Short description
+
 Describes the support available for ANSI escape sequences in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -9,6 +9,7 @@ title: about_Arithmetic_Operators
 # about_Arithmetic_Operators
 
 ## Short description
+
 Describes the operators that perform arithmetic in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -10,6 +10,7 @@ title: about_Arrays
 # about_Arrays
 
 ## Short description
+
 Describes arrays, which are data structures designed to store collections of
 items.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -9,6 +9,7 @@ title: about_Assignment_Operators
 # about_Assignment_Operators
 
 ## Short description
+
 Describes how to use operators to assign values to variables.
 
 ## Long description
@@ -647,7 +648,6 @@ $x
 
 For more information, see
 [Null-coalescing operator][04].
-
 
 ## Microsoft .NET types
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Booleans.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Booleans.md
@@ -9,6 +9,7 @@ title: about_Booleans
 # about_Booleans
 
 ## Short description
+
 Describes how boolean expressions are evaluated.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Break.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Break.md
@@ -9,6 +9,7 @@ title: about_Break
 # about_Break
 
 ## Short description
+
 Describes the `break` statement, which provides a way to exit the current
 control block.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Case-Sensitivity.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Case-Sensitivity.md
@@ -9,6 +9,7 @@ title: about_Case-Sensitivity
 # about_Case-Sensitivity
 
 ## Short description
+
 PowerShell is as case-insensitive as possible while preserving case.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Character_Encoding.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Character_Encoding.md
@@ -9,6 +9,7 @@ title: about_Character_Encoding
 # about_Character_Encoding
 
 ## Short description
+
 Describes how PowerShell uses character encoding for input and output of string
 data.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_CimSession.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_CimSession.md
@@ -9,6 +9,7 @@ title: about_CimSession
 # about_CimSession
 
 ## Short description
+
 Describes a **CimSession** object and the difference between CIM sessions and
 PowerShell sessions.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -9,6 +9,7 @@ title: about_Classes
 # about_Classes
 
 ## Short description
+
 Describes how you can use classes to create your own custom types.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
@@ -9,6 +9,7 @@ title: about_Command_Syntax
 # about_Command_Syntax
 
 ## Short description
+
 Describes the syntax diagrams that are used in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -10,6 +10,7 @@ title: about_Comment_Based_Help
 # about_Comment_Based_Help
 
 ## Short description
+
 Describes how to write comment-based help topics for functions and scripts.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Core_Commands.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Core_Commands.md
@@ -9,6 +9,7 @@ title: about_Core_Commands
 # about_Core_Commands
 
 ## Short description
+
 Lists the cmdlets that are designed for use with PowerShell providers.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Data_Files.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Data_Files.md
@@ -9,6 +9,7 @@ title: about_Data_Files
 # about_Data_Files
 
 ## Short description
+
 PowerShell data files are used to store arbitrary data using PowerShell syntax.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -9,6 +9,7 @@ title: about_Data_Sections
 # about_Data_Sections
 
 ## Short description
+
 Explains Data sections, which isolate text strings and other read-only
 data from script logic.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Do.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Do.md
@@ -9,6 +9,7 @@ title: about_Do
 # about_Do
 
 ## Short description
+
 Runs a statement list one or more times, subject to a `While` or `Until`
 condition.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Environment_Provider.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Environment_Provider.md
@@ -9,6 +9,7 @@ title: about_Environment_Provider
 # about_Environment_Provider
 
 ## Provider name
+
 Environment
 
 ## Drives

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -9,6 +9,7 @@ title: about_Environment_Variables
 # about_Environment_Variables
 
 ## Short description
+
 Describes how to access and manage environment variables in PowerShell.
 
 Environment variables store data that's used by the operating system and other

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_For.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_For.md
@@ -9,6 +9,7 @@ title: about_For
 # about_For
 
 ## Short description
+
 Describes a language command you can use to run statements based on a
 conditional test.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Foreach.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Foreach.md
@@ -9,6 +9,7 @@ title: about_Foreach
 # about_Foreach
 
 ## Short description
+
 Describes a language command you can use to traverse all the items in a
 collection of items.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Function_Provider.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Function_Provider.md
@@ -9,6 +9,7 @@ title: about_Function_Provider
 # about_Function_Provider
 
 ## Provider name
+
 Function
 
 ## Drives

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -9,6 +9,7 @@ title: about_Functions_Advanced
 # about_Functions_Advanced
 
 ## Short description
+
 Introduces advanced functions that are a way to create cmdlets using scripts.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Argument_Completion.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Argument_Completion.md
@@ -9,6 +9,7 @@ title: About_functions_argument_completion
 # about_Functions_Argument_Completion
 
 ## Short description
+
 Argument completion is a feature of PowerShell that provide hints, enables
 discovery, and speeds up input entry of argument values.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -9,6 +9,7 @@ title: about_Functions_CmdletBindingAttribute
 # about_Functions_CmdletBindingAttribute
 
 ## Short description
+
 Describes the attribute that makes a function work like a compiled cmdlet.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
@@ -9,6 +9,7 @@ title: about_Functions_OutputTypeAttribute
 # about_Functions_OutputTypeAttribute
 
 ## Short description
+
 Describes an attribute that reports the type of object that the function
 returns.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -10,6 +10,7 @@ title: about_Hash_Tables
 # about_Hash_Tables
 
 ## Short description
+
 Describes how to create, use, and sort hashtables in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Hidden.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Hidden.md
@@ -9,6 +9,7 @@ title: about_Hidden
 # about_Hidden
 
 ## Short description
+
 Describes the `hidden` keyword, which hides class members from default
 `Get-Member` results.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_History.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_History.md
@@ -9,6 +9,7 @@ title: about_History
 # about_History
 
 ## Short description
+
 Describes how to get and run commands in the command history.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_If.md
@@ -9,6 +9,7 @@ title: about_If
 # about_If
 
 ## Short description
+
 Describes a language command you can use to run statement lists based on the
 results of one or more conditional tests.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -9,6 +9,7 @@ title: about_Job_Details
 # about_Job_Details
 
 ## Short description
+
 Provides details about background jobs on local and remote computers.
 
 ## Detailed description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Jobs.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Jobs.md
@@ -9,6 +9,7 @@ title: about_Jobs
 # about_Jobs
 
 ## Short description
+
 Provides information about how PowerShell background jobs run a command or
 expression in the background without interacting with the current session.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Join.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Join.md
@@ -9,6 +9,7 @@ title: about_Join
 # about_Join
 
 ## Short description
+
 Describes how the join operator (-join) combines multiple strings into a
 single string.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -9,6 +9,7 @@ title: about_Language_Keywords
 # about_Language_Keywords
 
 ## Short description
+
 Describes the keywords in the PowerShell scripting language.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -10,6 +10,7 @@ title: about_Language_Modes
 # about_Language_Modes
 
 ## Short description
+
 Explains language modes and their effect on PowerShell sessions.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Logging_Windows.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Logging_Windows.md
@@ -10,6 +10,7 @@ title: about_Logging_Windows
 # about_Logging_Windows
 
 ## Short description
+
 PowerShell logs internal operations from the engine, providers, and cmdlets to
 the Windows event log.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
@@ -9,6 +9,7 @@ title: about_Logical_Operators
 # about_Logical_Operators
 
 ## Short description
+
 Describes the operators that connect statements in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Methods.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Methods.md
@@ -9,6 +9,7 @@ title: about_Methods
 # about_Methods
 
 ## Short description
+
 Describes how to use methods to perform actions on objects in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
@@ -9,6 +9,7 @@ title: about_Module_Manifests
 # about_Module_Manifests
 
 ## Short description
+
 Describes the settings and practices for writing module manifest files.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -9,6 +9,7 @@ title: about_Modules
 # about_Modules
 
 ## Short description
+
 Explains how to install, import, and use PowerShell modules.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Numeric_Literals.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Numeric_Literals.md
@@ -10,9 +10,11 @@ title: about_Numeric_Literals
 # about_Numeric_Literals
 
 ## Short description
+
 This article describes the syntax and usage of numeric values in PowerShell.
 
 ## Long description
+
 There are two kinds of numeric literals: integer and real. Both can have type
 and multiplier suffixes.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Objects.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Objects.md
@@ -9,6 +9,7 @@ title: about_Objects
 # about_Objects
 
 ## Short description
+
 Provides essential information about objects in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -9,6 +9,7 @@ title: about_Operator_Precedence
 # about_Operator_Precedence
 
 ## Short description
+
 Lists the PowerShell operators in precedence order.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -9,6 +9,7 @@ title: about_Operators
 # about_Operators
 
 ## Short description
+
 Describes the operators that are supported by PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Output_Streams.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Output_Streams.md
@@ -10,6 +10,7 @@ title: about_Output_Streams
 # about_Output_Streams
 
 ## Short description
+
 Explains the availability and purpose of output streams in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_PSConsoleHostReadLine.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_PSConsoleHostReadLine.md
@@ -9,6 +9,7 @@ title: about_PSConsoleHostReadLine
 # about_PSConsoleHostReadLine
 
 ## Short description
+
 Explains how to create a customize how PowerShell reads input at the console
 prompt.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
@@ -9,6 +9,7 @@ title: about_PSCustomObject
 # about_PSCustomObject
 
 ## Short description
+
 Explains the differences between the `[psobject]` and `[pscustomobject]` type
 accelerators.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
@@ -9,6 +9,7 @@ title: about_PSSession_Details
 # about_PSSession_Details
 
 ## Short description
+
 Provides detailed information about PowerShell sessions and the
 role they play in remote commands.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_PSSessions.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_PSSessions.md
@@ -9,6 +9,7 @@ title: about_PSSessions
 # about_PSSessions
 
 ## Short description
+
 Describes PowerShell sessions (PSSessions) and explains how to
 establish a persistent connection to a remote computer.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_PackageManagement.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_PackageManagement.md
@@ -9,6 +9,7 @@ title: about_PackageManagement
 # about_PackageManagement
 
 ## Short description
+
 PackageManagement is an aggregator for software package managers.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -8,6 +8,7 @@ title: about_Parameter_Sets
 # about_Parameter_Sets
 
 ## Short description
+
 Describes how to define and use parameter sets in advanced functions.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameters.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameters.md
@@ -9,6 +9,7 @@ title: about_Parameters
 # about_Parameters
 
 ## Short description
+
 Describes how to work with command parameters in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Path_Syntax.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Path_Syntax.md
@@ -9,6 +9,7 @@ title: about_Path_Syntax
 # about_Path_Syntax
 
 ## Short description
+
 Describes the full and relative path formats in  PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
@@ -9,6 +9,7 @@ title: about_PowerShell_Config
 # about_PowerShell_Config
 
 ## Short description
+
 Configuration files for PowerShell, replacing Registry configuration.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_PowerShell_Editions.md
@@ -9,6 +9,7 @@ title: about_PowerShell_Editions
 # about_PowerShell_Editions
 
 ## Short description
+
 Different editions of PowerShell run on different underlying runtimes.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -9,6 +9,7 @@ title: about_Profiles
 # about_Profiles
 
 ## Short description
+
 Describes how to create and use a PowerShell profile.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -9,6 +9,7 @@ title: about_Prompts
 # about_Prompts
 
 ## Short description
+
 Describes the `Prompt` function and demonstrates how to create a custom
 `Prompt` function.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -9,6 +9,7 @@ title: about_Properties
 # about_Properties
 
 ## Short description
+
 Describes how to use object properties in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -9,6 +9,7 @@ title: about_Providers
 # about_Providers
 
 ## Short description
+
 Describes how PowerShell providers provide access to data and components that
 wouldn't otherwise be easily accessible at the command line. The data is
 presented in a consistent format that resembles a file system drive.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -10,6 +10,7 @@ title: about_Pwsh
 # about_Pwsh
 
 ## Short description
+
 Explains how to use the `pwsh` command-line interface. Displays the
 command-line parameters and describes the syntax.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -9,6 +9,7 @@ title: about_Quoting_Rules
 # about_Quoting_Rules
 
 ## Short description
+
 Describes rules for using single and double quotation marks in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -9,6 +9,7 @@ title: about_Redirection
 # about_Redirection
 
 ## Short description
+
 Explains how to redirect output from PowerShell to text files.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Ref.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Ref.md
@@ -9,6 +9,7 @@ title: about_Ref
 # about_Ref
 
 ## Short description
+
 Describes how to create and use a reference type variable. You can use
 reference type variables to permit a function to change the value
 of a variable that is passed to it.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -9,6 +9,7 @@ title: about_Regular_Expressions
 # about_Regular_Expressions
 
 ## Short description
+
 Describes regular expressions in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Remote.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Remote.md
@@ -9,6 +9,7 @@ title: about_Remote
 # about_Remote
 
 ## Short description
+
 Describes how to run remote commands in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
@@ -9,6 +9,7 @@ title: about_Remote_Jobs
 # about_Remote_Jobs
 
 ## Short description
+
 Describes how to run background jobs on remote computers.
 
 ## Detailed Description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -10,6 +10,7 @@ title: about_Remote_Requirements
 # about_Remote_Requirements
 
 ## Short description
+
 Describes the system requirements and configuration requirements for running
 remote commands in PowerShell.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -9,6 +9,7 @@ title: about_Remote_Troubleshooting
 # about_Remote_Troubleshooting
 
 ## Short description
+
 Describes how to troubleshoot remote operations in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
@@ -9,6 +9,7 @@ title: about_Reserved_Words
 # about_Reserved_Words
 
 ## Short description
+
 Lists the reserved words that cannot be used as identifiers because they
 have a special meaning in PowerShell.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -9,6 +9,7 @@ title: about_Scopes
 # about_Scopes
 
 ## Short description
+
 Explains the concept of scope in PowerShell and shows how to set and change
 the scope of elements.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -9,6 +9,7 @@ title: about_Script_Internationalization
 # about_Script_Internationalization
 
 ## Short description
+
 Describes the script internationalization features that make it easy for
 scripts to display messages and instructions to users in their user interface
 (UI) language.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -9,6 +9,7 @@ title: about_Scripts
 # about_Scripts
 
 ## Short description
+
 Describes how to run and write scripts in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -9,6 +9,7 @@ title: about_Session_Configuration_Files
 # about_Session_Configuration_Files
 
 ## Short description
+
 Describes session configuration files, which are used in a session
 configuration (also known as an "endpoint") to define the environment of
 sessions that use the session configuration.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -9,6 +9,7 @@ title: about_Session_Configurations
 # about_Session_Configurations
 
 ## Short description
+
 Describes session configurations, which determine the users who can connect to
 the computer remotely and the commands they can run.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
@@ -9,6 +9,7 @@ title: about_Simplified_Syntax
 # about_Simplified_Syntax
 
 ## Short description
+
 Describes easier, more natural-language ways of scripting filters for
 collections of objects.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Split.md
@@ -9,6 +9,7 @@ title: about_Split
 # about_Split
 
 ## Short description
+
 Explains how to use the Split operator to split one or more strings into
 substrings.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -9,6 +9,7 @@ title: about_Switch
 # about_Switch
 
 ## Short description
+
 Explains how to use a switch to handle multiple `if` statements.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Tab_Expansion.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Tab_Expansion.md
@@ -10,6 +10,7 @@ title: About_tab_expansion
 # about_Tab_Expansion
 
 ## Short description
+
 PowerShell provides completions on input to provide hints, enable discovery,
 and speed up input entry. Command names, parameter names, argument values and
 file paths can all be completed by pressing the <kbd>Tab</kbd> key.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Throw.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Throw.md
@@ -9,6 +9,7 @@ title: about_Throw
 # about_Throw
 
 ## Short description
+
 Describes the `throw` keyword that generates a terminating error.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
@@ -9,6 +9,7 @@ title: about_Try_Catch_Finally
 # about_Try_Catch_Finally
 
 ## Short description
+
 Describes how to use the `try`, `catch`, and `finally` blocks to handle
 terminating errors.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Type_Accelerators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Type_Accelerators.md
@@ -9,6 +9,7 @@ title: about_Type_Accelerators
 # about_Type_Accelerators
 
 ## SHORT DESCRIPTION
+
 Describes the Type accelerators available for .NET framework classes
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -10,6 +10,7 @@ title: about_Type_Operators
 # about_Type_Operators
 
 ## Short description
+
 Describes the operators that work with Microsoft .NET types.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -9,6 +9,7 @@ title: about_Types.ps1xml
 # about_Types.ps1xml
 
 ## Short description
+
 Explains how to use `Types.ps1xml` files to extend the types of objects that
 are used in PowerShell.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -9,6 +9,7 @@ title: about_Updatable_Help
 # about_Updatable_Help
 
 ## Short description
+
 Describes the updatable help system in PowerShell.
 
 ## Long description

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
@@ -9,6 +9,7 @@ title: about_Variable_Provider
 # about_Variable_Provider
 
 ## Provider name
+
 Variable
 
 ## Drives

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_While.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_While.md
@@ -9,6 +9,7 @@ title: about_While
 # about_While
 
 ## Short description
+
 Describes a language statement that you can use to run a command block based on
 the results of a conditional test.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/Exit-PSHostProcess.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Exit-PSHostProcess.md
@@ -57,4 +57,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Enter-PSHostProcess](Enter-PSHostProcess.md)
-

--- a/reference/7.5/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Get-Job.md
@@ -223,7 +223,6 @@ Handles  NPM(K)    PM(K)      WS(K) VM(M)   CPU(s)     Id ProcessName
 ...
 ```
 
-
 ### Example 8: Get all jobs including jobs started by a different method
 
 This example demonstrates that the `Get-Job` cmdlet can get all of the jobs that were started in the

--- a/reference/7.5/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Get-Module.md
@@ -549,7 +549,6 @@ The `Get-Module` cmdlet checks **CompatiblePSEditions** property of **PSModuleIn
 specified value and returns only those modules that have it set.
 
 > [!NOTE]
->
 > - **Desktop Edition:** Built on .NET Framework and provides compatibility with scripts and modules
 >   targeting versions of PowerShell running on full footprint editions of Windows such as Server
 >   Core and Windows Desktop.

--- a/reference/7.5/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Get-Module.md
@@ -549,6 +549,7 @@ The `Get-Module` cmdlet checks **CompatiblePSEditions** property of **PSModuleIn
 specified value and returns only those modules that have it set.
 
 > [!NOTE]
+>
 > - **Desktop Edition:** Built on .NET Framework and provides compatibility with scripts and modules
 >   targeting versions of PowerShell running on full footprint editions of Windows such as Server
 >   Core and Windows Desktop.

--- a/reference/7.5/Microsoft.PowerShell.Core/Get-PSHostProcessInfo.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Get-PSHostProcessInfo.md
@@ -139,4 +139,3 @@ You can pipe a **Process** object from `Get-Process` to this cmdlet.
 ## RELATED LINKS
 
 [Get-Process](../Microsoft.PowerShell.Management/get-process.md)
-

--- a/reference/7.5/Microsoft.PowerShell.Core/Get-PSSubsystem.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Get-PSSubsystem.md
@@ -86,7 +86,6 @@ Implementations           : {}
 
 ### -Kind
 
-
 Specifies the kind of subsystem to be returned. Valid values are: `CommandPredictor`.
 
 ```yaml

--- a/reference/7.5/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md
@@ -20,185 +20,245 @@ startup. This is not a module. You can't import it using `Import-Module` or remo
 ## Microsoft.PowerShell.Core Cmdlets
 
 ### [Add-History](Add-History.md)
+
 Appends entries to the session history.
 
 ### [Clear-History](Clear-History.md)
+
 Deletes entries from the PowerShell session command history.
 
 ### [Clear-Host](Clear-Host.md)
+
 Clears the display in the host program.
 
 ### [Connect-PSSession](Connect-PSSession.md)
+
 Reconnects to disconnected sessions.
 
 ### [Debug-Job](Debug-Job.md)
+
 Debugs a running background, remote, or PowerShell Workflow job.
 
 ### [Disable-ExperimentalFeature](Disable-ExperimentalFeature.md)
+
 Disable an experimental feature on startup of new instance of PowerShell.
 
 ### [Disable-PSRemoting](Disable-PSRemoting.md)
+
 Prevents PowerShell endpoints from receiving remote connections.
 
 ### [Disable-PSSessionConfiguration](Disable-PSSessionConfiguration.md)
+
 Disables session configurations on the local computer.
 
 ### [Disconnect-PSSession](Disconnect-PSSession.md)
+
 Disconnects from a session.
 
 ### [Enable-ExperimentalFeature](Enable-ExperimentalFeature.md)
+
 Enable an experimental feature on startup of new instance of PowerShell.
 
 ### [Enable-PSRemoting](Enable-PSRemoting.md)
+
 Configures the computer to receive remote commands.
 
 ### [Enable-PSSessionConfiguration](Enable-PSSessionConfiguration.md)
+
 Enables the session configurations on the local computer.
 
 ### [Enter-PSHostProcess](Enter-PSHostProcess.md)
+
 Connects to and enters into an interactive session with a local process.
 
 ### [Enter-PSSession](Enter-PSSession.md)
+
 Starts an interactive session with a remote computer.
 
 ### [Exit-PSHostProcess](Exit-PSHostProcess.md)
+
 Closes an interactive session with a local process.
 
 ### [Exit-PSSession](Exit-PSSession.md)
+
 Ends an interactive session with a remote computer.
 
 ### [Export-ModuleMember](Export-ModuleMember.md)
+
 Specifies the module members that are exported.
 
 ### [ForEach-Object](ForEach-Object.md)
+
 Performs an operation against each item in a collection of input objects.
 
 ### [Get-Command](Get-Command.md)
+
 Gets all commands.
 
 ### [Get-ExperimentalFeature](Get-ExperimentalFeature.md)
+
 Gets experimental features.
 
 ### [Get-Help](Get-Help.md)
+
 Displays information about PowerShell commands and concepts.
 
 ### [Get-History](Get-History.md)
+
 Gets a list of the commands entered during the current session.
 
 ### [Get-Job](Get-Job.md)
+
 Gets PowerShell background jobs that are running in the current session.
 
 ### [Get-Module](Get-Module.md)
+
 Gets the modules that have been imported or that can be imported into the current session.
 
 ### [Get-PSHostProcessInfo](Get-PSHostProcessInfo.md)
+
 Gets process information about the PowerShell host.
 
 ### [Get-PSSession](Get-PSSession.md)
+
 Gets the PowerShell sessions on local and remote computers.
 
 ### [Get-PSSessionCapability](Get-PSSessionCapability.md)
+
 Gets the capabilities of a specific user on a constrained session configuration.
 
 ### [Get-PSSessionConfiguration](Get-PSSessionConfiguration.md)
+
 Gets the registered session configurations on the computer.
 
 ### [Get-PSSubsystem](Get-PSSubsystem.md)
+
 Retrieves information about the subsystems registered in PowerShell. (Experimental Feature)
 
 ### [Import-Module](Import-Module.md)
+
 Adds modules to the current session.
 
 ### [Invoke-Command](Invoke-Command.md)
+
 Runs commands on local and remote computers.
 
 ### [Invoke-History](Invoke-History.md)
+
 Runs commands from the session history.
 
 ### [New-Module](New-Module.md)
+
 Creates a new dynamic module that exists only in memory.
 
 ### [New-ModuleManifest](New-ModuleManifest.md)
+
 Creates a new module manifest.
 
 ### [New-PSRoleCapabilityFile](New-PSRoleCapabilityFile.md)
+
 Creates a file that defines a set of capabilities to be exposed through a session configuration.
 
 ### [New-PSSession](New-PSSession.md)
+
 Creates a persistent connection to a local or remote computer.
 
 ### [New-PSSessionConfigurationFile](New-PSSessionConfigurationFile.md)
+
 Creates a file that defines a session configuration.
 
 ### [New-PSSessionOption](New-PSSessionOption.md)
+
 Creates an object that contains advanced options for a PSSession.
 
 ### [New-PSTransportOption](New-PSTransportOption.md)
+
 Creates an object that contains advanced options for a session configuration.
 
 ### [Out-Default](Out-Default.md)
+
 Sends the output to the default formatter and to the default output cmdlet.
 
 ### [Out-Host](Out-Host.md)
+
 Sends output to the command line.
 
 ### [Out-Null](Out-Null.md)
+
 Hides the output instead of sending it down the pipeline or displaying it.
 
 ### [Receive-Job](Receive-Job.md)
+
 Gets the results of the PowerShell background jobs in the current session.
 
 ### [Receive-PSSession](Receive-PSSession.md)
+
 Gets results of commands in disconnected sessions
 
 ### [Register-ArgumentCompleter](Register-ArgumentCompleter.md)
+
 Registers a custom argument completer.
 
 ### [Register-PSSessionConfiguration](Register-PSSessionConfiguration.md)
+
 Creates and registers a new session configuration.
 
 ### [Remove-Job](Remove-Job.md)
+
 Deletes a PowerShell background job.
 
 ### [Remove-Module](Remove-Module.md)
+
 Removes modules from the current session.
 
 ### [Remove-PSSession](Remove-PSSession.md)
+
 Closes one or more PowerShell sessions (PSSessions).
 
 ### [Save-Help](Save-Help.md)
+
 Downloads and saves the newest help files to a file system directory.
 
 ### [Set-PSDebug](Set-PSDebug.md)
+
 Turns script debugging features on and off, sets the trace level, and toggles strict mode.
 
 ### [Set-PSSessionConfiguration](Set-PSSessionConfiguration.md)
+
 Changes the properties of a registered session configuration.
 
 ### [Set-StrictMode](Set-StrictMode.md)
+
 Establishes and enforces coding rules in expressions, scripts, and script blocks.
 
 ### [Start-Job](Start-Job.md)
+
 Starts a PowerShell background job.
 
 ### [Stop-Job](Stop-Job.md)
+
 Stops a PowerShell background job.
 
 ### [Test-ModuleManifest](Test-ModuleManifest.md)
+
 Verifies that a module manifest file accurately describes the contents of a module.
 
 ### [Test-PSSessionConfigurationFile](Test-PSSessionConfigurationFile.md)
+
 Verifies the keys and values in a session configuration file.
 
 ### [Unregister-PSSessionConfiguration](Unregister-PSSessionConfiguration.md)
+
 Deletes registered session configurations from the computer.
 
 ### [Update-Help](Update-Help.md)
+
 Downloads and installs the newest help files on your computer.
 
 ### [Wait-Job](Wait-Job.md)
+
 Suppresses the command prompt until one or all of the PowerShell background jobs running in the session are completed.
 
 ### [Where-Object](Where-Object.md)
-Selects objects from a collection based on their property values.
 
+Selects objects from a collection based on their property values.

--- a/reference/7.5/Microsoft.PowerShell.Core/New-Module.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/New-Module.md
@@ -426,4 +426,3 @@ PowerShell includes the following aliases for `New-Module`:
 [Import-Module](Import-Module.md)
 
 [Remove-Module](Remove-Module.md)
-

--- a/reference/7.5/Microsoft.PowerShell.Diagnostics/Microsoft.PowerShell.Diagnostics.md
+++ b/reference/7.5/Microsoft.PowerShell.Diagnostics/Microsoft.PowerShell.Diagnostics.md
@@ -20,11 +20,13 @@ This module is only available on the Windows platform.
 ## Microsoft.PowerShell.Diagnostics Cmdlets
 
 ### [Get-Counter](Get-Counter.md)
+
 Gets performance counter data from local and remote computers.
 
 ### [Get-WinEvent](Get-WinEvent.md)
+
 Gets events from event logs and event tracing log files on local and remote computers.
 
 ### [New-WinEvent](New-WinEvent.md)
-Creates a new Windows event for the specified event provider.
 
+Creates a new Windows event for the specified event provider.

--- a/reference/7.5/Microsoft.PowerShell.Host/Microsoft.PowerShell.Host.md
+++ b/reference/7.5/Microsoft.PowerShell.Host/Microsoft.PowerShell.Host.md
@@ -19,8 +19,9 @@ programs.
 ## Microsoft.PowerShell.Host Cmdlets
 
 ### [Start-Transcript](Start-Transcript.md)
+
 Creates a record of all or part of a PowerShell session to a text file.
 
 ### [Stop-Transcript](Stop-Transcript.md)
-Stops a transcript.
 
+Stops a transcript.

--- a/reference/7.5/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Add-Content.md
@@ -432,7 +432,6 @@ the `Unblock-File` cmdlet.
 This parameter was introduced in PowerShell 3.0.  As of PowerShell 7.2, `Add-Content` can
 target alternative data streams on both files and directories.
 
-
 ```yaml
 Type: System.String
 Parameter Sets: (All)

--- a/reference/7.5/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.md
@@ -19,185 +19,245 @@ Windows in PowerShell.
 ## Microsoft.PowerShell.Management Cmdlets
 
 ### [Add-Content](Add-Content.md)
+
 Adds content to the specified items, such as adding words to a file.
 
 ### [Clear-Content](Clear-Content.md)
+
 Deletes the contents of an item, but does not delete the item.
 
 ### [Clear-Item](Clear-Item.md)
+
 Clears the contents of an item, but does not delete the item.
 
 ### [Clear-ItemProperty](Clear-ItemProperty.md)
+
 Clears the value of a property but does not delete the property.
 
 ### [Clear-RecycleBin](Clear-RecycleBin.md)
+
 Clears the contents of a recycle bin.
 
 ### [Convert-Path](Convert-Path.md)
+
 Converts a path from a PowerShell path to a PowerShell provider path.
 
 ### [Copy-Item](Copy-Item.md)
+
 Copies an item from one location to another.
 
 ### [Copy-ItemProperty](Copy-ItemProperty.md)
+
 Copies a property and value from a specified location to another location.
 
 ### [Debug-Process](Debug-Process.md)
+
 Debugs one or more processes running on the local computer.
 
 ### [Get-ChildItem](Get-ChildItem.md)
+
 Gets the items and child items in one or more specified locations.
 
 ### [Get-Clipboard](Get-Clipboard.md)
+
 Gets the contents of the clipboard.  [!NOTE] > On Linux, this cmdlet requires the `xclip` utility to be in the path.
 
 ### [Get-ComputerInfo](Get-ComputerInfo.md)
+
 Gets a consolidated object of system and operating system properties.
 
 ### [Get-Content](Get-Content.md)
+
 Gets the content of the item at the specified location.
 
 ### [Get-HotFix](Get-HotFix.md)
+
 Gets the hotfixes that are installed on local or remote computers.
 
 ### [Get-Item](Get-Item.md)
+
 Gets the item at the specified location.
 
 ### [Get-ItemProperty](Get-ItemProperty.md)
+
 Gets the properties of a specified item.
 
 ### [Get-ItemPropertyValue](Get-ItemPropertyValue.md)
+
 Gets the value for one or more properties of a specified item.
 
 ### [Get-Location](Get-Location.md)
+
 Gets information about the current working location or a location stack.
 
 ### [Get-Process](Get-Process.md)
+
 Gets the processes that are running on the local computer.
 
 ### [Get-PSDrive](Get-PSDrive.md)
+
 Gets drives in the current session.
 
 ### [Get-PSProvider](Get-PSProvider.md)
+
 Gets information about the specified PowerShell provider.
 
 ### [Get-Service](Get-Service.md)
+
 Gets the services on the computer.
 
 ### [Get-TimeZone](Get-TimeZone.md)
+
 Gets the current time zone or a list of available time zones.
 
 ### [Invoke-Item](Invoke-Item.md)
+
 Performs the default action on the specified item.
 
 ### [Join-Path](Join-Path.md)
+
 Combines a path and a child path into a single path.
 
 ### [Move-Item](Move-Item.md)
+
 Moves an item from one location to another.
 
 ### [Move-ItemProperty](Move-ItemProperty.md)
+
 Moves a property from one location to another.
 
 ### [New-Item](New-Item.md)
+
 Creates a new item.
 
 ### [New-ItemProperty](New-ItemProperty.md)
+
 Creates a new property for an item and sets its value.
 
 ### [New-PSDrive](New-PSDrive.md)
+
 Creates temporary and persistent mapped network drives.
 
 ### [New-Service](New-Service.md)
+
 Creates a new Windows service.
 
 ### [Pop-Location](Pop-Location.md)
+
 Changes the current location to the location most recently pushed onto the stack.
 
 ### [Push-Location](Push-Location.md)
+
 Adds the current location to the top of a location stack.
 
 ### [Remove-Item](Remove-Item.md)
+
 Deletes the specified items.
 
 ### [Remove-ItemProperty](Remove-ItemProperty.md)
+
 Deletes the property and its value from an item.
 
 ### [Remove-PSDrive](Remove-PSDrive.md)
+
 Deletes temporary PowerShell drives and disconnects mapped network drives.
 
 ### [Remove-Service](Remove-Service.md)
+
 Removes a Windows service.
 
 ### [Rename-Computer](Rename-Computer.md)
+
 Renames a computer.
 
 ### [Rename-Item](Rename-Item.md)
+
 Renames an item in a PowerShell provider namespace.
 
 ### [Rename-ItemProperty](Rename-ItemProperty.md)
+
 Renames a property of an item.
 
 ### [Resolve-Path](Resolve-Path.md)
+
 Resolves the wildcard characters in a path, and displays the path contents.
 
 ### [Restart-Computer](Restart-Computer.md)
+
 Restarts the operating system on local and remote computers.
 
 ### [Restart-Service](Restart-Service.md)
+
 Stops and then starts one or more services.
 
 ### [Resume-Service](Resume-Service.md)
+
 Resumes one or more suspended (paused) services.
 
 ### [Set-Clipboard](Set-Clipboard.md)
+
 Sets the contents of the clipboard.
 
 ### [Set-Content](Set-Content.md)
+
 Writes new content or replaces existing content in a file.
 
 ### [Set-Item](Set-Item.md)
+
 Changes the value of an item to the value specified in the command.
 
 ### [Set-ItemProperty](Set-ItemProperty.md)
+
 Creates or changes the value of a property of an item.
 
 ### [Set-Location](Set-Location.md)
+
 Sets the current working location to a specified location.
 
 ### [Set-Service](Set-Service.md)
+
 Starts, stops, and suspends a service, and changes its properties.
 
 ### [Set-TimeZone](Set-TimeZone.md)
+
 Sets the system time zone to a specified time zone.
 
 ### [Split-Path](Split-Path.md)
+
 Returns the specified part of a path.
 
 ### [Start-Process](Start-Process.md)
+
 Starts one or more processes on the local computer.
 
 ### [Start-Service](Start-Service.md)
+
 Starts one or more stopped services.
 
 ### [Stop-Computer](Stop-Computer.md)
+
 Stops (shuts down) local and remote computers.
 
 ### [Stop-Process](Stop-Process.md)
+
 Stops one or more running processes.
 
 ### [Stop-Service](Stop-Service.md)
+
 Stops one or more running services.
 
 ### [Suspend-Service](Suspend-Service.md)
+
 Suspends (pauses) one or more running services.
 
 ### [Test-Connection](Test-Connection.md)
+
 Sends ICMP echo request packets, or pings, to one or more computers.
 
 ### [Test-Path](Test-Path.md)
+
 Determines whether all elements of a path exist.
 
 ### [Wait-Process](Wait-Process.md)
-Waits for the processes to be stopped before accepting more input.
 
+Waits for the processes to be stopped before accepting more input.

--- a/reference/7.5/Microsoft.PowerShell.Security/Get-CmsMessage.md
+++ b/reference/7.5/Microsoft.PowerShell.Security/Get-CmsMessage.md
@@ -169,4 +169,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Protect-CmsMessage](Protect-CmsMessage.md)
 
 [Unprotect-CmsMessage](Unprotect-CmsMessage.md)
-

--- a/reference/7.5/Microsoft.PowerShell.Security/Get-PfxCertificate.md
+++ b/reference/7.5/Microsoft.PowerShell.Security/Get-PfxCertificate.md
@@ -169,4 +169,3 @@ certificate file is not password protected, the value of the **Authentication** 
 [Get-AuthenticodeSignature](Get-AuthenticodeSignature.md)
 
 [Set-AuthenticodeSignature](Set-AuthenticodeSignature.md)
-

--- a/reference/7.5/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.md
+++ b/reference/7.5/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.md
@@ -19,48 +19,62 @@ the basic security features of Windows.
 ## Microsoft.PowerShell.Security Cmdlets
 
 ### [ConvertFrom-SecureString](ConvertFrom-SecureString.md)
+
 Converts a secure string to an encrypted standard string.
 
 ### [ConvertTo-SecureString](ConvertTo-SecureString.md)
+
 Converts encrypted standard strings to secure strings.
 
 ### [Get-Acl](Get-Acl.md)
+
 Gets the security descriptor for a resource, such as a file or registry key.
 
 ### [Get-AuthenticodeSignature](Get-AuthenticodeSignature.md)
+
 Gets information about the Authenticode signature for a file.
 
 ### [Get-CmsMessage](Get-CmsMessage.md)
+
 Gets content that has been encrypted by using the Cryptographic Message Syntax format.
 
 ### [Get-Credential](Get-Credential.md)
+
 Gets a credential object based on a user name and password.
 
 ### [Get-ExecutionPolicy](Get-ExecutionPolicy.md)
+
 Gets the execution policies for the current session.
 
 ### [Get-PfxCertificate](Get-PfxCertificate.md)
+
 Gets information about PFX certificate files on the computer.
 
 ### [New-FileCatalog](New-FileCatalog.md)
+
 Creates a Windows catalog file containing cryptographic hashes for files and folders in specified
 paths.
 
 ### [Protect-CmsMessage](Protect-CmsMessage.md)
+
 Encrypts content by using the Cryptographic Message Syntax format.
 
 ### [Set-Acl](Set-Acl.md)
+
 Changes the security descriptor of a specified item, such as a file or a registry key.
 
 ### [Set-AuthenticodeSignature](Set-AuthenticodeSignature.md)
+
 Adds an Authenticode signature to a PowerShell script or other file.
 
 ### [Set-ExecutionPolicy](Set-ExecutionPolicy.md)
+
 Sets the PowerShell execution policies for Windows computers.
 
 ### [Test-FileCatalog](Test-FileCatalog.md)
+
 Validates whether the hashes contained in a catalog file (.cat) matches the hashes of the actual files in order to validate their authenticity.
 
 ### [Unprotect-CmsMessage](Unprotect-CmsMessage.md)
-Decrypts content that has been encrypted by using the Cryptographic Message Syntax format.
 
+Decrypts content that has been encrypted by using the Cryptographic Message Syntax format.

--- a/reference/7.5/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Add-Type.md
@@ -278,7 +278,6 @@ If .NET fails to resolve the name, PowerShell then looks in the current location
 assembly. When you use wildcards in the **AssemblyName** parameter, the .NET assembly resolution
 process fails causing PowerShell to look in the current location.
 
-
 ```yaml
 Type: System.String[]
 Parameter Sets: FromAssemblyName

--- a/reference/7.5/Microsoft.PowerShell.Utility/ConvertFrom-Markdown.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/ConvertFrom-Markdown.md
@@ -178,4 +178,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Markdown Parser](https://github.com/lunet-io/markdig)
 
 [ANSI escape code](https://wikipedia.org/wiki/ANSI_escape_code)
-

--- a/reference/7.5/Microsoft.PowerShell.Utility/Disable-RunspaceDebug.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Disable-RunspaceDebug.md
@@ -180,4 +180,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Enable-RunspaceDebug](Enable-RunspaceDebug.md)
 
 [Get-RunspaceDebug](Get-RunspaceDebug.md)
-

--- a/reference/7.5/Microsoft.PowerShell.Utility/Enable-RunspaceDebug.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Enable-RunspaceDebug.md
@@ -198,4 +198,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Disable-RunspaceDebug](Disable-RunspaceDebug.md)
 
 [Get-RunspaceDebug](Get-RunspaceDebug.md)
-

--- a/reference/7.5/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -374,4 +374,3 @@ Generally, each byte is interpreted as a Unicode code point, which means that:
 [Format-Table](Format-Table.md)
 
 [Format-Wide](Format-Wide.md)
-

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-RunspaceDebug.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-RunspaceDebug.md
@@ -178,4 +178,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Disable-RunspaceDebug](Disable-RunspaceDebug.md)
 
 [Enable-RunspaceDebug](Enable-RunspaceDebug.md)
-

--- a/reference/7.5/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -1307,6 +1307,7 @@ Accept wildcard characters: False
 ```
 
 ### -UnixSocket
+
 Specifies the name of the Unix socket to connect to. This parameter is supported on Unix-based
 systems and Windows version 1803 and later. For more information about Windows support of Unix
 sockets, see the

--- a/reference/7.5/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
@@ -19,347 +19,461 @@ PowerShell.
 ## Microsoft.PowerShell.Utility Cmdlets
 
 ### [Add-Member](Add-Member.md)
+
 Adds custom properties and methods to an instance of a PowerShell object.
 
 ### [Add-Type](Add-Type.md)
+
 Adds a Microsoft .NET class to a PowerShell session.
 
 ### [Clear-Variable](Clear-Variable.md)
+
 Deletes the value of a variable.
 
 ### [Compare-Object](Compare-Object.md)
+
 Compares two sets of objects.
 
 ### [ConvertFrom-Csv](ConvertFrom-Csv.md)
+
 Converts object properties in character-separated value (CSV) format into CSV versions of the original objects.
 
 ### [ConvertFrom-Json](ConvertFrom-Json.md)
+
 Converts a JSON-formatted string to a custom object or a hash table.
 
 ### [ConvertFrom-Markdown](ConvertFrom-Markdown.md)
+
 Convert the contents of a string or a file to a **MarkdownInfo** object.
 
 ### [ConvertFrom-SddlString](ConvertFrom-SddlString.md)
+
 Converts a SDDL string to a custom object.
 
 ### [ConvertFrom-StringData](ConvertFrom-StringData.md)
+
 Converts a string containing one or more key and value pairs to a hash table.
 
 ### [ConvertTo-Csv](ConvertTo-Csv.md)
+
 Converts .NET objects into a series of character-separated value (CSV) strings.
 
 ### [ConvertTo-Html](ConvertTo-Html.md)
+
 Converts .NET objects into HTML that can be displayed in a Web browser.
 
 ### [ConvertTo-Json](ConvertTo-Json.md)
+
 Converts an object to a JSON-formatted string.
 
 ### [ConvertTo-Xml](ConvertTo-Xml.md)
+
 Creates an XML-based representation of an object.
 
 ### [Debug-Runspace](Debug-Runspace.md)
+
 Starts an interactive debugging session with a runspace.
 
 ### [Disable-PSBreakpoint](Disable-PSBreakpoint.md)
+
 Disables the breakpoints in the current console.
 
 ### [Disable-RunspaceDebug](Disable-RunspaceDebug.md)
+
 Disables debugging on one or more runspaces, and releases any pending debugger stop.
 
 ### [Enable-PSBreakpoint](Enable-PSBreakpoint.md)
+
 Enables the breakpoints in the current console.
 
 ### [Enable-RunspaceDebug](Enable-RunspaceDebug.md)
+
 Enables debugging on runspaces where any breakpoint is preserved until a debugger is attached.
 
 ### [Export-Alias](Export-Alias.md)
+
 Exports information about currently defined aliases to a file.
 
 ### [Export-Clixml](Export-Clixml.md)
+
 Creates an XML-based representation of an object or objects and stores it in a file.
 
 ### [Export-Csv](Export-Csv.md)
+
 Converts objects into a series of character-separated value (CSV) strings and saves the strings to a file.
 
 ### [Export-FormatData](Export-FormatData.md)
+
 Saves formatting data from the current session in a formatting file.
 
 ### [Export-PSSession](Export-PSSession.md)
+
 Exports commands from another session and saves them in a PowerShell module.
 
 ### [Format-Custom](Format-Custom.md)
+
 Uses a customized view to format the output.
 
 ### [Format-Hex](Format-Hex.md)
+
 Displays a file or other input as hexadecimal.
 
 ### [Format-List](Format-List.md)
+
 Formats the output as a list of properties in which each property appears on a new line.
 
 ### [Format-Table](Format-Table.md)
+
 Formats the output as a table.
 
 ### [Format-Wide](Format-Wide.md)
+
 Formats objects as a wide table that displays only one property of each object.
 
 ### [Get-Alias](Get-Alias.md)
+
 Gets the aliases for the current session.
 
 ### [Get-Culture](Get-Culture.md)
+
 Gets the current culture set in the operating system.
 
 ### [Get-Date](Get-Date.md)
+
 Gets the current date and time.
 
 ### [Get-Error](Get-Error.md)
+
 Gets and displays the most recent error messages from the current session.
 
 ### [Get-Event](Get-Event.md)
+
 Gets the events in the event queue.
 
 ### [Get-EventSubscriber](Get-EventSubscriber.md)
+
 Gets the event subscribers in the current session.
 
 ### [Get-FileHash](Get-FileHash.md)
+
 Computes the hash value for a file by using a specified hash algorithm.
 
 ### [Get-FormatData](Get-FormatData.md)
+
 Gets the formatting data in the current session.
 
 ### [Get-Host](Get-Host.md)
+
 Gets an object that represents the current host program.
 
 ### [Get-MarkdownOption](Get-MarkdownOption.md)
+
 Returns the current colors and styles used for rendering Markdown content in the console.
 
 ### [Get-Member](Get-Member.md)
+
 Gets the properties and methods of objects.
 
 ### [Get-PSBreakpoint](Get-PSBreakpoint.md)
+
 Gets the breakpoints that are set in the current session.
 
 ### [Get-PSCallStack](Get-PSCallStack.md)
+
 Displays the current call stack.
 
 ### [Get-Random](Get-Random.md)
+
 Gets a random number, or selects objects randomly from a collection.
 
 ### [Get-Runspace](Get-Runspace.md)
+
 Gets active runspaces within a PowerShell host process.
 
 ### [Get-RunspaceDebug](Get-RunspaceDebug.md)
+
 Shows runspace debugging options.
 
 ### [Get-TraceSource](Get-TraceSource.md)
+
 Gets PowerShell components that are instrumented for tracing.
 
 ### [Get-TypeData](Get-TypeData.md)
+
 Gets the extended type data in the current session.
 
 ### [Get-UICulture](Get-UICulture.md)
+
 Gets the current UI culture settings in the operating system.
 
 ### [Get-Unique](Get-Unique.md)
+
 Returns unique items from a sorted list.
 
 ### [Get-Uptime](Get-Uptime.md)
+
 Get the **TimeSpan** since last boot.
 
 ### [Get-Variable](Get-Variable.md)
+
 Gets the variables in the current console.
 
 ### [Get-Verb](Get-Verb.md)
+
 Gets approved PowerShell verbs.
 
 ### [Group-Object](Group-Object.md)
+
 Groups objects that contain the same value for specified properties.
 
 ### [Import-Alias](Import-Alias.md)
+
 Imports an alias list from a file.
 
 ### [Import-Clixml](Import-Clixml.md)
+
 Imports a CLIXML file and creates corresponding objects in PowerShell.
 
 ### [Import-Csv](Import-Csv.md)
+
 Creates table-like custom objects from the items in a character-separated value (CSV) file.
 
 ### [Import-LocalizedData](Import-LocalizedData.md)
+
 Imports language-specific data into scripts and functions based on the UI culture that is selected for the operating system.
 
 ### [Import-PowerShellDataFile](Import-PowerShellDataFile.md)
+
 Imports values from a `.PSD1` file without invoking its contents.
 
 ### [Import-PSSession](Import-PSSession.md)
+
 Imports commands from another session into the current session.
 
 ### [Invoke-Expression](Invoke-Expression.md)
+
 Runs commands or expressions on the local computer.
 
 ### [Invoke-RestMethod](Invoke-RestMethod.md)
+
 Sends an HTTP or HTTPS request to a RESTful web service.
 
 ### [Invoke-WebRequest](Invoke-WebRequest.md)
+
 Gets content from a web page on the internet.
 
 ### [Join-String](Join-String.md)
+
 Combines objects from the pipeline into a single string.
 
 ### [Measure-Command](Measure-Command.md)
+
 Measures the time it takes to run script blocks and cmdlets.
 
 ### [Measure-Object](Measure-Object.md)
+
 Calculates the numeric properties of objects, and the characters, words, and lines in string objects, such as files of text.
 
 ### [New-Alias](New-Alias.md)
+
 Creates a new alias.
 
 ### [New-Event](New-Event.md)
+
 Creates a new event.
 
 ### [New-Guid](New-Guid.md)
+
 Creates a GUID.
 
 ### [New-Object](New-Object.md)
+
 Creates an instance of a Microsoft .NET Framework or COM object.
 
 ### [New-TemporaryFile](New-TemporaryFile.md)
+
 Creates a temporary file.
 
 ### [New-TimeSpan](New-TimeSpan.md)
+
 Creates a TimeSpan object.
 
 ### [New-Variable](New-Variable.md)
+
 Creates a new variable.
 
 ### [Out-File](Out-File.md)
+
 Sends output to a file.
 
 ### [Out-GridView](Out-GridView.md)
+
 Sends output to an interactive table in a separate window.
 
 ### [Out-Printer](Out-Printer.md)
+
 Sends output to a printer.
 
 ### [Out-String](Out-String.md)
+
 Outputs input objects as a strings.
 
 ### [Read-Host](Read-Host.md)
+
 Reads a line of input from the console.
 
 ### [Register-EngineEvent](Register-EngineEvent.md)
+
 Subscribes to events that are generated by the PowerShell engine and by the `New-Event` cmdlet.
 
 ### [Register-ObjectEvent](Register-ObjectEvent.md)
+
 Subscribes to the events that are generated by a Microsoft .NET Framework object.
 
 ### [Remove-Alias](Remove-Alias.md)
+
 Remove an alias from the current session.
 
 ### [Remove-Event](Remove-Event.md)
+
 Deletes events from the event queue.
 
 ### [Remove-PSBreakpoint](Remove-PSBreakpoint.md)
+
 Deletes breakpoints from the current console.
 
 ### [Remove-TypeData](Remove-TypeData.md)
+
 Deletes extended types from the current session.
 
 ### [Remove-Variable](Remove-Variable.md)
+
 Deletes a variable and its value.
 
 ### [Select-Object](Select-Object.md)
+
 Selects objects or object properties.
 
 ### [Select-String](Select-String.md)
+
 Finds text in strings and files.
 
 ### [Select-Xml](Select-Xml.md)
+
 Finds text in an XML string or document.
 
 ### [Send-MailMessage](Send-MailMessage.md)
+
 Sends an email message.
 
 ### [Set-Alias](Set-Alias.md)
+
 Creates or changes an alias for a cmdlet or other command in the current PowerShell session.
 
 ### [Set-Date](Set-Date.md)
+
 Changes the system time on the computer to a time that you specify.
 
 ### [Set-MarkdownOption](Set-MarkdownOption.md)
+
 Sets the colors and styles used for rendering Markdown content in the console.
 
 ### [Set-PSBreakpoint](Set-PSBreakpoint.md)
+
 Sets a breakpoint on a line, command, or variable.
 
 ### [Set-TraceSource](Set-TraceSource.md)
+
 Configures, starts, and stops a trace of PowerShell components.
 
 ### [Set-Variable](Set-Variable.md)
+
 Sets the value of a variable. Creates the variable if one with the requested name does not exist.
 
 ### [Show-Command](Show-Command.md)
+
 Displays PowerShell command information in a graphical window.
 
 ### [Show-Markdown](Show-Markdown.md)
+
 Shows a Markdown file or string in the console in a friendly way using VT100 escape sequences or in a browser using HTML.
 
 ### [Sort-Object](Sort-Object.md)
+
 Sorts objects by property values.
 
 ### [Start-Sleep](Start-Sleep.md)
+
 Suspends the activity in a script or session for the specified period of time.
 
 ### [Tee-Object](Tee-Object.md)
+
 Saves command output in a file or variable and also sends it down the pipeline.
 
 ### [Test-Json](Test-Json.md)
+
 Tests whether a string is a valid JSON document
 
 ### [Trace-Command](Trace-Command.md)
+
 Configures and starts a trace of the specified expression or command.
 
 ### [Unblock-File](Unblock-File.md)
+
 Unblocks files that were downloaded from the Internet.
 
 ### [Unregister-Event](Unregister-Event.md)
+
 Cancels an event subscription.
 
 ### [Update-FormatData](Update-FormatData.md)
+
 Updates the formatting data in the current session.
 
 ### [Update-List](Update-List.md)
+
 Adds items to and removes items from a property value that contains a collection of objects.
 
 ### [Update-TypeData](Update-TypeData.md)
+
 Updates the extended type data in the session.
 
 ### [Wait-Debugger](Wait-Debugger.md)
+
 Stops a script in the debugger before running the next statement in the script.
 
 ### [Wait-Event](Wait-Event.md)
+
 Waits until a particular event is raised before continuing to run.
 
 ### [Write-Debug](Write-Debug.md)
+
 Writes a debug message to the console.
 
 ### [Write-Error](Write-Error.md)
+
 Writes an object to the error stream.
 
 ### [Write-Host](Write-Host.md)
+
 Writes customized output to a host.
 
 ### [Write-Information](Write-Information.md)
+
 Specifies how PowerShell handles information stream data for a command.
 
 ### [Write-Output](Write-Output.md)
+
 Sends the specified objects to the next command in the pipeline. If the command is the last command in the pipeline, the objects are displayed in the console.
 
 ### [Write-Progress](Write-Progress.md)
+
 Displays a progress bar within a PowerShell command window.
 
 ### [Write-Verbose](Write-Verbose.md)
+
 Writes text to the verbose message stream.
 
 ### [Write-Warning](Write-Warning.md)
-Writes a warning message.
 
+Writes a warning message.

--- a/reference/7.5/Microsoft.PowerShell.Utility/New-Guid.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/New-Guid.md
@@ -15,16 +15,19 @@ Creates a GUID.
 ## SYNTAX
 
 ### Default (Default)
+
 ```
 New-Guid [<CommonParameters>]
 ```
 
 ### Empty
+
 ```
 New-Guid [-Empty] [<CommonParameters>]
 ```
 
 ### InputObject
+
 ```
 New-Guid [-InputObject <String>] [<CommonParameters>]
 ```

--- a/reference/7.5/Microsoft.PowerShell.Utility/New-TemporaryFile.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/New-TemporaryFile.md
@@ -102,4 +102,3 @@ This cmdlet returns a **FileInfo** object that represents the temporary file.
 ## NOTES
 
 ## RELATED LINKS
-

--- a/reference/7.5/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
@@ -159,6 +159,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -174,6 +175,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -169,7 +169,6 @@ about here-strings, see
 The third command is the same as the second, except that tt uses a pipeline operator (`|`) to send
 the XML in the `$Xml` variable to the `Select-Xml` cmdlet.
 
-
 ```powershell
 $Xml = @"
 <?xml version="1.0" encoding="utf-8"?>

--- a/reference/7.5/Microsoft.PowerShell.Utility/Set-MarkdownOption.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Set-MarkdownOption.md
@@ -362,4 +362,3 @@ The string values used to define the color and style must match the regular expr
 [ANSI_escape_code](https://en.wikipedia.org/wiki/ANSI_escape_code)
 
 [CommonMark](https://commonmark.org/)
-

--- a/reference/7.5/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -350,6 +350,7 @@ Accept wildcard characters: False
 ```
 
 ### -Runspace
+
 Specifies the Id of a **Runspace** object so you can interact with breakpoints in the specified
 runspace.
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Show-Markdown.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Show-Markdown.md
@@ -172,4 +172,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [ConvertFrom-Markdown](ConvertFrom-Markdown.md)
-

--- a/reference/7.5/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -124,7 +124,6 @@ Specifies a command that's being processed during the trace.
 When you use this parameter, PowerShell processes the command just as it would be processed in a
 pipeline. For example, command discovery isn't repeated for each incoming object.
 
-
 ```yaml
 Type: System.String
 Parameter Sets: commandSet

--- a/reference/7.5/Microsoft.PowerShell.Utility/Wait-Event.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Wait-Event.md
@@ -164,4 +164,3 @@ current session, the event queue is discarded and the event subscription is canc
 [Unregister-Event](Unregister-Event.md)
 
 [Wait-Event](Wait-Event.md)
-

--- a/reference/7.5/Microsoft.PowerShell.Utility/Write-Warning.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Write-Warning.md
@@ -100,6 +100,7 @@ For more information about the **WarningAction** common parameter, see
 ## PARAMETERS
 
 ### -Message
+
 Specifies the warning message.
 
 ```yaml

--- a/reference/7.5/Microsoft.WSMan.Management/Microsoft.WSMan.Management.md
+++ b/reference/7.5/Microsoft.WSMan.Management/Microsoft.WSMan.Management.md
@@ -21,41 +21,53 @@ This module is only available on the Windows platform.
 ## Microsoft.WSMan.Management Cmdlets
 
 ### [Connect-WSMan](Connect-WSMan.md)
+
 Connects to the WinRM service on a remote computer.
 
 ### [Disable-WSManCredSSP](Disable-WSManCredSSP.md)
+
 Disables CredSSP authentication on a computer.
 
 ### [Disconnect-WSMan](Disconnect-WSMan.md)
+
 Disconnects the client from the WinRM service on a remote computer.
 
 ### [Enable-WSManCredSSP](Enable-WSManCredSSP.md)
+
 Enables CredSSP authentication on a computer.
 
 ### [Get-WSManCredSSP](Get-WSManCredSSP.md)
+
 Gets the Credential Security Support Provider-related configuration for the client.
 
 ### [Get-WSManInstance](Get-WSManInstance.md)
+
 Displays management information for a resource instance specified by a Resource URI.
 
 ### [Invoke-WSManAction](Invoke-WSManAction.md)
+
 Invokes an action on the object that is specified by the Resource URI and by the selectors.
 
 ### [New-WSManInstance](New-WSManInstance.md)
+
 Creates a new instance of a management resource.
 
 ### [New-WSManSessionOption](New-WSManSessionOption.md)
+
 Creates session option hash table to use as input parameters for WS-Management cmdlets.
 
 ### [Remove-WSManInstance](Remove-WSManInstance.md)
+
 Deletes a management resource instance.
 
 ### [Set-WSManInstance](Set-WSManInstance.md)
+
 Modifies the management information that is related to a resource.
 
 ### [Set-WSManQuickConfig](Set-WSManQuickConfig.md)
+
 Configures the local computer for remote management.
 
 ### [Test-WSMan](Test-WSMan.md)
-Tests whether the WinRM service is running on a local or remote computer.
 
+Tests whether the WinRM service is running on a local or remote computer.

--- a/reference/7.5/PSDiagnostics/PSDiagnostics.md
+++ b/reference/7.5/PSDiagnostics/PSDiagnostics.md
@@ -20,32 +20,41 @@ This module is only available on the Windows platform.
 ## PSDiagnostics Cmdlets
 
 ### [Disable-PSTrace](Disable-PSTrace.md)
+
 Disables the Microsoft-Windows-PowerShell event provider logs.
 
 ### [Disable-PSWSManCombinedTrace](Disable-PSWSManCombinedTrace.md)
+
 Stop the logging session started by Enable-PSWSManCombinedTrace.
 
 ### [Disable-WSManTrace](Disable-WSManTrace.md)
+
 Stop the WSMan logging session started by Enable-WSManTrace.
 
 ### [Enable-PSTrace](Enable-PSTrace.md)
+
 Enables the Microsoft-Windows-PowerShell event provider logs.
 
 ### [Enable-PSWSManCombinedTrace](Enable-PSWSManCombinedTrace.md)
+
 Start a logging session with the WSMan and PowerShell providers enabled.
 
 ### [Enable-WSManTrace](Enable-WSManTrace.md)
+
 Start a logging session with the WSMan providers enabled.
 
 ### [Get-LogProperties](Get-LogProperties.md)
+
 Retrieves the properties of a Windows event log.
 
 ### [Set-LogProperties](Set-LogProperties.md)
+
 Changes the properties of a Windows event log.
 
 ### [Start-Trace](Start-Trace.md)
+
 Start an Event Trace logging session.
 
 ### [Stop-Trace](Stop-Trace.md)
-Stop an Event Trace logging session.
 
+Stop an Event Trace logging session.

--- a/reference/7.5/PSReadLine/About/about_PSReadLine_Functions.md
+++ b/reference/7.5/PSReadLine/About/about_PSReadLine_Functions.md
@@ -1337,7 +1337,6 @@ Show the tooltip of the currently selected list item in the full view.
 - Emacs mode: `F4`
 - Vi insert mode: `F4`
 
-
 ### SwitchPredictionView
 
 Switch the view style for prediction between `InlineView` and `ListView`.

--- a/reference/7.5/PSReadLine/PSReadLine.md
+++ b/reference/7.5/PSReadLine/PSReadLine.md
@@ -40,22 +40,25 @@ These articles document version 2.3.5 of PSReadLine.
 ## PSReadLine Cmdlets
 
 ### [PSConsoleHostReadLine](PSConsoleHostReadLine.md)
+
 The main entry point for PSReadLine.
 
 ### [Get-PSReadLineKeyHandler](Get-PSReadLineKeyHandler.md)
+
 Gets the key bindings for the PSReadLine module.
 
 ### [Get-PSReadLineOption](Get-PSReadLineOption.md)
+
 Gets values for the options that can be configured.
 
-### [PSConsoleHostReadLine](PSConsoleHostReadLine.md)
-This function is the main entry point for PSReadLine.
-
 ### [Remove-PSReadLineKeyHandler](Remove-PSReadLineKeyHandler.md)
+
 Removes a key binding.
 
 ### [Set-PSReadLineKeyHandler](Set-PSReadLineKeyHandler.md)
+
 Binds keys to user-defined or PSReadLine key handler functions.
 
 ### [Set-PSReadLineOption](Set-PSReadLineOption.md)
+
 Customizes the behavior of command line editing in **PSReadLine**.

--- a/reference/7.5/PSReadLine/PSReadLine.md
+++ b/reference/7.5/PSReadLine/PSReadLine.md
@@ -39,10 +39,6 @@ These articles document version 2.3.5 of PSReadLine.
 
 ## PSReadLine Cmdlets
 
-### [PSConsoleHostReadLine](PSConsoleHostReadLine.md)
-
-The main entry point for PSReadLine.
-
 ### [Get-PSReadLineKeyHandler](Get-PSReadLineKeyHandler.md)
 
 Gets the key bindings for the PSReadLine module.
@@ -50,6 +46,10 @@ Gets the key bindings for the PSReadLine module.
 ### [Get-PSReadLineOption](Get-PSReadLineOption.md)
 
 Gets values for the options that can be configured.
+
+### [PSConsoleHostReadLine](PSConsoleHostReadLine.md)
+
+This function is the main entry point for PSReadLine.
 
 ### [Remove-PSReadLineKeyHandler](Remove-PSReadLineKeyHandler.md)
 

--- a/reference/7.5/ThreadJob/ThreadJob.md
+++ b/reference/7.5/ThreadJob/ThreadJob.md
@@ -11,6 +11,7 @@ title: ThreadJob Module
 # ThreadJob Module
 
 ## Description
+
 This module extends the existing PowerShell BackgroundJob to include a new thread based
 **ThreadJob** job. This is a lighter weight solution for running concurrent PowerShell scripts that
 works within the existing PowerShell job infrastructure.
@@ -18,4 +19,5 @@ works within the existing PowerShell job infrastructure.
 ## ThreadJob Cmdlets
 
 ### [Start-ThreadJob](Start-ThreadJob.md)
+
 Creates background jobs similar to the `Start-Job` cmdlet.


### PR DESCRIPTION
# PR Summary
Fixing markdown warnings to align with the markdown rules per https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/.markdownlint.yaml

Specifically:
MD022 (with exception to SYNOPSIS)   saved you about 300 changes, *thanks for the heads up @sdwheeler !*
MD012

One exception is in the PSReadLine lines 51-52 that triggered MD024 as its a duplicate of lines 42-43

Next batch containing some other MD rules for 7.5 and content coming up as well this week.

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
