### PR TITLE
Fix `$args` automatic variable case (1/13)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -126,7 +126,7 @@ for the following automatic variables:
 
 ```powershell
 $_
-$Args
+$args
 $Input
 $MyInvocation
 $PSBoundParameters
@@ -144,7 +144,7 @@ variable.
 For example,
 
 ```powershell
-$scriptArgs = $Args
+$scriptArgs = $args
 $scriptname = $MyInvocation.PSCommandPath
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -423,15 +423,15 @@ need to declare or enumerate the command parameters, or change the function
 when command parameters change.
 
 The following sample function calls the `Get-Command` cmdlet. The command uses
-`@Args` to represent the parameters of `Get-Command`.
+`@args` to represent the parameters of `Get-Command`.
 
 ```powershell
-function Get-MyCommand { Get-Command @Args }
+function Get-MyCommand { Get-Command @args }
 ```
 
 You can use all the parameters of `Get-Command` when you call the
 `Get-MyCommand` function. The parameters and parameter values are passed to the
-command using `@Args`.
+command using `@args`.
 
 ```powershell
 Get-MyCommand -Name Get-ChildItem
@@ -443,7 +443,7 @@ CommandType     Name                ModuleName
 Cmdlet          Get-ChildItem       Microsoft.PowerShell.Management
 ```
 
-The `@Args` feature uses the `$Args` automatic parameter, which represents
+The `@args` feature uses the `$args` automatic parameter, which represents
 undeclared cmdlet parameters and values from remaining arguments.
 
 For more information, see [about_Splatting][19].

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -23,7 +23,7 @@ When you use the `CmdletBinding` attribute, PowerShell automatically adds the
 Common Parameters. You can't create any parameters that use the same names as
 the Common Parameters. For more information, see [about_CommonParameters][06].
 
-Beginning in PowerShell 3.0, you can use splatting with `@Args` to represent
+Beginning in PowerShell 3.0, you can use splatting with `@args` to represent
 the parameters in a command. Splatting is valid on simple and advanced
 functions. For more information, see [about_Functions][14] and
 [about_Splatting][17].

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -24,7 +24,7 @@ the Common Parameters. For more information, see [about_CommonParameters][02].
 PowerShell binds the parameters of functions that have the `CmdletBinding`
 attribute in the same way that it binds the parameters of compiled cmdlets. The
 `$PSCmdlet` automatic variable is available to functions with the
-`CmdletBinding` attribute, but the `$Args` variable is not available.
+`CmdletBinding` attribute, but the `$args` variable is not available.
 
 In functions that have the `CmdletBinding` attribute, unknown parameters and
 positional arguments that have no matching positional parameters cause

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -258,22 +258,22 @@ You can use splatting to represent the parameters of a command. This technique
 is useful when you are creating a proxy function, that is, a function that
 calls another command. This feature is introduced in Windows PowerShell 3.0.
 
-To splat the parameters of a command, use `@Args` to represent the command
+To splat the parameters of a command, use `@args` to represent the command
 parameters. This technique is easier than enumerating command parameters and
 it works without revision even if the parameters of the called command change.
 
-The feature uses the `$Args` automatic variable, which contains all unassigned
+The feature uses the `$args` automatic variable, which contains all unassigned
 parameter values.
 
 For example, the following function calls the `Get-Process` cmdlet. In this
-function, `@Args` represents all the parameters of the `Get-Process` cmdlet.
+function, `@args` represents all the parameters of the `Get-Process` cmdlet.
 
 ```powershell
-function Get-MyProcess { Get-Process @Args }
+function Get-MyProcess { Get-Process @args }
 ```
 
 When you use the `Get-MyProcess` function, all unassigned parameters and
-parameter values are passed to `@Args`, as shown in the following commands.
+parameter values are passed to `@args`, as shown in the following commands.
 
 ```powershell
 Get-MyProcess -Name PowerShell
@@ -295,16 +295,16 @@ ProductVersion   FileVersion      FileName
 6.2.9200.16384   6.2.9200.1638... C:\Windows\system32\WindowsPowerShell\...
 ```
 
-You can use `@Args` in a function that has explicitly declared parameters. You
+You can use `@args` in a function that has explicitly declared parameters. You
 can use it more than once in a function, but all parameters that you enter are
-passed to all instances of `@Args`, as shown in the following example.
+passed to all instances of `@args`, as shown in the following example.
 
 ```powershell
 function Get-MyCommand
 {
     Param ([switch]$P, [switch]$C)
-    if ($P) { Get-Process @Args }
-    if ($C) { Get-Command @Args }
+    if ($P) { Get-Process @args }
+    if ($C) { Get-Command @args }
 }
 
 Get-MyCommand -P -C -Name PowerShell

--- a/reference/5.1/Microsoft.PowerShell.Management/Register-WmiEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Register-WmiEvent.md
@@ -122,7 +122,7 @@ event is raised instead of sending the event to the event queue. Enclose the com
 (`{}`) to create a script block.
 
 The value of **Action** can include the `$Event`, `$EventSubscriber`, `$Sender`, `$EventArgs`, and
-`$Args` automatic variables, which provide information about the event to the **Action** script
+`$args` automatic variables, which provide information about the event to the **Action** script
 block. For more information, see [about_Automatic_Variables](../Microsoft.PowerShell.Core/About/about_Automatic_Variables.md).
 
 When you specify an action, `Register-WmiEvent` returns an event job object that represents that

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Event.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Event.md
@@ -186,8 +186,8 @@ The `Get-Event` cmdlet returns a **PSEventArgs** object
   automatic variable contains this value.
 
 - SourceArgs. All parameters of the original event signature. For a standard event signature,
-  `$Args[0]` represents the sender, and `$Args[1]` represents the **SourceEventArgs**. In the
-  value of the **Action** parameter, the `$Args` automatic variable contains this value.
+  `$args[0]` represents the sender, and `$args[1]` represents the **SourceEventArgs**. In the
+  value of the **Action** parameter, the `$args` automatic variable contains this value.
 
 - SourceIdentifier. A string that identifies the event subscription. In the value of the
   **Action** parameter, the **SourceIdentifier** property of the `$Event` automatic variable

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Event.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Event.md
@@ -59,7 +59,7 @@ PS C:\> function Enable-ProcessCreationEvent
    $Identifier = "WMI.ProcessCreated"
    Register-ObjectEvent $ProcessWatcher "EventArrived" -SupportEvent $Identifier -Action
    {
-      [void] (New-Event -SourceID "PowerShell.ProcessCreated" -Sender $Args[0] -EventArguments $Args[1].SourceEventArgs.NewEvent.TargetInstance)
+      [void] (New-Event -SourceID "PowerShell.ProcessCreated" -Sender $args[0] -EventArguments $args[1].SourceEventArgs.NewEvent.TargetInstance)
    }
 }
 ```

--- a/reference/5.1/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -160,7 +160,7 @@ instead of sending the event to the event queue. Enclose the commands in braces 
 script block.
 
 The value of the **Action** parameter can include the `$Event`, `$EventSubscriber`, `$Sender`,
-`$EventArgs`, and `$Args` automatic variables, which provide information about the event to the
+`$EventArgs`, and `$args` automatic variables, which provide information about the event to the
 **Action** script block. For more information, see
 [about_Automatic_Variables](../Microsoft.PowerShell.Core/About/about_Automatic_Variables.md).
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -196,7 +196,7 @@ raised, instead of sending the event to the event queue. Enclose the commands in
 create a script block.
 
 The value of the **Action** parameter can include the `$Event`, `$EventSubscriber`, `$Sender`,
-`$EventArgs`, and `$Args` automatic variables. These variables provide information about the event
+`$EventArgs`, and `$args` automatic variables. These variables provide information about the event
 to the **Action** script block. For more information, see [about_Automatic_Variables](../Microsoft.PowerShell.Core/About/about_Automatic_Variables.md).
 
 When you specify an action, `Register-ObjectEvent` returns an event job object that represents

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -126,7 +126,7 @@ for the following automatic variables:
 
 ```powershell
 $_
-$Args
+$args
 $Input
 $MyInvocation
 $PSBoundParameters
@@ -144,7 +144,7 @@ variable.
 For example,
 
 ```powershell
-$scriptArgs = $Args
+$scriptArgs = $args
 $scriptname = $MyInvocation.PSCommandPath
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -450,15 +450,15 @@ need to declare or enumerate the command parameters, or change the function
 when command parameters change.
 
 The following sample function calls the `Get-Command` cmdlet. The command uses
-`@Args` to represent the parameters of `Get-Command`.
+`@args` to represent the parameters of `Get-Command`.
 
 ```powershell
-function Get-MyCommand { Get-Command @Args }
+function Get-MyCommand { Get-Command @args }
 ```
 
 You can use all the parameters of `Get-Command` when you call the
 `Get-MyCommand` function. The parameters and parameter values are passed to the
-command using `@Args`.
+command using `@args`.
 
 ```powershell
 Get-MyCommand -Name Get-ChildItem
@@ -470,7 +470,7 @@ CommandType     Name                ModuleName
 Cmdlet          Get-ChildItem       Microsoft.PowerShell.Management
 ```
 
-The `@Args` feature uses the `$Args` automatic parameter, which represents
+The `@args` feature uses the `$args` automatic parameter, which represents
 undeclared cmdlet parameters and values from remaining arguments.
 
 For more information, see [about_Splatting][19].

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -23,7 +23,7 @@ When you use the `CmdletBinding` attribute, PowerShell automatically adds the
 Common Parameters. You can't create any parameters that use the same names as
 the Common Parameters. For more information, see [about_CommonParameters][06].
 
-Beginning in PowerShell 3.0, you can use splatting with `@Args` to represent
+Beginning in PowerShell 3.0, you can use splatting with `@args` to represent
 the parameters in a command. Splatting is valid on simple and advanced
 functions. For more information, see [about_Functions][14] and
 [about_Splatting][17].

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -24,7 +24,7 @@ the Common Parameters. For more information, see [about_CommonParameters][02].
 PowerShell binds the parameters of functions that have the `CmdletBinding`
 attribute in the same way that it binds the parameters of compiled cmdlets. The
 `$PSCmdlet` automatic variable is available to functions with the
-`CmdletBinding` attribute, but the `$Args` variable is not available.
+`CmdletBinding` attribute, but the `$args` variable is not available.
 
 In functions that have the `CmdletBinding` attribute, unknown parameters and
 positional arguments that have no matching positional parameters cause

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -301,22 +301,22 @@ You can use splatting to represent the parameters of a command. This technique
 is useful when you are creating a proxy function, that is, a function that
 calls another command. This feature is introduced in Windows PowerShell 3.0.
 
-To splat the parameters of a command, use `@Args` to represent the command
+To splat the parameters of a command, use `@args` to represent the command
 parameters. This technique is easier than enumerating command parameters and
 it works without revision even if the parameters of the called command change.
 
-The feature uses the `$Args` automatic variable, which contains all unassigned
+The feature uses the `$args` automatic variable, which contains all unassigned
 parameter values.
 
 For example, the following function calls the `Get-Process` cmdlet. In this
-function, `@Args` represents all the parameters of the `Get-Process` cmdlet.
+function, `@args` represents all the parameters of the `Get-Process` cmdlet.
 
 ```powershell
-function Get-MyProcess { Get-Process @Args }
+function Get-MyProcess { Get-Process @args }
 ```
 
 When you use the `Get-MyProcess` function, all unassigned parameters and
-parameter values are passed to `@Args`, as shown in the following commands.
+parameter values are passed to `@args`, as shown in the following commands.
 
 ```powershell
 Get-MyProcess -Name PowerShell
@@ -338,16 +338,16 @@ ProductVersion   FileVersion      FileName
 6.2.9200.16384   6.2.9200.1638... C:\Windows\system32\WindowsPowerShell\...
 ```
 
-You can use `@Args` in a function that has explicitly declared parameters. You
+You can use `@args` in a function that has explicitly declared parameters. You
 can use it more than once in a function, but all parameters that you enter are
-passed to all instances of `@Args`, as shown in the following example.
+passed to all instances of `@args`, as shown in the following example.
 
 ```powershell
 function Get-MyCommand
 {
     Param ([switch]$P, [switch]$C)
-    if ($P) { Get-Process @Args }
-    if ($C) { Get-Command @Args }
+    if ($P) { Get-Process @args }
+    if ($C) { Get-Command @args }
 }
 
 Get-MyCommand -P -C -Name PowerShell

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-Event.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-Event.md
@@ -188,8 +188,8 @@ The `Get-Event` cmdlet returns a **PSEventArgs** object
   automatic variable contains this value.
 
 - SourceArgs. All parameters of the original event signature. For a standard event signature,
-  `$Args[0]` represents the sender, and `$Args[1]` represents the **SourceEventArgs**. In the
-  value of the **Action** parameter, the `$Args` automatic variable contains this value.
+  `$args[0]` represents the sender, and `$args[1]` represents the **SourceEventArgs**. In the
+  value of the **Action** parameter, the `$args` automatic variable contains this value.
 
 - SourceIdentifier. A string that identifies the event subscription. In the value of the
   **Action** parameter, the **SourceIdentifier** property of the `$Event` automatic variable

--- a/reference/7.4/Microsoft.PowerShell.Utility/New-Event.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/New-Event.md
@@ -59,7 +59,7 @@ PS C:\> function Enable-ProcessCreationEvent
    $Identifier = "WMI.ProcessCreated"
    Register-ObjectEvent $ProcessWatcher "EventArrived" -SupportEvent $Identifier -Action
    {
-      [void] (New-Event -SourceID "PowerShell.ProcessCreated" -Sender $Args[0] -EventArguments $Args[1].SourceEventArgs.NewEvent.TargetInstance)
+      [void] (New-Event -SourceID "PowerShell.ProcessCreated" -Sender $args[0] -EventArguments $args[1].SourceEventArgs.NewEvent.TargetInstance)
    }
 }
 ```

--- a/reference/7.4/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -160,7 +160,7 @@ instead of sending the event to the event queue. Enclose the commands in braces 
 script block.
 
 The value of the **Action** parameter can include the `$Event`, `$EventSubscriber`, `$Sender`,
-`$EventArgs`, and `$Args` automatic variables, which provide information about the event to the
+`$EventArgs`, and `$args` automatic variables, which provide information about the event to the
 **Action** script block. For more information, see
 [about_Automatic_Variables](../Microsoft.PowerShell.Core/About/about_Automatic_Variables.md).
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -196,7 +196,7 @@ raised, instead of sending the event to the event queue. Enclose the commands in
 create a script block.
 
 The value of the **Action** parameter can include the `$Event`, `$EventSubscriber`, `$Sender`,
-`$EventArgs`, and `$Args` automatic variables. These variables provide information about the event
+`$EventArgs`, and `$args` automatic variables. These variables provide information about the event
 to the **Action** script block. For more information, see [about_Automatic_Variables](../Microsoft.PowerShell.Core/About/about_Automatic_Variables.md).
 
 When you specify an action, `Register-ObjectEvent` returns an event job object that represents

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -126,7 +126,7 @@ for the following automatic variables:
 
 ```powershell
 $_
-$Args
+$args
 $Input
 $MyInvocation
 $PSBoundParameters
@@ -144,7 +144,7 @@ variable.
 For example,
 
 ```powershell
-$scriptArgs = $Args
+$scriptArgs = $args
 $scriptname = $MyInvocation.PSCommandPath
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -450,15 +450,15 @@ need to declare or enumerate the command parameters, or change the function
 when command parameters change.
 
 The following sample function calls the `Get-Command` cmdlet. The command uses
-`@Args` to represent the parameters of `Get-Command`.
+`@args` to represent the parameters of `Get-Command`.
 
 ```powershell
-function Get-MyCommand { Get-Command @Args }
+function Get-MyCommand { Get-Command @args }
 ```
 
 You can use all the parameters of `Get-Command` when you call the
 `Get-MyCommand` function. The parameters and parameter values are passed to the
-command using `@Args`.
+command using `@args`.
 
 ```powershell
 Get-MyCommand -Name Get-ChildItem
@@ -470,7 +470,7 @@ CommandType     Name                ModuleName
 Cmdlet          Get-ChildItem       Microsoft.PowerShell.Management
 ```
 
-The `@Args` feature uses the `$Args` automatic parameter, which represents
+The `@args` feature uses the `$args` automatic parameter, which represents
 undeclared cmdlet parameters and values from remaining arguments.
 
 For more information, see [about_Splatting][19].

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -23,7 +23,7 @@ When you use the `CmdletBinding` attribute, PowerShell automatically adds the
 Common Parameters. You can't create any parameters that use the same names as
 the Common Parameters. For more information, see [about_CommonParameters][06].
 
-Beginning in PowerShell 3.0, you can use splatting with `@Args` to represent
+Beginning in PowerShell 3.0, you can use splatting with `@args` to represent
 the parameters in a command. Splatting is valid on simple and advanced
 functions. For more information, see [about_Functions][14] and
 [about_Splatting][17].

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -25,7 +25,7 @@ the Common Parameters. For more information, see [about_CommonParameters][02].
 PowerShell binds the parameters of functions that have the `CmdletBinding`
 attribute in the same way that it binds the parameters of compiled cmdlets. The
 `$PSCmdlet` automatic variable is available to functions with the
-`CmdletBinding` attribute, but the `$Args` variable is not available.
+`CmdletBinding` attribute, but the `$args` variable is not available.
 
 In functions that have the `CmdletBinding` attribute, unknown parameters and
 positional arguments that have no matching positional parameters cause

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -301,22 +301,22 @@ You can use splatting to represent the parameters of a command. This technique
 is useful when you are creating a proxy function, that is, a function that
 calls another command. This feature is introduced in Windows PowerShell 3.0.
 
-To splat the parameters of a command, use `@Args` to represent the command
+To splat the parameters of a command, use `@args` to represent the command
 parameters. This technique is easier than enumerating command parameters and
 it works without revision even if the parameters of the called command change.
 
-The feature uses the `$Args` automatic variable, which contains all unassigned
+The feature uses the `$args` automatic variable, which contains all unassigned
 parameter values.
 
 For example, the following function calls the `Get-Process` cmdlet. In this
-function, `@Args` represents all the parameters of the `Get-Process` cmdlet.
+function, `@args` represents all the parameters of the `Get-Process` cmdlet.
 
 ```powershell
-function Get-MyProcess { Get-Process @Args }
+function Get-MyProcess { Get-Process @args }
 ```
 
 When you use the `Get-MyProcess` function, all unassigned parameters and
-parameter values are passed to `@Args`, as shown in the following commands.
+parameter values are passed to `@args`, as shown in the following commands.
 
 ```powershell
 Get-MyProcess -Name PowerShell
@@ -338,16 +338,16 @@ ProductVersion   FileVersion      FileName
 6.2.9200.16384   6.2.9200.1638... C:\Windows\system32\WindowsPowerShell\...
 ```
 
-You can use `@Args` in a function that has explicitly declared parameters. You
+You can use `@args` in a function that has explicitly declared parameters. You
 can use it more than once in a function, but all parameters that you enter are
-passed to all instances of `@Args`, as shown in the following example.
+passed to all instances of `@args`, as shown in the following example.
 
 ```powershell
 function Get-MyCommand
 {
     Param ([switch]$P, [switch]$C)
-    if ($P) { Get-Process @Args }
-    if ($C) { Get-Command @Args }
+    if ($P) { Get-Process @args }
+    if ($C) { Get-Command @args }
 }
 
 Get-MyCommand -P -C -Name PowerShell

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-Event.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-Event.md
@@ -188,8 +188,8 @@ The `Get-Event` cmdlet returns a **PSEventArgs** object
   automatic variable contains this value.
 
 - SourceArgs. All parameters of the original event signature. For a standard event signature,
-  `$Args[0]` represents the sender, and `$Args[1]` represents the **SourceEventArgs**. In the
-  value of the **Action** parameter, the `$Args` automatic variable contains this value.
+  `$args[0]` represents the sender, and `$args[1]` represents the **SourceEventArgs**. In the
+  value of the **Action** parameter, the `$args` automatic variable contains this value.
 
 - SourceIdentifier. A string that identifies the event subscription. In the value of the
   **Action** parameter, the **SourceIdentifier** property of the `$Event` automatic variable

--- a/reference/7.5/Microsoft.PowerShell.Utility/New-Event.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/New-Event.md
@@ -59,7 +59,7 @@ PS C:\> function Enable-ProcessCreationEvent
    $Identifier = "WMI.ProcessCreated"
    Register-ObjectEvent $ProcessWatcher "EventArrived" -SupportEvent $Identifier -Action
    {
-      [void] (New-Event -SourceID "PowerShell.ProcessCreated" -Sender $Args[0] -EventArguments $Args[1].SourceEventArgs.NewEvent.TargetInstance)
+      [void] (New-Event -SourceID "PowerShell.ProcessCreated" -Sender $args[0] -EventArguments $args[1].SourceEventArgs.NewEvent.TargetInstance)
    }
 }
 ```

--- a/reference/7.5/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -160,7 +160,7 @@ instead of sending the event to the event queue. Enclose the commands in braces 
 script block.
 
 The value of the **Action** parameter can include the `$Event`, `$EventSubscriber`, `$Sender`,
-`$EventArgs`, and `$Args` automatic variables, which provide information about the event to the
+`$EventArgs`, and `$args` automatic variables, which provide information about the event to the
 **Action** script block. For more information, see
 [about_Automatic_Variables](../Microsoft.PowerShell.Core/About/about_Automatic_Variables.md).
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -196,7 +196,7 @@ raised, instead of sending the event to the event queue. Enclose the commands in
 create a script block.
 
 The value of the **Action** parameter can include the `$Event`, `$EventSubscriber`, `$Sender`,
-`$EventArgs`, and `$Args` automatic variables. These variables provide information about the event
+`$EventArgs`, and `$args` automatic variables. These variables provide information about the event
 to the **Action** script block. For more information, see [about_Automatic_Variables](../Microsoft.PowerShell.Core/About/about_Automatic_Variables.md).
 
 When you specify an action, `Register-ObjectEvent` returns an event job object that represents

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -126,7 +126,7 @@ for the following automatic variables:
 
 ```powershell
 $_
-$Args
+$args
 $Input
 $MyInvocation
 $PSBoundParameters
@@ -144,7 +144,7 @@ variable.
 For example,
 
 ```powershell
-$scriptArgs = $Args
+$scriptArgs = $args
 $scriptname = $MyInvocation.PSCommandPath
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -450,15 +450,15 @@ need to declare or enumerate the command parameters, or change the function
 when command parameters change.
 
 The following sample function calls the `Get-Command` cmdlet. The command uses
-`@Args` to represent the parameters of `Get-Command`.
+`@args` to represent the parameters of `Get-Command`.
 
 ```powershell
-function Get-MyCommand { Get-Command @Args }
+function Get-MyCommand { Get-Command @args }
 ```
 
 You can use all the parameters of `Get-Command` when you call the
 `Get-MyCommand` function. The parameters and parameter values are passed to the
-command using `@Args`.
+command using `@args`.
 
 ```powershell
 Get-MyCommand -Name Get-ChildItem
@@ -470,7 +470,7 @@ CommandType     Name                ModuleName
 Cmdlet          Get-ChildItem       Microsoft.PowerShell.Management
 ```
 
-The `@Args` feature uses the `$Args` automatic parameter, which represents
+The `@args` feature uses the `$args` automatic parameter, which represents
 undeclared cmdlet parameters and values from remaining arguments.
 
 For more information, see [about_Splatting][19].

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -23,7 +23,7 @@ When you use the `CmdletBinding` attribute, PowerShell automatically adds the
 Common Parameters. You can't create any parameters that use the same names as
 the Common Parameters. For more information, see [about_CommonParameters][06].
 
-Beginning in PowerShell 3.0, you can use splatting with `@Args` to represent
+Beginning in PowerShell 3.0, you can use splatting with `@args` to represent
 the parameters in a command. Splatting is valid on simple and advanced
 functions. For more information, see [about_Functions][14] and
 [about_Splatting][17].

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -25,7 +25,7 @@ the Common Parameters. For more information, see [about_CommonParameters][02].
 PowerShell binds the parameters of functions that have the `CmdletBinding`
 attribute in the same way that it binds the parameters of compiled cmdlets. The
 `$PSCmdlet` automatic variable is available to functions with the
-`CmdletBinding` attribute, but the `$Args` variable is not available.
+`CmdletBinding` attribute, but the `$args` variable is not available.
 
 In functions that have the `CmdletBinding` attribute, unknown parameters and
 positional arguments that have no matching positional parameters cause

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -301,22 +301,22 @@ You can use splatting to represent the parameters of a command. This technique
 is useful when you are creating a proxy function, that is, a function that
 calls another command. This feature is introduced in Windows PowerShell 3.0.
 
-To splat the parameters of a command, use `@Args` to represent the command
+To splat the parameters of a command, use `@args` to represent the command
 parameters. This technique is easier than enumerating command parameters and
 it works without revision even if the parameters of the called command change.
 
-The feature uses the `$Args` automatic variable, which contains all unassigned
+The feature uses the `$args` automatic variable, which contains all unassigned
 parameter values.
 
 For example, the following function calls the `Get-Process` cmdlet. In this
-function, `@Args` represents all the parameters of the `Get-Process` cmdlet.
+function, `@args` represents all the parameters of the `Get-Process` cmdlet.
 
 ```powershell
-function Get-MyProcess { Get-Process @Args }
+function Get-MyProcess { Get-Process @args }
 ```
 
 When you use the `Get-MyProcess` function, all unassigned parameters and
-parameter values are passed to `@Args`, as shown in the following commands.
+parameter values are passed to `@args`, as shown in the following commands.
 
 ```powershell
 Get-MyProcess -Name PowerShell
@@ -338,16 +338,16 @@ ProductVersion   FileVersion      FileName
 6.2.9200.16384   6.2.9200.1638... C:\Windows\system32\WindowsPowerShell\...
 ```
 
-You can use `@Args` in a function that has explicitly declared parameters. You
+You can use `@args` in a function that has explicitly declared parameters. You
 can use it more than once in a function, but all parameters that you enter are
-passed to all instances of `@Args`, as shown in the following example.
+passed to all instances of `@args`, as shown in the following example.
 
 ```powershell
 function Get-MyCommand
 {
     Param ([switch]$P, [switch]$C)
-    if ($P) { Get-Process @Args }
-    if ($C) { Get-Command @Args }
+    if ($P) { Get-Process @args }
+    if ($C) { Get-Command @args }
 }
 
 Get-MyCommand -P -C -Name PowerShell

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-Event.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-Event.md
@@ -188,8 +188,8 @@ The `Get-Event` cmdlet returns a **PSEventArgs** object
   automatic variable contains this value.
 
 - SourceArgs. All parameters of the original event signature. For a standard event signature,
-  `$Args[0]` represents the sender, and `$Args[1]` represents the **SourceEventArgs**. In the
-  value of the **Action** parameter, the `$Args` automatic variable contains this value.
+  `$args[0]` represents the sender, and `$args[1]` represents the **SourceEventArgs**. In the
+  value of the **Action** parameter, the `$args` automatic variable contains this value.
 
 - SourceIdentifier. A string that identifies the event subscription. In the value of the
   **Action** parameter, the **SourceIdentifier** property of the `$Event` automatic variable

--- a/reference/7.6/Microsoft.PowerShell.Utility/New-Event.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/New-Event.md
@@ -59,7 +59,7 @@ PS C:\> function Enable-ProcessCreationEvent
    $Identifier = "WMI.ProcessCreated"
    Register-ObjectEvent $ProcessWatcher "EventArrived" -SupportEvent $Identifier -Action
    {
-      [void] (New-Event -SourceID "PowerShell.ProcessCreated" -Sender $Args[0] -EventArguments $Args[1].SourceEventArgs.NewEvent.TargetInstance)
+      [void] (New-Event -SourceID "PowerShell.ProcessCreated" -Sender $args[0] -EventArguments $args[1].SourceEventArgs.NewEvent.TargetInstance)
    }
 }
 ```

--- a/reference/7.6/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -160,7 +160,7 @@ instead of sending the event to the event queue. Enclose the commands in braces 
 script block.
 
 The value of the **Action** parameter can include the `$Event`, `$EventSubscriber`, `$Sender`,
-`$EventArgs`, and `$Args` automatic variables, which provide information about the event to the
+`$EventArgs`, and `$args` automatic variables, which provide information about the event to the
 **Action** script block. For more information, see
 [about_Automatic_Variables](../Microsoft.PowerShell.Core/About/about_Automatic_Variables.md).
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -196,7 +196,7 @@ raised, instead of sending the event to the event queue. Enclose the commands in
 create a script block.
 
 The value of the **Action** parameter can include the `$Event`, `$EventSubscriber`, `$Sender`,
-`$EventArgs`, and `$Args` automatic variables. These variables provide information about the event
+`$EventArgs`, and `$args` automatic variables. These variables provide information about the event
 to the **Action** script block. For more information, see [about_Automatic_Variables](../Microsoft.PowerShell.Core/About/about_Automatic_Variables.md).
 
 When you specify an action, `Register-ObjectEvent` returns an event job object that represents

--- a/reference/docs-conceptual/windows-powershell/ise/How-to-Debug-Scripts-in-Windows-PowerShell-ISE.md
+++ b/reference/docs-conceptual/windows-powershell/ise/How-to-Debug-Scripts-in-Windows-PowerShell-ISE.md
@@ -234,11 +234,11 @@ debugging a script. However, these methods do not work for the following automat
 
 - `$PSBoundParameters`
 
-- `$Args`
+- `$args`
 
 If you try to display the value of any of these variables, you get the value of that variable for in
 an internal pipeline the debugger uses, not the value of the variable in the script. You can work
-around this for a few variables (`$_`, `$Input`, `$MyInvocation`, `$PSBoundParameters`, and `$Args`)
+around this for a few variables (`$_`, `$Input`, `$MyInvocation`, `$PSBoundParameters`, and `$args`)
 by using the following method:
 
 1. In the script, assign the value of the automatic variable to a new variable.


### PR DESCRIPTION
# PR Summary

This PR (**_1/13_**) fixes incorrect [automatic variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables) casing used throughout the documentation. E.g., `$Args` (incorrect) -> `$args` (correct).

In this PR:

- `$args`

## Context

This series of PRs ensures the correct case is consistently used for each individual automatic variable, as documented in `about_Automatic_Variables` and verified by tab completion.

Changes in scope:

- Variables with a `$` or `@` sigil.
- Variables referenced by name without a sigil.

Out of scope:

- Preference variables (separate PRs to follow).
- Misuse of an automatic variable (e.g., naming a function parameter as `$Input`).
- Reference to the variable's _value_ (e.g., `false`/`False`/`FALSE` when referring to the _value_ of `$false`).

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide