### PR TITLE
Updated Write-Output cmdlet documentations (5.1, 7.4, 7.5) because -NoEnumerate switch was missing in example.

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Output.md
@@ -105,7 +105,8 @@ Accept wildcard characters: False
 By default, the `Write-Output` cmdlet always enumerates its output. The **NoEnumerate** parameter
 suppresses the default behavior, and prevents `Write-Output` from enumerating output. The
 **NoEnumerate** parameter has no effect if the command is wrapped in parentheses, because the
-parentheses force enumeration. For example, `(Write-Output 1,2,3)` still enumerates the array.
+parentheses force enumeration. For example, `(Write-Output 1,2,3 -NoEnumerate)` still enumerates
+the array.
 
 The **NoEnumerate** parameter is only useful within a pipeline. Trying to see the effects of
 **NoEnumerate** in the console is problematic because PowerShell adds `Out-Default` to the end of

--- a/reference/7.4/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Write-Output.md
@@ -105,7 +105,8 @@ Accept wildcard characters: False
 By default, the `Write-Output` cmdlet always enumerates its output. The **NoEnumerate** parameter
 suppresses the default behavior, and prevents `Write-Output` from enumerating output. The
 **NoEnumerate** parameter has no effect if the command is wrapped in parentheses, because the
-parentheses force enumeration. For example, `(Write-Output 1,2,3)` still enumerates the array.
+parentheses force enumeration. For example, `(Write-Output 1,2,3 -NoEnumerate)` still enumerates
+the array.
 
 The **NoEnumerate** parameter is only useful within a pipeline. Trying to see the effects of
 **NoEnumerate** in the console is problematic because PowerShell adds `Out-Default` to the end of

--- a/reference/7.5/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Write-Output.md
@@ -105,7 +105,8 @@ Accept wildcard characters: False
 By default, the `Write-Output` cmdlet always enumerates its output. The **NoEnumerate** parameter
 suppresses the default behavior, and prevents `Write-Output` from enumerating output. The
 **NoEnumerate** parameter has no effect if the command is wrapped in parentheses, because the
-parentheses force enumeration. For example, `(Write-Output 1,2,3)` still enumerates the array.
+parentheses force enumeration. For example, `(Write-Output 1,2,3 -NoEnumerate)` still enumerates
+the array.
 
 The **NoEnumerate** parameter is only useful within a pipeline. Trying to see the effects of
 **NoEnumerate** in the console is problematic because PowerShell adds `Out-Default` to the end of


### PR DESCRIPTION
# PR Summary

Added `-NoEnumerate` switch to example in `Write-Output` cmdlet documentation (5.1, 7.4, 7.5) because without that switch it didn't make sense in that context. 

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
