### PR TITLE
Fix automatic variable case (3/9)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
@@ -130,7 +130,7 @@ the dollar sign (`$`). This has the same effect as prefixing the variables name
 with the dollar sign (`$`).
 
 ```powershell
-$variable:home
+$variable:HOME
 ```
 
 ### Get variables using wildcards

--- a/reference/5.1/Microsoft.PowerShell.Core/Enable-PSRemoting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Enable-PSRemoting.md
@@ -219,7 +219,7 @@ This cmdlet returns strings that describe its results.
 ## NOTES
 
 Starting in PowerShell 3.0, `Enable-PSRemoting` enables all session configurations by setting the
-value of the **Enabled** property of all session configurations to `$True`.
+value of the **Enabled** property of all session configurations to `$true`.
 
 - On server versions of the Windows operating system, `Enable-PSRemoting` creates firewall rules for
   private and domain networks that allow remote access, and creates a firewall rule for public
@@ -236,7 +236,7 @@ value of the **Enabled** property of all session configurations to `$True`.
   `Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP-PUBLIC" -RemoteAddress Any`
 
 `Enable-PSRemoting` enables all session configurations by setting the value of the **Enabled**
-property of all session configurations to `$True`.
+property of all session configurations to `$true`.
 
 `Enable-PSRemoting` removes the **Deny_All** and **Network_Deny_All** settings. This provides remote
 access to session configurations that were reserved for local use.

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-Job.md
@@ -547,7 +547,7 @@ Accept wildcard characters: False
 
 Indicates whether this cmdlet gets only jobs that have the specified **HasMoreData** property value.
 The **HasMoreData** property indicates whether all job results have been received in the current
-session. To get jobs that have more results, specify a value of `$True`. To get jobs that do not
+session. To get jobs that have more results, specify a value of `$true`. To get jobs that do not
 have more results, specify a value of `$false`.
 
 To get the results of a job, use the `Receive-Job` cmdlet.

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-Module.md
@@ -266,7 +266,7 @@ Get-Content $m.Path
     CLRVersion         = "2.0"
     NestedModules      = "Microsoft.BackgroundIntelligentTransfer.Management"
     FormatsToProcess   = "FileTransfer.Format.ps1xml"
-    RequiredAssemblies = Join-Path $psScriptRoot "Microsoft.BackgroundIntelligentTransfer.Management.Interop.dll"
+    RequiredAssemblies = Join-Path $PSScriptRoot "Microsoft.BackgroundIntelligentTransfer.Management.Interop.dll"
 }
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -1080,7 +1080,7 @@ Accept wildcard characters: False
 Specifies input to the command. Enter a variable that contains the objects or type a command or
 expression that gets the objects.
 
-When using the **InputObject** parameter, use the `$Input` automatic variable in the value of the
+When using the **InputObject** parameter, use the `$input` automatic variable in the value of the
 **ScriptBlock** parameter to represent the input objects.
 
 ```yaml
@@ -1375,7 +1375,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.ScriptBlock
 
-You can pipe a command in a script block to `Invoke-Command`. Use the `$Input` automatic variable to
+You can pipe a command in a script block to `Invoke-Command`. Use the `$input` automatic variable to
 represent the input objects in the command.
 
 ## OUTPUTS

--- a/reference/5.1/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -772,7 +772,7 @@ Accept wildcard characters: False
 ### -Path
 
 Specifies the path and file name of the new module manifest. Enter a path and file name with a
-`.psd1` file name extension, such as `$pshome\Modules\MyModule\MyModule.psd1`. The **Path**
+`.psd1` file name extension, such as `$PSHOME\Modules\MyModule\MyModule.psd1`. The **Path**
 parameter is required.
 
 If you specify the path to an existing file, `New-ModuleManifest` replaces the file without warning
@@ -1136,7 +1136,7 @@ manifest.
 Module manifests are usually optional. However, a module manifest is required to export an assembly
 that is installed in the global assembly cache.
 
-To add or change files in the `$pshome\Modules` directory, start PowerShell with the **Run as
+To add or change files in the `$PSHOME\Modules` directory, start PowerShell with the **Run as
 administrator** option.
 
 In PowerShell 2.0, many parameters of `New-ModuleManifest` were mandatory, even though they weren't

--- a/reference/5.1/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -169,7 +169,7 @@ True
 ```
 
 Use the **Verbose** parameter with `Test-PSSessionConfigurationFile` to display any errors that are
-detected. The cmdlet returns `$True` if no errors are detected in the file.
+detected. The cmdlet returns `$true` if no errors are detected in the file.
 
 ### Example 5: Create a sample configuration file
 
@@ -583,7 +583,7 @@ The acceptable values for this parameter are:
   elements, such as script blocks, variables, or operators.
 - RestrictedLanguage - Users may run cmdlets and functions, but are not permitted to use script
   blocks or variables except for the following permitted variables: `$PSCulture`, `$PSUICulture`,
-  `$True`, `$false`, and `$Null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
+  `$true`, `$false`, and `$null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
   `-lt`). Assignment statements, property references, and method calls are not permitted.
 
 The default value of the **LanguageMode** parameter depends on the value of the **SessionType**

--- a/reference/5.1/Microsoft.PowerShell.Core/New-PSSessionOption.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-PSSessionOption.md
@@ -314,7 +314,7 @@ Specifies the culture to use for the session. Enter a culture name in
 `<languagecode2>-<country/regioncode2>` format (like `ja-JP`), a variable that contains a
 **CultureInfo** object, or a command that gets a **CultureInfo** object.
 
-The default value is `$Null`, and the culture that is set in the operating system is used in the
+The default value is `$null`, and the culture that is set in the operating system is used in the
 session.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -248,7 +248,7 @@ disconnected and get the results of jobs that were running in the sessions.
 
 ```
 PS> $parms = @{
-      InDisconnectedSession = $True
+      InDisconnectedSession = $true
       ComputerName = "Server01", "Server02", "Server30"
       FilePath = "\\Server12\Scripts\SharedScripts\Get-BugStatus.ps1"
       Name = "BugStatus"

--- a/reference/5.1/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Save-Help.md
@@ -69,7 +69,7 @@ cabinet file. The `Update-Help` cmdlet extracts the help files, validates the XM
 then installs the help files and the help information file in a language-specific subfolder of the
 module folder.
 
-To save the help files for modules in the PowerShell installation folder (`$pshome\Modules`), start
+To save the help files for modules in the PowerShell installation folder (`$PSHOME\Modules`), start
 PowerShell by using the Run as administrator option. You must be a member of the Administrators
 group on the computer to download the help files for these modules.
 
@@ -441,9 +441,9 @@ This cmdlet returns no output.
 
 ## NOTES
 
-- To save help for modules in the $pshome\Modules folder, start PowerShell by using the Run as
+- To save help for modules in the $PSHOME\Modules folder, start PowerShell by using the Run as
   administrator option. Only members of the Administrators group on the computer can download help
-  for modules in the $pshome\Modules folder.
+  for modules in the $PSHOME\Modules folder.
 - The saved help for each module consists of one help information (HelpInfo XML) file and one
   cabinet (.cab) file for the help files each UI culture. You do not have to extract the help files
   from the cabinet file. The `Update-Help` cmdlet extracts the help files, validates the XML, and

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
@@ -130,7 +130,7 @@ the dollar sign (`$`). This has the same effect as prefixing the variables name
 with the dollar sign (`$`).
 
 ```powershell
-$variable:home
+$variable:HOME
 ```
 
 ### Get variables using wildcards

--- a/reference/7.4/Microsoft.PowerShell.Core/Enable-PSRemoting.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Enable-PSRemoting.md
@@ -333,7 +333,7 @@ networks that removes the local subnet restriction and allows remote access , us
 `Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP-PUBLIC" -RemoteAddress Any`
 
 `Enable-PSRemoting` enables all session configurations by setting the value of the **Enabled**
-property of all session configurations to `$True`.
+property of all session configurations to `$true`.
 
 `Enable-PSRemoting` removes the **Deny_All** and **Network_Deny_All** settings. This provides remote
 access to session configurations that were reserved for local use.

--- a/reference/7.4/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Get-Job.md
@@ -547,7 +547,7 @@ Accept wildcard characters: False
 
 Indicates whether this cmdlet gets only jobs that have the specified **HasMoreData** property value.
 The **HasMoreData** property indicates whether all job results have been received in the current
-session. To get jobs that have more results, specify a value of `$True`. To get jobs that do not
+session. To get jobs that have more results, specify a value of `$true`. To get jobs that do not
 have more results, specify a value of `$false`.
 
 To get the results of a job, use the `Receive-Job` cmdlet.

--- a/reference/7.4/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Get-Module.md
@@ -267,7 +267,7 @@ Get-Content $m.Path
     CLRVersion         = "2.0"
     NestedModules      = "Microsoft.BackgroundIntelligentTransfer.Management"
     FormatsToProcess   = "FileTransfer.Format.ps1xml"
-    RequiredAssemblies = Join-Path $psScriptRoot "Microsoft.BackgroundIntelligentTransfer.Management.Interop.dll"
+    RequiredAssemblies = Join-Path $PSScriptRoot "Microsoft.BackgroundIntelligentTransfer.Management.Interop.dll"
 }
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -1228,7 +1228,7 @@ Accept wildcard characters: False
 Specifies input to the command. Enter a variable that contains the objects or type a command or
 expression that gets the objects.
 
-When using the **InputObject** parameter, use the `$Input` automatic variable in the value of the
+When using the **InputObject** parameter, use the `$input` automatic variable in the value of the
 **ScriptBlock** parameter to represent the input objects.
 
 ```yaml
@@ -1689,7 +1689,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.ScriptBlock
 
-You can pipe a command in a script block to `Invoke-Command`. Use the `$Input` automatic variable to
+You can pipe a command in a script block to `Invoke-Command`. Use the `$input` automatic variable to
 represent the input objects in the command.
 
 ## OUTPUTS

--- a/reference/7.4/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -801,7 +801,7 @@ Accept wildcard characters: False
 ### -Path
 
 Specifies the path and file name of the new module manifest. Enter a path and file name with a
-`.psd1` file name extension, such as `$pshome\Modules\MyModule\MyModule.psd1`. The **Path**
+`.psd1` file name extension, such as `$PSHOME\Modules\MyModule\MyModule.psd1`. The **Path**
 parameter is required.
 
 If you specify the path to an existing file, `New-ModuleManifest` replaces the file without warning
@@ -1202,7 +1202,7 @@ files encoded as **UTF8NoBOM**.
 Module manifests are usually optional. However, a module manifest is required to export an assembly
 that is installed in the global assembly cache.
 
-To add or change files in the `$pshome\Modules` directory, start PowerShell with the **Run as
+To add or change files in the `$PSHOME\Modules` directory, start PowerShell with the **Run as
 administrator** option.
 
 > [!NOTE]

--- a/reference/7.4/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -171,7 +171,7 @@ True
 ```
 
 Use the **Verbose** parameter with `Test-PSSessionConfigurationFile` to display any errors that are
-detected. The cmdlet returns `$True` if no errors are detected in the file.
+detected. The cmdlet returns `$true` if no errors are detected in the file.
 
 ### Example 5: Create a sample configuration file
 
@@ -585,7 +585,7 @@ The acceptable values for this parameter are:
   elements, such as script blocks, variables, or operators.
 - RestrictedLanguage - Users may run cmdlets and functions, but are not permitted to use script
   blocks or variables except for the following permitted variables: `$PSCulture`, `$PSUICulture`,
-  `$True`, `$false`, and `$Null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
+  `$true`, `$false`, and `$null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
   `-lt`). Assignment statements, property references, and method calls are not permitted.
 
 The default value of the **LanguageMode** parameter depends on the value of the **SessionType**

--- a/reference/7.4/Microsoft.PowerShell.Core/New-PSSessionOption.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/New-PSSessionOption.md
@@ -314,7 +314,7 @@ Specifies the culture to use for the session. Enter a culture name in
 `<languagecode2>-<country/regioncode2>` format (like `ja-JP`), a variable that contains a
 **CultureInfo** object, or a command that gets a **CultureInfo** object.
 
-The default value is `$Null`, and the culture that is set in the operating system is used in the
+The default value is `$null`, and the culture that is set in the operating system is used in the
 session.
 
 ```yaml

--- a/reference/7.4/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -250,7 +250,7 @@ disconnected and get the results of jobs that were running in the sessions.
 
 ```
 PS> $parms = @{
-      InDisconnectedSession = $True
+      InDisconnectedSession = $true
       ComputerName = "Server01", "Server02", "Server30"
       FilePath = "\\Server12\Scripts\SharedScripts\Get-BugStatus.ps1"
       Name = "BugStatus"

--- a/reference/7.4/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Save-Help.md
@@ -71,7 +71,7 @@ cabinet file. The `Update-Help` cmdlet extracts the help files, validates the XM
 then installs the help files and the help information file in a language-specific subfolder of the
 module folder.
 
-To save the help files for modules in the PowerShell installation folder (`$pshome\Modules`), start
+To save the help files for modules in the PowerShell installation folder (`$PSHOME\Modules`), start
 PowerShell by using the Run as administrator option. You must be a member of the Administrators
 group on the computer to download the help files for these modules.
 
@@ -461,9 +461,9 @@ This cmdlet returns no output.
 
 ## NOTES
 
-- To save help for modules in the $pshome\Modules folder, start PowerShell by using the Run as
+- To save help for modules in the $PSHOME\Modules folder, start PowerShell by using the Run as
   administrator option. Only members of the Administrators group on the computer can download help
-  for modules in the $pshome\Modules folder.
+  for modules in the $PSHOME\Modules folder.
 - The saved help for each module consists of one help information (HelpInfo XML) file and one
   cabinet (.cab) file for the help files each UI culture. You do not have to extract the help files
   from the cabinet file. The `Update-Help` cmdlet extracts the help files, validates the XML, and

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
@@ -130,7 +130,7 @@ the dollar sign (`$`). This has the same effect as prefixing the variables name
 with the dollar sign (`$`).
 
 ```powershell
-$variable:home
+$variable:HOME
 ```
 
 ### Get variables using wildcards

--- a/reference/7.5/Microsoft.PowerShell.Core/Enable-PSRemoting.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Enable-PSRemoting.md
@@ -333,7 +333,7 @@ networks that removes the local subnet restriction and allows remote access , us
 `Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP-PUBLIC" -RemoteAddress Any`
 
 `Enable-PSRemoting` enables all session configurations by setting the value of the **Enabled**
-property of all session configurations to `$True`.
+property of all session configurations to `$true`.
 
 `Enable-PSRemoting` removes the **Deny_All** and **Network_Deny_All** settings. This provides remote
 access to session configurations that were reserved for local use.

--- a/reference/7.5/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Get-Job.md
@@ -547,7 +547,7 @@ Accept wildcard characters: False
 
 Indicates whether this cmdlet gets only jobs that have the specified **HasMoreData** property value.
 The **HasMoreData** property indicates whether all job results have been received in the current
-session. To get jobs that have more results, specify a value of `$True`. To get jobs that do not
+session. To get jobs that have more results, specify a value of `$true`. To get jobs that do not
 have more results, specify a value of `$false`.
 
 To get the results of a job, use the `Receive-Job` cmdlet.

--- a/reference/7.5/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Get-Module.md
@@ -267,7 +267,7 @@ Get-Content $m.Path
     CLRVersion         = "2.0"
     NestedModules      = "Microsoft.BackgroundIntelligentTransfer.Management"
     FormatsToProcess   = "FileTransfer.Format.ps1xml"
-    RequiredAssemblies = Join-Path $psScriptRoot "Microsoft.BackgroundIntelligentTransfer.Management.Interop.dll"
+    RequiredAssemblies = Join-Path $PSScriptRoot "Microsoft.BackgroundIntelligentTransfer.Management.Interop.dll"
 }
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -1228,7 +1228,7 @@ Accept wildcard characters: False
 Specifies input to the command. Enter a variable that contains the objects or type a command or
 expression that gets the objects.
 
-When using the **InputObject** parameter, use the `$Input` automatic variable in the value of the
+When using the **InputObject** parameter, use the `$input` automatic variable in the value of the
 **ScriptBlock** parameter to represent the input objects.
 
 ```yaml
@@ -1689,7 +1689,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.ScriptBlock
 
-You can pipe a command in a script block to `Invoke-Command`. Use the `$Input` automatic variable to
+You can pipe a command in a script block to `Invoke-Command`. Use the `$input` automatic variable to
 represent the input objects in the command.
 
 ## OUTPUTS

--- a/reference/7.5/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -810,7 +810,7 @@ Accept wildcard characters: False
 ### -Path
 
 Specifies the path and file name of the new module manifest. Enter a path and file name with a
-`.psd1` file name extension, such as `$pshome\Modules\MyModule\MyModule.psd1`. The **Path**
+`.psd1` file name extension, such as `$PSHOME\Modules\MyModule\MyModule.psd1`. The **Path**
 parameter is required.
 
 If you specify the path to an existing file, `New-ModuleManifest` replaces the file without warning
@@ -1211,7 +1211,7 @@ files encoded as **UTF8NoBOM**.
 Module manifests are usually optional. However, a module manifest is required to export an assembly
 that is installed in the global assembly cache.
 
-To add or change files in the `$pshome\Modules` directory, start PowerShell with the **Run as
+To add or change files in the `$PSHOME\Modules` directory, start PowerShell with the **Run as
 administrator** option.
 
 > [!NOTE]

--- a/reference/7.5/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -171,7 +171,7 @@ True
 ```
 
 Use the **Verbose** parameter with `Test-PSSessionConfigurationFile` to display any errors that are
-detected. The cmdlet returns `$True` if no errors are detected in the file.
+detected. The cmdlet returns `$true` if no errors are detected in the file.
 
 ### Example 5: Create a sample configuration file
 
@@ -589,7 +589,7 @@ The acceptable values for this parameter are:
   elements, such as script blocks, variables, or operators.
 - RestrictedLanguage - Users may run cmdlets and functions, but are not permitted to use script
   blocks or variables except for the following permitted variables: `$PSCulture`, `$PSUICulture`,
-  `$True`, `$false`, and `$Null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
+  `$true`, `$false`, and `$null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
   `-lt`). Assignment statements, property references, and method calls are not permitted.
 
 The default value of the **LanguageMode** parameter depends on the value of the **SessionType**

--- a/reference/7.5/Microsoft.PowerShell.Core/New-PSSessionOption.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/New-PSSessionOption.md
@@ -314,7 +314,7 @@ Specifies the culture to use for the session. Enter a culture name in
 `<languagecode2>-<country/regioncode2>` format (like `ja-JP`), a variable that contains a
 **CultureInfo** object, or a command that gets a **CultureInfo** object.
 
-The default value is `$Null`, and the culture that is set in the operating system is used in the
+The default value is `$null`, and the culture that is set in the operating system is used in the
 session.
 
 ```yaml

--- a/reference/7.5/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -250,7 +250,7 @@ disconnected and get the results of jobs that were running in the sessions.
 
 ```powershell
 PS> $parms = @{
-      InDisconnectedSession = $True
+      InDisconnectedSession = $true
       ComputerName = "Server01", "Server02", "Server30"
       FilePath = "\\Server12\Scripts\SharedScripts\Get-BugStatus.ps1"
       Name = "BugStatus"

--- a/reference/7.5/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Save-Help.md
@@ -71,7 +71,7 @@ cabinet file. The `Update-Help` cmdlet extracts the help files, validates the XM
 then installs the help files and the help information file in a language-specific subfolder of the
 module folder.
 
-To save the help files for modules in the PowerShell installation folder (`$pshome\Modules`), start
+To save the help files for modules in the PowerShell installation folder (`$PSHOME\Modules`), start
 PowerShell by using the Run as administrator option. You must be a member of the Administrators
 group on the computer to download the help files for these modules.
 
@@ -464,9 +464,9 @@ This cmdlet returns no output.
 
 ## NOTES
 
-- To save help for modules in the $pshome\Modules folder, start PowerShell by using the Run as
+- To save help for modules in the $PSHOME\Modules folder, start PowerShell by using the Run as
   administrator option. Only members of the Administrators group on the computer can download help
-  for modules in the $pshome\Modules folder.
+  for modules in the $PSHOME\Modules folder.
 - The saved help for each module consists of one help information (HelpInfo XML) file and one
   cabinet (.cab) file for the help files each UI culture. You do not have to extract the help files
   from the cabinet file. The `Update-Help` cmdlet extracts the help files, validates the XML, and

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
@@ -130,7 +130,7 @@ the dollar sign (`$`). This has the same effect as prefixing the variables name
 with the dollar sign (`$`).
 
 ```powershell
-$variable:home
+$variable:HOME
 ```
 
 ### Get variables using wildcards

--- a/reference/7.6/Microsoft.PowerShell.Core/Enable-PSRemoting.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Enable-PSRemoting.md
@@ -333,7 +333,7 @@ networks that removes the local subnet restriction and allows remote access , us
 `Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP-PUBLIC" -RemoteAddress Any`
 
 `Enable-PSRemoting` enables all session configurations by setting the value of the **Enabled**
-property of all session configurations to `$True`.
+property of all session configurations to `$true`.
 
 `Enable-PSRemoting` removes the **Deny_All** and **Network_Deny_All** settings. This provides remote
 access to session configurations that were reserved for local use.

--- a/reference/7.6/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Get-Job.md
@@ -546,7 +546,7 @@ Accept wildcard characters: False
 
 Indicates whether this cmdlet gets only jobs that have the specified **HasMoreData** property value.
 The **HasMoreData** property indicates whether all job results have been received in the current
-session. To get jobs that have more results, specify a value of `$True`. To get jobs that do not
+session. To get jobs that have more results, specify a value of `$true`. To get jobs that do not
 have more results, specify a value of `$false`.
 
 To get the results of a job, use the `Receive-Job` cmdlet.

--- a/reference/7.6/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Get-Module.md
@@ -267,7 +267,7 @@ Get-Content $m.Path
     CLRVersion         = "2.0"
     NestedModules      = "Microsoft.BackgroundIntelligentTransfer.Management"
     FormatsToProcess   = "FileTransfer.Format.ps1xml"
-    RequiredAssemblies = Join-Path $psScriptRoot "Microsoft.BackgroundIntelligentTransfer.Management.Interop.dll"
+    RequiredAssemblies = Join-Path $PSScriptRoot "Microsoft.BackgroundIntelligentTransfer.Management.Interop.dll"
 }
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -1228,7 +1228,7 @@ Accept wildcard characters: False
 Specifies input to the command. Enter a variable that contains the objects or type a command or
 expression that gets the objects.
 
-When using the **InputObject** parameter, use the `$Input` automatic variable in the value of the
+When using the **InputObject** parameter, use the `$input` automatic variable in the value of the
 **ScriptBlock** parameter to represent the input objects.
 
 ```yaml
@@ -1689,7 +1689,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.ScriptBlock
 
-You can pipe a command in a script block to `Invoke-Command`. Use the `$Input` automatic variable to
+You can pipe a command in a script block to `Invoke-Command`. Use the `$input` automatic variable to
 represent the input objects in the command.
 
 ## OUTPUTS

--- a/reference/7.6/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -801,7 +801,7 @@ Accept wildcard characters: False
 ### -Path
 
 Specifies the path and file name of the new module manifest. Enter a path and file name with a
-`.psd1` file name extension, such as `$pshome\Modules\MyModule\MyModule.psd1`. The **Path**
+`.psd1` file name extension, such as `$PSHOME\Modules\MyModule\MyModule.psd1`. The **Path**
 parameter is required.
 
 If you specify the path to an existing file, `New-ModuleManifest` replaces the file without warning
@@ -1202,7 +1202,7 @@ files encoded as **UTF8NoBOM**.
 Module manifests are usually optional. However, a module manifest is required to export an assembly
 that is installed in the global assembly cache.
 
-To add or change files in the `$pshome\Modules` directory, start PowerShell with the **Run as
+To add or change files in the `$PSHOME\Modules` directory, start PowerShell with the **Run as
 administrator** option.
 
 > [!NOTE]

--- a/reference/7.6/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -171,7 +171,7 @@ True
 ```
 
 Use the **Verbose** parameter with `Test-PSSessionConfigurationFile` to display any errors that are
-detected. The cmdlet returns `$True` if no errors are detected in the file.
+detected. The cmdlet returns `$true` if no errors are detected in the file.
 
 ### Example 5: Create a sample configuration file
 
@@ -585,7 +585,7 @@ The acceptable values for this parameter are:
   elements, such as script blocks, variables, or operators.
 - RestrictedLanguage - Users may run cmdlets and functions, but are not permitted to use script
   blocks or variables except for the following permitted variables: `$PSCulture`, `$PSUICulture`,
-  `$True`, `$false`, and `$Null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
+  `$true`, `$false`, and `$null`. Users may use only the basic comparison operators (`-eq`, `-gt`,
   `-lt`). Assignment statements, property references, and method calls are not permitted.
 
 The default value of the **LanguageMode** parameter depends on the value of the **SessionType**

--- a/reference/7.6/Microsoft.PowerShell.Core/New-PSSessionOption.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/New-PSSessionOption.md
@@ -314,7 +314,7 @@ Specifies the culture to use for the session. Enter a culture name in
 `<languagecode2>-<country/regioncode2>` format (like `ja-JP`), a variable that contains a
 **CultureInfo** object, or a command that gets a **CultureInfo** object.
 
-The default value is `$Null`, and the culture that is set in the operating system is used in the
+The default value is `$null`, and the culture that is set in the operating system is used in the
 session.
 
 ```yaml

--- a/reference/7.6/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -250,7 +250,7 @@ disconnected and get the results of jobs that were running in the sessions.
 
 ```
 PS> $parms = @{
-      InDisconnectedSession = $True
+      InDisconnectedSession = $true
       ComputerName = "Server01", "Server02", "Server30"
       FilePath = "\\Server12\Scripts\SharedScripts\Get-BugStatus.ps1"
       Name = "BugStatus"

--- a/reference/7.6/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Save-Help.md
@@ -71,7 +71,7 @@ cabinet file. The `Update-Help` cmdlet extracts the help files, validates the XM
 then installs the help files and the help information file in a language-specific subfolder of the
 module folder.
 
-To save the help files for modules in the PowerShell installation folder (`$pshome\Modules`), start
+To save the help files for modules in the PowerShell installation folder (`$PSHOME\Modules`), start
 PowerShell by using the Run as administrator option. You must be a member of the Administrators
 group on the computer to download the help files for these modules.
 
@@ -461,9 +461,9 @@ This cmdlet returns no output.
 
 ## NOTES
 
-- To save help for modules in the $pshome\Modules folder, start PowerShell by using the Run as
+- To save help for modules in the $PSHOME\Modules folder, start PowerShell by using the Run as
   administrator option. Only members of the Administrators group on the computer can download help
-  for modules in the $pshome\Modules folder.
+  for modules in the $PSHOME\Modules folder.
 - The saved help for each module consists of one help information (HelpInfo XML) file and one
   cabinet (.cab) file for the help files each UI culture. You do not have to extract the help files
   from the cabinet file. The `Update-Help` cmdlet extracts the help files, validates the XML, and


### PR DESCRIPTION
# PR Summary

This PR fixes incorrect [automatic variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables) casing used in selected files. E.g., `$Args` (incorrect) -> `$args` (correct).

## Context

This is PR **_3/9_** in a series that ensures the correct case is consistently used for individual automatic variables, as documented in `about_Automatic_Variables` and verified by tab completion. As requested, the PRs are split into groups of ~40 files. Within each file, correct casing is applied to all referenced automatic variables.

Changes in scope:

- Variables with a `$` or `@` sigil.
- Variables referenced by name without a sigil.

Out of scope:

- Preference variables (separate PRs to follow).
- Misuse of an automatic variable (e.g., naming a function parameter as `$Input`).
- Reference to the variable's _value_ (e.g., `false`/`False`/`FALSE` when referring to the _value_ of `$false`).

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide