### PR TITLE
Fix automatic variable case (1/9)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -205,7 +205,7 @@ non-zero integer.
 ### `$foreach`
 
 Contains the enumerator (not the resulting values) of a [ForEach][56] loop. The
-`$ForEach` variable exists only while the `ForEach` loop is running; it's
+`$foreach` variable exists only while the `ForEach` loop is running; it's
 deleted after the loop is completed.
 
 Enumerators contain properties and methods you can use to retrieve loop values

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -46,8 +46,8 @@ is limited to the following elements:
 
 - All PowerShell operators, except `-match`
 - `If`, `Else`, and `ElseIf` statements
-- The following automatic variables: `$PsCulture`, `$PsUICulture`, `$True`,
-  `$false`, and `$Null`
+- The following automatic variables: `$PSCulture`, `$PSUICulture`, `$true`,
+  `$false`, and `$null`
 - Comments
 - Pipelines
 - Statements separated by semicolons (`;`)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -127,7 +127,7 @@ for the following automatic variables:
 ```powershell
 $_
 $args
-$Input
+$input
 $MyInvocation
 $PSBoundParameters
 ```

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
@@ -581,7 +581,7 @@ system files and folders, use the **Attributes** parameter.
 
 ### NewerThan \<DateTime\>
 
-Returns `$True` when the `LastWriteTime` value of a file is greater than the
+Returns `$true` when the `LastWriteTime` value of a file is greater than the
 specified date. Otherwise, it returns `$false`.
 
 Enter a [DateTime][01] object, such as one that the [Get-Date][37] cmdlet
@@ -594,7 +594,7 @@ returns, or a string that can be converted to a **DateTime** object, such as
 
 ### OlderThan \<DateTime\>
 
-Returns `$True` when the `LastWriteTime` value of a file is less than the
+Returns `$true` when the `LastWriteTime` value of a file is less than the
 specified date. Otherwise, it returns `$false`.
 
 Enter a **DateTime** object, such as one that the `Get-Date` cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -119,7 +119,7 @@ processing, and an `end` block for one-time post-processing.
 ```powershell
 Function Test-ScriptCmdlet
 {
-[CmdletBinding(SupportsShouldProcess=$True)]
+[CmdletBinding(SupportsShouldProcess=$true)]
     Param ($Parameter1)
     begin{}
     process{}

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -53,7 +53,7 @@ processing, and an `end` block for one-time post-processing.
 ```powershell
 Function Test-ScriptCmdlet
 {
-[CmdletBinding(SupportsShouldProcess=$True)]
+[CmdletBinding(SupportsShouldProcess=$true)]
     param ($Parameter1)
     begin{}
     process{}

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1203,7 +1203,7 @@ function Test-UserDrivePath{
         [ValidateUserDrive()]
         [string]$Path
     )
-    $True
+    $true
 }
 
 Test-UserDrivePath -Path C:\

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -174,7 +174,7 @@ lists the changes that the command would make, instead of running the command.
 ## PositionalBinding
 
 The **PositionalBinding** argument determines whether parameters in the
-function are positional by default. The default value is `$True`. You can use
+function are positional by default. The default value is `$true`. You can use
 the **PositionalBinding** argument with a value of `$false` to disable
 positional binding.
 
@@ -188,7 +188,7 @@ function command.
 When parameters are not positional (they are "named"), the parameter
 name (or an abbreviation or alias of the name) is required in the command.
 
-When **PositionalBinding** is `$True`, function parameters are positional by
+When **PositionalBinding** is `$true`, function parameters are positional by
 default. PowerShell assigns position number to the parameters in the order in
 which they are declared in the function.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
@@ -80,7 +80,7 @@ Import-Module <Module-Name>
 
 To turn on module logging for all sessions on a particular computer, add the
 previous commands to the 'All Users' PowerShell profile
-(`$Profile.AllUsersAllHosts`).
+(`$PROFILE.AllUsersAllHosts`).
 
 For more information about module logging, see
 [about_Modules](about_Modules.md).

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -166,9 +166,9 @@ mode:
 
 - `$PSCulture`
 - `$PSUICulture`
-- `$True`
+- `$true`
 - `$false`
-- `$Null`
+- `$null`
 
 Module manifests are loaded in `RestrictedLanguage` mode and may use these
 additional variables:

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -212,7 +212,7 @@ non-zero integer.
 ### `$foreach`
 
 Contains the enumerator (not the resulting values) of a [ForEach][56] loop. The
-`$ForEach` variable exists only while the `ForEach` loop is running; it's
+`$foreach` variable exists only while the `ForEach` loop is running; it's
 deleted after the loop is completed.
 
 Enumerators contain properties and methods you can use to retrieve loop values
@@ -644,7 +644,7 @@ following items:
 - **GitCommitId** - The commit Id of the source files, in GitHub,
 - **OS** - Description of the operating system that PowerShell is running on.
 - **Platform** - Platform that the operating system is running on. The value on
-  Linux and macOS is **Unix**. See `$IsMacOs` and `$IsLinux`.
+  Linux and macOS is **Unix**. See `$IsMacOS` and `$IsLinux`.
 - **PSCompatibleVersions** - Versions of PowerShell that are compatible with
   the current version
 - **PSRemotingProtocolVersion** - The version of the PowerShell remote

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -46,8 +46,8 @@ is limited to the following elements:
 
 - All PowerShell operators, except `-match`
 - `If`, `Else`, and `ElseIf` statements
-- The following automatic variables: `$PsCulture`, `$PsUICulture`, `$True`,
-  `$false`, and `$Null`
+- The following automatic variables: `$PSCulture`, `$PSUICulture`, `$true`,
+  `$false`, and `$null`
 - Comments
 - Pipelines
 - Statements separated by semicolons (`;`)

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -127,7 +127,7 @@ for the following automatic variables:
 ```powershell
 $_
 $args
-$Input
+$input
 $MyInvocation
 $PSBoundParameters
 ```

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
@@ -586,7 +586,7 @@ system files and folders, use the **Attributes** parameter.
 
 ### NewerThan \<DateTime\>
 
-Returns `$True` when the `LastWriteTime` value of a file is greater than the
+Returns `$true` when the `LastWriteTime` value of a file is greater than the
 specified date. Otherwise, it returns `$false`.
 
 Enter a [DateTime][01] object, such as one that the [Get-Date][37] cmdlet
@@ -599,7 +599,7 @@ returns, or a string that can be converted to a **DateTime** object, such as
 
 ### OlderThan \<DateTime\>
 
-Returns `$True` when the `LastWriteTime` value of a file is less than the
+Returns `$true` when the `LastWriteTime` value of a file is less than the
 specified date. Otherwise, it returns `$false`.
 
 Enter a **DateTime** object, such as one that the `Get-Date` cmdlet

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -122,7 +122,7 @@ processing, and an `end` block for one-time post-processing.
 ```powershell
 Function Test-ScriptCmdlet
 {
-[CmdletBinding(SupportsShouldProcess=$True)]
+[CmdletBinding(SupportsShouldProcess=$true)]
     Param ($Parameter1)
     begin{}
     process{}

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -54,7 +54,7 @@ processing, and an `end` block for one-time post-processing.
 ```powershell
 Function Test-ScriptCmdlet
 {
-[CmdletBinding(SupportsShouldProcess=$True)]
+[CmdletBinding(SupportsShouldProcess=$true)]
     param ($Parameter1)
     begin{}
     process{}

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1292,7 +1292,7 @@ function Test-UserDrivePath{
         [ValidateUserDrive()]
         [string]$Path
     )
-    $True
+    $true
 }
 
 Test-UserDrivePath -Path C:\

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -174,7 +174,7 @@ lists the changes that the command would make, instead of running the command.
 ## PositionalBinding
 
 The **PositionalBinding** argument determines whether parameters in the
-function are positional by default. The default value is `$True`. You can use
+function are positional by default. The default value is `$true`. You can use
 the **PositionalBinding** argument with a value of `$false` to disable
 positional binding.
 
@@ -188,7 +188,7 @@ function command.
 When parameters are not positional (they are "named"), the parameter
 name (or an abbreviation or alias of the name) is required in the command.
 
-When **PositionalBinding** is `$True`, function parameters are positional by
+When **PositionalBinding** is `$true`, function parameters are positional by
 default. PowerShell assigns position number to the parameters in the order in
 which they are declared in the function.
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
@@ -132,7 +132,7 @@ Import-Module <Module-Name>
 
 To turn on module logging for all sessions on a particular computer, add the
 previous commands to the 'All Users' PowerShell profile
-(`$Profile.AllUsersAllHosts`).
+(`$PROFILE.AllUsersAllHosts`).
 
 For more information about module logging, see
 [about_Modules](about_Modules.md).

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -169,9 +169,9 @@ mode:
 
 - `$PSCulture`
 - `$PSUICulture`
-- `$True`
+- `$true`
 - `$false`
-- `$Null`
+- `$null`
 
 Module manifests are loaded in `RestrictedLanguage` mode and may use these
 additional variables:

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -212,7 +212,7 @@ non-zero integer.
 ### `$foreach`
 
 Contains the enumerator (not the resulting values) of a [ForEach][56] loop. The
-`$ForEach` variable exists only while the `ForEach` loop is running; it's
+`$foreach` variable exists only while the `ForEach` loop is running; it's
 deleted after the loop is completed.
 
 Enumerators contain properties and methods you can use to retrieve loop values
@@ -644,7 +644,7 @@ following items:
 - **GitCommitId** - The commit Id of the source files, in GitHub,
 - **OS** - Description of the operating system that PowerShell is running on.
 - **Platform** - Platform that the operating system is running on. The value on
-  Linux and macOS is **Unix**. See `$IsMacOs` and `$IsLinux`.
+  Linux and macOS is **Unix**. See `$IsMacOS` and `$IsLinux`.
 - **PSCompatibleVersions** - Versions of PowerShell that are compatible with
   the current version
 - **PSRemotingProtocolVersion** - The version of the PowerShell remote

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -46,8 +46,8 @@ is limited to the following elements:
 
 - All PowerShell operators, except `-match`
 - `If`, `Else`, and `ElseIf` statements
-- The following automatic variables: `$PsCulture`, `$PsUICulture`, `$True`,
-  `$false`, and `$Null`
+- The following automatic variables: `$PSCulture`, `$PSUICulture`, `$true`,
+  `$false`, and `$null`
 - Comments
 - Pipelines
 - Statements separated by semicolons (`;`)

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -127,7 +127,7 @@ for the following automatic variables:
 ```powershell
 $_
 $args
-$Input
+$input
 $MyInvocation
 $PSBoundParameters
 ```

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
@@ -586,7 +586,7 @@ system files and folders, use the **Attributes** parameter.
 
 ### NewerThan \<DateTime\>
 
-Returns `$True` when the `LastWriteTime` value of a file is greater than the
+Returns `$true` when the `LastWriteTime` value of a file is greater than the
 specified date. Otherwise, it returns `$false`.
 
 Enter a [DateTime][01] object, such as one that the [Get-Date][37] cmdlet
@@ -599,7 +599,7 @@ returns, or a string that can be converted to a **DateTime** object, such as
 
 ### OlderThan \<DateTime\>
 
-Returns `$True` when the `LastWriteTime` value of a file is less than the
+Returns `$true` when the `LastWriteTime` value of a file is less than the
 specified date. Otherwise, it returns `$false`.
 
 Enter a **DateTime** object, such as one that the `Get-Date` cmdlet

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -122,7 +122,7 @@ processing, and an `end` block for one-time post-processing.
 ```powershell
 Function Test-ScriptCmdlet
 {
-[CmdletBinding(SupportsShouldProcess=$True)]
+[CmdletBinding(SupportsShouldProcess=$true)]
     Param ($Parameter1)
     begin{}
     process{}

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -54,7 +54,7 @@ processing, and an `end` block for one-time post-processing.
 ```powershell
 Function Test-ScriptCmdlet
 {
-[CmdletBinding(SupportsShouldProcess=$True)]
+[CmdletBinding(SupportsShouldProcess=$true)]
     param ($Parameter1)
     begin{}
     process{}

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1292,7 +1292,7 @@ function Test-UserDrivePath{
         [ValidateUserDrive()]
         [string]$Path
     )
-    $True
+    $true
 }
 
 Test-UserDrivePath -Path C:\

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -175,7 +175,7 @@ lists the changes that the command would make, instead of running the command.
 ## PositionalBinding
 
 The **PositionalBinding** argument determines whether parameters in the
-function are positional by default. The default value is `$True`. You can use
+function are positional by default. The default value is `$true`. You can use
 the **PositionalBinding** argument with a value of `$false` to disable
 positional binding.
 
@@ -189,7 +189,7 @@ function command.
 When parameters are not positional (they are "named"), the parameter
 name (or an abbreviation or alias of the name) is required in the command.
 
-When **PositionalBinding** is `$True`, function parameters are positional by
+When **PositionalBinding** is `$true`, function parameters are positional by
 default. PowerShell assigns position number to the parameters in the order in
 which they are declared in the function.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
@@ -132,7 +132,7 @@ Import-Module <Module-Name>
 
 To turn on module logging for all sessions on a particular computer, add the
 previous commands to the 'All Users' PowerShell profile
-(`$Profile.AllUsersAllHosts`).
+(`$PROFILE.AllUsersAllHosts`).
 
 For more information about module logging, see
 [about_Modules](about_Modules.md).

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -169,9 +169,9 @@ mode:
 
 - `$PSCulture`
 - `$PSUICulture`
-- `$True`
+- `$true`
 - `$false`
-- `$Null`
+- `$null`
 
 Module manifests are loaded in `RestrictedLanguage` mode and may use these
 additional variables:

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -212,7 +212,7 @@ non-zero integer.
 ### `$foreach`
 
 Contains the enumerator (not the resulting values) of a [ForEach][56] loop. The
-`$ForEach` variable exists only while the `ForEach` loop is running; it's
+`$foreach` variable exists only while the `ForEach` loop is running; it's
 deleted after the loop is completed.
 
 Enumerators contain properties and methods you can use to retrieve loop values
@@ -644,7 +644,7 @@ following items:
 - **GitCommitId** - The commit Id of the source files, in GitHub,
 - **OS** - Description of the operating system that PowerShell is running on.
 - **Platform** - Platform that the operating system is running on. The value on
-  Linux and macOS is **Unix**. See `$IsMacOs` and `$IsLinux`.
+  Linux and macOS is **Unix**. See `$IsMacOS` and `$IsLinux`.
 - **PSCompatibleVersions** - Versions of PowerShell that are compatible with
   the current version
 - **PSRemotingProtocolVersion** - The version of the PowerShell remote

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -46,8 +46,8 @@ is limited to the following elements:
 
 - All PowerShell operators, except `-match`
 - `If`, `Else`, and `ElseIf` statements
-- The following automatic variables: `$PsCulture`, `$PsUICulture`, `$True`,
-  `$false`, and `$Null`
+- The following automatic variables: `$PSCulture`, `$PSUICulture`, `$true`,
+  `$false`, and `$null`
 - Comments
 - Pipelines
 - Statements separated by semicolons (`;`)

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -127,7 +127,7 @@ for the following automatic variables:
 ```powershell
 $_
 $args
-$Input
+$input
 $MyInvocation
 $PSBoundParameters
 ```

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
@@ -586,7 +586,7 @@ system files and folders, use the **Attributes** parameter.
 
 ### NewerThan \<DateTime\>
 
-Returns `$True` when the `LastWriteTime` value of a file is greater than the
+Returns `$true` when the `LastWriteTime` value of a file is greater than the
 specified date. Otherwise, it returns `$false`.
 
 Enter a [DateTime][01] object, such as one that the [Get-Date][37] cmdlet
@@ -599,7 +599,7 @@ returns, or a string that can be converted to a **DateTime** object, such as
 
 ### OlderThan \<DateTime\>
 
-Returns `$True` when the `LastWriteTime` value of a file is less than the
+Returns `$true` when the `LastWriteTime` value of a file is less than the
 specified date. Otherwise, it returns `$false`.
 
 Enter a **DateTime** object, such as one that the `Get-Date` cmdlet

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -122,7 +122,7 @@ processing, and an `end` block for one-time post-processing.
 ```powershell
 Function Test-ScriptCmdlet
 {
-[CmdletBinding(SupportsShouldProcess=$True)]
+[CmdletBinding(SupportsShouldProcess=$true)]
     Param ($Parameter1)
     begin{}
     process{}

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -54,7 +54,7 @@ processing, and an `end` block for one-time post-processing.
 ```powershell
 Function Test-ScriptCmdlet
 {
-[CmdletBinding(SupportsShouldProcess=$True)]
+[CmdletBinding(SupportsShouldProcess=$true)]
     param ($Parameter1)
     begin{}
     process{}

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1292,7 +1292,7 @@ function Test-UserDrivePath{
         [ValidateUserDrive()]
         [string]$Path
     )
-    $True
+    $true
 }
 
 Test-UserDrivePath -Path C:\

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -175,7 +175,7 @@ lists the changes that the command would make, instead of running the command.
 ## PositionalBinding
 
 The **PositionalBinding** argument determines whether parameters in the
-function are positional by default. The default value is `$True`. You can use
+function are positional by default. The default value is `$true`. You can use
 the **PositionalBinding** argument with a value of `$false` to disable
 positional binding.
 
@@ -189,7 +189,7 @@ function command.
 When parameters are not positional (they are "named"), the parameter
 name (or an abbreviation or alias of the name) is required in the command.
 
-When **PositionalBinding** is `$True`, function parameters are positional by
+When **PositionalBinding** is `$true`, function parameters are positional by
 default. PowerShell assigns position number to the parameters in the order in
 which they are declared in the function.
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
@@ -132,7 +132,7 @@ Import-Module <Module-Name>
 
 To turn on module logging for all sessions on a particular computer, add the
 previous commands to the 'All Users' PowerShell profile
-(`$Profile.AllUsersAllHosts`).
+(`$PROFILE.AllUsersAllHosts`).
 
 For more information about module logging, see
 [about_Modules](about_Modules.md).

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -169,9 +169,9 @@ mode:
 
 - `$PSCulture`
 - `$PSUICulture`
-- `$True`
+- `$true`
 - `$false`
-- `$Null`
+- `$null`
 
 Module manifests are loaded in `RestrictedLanguage` mode and may use these
 additional variables:


### PR DESCRIPTION
# PR Summary

This PR fixes incorrect [automatic variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables) casing used in selected files. E.g., `$Args` (incorrect) -> `$args` (correct).

## Context

This is PR **_1/9_** in a series that ensures the correct case is consistently used for individual automatic variables, as documented in `about_Automatic_Variables` and verified by tab completion. As requested, the PRs are split into groups of ~40 files. Within each file, correct casing is applied to all referenced automatic variables.

Changes in scope:

- Variables with a `$` or `@` sigil.
- Variables referenced by name without a sigil.

Out of scope:

- Preference variables (separate PRs to follow).
- Misuse of an automatic variable (e.g., naming a function parameter as `$Input`).
- Reference to the variable's _value_ (e.g., `false`/`False`/`FALSE` when referring to the _value_ of `$false`).

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide