### PR TITLE
Add missing containment operators to list

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 06/06/2024
+ms.date: 01/19/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
@@ -44,8 +44,8 @@ specified patterns. PowerShell includes the following comparison operators:
 - `-contains`, `-icontains`, `-ccontains` - collection contains a value
 - `-notcontains`, `-inotcontains`, `-cnotcontains` - collection doesn't
   contain a value
-- `-in` - value is in a collection
-- `-notin` - value isn't in a collection
+- `-in`, `-iin`, `-cin` - value is in a collection
+- `-notin`, `-inotin`, `-cnotin` - value isn't in a collection
 
 **Type**
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 06/06/2024
+ms.date: 01/19/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
@@ -44,8 +44,8 @@ specified patterns. PowerShell includes the following comparison operators:
 - `-contains`, `-icontains`, `-ccontains` - collection contains a value
 - `-notcontains`, `-inotcontains`, `-cnotcontains` - collection doesn't
   contain a value
-- `-in` - value is in a collection
-- `-notin` - value isn't in a collection
+- `-in`, `-iin`, `-cin` - value is in a collection
+- `-notin`, `-inotin`, `-cnotin` - value isn't in a collection
 
 **Type**
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 06/06/2024
+ms.date: 01/19/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
@@ -44,8 +44,8 @@ specified patterns. PowerShell includes the following comparison operators:
 - `-contains`, `-icontains`, `-ccontains` - collection contains a value
 - `-notcontains`, `-inotcontains`, `-cnotcontains` - collection doesn't
   contain a value
-- `-in` - value is in a collection
-- `-notin` - value isn't in a collection
+- `-in`, `-iin`, `-cin` - value is in a collection
+- `-notin`, `-inotin`, `-cnotin` - value isn't in a collection
 
 **Type**
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,7 +1,7 @@
 ---
 description: Describes the operators that compare values in PowerShell.
 Locale: en-US
-ms.date: 06/06/2024
+ms.date: 01/19/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Comparison_Operators
@@ -44,8 +44,8 @@ specified patterns. PowerShell includes the following comparison operators:
 - `-contains`, `-icontains`, `-ccontains` - collection contains a value
 - `-notcontains`, `-inotcontains`, `-cnotcontains` - collection doesn't
   contain a value
-- `-in` - value is in a collection
-- `-notin` - value isn't in a collection
+- `-in`, `-iin`, `-cin` - value is in a collection
+- `-notin`, `-inotin`, `-cnotin` - value isn't in a collection
 
 **Type**
 


### PR DESCRIPTION
# PR Summary

This adds the missing `-iin`, `-cin`, `-inotin` and `-cnotin` operators to the list in `about_Comparison_Operators`.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide