### PR TITLE
(GH-11534) Separate codeblocks for installing with WinGet by ID

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-on-Windows.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-on-Windows.md
@@ -63,6 +63,9 @@ Install PowerShell or PowerShell Preview using the `id` parameter
 
 ```powershell
 winget install --id Microsoft.PowerShell --source winget
+```
+
+```powershell
 winget install --id Microsoft.PowerShell.Preview --source winget
 ```
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the article for installing PowerShell on Windows used a single codeblock to show readers how to install PowerShell and PowerShell preview with WinGet by ID. On the webpage, this results in a single codeblock with a copy button. If a reader uses the copy button and pastes the copied code into their terminal, both commands will run. If a user wanted to install only one edition, they need to edit the copied code to remove the line they don't want.

This change:

- Separates the codeblocks for installing PowerShell with WinGet and specifying the ID parameter for PowerShell and PowerShell preview, so that readers may copy either codeblock and paste into their terminal instead of copying both.
- Fixes #11534
- Fixes [AB#343802](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/343802)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
