### PR TITLE
Fix about_Regular_Expressions.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -214,7 +214,7 @@ To read more about these options and how to use them, visit the
 The backslash (`\`) is used to escape characters so they aren't parsed by the
 regular expression engine.
 
-The following characters are reserved: `[]().\^$|?*+{}`.
+The following characters are reserved: `[().\^$|?*+{`.
 
 You'll need to escape these characters in your patterns to match them in your
 input strings.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -214,7 +214,7 @@ To read more about these options and how to use them, visit the
 The backslash (`\`) is used to escape characters so they aren't parsed by the
 regular expression engine.
 
-The following characters are reserved: `[]().\^$|?*+{}`.
+The following characters are reserved: `[().\^$|?*+{`.
 
 You'll need to escape these characters in your patterns to match them in your
 input strings.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -215,7 +215,7 @@ To read more about these options and how to use them, visit the
 The backslash (`\`) is used to escape characters so they aren't parsed by the
 regular expression engine.
 
-The following characters are reserved: `[]().\^$|?*+{}`.
+The following characters are reserved: `[().\^$|?*+{`.
 
 You'll need to escape these characters in your patterns to match them in your
 input strings.


### PR DESCRIPTION
# PR Summary

According to [Character Escapes in Regular Expressions](https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-escapes-in-regular-expressions) \
(and even `[regex]::escape('3.\d{2,}')` example below) \
closing square bracket `]` and closing squiggle brace `}` are not special symbols and need not to be escaped.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].


[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
