### PR TITLE
docs: Mention PS 5.1 bug where Start-Transcript inverts when it should log Write-Information messages

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -266,6 +266,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -WarningAction, and -WarningVariable. For more information, see
 [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
+> [!NOTE]
+> The `Write-Information` logic is reversed in `Start-Transcript`. This means if the
+> **InformationPreference** is set to `Continue`, Information messages will be written to the
+> console, but not to the transcript file. If the **InformationPreference** is set to
+> `SilentlyContinue`, Information messages will not be written to the console, but will be written
+> to the transcript file. This is fixed in PowerShell 6.
+
 ## INPUTS
 
 ### None

--- a/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -266,12 +266,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 -WarningAction, and -WarningVariable. For more information, see
 [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-> [!NOTE]
-> The `Write-Information` logic is reversed in `Start-Transcript`. This means if the
-> **InformationPreference** is set to `Continue`, Information messages will be written to the
-> console, but not to the transcript file. If the **InformationPreference** is set to
-> `SilentlyContinue`, Information messages will not be written to the console, but will be written
-> to the transcript file. This is fixed in PowerShell 6.
 
 ## INPUTS
 
@@ -291,6 +285,13 @@ To stop a transcript, use the `Stop-Transcript` cmdlet.
 
 To record an entire session, add the `Start-Transcript` command to your profile. For more
 information, see [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
+
+> [!NOTE]
+> When you use `Start-Transcript`, the default value of `$InformationPreference`** is changed to
+> `Continue`. Output from `Write-Information` is written to the console, but not to the transcript
+> file. If the **InformationPreference** is set to `SilentlyContinue`, Information messages aren't
+> written to the console, but are written to the transcript file. This is fixed in PowerShell 6 and
+> higher.
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -287,9 +287,9 @@ To record an entire session, add the `Start-Transcript` command to your profile.
 information, see [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
 
 > [!NOTE]
-> When you use `Start-Transcript`, the default value of `$InformationPreference`** is changed to
+> When you use `Start-Transcript`, the default value of `$InformationPreference` is changed to
 > `Continue`. Output from `Write-Information` is written to the console, but not to the transcript
-> file. If the **InformationPreference** is set to `SilentlyContinue`, Information messages aren't
+> file. If the `$InformationPreference` is set to `SilentlyContinue`, Information messages aren't
 > written to the console, but are written to the transcript file. This is fixed in PowerShell 6 and
 > higher.
 


### PR DESCRIPTION
# PR Summary

There is a bug in Windows PowerShell 5.1 with the Start-Transcript cmdlet where it writes Information messages to the transcript file when it shouldn't, and doesn't write them when it should. There is a GitHub repo to easily reproduce this issue [here](https://github.com/deadlydog/PowerShell.Experiment.BugReproductions/blob/main/src/5.1/Start-TranscriptInvertsWrite-Information/ReadMe.md).

This change adds a note to the documentation to make the unexpected behaviour more well-known.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
