### PR TITLE
Fix powershell-lts verification command

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-on-macOS.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-on-macOS.md
@@ -93,7 +93,7 @@ brew install powershell/tap/powershell-lts
 You can now verify your install
 
 ```sh
-pwsh
+pwsh-lts
 ```
 
 When new versions of PowerShell are released, run the following command.


### PR DESCRIPTION
# PR Summary

Update the installation verification command for powershell-lts on macOS, replacing `pwsh` with the correct `pwsh-lts`.

