### PR TITLE
docs: Mention PS 5.1 bug where Get-ChildItem ignores -Depth parameter when used with -Include

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -522,7 +522,7 @@ output.
 
 > [!NOTE]
 > The **Depth** parameter has no effect when used with the **Include** parameter. To work around
-> this issue, use the **Filter** parameter instead. This is fixed in PowerShell 6.
+> this issue, use the **Filter** parameter instead. This is fixed in PowerShell 6 and higher.
 
 > [!NOTE]
 > On a Windows computer from PowerShell or **cmd.exe**, you can display a graphical view of a

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -521,6 +521,10 @@ and second level of subdirectories. By default directory names and filenames are
 output.
 
 > [!NOTE]
+> The **Depth** parameter has no effect when used with the **Include** parameter. To work around
+> this issue, use the **Filter** parameter instead. This is fixed in PowerShell 6.
+
+> [!NOTE]
 > On a Windows computer from PowerShell or **cmd.exe**, you can display a graphical view of a
 > directory structure with the **tree.com** command.
 
@@ -801,6 +805,10 @@ after the inclusions, which can affect the final output.
 > [!NOTE]
 > The **Include** and **Exclude** parameters have no effect when used with the **LiteralPath**
 > parameter. This is fixed in PowerShell 7.
+
+> [!NOTE]
+> The **Depth** parameter has no effect when used with the **Include** parameter. To work around
+> this issue, use the **Filter** parameter instead. This is fixed in PowerShell 6.
 
 ```yaml
 Type: System.String[]


### PR DESCRIPTION
# PR Summary

There is a bug in Windows PowerShell 5.1 with the Get-ChildItem cmdlet where it ignores the `-Depth` parameter when it is used with the `-Include` parameter. There is a GitHub repo to easily reproduce this issue [here](https://github.com/deadlydog/PowerShell.Experiment.BugReproductions/blob/main/src/5.1/Get-ChildItemIgnoresDepthParameter/ReadMe.md).

This change adds a note to the documentation to make the unexpected behaviour more well-known.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
