### PR TITLE
Fixing Passthru to proper PascalCase

### DIFF
--- a/reference/5.1/CimCmdlets/Set-CimInstance.md
+++ b/reference/5.1/CimCmdlets/Set-CimInstance.md
@@ -100,14 +100,14 @@ Set-CimInstance -InputObject $x -Property @{VariableValue="somevalue"} -PassThru
 This example retrieves the CIM instance objects filtered by the Query parameter in to a variable
 `$x` using `Get-CimInstance`, and then passes the contents of the variable to the `Set-CimInstance`
 cmdlet. `Set-CimInstance` then modifies the **VariableValue** property to **somevalue**. Because the
-**Passthru** parameter is used, This example returns a modified CIM instance object.
+**PassThru** parameter is used, This example returns a modified CIM instance object.
 
 ### Example 4: Set the CIM instance property
 
 This example retrieves the CIM instance object that is specified in the **Query** parameter into a
 variable `$x` using the `Get-CimInstance` cmdlet, and changes the **VariableValue** property value
 of the object to change. The CIM instance object is then saved using the `Set-CimInstance` cmdlet.
-Because the **Passthru** parameter is used, This example returns a modified CIM instance object.
+Because the **PassThru** parameter is used, This example returns a modified CIM instance object.
 
 ```powershell
 $x = Get-CimInstance -Query 'Select * from Win32_Environment where name="testvar"'
@@ -138,7 +138,7 @@ Set-CimInstance -Query 'Select * from Win32_Environment where name LIKE "testvar
 This example creates a CIM instance with the specified properties using the `New-CimInstance`
 cmdlet, and retrieves its contents in to a variable `$x`. The variable is then passed to the
 `Set-CimInstance` cmdlet, which modifies the value of **VariableValue** property to **somevalue**.
-Because the **Passthru** parameter is used, This example returns a modified CIM instance object.
+Because the **PassThru** parameter is used, This example returns a modified CIM instance object.
 
 ```powershell
 $x = New-CimInstance -ClassName Win32_Environment -Property @{Name="testvar";UserName="domain\user"} -Key Name,UserName -ClientOnly
@@ -409,7 +409,7 @@ By default, this cmdlet returns no output.
 
 ### Microsoft.Management.Infrastructure.CimInstance
 
-When you use the **Passthru** parameter, this cmdlet returns the modified CIM instance object.
+When you use the **PassThru** parameter, this cmdlet returns the modified CIM instance object.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Add-History.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Add-History.md
@@ -16,7 +16,7 @@ Appends entries to the session history.
 ## SYNTAX
 
 ```
-Add-History [[-InputObject] <PSObject[]>] [-Passthru] [<CommonParameters>]
+Add-History [[-InputObject] <PSObject[]>] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -138,7 +138,7 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Passthru
+### -PassThru
 
 Indicates that this cmdlet returns a **HistoryInfo** object for each history entry. By default, this
 cmdlet does not generate any output.

--- a/reference/5.1/Microsoft.PowerShell.Core/Add-PSSnapin.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Add-PSSnapin.md
@@ -46,7 +46,7 @@ This command adds the Microsoft Exchange and Active Directory snap-ins to the cu
 ### Example 2: Add all the registered snap-ins
 
 ```powershell
-PS C:\> Get-PSSnapin -Registered | Add-PSSnapin -Passthru
+PS C:\> Get-PSSnapin -Registered | Add-PSSnapin -PassThru
 ```
 
 This command adds all of the registered Windows PowerShell snap-ins to the session. It uses the

--- a/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
@@ -292,7 +292,7 @@ TestCmdlets       Script
 ```
 
 ```powershell
-$a = Import-Module -Name Show-Calendar -AsCustomObject -Passthru
+$a = Import-Module -Name Show-Calendar -AsCustomObject -PassThru
 $a | Get-Member
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Security/Set-Acl.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Set-Acl.md
@@ -19,14 +19,14 @@ Changes the security descriptor of a specified item, such as a file or a registr
 
 ```
 Set-Acl [-Path] <String[]> [-AclObject] <Object> [[-CentralAccessPolicy] <String>] [-ClearCentralAccessPolicy]
- [-Passthru] [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-WhatIf] [-Confirm]
+ [-PassThru] [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-WhatIf] [-Confirm]
  [-UseTransaction] [<CommonParameters>]
 ```
 
 ### ByInputObject
 
 ```
-Set-Acl [-InputObject] <PSObject> [-AclObject] <Object> [-Passthru] [-Filter <String>] [-Include <String[]>]
+Set-Acl [-InputObject] <PSObject> [-AclObject] <Object> [-PassThru] [-Filter <String>] [-Include <String[]>]
  [-Exclude <String[]>] [-WhatIf] [-Confirm] [-UseTransaction] [<CommonParameters>]
 ```
 
@@ -34,7 +34,7 @@ Set-Acl [-InputObject] <PSObject> [-AclObject] <Object> [-Passthru] [-Filter <St
 
 ```
 Set-Acl -LiteralPath <String[]> [-AclObject] <Object> [[-CentralAccessPolicy] <String>]
- [-ClearCentralAccessPolicy] [-Passthru] [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
+ [-ClearCentralAccessPolicy] [-PassThru] [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>]
  [-WhatIf] [-Confirm] [-UseTransaction] [<CommonParameters>]
 ```
 
@@ -341,7 +341,7 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -Passthru
+### -PassThru
 
 Returns an object that represents the security descriptor that was changed. By default, this cmdlet
 does not generate any output.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -434,7 +434,7 @@ Specifies the output file for which this cmdlet saves the response body. Enter a
 If you omit the path, the default is the current location.
 
 By default, `Invoke-WebRequest` returns the results to the pipeline. To send the results to a file
-and to the pipeline, use the **Passthru** parameter.
+and to the pipeline, use the **PassThru** parameter.
 
 ```yaml
 Type: System.String

--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-GridView.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-GridView.md
@@ -188,7 +188,7 @@ The values of this parameter determine how many items you can send down the pipe
 - `Single`. Zero items or one item. Use this value when the next command can take only one input
   object.
 - `Multiple`. Zero, one, or many items. Use this value when the next command can take multiple input
-  objects. This value is equivalent to the **Passthru** parameter.
+  objects. This value is equivalent to the **PassThru** parameter.
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/5.1/PSScheduledJob/About/about_Scheduled_Jobs.md
+++ b/reference/5.1/PSScheduledJob/About/about_Scheduled_Jobs.md
@@ -96,7 +96,7 @@ This example uses the **ContinueIfGoingOnBattery** parameter of the
 
 ```powershell
 Get-ScheduledJob -Name ProcessJob | Set-ScheduledJobOption `
--ContinueIfGoingOnBattery -Passthru
+-ContinueIfGoingOnBattery -PassThru
 ```
 
 ```Output

--- a/reference/5.1/PSScheduledJob/Disable-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Disable-ScheduledJob.md
@@ -59,7 +59,7 @@ This cmdlet was introduced in Windows PowerShell 3.0.
 This example disables a scheduled job on the local computer.
 
 ```powershell
-Disable-ScheduledJob -ID 2 -Passthru
+Disable-ScheduledJob -ID 2 -PassThru
 ```
 
 This command disables the scheduled job with ID 2 on the local computer.
@@ -69,7 +69,7 @@ This command disables the scheduled job with ID 2 on the local computer.
 This example disables all scheduled jobs on the local computer.
 
 ```powershell
-Get-ScheduledJob | Disable-ScheduledJob -Passthru
+Get-ScheduledJob | Disable-ScheduledJob -PassThru
 ```
 
 ```Output

--- a/reference/5.1/PSScheduledJob/Enable-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Enable-ScheduledJob.md
@@ -57,7 +57,7 @@ This cmdlet was introduced in Windows PowerShell 3.0.
 This example enables the scheduled job on a local computer.
 
 ```powershell
-Enable-ScheduledJob -ID 2 -Passthru
+Enable-ScheduledJob -ID 2 -PassThru
 ```
 
 The `Enable-ScheduledJob` command enables the scheduled job with ID 2 on the local computer. The

--- a/reference/5.1/PSScheduledJob/Set-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Set-JobTrigger.md
@@ -69,7 +69,7 @@ Id         Frequency       Time                   DaysOfWeek              Enable
 ```
 
 ```powershell
-Get-JobTrigger -Name "DeployPackage" | Set-JobTrigger -DaysOfWeek "Wednesday", "Sunday" -Passthru
+Get-JobTrigger -Name "DeployPackage" | Set-JobTrigger -DaysOfWeek "Wednesday", "Sunday" -PassThru
 ```
 
 ```Output
@@ -85,7 +85,7 @@ Saturdays.
 The second command uses the `Get-JobTrigger` cmdlet to get the job trigger of the `DeployPackage`
 scheduled job. A pipeline operator (`|`) sends the trigger to the `Set-JobTrigger` cmdlet, which
 changes the job trigger so that it starts the `DeployPackage` job on Wednesdays and Sundays. The
-command uses the **Passthru** parameter to return the trigger after the change.
+command uses the **PassThru** parameter to return the trigger after the change.
 
 This command is not required; it is included only to show the effect of the trigger change.
 
@@ -124,7 +124,7 @@ The second command uses the `Get-JobTrigger` cmdlet to get the **AtStartup** job
 `Inventory` job. The command uses the **TriggerID** parameter to identify the job trigger. A
 pipeline operator (`|`) sends the job trigger to the `Set-JobTrigger` cmdlet, which changes it to a
 weekly job trigger that runs every four weeks on Monday at midnight. The command uses the
-**Passthru** parameter to return the trigger after the change.
+**PassThru** parameter to return the trigger after the change.
 
 This command is not required; it is included only to show the effect of the trigger change.
 

--- a/reference/5.1/PSScheduledJob/Set-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Set-ScheduledJob.md
@@ -88,7 +88,7 @@ Id         Name            Triggers        Command                              
 ```
 
 ```powershell
-Get-ScheduledJob -Name "Inventory" | Set-ScheduledJob -FilePath "C:\Scripts\Get-FullInventory.ps1" -Passthru
+Get-ScheduledJob -Name "Inventory" | Set-ScheduledJob -FilePath "C:\Scripts\Get-FullInventory.ps1" -PassThru
 ```
 
 ```Output
@@ -103,7 +103,7 @@ shows that the job runs the Get-Inventory.ps1 script.
 The second command uses the `Get-ScheduledJob` cmdlet to get the Inventory scheduled job. A pipeline
 operator (`|`) sends the scheduled job to the `Set-ScheduledJob` cmdlet. The `Set-ScheduledJob`
 cmdlet uses the **Script** parameter to specify a new script, `Get-FullInventory.ps1`. The command
-uses the **Passthru** parameter to return the scheduled job after the change.
+uses the **PassThru** parameter to return the scheduled job after the change.
 
 This command is not required; it is included only to show the effect of the script change.
 

--- a/reference/5.1/PSScheduledJob/Set-ScheduledJobOption.md
+++ b/reference/5.1/PSScheduledJob/Set-ScheduledJobOption.md
@@ -77,7 +77,7 @@ JobDefinition          :
 
 ```powershell
 Get-ScheduledJobOption -Name "DeployPackage" |
-    Set-ScheduledJobOption -WakeToRun -RequireNetwork:$false -Passthru
+    Set-ScheduledJobOption -WakeToRun -RequireNetwork:$false -PassThru
 ```
 
 ```Output
@@ -103,7 +103,7 @@ DeployPackage scheduled job. The output shows that the WakeToRun and RunElevated
 to `$false`.
 
 The second command uses the `Set-ScheduledJobOpton` cmdlet to change the job options so the values
-of the WakeToRun and RunWithoutNetwork properties are $True. The command uses the **Passthru**
+of the WakeToRun and RunWithoutNetwork properties are $True. The command uses the **PassThru**
 parameter to return the trigger after the change.
 
 This command is not required; it is included only to show the effect of the option change.

--- a/reference/7.4/CimCmdlets/Set-CimInstance.md
+++ b/reference/7.4/CimCmdlets/Set-CimInstance.md
@@ -102,14 +102,14 @@ Set-CimInstance -InputObject $x -Property @{VariableValue="somevalue"} -PassThru
 This example retrieves the CIM instance objects filtered by the Query parameter in to a variable
 `$x` using `Get-CimInstance`, and then passes the contents of the variable to the `Set-CimInstance`
 cmdlet. `Set-CimInstance` then modifies the **VariableValue** property to **somevalue**. Because the
-**Passthru** parameter is used, This example returns a modified CIM instance object.
+**PassThru** parameter is used, This example returns a modified CIM instance object.
 
 ### Example 4: Set the CIM instance property
 
 This example retrieves the CIM instance object that is specified in the **Query** parameter into a
 variable `$x` using the `Get-CimInstance` cmdlet, and changes the **VariableValue** property value
 of the object to change. The CIM instance object is then saved using the `Set-CimInstance` cmdlet.
-Because the **Passthru** parameter is used, This example returns a modified CIM instance object.
+Because the **PassThru** parameter is used, This example returns a modified CIM instance object.
 
 ```powershell
 $x = Get-CimInstance -Query 'Select * from Win32_Environment where name="testvar"'
@@ -140,7 +140,7 @@ Set-CimInstance -Query 'Select * from Win32_Environment where name LIKE "testvar
 This example creates a CIM instance with the specified properties using the `New-CimInstance`
 cmdlet, and retrieves its contents in to a variable `$x`. The variable is then passed to the
 `Set-CimInstance` cmdlet, which modifies the value of **VariableValue** property to **somevalue**.
-Because the **Passthru** parameter is used, This example returns a modified CIM instance object.
+Because the **PassThru** parameter is used, This example returns a modified CIM instance object.
 
 ```powershell
 $x = New-CimInstance -ClassName Win32_Environment -Property @{Name="testvar";UserName="domain\user"} -Key Name,UserName -ClientOnly
@@ -411,7 +411,7 @@ By default, this cmdlet returns no output.
 
 ### Microsoft.Management.Infrastructure.CimInstance
 
-When you use the **Passthru** parameter, this cmdlet returns the modified CIM instance object.
+When you use the **PassThru** parameter, this cmdlet returns the modified CIM instance object.
 
 ## NOTES
 

--- a/reference/7.4/Microsoft.PowerShell.Core/Add-History.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Add-History.md
@@ -16,7 +16,7 @@ Appends entries to the session history.
 ## SYNTAX
 
 ```
-Add-History [[-InputObject] <PSObject[]>] [-Passthru] [<CommonParameters>]
+Add-History [[-InputObject] <PSObject[]>] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -138,7 +138,7 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Passthru
+### -PassThru
 
 Indicates that this cmdlet returns a **HistoryInfo** object for each history entry. By default, this
 cmdlet does not generate any output.

--- a/reference/7.4/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Import-Module.md
@@ -311,7 +311,7 @@ TestCmdlets       Script
 ```
 
 ```powershell
-$a = Import-Module -Name Show-Calendar -AsCustomObject -Passthru
+$a = Import-Module -Name Show-Calendar -AsCustomObject -PassThru
 $a | Get-Member
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Security/Set-Acl.md
+++ b/reference/7.4/Microsoft.PowerShell.Security/Set-Acl.md
@@ -18,21 +18,21 @@ Changes the security descriptor of a specified item, such as a file or a registr
 ### ByPath (Default)
 
 ```
-Set-Acl [-Path] <String[]> [-AclObject] <Object> [-ClearCentralAccessPolicy] [-Passthru] [-Filter <String>]
+Set-Acl [-Path] <String[]> [-AclObject] <Object> [-ClearCentralAccessPolicy] [-PassThru] [-Filter <String>]
  [-Include <String[]>] [-Exclude <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByInputObject
 
 ```
-Set-Acl [-InputObject] <PSObject> [-AclObject] <Object> [-Passthru] [-Filter <String>] [-Include <String[]>]
+Set-Acl [-InputObject] <PSObject> [-AclObject] <Object> [-PassThru] [-Filter <String>] [-Include <String[]>]
  [-Exclude <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Set-Acl -LiteralPath <String[]> [-AclObject] <Object> [-ClearCentralAccessPolicy] [-Passthru]
+Set-Acl -LiteralPath <String[]> [-AclObject] <Object> [-ClearCentralAccessPolicy] [-PassThru]
  [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -318,7 +318,7 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -Passthru
+### -PassThru
 
 Returns an object that represents the security descriptor that was changed. By default, this cmdlet
 does not generate any output.

--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -892,7 +892,7 @@ Accept wildcard characters: False
 
 By default, `Invoke-RestMethod` returns the results to the pipeline. When you use the **OutFile**
 parameter, the results are saved to the specified file and not returned to the pipeline. Enter a
-path and filename. To send the results to a file and to the pipeline, add the **Passthru**
+path and filename. To send the results to a file and to the pipeline, add the **PassThru**
 parameter.
 
 If you omit the path, the default is the current location. The name is treated as a literal path.

--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -917,7 +917,7 @@ Accept wildcard characters: False
 
 By default, `Invoke-WebRequest` returns the results to the pipeline. When you use the **OutFile**
 parameter, the results are saved to the specified file and not returned to the pipeline. Enter a
-path and filename. To send the results to a file and to the pipeline, add the **Passthru**
+path and filename. To send the results to a file and to the pipeline, add the **PassThru**
 parameter.
 
 If you omit the path, the default is the current location. The name is treated as a literal path.

--- a/reference/7.4/Microsoft.PowerShell.Utility/Out-GridView.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Out-GridView.md
@@ -196,7 +196,7 @@ The values of this parameter determine how many items you can send down the pipe
 - `Single`. Zero items or one item. Use this value when the next command can take only one input
   object.
 - `Multiple`. Zero, one, or many items. Use this value when the next command can take multiple input
-  objects. This value is equivalent to the **Passthru** parameter.
+  objects. This value is equivalent to the **PassThru** parameter.
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/7.5/CimCmdlets/Set-CimInstance.md
+++ b/reference/7.5/CimCmdlets/Set-CimInstance.md
@@ -102,14 +102,14 @@ Set-CimInstance -InputObject $x -Property @{VariableValue="somevalue"} -PassThru
 This example retrieves the CIM instance objects filtered by the Query parameter in to a variable
 `$x` using `Get-CimInstance`, and then passes the contents of the variable to the `Set-CimInstance`
 cmdlet. `Set-CimInstance` then modifies the **VariableValue** property to **somevalue**. Because the
-**Passthru** parameter is used, This example returns a modified CIM instance object.
+**PassThru** parameter is used, This example returns a modified CIM instance object.
 
 ### Example 4: Set the CIM instance property
 
 This example retrieves the CIM instance object that is specified in the **Query** parameter into a
 variable `$x` using the `Get-CimInstance` cmdlet, and changes the **VariableValue** property value
 of the object to change. The CIM instance object is then saved using the `Set-CimInstance` cmdlet.
-Because the **Passthru** parameter is used, This example returns a modified CIM instance object.
+Because the **PassThru** parameter is used, This example returns a modified CIM instance object.
 
 ```powershell
 $x = Get-CimInstance -Query 'Select * from Win32_Environment where name="testvar"'
@@ -140,7 +140,7 @@ Set-CimInstance -Query 'Select * from Win32_Environment where name LIKE "testvar
 This example creates a CIM instance with the specified properties using the `New-CimInstance`
 cmdlet, and retrieves its contents in to a variable `$x`. The variable is then passed to the
 `Set-CimInstance` cmdlet, which modifies the value of **VariableValue** property to **somevalue**.
-Because the **Passthru** parameter is used, This example returns a modified CIM instance object.
+Because the **PassThru** parameter is used, This example returns a modified CIM instance object.
 
 ```powershell
 $x = New-CimInstance -ClassName Win32_Environment -Property @{Name="testvar";UserName="domain\user"} -Key Name,UserName -ClientOnly
@@ -411,7 +411,7 @@ By default, this cmdlet returns no output.
 
 ### Microsoft.Management.Infrastructure.CimInstance
 
-When you use the **Passthru** parameter, this cmdlet returns the modified CIM instance object.
+When you use the **PassThru** parameter, this cmdlet returns the modified CIM instance object.
 
 ## NOTES
 

--- a/reference/7.5/Microsoft.PowerShell.Core/Add-History.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Add-History.md
@@ -16,7 +16,7 @@ Appends entries to the session history.
 ## SYNTAX
 
 ```
-Add-History [[-InputObject] <PSObject[]>] [-Passthru] [<CommonParameters>]
+Add-History [[-InputObject] <PSObject[]>] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -138,7 +138,7 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Passthru
+### -PassThru
 
 Indicates that this cmdlet returns a **HistoryInfo** object for each history entry. By default, this
 cmdlet does not generate any output.

--- a/reference/7.5/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Import-Module.md
@@ -311,7 +311,7 @@ TestCmdlets       Script
 ```
 
 ```powershell
-$a = Import-Module -Name Show-Calendar -AsCustomObject -Passthru
+$a = Import-Module -Name Show-Calendar -AsCustomObject -PassThru
 $a | Get-Member
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Security/Set-Acl.md
+++ b/reference/7.5/Microsoft.PowerShell.Security/Set-Acl.md
@@ -18,21 +18,21 @@ Changes the security descriptor of a specified item, such as a file or a registr
 ### ByPath (Default)
 
 ```
-Set-Acl [-Path] <String[]> [-AclObject] <Object> [-ClearCentralAccessPolicy] [-Passthru] [-Filter <String>]
+Set-Acl [-Path] <String[]> [-AclObject] <Object> [-ClearCentralAccessPolicy] [-PassThru] [-Filter <String>]
  [-Include <String[]>] [-Exclude <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByInputObject
 
 ```
-Set-Acl [-InputObject] <PSObject> [-AclObject] <Object> [-Passthru] [-Filter <String>] [-Include <String[]>]
+Set-Acl [-InputObject] <PSObject> [-AclObject] <Object> [-PassThru] [-Filter <String>] [-Include <String[]>]
  [-Exclude <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Set-Acl -LiteralPath <String[]> [-AclObject] <Object> [-ClearCentralAccessPolicy] [-Passthru]
+Set-Acl -LiteralPath <String[]> [-AclObject] <Object> [-ClearCentralAccessPolicy] [-PassThru]
  [-Filter <String>] [-Include <String[]>] [-Exclude <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -318,7 +318,7 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -Passthru
+### -PassThru
 
 Returns an object that represents the security descriptor that was changed. By default, this cmdlet
 does not generate any output.

--- a/reference/7.5/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -892,7 +892,7 @@ Accept wildcard characters: False
 
 By default, `Invoke-RestMethod` returns the results to the pipeline. When you use the **OutFile**
 parameter, the results are saved to the specified file and not returned to the pipeline. Enter a
-path and filename. To send the results to a file and to the pipeline, add the **Passthru**
+path and filename. To send the results to a file and to the pipeline, add the **PassThru**
 parameter.
 
 If you omit the path, the default is the current location. The name is treated as a literal path.

--- a/reference/7.5/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -917,7 +917,7 @@ Accept wildcard characters: False
 
 By default, `Invoke-WebRequest` returns the results to the pipeline. When you use the **OutFile**
 parameter, the results are saved to the specified file and not returned to the pipeline. Enter a
-path and filename. To send the results to a file and to the pipeline, add the **Passthru**
+path and filename. To send the results to a file and to the pipeline, add the **PassThru**
 parameter.
 
 If you omit the path, the default is the current location. The name is treated as a literal path.

--- a/reference/7.5/Microsoft.PowerShell.Utility/Out-GridView.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Out-GridView.md
@@ -196,7 +196,7 @@ The values of this parameter determine how many items you can send down the pipe
 - `Single`. Zero items or one item. Use this value when the next command can take only one input
   object.
 - `Multiple`. Zero, one, or many items. Use this value when the next command can take multiple input
-  objects. This value is equivalent to the **Passthru** parameter.
+  objects. This value is equivalent to the **PassThru** parameter.
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/docs-conceptual/samples/Manipulating-Items-Directly.md
+++ b/reference/docs-conceptual/samples/Manipulating-Items-Directly.md
@@ -187,7 +187,7 @@ in the command. If you have already copied the directory without its contents, a
 parameter, which allows you to overwrite the empty folder.
 
 ```powershell
-Copy-Item -Path C:\New.Directory -Destination C:\temp -Recurse -Force -Passthru
+Copy-Item -Path C:\New.Directory -Destination C:\temp -Recurse -Force -PassThru
 ```
 
 ```Output


### PR DESCRIPTION
# PR Summary

This pull requests fixes every instance of -Passthru to proper CamelCase of -PassThru
This excludes the 7.2 sub folder as its being removed

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
