### PR TITLE
Fix `$false` automatic variable case (3/13)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -47,7 +47,7 @@ is limited to the following elements:
 - All PowerShell operators, except `-match`
 - `If`, `Else`, and `ElseIf` statements
 - The following automatic variables: `$PsCulture`, `$PsUICulture`, `$True`,
-  `$False`, and `$Null`
+  `$false`, and `$Null`
 - Comments
 - Pipelines
 - Statements separated by semicolons (`;`)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
@@ -582,7 +582,7 @@ system files and folders, use the **Attributes** parameter.
 ### NewerThan \<DateTime\>
 
 Returns `$True` when the `LastWriteTime` value of a file is greater than the
-specified date. Otherwise, it returns `$False`.
+specified date. Otherwise, it returns `$false`.
 
 Enter a [DateTime][01] object, such as one that the [Get-Date][37] cmdlet
 returns, or a string that can be converted to a **DateTime** object, such as
@@ -595,7 +595,7 @@ returns, or a string that can be converted to a **DateTime** object, such as
 ### OlderThan \<DateTime\>
 
 Returns `$True` when the `LastWriteTime` value of a file is less than the
-specified date. Otherwise, it returns `$False`.
+specified date. Otherwise, it returns `$false`.
 
 Enter a **DateTime** object, such as one that the `Get-Date` cmdlet
 returns, or a string that can be converted to a [DateTime][01] object, such as

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -413,7 +413,7 @@ parameter is used in a command.
 By default, all function parameters are positional. PowerShell assigns position
 numbers to parameters in the order the parameters are declared in the function.
 To disable this feature, set the value of the `PositionalBinding` argument of
-the **CmdletBinding** attribute to `$False`. The `Position` argument takes
+the **CmdletBinding** attribute to `$false`. The `Position` argument takes
 precedence over the value of the `PositionalBinding` argument of the
 **CmdletBinding** attribute. For more information, see `PositionalBinding` in
 [about_Functions_CmdletBindingAttribute][12].

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -175,7 +175,7 @@ lists the changes that the command would make, instead of running the command.
 
 The **PositionalBinding** argument determines whether parameters in the
 function are positional by default. The default value is `$True`. You can use
-the **PositionalBinding** argument with a value of `$False` to disable
+the **PositionalBinding** argument with a value of `$false` to disable
 positional binding.
 
 The **PositionalBinding** argument is introduced in Windows PowerShell 3.0.
@@ -192,7 +192,7 @@ When **PositionalBinding** is `$True`, function parameters are positional by
 default. PowerShell assigns position number to the parameters in the order in
 which they are declared in the function.
 
-When **PositionalBinding** is `$False`, function parameters are not positional
+When **PositionalBinding** is `$false`, function parameters are not positional
 by default. Unless the **Position** argument of the **Parameter** attribute is
 declared on the parameter, the parameter name (or an alias or abbreviation)
 must be included when the parameter is used in a function.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
@@ -67,7 +67,7 @@ any PowerShell modules.
 If this policy setting isn't configured, the **LogPipelineExecutionDetails**
 property of each module determines whether PowerShell logs the execution events
 of that module. By default, the **LogPipelineExecutionDetails** property of all
-modules is set to `$False`.
+modules is set to `$false`.
 
 To turn on module logging for a module, use the following command format. The
 module must be imported into the session and the setting is effective only in

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -167,7 +167,7 @@ mode:
 - `$PSCulture`
 - `$PSUICulture`
 - `$True`
-- `$False`
+- `$false`
 - `$Null`
 
 Module manifests are loaded in `RestrictedLanguage` mode and may use these

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -32,8 +32,8 @@ The following table lists the preference variables and their default values.
 | [`$ErrorView`][05]                     | [`NormalView`][57]                                               |
 | [`$FormatEnumerationLimit`][06]        | `4`                                                              |
 | [`$InformationPreference`][07]         | [`SilentlyContinue`][54]                                         |
-| [`$LogCommandHealthEvent`][08]         | `$False` (not logged)                                            |
-| [`$LogCommandLifecycleEvent`][08]      | `$False` (not logged)                                            |
+| [`$LogCommandHealthEvent`][08]         | `$false` (not logged)                                            |
+| [`$LogCommandLifecycleEvent`][08]      | `$false` (not logged)                                            |
 | [`$LogEngineHealthEvent`][08]          | `$True` (logged)                                                 |
 | [`$LogEngineLifecycleEvent`][08]       | `$True` (logged)                                                 |
 | [`$LogProviderLifecycleEvent`][08]     | `$True` (logged)                                                 |
@@ -56,7 +56,7 @@ The following table lists the preference variables and their default values.
 | [`$Transcript`][24]                    | `$Null` (none)                                                   |
 | [`$VerbosePreference`][25]             | [`SilentlyContinue`][54]                                         |
 | [`$WarningPreference`][26]             | [`Continue`][54]                                                 |
-| [`$WhatIfPreference`][27]              | `$False`                                                         |
+| [`$WhatIfPreference`][27]              | `$false`                                                         |
 
 PowerShell includes the following environment variables that store user
 preferences. For more information about these environment variables, see

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -28,7 +28,7 @@ object, the file changes too.
 Most objects have properties. Properties are the data that are associated with
 an object. Different types of object have different properties. For example, a
 **FileInfo** object, which represents a file, has an **IsReadOnly** property
-that contains `$True` if the file has the read-only attribute and `$False` if
+that contains `$True` if the file has the read-only attribute and `$false` if
 it doesn't. A **DirectoryInfo** object, which represents a file system
 directory, has a **Parent** property that contains the path to the parent
 directory.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -70,7 +70,7 @@ variable in a command with splatting. The At symbol (`@HashArguments`) replaces
 the dollar sign (`$HashArguments`) in the command.
 
 To provide a value for the **WhatIf** switch parameter, use `$True` or
-`$False`.
+`$false`.
 
 ```powershell
 $HashArguments = @{

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-Job.md
@@ -548,13 +548,13 @@ Accept wildcard characters: False
 Indicates whether this cmdlet gets only jobs that have the specified **HasMoreData** property value.
 The **HasMoreData** property indicates whether all job results have been received in the current
 session. To get jobs that have more results, specify a value of `$True`. To get jobs that do not
-have more results, specify a value of `$False`.
+have more results, specify a value of `$false`.
 
 To get the results of a job, use the `Receive-Job` cmdlet.
 
 When you use the `Receive-Job` cmdlet, it deletes from its in-memory, session-specific storage the
 results that it returned. When it has returned all results of the job in the current session, it
-sets the value of the **HasMoreData** property of the job to `$False`) to indicate that it has no
+sets the value of the **HasMoreData** property of the job to `$false`) to indicate that it has no
 more results for the job in the current session. Use the **Keep** parameter of `Receive-Job` to
 prevent `Receive-Job` from deleting results and changing the value of the **HasMoreData** property.
 For more information, type `Get-Help Receive-Job`.
@@ -562,7 +562,7 @@ For more information, type `Get-Help Receive-Job`.
 The **HasMoreData** property is specific to the current session. If results for a custom job type
 are saved outside of the session, such as the scheduled job type, which saves job results on disk,
 you can use the `Receive-Job` cmdlet in a different session to get the job results again, even if
-the value of **HasMoreData** is `$False`. For more information, see the help topics for the custom
+the value of **HasMoreData** is `$false`. For more information, see the help topics for the custom
 job type.
 
 This parameter was introduced in Windows PowerShell 3.0.

--- a/reference/5.1/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -583,7 +583,7 @@ The acceptable values for this parameter are:
   elements, such as script blocks, variables, or operators.
 - RestrictedLanguage - Users may run cmdlets and functions, but are not permitted to use script
   blocks or variables except for the following permitted variables: `$PSCulture`, `$PSUICulture`,
-  `$True`, `$False`, and `$Null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
+  `$True`, `$false`, and `$Null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
   `-lt`). Assignment statements, property references, and method calls are not permitted.
 
 The default value of the **LanguageMode** parameter depends on the value of the **SessionType**

--- a/reference/5.1/Microsoft.PowerShell.Core/Test-ModuleManifest.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Test-ModuleManifest.md
@@ -87,7 +87,7 @@ function Test-ManifestBool ($path)
 ```
 
 This function is like `Test-ModuleManifest`, but it returns a Boolean value. The function returns
-`$True` if the manifest passed the test and `$False` otherwise.
+`$True` if the manifest passed the test and `$false` otherwise.
 
 The function uses the Get-ChildItem cmdlet, alias = dir, to get the module manifest specified by the
 `$path` variable. The command uses a pipeline operator (`|`) to pass the file object to
@@ -99,7 +99,7 @@ object that `Test-ModuleManifest` returns in the $a variable. Therefore, the obj
 displayed.
 
 Then, in a separate command, the function displays the value of the `$?` automatic variable. If the
-previous command generates no error, the command displays `$True`, and `$False` otherwise.
+previous command generates no error, the command displays `$True`, and `$false` otherwise.
 
 You can use this function in conditional statements, such as those that might precede an
 `Import-Module` command or a command that uses the module.

--- a/reference/5.1/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
@@ -23,7 +23,7 @@ Test-PSSessionConfigurationFile [-Path] <String> [<CommonParameters>]
 This cmdlet verifies that a session configuration file contains valid keys and the values are of the
 correct type. For enumerated values, the cmdlet verifies that the specified values are valid.
 
-The cmdlet returns `$True` if the file passes all tests and `$False` if it does not. To find any
+The cmdlet returns `$True` if the file passes all tests and `$false` if it does not. To find any
 errors, use the **Verbose** parameter.
 
 `Test-PSSessionConfigurationFile` verifies the session configuration files, such as those created by

--- a/reference/5.1/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Update-Help.md
@@ -245,7 +245,7 @@ The script uses the **PSCustomObject** class and a hash table to create a custom
 ```powershell
 # Get-UpdateHelpVersion.ps1
 Param(
-    [parameter(Mandatory=$False)]
+    [parameter(Mandatory=$false)]
     [String[]]
     $Module
 )

--- a/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
@@ -366,11 +366,11 @@ Get-ChildItem | Where-Object { $_.PSIsContainer }
 ```powershell
 # Finally, use the -not operator (!) to get objects that are not containers.
 # This gets objects that do have the **PSIsContainer** property and those
-# that have a value of $False for the **PSIsContainer** property.
+# that have a value of $false for the **PSIsContainer** property.
 Get-ChildItem | Where-Object { !$_.PSIsContainer }
 # You cannot use the -not operator (!) in the comparison statement format
 # of the command.
-Get-ChildItem | Where-Object PSIsContainer -eq $False
+Get-ChildItem | Where-Object PSIsContainer -eq $false
 ```
 
 ### Example 6: Use multiple conditions

--- a/reference/5.1/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Split-Path.md
@@ -132,7 +132,7 @@ the full path of the parent container.
 ### Example 4: Determines whether a path is absolute
 
 This command determines whether the path is relative or absolute. In this case, because the path is
-relative to the current folder, which is represented by a dot (`.`), it returns `$False`.
+relative to the current folder, which is represented by a dot (`.`), it returns `$false`.
 
 ```powershell
 Split-Path -Path ".\My Pictures\*.jpg" -IsAbsolute
@@ -192,7 +192,7 @@ Accept wildcard characters: False
 
 ### -IsAbsolute
 
-Indicates that this cmdlet returns `$True` if the path is absolute and `$False` if it's relative. On
+Indicates that this cmdlet returns `$True` if the path is absolute and `$false` if it's relative. On
 Windows, an absolute path string must start with a provider drive specifier, like `C:` or `HKCU:`. A
 relative path starts with a dot (`.`) or a dot-dot (`..`).
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
@@ -27,7 +27,7 @@ The `Test-ComputerSecureChannel` cmdlet verifies that the channel between the lo
 domain is working correctly by checking the status of its trust relationships. If a connection
 fails, you can use the **Repair** parameter to try to restore it.
 
-`Test-ComputerSecureChannel` returns $True if the channel is working correctly and $False if it is
+`Test-ComputerSecureChannel` returns $True if the channel is working correctly and $false if it is
 not. This result lets you use the cmdlet in conditional statements in functions and scripts. To get
 more detailed test results, use the **Verbose** parameter.
 
@@ -200,7 +200,7 @@ You cannot pipe input to this cmdlet.
 
 ### System.Boolean
 
-This cmdlet returns `$True` if the connection is working correctly and `$False` if it is not.
+This cmdlet returns `$True` if the connection is working correctly and `$false` if it is not.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
@@ -153,7 +153,7 @@ if (Test-Connection -ComputerName Server01 -Quiet) {New-PSSession Server01}
 
 The `if` command uses the `Test-Connection` cmdlet to ping the Server01 computer. The command uses
 the **Quiet** parameter, which returns a **Boolean** value, instead of a **Win32_PingStatus**
-object. The value is `$True` if any of the four pings succeed and is, otherwise, `$False`.
+object. The value is `$True` if any of the four pings succeed and is, otherwise, `$false`.
 
 If the `Test-Connection` command returns a value of `$True`, the command uses the `New-PSSession`
 cmdlet to create the **PSSession**.
@@ -359,7 +359,7 @@ specifies multiple computers, an array of **Boolean** values is returned.
 
 If **any** ping succeeds, `$True` is returned.
 
-If **all** pings fail, `$False` is returned.
+If **all** pings fail, `$false` is returned.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/5.1/Microsoft.PowerShell.Operation.Validation/Invoke-OperationValidation.md
+++ b/reference/5.1/Microsoft.PowerShell.Operation.Validation/Invoke-OperationValidation.md
@@ -84,7 +84,7 @@ pass it to the `Invoke-OperationValidation` cmdlet, which runs the test.
 
 ### -IncludePesterOutput
 
-Includes Pester test output. The default is `$False`.
+Includes Pester test output. The default is `$false`.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -191,7 +191,7 @@ two properties, **Status** in descending order and **DisplayName** in ascending 
 
 **Status** is an enumerated property. **Stopped** has a value of **1** and **Running** has a value
 of **4**. The **Descending** parameter is set to `$True` so that **Running** processes are displayed
-before **Stopped** processes. **DisplayName** sets the **Descending** parameter to `$False` to sort
+before **Stopped** processes. **DisplayName** sets the **Descending** parameter to `$false` to sort
 the display names in alphabetical order.
 
 ### Example 6: Sort text files by time span

--- a/reference/5.1/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -495,11 +495,11 @@ Indicates whether the set of properties that are serialized is inherited. The de
 `$Null`. The acceptable values for this parameter are:
 
 - `$True`. The property set is inherited.
-- `$False`. The property set is not inherited.
+- `$false`. The property set is not inherited.
 - `$Null`. Inheritance is not defined.
 
 This parameter is valid only when the value of the **SerializationMethod** parameter is
-`SpecificProperties`. When the value of this parameter is `$False`, the **PropertySerializationSet**
+`SpecificProperties`. When the value of this parameter is `$false`, the **PropertySerializationSet**
 parameter is required.
 
 This parameter was introduced in Windows PowerShell 3.0.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Wait-Event.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Wait-Event.md
@@ -62,7 +62,7 @@ $objectEventArgs = @{
 }
 Register-ObjectEvent @objectEventArgs
 $Timer.Interval = 2000
-$Timer.Autoreset = $False
+$Timer.Autoreset = $false
 $Timer.Enabled = $True
 Wait-Event Timer.Elapsed
 ```

--- a/reference/5.1/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/5.1/PSReadLine/Set-PSReadLineOption.md
@@ -493,12 +493,12 @@ to see the command multiple times when recalling or searching the history.
 
 By default, the **HistoryNoDuplicates** property of the global **PSConsoleReadLineOptions** object
 is set to `True`. To change the property value, you must specify the value of the
-**SwitchParameter** as follows: `-HistoryNoDuplicates:$False`. You can set back to `True` by using
+**SwitchParameter** as follows: `-HistoryNoDuplicates:$false`. You can set back to `True` by using
 just the **SwitchParameter**, `-HistoryNoDuplicates`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).HistoryNoDuplicates = $False`
+`(Get-PSReadLineOption).HistoryNoDuplicates = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -569,11 +569,11 @@ Specifies that history searching is case-sensitive in functions like **ReverseSe
 By default, the **HistorySearchCaseSensitive** property of the global **PSConsoleReadLineOptions**
 object is set to `False`. Using this **SwitchParameter** sets the property value to `True`. To
 change the property value back, you must specify the value of the **SwitchParameter** as follows:
-`-HistorySearchCaseSensitive:$False`.
+`-HistorySearchCaseSensitive:$false`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).HistorySearchCaseSensitive = $False`
+`(Get-PSReadLineOption).HistorySearchCaseSensitive = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -590,17 +590,17 @@ Accept wildcard characters: False
 ### -HistorySearchCursorMovesToEnd
 
 Indicates that the cursor moves to the end of commands that you load from history by using a search.
-When this parameter is set to `$False`, the cursor remains at the position it was when you pressed
+When this parameter is set to `$false`, the cursor remains at the position it was when you pressed
 the up or down arrows.
 
 By default, the **HistorySearchCursorMovesToEnd** property of the global
 **PSConsoleReadLineOptions** object is set to `False`. Using this **SwitchParameter** set the
 property value to `True`. To change the property value back, you must specify the value of the
-**SwitchParameter** as follows: `-HistorySearchCursorMovesToEnd:$False`.
+**SwitchParameter** as follows: `-HistorySearchCursorMovesToEnd:$false`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).HistorySearchCursorMovesToEnd = $False`
+`(Get-PSReadLineOption).HistorySearchCursorMovesToEnd = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -677,15 +677,15 @@ Accept wildcard characters: False
 When displaying possible completions, tooltips are shown in the list of completions.
 
 This option is enabled by default. This option wasn't enabled by default in prior versions of
-**PSReadLine**. To disable, set this option to `$False`.
+**PSReadLine**. To disable, set this option to `$false`.
 
 By default, the **ShowToolTips** property of the global **PSConsoleReadLineOptions** object is set
 to `True`. Using this **SwitchParameter** sets the property value to `True`. To change the property
-value, you must specify the value of the **SwitchParameter** as follows: `-ShowToolTips:$False`.
+value, you must specify the value of the **SwitchParameter** as follows: `-ShowToolTips:$false`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).ShowToolTips = $False`
+`(Get-PSReadLineOption).ShowToolTips = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/5.1/PSScheduledJob/Disable-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Disable-JobTrigger.md
@@ -29,7 +29,7 @@ To use this cmdlet, use the `Get-JobTrigger` cmdlet to get the job triggers. The
 triggers to `Disable-JobTrigger` or use its **InputObject** parameter.
 
 To disable a job trigger, the `Disable-JobTrigger` cmdlet sets the Enabled property of the job
-trigger to `$False`. To re-enable the job trigger, use the `Enable-JobTrigger` cmdlet, which sets
+trigger to `$false`. To re-enable the job trigger, use the `Enable-JobTrigger` cmdlet, which sets
 the **Enabled** property of the job trigger to $True. Disabling a job trigger does not disable the
 scheduled job, such as is done by the `Disable-ScheduledJob` cmdlet, but if you disable all job
 triggers, the effect is the same as disabling the scheduled job.

--- a/reference/5.1/PSScheduledJob/New-ScheduledJobOption.md
+++ b/reference/5.1/PSScheduledJob/New-ScheduledJobOption.md
@@ -500,7 +500,7 @@ This cmdlet returns a **ScheduledJobOptions** object representing the created op
   **ScheduledJobOption** parameter can also take a hash table value that specifies the properties of
   the **ScheduledJobOptions** object and their values, such as:
 
-  `@{ShowInTaskScheduler=$False; RunElevated=$True; IdleDuration="00:05"}`
+  `@{ShowInTaskScheduler=$false; RunElevated=$True; IdleDuration="00:05"}`
 
 ## RELATED LINKS
 

--- a/reference/5.1/PSScheduledJob/Register-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Register-ScheduledJob.md
@@ -464,7 +464,7 @@ options, including the default values, see `New-ScheduledJobOption`.
 To submit a hash table, use the following keys. In the following hash table, the keys are shown with
 their default values.
 
-`@{StartIfOnBattery=$False; StopIfGoingOnBattery=$True; WakeToRun=$False; StartIfNotIdle=$False; IdleDuration="00:10:00"; IdleTimeout="01:00:00"; StopIfGoingOffIdle=$True; RestartOnIdleResume=$False; ShowInTaskScheduler=$True; RunElevated=$False; RunWithoutNetwork=$False; DoNotAllowDemandStart=$False; MultipleInstancePolicy="IgnoreNew"}`
+`@{StartIfOnBattery=$false; StopIfGoingOnBattery=$True; WakeToRun=$false; StartIfNotIdle=$false; IdleDuration="00:10:00"; IdleTimeout="01:00:00"; StopIfGoingOffIdle=$True; RestartOnIdleResume=$false; ShowInTaskScheduler=$True; RunElevated=$false; RunWithoutNetwork=$false; DoNotAllowDemandStart=$false; MultipleInstancePolicy="IgnoreNew"}`
 
 ```yaml
 Type: Microsoft.PowerShell.ScheduledJob.ScheduledJobOptions

--- a/reference/5.1/PSScheduledJob/Set-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Set-ScheduledJob.md
@@ -443,7 +443,7 @@ options, including the default values, see `New-ScheduledJobOption`.
 To submit a hash table, use the following keys.
 In the following hash table, the keys are shown with their default values.
 
-`@{# Power SettingsStartIfOnBattery=$False;StopIfGoingOnBattery=$True; WakeToRun=$False; # Idle SettingsStartIfNotIdle=$False; IdleDuration="00:10:00"; IdleTimeout="01:00:00"; StopIfGoingOffIdle=$True; RestartOnIdleResume=$False;# Security settingsShowInTaskScheduler=$TrueRunElevated=$False;# MiscRunWithoutNetwork=$False;DoNotAllowDemandStart=$False;MultipleInstancePolicy=IgnoreNew# Can be IgnoreNew, Parallel, Queue, StopExisting}`
+`@{# Power SettingsStartIfOnBattery=$false;StopIfGoingOnBattery=$True; WakeToRun=$false; # Idle SettingsStartIfNotIdle=$false; IdleDuration="00:10:00"; IdleTimeout="01:00:00"; StopIfGoingOffIdle=$True; RestartOnIdleResume=$false;# Security settingsShowInTaskScheduler=$TrueRunElevated=$false;# MiscRunWithoutNetwork=$false;DoNotAllowDemandStart=$false;MultipleInstancePolicy=IgnoreNew# Can be IgnoreNew, Parallel, Queue, StopExisting}`
 
 ```yaml
 Type: Microsoft.PowerShell.ScheduledJob.ScheduledJobOptions

--- a/reference/5.1/PSWorkflow/About/about_ActivityCommonParameters.md
+++ b/reference/5.1/PSWorkflow/About/about_ActivityCommonParameters.md
@@ -65,7 +65,7 @@ This section describes the activity common parameters.
 #### AppendOutput \<Boolean\>
 
 A value of `$True` adds the output of the activity to the value of the variable.
-A value of `$False` has no effect. By default, assigning a value to a variable
+A value of `$false` has no effect. By default, assigning a value to a variable
 replaces the variable value.
 
 For example, the following commands add a process object to the service object
@@ -144,7 +144,7 @@ piping objects to the activity one at a time.
 
 #### MergeErrorToOutput \<Boolean\>
 
-A value of `$True` adds errors to the output stream. A value of `$False` has
+A value of `$True` adds errors to the output stream. A value of `$false` has
 no effect. Use this parameter with the **Parallel** and `ForEach -Parallel`
 keywords to collect errors and output from multiple parallel commands
 in a single collection.
@@ -170,7 +170,7 @@ affected target computer.
 #### PSAllowRedirection \<Boolean\>
 
 A value of `$True` allows redirection of the connection to the target computers.
-A value of `$False` has no effect. This activity common parameter is also a
+A value of `$false` has no effect. This activity common parameter is also a
 workflow common parameter.
 
 When you use the **PSConnectionURI** parameter, the remote destination can return
@@ -365,7 +365,7 @@ Valid values:
 - `$True`. Directs all activities within a workflow to return
   "live" (not serialized) objects. The resulting objects have methods, as well
   as properties, but they cannot be saved when a checkpoint is taken.
-- `$False`. Workflow objects are serialized.
+- `$false`. Workflow objects are serialized.
 
 #### PSError \<PSDataCollection[ErrorRecord]\>
 
@@ -414,7 +414,7 @@ Valid values:
 - `$True`. Takes a checkpoint after the activity completes. This checkpoint is
   in addition to any checkpoints that are specified in the workflow.
 
-- `$False`. No checkpoints are added. Checkpoints are taken only when specified
+- `$false`. No checkpoints are added. Checkpoints are taken only when specified
   in the workflow.
 
 #### PSPort \<Int32\>
@@ -501,7 +501,7 @@ For more information about the `$PSSessionOption` preference variable, see
 
 A value of `$True` uses the Secure Sockets Layer (SSL) protocol to establish a
 connection to the target computer. By default, SSL is not used. A value of
-`$False` has no effect. This activity common parameter is also a workflow common
+`$false` has no effect. This activity common parameter is also a workflow common
 parameter.
 
 WS-Management encrypts all Windows PowerShell content transmitted over the

--- a/reference/5.1/PSWorkflow/About/about_WorkflowCommonParameters.md
+++ b/reference/5.1/PSWorkflow/About/about_WorkflowCommonParameters.md
@@ -292,7 +292,7 @@ Valid values:
   checkpoint after each activity, in addition to any checkpoints that are
   specified in the workflow.
 
-- `$False`. No checkpoints are added. Checkpoints are taken only when specified
+- `$false`. No checkpoints are added. Checkpoints are taken only when specified
   in the workflow.
 
 #### -PSPort \<Int32\>

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -47,7 +47,7 @@ is limited to the following elements:
 - All PowerShell operators, except `-match`
 - `If`, `Else`, and `ElseIf` statements
 - The following automatic variables: `$PsCulture`, `$PsUICulture`, `$True`,
-  `$False`, and `$Null`
+  `$false`, and `$Null`
 - Comments
 - Pipelines
 - Statements separated by semicolons (`;`)

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
@@ -587,7 +587,7 @@ system files and folders, use the **Attributes** parameter.
 ### NewerThan \<DateTime\>
 
 Returns `$True` when the `LastWriteTime` value of a file is greater than the
-specified date. Otherwise, it returns `$False`.
+specified date. Otherwise, it returns `$false`.
 
 Enter a [DateTime][01] object, such as one that the [Get-Date][37] cmdlet
 returns, or a string that can be converted to a **DateTime** object, such as
@@ -600,7 +600,7 @@ returns, or a string that can be converted to a **DateTime** object, such as
 ### OlderThan \<DateTime\>
 
 Returns `$True` when the `LastWriteTime` value of a file is less than the
-specified date. Otherwise, it returns `$False`.
+specified date. Otherwise, it returns `$false`.
 
 Enter a **DateTime** object, such as one that the `Get-Date` cmdlet
 returns, or a string that can be converted to a [DateTime][01] object, such as

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -408,7 +408,7 @@ parameter is used in a command.
 By default, all function parameters are positional. PowerShell assigns position
 numbers to parameters in the order the parameters are declared in the function.
 To disable this feature, set the value of the `PositionalBinding` argument of
-the **CmdletBinding** attribute to `$False`. The `Position` argument takes
+the **CmdletBinding** attribute to `$false`. The `Position` argument takes
 precedence over the value of the `PositionalBinding` argument of the
 **CmdletBinding** attribute. For more information, see `PositionalBinding` in
 [about_Functions_CmdletBindingAttribute][12].

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -175,7 +175,7 @@ lists the changes that the command would make, instead of running the command.
 
 The **PositionalBinding** argument determines whether parameters in the
 function are positional by default. The default value is `$True`. You can use
-the **PositionalBinding** argument with a value of `$False` to disable
+the **PositionalBinding** argument with a value of `$false` to disable
 positional binding.
 
 The **PositionalBinding** argument is introduced in Windows PowerShell 3.0.
@@ -192,7 +192,7 @@ When **PositionalBinding** is `$True`, function parameters are positional by
 default. PowerShell assigns position number to the parameters in the order in
 which they are declared in the function.
 
-When **PositionalBinding** is `$False`, function parameters are not positional
+When **PositionalBinding** is `$false`, function parameters are not positional
 by default. Unless the **Position** argument of the **Parameter** attribute is
 declared on the parameter, the parameter name (or an alias or abbreviation)
 must be included when the parameter is used in a function.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
@@ -119,7 +119,7 @@ any PowerShell modules.
 If this policy setting isn't configured, the **LogPipelineExecutionDetails**
 property of each module determines whether PowerShell logs the execution events
 of that module. By default, the **LogPipelineExecutionDetails** property of all
-modules is set to `$False`.
+modules is set to `$false`.
 
 To turn on module logging for a module, use the following command format. The
 module must be imported into the session and the setting is effective only in

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -170,7 +170,7 @@ mode:
 - `$PSCulture`
 - `$PSUICulture`
 - `$True`
-- `$False`
+- `$false`
 - `$Null`
 
 Module manifests are loaded in `RestrictedLanguage` mode and may use these

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -28,7 +28,7 @@ object, the file changes too.
 Most objects have properties. Properties are the data that are associated with
 an object. Different types of object have different properties. For example, a
 **FileInfo** object, which represents a file, has an **IsReadOnly** property
-that contains `$True` if the file has the read-only attribute and `$False` if
+that contains `$True` if the file has the read-only attribute and `$false` if
 it doesn't. A **DirectoryInfo** object, which represents a file system
 directory, has a **Parent** property that contains the path to the parent
 directory.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -77,7 +77,7 @@ In rare cases, you might need to provide a **Boolean** value for a switch
 parameter. To provide a **Boolean** value for a switch parameter in the value
 of the **File** parameter, Use the parameter normally followed immediately by a
 colon and the boolean value, such as the following:
-`-File .\Get-Script.ps1 -All:$False`.
+`-File .\Get-Script.ps1 -All:$false`.
 
 Parameters passed to the script are passed as literal strings, after
 interpretation by the current shell. For example, if you are in `cmd.exe` and

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -73,7 +73,7 @@ variable in a command with splatting. The At symbol (`@HashArguments`) replaces
 the dollar sign (`$HashArguments`) in the command.
 
 To provide a value for the **WhatIf** switch parameter, use `$True` or
-`$False`.
+`$false`.
 
 ```powershell
 $HashArguments = @{

--- a/reference/7.4/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Get-Job.md
@@ -548,13 +548,13 @@ Accept wildcard characters: False
 Indicates whether this cmdlet gets only jobs that have the specified **HasMoreData** property value.
 The **HasMoreData** property indicates whether all job results have been received in the current
 session. To get jobs that have more results, specify a value of `$True`. To get jobs that do not
-have more results, specify a value of `$False`.
+have more results, specify a value of `$false`.
 
 To get the results of a job, use the `Receive-Job` cmdlet.
 
 When you use the `Receive-Job` cmdlet, it deletes from its in-memory, session-specific storage the
 results that it returned. When it has returned all results of the job in the current session, it
-sets the value of the **HasMoreData** property of the job to `$False`) to indicate that it has no
+sets the value of the **HasMoreData** property of the job to `$false`) to indicate that it has no
 more results for the job in the current session. Use the **Keep** parameter of `Receive-Job` to
 prevent `Receive-Job` from deleting results and changing the value of the **HasMoreData** property.
 For more information, type `Get-Help Receive-Job`.
@@ -562,7 +562,7 @@ For more information, type `Get-Help Receive-Job`.
 The **HasMoreData** property is specific to the current session. If results for a custom job type
 are saved outside of the session, such as the scheduled job type, which saves job results on disk,
 you can use the `Receive-Job` cmdlet in a different session to get the job results again, even if
-the value of **HasMoreData** is `$False`. For more information, see the help topics for the custom
+the value of **HasMoreData** is `$false`. For more information, see the help topics for the custom
 job type.
 
 This parameter was introduced in Windows PowerShell 3.0.

--- a/reference/7.4/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -585,7 +585,7 @@ The acceptable values for this parameter are:
   elements, such as script blocks, variables, or operators.
 - RestrictedLanguage - Users may run cmdlets and functions, but are not permitted to use script
   blocks or variables except for the following permitted variables: `$PSCulture`, `$PSUICulture`,
-  `$True`, `$False`, and `$Null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
+  `$True`, `$false`, and `$Null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
   `-lt`). Assignment statements, property references, and method calls are not permitted.
 
 The default value of the **LanguageMode** parameter depends on the value of the **SessionType**

--- a/reference/7.4/Microsoft.PowerShell.Core/Test-ModuleManifest.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Test-ModuleManifest.md
@@ -87,7 +87,7 @@ function Test-ManifestBool ($path)
 ```
 
 This function is like `Test-ModuleManifest`, but it returns a Boolean value. The function returns
-`$True` if the manifest passed the test and `$False` otherwise.
+`$True` if the manifest passed the test and `$false` otherwise.
 
 The function uses the Get-ChildItem cmdlet, alias = dir, to get the module manifest specified by the
 `$path` variable. The command uses a pipeline operator (`|`) to pass the file object to
@@ -99,7 +99,7 @@ object that `Test-ModuleManifest` returns in the $a variable. Therefore, the obj
 displayed.
 
 Then, in a separate command, the function displays the value of the `$?` automatic variable. If the
-previous command generates no error, the command displays `$True`, and `$False` otherwise.
+previous command generates no error, the command displays `$True`, and `$false` otherwise.
 
 You can use this function in conditional statements, such as those that might precede an
 `Import-Module` command or a command that uses the module.

--- a/reference/7.4/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
@@ -25,7 +25,7 @@ Test-PSSessionConfigurationFile [-Path] <String> [<CommonParameters>]
 This cmdlet verifies that a session configuration file contains valid keys and the values are of the
 correct type. For enumerated values, the cmdlet verifies that the specified values are valid.
 
-The cmdlet returns `$True` if the file passes all tests and `$False` if it does not. To find any
+The cmdlet returns `$True` if the file passes all tests and `$false` if it does not. To find any
 errors, use the **Verbose** parameter.
 
 `Test-PSSessionConfigurationFile` verifies the session configuration files, such as those created by

--- a/reference/7.4/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Update-Help.md
@@ -193,7 +193,7 @@ The script uses the **PSCustomObject** class and a hash table to create a custom
 ```powershell
 # Get-UpdateHelpVersion.ps1
 Param(
-    [parameter(Mandatory=$False)]
+    [parameter(Mandatory=$false)]
     [String[]]
     $Module
 )

--- a/reference/7.4/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Where-Object.md
@@ -373,7 +373,7 @@ Get-ChildItem | Where-Object { $_.PSIsContainer }
 ```powershell
 # Finally, use the -not operator (!) to get objects that are not containers.
 # This gets objects that do have the **PSIsContainer** property and those
-# that have a value of $False for the **PSIsContainer** property.
+# that have a value of $false for the **PSIsContainer** property.
 Get-ChildItem | Where-Object -Not PSIsContainer
 Get-ChildItem | Where-Object { !$_.PSIsContainer }
 ```

--- a/reference/7.4/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Split-Path.md
@@ -146,7 +146,7 @@ the full path of the parent container.
 ### Example 4: Determines whether a path is absolute
 
 This command determines whether the path is relative or absolute. In this case, because the path is
-relative to the current folder, which is represented by a dot (`.`), it returns `$False`.
+relative to the current folder, which is represented by a dot (`.`), it returns `$false`.
 
 ```powershell
 Split-Path -Path ".\My Pictures\*.jpg" -IsAbsolute
@@ -225,7 +225,7 @@ Accept wildcard characters: False
 
 ### -IsAbsolute
 
-Indicates that this cmdlet returns `$True` if the path is absolute and `$False` if it's relative. On
+Indicates that this cmdlet returns `$True` if the path is absolute and `$false` if it's relative. On
 Windows, an absolute path string must start with a provider drive specifier, like `C:` or `HKCU:`. A
 relative path starts with a dot (`.`) or a dot-dot (`..`).
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Test-Connection.md
@@ -147,7 +147,7 @@ if (Test-Connection -TargetName Server01 -Quiet) { New-PSSession -ComputerName S
 
 The `Test-Connection` cmdlet pings the `Server01` computer, with the **Quiet** parameter provided.
 The resulting value is `$True` if any of the four pings succeed. If none of the pings succeed,
-the value is `$False`.
+the value is `$false`.
 
 If the `Test-Connection` command returns a value of `$True`, the command uses the `New-PSSession`
 cmdlet to create the **PSSession**.
@@ -406,7 +406,7 @@ specifies multiple computers, an array of **Boolean** values is returned.
 
 If **any** ping to a given target succeeds, `$True` is returned.
 
-If **all** pings to a given target fail, `$False` is returned.
+If **all** pings to a given target fail, `$false` is returned.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -501,7 +501,7 @@ Specifies the TCP port number on the target to be used in the TCP connection tes
 The cmdlet attempts to make a TCP connection to the specified port on the target.
 
 - The cmdlet returns `$True` if a connection is made.
-- The cmdlet returns `$False` if a connection is not made.
+- The cmdlet returns `$false` if a connection is not made.
 
 ```yaml
 Type: System.Int32

--- a/reference/7.4/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -209,7 +209,7 @@ two properties, **Status** in descending order and **DisplayName** in ascending 
 
 **Status** is an enumerated property. **Stopped** has a value of **1** and **Running** has a value
 of **4**. The **Descending** parameter is set to `$True` so that **Running** processes are displayed
-before **Stopped** processes. **DisplayName** sets the **Descending** parameter to `$False` to sort
+before **Stopped** processes. **DisplayName** sets the **Descending** parameter to `$false` to sort
 the display names in alphabetical order.
 
 ### Example 6: Sort text files by time span

--- a/reference/7.4/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -503,11 +503,11 @@ Indicates whether the set of properties that are serialized is inherited. The de
 `$Null`. The acceptable values for this parameter are:
 
 - `$True`. The property set is inherited.
-- `$False`. The property set is not inherited.
+- `$false`. The property set is not inherited.
 - `$Null`. Inheritance is not defined.
 
 This parameter is valid only when the value of the **SerializationMethod** parameter is
-`SpecificProperties`. When the value of this parameter is `$False`, the **PropertySerializationSet**
+`SpecificProperties`. When the value of this parameter is `$false`, the **PropertySerializationSet**
 parameter is required.
 
 This parameter was introduced in Windows PowerShell 3.0.

--- a/reference/7.4/Microsoft.PowerShell.Utility/Wait-Event.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Wait-Event.md
@@ -62,7 +62,7 @@ $objectEventArgs = @{
 }
 Register-ObjectEvent @objectEventArgs
 $Timer.Interval = 2000
-$Timer.Autoreset = $False
+$Timer.Autoreset = $false
 $Timer.Enabled = $True
 Wait-Event Timer.Elapsed
 ```

--- a/reference/7.4/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.4/PSReadLine/Set-PSReadLineOption.md
@@ -504,12 +504,12 @@ to see the command multiple times when recalling or searching the history.
 
 By default, the **HistoryNoDuplicates** property of the global **PSConsoleReadLineOptions** object
 is set to `True`. To change the property value, you must specify the value of the
-**SwitchParameter** as follows: `-HistoryNoDuplicates:$False`. You can set back to `True` by using
+**SwitchParameter** as follows: `-HistoryNoDuplicates:$false`. You can set back to `True` by using
 just the **SwitchParameter**, `-HistoryNoDuplicates`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).HistoryNoDuplicates = $False`
+`(Get-PSReadLineOption).HistoryNoDuplicates = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -587,11 +587,11 @@ Specifies that history searching is case-sensitive in functions like **ReverseSe
 By default, the **HistorySearchCaseSensitive** property of the global **PSConsoleReadLineOptions**
 object is set to `False`. Using this **SwitchParameter** sets the property value to `True`. To
 change the property value back, you must specify the value of the **SwitchParameter** as follows:
-`-HistorySearchCaseSensitive:$False`.
+`-HistorySearchCaseSensitive:$false`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).HistorySearchCaseSensitive = $False`
+`(Get-PSReadLineOption).HistorySearchCaseSensitive = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -608,17 +608,17 @@ Accept wildcard characters: False
 ### -HistorySearchCursorMovesToEnd
 
 Indicates that the cursor moves to the end of commands that you load from history by using a search.
-When this parameter is set to `$False`, the cursor remains at the position it was when you pressed
+When this parameter is set to `$false`, the cursor remains at the position it was when you pressed
 the up or down arrows.
 
 By default, the **HistorySearchCursorMovesToEnd** property of the global
 **PSConsoleReadLineOptions** object is set to `False`. Using this **SwitchParameter** set the
 property value to `True`. To change the property value back, you must specify the value of the
-**SwitchParameter** as follows: `-HistorySearchCursorMovesToEnd:$False`.
+**SwitchParameter** as follows: `-HistorySearchCursorMovesToEnd:$false`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).HistorySearchCursorMovesToEnd = $False`
+`(Get-PSReadLineOption).HistorySearchCursorMovesToEnd = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -743,17 +743,17 @@ Accept wildcard characters: False
 When displaying possible completions, tooltips are shown in the list of completions.
 
 This option is enabled by default. This option wasn't enabled by default in prior versions of
-**PSReadLine**. To disable, set this option to `$False`.
+**PSReadLine**. To disable, set this option to `$false`.
 
 This parameter and option were added in PSReadLine 2.3.4.
 
 By default, the **ShowToolTips** property of the global **PSConsoleReadLineOptions** object is set
 to `True`. Using this **SwitchParameter** sets the property value to `True`. To change the property
-value, you must specify the value of the **SwitchParameter** as follows: `-ShowToolTips:$False`.
+value, you must specify the value of the **SwitchParameter** as follows: `-ShowToolTips:$false`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).ShowToolTips = $False`
+`(Get-PSReadLineOption).ShowToolTips = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -47,7 +47,7 @@ is limited to the following elements:
 - All PowerShell operators, except `-match`
 - `If`, `Else`, and `ElseIf` statements
 - The following automatic variables: `$PsCulture`, `$PsUICulture`, `$True`,
-  `$False`, and `$Null`
+  `$false`, and `$Null`
 - Comments
 - Pipelines
 - Statements separated by semicolons (`;`)

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
@@ -587,7 +587,7 @@ system files and folders, use the **Attributes** parameter.
 ### NewerThan \<DateTime\>
 
 Returns `$True` when the `LastWriteTime` value of a file is greater than the
-specified date. Otherwise, it returns `$False`.
+specified date. Otherwise, it returns `$false`.
 
 Enter a [DateTime][01] object, such as one that the [Get-Date][37] cmdlet
 returns, or a string that can be converted to a **DateTime** object, such as
@@ -600,7 +600,7 @@ returns, or a string that can be converted to a **DateTime** object, such as
 ### OlderThan \<DateTime\>
 
 Returns `$True` when the `LastWriteTime` value of a file is less than the
-specified date. Otherwise, it returns `$False`.
+specified date. Otherwise, it returns `$false`.
 
 Enter a **DateTime** object, such as one that the `Get-Date` cmdlet
 returns, or a string that can be converted to a [DateTime][01] object, such as

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -408,7 +408,7 @@ parameter is used in a command.
 By default, all function parameters are positional. PowerShell assigns position
 numbers to parameters in the order the parameters are declared in the function.
 To disable this feature, set the value of the `PositionalBinding` argument of
-the **CmdletBinding** attribute to `$False`. The `Position` argument takes
+the **CmdletBinding** attribute to `$false`. The `Position` argument takes
 precedence over the value of the `PositionalBinding` argument of the
 **CmdletBinding** attribute. For more information, see `PositionalBinding` in
 [about_Functions_CmdletBindingAttribute][12].

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -176,7 +176,7 @@ lists the changes that the command would make, instead of running the command.
 
 The **PositionalBinding** argument determines whether parameters in the
 function are positional by default. The default value is `$True`. You can use
-the **PositionalBinding** argument with a value of `$False` to disable
+the **PositionalBinding** argument with a value of `$false` to disable
 positional binding.
 
 The **PositionalBinding** argument is introduced in Windows PowerShell 3.0.
@@ -193,7 +193,7 @@ When **PositionalBinding** is `$True`, function parameters are positional by
 default. PowerShell assigns position number to the parameters in the order in
 which they are declared in the function.
 
-When **PositionalBinding** is `$False`, function parameters are not positional
+When **PositionalBinding** is `$false`, function parameters are not positional
 by default. Unless the **Position** argument of the **Parameter** attribute is
 declared on the parameter, the parameter name (or an alias or abbreviation)
 must be included when the parameter is used in a function.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
@@ -119,7 +119,7 @@ any PowerShell modules.
 If this policy setting isn't configured, the **LogPipelineExecutionDetails**
 property of each module determines whether PowerShell logs the execution events
 of that module. By default, the **LogPipelineExecutionDetails** property of all
-modules is set to `$False`.
+modules is set to `$false`.
 
 To turn on module logging for a module, use the following command format. The
 module must be imported into the session and the setting is effective only in

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -170,7 +170,7 @@ mode:
 - `$PSCulture`
 - `$PSUICulture`
 - `$True`
-- `$False`
+- `$false`
 - `$Null`
 
 Module manifests are loaded in `RestrictedLanguage` mode and may use these

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -28,7 +28,7 @@ object, the file changes too.
 Most objects have properties. Properties are the data that are associated with
 an object. Different types of object have different properties. For example, a
 **FileInfo** object, which represents a file, has an **IsReadOnly** property
-that contains `$True` if the file has the read-only attribute and `$False` if
+that contains `$True` if the file has the read-only attribute and `$false` if
 it doesn't. A **DirectoryInfo** object, which represents a file system
 directory, has a **Parent** property that contains the path to the parent
 directory.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -77,7 +77,7 @@ In rare cases, you might need to provide a **Boolean** value for a switch
 parameter. To provide a **Boolean** value for a switch parameter in the value
 of the **File** parameter, Use the parameter normally followed immediately by a
 colon and the boolean value, such as the following:
-`-File .\Get-Script.ps1 -All:$False`.
+`-File .\Get-Script.ps1 -All:$false`.
 
 Parameters passed to the script are passed as literal strings, after
 interpretation by the current shell. For example, if you are in `cmd.exe` and

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -73,7 +73,7 @@ variable in a command with splatting. The At symbol (`@HashArguments`) replaces
 the dollar sign (`$HashArguments`) in the command.
 
 To provide a value for the **WhatIf** switch parameter, use `$True` or
-`$False`.
+`$false`.
 
 ```powershell
 $HashArguments = @{

--- a/reference/7.5/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Get-Job.md
@@ -548,13 +548,13 @@ Accept wildcard characters: False
 Indicates whether this cmdlet gets only jobs that have the specified **HasMoreData** property value.
 The **HasMoreData** property indicates whether all job results have been received in the current
 session. To get jobs that have more results, specify a value of `$True`. To get jobs that do not
-have more results, specify a value of `$False`.
+have more results, specify a value of `$false`.
 
 To get the results of a job, use the `Receive-Job` cmdlet.
 
 When you use the `Receive-Job` cmdlet, it deletes from its in-memory, session-specific storage the
 results that it returned. When it has returned all results of the job in the current session, it
-sets the value of the **HasMoreData** property of the job to `$False`) to indicate that it has no
+sets the value of the **HasMoreData** property of the job to `$false`) to indicate that it has no
 more results for the job in the current session. Use the **Keep** parameter of `Receive-Job` to
 prevent `Receive-Job` from deleting results and changing the value of the **HasMoreData** property.
 For more information, type `Get-Help Receive-Job`.
@@ -562,7 +562,7 @@ For more information, type `Get-Help Receive-Job`.
 The **HasMoreData** property is specific to the current session. If results for a custom job type
 are saved outside of the session, such as the scheduled job type, which saves job results on disk,
 you can use the `Receive-Job` cmdlet in a different session to get the job results again, even if
-the value of **HasMoreData** is `$False`. For more information, see the help topics for the custom
+the value of **HasMoreData** is `$false`. For more information, see the help topics for the custom
 job type.
 
 This parameter was introduced in Windows PowerShell 3.0.

--- a/reference/7.5/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -589,7 +589,7 @@ The acceptable values for this parameter are:
   elements, such as script blocks, variables, or operators.
 - RestrictedLanguage - Users may run cmdlets and functions, but are not permitted to use script
   blocks or variables except for the following permitted variables: `$PSCulture`, `$PSUICulture`,
-  `$True`, `$False`, and `$Null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
+  `$True`, `$false`, and `$Null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
   `-lt`). Assignment statements, property references, and method calls are not permitted.
 
 The default value of the **LanguageMode** parameter depends on the value of the **SessionType**

--- a/reference/7.5/Microsoft.PowerShell.Core/Test-ModuleManifest.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Test-ModuleManifest.md
@@ -87,7 +87,7 @@ function Test-ManifestBool ($path)
 ```
 
 This function is like `Test-ModuleManifest`, but it returns a Boolean value. The function returns
-`$True` if the manifest passed the test and `$False` otherwise.
+`$True` if the manifest passed the test and `$false` otherwise.
 
 The function uses the Get-ChildItem cmdlet, alias = dir, to get the module manifest specified by the
 `$path` variable. The command uses a pipeline operator (`|`) to pass the file object to
@@ -99,7 +99,7 @@ object that `Test-ModuleManifest` returns in the $a variable. Therefore, the obj
 displayed.
 
 Then, in a separate command, the function displays the value of the `$?` automatic variable. If the
-previous command generates no error, the command displays `$True`, and `$False` otherwise.
+previous command generates no error, the command displays `$True`, and `$false` otherwise.
 
 You can use this function in conditional statements, such as those that might precede an
 `Import-Module` command or a command that uses the module.

--- a/reference/7.5/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
@@ -25,7 +25,7 @@ Test-PSSessionConfigurationFile [-Path] <String> [<CommonParameters>]
 This cmdlet verifies that a session configuration file contains valid keys and the values are of the
 correct type. For enumerated values, the cmdlet verifies that the specified values are valid.
 
-The cmdlet returns `$True` if the file passes all tests and `$False` if it does not. To find any
+The cmdlet returns `$True` if the file passes all tests and `$false` if it does not. To find any
 errors, use the **Verbose** parameter.
 
 `Test-PSSessionConfigurationFile` verifies the session configuration files, such as those created by

--- a/reference/7.5/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Update-Help.md
@@ -193,7 +193,7 @@ The script uses the **PSCustomObject** class and a hash table to create a custom
 ```powershell
 # Get-UpdateHelpVersion.ps1
 Param(
-    [parameter(Mandatory=$False)]
+    [parameter(Mandatory=$false)]
     [String[]]
     $Module
 )

--- a/reference/7.5/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Where-Object.md
@@ -373,7 +373,7 @@ Get-ChildItem | Where-Object { $_.PSIsContainer }
 ```powershell
 # Finally, use the -not operator (!) to get objects that are not containers.
 # This gets objects that do have the **PSIsContainer** property and those
-# that have a value of $False for the **PSIsContainer** property.
+# that have a value of $false for the **PSIsContainer** property.
 Get-ChildItem | Where-Object -Not PSIsContainer
 Get-ChildItem | Where-Object { !$_.PSIsContainer }
 ```

--- a/reference/7.5/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Split-Path.md
@@ -146,7 +146,7 @@ the full path of the parent container.
 ### Example 4: Determines whether a path is absolute
 
 This command determines whether the path is relative or absolute. In this case, because the path is
-relative to the current folder, which is represented by a dot (`.`), it returns `$False`.
+relative to the current folder, which is represented by a dot (`.`), it returns `$false`.
 
 ```powershell
 Split-Path -Path ".\My Pictures\*.jpg" -IsAbsolute
@@ -225,7 +225,7 @@ Accept wildcard characters: False
 
 ### -IsAbsolute
 
-Indicates that this cmdlet returns `$True` if the path is absolute and `$False` if it's relative. On
+Indicates that this cmdlet returns `$True` if the path is absolute and `$false` if it's relative. On
 Windows, an absolute path string must start with a provider drive specifier, like `C:` or `HKCU:`. A
 relative path starts with a dot (`.`) or a dot-dot (`..`).
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Test-Connection.md
@@ -147,7 +147,7 @@ if (Test-Connection -TargetName Server01 -Quiet) { New-PSSession -ComputerName S
 
 The `Test-Connection` cmdlet pings the `Server01` computer, with the **Quiet** parameter provided.
 The resulting value is `$True` if any of the four pings succeed. If none of the pings succeed,
-the value is `$False`.
+the value is `$false`.
 
 If the `Test-Connection` command returns a value of `$True`, the command uses the `New-PSSession`
 cmdlet to create the **PSSession**.
@@ -406,7 +406,7 @@ specifies multiple computers, an array of **Boolean** values is returned.
 
 If **any** ping to a given target succeeds, `$True` is returned.
 
-If **all** pings to a given target fail, `$False` is returned.
+If **all** pings to a given target fail, `$false` is returned.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -501,7 +501,7 @@ Specifies the TCP port number on the target to be used in the TCP connection tes
 The cmdlet attempts to make a TCP connection to the specified port on the target.
 
 - The cmdlet returns `$True` if a connection is made.
-- The cmdlet returns `$False` if a connection is not made.
+- The cmdlet returns `$false` if a connection is not made.
 
 ```yaml
 Type: System.Int32

--- a/reference/7.5/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -209,7 +209,7 @@ two properties, **Status** in descending order and **DisplayName** in ascending 
 
 **Status** is an enumerated property. **Stopped** has a value of **1** and **Running** has a value
 of **4**. The **Descending** parameter is set to `$True` so that **Running** processes are displayed
-before **Stopped** processes. **DisplayName** sets the **Descending** parameter to `$False` to sort
+before **Stopped** processes. **DisplayName** sets the **Descending** parameter to `$false` to sort
 the display names in alphabetical order.
 
 ### Example 6: Sort text files by time span

--- a/reference/7.5/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -503,11 +503,11 @@ Indicates whether the set of properties that are serialized is inherited. The de
 `$Null`. The acceptable values for this parameter are:
 
 - `$True`. The property set is inherited.
-- `$False`. The property set is not inherited.
+- `$false`. The property set is not inherited.
 - `$Null`. Inheritance is not defined.
 
 This parameter is valid only when the value of the **SerializationMethod** parameter is
-`SpecificProperties`. When the value of this parameter is `$False`, the **PropertySerializationSet**
+`SpecificProperties`. When the value of this parameter is `$false`, the **PropertySerializationSet**
 parameter is required.
 
 This parameter was introduced in Windows PowerShell 3.0.

--- a/reference/7.5/Microsoft.PowerShell.Utility/Wait-Event.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Wait-Event.md
@@ -62,7 +62,7 @@ $objectEventArgs = @{
 }
 Register-ObjectEvent @objectEventArgs
 $Timer.Interval = 2000
-$Timer.AutoReset = $False
+$Timer.AutoReset = $false
 $Timer.Enabled = $True
 Wait-Event Timer.Elapsed
 ```

--- a/reference/7.5/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.5/PSReadLine/Set-PSReadLineOption.md
@@ -504,12 +504,12 @@ to see the command multiple times when recalling or searching the history.
 
 By default, the **HistoryNoDuplicates** property of the global **PSConsoleReadLineOptions** object
 is set to `True`. To change the property value, you must specify the value of the
-**SwitchParameter** as follows: `-HistoryNoDuplicates:$False`. You can set back to `True` by using
+**SwitchParameter** as follows: `-HistoryNoDuplicates:$false`. You can set back to `True` by using
 just the **SwitchParameter**, `-HistoryNoDuplicates`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).HistoryNoDuplicates = $False`
+`(Get-PSReadLineOption).HistoryNoDuplicates = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -587,11 +587,11 @@ Specifies that history searching is case-sensitive in functions like **ReverseSe
 By default, the **HistorySearchCaseSensitive** property of the global **PSConsoleReadLineOptions**
 object is set to `False`. Using this **SwitchParameter** sets the property value to `True`. To
 change the property value back, you must specify the value of the **SwitchParameter** as follows:
-`-HistorySearchCaseSensitive:$False`.
+`-HistorySearchCaseSensitive:$false`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).HistorySearchCaseSensitive = $False`
+`(Get-PSReadLineOption).HistorySearchCaseSensitive = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -608,17 +608,17 @@ Accept wildcard characters: False
 ### -HistorySearchCursorMovesToEnd
 
 Indicates that the cursor moves to the end of commands that you load from history by using a search.
-When this parameter is set to `$False`, the cursor remains at the position it was when you pressed
+When this parameter is set to `$false`, the cursor remains at the position it was when you pressed
 the up or down arrows.
 
 By default, the **HistorySearchCursorMovesToEnd** property of the global
 **PSConsoleReadLineOptions** object is set to `False`. Using this **SwitchParameter** set the
 property value to `True`. To change the property value back, you must specify the value of the
-**SwitchParameter** as follows: `-HistorySearchCursorMovesToEnd:$False`.
+**SwitchParameter** as follows: `-HistorySearchCursorMovesToEnd:$false`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).HistorySearchCursorMovesToEnd = $False`
+`(Get-PSReadLineOption).HistorySearchCursorMovesToEnd = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -743,17 +743,17 @@ Accept wildcard characters: False
 When displaying possible completions, tooltips are shown in the list of completions.
 
 This option is enabled by default. This option wasn't enabled by default in prior versions of
-**PSReadLine**. To disable, set this option to `$False`.
+**PSReadLine**. To disable, set this option to `$false`.
 
 This parameter and option were added in PSReadLine 2.3.4.
 
 By default, the **ShowToolTips** property of the global **PSConsoleReadLineOptions** object is set
 to `True`. Using this **SwitchParameter** sets the property value to `True`. To change the property
-value, you must specify the value of the **SwitchParameter** as follows: `-ShowToolTips:$False`.
+value, you must specify the value of the **SwitchParameter** as follows: `-ShowToolTips:$false`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).ShowToolTips = $False`
+`(Get-PSReadLineOption).ShowToolTips = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -47,7 +47,7 @@ is limited to the following elements:
 - All PowerShell operators, except `-match`
 - `If`, `Else`, and `ElseIf` statements
 - The following automatic variables: `$PsCulture`, `$PsUICulture`, `$True`,
-  `$False`, and `$Null`
+  `$false`, and `$Null`
 - Comments
 - Pipelines
 - Statements separated by semicolons (`;`)

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
@@ -587,7 +587,7 @@ system files and folders, use the **Attributes** parameter.
 ### NewerThan \<DateTime\>
 
 Returns `$True` when the `LastWriteTime` value of a file is greater than the
-specified date. Otherwise, it returns `$False`.
+specified date. Otherwise, it returns `$false`.
 
 Enter a [DateTime][01] object, such as one that the [Get-Date][37] cmdlet
 returns, or a string that can be converted to a **DateTime** object, such as
@@ -600,7 +600,7 @@ returns, or a string that can be converted to a **DateTime** object, such as
 ### OlderThan \<DateTime\>
 
 Returns `$True` when the `LastWriteTime` value of a file is less than the
-specified date. Otherwise, it returns `$False`.
+specified date. Otherwise, it returns `$false`.
 
 Enter a **DateTime** object, such as one that the `Get-Date` cmdlet
 returns, or a string that can be converted to a [DateTime][01] object, such as

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -408,7 +408,7 @@ parameter is used in a command.
 By default, all function parameters are positional. PowerShell assigns position
 numbers to parameters in the order the parameters are declared in the function.
 To disable this feature, set the value of the `PositionalBinding` argument of
-the **CmdletBinding** attribute to `$False`. The `Position` argument takes
+the **CmdletBinding** attribute to `$false`. The `Position` argument takes
 precedence over the value of the `PositionalBinding` argument of the
 **CmdletBinding** attribute. For more information, see `PositionalBinding` in
 [about_Functions_CmdletBindingAttribute][12].

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -176,7 +176,7 @@ lists the changes that the command would make, instead of running the command.
 
 The **PositionalBinding** argument determines whether parameters in the
 function are positional by default. The default value is `$True`. You can use
-the **PositionalBinding** argument with a value of `$False` to disable
+the **PositionalBinding** argument with a value of `$false` to disable
 positional binding.
 
 The **PositionalBinding** argument is introduced in Windows PowerShell 3.0.
@@ -193,7 +193,7 @@ When **PositionalBinding** is `$True`, function parameters are positional by
 default. PowerShell assigns position number to the parameters in the order in
 which they are declared in the function.
 
-When **PositionalBinding** is `$False`, function parameters are not positional
+When **PositionalBinding** is `$false`, function parameters are not positional
 by default. Unless the **Position** argument of the **Parameter** attribute is
 declared on the parameter, the parameter name (or an alias or abbreviation)
 must be included when the parameter is used in a function.

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
@@ -119,7 +119,7 @@ any PowerShell modules.
 If this policy setting isn't configured, the **LogPipelineExecutionDetails**
 property of each module determines whether PowerShell logs the execution events
 of that module. By default, the **LogPipelineExecutionDetails** property of all
-modules is set to `$False`.
+modules is set to `$false`.
 
 To turn on module logging for a module, use the following command format. The
 module must be imported into the session and the setting is effective only in

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -170,7 +170,7 @@ mode:
 - `$PSCulture`
 - `$PSUICulture`
 - `$True`
-- `$False`
+- `$false`
 - `$Null`
 
 Module manifests are loaded in `RestrictedLanguage` mode and may use these

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -28,7 +28,7 @@ object, the file changes too.
 Most objects have properties. Properties are the data that are associated with
 an object. Different types of object have different properties. For example, a
 **FileInfo** object, which represents a file, has an **IsReadOnly** property
-that contains `$True` if the file has the read-only attribute and `$False` if
+that contains `$True` if the file has the read-only attribute and `$false` if
 it doesn't. A **DirectoryInfo** object, which represents a file system
 directory, has a **Parent** property that contains the path to the parent
 directory.

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Pwsh.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Pwsh.md
@@ -77,7 +77,7 @@ In rare cases, you might need to provide a **Boolean** value for a switch
 parameter. To provide a **Boolean** value for a switch parameter in the value
 of the **File** parameter, Use the parameter normally followed immediately by a
 colon and the boolean value, such as the following:
-`-File .\Get-Script.ps1 -All:$False`.
+`-File .\Get-Script.ps1 -All:$false`.
 
 Parameters passed to the script are passed as literal strings, after
 interpretation by the current shell. For example, if you are in `cmd.exe` and

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -73,7 +73,7 @@ variable in a command with splatting. The At symbol (`@HashArguments`) replaces
 the dollar sign (`$HashArguments`) in the command.
 
 To provide a value for the **WhatIf** switch parameter, use `$True` or
-`$False`.
+`$false`.
 
 ```powershell
 $HashArguments = @{

--- a/reference/7.6/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Get-Job.md
@@ -547,13 +547,13 @@ Accept wildcard characters: False
 Indicates whether this cmdlet gets only jobs that have the specified **HasMoreData** property value.
 The **HasMoreData** property indicates whether all job results have been received in the current
 session. To get jobs that have more results, specify a value of `$True`. To get jobs that do not
-have more results, specify a value of `$False`.
+have more results, specify a value of `$false`.
 
 To get the results of a job, use the `Receive-Job` cmdlet.
 
 When you use the `Receive-Job` cmdlet, it deletes from its in-memory, session-specific storage the
 results that it returned. When it has returned all results of the job in the current session, it
-sets the value of the **HasMoreData** property of the job to `$False`) to indicate that it has no
+sets the value of the **HasMoreData** property of the job to `$false`) to indicate that it has no
 more results for the job in the current session. Use the **Keep** parameter of `Receive-Job` to
 prevent `Receive-Job` from deleting results and changing the value of the **HasMoreData** property.
 For more information, type `Get-Help Receive-Job`.
@@ -561,7 +561,7 @@ For more information, type `Get-Help Receive-Job`.
 The **HasMoreData** property is specific to the current session. If results for a custom job type
 are saved outside of the session, such as the scheduled job type, which saves job results on disk,
 you can use the `Receive-Job` cmdlet in a different session to get the job results again, even if
-the value of **HasMoreData** is `$False`. For more information, see the help topics for the custom
+the value of **HasMoreData** is `$false`. For more information, see the help topics for the custom
 job type.
 
 This parameter was introduced in Windows PowerShell 3.0.

--- a/reference/7.6/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -585,7 +585,7 @@ The acceptable values for this parameter are:
   elements, such as script blocks, variables, or operators.
 - RestrictedLanguage - Users may run cmdlets and functions, but are not permitted to use script
   blocks or variables except for the following permitted variables: `$PSCulture`, `$PSUICulture`,
-  `$True`, `$False`, and `$Null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
+  `$True`, `$false`, and `$Null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
   `-lt`). Assignment statements, property references, and method calls are not permitted.
 
 The default value of the **LanguageMode** parameter depends on the value of the **SessionType**

--- a/reference/7.6/Microsoft.PowerShell.Core/Test-ModuleManifest.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Test-ModuleManifest.md
@@ -87,7 +87,7 @@ function Test-ManifestBool ($path)
 ```
 
 This function is like `Test-ModuleManifest`, but it returns a Boolean value. The function returns
-`$True` if the manifest passed the test and `$False` otherwise.
+`$True` if the manifest passed the test and `$false` otherwise.
 
 The function uses the Get-ChildItem cmdlet, alias = dir, to get the module manifest specified by the
 `$path` variable. The command uses a pipeline operator (`|`) to pass the file object to
@@ -99,7 +99,7 @@ object that `Test-ModuleManifest` returns in the $a variable. Therefore, the obj
 displayed.
 
 Then, in a separate command, the function displays the value of the `$?` automatic variable. If the
-previous command generates no error, the command displays `$True`, and `$False` otherwise.
+previous command generates no error, the command displays `$True`, and `$false` otherwise.
 
 You can use this function in conditional statements, such as those that might precede an
 `Import-Module` command or a command that uses the module.

--- a/reference/7.6/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
@@ -25,7 +25,7 @@ Test-PSSessionConfigurationFile [-Path] <String> [<CommonParameters>]
 This cmdlet verifies that a session configuration file contains valid keys and the values are of the
 correct type. For enumerated values, the cmdlet verifies that the specified values are valid.
 
-The cmdlet returns `$True` if the file passes all tests and `$False` if it does not. To find any
+The cmdlet returns `$True` if the file passes all tests and `$false` if it does not. To find any
 errors, use the **Verbose** parameter.
 
 `Test-PSSessionConfigurationFile` verifies the session configuration files, such as those created by

--- a/reference/7.6/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Update-Help.md
@@ -193,7 +193,7 @@ The script uses the **PSCustomObject** class and a hash table to create a custom
 ```powershell
 # Get-UpdateHelpVersion.ps1
 Param(
-    [parameter(Mandatory=$False)]
+    [parameter(Mandatory=$false)]
     [String[]]
     $Module
 )

--- a/reference/7.6/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Where-Object.md
@@ -373,7 +373,7 @@ Get-ChildItem | Where-Object { $_.PSIsContainer }
 ```powershell
 # Finally, use the -not operator (!) to get objects that are not containers.
 # This gets objects that do have the **PSIsContainer** property and those
-# that have a value of $False for the **PSIsContainer** property.
+# that have a value of $false for the **PSIsContainer** property.
 Get-ChildItem | Where-Object -Not PSIsContainer
 Get-ChildItem | Where-Object { !$_.PSIsContainer }
 ```

--- a/reference/7.6/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Split-Path.md
@@ -146,7 +146,7 @@ the full path of the parent container.
 ### Example 4: Determines whether a path is absolute
 
 This command determines whether the path is relative or absolute. In this case, because the path is
-relative to the current folder, which is represented by a dot (`.`), it returns `$False`.
+relative to the current folder, which is represented by a dot (`.`), it returns `$false`.
 
 ```powershell
 Split-Path -Path ".\My Pictures\*.jpg" -IsAbsolute
@@ -225,7 +225,7 @@ Accept wildcard characters: False
 
 ### -IsAbsolute
 
-Indicates that this cmdlet returns `$True` if the path is absolute and `$False` if it's relative. On
+Indicates that this cmdlet returns `$True` if the path is absolute and `$false` if it's relative. On
 Windows, an absolute path string must start with a provider drive specifier, like `C:` or `HKCU:`. A
 relative path starts with a dot (`.`) or a dot-dot (`..`).
 

--- a/reference/7.6/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Test-Connection.md
@@ -147,7 +147,7 @@ if (Test-Connection -TargetName Server01 -Quiet) { New-PSSession -ComputerName S
 
 The `Test-Connection` cmdlet pings the `Server01` computer, with the **Quiet** parameter provided.
 The resulting value is `$True` if any of the four pings succeed. If none of the pings succeed,
-the value is `$False`.
+the value is `$false`.
 
 If the `Test-Connection` command returns a value of `$True`, the command uses the `New-PSSession`
 cmdlet to create the **PSSession**.
@@ -406,7 +406,7 @@ specifies multiple computers, an array of **Boolean** values is returned.
 
 If **any** ping to a given target succeeds, `$True` is returned.
 
-If **all** pings to a given target fail, `$False` is returned.
+If **all** pings to a given target fail, `$false` is returned.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -501,7 +501,7 @@ Specifies the TCP port number on the target to be used in the TCP connection tes
 The cmdlet attempts to make a TCP connection to the specified port on the target.
 
 - The cmdlet returns `$True` if a connection is made.
-- The cmdlet returns `$False` if a connection is not made.
+- The cmdlet returns `$false` if a connection is not made.
 
 ```yaml
 Type: System.Int32

--- a/reference/7.6/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -209,7 +209,7 @@ two properties, **Status** in descending order and **DisplayName** in ascending 
 
 **Status** is an enumerated property. **Stopped** has a value of **1** and **Running** has a value
 of **4**. The **Descending** parameter is set to `$True` so that **Running** processes are displayed
-before **Stopped** processes. **DisplayName** sets the **Descending** parameter to `$False` to sort
+before **Stopped** processes. **DisplayName** sets the **Descending** parameter to `$false` to sort
 the display names in alphabetical order.
 
 ### Example 6: Sort text files by time span

--- a/reference/7.6/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -503,11 +503,11 @@ Indicates whether the set of properties that are serialized is inherited. The de
 `$Null`. The acceptable values for this parameter are:
 
 - `$True`. The property set is inherited.
-- `$False`. The property set is not inherited.
+- `$false`. The property set is not inherited.
 - `$Null`. Inheritance is not defined.
 
 This parameter is valid only when the value of the **SerializationMethod** parameter is
-`SpecificProperties`. When the value of this parameter is `$False`, the **PropertySerializationSet**
+`SpecificProperties`. When the value of this parameter is `$false`, the **PropertySerializationSet**
 parameter is required.
 
 This parameter was introduced in Windows PowerShell 3.0.

--- a/reference/7.6/Microsoft.PowerShell.Utility/Wait-Event.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Wait-Event.md
@@ -62,7 +62,7 @@ $objectEventArgs = @{
 }
 Register-ObjectEvent @objectEventArgs
 $Timer.Interval = 2000
-$Timer.AutoReset = $False
+$Timer.AutoReset = $false
 $Timer.Enabled = $True
 Wait-Event Timer.Elapsed
 ```

--- a/reference/7.6/PSReadLine/Set-PSReadLineOption.md
+++ b/reference/7.6/PSReadLine/Set-PSReadLineOption.md
@@ -504,12 +504,12 @@ to see the command multiple times when recalling or searching the history.
 
 By default, the **HistoryNoDuplicates** property of the global **PSConsoleReadLineOptions** object
 is set to `True`. To change the property value, you must specify the value of the
-**SwitchParameter** as follows: `-HistoryNoDuplicates:$False`. You can set back to `True` by using
+**SwitchParameter** as follows: `-HistoryNoDuplicates:$false`. You can set back to `True` by using
 just the **SwitchParameter**, `-HistoryNoDuplicates`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).HistoryNoDuplicates = $False`
+`(Get-PSReadLineOption).HistoryNoDuplicates = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -587,11 +587,11 @@ Specifies that history searching is case-sensitive in functions like **ReverseSe
 By default, the **HistorySearchCaseSensitive** property of the global **PSConsoleReadLineOptions**
 object is set to `False`. Using this **SwitchParameter** sets the property value to `True`. To
 change the property value back, you must specify the value of the **SwitchParameter** as follows:
-`-HistorySearchCaseSensitive:$False`.
+`-HistorySearchCaseSensitive:$false`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).HistorySearchCaseSensitive = $False`
+`(Get-PSReadLineOption).HistorySearchCaseSensitive = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -608,17 +608,17 @@ Accept wildcard characters: False
 ### -HistorySearchCursorMovesToEnd
 
 Indicates that the cursor moves to the end of commands that you load from history by using a search.
-When this parameter is set to `$False`, the cursor remains at the position it was when you pressed
+When this parameter is set to `$false`, the cursor remains at the position it was when you pressed
 the up or down arrows.
 
 By default, the **HistorySearchCursorMovesToEnd** property of the global
 **PSConsoleReadLineOptions** object is set to `False`. Using this **SwitchParameter** set the
 property value to `True`. To change the property value back, you must specify the value of the
-**SwitchParameter** as follows: `-HistorySearchCursorMovesToEnd:$False`.
+**SwitchParameter** as follows: `-HistorySearchCursorMovesToEnd:$false`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).HistorySearchCursorMovesToEnd = $False`
+`(Get-PSReadLineOption).HistorySearchCursorMovesToEnd = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -743,17 +743,17 @@ Accept wildcard characters: False
 When displaying possible completions, tooltips are shown in the list of completions.
 
 This option is enabled by default. This option wasn't enabled by default in prior versions of
-**PSReadLine**. To disable, set this option to `$False`.
+**PSReadLine**. To disable, set this option to `$false`.
 
 This parameter and option were added in PSReadLine 2.3.4.
 
 By default, the **ShowToolTips** property of the global **PSConsoleReadLineOptions** object is set
 to `True`. Using this **SwitchParameter** sets the property value to `True`. To change the property
-value, you must specify the value of the **SwitchParameter** as follows: `-ShowToolTips:$False`.
+value, you must specify the value of the **SwitchParameter** as follows: `-ShowToolTips:$false`.
 
 Using the following command, you can set the property value directly:
 
-`(Get-PSReadLineOption).ShowToolTips = $False`
+`(Get-PSReadLineOption).ShowToolTips = $false`
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter


### PR DESCRIPTION
# PR Summary

This PR (**_3/13_**) fixes incorrect [automatic variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables) casing used throughout the documentation. E.g., `$Args` (incorrect) -> `$args` (correct).

This PR fixes all occurrences of:

- `$false`

## Context

This series of PRs ensures the correct case is consistently used for each individual automatic variable, as documented in `about_Automatic_Variables` and verified by tab completion.

Changes in scope:

- Variables with a `$` or `@` sigil.
- Variables referenced by name without a sigil.

Out of scope:

- Preference variables (separate PRs to follow).
- Misuse of an automatic variable (e.g., naming a function parameter as `$Input`).
- Reference to the variable's _value_ (e.g., `false`/`False`/`FALSE` when referring to the _value_ of `$false`).

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide