### PR TITLE
Fix automatic variable case (4/9)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
@@ -60,7 +60,7 @@ local computer.
 Use the **Name** parameter to identify the session configuration that you want to change. Use the
 other parameters to specify new values for the properties of the session configuration. To delete a
 property value from the configuration, and use the default value, enter an empty string (`""`) or a
-value of `$Null` for the corresponding parameter.
+value of `$null` for the corresponding parameter.
 
 Starting in PowerShell 3.0, you can use a session configuration file to define a session
 configuration. This feature provides a simple and discoverable method for setting and changing the
@@ -104,7 +104,7 @@ The third command removes the `AdminConfig.ps1` script from the configuration.
 ```powershell
 Register-PSSessionConfiguration -Name "AdminShell" -AssemblyName "C:\Shells\AdminShell.dll" -ConfigurationTypeName "AdminClass"
 Set-PSSessionConfiguration -Name "AdminShell" -StartupScript "AdminConfig.ps1"
-Set-PSSessionConfiguration -Name "AdminShell" -StartupScript $Null
+Set-PSSessionConfiguration -Name "AdminShell" -StartupScript $null
 ```
 
 ### Example 3: Display results
@@ -490,7 +490,7 @@ use a session configuration in a session, users must have at least `Execute(Invo
 the configuration.
 
 To use the default security descriptor for the configuration, enter an empty string (`""`) or a
-value of `$Null`. The default is the root SDDL in the `WSMan:` drive.
+value of `$null`. The default is the root SDDL in the `WSMan:` drive.
 
 If the security descriptor is complex, consider using the **ShowSecurityDescriptorUI** parameter
 instead of this one. You cannot use both parameters in the same command.
@@ -562,7 +562,7 @@ Specifies the startup script for the configuration. Enter the fully qualified pa
 script. The specified script runs in the new session that uses the session configuration.
 
 To delete a startup script from a session configuration, enter an empty string (`""`) or a value of
-`$Null`.
+`$null`.
 
 You can use a startup script to further configure the user session. If the script generates an
 error, even a non-terminating error, the session is not created and the `New-PSSession` command

--- a/reference/5.1/Microsoft.PowerShell.Core/Set-StrictMode.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Set-StrictMode.md
@@ -40,10 +40,10 @@ override the setting inherited from the global scope.
 
 When `Set-StrictMode` is off, PowerShell has the following behaviors:
 
-- Uninitialized variables are assumed to have a value of `0` (zero) or `$Null`, depending on type
-- References to non-existent properties return `$Null`
+- Uninitialized variables are assumed to have a value of `0` (zero) or `$null`, depending on type
+- References to non-existent properties return `$null`
 - Results of improper function syntax vary with the error conditions
-- Attempting to retrieve a value using an invalid index in an array returns `$Null`
+- Attempting to retrieve a value using an invalid index in an array returns `$null`
 
 ## EXAMPLES
 
@@ -151,7 +151,7 @@ which nothing is added. With version `2.0` strict mode, it's correctly interpret
 syntax for submitting two values.
 
 Without version `2.0`, the reference to the non-existent **Month** property of a string returns only
-`$Null`. With version `2.0`, it's interpreted correctly as a reference error.
+`$null`. With version `2.0`, it's interpreted correctly as a reference error.
 
 ### Example 3: Turn on strict mode as version 3.0
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Test-ModuleManifest.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Test-ModuleManifest.md
@@ -36,7 +36,7 @@ cmdlet also generates an error for each missing file.
 ### Example 1: Test a manifest
 
 ```powershell
-Test-ModuleManifest -Path "$pshome\Modules\TestModule.psd1"
+Test-ModuleManifest -Path "$PSHOME\Modules\TestModule.psd1"
 ```
 
 This command tests the `TestModule.psd1` module manifest.
@@ -44,14 +44,14 @@ This command tests the `TestModule.psd1` module manifest.
 ### Example 2: Test a manifest by using the pipeline
 
 ```powershell
-"$pshome\Modules\TestModule.psd1" | test-modulemanifest
+"$PSHOME\Modules\TestModule.psd1" | test-modulemanifest
 ```
 
 ```Output
 Test-ModuleManifest : The specified type data file 'C:\Windows\System32\Wi
 ndowsPowerShell\v1.0\Modules\TestModule\TestTypes.ps1xml' could not be processed because the file was not found. Please correct the path and try again.
 At line:1 char:34
-+ "$pshome\Modules\TestModule.psd1" | test-modulemanifest <<<<
++ "$PSHOME\Modules\TestModule.psd1" | test-modulemanifest <<<<
 + CategoryInfo          : ResourceUnavailable: (C:\Windows\System32\WindowsPowerShell\v1.0\Modules\TestModule\TestTypes.ps1xml:String) [Test-ModuleManifest], FileNotFoundException
 + FullyQualifiedErrorId : Modules_TypeDataFileNotFound,Microsoft.PowerShell.Commands.TestModuleManifestCommandName
 
@@ -87,7 +87,7 @@ function Test-ManifestBool ($path)
 ```
 
 This function is like `Test-ModuleManifest`, but it returns a Boolean value. The function returns
-`$True` if the manifest passed the test and `$false` otherwise.
+`$true` if the manifest passed the test and `$false` otherwise.
 
 The function uses the Get-ChildItem cmdlet, alias = dir, to get the module manifest specified by the
 `$path` variable. The command uses a pipeline operator (`|`) to pass the file object to
@@ -99,7 +99,7 @@ object that `Test-ModuleManifest` returns in the $a variable. Therefore, the obj
 displayed.
 
 Then, in a separate command, the function displays the value of the `$?` automatic variable. If the
-previous command generates no error, the command displays `$True`, and `$false` otherwise.
+previous command generates no error, the command displays `$true`, and `$false` otherwise.
 
 You can use this function in conditional statements, such as those that might precede an
 `Import-Module` command or a command that uses the module.

--- a/reference/5.1/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
@@ -23,7 +23,7 @@ Test-PSSessionConfigurationFile [-Path] <String> [<CommonParameters>]
 This cmdlet verifies that a session configuration file contains valid keys and the values are of the
 correct type. For enumerated values, the cmdlet verifies that the specified values are valid.
 
-The cmdlet returns `$True` if the file passes all tests and `$false` if it does not. To find any
+The cmdlet returns `$true` if the file passes all tests and `$false` if it does not. To find any
 errors, use the **Verbose** parameter.
 
 `Test-PSSessionConfigurationFile` verifies the session configuration files, such as those created by

--- a/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
@@ -357,7 +357,7 @@ Get-Command | Where-Object { $_.OutputType }
 
 ```powershell
 # Use Where-Object to get objects that are containers. This gets objects that
-# have the **PSIsContainer** property with a value of $True and excludes all
+# have the **PSIsContainer** property with a value of $true and excludes all
 # others.
 Get-ChildItem | Where-Object PSIsContainer
 Get-ChildItem | Where-Object { $_.PSIsContainer }

--- a/reference/5.1/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Add-Content.md
@@ -131,7 +131,7 @@ The steps to create a read-only file are included in the example.
 
 ```powershell
 New-Item -Path .\IsReadOnlyTextFile.txt -ItemType File
-Set-ItemProperty -Path .\IsReadOnlyTextFile.txt -Name IsReadOnly -Value $True
+Set-ItemProperty -Path .\IsReadOnlyTextFile.txt -Name IsReadOnly -Value $true
 Get-ChildItem -Path .\IsReadOnlyTextFile.txt
 Add-Content -Path .\IsReadOnlyTextFile.txt -Value 'Add value to read-only text file' -Force
 Get-Content -Path .\IsReadOnlyTextFile.txt

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
@@ -121,7 +121,7 @@ cmdlet, then to the `Format-Table` cmdlet, which formats the processes by using 
 view.
 
 The **Priority** view, and other views, are defined in the PS1XML format files in the PowerShell
-home directory (`$pshome`).
+home directory (`$PSHOME`).
 
 ### Example 5: Add a property to the standard Get-Process output display
 

--- a/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
@@ -95,13 +95,13 @@ New-Item -Path "c:\" -Name "logfiles" -ItemType "directory"
 
 ### Example 3: Create a profile
 
-This command creates a PowerShell profile in the path that is specified by the `$profile` variable.
+This command creates a PowerShell profile in the path that is specified by the `$PROFILE` variable.
 
-You can use profiles to customize PowerShell. `$profile` is an automatic (built-in) variable that
+You can use profiles to customize PowerShell. `$PROFILE` is an automatic (built-in) variable that
 stores the path and file name of the "CurrentUser/CurrentHost" profile. By default, the profile does
 not exist, even though PowerShell stores a path and file name for it.
 
-In this command, the `$profile` variable represents the path of the file. **ItemType** parameter
+In this command, the `$PROFILE` variable represents the path of the file. **ItemType** parameter
 specifies that the command creates a file. The **Force** parameter lets you create a file in the
 profile path, even when the directories in the path do not exist.
 
@@ -112,7 +112,7 @@ For more information, see [about_Automatic_Variables](../Microsoft.PowerShell.Co
 and [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
 
 ```powershell
-New-Item -Path $profile -ItemType "file" -Force
+New-Item -Path $PROFILE -ItemType "file" -Force
 ```
 
 > [!NOTE]

--- a/reference/5.1/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Pop-Location.md
@@ -199,7 +199,7 @@ If you make a named location stack the current location stack, you can no longer
 `Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
 `Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
 the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
-`$Null` or an empty string (`""`).
+`$null` or an empty string (`""`).
 
 `Pop-Location` is designed to work with the data exposed by any provider. To list the
 providers available in your session, type `Get-PSProvider`. For more information, see

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -84,7 +84,7 @@ Set-ItemProperty -LiteralPath <string[]> -InputObject <psobject> [-PassThru] [-F
 The `Set-ItemProperty` cmdlet changes the value of the property of the specified item.
 You can use the cmdlet to establish or change the properties of items.
 For example, you can use `Set-ItemProperty` to set the value of the **IsReadOnly** property of a
-file object to `$True`.
+file object to `$true`.
 
 You also use `Set-ItemProperty` to create and change registry values and data.
 For example, you can add a new registry entry to a key and establish or change its value.
@@ -170,7 +170,7 @@ Th example uses `Get-ChildItem` to get the `weekly.txt` file. The file object is
 specify the property and its new value.
 
 ```powershell
-Get-ChildItem weekly.txt | Set-ItemProperty -Name IsReadOnly -Value $True
+Get-ChildItem weekly.txt | Set-ItemProperty -Name IsReadOnly -Value $true
 ```
 
 ## PARAMETERS

--- a/reference/7.4/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
@@ -62,7 +62,7 @@ local computer.
 Use the **Name** parameter to identify the session configuration that you want to change. Use the
 other parameters to specify new values for the properties of the session configuration. To delete a
 property value from the configuration, and use the default value, enter an empty string (`""`) or a
-value of `$Null` for the corresponding parameter.
+value of `$null` for the corresponding parameter.
 
 Starting in PowerShell 3.0, you can use a session configuration file to define a session
 configuration. This feature provides a simple and discoverable method for setting and changing the
@@ -97,7 +97,7 @@ The third command removes the `AdminConfig.ps1` script from the configuration.
 ```powershell
 Register-PSSessionConfiguration -Name "AdminShell" -AssemblyName "C:\Shells\AdminShell.dll" -ConfigurationTypeName "AdminClass"
 Set-PSSessionConfiguration -Name "AdminShell" -StartupScript "AdminConfig.ps1"
-Set-PSSessionConfiguration -Name "AdminShell" -StartupScript $Null
+Set-PSSessionConfiguration -Name "AdminShell" -StartupScript $null
 ```
 
 ### Example 2: Display results
@@ -483,7 +483,7 @@ use a session configuration in a session, users must have at least `Execute(Invo
 the configuration.
 
 To use the default security descriptor for the configuration, enter an empty string (`""`) or a
-value of `$Null`. The default is the root SDDL in the `WSMan:` drive.
+value of `$null`. The default is the root SDDL in the `WSMan:` drive.
 
 If the security descriptor is complex, consider using the **ShowSecurityDescriptorUI** parameter
 instead of this one. You cannot use both parameters in the same command.
@@ -555,7 +555,7 @@ Specifies the startup script for the configuration. Enter the fully qualified pa
 script. The specified script runs in the new session that uses the session configuration.
 
 To delete a startup script from a session configuration, enter an empty string (`""`) or a value of
-`$Null`.
+`$null`.
 
 You can use a startup script to further configure the user session. If the script generates an
 error, even a non-terminating error, the session is not created and the `New-PSSession` command

--- a/reference/7.4/Microsoft.PowerShell.Core/Set-StrictMode.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Set-StrictMode.md
@@ -40,10 +40,10 @@ override the setting inherited from the global scope.
 
 When `Set-StrictMode` is off, PowerShell has the following behaviors:
 
-- Uninitialized variables are assumed to have a value of `0` (zero) or `$Null`, depending on type
-- References to non-existent properties return `$Null`
+- Uninitialized variables are assumed to have a value of `0` (zero) or `$null`, depending on type
+- References to non-existent properties return `$null`
 - Results of improper function syntax vary with the error conditions
-- Attempting to retrieve a value using an invalid index in an array returns `$Null`
+- Attempting to retrieve a value using an invalid index in an array returns `$null`
 
 ## EXAMPLES
 
@@ -137,7 +137,7 @@ which nothing is added. With version `2.0` strict mode, it's correctly interpret
 syntax for submitting two values.
 
 Without version `2.0`, the reference to the non-existent **Month** property of a string returns only
-`$Null`. With version `2.0`, it's interpreted correctly as a reference error.
+`$null`. With version `2.0`, it's interpreted correctly as a reference error.
 
 ### Example 3: Turn on strict mode as version 3.0
 

--- a/reference/7.4/Microsoft.PowerShell.Core/Test-ModuleManifest.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Test-ModuleManifest.md
@@ -36,7 +36,7 @@ cmdlet also generates an error for each missing file.
 ### Example 1: Test a manifest
 
 ```powershell
-Test-ModuleManifest -Path "$pshome\Modules\TestModule.psd1"
+Test-ModuleManifest -Path "$PSHOME\Modules\TestModule.psd1"
 ```
 
 This command tests the `TestModule.psd1` module manifest.
@@ -44,14 +44,14 @@ This command tests the `TestModule.psd1` module manifest.
 ### Example 2: Test a manifest by using the pipeline
 
 ```powershell
-"$pshome\Modules\TestModule.psd1" | test-modulemanifest
+"$PSHOME\Modules\TestModule.psd1" | test-modulemanifest
 ```
 
 ```Output
 Test-ModuleManifest : The specified type data file 'C:\Windows\System32\Wi
 ndowsPowerShell\v1.0\Modules\TestModule\TestTypes.ps1xml' could not be processed because the file was not found. Please correct the path and try again.
 At line:1 char:34
-+ "$pshome\Modules\TestModule.psd1" | test-modulemanifest <<<<
++ "$PSHOME\Modules\TestModule.psd1" | test-modulemanifest <<<<
 + CategoryInfo          : ResourceUnavailable: (C:\Windows\System32\WindowsPowerShell\v1.0\Modules\TestModule\TestTypes.ps1xml:String) [Test-ModuleManifest], FileNotFoundException
 + FullyQualifiedErrorId : Modules_TypeDataFileNotFound,Microsoft.PowerShell.Commands.TestModuleManifestCommandName
 
@@ -87,7 +87,7 @@ function Test-ManifestBool ($path)
 ```
 
 This function is like `Test-ModuleManifest`, but it returns a Boolean value. The function returns
-`$True` if the manifest passed the test and `$false` otherwise.
+`$true` if the manifest passed the test and `$false` otherwise.
 
 The function uses the Get-ChildItem cmdlet, alias = dir, to get the module manifest specified by the
 `$path` variable. The command uses a pipeline operator (`|`) to pass the file object to
@@ -99,7 +99,7 @@ object that `Test-ModuleManifest` returns in the $a variable. Therefore, the obj
 displayed.
 
 Then, in a separate command, the function displays the value of the `$?` automatic variable. If the
-previous command generates no error, the command displays `$True`, and `$false` otherwise.
+previous command generates no error, the command displays `$true`, and `$false` otherwise.
 
 You can use this function in conditional statements, such as those that might precede an
 `Import-Module` command or a command that uses the module.

--- a/reference/7.4/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
@@ -25,7 +25,7 @@ Test-PSSessionConfigurationFile [-Path] <String> [<CommonParameters>]
 This cmdlet verifies that a session configuration file contains valid keys and the values are of the
 correct type. For enumerated values, the cmdlet verifies that the specified values are valid.
 
-The cmdlet returns `$True` if the file passes all tests and `$false` if it does not. To find any
+The cmdlet returns `$true` if the file passes all tests and `$false` if it does not. To find any
 errors, use the **Verbose** parameter.
 
 `Test-PSSessionConfigurationFile` verifies the session configuration files, such as those created by

--- a/reference/7.4/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Where-Object.md
@@ -364,7 +364,7 @@ Get-Command | Where-Object { $_.OutputType }
 
 ```powershell
 # Use Where-Object to get objects that are containers. This gets objects that
-# have the **PSIsContainer** property with a value of $True and excludes all
+# have the **PSIsContainer** property with a value of $true and excludes all
 # others.
 Get-ChildItem | Where-Object PSIsContainer
 Get-ChildItem | Where-Object { $_.PSIsContainer }

--- a/reference/7.4/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Add-Content.md
@@ -131,7 +131,7 @@ The steps to create a read-only file are included in the example.
 
 ```powershell
 New-Item -Path .\IsReadOnlyTextFile.txt -ItemType File
-Set-ItemProperty -Path .\IsReadOnlyTextFile.txt -Name IsReadOnly -Value $True
+Set-ItemProperty -Path .\IsReadOnlyTextFile.txt -Name IsReadOnly -Value $true
 Get-ChildItem -Path .\IsReadOnlyTextFile.txt
 Add-Content -Path .\IsReadOnlyTextFile.txt -Value 'Add value to read-only text file' -Force
 Get-Content -Path .\IsReadOnlyTextFile.txt

--- a/reference/7.4/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Get-Process.md
@@ -118,7 +118,7 @@ cmdlet, then to the `Format-Table` cmdlet, which formats the processes by using 
 view.
 
 The **Priority** view, and other views, are defined in the PS1XML format files in the PowerShell
-home directory (`$pshome`).
+home directory (`$PSHOME`).
 
 ### Example 5: Add a property to the standard Get-Process output display
 

--- a/reference/7.4/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/New-Item.md
@@ -95,13 +95,13 @@ New-Item -Path "c:\" -Name "logfiles" -ItemType "directory"
 
 ### Example 3: Create a profile
 
-This command creates a PowerShell profile in the path that is specified by the `$profile` variable.
+This command creates a PowerShell profile in the path that is specified by the `$PROFILE` variable.
 
-You can use profiles to customize PowerShell. `$profile` is an automatic (built-in) variable that
+You can use profiles to customize PowerShell. `$PROFILE` is an automatic (built-in) variable that
 stores the path and file name of the "CurrentUser/CurrentHost" profile. By default, the profile does
 not exist, even though PowerShell stores a path and file name for it.
 
-In this command, the `$profile` variable represents the path of the file. **ItemType** parameter
+In this command, the `$PROFILE` variable represents the path of the file. **ItemType** parameter
 specifies that the command creates a file. The **Force** parameter lets you create a file in the
 profile path, even when the directories in the path do not exist.
 
@@ -112,7 +112,7 @@ For more information, see [about_Automatic_Variables](../Microsoft.PowerShell.Co
 and [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
 
 ```powershell
-New-Item -Path $profile -ItemType "file" -Force
+New-Item -Path $PROFILE -ItemType "file" -Force
 ```
 
 ### Example 4: Create a directory in a different directory

--- a/reference/7.4/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Pop-Location.md
@@ -182,7 +182,7 @@ If you make a named location stack the current location stack, you can no longer
 `Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
 `Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
 the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
-`$Null` or an empty string (`""`).
+`$null` or an empty string (`""`).
 
 You can also refer to `Pop-Location` by its built-in alias, `popd`. For more information, see
 [about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).

--- a/reference/7.4/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -84,7 +84,7 @@ Set-ItemProperty -LiteralPath <string[]> -InputObject <psobject> [-PassThru] [-F
 The `Set-ItemProperty` cmdlet changes the value of the property of the specified item.
 You can use the cmdlet to establish or change the properties of items.
 For example, you can use `Set-ItemProperty` to set the value of the **IsReadOnly** property of a
-file object to `$True`.
+file object to `$true`.
 
 You also use `Set-ItemProperty` to create and change registry values and data.
 For example, you can add a new registry entry to a key and establish or change its value.
@@ -170,7 +170,7 @@ Th example uses `Get-ChildItem` to get the `weekly.txt` file. The file object is
 specify the property and its new value.
 
 ```powershell
-Get-ChildItem weekly.txt | Set-ItemProperty -Name IsReadOnly -Value $True
+Get-ChildItem weekly.txt | Set-ItemProperty -Name IsReadOnly -Value $true
 ```
 
 ## PARAMETERS

--- a/reference/7.5/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
@@ -62,7 +62,7 @@ local computer.
 Use the **Name** parameter to identify the session configuration that you want to change. Use the
 other parameters to specify new values for the properties of the session configuration. To delete a
 property value from the configuration, and use the default value, enter an empty string (`""`) or a
-value of `$Null` for the corresponding parameter.
+value of `$null` for the corresponding parameter.
 
 Starting in PowerShell 3.0, you can use a session configuration file to define a session
 configuration. This feature provides a simple and discoverable method for setting and changing the
@@ -97,7 +97,7 @@ The third command removes the `AdminConfig.ps1` script from the configuration.
 ```powershell
 Register-PSSessionConfiguration -Name "AdminShell" -AssemblyName "C:\Shells\AdminShell.dll" -ConfigurationTypeName "AdminClass"
 Set-PSSessionConfiguration -Name "AdminShell" -StartupScript "AdminConfig.ps1"
-Set-PSSessionConfiguration -Name "AdminShell" -StartupScript $Null
+Set-PSSessionConfiguration -Name "AdminShell" -StartupScript $null
 ```
 
 ### Example 2: Display results
@@ -483,7 +483,7 @@ use a session configuration in a session, users must have at least `Execute(Invo
 the configuration.
 
 To use the default security descriptor for the configuration, enter an empty string (`""`) or a
-value of `$Null`. The default is the root SDDL in the `WSMan:` drive.
+value of `$null`. The default is the root SDDL in the `WSMan:` drive.
 
 If the security descriptor is complex, consider using the **ShowSecurityDescriptorUI** parameter
 instead of this one. You cannot use both parameters in the same command.
@@ -555,7 +555,7 @@ Specifies the startup script for the configuration. Enter the fully qualified pa
 script. The specified script runs in the new session that uses the session configuration.
 
 To delete a startup script from a session configuration, enter an empty string (`""`) or a value of
-`$Null`.
+`$null`.
 
 You can use a startup script to further configure the user session. If the script generates an
 error, even a non-terminating error, the session is not created and the `New-PSSession` command

--- a/reference/7.5/Microsoft.PowerShell.Core/Set-StrictMode.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Set-StrictMode.md
@@ -40,10 +40,10 @@ override the setting inherited from the global scope.
 
 When `Set-StrictMode` is off, PowerShell has the following behaviors:
 
-- Uninitialized variables are assumed to have a value of `0` (zero) or `$Null`, depending on type
-- References to non-existent properties return `$Null`
+- Uninitialized variables are assumed to have a value of `0` (zero) or `$null`, depending on type
+- References to non-existent properties return `$null`
 - Results of improper function syntax vary with the error conditions
-- Attempting to retrieve a value using an invalid index in an array returns `$Null`
+- Attempting to retrieve a value using an invalid index in an array returns `$null`
 
 ## EXAMPLES
 
@@ -137,7 +137,7 @@ which nothing is added. With version `2.0` strict mode, it's correctly interpret
 syntax for submitting two values.
 
 Without version `2.0`, the reference to the non-existent **Month** property of a string returns only
-`$Null`. With version `2.0`, it's interpreted correctly as a reference error.
+`$null`. With version `2.0`, it's interpreted correctly as a reference error.
 
 ### Example 3: Turn on strict mode as version 3.0
 

--- a/reference/7.5/Microsoft.PowerShell.Core/Test-ModuleManifest.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Test-ModuleManifest.md
@@ -36,7 +36,7 @@ cmdlet also generates an error for each missing file.
 ### Example 1: Test a manifest
 
 ```powershell
-Test-ModuleManifest -Path "$pshome\Modules\TestModule.psd1"
+Test-ModuleManifest -Path "$PSHOME\Modules\TestModule.psd1"
 ```
 
 This command tests the `TestModule.psd1` module manifest.
@@ -44,14 +44,14 @@ This command tests the `TestModule.psd1` module manifest.
 ### Example 2: Test a manifest by using the pipeline
 
 ```powershell
-"$pshome\Modules\TestModule.psd1" | Test-ModuleManifest
+"$PSHOME\Modules\TestModule.psd1" | Test-ModuleManifest
 ```
 
 ```Output
 Test-ModuleManifest : The specified type data file 'C:\Windows\System32\Wi
 ndowsPowerShell\v1.0\Modules\TestModule\TestTypes.ps1xml' could not be processed because the file was not found. Please correct the path and try again.
 At line:1 char:34
-+ "$pshome\Modules\TestModule.psd1" | test-modulemanifest <<<<
++ "$PSHOME\Modules\TestModule.psd1" | test-modulemanifest <<<<
 + CategoryInfo          : ResourceUnavailable: (C:\Windows\System32\WindowsPowerShell\v1.0\Modules\TestModule\TestTypes.ps1xml:String) [Test-ModuleManifest], FileNotFoundException
 + FullyQualifiedErrorId : Modules_TypeDataFileNotFound,Microsoft.PowerShell.Commands.TestModuleManifestCommandName
 
@@ -87,7 +87,7 @@ function Test-ManifestBool ($path)
 ```
 
 This function is like `Test-ModuleManifest`, but it returns a Boolean value. The function returns
-`$True` if the manifest passed the test and `$false` otherwise.
+`$true` if the manifest passed the test and `$false` otherwise.
 
 The function uses the Get-ChildItem cmdlet, alias = dir, to get the module manifest specified by the
 `$path` variable. The command uses a pipeline operator (`|`) to pass the file object to
@@ -99,7 +99,7 @@ object that `Test-ModuleManifest` returns in the $a variable. Therefore, the obj
 displayed.
 
 Then, in a separate command, the function displays the value of the `$?` automatic variable. If the
-previous command generates no error, the command displays `$True`, and `$false` otherwise.
+previous command generates no error, the command displays `$true`, and `$false` otherwise.
 
 You can use this function in conditional statements, such as those that might precede an
 `Import-Module` command or a command that uses the module.

--- a/reference/7.5/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
@@ -25,7 +25,7 @@ Test-PSSessionConfigurationFile [-Path] <String> [<CommonParameters>]
 This cmdlet verifies that a session configuration file contains valid keys and the values are of the
 correct type. For enumerated values, the cmdlet verifies that the specified values are valid.
 
-The cmdlet returns `$True` if the file passes all tests and `$false` if it does not. To find any
+The cmdlet returns `$true` if the file passes all tests and `$false` if it does not. To find any
 errors, use the **Verbose** parameter.
 
 `Test-PSSessionConfigurationFile` verifies the session configuration files, such as those created by

--- a/reference/7.5/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Where-Object.md
@@ -364,7 +364,7 @@ Get-Command | Where-Object { $_.OutputType }
 
 ```powershell
 # Use Where-Object to get objects that are containers. This gets objects that
-# have the **PSIsContainer** property with a value of $True and excludes all
+# have the **PSIsContainer** property with a value of $true and excludes all
 # others.
 Get-ChildItem | Where-Object PSIsContainer
 Get-ChildItem | Where-Object { $_.PSIsContainer }

--- a/reference/7.5/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Add-Content.md
@@ -131,7 +131,7 @@ The steps to create a read-only file are included in the example.
 
 ```powershell
 New-Item -Path .\IsReadOnlyTextFile.txt -ItemType File
-Set-ItemProperty -Path .\IsReadOnlyTextFile.txt -Name IsReadOnly -Value $True
+Set-ItemProperty -Path .\IsReadOnlyTextFile.txt -Name IsReadOnly -Value $true
 Get-ChildItem -Path .\IsReadOnlyTextFile.txt
 Add-Content -Path .\IsReadOnlyTextFile.txt -Value 'Add value to read-only text file' -Force
 Get-Content -Path .\IsReadOnlyTextFile.txt

--- a/reference/7.5/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Get-Process.md
@@ -118,7 +118,7 @@ cmdlet, then to the `Format-Table` cmdlet, which formats the processes by using 
 view.
 
 The **Priority** view, and other views, are defined in the PS1XML format files in the PowerShell
-home directory (`$pshome`).
+home directory (`$PSHOME`).
 
 ### Example 5: Add a property to the standard Get-Process output display
 

--- a/reference/7.5/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/New-Item.md
@@ -95,13 +95,13 @@ New-Item -Path "c:\" -Name "Logfiles" -ItemType "directory"
 
 ### Example 3: Create a profile
 
-This command creates a PowerShell profile in the path that is specified by the `$profile` variable.
+This command creates a PowerShell profile in the path that is specified by the `$PROFILE` variable.
 
-You can use profiles to customize PowerShell. `$profile` is an automatic (built-in) variable that
+You can use profiles to customize PowerShell. `$PROFILE` is an automatic (built-in) variable that
 stores the path and file name of the "CurrentUser/CurrentHost" profile. By default, the profile does
 not exist, even though PowerShell stores a path and file name for it.
 
-In this command, the `$profile` variable represents the path of the file. **ItemType** parameter
+In this command, the `$PROFILE` variable represents the path of the file. **ItemType** parameter
 specifies that the command creates a file. The **Force** parameter lets you create a file in the
 profile path, even when the directories in the path do not exist.
 
@@ -113,7 +113,7 @@ For more information, see
 and [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
 
 ```powershell
-New-Item -Path $profile -ItemType "file" -Force
+New-Item -Path $PROFILE -ItemType "file" -Force
 ```
 
 ### Example 4: Create a directory in a different directory

--- a/reference/7.5/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Pop-Location.md
@@ -182,7 +182,7 @@ If you make a named location stack the current location stack, you can no longer
 `Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
 `Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
 the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
-`$Null` or an empty string (`""`).
+`$null` or an empty string (`""`).
 
 You can also refer to `Pop-Location` by its built-in alias, `popd`. For more information, see
 [about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).

--- a/reference/7.5/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -84,7 +84,7 @@ Set-ItemProperty -LiteralPath <string[]> -InputObject <psobject> [-PassThru] [-F
 The `Set-ItemProperty` cmdlet changes the value of the property of the specified item.
 You can use the cmdlet to establish or change the properties of items.
 For example, you can use `Set-ItemProperty` to set the value of the **IsReadOnly** property of a
-file object to `$True`.
+file object to `$true`.
 
 You also use `Set-ItemProperty` to create and change registry values and data.
 For example, you can add a new registry entry to a key and establish or change its value.
@@ -170,7 +170,7 @@ Th example uses `Get-ChildItem` to get the `weekly.txt` file. The file object is
 specify the property and its new value.
 
 ```powershell
-Get-ChildItem weekly.txt | Set-ItemProperty -Name IsReadOnly -Value $True
+Get-ChildItem weekly.txt | Set-ItemProperty -Name IsReadOnly -Value $true
 ```
 
 ## PARAMETERS

--- a/reference/7.6/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
@@ -62,7 +62,7 @@ local computer.
 Use the **Name** parameter to identify the session configuration that you want to change. Use the
 other parameters to specify new values for the properties of the session configuration. To delete a
 property value from the configuration, and use the default value, enter an empty string (`""`) or a
-value of `$Null` for the corresponding parameter.
+value of `$null` for the corresponding parameter.
 
 Starting in PowerShell 3.0, you can use a session configuration file to define a session
 configuration. This feature provides a simple and discoverable method for setting and changing the
@@ -97,7 +97,7 @@ The third command removes the `AdminConfig.ps1` script from the configuration.
 ```powershell
 Register-PSSessionConfiguration -Name "AdminShell" -AssemblyName "C:\Shells\AdminShell.dll" -ConfigurationTypeName "AdminClass"
 Set-PSSessionConfiguration -Name "AdminShell" -StartupScript "AdminConfig.ps1"
-Set-PSSessionConfiguration -Name "AdminShell" -StartupScript $Null
+Set-PSSessionConfiguration -Name "AdminShell" -StartupScript $null
 ```
 
 ### Example 2: Display results
@@ -483,7 +483,7 @@ use a session configuration in a session, users must have at least `Execute(Invo
 the configuration.
 
 To use the default security descriptor for the configuration, enter an empty string (`""`) or a
-value of `$Null`. The default is the root SDDL in the `WSMan:` drive.
+value of `$null`. The default is the root SDDL in the `WSMan:` drive.
 
 If the security descriptor is complex, consider using the **ShowSecurityDescriptorUI** parameter
 instead of this one. You cannot use both parameters in the same command.
@@ -555,7 +555,7 @@ Specifies the startup script for the configuration. Enter the fully qualified pa
 script. The specified script runs in the new session that uses the session configuration.
 
 To delete a startup script from a session configuration, enter an empty string (`""`) or a value of
-`$Null`.
+`$null`.
 
 You can use a startup script to further configure the user session. If the script generates an
 error, even a non-terminating error, the session is not created and the `New-PSSession` command

--- a/reference/7.6/Microsoft.PowerShell.Core/Set-StrictMode.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Set-StrictMode.md
@@ -40,10 +40,10 @@ override the setting inherited from the global scope.
 
 When `Set-StrictMode` is off, PowerShell has the following behaviors:
 
-- Uninitialized variables are assumed to have a value of `0` (zero) or `$Null`, depending on type
-- References to non-existent properties return `$Null`
+- Uninitialized variables are assumed to have a value of `0` (zero) or `$null`, depending on type
+- References to non-existent properties return `$null`
 - Results of improper function syntax vary with the error conditions
-- Attempting to retrieve a value using an invalid index in an array returns `$Null`
+- Attempting to retrieve a value using an invalid index in an array returns `$null`
 
 ## EXAMPLES
 
@@ -137,7 +137,7 @@ which nothing is added. With version `2.0` strict mode, it's correctly interpret
 syntax for submitting two values.
 
 Without version `2.0`, the reference to the non-existent **Month** property of a string returns only
-`$Null`. With version `2.0`, it's interpreted correctly as a reference error.
+`$null`. With version `2.0`, it's interpreted correctly as a reference error.
 
 ### Example 3: Turn on strict mode as version 3.0
 

--- a/reference/7.6/Microsoft.PowerShell.Core/Test-ModuleManifest.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Test-ModuleManifest.md
@@ -36,7 +36,7 @@ cmdlet also generates an error for each missing file.
 ### Example 1: Test a manifest
 
 ```powershell
-Test-ModuleManifest -Path "$pshome\Modules\TestModule.psd1"
+Test-ModuleManifest -Path "$PSHOME\Modules\TestModule.psd1"
 ```
 
 This command tests the `TestModule.psd1` module manifest.
@@ -44,14 +44,14 @@ This command tests the `TestModule.psd1` module manifest.
 ### Example 2: Test a manifest by using the pipeline
 
 ```powershell
-"$pshome\Modules\TestModule.psd1" | Test-ModuleManifest
+"$PSHOME\Modules\TestModule.psd1" | Test-ModuleManifest
 ```
 
 ```Output
 Test-ModuleManifest : The specified type data file 'C:\Windows\System32\Wi
 ndowsPowerShell\v1.0\Modules\TestModule\TestTypes.ps1xml' could not be processed because the file was not found. Please correct the path and try again.
 At line:1 char:34
-+ "$pshome\Modules\TestModule.psd1" | test-modulemanifest <<<<
++ "$PSHOME\Modules\TestModule.psd1" | test-modulemanifest <<<<
 + CategoryInfo          : ResourceUnavailable: (C:\Windows\System32\WindowsPowerShell\v1.0\Modules\TestModule\TestTypes.ps1xml:String) [Test-ModuleManifest], FileNotFoundException
 + FullyQualifiedErrorId : Modules_TypeDataFileNotFound,Microsoft.PowerShell.Commands.TestModuleManifestCommandName
 
@@ -87,7 +87,7 @@ function Test-ManifestBool ($path)
 ```
 
 This function is like `Test-ModuleManifest`, but it returns a Boolean value. The function returns
-`$True` if the manifest passed the test and `$false` otherwise.
+`$true` if the manifest passed the test and `$false` otherwise.
 
 The function uses the Get-ChildItem cmdlet, alias = dir, to get the module manifest specified by the
 `$path` variable. The command uses a pipeline operator (`|`) to pass the file object to
@@ -99,7 +99,7 @@ object that `Test-ModuleManifest` returns in the $a variable. Therefore, the obj
 displayed.
 
 Then, in a separate command, the function displays the value of the `$?` automatic variable. If the
-previous command generates no error, the command displays `$True`, and `$false` otherwise.
+previous command generates no error, the command displays `$true`, and `$false` otherwise.
 
 You can use this function in conditional statements, such as those that might precede an
 `Import-Module` command or a command that uses the module.

--- a/reference/7.6/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
@@ -25,7 +25,7 @@ Test-PSSessionConfigurationFile [-Path] <String> [<CommonParameters>]
 This cmdlet verifies that a session configuration file contains valid keys and the values are of the
 correct type. For enumerated values, the cmdlet verifies that the specified values are valid.
 
-The cmdlet returns `$True` if the file passes all tests and `$false` if it does not. To find any
+The cmdlet returns `$true` if the file passes all tests and `$false` if it does not. To find any
 errors, use the **Verbose** parameter.
 
 `Test-PSSessionConfigurationFile` verifies the session configuration files, such as those created by

--- a/reference/7.6/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Where-Object.md
@@ -364,7 +364,7 @@ Get-Command | Where-Object { $_.OutputType }
 
 ```powershell
 # Use Where-Object to get objects that are containers. This gets objects that
-# have the **PSIsContainer** property with a value of $True and excludes all
+# have the **PSIsContainer** property with a value of $true and excludes all
 # others.
 Get-ChildItem | Where-Object PSIsContainer
 Get-ChildItem | Where-Object { $_.PSIsContainer }

--- a/reference/7.6/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Add-Content.md
@@ -131,7 +131,7 @@ The steps to create a read-only file are included in the example.
 
 ```powershell
 New-Item -Path .\IsReadOnlyTextFile.txt -ItemType File
-Set-ItemProperty -Path .\IsReadOnlyTextFile.txt -Name IsReadOnly -Value $True
+Set-ItemProperty -Path .\IsReadOnlyTextFile.txt -Name IsReadOnly -Value $true
 Get-ChildItem -Path .\IsReadOnlyTextFile.txt
 Add-Content -Path .\IsReadOnlyTextFile.txt -Value 'Add value to read-only text file' -Force
 Get-Content -Path .\IsReadOnlyTextFile.txt

--- a/reference/7.6/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Get-Process.md
@@ -118,7 +118,7 @@ cmdlet, then to the `Format-Table` cmdlet, which formats the processes by using 
 view.
 
 The **Priority** view, and other views, are defined in the PS1XML format files in the PowerShell
-home directory (`$pshome`).
+home directory (`$PSHOME`).
 
 ### Example 5: Add a property to the standard Get-Process output display
 

--- a/reference/7.6/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/New-Item.md
@@ -95,13 +95,13 @@ New-Item -Path "c:\" -Name "Logfiles" -ItemType "directory"
 
 ### Example 3: Create a profile
 
-This command creates a PowerShell profile in the path that is specified by the `$profile` variable.
+This command creates a PowerShell profile in the path that is specified by the `$PROFILE` variable.
 
-You can use profiles to customize PowerShell. `$profile` is an automatic (built-in) variable that
+You can use profiles to customize PowerShell. `$PROFILE` is an automatic (built-in) variable that
 stores the path and file name of the "CurrentUser/CurrentHost" profile. By default, the profile does
 not exist, even though PowerShell stores a path and file name for it.
 
-In this command, the `$profile` variable represents the path of the file. **ItemType** parameter
+In this command, the `$PROFILE` variable represents the path of the file. **ItemType** parameter
 specifies that the command creates a file. The **Force** parameter lets you create a file in the
 profile path, even when the directories in the path do not exist.
 
@@ -112,7 +112,7 @@ For more information, see [about_Automatic_Variables](../Microsoft.PowerShell.Co
 and [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
 
 ```powershell
-New-Item -Path $profile -ItemType "file" -Force
+New-Item -Path $PROFILE -ItemType "file" -Force
 ```
 
 ### Example 4: Create a directory in a different directory

--- a/reference/7.6/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Pop-Location.md
@@ -182,7 +182,7 @@ If you make a named location stack the current location stack, you can no longer
 `Push-Location` or `Pop-Location` cmdlets to add or get items from the default stack or use the
 `Get-Location` cmdlet to display the locations in the unnamed stack. To make the unnamed stack
 the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of
-`$Null` or an empty string (`""`).
+`$null` or an empty string (`""`).
 
 You can also refer to `Pop-Location` by its built-in alias, `popd`. For more information, see
 [about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).

--- a/reference/7.6/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -84,7 +84,7 @@ Set-ItemProperty -LiteralPath <string[]> -InputObject <psobject> [-PassThru] [-F
 The `Set-ItemProperty` cmdlet changes the value of the property of the specified item.
 You can use the cmdlet to establish or change the properties of items.
 For example, you can use `Set-ItemProperty` to set the value of the **IsReadOnly** property of a
-file object to `$True`.
+file object to `$true`.
 
 You also use `Set-ItemProperty` to create and change registry values and data.
 For example, you can add a new registry entry to a key and establish or change its value.
@@ -170,7 +170,7 @@ Th example uses `Get-ChildItem` to get the `weekly.txt` file. The file object is
 specify the property and its new value.
 
 ```powershell
-Get-ChildItem weekly.txt | Set-ItemProperty -Name IsReadOnly -Value $True
+Get-ChildItem weekly.txt | Set-ItemProperty -Name IsReadOnly -Value $true
 ```
 
 ## PARAMETERS


### PR DESCRIPTION
# PR Summary

This PR fixes incorrect [automatic variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables) casing used in selected files. E.g., `$Args` (incorrect) -> `$args` (correct).

## Context

This is PR **_4/9_** in a series that ensures the correct case is consistently used for individual automatic variables, as documented in `about_Automatic_Variables` and verified by tab completion. As requested, the PRs are split into groups of ~40 files. Within each file, correct casing is applied to all referenced automatic variables.

Changes in scope:

- Variables with a `$` or `@` sigil.
- Variables referenced by name without a sigil.

Out of scope:

- Preference variables (separate PRs to follow).
- Misuse of an automatic variable (e.g., naming a function parameter as `$Input`).
- Reference to the variable's _value_ (e.g., `false`/`False`/`FALSE` when referring to the _value_ of `$false`).

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide