### PR TITLE
(GH-11696) Fix note about static property mutablity

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes_Properties.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes_Properties.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to define properties for PowerShell classes.
 Locale: en-US
-ms.date: 11/13/2023
+ms.date: 01/21/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_classes_properties?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Classes_Properties
@@ -527,7 +527,8 @@ properties:
 
 > [!IMPORTANT]
 > Static properties for classes defined in PowerShell aren't immutable. They
-> can
+> can be overridden to any valid value, as defined by the static property's
+> type and attributes.
 
 ## Derived class properties
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Classes_Properties.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Classes_Properties.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to define properties for PowerShell classes.
 Locale: en-US
-ms.date: 11/13/2023
+ms.date: 01/21/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_classes_properties?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Classes_Properties
@@ -523,7 +523,8 @@ properties:
 
 > [!IMPORTANT]
 > Static properties for classes defined in PowerShell aren't immutable. They
-> can
+> can be overridden to any valid value, as defined by the static property's
+> type and attributes.
 
 ## Derived class properties
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Classes_Properties.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Classes_Properties.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to define properties for PowerShell classes.
 Locale: en-US
-ms.date: 11/13/2023
+ms.date: 01/21/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_classes_properties?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Classes_Properties
@@ -522,7 +522,8 @@ properties:
 
 > [!IMPORTANT]
 > Static properties for classes defined in PowerShell aren't immutable. They
-> can
+> can be overridden to any valid value, as defined by the static property's
+> type and attributes.
 
 ## Derived class properties
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Classes_Properties.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Classes_Properties.md
@@ -1,7 +1,7 @@
 ---
 description: Describes how to define properties for PowerShell classes.
 Locale: en-US
-ms.date: 11/13/2023
+ms.date: 01/21/2025
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_classes_properties?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: about_Classes_Properties
@@ -523,7 +523,8 @@ properties:
 
 > [!IMPORTANT]
 > Static properties for classes defined in PowerShell aren't immutable. They
-> can
+> can be overridden to any valid value, as defined by the static property's
+> type and attributes.
 
 ## Derived class properties
 


### PR DESCRIPTION
# PR Summary

This change fixes #11696 by adding the missing text explaining how static properties defined on classes implemented in PowerShell are not immutable and can be overriden.


## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
