### PR TITLE
Fix `about_Type_Accelerators` typo

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Type_Accelerators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Type_Accelerators.md
@@ -35,7 +35,7 @@ cast an object to a specific type. For those cases, you must enclose the type
 name or its accelerator in square brackets (`[]`). For example, `[int]` or
 `[int32]`.
 
-In some contexts, you can specify allow type accelerator name as a string. For
+In some contexts, you can specify the type accelerator name as a string. For
 example:
 
 - When used with type comparison operators

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Type_Accelerators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Type_Accelerators.md
@@ -35,7 +35,7 @@ cast an object to a specific type. For those cases, you must enclose the type
 name or its accelerator in square brackets (`[]`). For example, `[int]` or
 `[int32]`.
 
-In some contexts, you can specify allow type accelerator name as a string. For
+In some contexts, you can specify the type accelerator name as a string. For
 example:
 
 - When used with type comparison operators

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Type_Accelerators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Type_Accelerators.md
@@ -35,7 +35,7 @@ cast an object to a specific type. For those cases, you must enclose the type
 name or its accelerator in square brackets (`[]`). For example, `[int]` or
 `[int32]`.
 
-In some contexts, you can specify allow type accelerator name as a string. For
+In some contexts, you can specify the type accelerator name as a string. For
 example:
 
 - When used with type comparison operators

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Type_Accelerators.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Type_Accelerators.md
@@ -35,7 +35,7 @@ cast an object to a specific type. For those cases, you must enclose the type
 name or its accelerator in square brackets (`[]`). For example, `[int]` or
 `[int32]`.
 
-In some contexts, you can specify allow type accelerator name as a string. For
+In some contexts, you can specify the type accelerator name as a string. For
 example:
 
 - When used with type comparison operators


### PR DESCRIPTION
# PR Summary

This fixes a typo in [`about_Type_Accelerators`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_type_accelerators#using-type-accelerators).

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide