### PR TITLE
Fix automatic variable case (2/9)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Object_Creation.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Object_Creation.md
@@ -251,7 +251,7 @@ For example, the following command creates a session option object.
 ```powershell
 [System.Management.Automation.Remoting.PSSessionOption]@{
   IdleTimeout=43200000
-  SkipCnCheck=$True
+  SkipCnCheck=$true
 }
 ```
 
@@ -291,7 +291,7 @@ cmdlet can be a hash table.
 ```powershell
 New-PSSession -ComputerName Server01 -SessionOption @{
   IdleTimeout=43200000
-  SkipCnCheck=$True
+  SkipCnCheck=$true
 }
 Register-ScheduledJob -Name Test -FilePath .\Get-Inventory.ps1 -Trigger @{
   Frequency="Daily"

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -73,7 +73,7 @@ For example:
 ```
 
 ```Output
-"PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) "
+"PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($NestedPromptLevel + 1)) "
 # .Link
 # https://go.microsoft.com/fwlink/?LinkID=225750
 # .ExternalHelp System.Management.Automation.dll-help.xml
@@ -114,7 +114,7 @@ PowerShell includes a built-in `Prompt` function.
 
 ```powershell
 function prompt {
-  "PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) ";
+  "PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($NestedPromptLevel + 1)) ";
   # .Link
   # https://go.microsoft.com/fwlink/?LinkID=225750
   # .ExternalHelp System.Management.Automation.dll-help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -28,7 +28,7 @@ object, the file changes too.
 Most objects have properties. Properties are the data that are associated with
 an object. Different types of object have different properties. For example, a
 **FileInfo** object, which represents a file, has an **IsReadOnly** property
-that contains `$True` if the file has the read-only attribute and `$false` if
+that contains `$true` if the file has the read-only attribute and `$false` if
 it doesn't. A **DirectoryInfo** object, which represents a file system
 directory, has a **Parent** property that contains the path to the parent
 directory.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -312,7 +312,7 @@ reproduced exactly. For example:
 
 ```powershell
 @'
-The $profile variable contains the path
+The $PROFILE variable contains the path
 of your PowerShell profile.
 '@
 ```
@@ -320,7 +320,7 @@ of your PowerShell profile.
 The output of this command is:
 
 ```Output
-The $profile variable contains the path
+The $PROFILE variable contains the path
 of your PowerShell profile.
 ```
 
@@ -331,7 +331,7 @@ example:
 @"
 Even if you have not created a profile,
 the path of the profile file is:
-$profile.
+$PROFILE.
 "@
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -160,7 +160,7 @@ if (!($username)) { $msgTable.promptMsg }
 ```
 
 If `Import-LocalizedData` cannot find a `.psd1` file that matches the value of
-`$PSUIculture`, the value of `$msgTable` is not replaced, and the call to
+`$PSUICulture`, the value of `$msgTable` is not replaced, and the call to
 `$msgTable.promptMsg` displays the fallback en-US strings.
 
 ## Examples

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -302,12 +302,12 @@ function and the `$ProfileName` variable.
 function New-Profile
 {
   Write-Host "Running New-Profile function"
-  $profileName = Split-Path $profile -Leaf
+  $profileName = Split-Path $PROFILE -Leaf
 
-  if (Test-Path $profile)
+  if (Test-Path $PROFILE)
     {Write-Error "Profile $profileName already exists on this computer."}
   else
-    {New-Item -Type file -Path $profile -Force }
+    {New-Item -Type file -Path $PROFILE -Force }
 }
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -205,7 +205,7 @@ active copy of the session configuration file.
 
 When you use a session configuration file in a session configuration,
 PowerShell creates an active copy of the session configuration file and stores
-it in the \$pshome\\SessionConfig directory on the local computer.
+it in the \$PSHOME\\SessionConfig directory on the local computer.
 
 The location of the active copy of a session configuration file is stored in
 the ConfigFilePath property of the session configuration object.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -69,7 +69,7 @@ table of parameter-name and parameter-value pairs and stores it in the
 variable in a command with splatting. The At symbol (`@HashArguments`) replaces
 the dollar sign (`$HashArguments`) in the command.
 
-To provide a value for the **WhatIf** switch parameter, use `$True` or
+To provide a value for the **WhatIf** switch parameter, use `$true` or
 `$false`.
 
 ```powershell

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -73,7 +73,7 @@ The **Boolean** type operators (`-is` and `-isnot`) always return a **Boolean**
 value, even if the input is a collection of objects.
 
 If `<input>` is a type that is the same as or is _derived_ from the .NET Type,
-the `-is` operator returns `$True`.
+the `-is` operator returns `$true`.
 
 For example, the **DirectoryInfo** type is derived from the **FileSystemInfo**
 type. Therefore, both of these examples return **True**.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -141,7 +141,7 @@ Update-Help -Module Microsoft.PowerShell.Security
 
 ## Permissions for updatable help
 
-To update help for the modules in the directory `$pshome/Modules`, you must be
+To update help for the modules in the directory `$PSHOME/Modules`, you must be
 member of the Administrators group on the computer.
 
 If you aren't a member of the Administrators group, you can't update help for

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Object_Creation.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Object_Creation.md
@@ -247,7 +247,7 @@ For example, the following command creates a session option object.
 ```powershell
 [System.Management.Automation.Remoting.PSSessionOption]@{
   IdleTimeout=43200000
-  SkipCnCheck=$True
+  SkipCnCheck=$true
 }
 ```
 
@@ -287,7 +287,7 @@ cmdlet can be a hash table.
 ```powershell
 New-PSSession -ComputerName Server01 -SessionOption @{
   IdleTimeout=43200000
-  SkipCnCheck=$True
+  SkipCnCheck=$true
 }
 Register-ScheduledJob -Name Test -FilePath .\Get-Inventory.ps1 -Trigger @{
   Frequency="Daily"

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -73,7 +73,7 @@ For example:
 ```
 
 ```Output
-"PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) "
+"PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($NestedPromptLevel + 1)) "
 # .Link
 # https://go.microsoft.com/fwlink/?LinkID=225750
 # .ExternalHelp System.Management.Automation.dll-help.xml
@@ -114,7 +114,7 @@ PowerShell includes a built-in `Prompt` function.
 
 ```powershell
 function prompt {
-  "PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) ";
+  "PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($NestedPromptLevel + 1)) ";
   # .Link
   # https://go.microsoft.com/fwlink/?LinkID=225750
   # .ExternalHelp System.Management.Automation.dll-help.xml

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -28,7 +28,7 @@ object, the file changes too.
 Most objects have properties. Properties are the data that are associated with
 an object. Different types of object have different properties. For example, a
 **FileInfo** object, which represents a file, has an **IsReadOnly** property
-that contains `$True` if the file has the read-only attribute and `$false` if
+that contains `$true` if the file has the read-only attribute and `$false` if
 it doesn't. A **DirectoryInfo** object, which represents a file system
 directory, has a **Parent** property that contains the path to the parent
 directory.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -312,7 +312,7 @@ reproduced exactly. For example:
 
 ```powershell
 @'
-The $profile variable contains the path
+The $PROFILE variable contains the path
 of your PowerShell profile.
 '@
 ```
@@ -320,7 +320,7 @@ of your PowerShell profile.
 The output of this command is:
 
 ```Output
-The $profile variable contains the path
+The $PROFILE variable contains the path
 of your PowerShell profile.
 ```
 
@@ -331,7 +331,7 @@ example:
 @"
 Even if you have not created a profile,
 the path of the profile file is:
-$profile.
+$PROFILE.
 "@
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -160,7 +160,7 @@ if (!($username)) { $msgTable.promptMsg }
 ```
 
 If `Import-LocalizedData` cannot find a `.psd1` file that matches the value of
-`$PSUIculture`, the value of `$msgTable` is not replaced, and the call to
+`$PSUICulture`, the value of `$msgTable` is not replaced, and the call to
 `$msgTable.promptMsg` displays the fallback en-US strings.
 
 ## Examples

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -305,12 +305,12 @@ function and the `$ProfileName` variable.
 function New-Profile
 {
   Write-Host "Running New-Profile function"
-  $profileName = Split-Path $profile -Leaf
+  $profileName = Split-Path $PROFILE -Leaf
 
-  if (Test-Path $profile)
+  if (Test-Path $PROFILE)
     {Write-Error "Profile $profileName already exists on this computer."}
   else
-    {New-Item -Type file -Path $profile -Force }
+    {New-Item -Type file -Path $PROFILE -Force }
 }
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -206,7 +206,7 @@ active copy of the session configuration file.
 
 When you use a session configuration file in a session configuration,
 PowerShell creates an active copy of the session configuration file and stores
-it in the \$pshome\\SessionConfig directory on the local computer.
+it in the \$PSHOME\\SessionConfig directory on the local computer.
 
 The location of the active copy of a session configuration file is stored in
 the ConfigFilePath property of the session configuration object.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -72,7 +72,7 @@ table of parameter-name and parameter-value pairs and stores it in the
 variable in a command with splatting. The At symbol (`@HashArguments`) replaces
 the dollar sign (`$HashArguments`) in the command.
 
-To provide a value for the **WhatIf** switch parameter, use `$True` or
+To provide a value for the **WhatIf** switch parameter, use `$true` or
 `$false`.
 
 ```powershell

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -73,7 +73,7 @@ The **Boolean** type operators (`-is` and `-isnot`) always return a **Boolean**
 value, even if the input is a collection of objects.
 
 If `<input>` is a type that is the same as or is _derived_ from the .NET Type,
-the `-is` operator returns `$True`.
+the `-is` operator returns `$true`.
 
 For example, the **DirectoryInfo** type is derived from the **FileSystemInfo**
 type. Therefore, both of these examples return **True**.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -133,7 +133,7 @@ Update-Help -Module Microsoft.PowerShell.Security
 
 ## Permissions for updatable help
 
-To update help for the modules in the directory `$pshome/Modules`, you must be
+To update help for the modules in the directory `$PSHOME/Modules`, you must be
 member of the Administrators group on the computer.
 
 If you aren't a member of the Administrators group, you can't update help for

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Object_Creation.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Object_Creation.md
@@ -247,7 +247,7 @@ For example, the following command creates a session option object.
 ```powershell
 [System.Management.Automation.Remoting.PSSessionOption]@{
   IdleTimeout=43200000
-  SkipCnCheck=$True
+  SkipCnCheck=$true
 }
 ```
 
@@ -287,7 +287,7 @@ cmdlet can be a hash table.
 ```powershell
 New-PSSession -ComputerName Server01 -SessionOption @{
   IdleTimeout=43200000
-  SkipCnCheck=$True
+  SkipCnCheck=$true
 }
 Register-ScheduledJob -Name Test -FilePath .\Get-Inventory.ps1 -Trigger @{
   Frequency="Daily"

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -74,7 +74,7 @@ For example:
 ```
 
 ```Output
-"PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) "
+"PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($NestedPromptLevel + 1)) "
 # .Link
 # https://go.microsoft.com/fwlink/?LinkID=225750
 # .ExternalHelp System.Management.Automation.dll-help.xml
@@ -115,7 +115,7 @@ PowerShell includes a built-in `Prompt` function.
 
 ```powershell
 function prompt {
-  "PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) ";
+  "PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($NestedPromptLevel + 1)) ";
   # .Link
   # https://go.microsoft.com/fwlink/?LinkID=225750
   # .ExternalHelp System.Management.Automation.dll-help.xml

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -28,7 +28,7 @@ object, the file changes too.
 Most objects have properties. Properties are the data that are associated with
 an object. Different types of object have different properties. For example, a
 **FileInfo** object, which represents a file, has an **IsReadOnly** property
-that contains `$True` if the file has the read-only attribute and `$false` if
+that contains `$true` if the file has the read-only attribute and `$false` if
 it doesn't. A **DirectoryInfo** object, which represents a file system
 directory, has a **Parent** property that contains the path to the parent
 directory.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -312,7 +312,7 @@ reproduced exactly. For example:
 
 ```powershell
 @'
-The $profile variable contains the path
+The $PROFILE variable contains the path
 of your PowerShell profile.
 '@
 ```
@@ -320,7 +320,7 @@ of your PowerShell profile.
 The output of this command is:
 
 ```Output
-The $profile variable contains the path
+The $PROFILE variable contains the path
 of your PowerShell profile.
 ```
 
@@ -331,7 +331,7 @@ example:
 @"
 Even if you have not created a profile,
 the path of the profile file is:
-$profile.
+$PROFILE.
 "@
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -160,7 +160,7 @@ if (!($username)) { $msgTable.promptMsg }
 ```
 
 If `Import-LocalizedData` cannot find a `.psd1` file that matches the value of
-`$PSUIculture`, the value of `$msgTable` is not replaced, and the call to
+`$PSUICulture`, the value of `$msgTable` is not replaced, and the call to
 `$msgTable.promptMsg` displays the fallback en-US strings.
 
 ## Examples

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -305,12 +305,12 @@ function and the `$ProfileName` variable.
 function New-Profile
 {
   Write-Host "Running New-Profile function"
-  $profileName = Split-Path $profile -Leaf
+  $profileName = Split-Path $PROFILE -Leaf
 
-  if (Test-Path $profile)
+  if (Test-Path $PROFILE)
     {Write-Error "Profile $profileName already exists on this computer."}
   else
-    {New-Item -Type file -Path $profile -Force }
+    {New-Item -Type file -Path $PROFILE -Force }
 }
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -207,7 +207,7 @@ active copy of the session configuration file.
 
 When you use a session configuration file in a session configuration,
 PowerShell creates an active copy of the session configuration file and stores
-it in the \$pshome\\SessionConfig directory on the local computer.
+it in the \$PSHOME\\SessionConfig directory on the local computer.
 
 The location of the active copy of a session configuration file is stored in
 the ConfigFilePath property of the session configuration object.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -72,7 +72,7 @@ table of parameter-name and parameter-value pairs and stores it in the
 variable in a command with splatting. The At symbol (`@HashArguments`) replaces
 the dollar sign (`$HashArguments`) in the command.
 
-To provide a value for the **WhatIf** switch parameter, use `$True` or
+To provide a value for the **WhatIf** switch parameter, use `$true` or
 `$false`.
 
 ```powershell

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -74,7 +74,7 @@ The **Boolean** type operators (`-is` and `-isnot`) always return a **Boolean**
 value, even if the input is a collection of objects.
 
 If `<input>` is a type that is the same as or is _derived_ from the .NET Type,
-the `-is` operator returns `$True`.
+the `-is` operator returns `$true`.
 
 For example, the **DirectoryInfo** type is derived from the **FileSystemInfo**
 type. Therefore, both of these examples return **True**.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -133,7 +133,7 @@ Update-Help -Module Microsoft.PowerShell.Security
 
 ## Permissions for updatable help
 
-To update help for the modules in the directory `$pshome/Modules`, you must be
+To update help for the modules in the directory `$PSHOME/Modules`, you must be
 member of the Administrators group on the computer.
 
 If you aren't a member of the Administrators group, you can't update help for

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Object_Creation.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Object_Creation.md
@@ -247,7 +247,7 @@ For example, the following command creates a session option object.
 ```powershell
 [System.Management.Automation.Remoting.PSSessionOption]@{
   IdleTimeout=43200000
-  SkipCnCheck=$True
+  SkipCnCheck=$true
 }
 ```
 
@@ -287,7 +287,7 @@ cmdlet can be a hash table.
 ```powershell
 New-PSSession -ComputerName Server01 -SessionOption @{
   IdleTimeout=43200000
-  SkipCnCheck=$True
+  SkipCnCheck=$true
 }
 Register-ScheduledJob -Name Test -FilePath .\Get-Inventory.ps1 -Trigger @{
   Frequency="Daily"

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -74,7 +74,7 @@ For example:
 ```
 
 ```Output
-"PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) "
+"PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($NestedPromptLevel + 1)) "
 # .Link
 # https://go.microsoft.com/fwlink/?LinkID=225750
 # .ExternalHelp System.Management.Automation.dll-help.xml
@@ -115,7 +115,7 @@ PowerShell includes a built-in `Prompt` function.
 
 ```powershell
 function prompt {
-  "PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) ";
+  "PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($NestedPromptLevel + 1)) ";
   # .Link
   # https://go.microsoft.com/fwlink/?LinkID=225750
   # .ExternalHelp System.Management.Automation.dll-help.xml

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -28,7 +28,7 @@ object, the file changes too.
 Most objects have properties. Properties are the data that are associated with
 an object. Different types of object have different properties. For example, a
 **FileInfo** object, which represents a file, has an **IsReadOnly** property
-that contains `$True` if the file has the read-only attribute and `$false` if
+that contains `$true` if the file has the read-only attribute and `$false` if
 it doesn't. A **DirectoryInfo** object, which represents a file system
 directory, has a **Parent** property that contains the path to the parent
 directory.

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -312,7 +312,7 @@ reproduced exactly. For example:
 
 ```powershell
 @'
-The $profile variable contains the path
+The $PROFILE variable contains the path
 of your PowerShell profile.
 '@
 ```
@@ -320,7 +320,7 @@ of your PowerShell profile.
 The output of this command is:
 
 ```Output
-The $profile variable contains the path
+The $PROFILE variable contains the path
 of your PowerShell profile.
 ```
 
@@ -331,7 +331,7 @@ example:
 @"
 Even if you have not created a profile,
 the path of the profile file is:
-$profile.
+$PROFILE.
 "@
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -160,7 +160,7 @@ if (!($username)) { $msgTable.promptMsg }
 ```
 
 If `Import-LocalizedData` cannot find a `.psd1` file that matches the value of
-`$PSUIculture`, the value of `$msgTable` is not replaced, and the call to
+`$PSUICulture`, the value of `$msgTable` is not replaced, and the call to
 `$msgTable.promptMsg` displays the fallback en-US strings.
 
 ## Examples

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -305,12 +305,12 @@ function and the `$ProfileName` variable.
 function New-Profile
 {
   Write-Host "Running New-Profile function"
-  $profileName = Split-Path $profile -Leaf
+  $profileName = Split-Path $PROFILE -Leaf
 
-  if (Test-Path $profile)
+  if (Test-Path $PROFILE)
     {Write-Error "Profile $profileName already exists on this computer."}
   else
-    {New-Item -Type file -Path $profile -Force }
+    {New-Item -Type file -Path $PROFILE -Force }
 }
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -206,7 +206,7 @@ active copy of the session configuration file.
 
 When you use a session configuration file in a session configuration,
 PowerShell creates an active copy of the session configuration file and stores
-it in the \$pshome\\SessionConfig directory on the local computer.
+it in the \$PSHOME\\SessionConfig directory on the local computer.
 
 The location of the active copy of a session configuration file is stored in
 the ConfigFilePath property of the session configuration object.

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -72,7 +72,7 @@ table of parameter-name and parameter-value pairs and stores it in the
 variable in a command with splatting. The At symbol (`@HashArguments`) replaces
 the dollar sign (`$HashArguments`) in the command.
 
-To provide a value for the **WhatIf** switch parameter, use `$True` or
+To provide a value for the **WhatIf** switch parameter, use `$true` or
 `$false`.
 
 ```powershell

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -74,7 +74,7 @@ The **Boolean** type operators (`-is` and `-isnot`) always return a **Boolean**
 value, even if the input is a collection of objects.
 
 If `<input>` is a type that is the same as or is _derived_ from the .NET Type,
-the `-is` operator returns `$True`.
+the `-is` operator returns `$true`.
 
 For example, the **DirectoryInfo** type is derived from the **FileSystemInfo**
 type. Therefore, both of these examples return **True**.

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -133,7 +133,7 @@ Update-Help -Module Microsoft.PowerShell.Security
 
 ## Permissions for updatable help
 
-To update help for the modules in the directory `$pshome/Modules`, you must be
+To update help for the modules in the directory `$PSHOME/Modules`, you must be
 member of the Administrators group on the computer.
 
 If you aren't a member of the Administrators group, you can't update help for


### PR DESCRIPTION
# PR Summary

This PR fixes incorrect [automatic variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables) casing used in selected files. E.g., `$Args` (incorrect) -> `$args` (correct).

## Context

This is PR **_2/9_** in a series that ensures the correct case is consistently used for individual automatic variables, as documented in `about_Automatic_Variables` and verified by tab completion. As requested, the PRs are split into groups of ~40 files. Within each file, correct casing is applied to all referenced automatic variables.

Changes in scope:

- Variables with a `$` or `@` sigil.
- Variables referenced by name without a sigil.

Out of scope:

- Preference variables (separate PRs to follow).
- Misuse of an automatic variable (e.g., naming a function parameter as `$Input`).
- Reference to the variable's _value_ (e.g., `false`/`False`/`FALSE` when referring to the _value_ of `$false`).

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide