### PR TITLE
Lower sub-heading since it's related to previous heading

### DIFF
--- a/reference/docs-conceptual/security/preventing-script-injection.md
+++ b/reference/docs-conceptual/security/preventing-script-injection.md
@@ -158,7 +158,7 @@ statements, one of which is arbitrary code injected by the user.
 pwnd!
 ```
 
-### Use the `EscapeSingleQuotedStringContent()` method
+#### Use the `EscapeSingleQuotedStringContent()` method
 
 To protect against the user inserting their own single quote characters to exploit the function you
 must use the `EscapeSingleQuotedStringContent()` API. This is a static public method of the PowerShell


### PR DESCRIPTION
# PR Summary

This section about "Use the EscapeSingleQuotedStringContent() method" is only relevant in the context of the "Wrap strings in single quotes" just above so it should be a sub-heading of it instead of a same-level heading following it

See how the previous ends "A malicious user can still use single quotes in their input to inject code." and this one begins "To protect against the user inserting their own single quote characters [...]"

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
