### PR TITLE
Fix automatic variable case (5/9)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Split-Path.md
@@ -147,12 +147,12 @@ False
 This command changes your location to the folder that contains the PowerShell profile.
 
 ```powershell
-PS C:\> Set-Location (Split-Path -Path $profile)
+PS C:\> Set-Location (Split-Path -Path $PROFILE)
 PS C:\Users\User01\Documents\PowerShell>
 ```
 
 The command in parentheses uses `Split-Path` to return only the parent of the path stored in the
-built-in `$Profile` variable. The **Parent** parameter is the default split location parameter.
+built-in `$PROFILE` variable. The **Parent** parameter is the default split location parameter.
 Therefore, you can omit it from the command. The parentheses direct PowerShell to run the command
 first. This is a useful way to move to a folder that has a long path name.
 
@@ -192,7 +192,7 @@ Accept wildcard characters: False
 
 ### -IsAbsolute
 
-Indicates that this cmdlet returns `$True` if the path is absolute and `$false` if it's relative. On
+Indicates that this cmdlet returns `$true` if the path is absolute and `$false` if it's relative. On
 Windows, an absolute path string must start with a provider drive specifier, like `C:` or `HKCU:`. A
 relative path starts with a dot (`.`) or a dot-dot (`..`).
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Stop-Process.md
@@ -102,7 +102,7 @@ to `Stop-Process`.
 The last command gets all of the processes on the computer that were running but that are now
 stopped. It uses `Get-Process` to get all of the processes on the computer. The pipeline operator
 (`|`) passes the results to the `Where-Object` cmdlet, which selects the ones where the value of the
-**HasExited** property is $True. **HasExited** is just one property of process objects. To find all
+**HasExited** property is $true. **HasExited** is just one property of process objects. To find all
 the properties, type `Get-Process | Get-Member`.
 
 ### Example 4: Stop a process not owned by the current user

--- a/reference/5.1/Microsoft.PowerShell.Management/Suspend-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Suspend-Service.md
@@ -82,7 +82,7 @@ PS C:\> Get-Service | Where-Object {$_.CanPauseAndContinue -eq "True"} | Suspend
 This command suspends all of the services on the computer that can be suspended. It uses
 `Get-Service` to get objects that represent the services on the computer. The pipeline operator
 passes the results to the `Where-Object` cmdlet, which selects only the services that have a value
-of `$True` for the **CanPauseAndContinue** property. Another pipeline operator passes the results to
+of `$true` for the **CanPauseAndContinue** property. Another pipeline operator passes the results to
 `Suspend-Service`. The **Confirm** parameter prompts you for confirmation before suspending each of
 the services.
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
@@ -153,9 +153,9 @@ if (Test-Connection -ComputerName Server01 -Quiet) {New-PSSession Server01}
 
 The `if` command uses the `Test-Connection` cmdlet to ping the Server01 computer. The command uses
 the **Quiet** parameter, which returns a **Boolean** value, instead of a **Win32_PingStatus**
-object. The value is `$True` if any of the four pings succeed and is, otherwise, `$false`.
+object. The value is `$true` if any of the four pings succeed and is, otherwise, `$false`.
 
-If the `Test-Connection` command returns a value of `$True`, the command uses the `New-PSSession`
+If the `Test-Connection` command returns a value of `$true`, the command uses the `New-PSSession`
 cmdlet to create the **PSSession**.
 
 ## PARAMETERS
@@ -357,7 +357,7 @@ parameter suppresses all errors.
 Each connection that's tested returns a **Boolean** value. If the **ComputerName** parameter
 specifies multiple computers, an array of **Boolean** values is returned.
 
-If **any** ping succeeds, `$True` is returned.
+If **any** ping succeeds, `$true` is returned.
 
 If **all** pings fail, `$false` is returned.
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Test-Path.md
@@ -73,7 +73,7 @@ returns `$false`. Otherwise, it returns `$true`.
 ### Example 2: Test the path of a profile
 
 ```powershell
-Test-Path -Path $profile
+Test-Path -Path $PROFILE
 ```
 
 ```Output
@@ -81,7 +81,7 @@ False
 ```
 
 ```powershell
-Test-Path -Path $profile -IsValid
+Test-Path -Path $PROFILE -IsValid
 ```
 
 ```Output
@@ -92,7 +92,7 @@ These commands test the path of the PowerShell profile.
 
 The first command determines whether all elements in the path exist. The second command determines
 whether the syntax of the path is correct. In this case, the path is `$false`, but the syntax is
-correct `$true`. These commands use `$profile`, the automatic variable that points to the location
+correct `$true`. These commands use `$PROFILE`, the automatic variable that points to the location
 for the profile, even if the profile doesn't exist.
 
 For more information about automatic variables, see
@@ -123,14 +123,14 @@ In this case, because the directory contains only .dwg files, the result is `$fa
 ### Example 4: Check for a file
 
 ```powershell
-Test-Path -Path $profile -PathType leaf
+Test-Path -Path $PROFILE -PathType leaf
 ```
 
 ```Output
 True
 ```
 
-This command checks whether the path stored in the `$profile` variable leads to a file. In this
+This command checks whether the path stored in the `$PROFILE` variable leads to a file. In this
 case, because the PowerShell profile is a `.ps1` file, the cmdlet returns `$true`.
 
 ### Example 5: Check paths in the Registry
@@ -169,7 +169,7 @@ file on the computer is newer than `July 13, 2009`.
 The NewerThan parameter works only in file system drives.
 
 ```powershell
-Test-Path $pshome\PowerShell.exe -NewerThan "July 13, 2009"
+Test-Path $PSHOME\PowerShell.exe -NewerThan "July 13, 2009"
 ```
 
 ```Output

--- a/reference/5.1/Microsoft.PowerShell.Security/Get-Credential.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Get-Credential.md
@@ -75,7 +75,7 @@ object.
 ### Example 3
 
 ```powershell
-$Credential = $host.ui.PromptForCredential("Need credentials", "Please enter your user name and password.", "", "NetBiosUserName")
+$Credential = $Host.ui.PromptForCredential("Need credentials", "Please enter your user name and password.", "", "NetBiosUserName")
 ```
 
 This command uses the **PromptForCredential** method to prompt the user for their user name and

--- a/reference/5.1/Microsoft.PowerShell.Security/Test-FileCatalog.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Test-FileCatalog.md
@@ -41,7 +41,7 @@ This cmdlet is only supported on Windows.
 ```powershell
 New-FileCatalog -Path $PSHOME\Modules\Microsoft.PowerShell.Utility -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -CatalogVersion 2.0
 
-Test-FileCatalog -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -Path "$PSHome\Modules\Microsoft.PowerShell.Utility\"
+Test-FileCatalog -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -Path "$PSHOME\Modules\Microsoft.PowerShell.Utility\"
 ```
 
 ```Output
@@ -51,7 +51,7 @@ Valid
 ### Example 2: Validate a file catalog with detailed output
 
 ```powershell
-Test-FileCatalog -Detailed -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -Path "$PSHome\Modules\Microsoft.PowerShell.Utility\"
+Test-FileCatalog -Detailed -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -Path "$PSHOME\Modules\Microsoft.PowerShell.Utility\"
 ```
 
 ```Output

--- a/reference/5.1/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Add-Member.md
@@ -144,8 +144,8 @@ This example adds the **SizeInMB** script method to a **FileInfo** object that c
 size to the nearest MegaByte. The second command creates a **ScriptBlock** that uses the **Round**
 static method from the `[math]` type to round the file size to the second decimal place.
 
-The **Value** parameter also uses the `$This` automatic variable, which represents the current
-object. The `$This` variable is valid only in script blocks that define new properties and methods.
+The **Value** parameter also uses the `$this` automatic variable, which represents the current
+object. The `$this` variable is valid only in script blocks that define new properties and methods.
 
 The last command uses dot notation to call the new **SizeInMB** script method on the object in the
 `$A` variable.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Add-Type.md
@@ -216,11 +216,11 @@ $ShowWindowAsync = Add-Type @addTypeSplat
 
 # Minimize the PowerShell console
 
-$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $pid).MainWindowHandle, 2)
+$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $PID).MainWindowHandle, 2)
 
 # Restore the PowerShell console
 
-$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $Pid).MainWindowHandle, 4)
+$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $PID).MainWindowHandle, 4)
 ```
 
 The `$Signature` variable stores the C# signature of the `ShowWindowAsync` function. To ensure that

--- a/reference/5.1/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -106,7 +106,7 @@ shows which input object the output belongs to.
 The following examples shows the different output types.
 
 ```powershell
-$a = $True
+$a = $true
 Compare-Object -IncludeEqual $a $a
 (Compare-Object -IncludeEqual $a $a) | Get-Member
 ```

--- a/reference/7.4/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Split-Path.md
@@ -161,12 +161,12 @@ False
 This command changes your location to the folder that contains the PowerShell profile.
 
 ```powershell
-PS C:\> Set-Location (Split-Path -Path $profile)
+PS C:\> Set-Location (Split-Path -Path $PROFILE)
 PS C:\Users\User01\Documents\PowerShell>
 ```
 
 The command in parentheses uses `Split-Path` to return only the parent of the path stored in the
-built-in `$Profile` variable. The **Parent** parameter is the default split location parameter.
+built-in `$PROFILE` variable. The **Parent** parameter is the default split location parameter.
 Therefore, you can omit it from the command. The parentheses direct PowerShell to run the command
 first. This is a useful way to move to a folder that has a long path name.
 
@@ -225,7 +225,7 @@ Accept wildcard characters: False
 
 ### -IsAbsolute
 
-Indicates that this cmdlet returns `$True` if the path is absolute and `$false` if it's relative. On
+Indicates that this cmdlet returns `$true` if the path is absolute and `$false` if it's relative. On
 Windows, an absolute path string must start with a provider drive specifier, like `C:` or `HKCU:`. A
 relative path starts with a dot (`.`) or a dot-dot (`..`).
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Stop-Process.md
@@ -102,7 +102,7 @@ to `Stop-Process`.
 The last command gets all of the processes on the computer that were running but that are now
 stopped. It uses `Get-Process` to get all of the processes on the computer. The pipeline operator
 (`|`) passes the results to the `Where-Object` cmdlet, which selects the ones where the value of the
-**HasExited** property is $True. **HasExited** is just one property of process objects. To find all
+**HasExited** property is $true. **HasExited** is just one property of process objects. To find all
 the properties, type `Get-Process | Get-Member`.
 
 ### Example 4: Stop a process not owned by the current user

--- a/reference/7.4/Microsoft.PowerShell.Management/Suspend-Service.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Suspend-Service.md
@@ -84,7 +84,7 @@ PS C:\> Get-Service | Where-Object {$_.CanPauseAndContinue -eq "True"} | Suspend
 This command suspends all of the services on the computer that can be suspended. It uses
 `Get-Service` to get objects that represent the services on the computer. The pipeline operator
 passes the results to the `Where-Object` cmdlet, which selects only the services that have a value
-of `$True` for the **CanPauseAndContinue** property. Another pipeline operator passes the results to
+of `$true` for the **CanPauseAndContinue** property. Another pipeline operator passes the results to
 `Suspend-Service`. The **Confirm** parameter prompts you for confirmation before suspending each of
 the services.
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Test-Connection.md
@@ -146,10 +146,10 @@ if (Test-Connection -TargetName Server01 -Quiet) { New-PSSession -ComputerName S
 ```
 
 The `Test-Connection` cmdlet pings the `Server01` computer, with the **Quiet** parameter provided.
-The resulting value is `$True` if any of the four pings succeed. If none of the pings succeed,
+The resulting value is `$true` if any of the four pings succeed. If none of the pings succeed,
 the value is `$false`.
 
-If the `Test-Connection` command returns a value of `$True`, the command uses the `New-PSSession`
+If the `Test-Connection` command returns a value of `$true`, the command uses the `New-PSSession`
 cmdlet to create the **PSSession**.
 
 ### Example 6: Use the Traceroute parameter
@@ -404,7 +404,7 @@ errors.
 Each connection that's tested returns a **Boolean** value. If the **TargetName** parameter
 specifies multiple computers, an array of **Boolean** values is returned.
 
-If **any** ping to a given target succeeds, `$True` is returned.
+If **any** ping to a given target succeeds, `$true` is returned.
 
 If **all** pings to a given target fail, `$false` is returned.
 
@@ -500,7 +500,7 @@ Specifies the TCP port number on the target to be used in the TCP connection tes
 
 The cmdlet attempts to make a TCP connection to the specified port on the target.
 
-- The cmdlet returns `$True` if a connection is made.
+- The cmdlet returns `$true` if a connection is made.
 - The cmdlet returns `$false` if a connection is not made.
 
 ```yaml

--- a/reference/7.4/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Test-Path.md
@@ -71,7 +71,7 @@ returns `$false`. Otherwise, it returns `$true`.
 ### Example 2: Test the path of a profile
 
 ```powershell
-Test-Path -Path $profile
+Test-Path -Path $PROFILE
 ```
 
 ```Output
@@ -79,7 +79,7 @@ False
 ```
 
 ```powershell
-Test-Path -Path $profile -IsValid
+Test-Path -Path $PROFILE -IsValid
 ```
 
 ```Output
@@ -90,7 +90,7 @@ These commands test the path of the PowerShell profile.
 
 The first command determines whether all elements in the path exist. The second command determines
 whether the syntax of the path is correct. In this case, the path is `$false`, but the syntax is
-correct `$true`. These commands use `$profile`, the automatic variable that points to the location
+correct `$true`. These commands use `$PROFILE`, the automatic variable that points to the location
 for the profile, even if the profile doesn't exist.
 
 For more information about automatic variables, see
@@ -121,14 +121,14 @@ In this case, because the directory contains only .dwg files, the result is `$fa
 ### Example 4: Check for a file
 
 ```powershell
-Test-Path -Path $profile -PathType leaf
+Test-Path -Path $PROFILE -PathType leaf
 ```
 
 ```Output
 True
 ```
 
-This command checks whether the path stored in the `$profile` variable leads to a file. In this
+This command checks whether the path stored in the `$PROFILE` variable leads to a file. In this
 case, because the PowerShell profile is a `.ps1` file, the cmdlet returns `$true`.
 
 ### Example 5: Check paths in the Registry
@@ -167,7 +167,7 @@ the computer is newer than `July 13, 2009`.
 The NewerThan parameter works only in file system drives.
 
 ```powershell
-Test-Path $pshome\pwsh.exe -NewerThan "July 13, 2009"
+Test-Path $PSHOME\pwsh.exe -NewerThan "July 13, 2009"
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Security/Get-Credential.md
+++ b/reference/7.4/Microsoft.PowerShell.Security/Get-Credential.md
@@ -73,7 +73,7 @@ object.
 ### Example 3
 
 ```powershell
-$Credential = $host.ui.PromptForCredential("Need credentials", "Please enter your user name and password.", "", "NetBiosUserName")
+$Credential = $Host.ui.PromptForCredential("Need credentials", "Please enter your user name and password.", "", "NetBiosUserName")
 ```
 
 This command uses the **PromptForCredential** method to prompt the user for their user name and

--- a/reference/7.4/Microsoft.PowerShell.Security/Test-FileCatalog.md
+++ b/reference/7.4/Microsoft.PowerShell.Security/Test-FileCatalog.md
@@ -43,7 +43,7 @@ This cmdlet is only supported on Windows.
 ```powershell
 New-FileCatalog -Path $PSHOME\Modules\Microsoft.PowerShell.Utility -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -CatalogVersion 2.0
 
-Test-FileCatalog -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -Path "$PSHome\Modules\Microsoft.PowerShell.Utility\"
+Test-FileCatalog -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -Path "$PSHOME\Modules\Microsoft.PowerShell.Utility\"
 ```
 
 ```Output
@@ -53,7 +53,7 @@ Valid
 ### Example 2: Validate a file catalog with detailed output
 
 ```powershell
-Test-FileCatalog -Detailed -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -Path "$PSHome\Modules\Microsoft.PowerShell.Utility\"
+Test-FileCatalog -Detailed -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -Path "$PSHOME\Modules\Microsoft.PowerShell.Utility\"
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Add-Member.md
@@ -144,8 +144,8 @@ This example adds the **SizeInMB** script method to a **FileInfo** object that c
 size to the nearest MegaByte. The second command creates a **ScriptBlock** that uses the **Round**
 static method from the `[math]` type to round the file size to the second decimal place.
 
-The **Value** parameter also uses the `$This` automatic variable, which represents the current
-object. The `$This` variable is valid only in script blocks that define new properties and methods.
+The **Value** parameter also uses the `$this` automatic variable, which represents the current
+object. The `$this` variable is valid only in script blocks that define new properties and methods.
 
 The last command uses dot notation to call the new **SizeInMB** script method on the object in the
 `$A` variable.

--- a/reference/7.4/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Add-Type.md
@@ -223,11 +223,11 @@ $ShowWindowAsync = Add-Type @addTypeSplat
 
 # Minimize the PowerShell console
 
-$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $pid).MainWindowHandle, 2)
+$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $PID).MainWindowHandle, 2)
 
 # Restore the PowerShell console
 
-$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $Pid).MainWindowHandle, 4)
+$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $PID).MainWindowHandle, 4)
 ```
 
 The `$Signature` variable stores the C# signature of the `ShowWindowAsync` function. To ensure that

--- a/reference/7.4/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -107,7 +107,7 @@ shows which input object the output belongs to.
 The following examples shows the different output types.
 
 ```powershell
-$a = $True
+$a = $true
 Compare-Object -IncludeEqual $a $a
 (Compare-Object -IncludeEqual $a $a) | Get-Member
 ```

--- a/reference/7.5/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Split-Path.md
@@ -161,12 +161,12 @@ False
 This command changes your location to the folder that contains the PowerShell profile.
 
 ```powershell
-PS C:\> Set-Location (Split-Path -Path $profile)
+PS C:\> Set-Location (Split-Path -Path $PROFILE)
 PS C:\Users\User01\Documents\PowerShell>
 ```
 
 The command in parentheses uses `Split-Path` to return only the parent of the path stored in the
-built-in `$Profile` variable. The **Parent** parameter is the default split location parameter.
+built-in `$PROFILE` variable. The **Parent** parameter is the default split location parameter.
 Therefore, you can omit it from the command. The parentheses direct PowerShell to run the command
 first. This is a useful way to move to a folder that has a long path name.
 
@@ -225,7 +225,7 @@ Accept wildcard characters: False
 
 ### -IsAbsolute
 
-Indicates that this cmdlet returns `$True` if the path is absolute and `$false` if it's relative. On
+Indicates that this cmdlet returns `$true` if the path is absolute and `$false` if it's relative. On
 Windows, an absolute path string must start with a provider drive specifier, like `C:` or `HKCU:`. A
 relative path starts with a dot (`.`) or a dot-dot (`..`).
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Stop-Process.md
@@ -103,7 +103,7 @@ to `Stop-Process`.
 The last command gets all of the processes on the computer that were running but that are now
 stopped. It uses `Get-Process` to get all of the processes on the computer. The pipeline operator
 (`|`) passes the results to the `Where-Object` cmdlet, which selects the ones where the value of the
-**HasExited** property is $True. **HasExited** is just one property of process objects. To find all
+**HasExited** property is $true. **HasExited** is just one property of process objects. To find all
 the properties, type `Get-Process | Get-Member`.
 
 ### Example 4: Stop a process not owned by the current user

--- a/reference/7.5/Microsoft.PowerShell.Management/Suspend-Service.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Suspend-Service.md
@@ -86,7 +86,7 @@ Get-Service |
 This command suspends all of the services on the computer that can be suspended. It uses
 `Get-Service` to get objects that represent the services on the computer. The pipeline operator
 passes the results to the `Where-Object` cmdlet, which selects only the services that have a value
-of `$True` for the **CanPauseAndContinue** property. Another pipeline operator passes the results to
+of `$true` for the **CanPauseAndContinue** property. Another pipeline operator passes the results to
 `Suspend-Service`. The **Confirm** parameter prompts you for confirmation before suspending each of
 the services.
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Test-Connection.md
@@ -146,10 +146,10 @@ if (Test-Connection -TargetName Server01 -Quiet) { New-PSSession -ComputerName S
 ```
 
 The `Test-Connection` cmdlet pings the `Server01` computer, with the **Quiet** parameter provided.
-The resulting value is `$True` if any of the four pings succeed. If none of the pings succeed,
+The resulting value is `$true` if any of the four pings succeed. If none of the pings succeed,
 the value is `$false`.
 
-If the `Test-Connection` command returns a value of `$True`, the command uses the `New-PSSession`
+If the `Test-Connection` command returns a value of `$true`, the command uses the `New-PSSession`
 cmdlet to create the **PSSession**.
 
 ### Example 6: Use the Traceroute parameter
@@ -404,7 +404,7 @@ errors.
 Each connection that's tested returns a **Boolean** value. If the **TargetName** parameter
 specifies multiple computers, an array of **Boolean** values is returned.
 
-If **any** ping to a given target succeeds, `$True` is returned.
+If **any** ping to a given target succeeds, `$true` is returned.
 
 If **all** pings to a given target fail, `$false` is returned.
 
@@ -500,7 +500,7 @@ Specifies the TCP port number on the target to be used in the TCP connection tes
 
 The cmdlet attempts to make a TCP connection to the specified port on the target.
 
-- The cmdlet returns `$True` if a connection is made.
+- The cmdlet returns `$true` if a connection is made.
 - The cmdlet returns `$false` if a connection is not made.
 
 ```yaml

--- a/reference/7.5/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Test-Path.md
@@ -71,7 +71,7 @@ returns `$false`. Otherwise, it returns `$true`.
 ### Example 2: Test the path of a profile
 
 ```powershell
-Test-Path -Path $profile
+Test-Path -Path $PROFILE
 ```
 
 ```Output
@@ -79,7 +79,7 @@ False
 ```
 
 ```powershell
-Test-Path -Path $profile -IsValid
+Test-Path -Path $PROFILE -IsValid
 ```
 
 ```Output
@@ -90,7 +90,7 @@ These commands test the path of the PowerShell profile.
 
 The first command determines whether all elements in the path exist. The second command determines
 whether the syntax of the path is correct. In this case, the path is `$false`, but the syntax is
-correct `$true`. These commands use `$profile`, the automatic variable that points to the location
+correct `$true`. These commands use `$PROFILE`, the automatic variable that points to the location
 for the profile, even if the profile doesn't exist.
 
 For more information about automatic variables, see
@@ -121,14 +121,14 @@ In this case, because the directory contains only .dwg files, the result is `$fa
 ### Example 4: Check for a file
 
 ```powershell
-Test-Path -Path $profile -PathType leaf
+Test-Path -Path $PROFILE -PathType leaf
 ```
 
 ```Output
 True
 ```
 
-This command checks whether the path stored in the `$profile` variable leads to a file. In this
+This command checks whether the path stored in the `$PROFILE` variable leads to a file. In this
 case, because the PowerShell profile is a `.ps1` file, the cmdlet returns `$true`.
 
 ### Example 5: Check paths in the Registry

--- a/reference/7.5/Microsoft.PowerShell.Security/Get-Credential.md
+++ b/reference/7.5/Microsoft.PowerShell.Security/Get-Credential.md
@@ -73,7 +73,7 @@ object.
 ### Example 3
 
 ```powershell
-$Credential = $host.ui.PromptForCredential(
+$Credential = $Host.ui.PromptForCredential(
     "Need credentials", "Please enter your user name and password.", "", "NetBiosUserName")
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Security/Test-FileCatalog.md
+++ b/reference/7.5/Microsoft.PowerShell.Security/Test-FileCatalog.md
@@ -50,7 +50,7 @@ New-FileCatalog @NewFileCatalogParams
 
 $TestFileCatalogParams = @{
     CatalogFilePath = "\temp\Microsoft.PowerShell.Utility.cat"
-    Path = "$PSHome\Modules\Microsoft.PowerShell.Utility\"
+    Path = "$PSHOME\Modules\Microsoft.PowerShell.Utility\"
 }
 Test-FileCatalog @TestFileCatalogParams
 ```
@@ -65,7 +65,7 @@ Valid
 $TestFileCatalogParams = @{
     Detailed = $true
     CatalogFilePath = "\temp\Microsoft.PowerShell.Utility.cat"
-    Path = "$PSHome\Modules\Microsoft.PowerShell.Utility\"
+    Path = "$PSHOME\Modules\Microsoft.PowerShell.Utility\"
 }
 Test-FileCatalog @TestFileCatalogParams
 ```

--- a/reference/7.5/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Add-Member.md
@@ -144,8 +144,8 @@ This example adds the **SizeInMB** script method to a **FileInfo** object that c
 size to the nearest MegaByte. The second command creates a **ScriptBlock** that uses the **Round**
 static method from the `[math]` type to round the file size to the second decimal place.
 
-The **Value** parameter also uses the `$This` automatic variable, which represents the current
-object. The `$This` variable is valid only in script blocks that define new properties and methods.
+The **Value** parameter also uses the `$this` automatic variable, which represents the current
+object. The `$this` variable is valid only in script blocks that define new properties and methods.
 
 The last command uses dot notation to call the new **SizeInMB** script method on the object in the
 `$A` variable.

--- a/reference/7.5/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Add-Type.md
@@ -224,11 +224,11 @@ $ShowWindowAsync = Add-Type @addTypeSplat
 
 # Minimize the PowerShell console
 
-$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $pid).MainWindowHandle, 2)
+$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $PID).MainWindowHandle, 2)
 
 # Restore the PowerShell console
 
-$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $Pid).MainWindowHandle, 4)
+$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $PID).MainWindowHandle, 4)
 ```
 
 The `$Signature` variable stores the C# signature of the `ShowWindowAsync` function. To ensure that

--- a/reference/7.5/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -111,7 +111,7 @@ shows which input object the output belongs to.
 The following examples shows the different output types.
 
 ```powershell
-$a = $True
+$a = $true
 Compare-Object -IncludeEqual $a $a
 (Compare-Object -IncludeEqual $a $a) | Get-Member
 ```

--- a/reference/7.6/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Split-Path.md
@@ -161,12 +161,12 @@ False
 This command changes your location to the folder that contains the PowerShell profile.
 
 ```powershell
-PS C:\> Set-Location (Split-Path -Path $profile)
+PS C:\> Set-Location (Split-Path -Path $PROFILE)
 PS C:\Users\User01\Documents\PowerShell>
 ```
 
 The command in parentheses uses `Split-Path` to return only the parent of the path stored in the
-built-in `$Profile` variable. The **Parent** parameter is the default split location parameter.
+built-in `$PROFILE` variable. The **Parent** parameter is the default split location parameter.
 Therefore, you can omit it from the command. The parentheses direct PowerShell to run the command
 first. This is a useful way to move to a folder that has a long path name.
 
@@ -225,7 +225,7 @@ Accept wildcard characters: False
 
 ### -IsAbsolute
 
-Indicates that this cmdlet returns `$True` if the path is absolute and `$false` if it's relative. On
+Indicates that this cmdlet returns `$true` if the path is absolute and `$false` if it's relative. On
 Windows, an absolute path string must start with a provider drive specifier, like `C:` or `HKCU:`. A
 relative path starts with a dot (`.`) or a dot-dot (`..`).
 

--- a/reference/7.6/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Stop-Process.md
@@ -102,7 +102,7 @@ to `Stop-Process`.
 The last command gets all of the processes on the computer that were running but that are now
 stopped. It uses `Get-Process` to get all of the processes on the computer. The pipeline operator
 (`|`) passes the results to the `Where-Object` cmdlet, which selects the ones where the value of the
-**HasExited** property is $True. **HasExited** is just one property of process objects. To find all
+**HasExited** property is $true. **HasExited** is just one property of process objects. To find all
 the properties, type `Get-Process | Get-Member`.
 
 ### Example 4: Stop a process not owned by the current user

--- a/reference/7.6/Microsoft.PowerShell.Management/Suspend-Service.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Suspend-Service.md
@@ -84,7 +84,7 @@ PS C:\> Get-Service | Where-Object {$_.CanPauseAndContinue -eq "True"} | Suspend
 This command suspends all of the services on the computer that can be suspended. It uses
 `Get-Service` to get objects that represent the services on the computer. The pipeline operator
 passes the results to the `Where-Object` cmdlet, which selects only the services that have a value
-of `$True` for the **CanPauseAndContinue** property. Another pipeline operator passes the results to
+of `$true` for the **CanPauseAndContinue** property. Another pipeline operator passes the results to
 `Suspend-Service`. The **Confirm** parameter prompts you for confirmation before suspending each of
 the services.
 

--- a/reference/7.6/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Test-Connection.md
@@ -146,10 +146,10 @@ if (Test-Connection -TargetName Server01 -Quiet) { New-PSSession -ComputerName S
 ```
 
 The `Test-Connection` cmdlet pings the `Server01` computer, with the **Quiet** parameter provided.
-The resulting value is `$True` if any of the four pings succeed. If none of the pings succeed,
+The resulting value is `$true` if any of the four pings succeed. If none of the pings succeed,
 the value is `$false`.
 
-If the `Test-Connection` command returns a value of `$True`, the command uses the `New-PSSession`
+If the `Test-Connection` command returns a value of `$true`, the command uses the `New-PSSession`
 cmdlet to create the **PSSession**.
 
 ### Example 6: Use the Traceroute parameter
@@ -404,7 +404,7 @@ errors.
 Each connection that's tested returns a **Boolean** value. If the **TargetName** parameter
 specifies multiple computers, an array of **Boolean** values is returned.
 
-If **any** ping to a given target succeeds, `$True` is returned.
+If **any** ping to a given target succeeds, `$true` is returned.
 
 If **all** pings to a given target fail, `$false` is returned.
 
@@ -500,7 +500,7 @@ Specifies the TCP port number on the target to be used in the TCP connection tes
 
 The cmdlet attempts to make a TCP connection to the specified port on the target.
 
-- The cmdlet returns `$True` if a connection is made.
+- The cmdlet returns `$true` if a connection is made.
 - The cmdlet returns `$false` if a connection is not made.
 
 ```yaml

--- a/reference/7.6/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Test-Path.md
@@ -71,7 +71,7 @@ returns `$false`. Otherwise, it returns `$true`.
 ### Example 2: Test the path of a profile
 
 ```powershell
-Test-Path -Path $profile
+Test-Path -Path $PROFILE
 ```
 
 ```Output
@@ -79,7 +79,7 @@ False
 ```
 
 ```powershell
-Test-Path -Path $profile -IsValid
+Test-Path -Path $PROFILE -IsValid
 ```
 
 ```Output
@@ -90,7 +90,7 @@ These commands test the path of the PowerShell profile.
 
 The first command determines whether all elements in the path exist. The second command determines
 whether the syntax of the path is correct. In this case, the path is `$false`, but the syntax is
-correct `$true`. These commands use `$profile`, the automatic variable that points to the location
+correct `$true`. These commands use `$PROFILE`, the automatic variable that points to the location
 for the profile, even if the profile doesn't exist.
 
 For more information about automatic variables, see
@@ -121,14 +121,14 @@ In this case, because the directory contains only .dwg files, the result is `$fa
 ### Example 4: Check for a file
 
 ```powershell
-Test-Path -Path $profile -PathType leaf
+Test-Path -Path $PROFILE -PathType leaf
 ```
 
 ```Output
 True
 ```
 
-This command checks whether the path stored in the `$profile` variable leads to a file. In this
+This command checks whether the path stored in the `$PROFILE` variable leads to a file. In this
 case, because the PowerShell profile is a `.ps1` file, the cmdlet returns `$true`.
 
 ### Example 5: Check paths in the Registry

--- a/reference/7.6/Microsoft.PowerShell.Security/Get-Credential.md
+++ b/reference/7.6/Microsoft.PowerShell.Security/Get-Credential.md
@@ -73,7 +73,7 @@ object.
 ### Example 3
 
 ```powershell
-$Credential = $host.ui.PromptForCredential("Need credentials", "Please enter your user name and password.", "", "NetBiosUserName")
+$Credential = $Host.ui.PromptForCredential("Need credentials", "Please enter your user name and password.", "", "NetBiosUserName")
 ```
 
 This command uses the **PromptForCredential** method to prompt the user for their user name and

--- a/reference/7.6/Microsoft.PowerShell.Security/Test-FileCatalog.md
+++ b/reference/7.6/Microsoft.PowerShell.Security/Test-FileCatalog.md
@@ -43,7 +43,7 @@ This cmdlet is only supported on Windows.
 ```powershell
 New-FileCatalog -Path $PSHOME\Modules\Microsoft.PowerShell.Utility -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -CatalogVersion 2.0
 
-Test-FileCatalog -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -Path "$PSHome\Modules\Microsoft.PowerShell.Utility\"
+Test-FileCatalog -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -Path "$PSHOME\Modules\Microsoft.PowerShell.Utility\"
 ```
 
 ```Output
@@ -53,7 +53,7 @@ Valid
 ### Example 2: Validate a file catalog with detailed output
 
 ```powershell
-Test-FileCatalog -Detailed -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -Path "$PSHome\Modules\Microsoft.PowerShell.Utility\"
+Test-FileCatalog -Detailed -CatalogFilePath \temp\Microsoft.PowerShell.Utility.cat -Path "$PSHOME\Modules\Microsoft.PowerShell.Utility\"
 ```
 
 ```Output

--- a/reference/7.6/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Add-Member.md
@@ -144,8 +144,8 @@ This example adds the **SizeInMB** script method to a **FileInfo** object that c
 size to the nearest MegaByte. The second command creates a **ScriptBlock** that uses the **Round**
 static method from the `[math]` type to round the file size to the second decimal place.
 
-The **Value** parameter also uses the `$This` automatic variable, which represents the current
-object. The `$This` variable is valid only in script blocks that define new properties and methods.
+The **Value** parameter also uses the `$this` automatic variable, which represents the current
+object. The `$this` variable is valid only in script blocks that define new properties and methods.
 
 The last command uses dot notation to call the new **SizeInMB** script method on the object in the
 `$A` variable.

--- a/reference/7.6/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Add-Type.md
@@ -223,11 +223,11 @@ $ShowWindowAsync = Add-Type @addTypeSplat
 
 # Minimize the PowerShell console
 
-$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $pid).MainWindowHandle, 2)
+$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $PID).MainWindowHandle, 2)
 
 # Restore the PowerShell console
 
-$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $Pid).MainWindowHandle, 4)
+$ShowWindowAsync::ShowWindowAsync((Get-Process -Id $PID).MainWindowHandle, 4)
 ```
 
 The `$Signature` variable stores the C# signature of the `ShowWindowAsync` function. To ensure that

--- a/reference/7.6/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -107,7 +107,7 @@ shows which input object the output belongs to.
 The following examples shows the different output types.
 
 ```powershell
-$a = $True
+$a = $true
 Compare-Object -IncludeEqual $a $a
 (Compare-Object -IncludeEqual $a $a) | Get-Member
 ```


### PR DESCRIPTION
# PR Summary

This PR fixes incorrect [automatic variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables) casing used in selected files. E.g., `$Args` (incorrect) -> `$args` (correct).

## Context

This is PR **_5/9_** in a series that ensures the correct case is consistently used for individual automatic variables, as documented in `about_Automatic_Variables` and verified by tab completion. As requested, the PRs are split into groups of ~40 files. Within each file, correct casing is applied to all referenced automatic variables.

Changes in scope:

- Variables with a `$` or `@` sigil.
- Variables referenced by name without a sigil.

Out of scope:

- Preference variables (separate PRs to follow).
- Misuse of an automatic variable (e.g., naming a function parameter as `$Input`).
- Reference to the variable's _value_ (e.g., `false`/`False`/`FALSE` when referring to the _value_ of `$false`).

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide