### PR TITLE
Fix automatic variable case (6/9)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -79,7 +79,7 @@ they have the read-only attribute.
 
 ```powershell
 Export-Alias -Path "alias.ps1" -As Script
-Add-Content -Path $Profile -Value (Get-Content alias.ps1)
+Add-Content -Path $PROFILE -Value (Get-Content alias.ps1)
 $S = New-PSSession -ComputerName Server01
 Invoke-Command -Session $S -FilePath .\alias.ps1
 ```
@@ -91,7 +91,7 @@ parameter with a value of Script to generate a file that contains a Set-Alias co
 alias.
 
 The second command adds the aliases in the Alias.ps1 file to the CurrentUser-CurrentHost profile.
-The path to the profile is saved in the `$Profile` variable. The command uses the `Get-Content`
+The path to the profile is saved in the `$PROFILE` variable. The command uses the `Get-Content`
 cmdlet to get the aliases from the Alias.ps1 file and the `Add-Content` cmdlet to add them to the
 profile. For more information, see
 [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -84,9 +84,9 @@ In this example, given a credential that you've stored in the `$Credential` vari
 > array. This provides some obfuscation but does not provide encryption.
 
 ```powershell
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential | Export-Clixml $Credxmlpath
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential = Import-Clixml $Credxmlpath
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-List.md
@@ -48,7 +48,7 @@ default output cmdlet for display.
 These commands display information about the PS1XML files in the PowerShell directory as a list.
 
 ```powershell
-$A = Get-ChildItem $pshome\*.ps1xml
+$A = Get-ChildItem $PSHOME\*.ps1xml
 Format-List -InputObject $A
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Culture.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Culture.md
@@ -161,8 +161,8 @@ This cmdlet returns a **CultureInfo** object representing the current culture.
 
 ## NOTES
 
-You can also use the `$PsCulture` and `$PsUICulture` variables. The `$PsCulture` variable stores the
-name of the current culture and the `$PsUICulture` variable stores the name of the current UI
+You can also use the `$PSCulture` and `$PSUICulture` variables. The `$PSCulture` variable stores the
+name of the current culture and the `$PSUICulture` variable stores the name of the current UI
 culture.
 
 ## RELATED LINKS

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -111,7 +111,7 @@ Id  Name           State      HasMoreData  Location  Command
 ```
 
 ```powershell
-$Timer.Enabled = $True
+$Timer.Enabled = $true
 $Subscriber = Get-EventSubscriber -SourceIdentifier Timer.Random
 ($Subscriber.action).gettype().fullname
 ```

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
@@ -502,9 +502,9 @@ Windows PowerShell includes the following aliases for `Get-Member`:
 You can get information about a collection object either using the **InputObject** parameter or by
 piping the object, preceded by a comma, to `Get-Member`.
 
-You can use the `$This` automatic variable in script blocks that define the values of new properties
-and methods. The `$This` variable refers to the instance of the object to which the properties and
-methods are being added. For more information about the `$This` variable, see
+You can use the `$this` automatic variable in script blocks that define the values of new properties
+and methods. The `$this` variable refers to the instance of the object to which the properties and
+methods are being added. For more information about the `$this` variable, see
 [about_Automatic_Variables](../Microsoft.PowerShell.Core/About/about_Automatic_Variables.md).
 
 If you pass an object representing a _type_, like a type literal such as `[int]`, `Get-Member`

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -74,9 +74,9 @@ In this example, given a credential that you've stored in the `$Credential` vari
 > such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential | Export-Clixml $Credxmlpath
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential = Import-Clixml $Credxmlpath
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-LocalizedData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-LocalizedData.md
@@ -55,7 +55,7 @@ Import-LocalizedData -BindingVariable "Messages"
 ```
 
 If the command is included in the Archives.ps1 script in the `C:\Test` directory, and the value of
-the `$PsUICulture` automatic variable is zh-CN, `Import-LocalizedData` imports the `Archives.psd1`
+the `$PSUICulture` automatic variable is zh-CN, `Import-LocalizedData` imports the `Archives.psd1`
 file in the `C:\test\zh-CN` directory into the `$Messages` variable.
 
 ### Example 2: Import localized data strings
@@ -160,13 +160,13 @@ command that converts the contents of the DATA section to a hashtable and stores
 
 The script also includes an `Import-LocalizedData` command, which imports a hashtable of translated
 text strings from the TestScript.psd1 file in the subdirectory specified by the value of the
-`$PsUICulture` variable. If the command finds the `.psd1` file, it saves the translated strings from
+`$PSUICulture` variable. If the command finds the `.psd1` file, it saves the translated strings from
 the file in the value of the same `$UserMessages` variable, overwriting the hashtable saved by the
 DATA section logic.
 
 The third command displays the first message in the `$UserMessages` variable.
 
-If the `Import-LocalizedData` command finds a `.psd1` file for the `$PsUICulture` language, the
+If the `Import-LocalizedData` command finds a `.psd1` file for the `$PSUICulture` language, the
 value of the `$UserMessages` variable contains the translated text strings. If the command fails for
 any reason, the command displays the default text strings defined in the DATA section of the script.
 
@@ -301,14 +301,14 @@ Accept wildcard characters: False
 
 ### -UICulture
 
-Specifies an alternate UI culture. The default is the value of the `$PsUICulture` automatic
+Specifies an alternate UI culture. The default is the value of the `$PSUICulture` automatic
 variable. Enter a UI culture in `<language>-<region>` format, such as `en-US`, `de-DE`, or `ar-SA`.
 
 The value of the **UICulture** parameter determines the language-specific subdirectory (within the
 base directory) from which `Import-LocalizedData` gets the `.psd1` file for the script.
 
 The cmdlet searches for a subdirectory with the same name as the value of the **UICulture**
-parameter or the `$PsUICulture` automatic variable, such as `de-DE` or `ar-SA`. If it can't find the
+parameter or the `$PSUICulture` automatic variable, such as `de-DE` or `ar-SA`. If it can't find the
 directory, or the directory doesn't contain a `.psd1` file for the script, it searches for a
 subdirectory with the name of the language code, such as de or ar. If it can't find the subdirectory
 or `.psd1` file, the command fails and the data is displayed in the default language specified in
@@ -363,7 +363,7 @@ parameter.
 
   `Import-LocalizedData` begins the search in the directory where the script file is located (or the
   value of the **BaseDirectory** parameter). It then searches within the base directory for a
-  subdirectory with the same name as the value of the `$PsUICulture` variable (or the value of the
+  subdirectory with the same name as the value of the `$PSUICulture` variable (or the value of the
   **UICulture** parameter), such as `de-DE` or `ar-SA`. Then, it searches in that subdirectory for a
   `.psd1` file with the same name as the script (or the value of the **FileName** parameter).
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-Expression.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-Expression.md
@@ -145,12 +145,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-You can pipe a string representing the expression to invoke to this cmdlet. Use the `$Input`
+You can pipe a string representing the expression to invoke to this cmdlet. Use the `$input`
 automatic variable to represent the input objects in the command.
 
 ### System.Management.Automation.PSObject
 
-You can pipe an object representing the expression to invoke to this cmdlet. Use the `$Input`
+You can pipe an object representing the expression to invoke to this cmdlet. Use the `$input`
 automatic variable to represent the input objects in the command.
 
 ## OUTPUTS

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Object.md
@@ -56,16 +56,16 @@ Major  Minor  Build  Revision
 
 This example creates two instances of the COM object that represents the Internet Explorer
 application. The first instance uses the **Property** parameter hash table to call the **Navigate2**
-method and set the **Visible** property of the object to `$True` to make the application visible.
+method and set the **Visible** property of the object to `$true` to make the application visible.
 The second instance gets the same results with individual commands.
 
 ```powershell
-$IE1 = New-Object -COMObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $True}
+$IE1 = New-Object -COMObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $true}
 
 # The following command gets the same results as the example above.
 $IE2 = New-Object -COMObject InternetExplorer.Application`
 $IE2.Navigate2("www.microsoft.com")`
-$IE2.Visible = $True`
+$IE2.Visible = $true`
 ```
 
 ### Example 3: Use the Strict parameter to generate a non-terminating error
@@ -74,7 +74,7 @@ This example demonstrates that adding the **Strict** parameter causes the `New-O
 generate a non-terminating error when the COM object uses an interop assembly.
 
 ```powershell
-$A = New-Object -COMObject Word.Application -Strict -Property @{Visible = $True}
+$A = New-Object -COMObject Word.Application -Strict -Property @{Visible = $true}
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -79,7 +79,7 @@ they have the read-only attribute.
 
 ```powershell
 Export-Alias -Path "alias.ps1" -As Script
-Add-Content -Path $Profile -Value (Get-Content alias.ps1)
+Add-Content -Path $PROFILE -Value (Get-Content alias.ps1)
 $S = New-PSSession -ComputerName Server01
 Invoke-Command -Session $S -FilePath .\alias.ps1
 ```
@@ -91,7 +91,7 @@ parameter with a value of Script to generate a file that contains a Set-Alias co
 alias.
 
 The second command adds the aliases in the Alias.ps1 file to the CurrentUser-CurrentHost profile.
-The path to the profile is saved in the `$Profile` variable. The command uses the `Get-Content`
+The path to the profile is saved in the `$PROFILE` variable. The command uses the `Get-Content`
 cmdlet to get the aliases from the Alias.ps1 file and the `Add-Content` cmdlet to add them to the
 profile. For more information, see
 [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).

--- a/reference/7.4/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -84,9 +84,9 @@ In this example, given a credential that you've stored in the `$Credential` vari
 > array. This provides some obfuscation but does not provide encryption.
 
 ```powershell
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential | Export-Clixml $Credxmlpath
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential = Import-Clixml $Credxmlpath
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Format-List.md
@@ -48,7 +48,7 @@ default output cmdlet for display.
 These commands display information about the PS1XML files in the PowerShell directory as a list.
 
 ```powershell
-$A = Get-ChildItem $pshome\*.ps1xml
+$A = Get-ChildItem $PSHOME\*.ps1xml
 Format-List -InputObject $A
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-Culture.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-Culture.md
@@ -243,8 +243,8 @@ This cmdlet returns a **CultureInfo** object representing the current culture.
 
 ## NOTES
 
-You can also use the `$PsCulture` and `$PsUICulture` variables. The `$PsCulture` variable stores the
-name of the current culture and the `$PsUICulture` variable stores the name of the current UI
+You can also use the `$PSCulture` and `$PSUICulture` variables. The `$PSCulture` variable stores the
+name of the current culture and the `$PSUICulture` variable stores the name of the current UI
 culture.
 
 ## RELATED LINKS

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -111,7 +111,7 @@ Id  Name           State      HasMoreData  Location  Command
 ```
 
 ```powershell
-$Timer.Enabled = $True
+$Timer.Enabled = $true
 $Subscriber = Get-EventSubscriber -SourceIdentifier Timer.Random
 ($Subscriber.action).gettype().fullname
 ```

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-Member.md
@@ -507,9 +507,9 @@ PowerShell includes the following aliases for `Get-Member`:
 You can get information about a collection object either using the **InputObject** parameter or by
 piping the object, preceded by a comma, to `Get-Member`.
 
-You can use the `$This` automatic variable in script blocks that define the values of new properties
-and methods. The `$This` variable refers to the instance of the object to which the properties and
-methods are being added. For more information about the `$This` variable, see
+You can use the `$this` automatic variable in script blocks that define the values of new properties
+and methods. The `$this` variable refers to the instance of the object to which the properties and
+methods are being added. For more information about the `$this` variable, see
 [about_Automatic_Variables](../Microsoft.PowerShell.Core/About/about_Automatic_Variables.md).
 
 If you pass an object representing a _type_, like a type literal such as `[int]`, `Get-Member`

--- a/reference/7.4/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -74,9 +74,9 @@ In this example, given a credential that you've stored in the `$Credential` vari
 > such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential | Export-Clixml $Credxmlpath
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential = Import-Clixml $Credxmlpath
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Import-LocalizedData.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Import-LocalizedData.md
@@ -55,7 +55,7 @@ Import-LocalizedData -BindingVariable "Messages"
 ```
 
 If the command is included in the Archives.ps1 script in the `C:\Test` directory, and the value of
-the `$PsUICulture` automatic variable is zh-CN, `Import-LocalizedData` imports the `Archives.psd1`
+the `$PSUICulture` automatic variable is zh-CN, `Import-LocalizedData` imports the `Archives.psd1`
 file in the `C:\test\zh-CN` directory into the `$Messages` variable.
 
 ### Example 2: Import localized data strings
@@ -160,13 +160,13 @@ command that converts the contents of the DATA section to a hashtable and stores
 
 The script also includes an `Import-LocalizedData` command, which imports a hashtable of translated
 text strings from the TestScript.psd1 file in the subdirectory specified by the value of the
-`$PsUICulture` variable. If the command finds the `.psd1` file, it saves the translated strings from
+`$PSUICulture` variable. If the command finds the `.psd1` file, it saves the translated strings from
 the file in the value of the same `$UserMessages` variable, overwriting the hashtable saved by the
 DATA section logic.
 
 The third command displays the first message in the `$UserMessages` variable.
 
-If the `Import-LocalizedData` command finds a `.psd1` file for the `$PsUICulture` language, the
+If the `Import-LocalizedData` command finds a `.psd1` file for the `$PSUICulture` language, the
 value of the `$UserMessages` variable contains the translated text strings. If the command fails for
 any reason, the command displays the default text strings defined in the DATA section of the script.
 
@@ -301,14 +301,14 @@ Accept wildcard characters: False
 
 ### -UICulture
 
-Specifies an alternate UI culture. The default is the value of the `$PsUICulture` automatic
+Specifies an alternate UI culture. The default is the value of the `$PSUICulture` automatic
 variable. Enter a UI culture in `<language>-<region>` format, such as `en-US`, `de-DE`, or `ar-SA`.
 
 The value of the **UICulture** parameter determines the language-specific subdirectory (within the
 base directory) from which `Import-LocalizedData` gets the `.psd1` file for the script.
 
 The cmdlet searches for a subdirectory with the same name as the value of the **UICulture**
-parameter or the `$PsUICulture` automatic variable, such as `de-DE` or `ar-SA`. If it can't find the
+parameter or the `$PSUICulture` automatic variable, such as `de-DE` or `ar-SA`. If it can't find the
 directory, or the directory doesn't contain a `.psd1` file for the script, it searches for a
 subdirectory with the name of the language code, such as de or ar. If it can't find the subdirectory
 or `.psd1` file, the command fails and the data is displayed in the default language specified in
@@ -363,7 +363,7 @@ parameter.
 
   `Import-LocalizedData` begins the search in the directory where the script file is located (or the
   value of the **BaseDirectory** parameter). It then searches within the base directory for a
-  subdirectory with the same name as the value of the `$PsUICulture` variable (or the value of the
+  subdirectory with the same name as the value of the `$PSUICulture` variable (or the value of the
   **UICulture** parameter), such as `de-DE` or `ar-SA`. Then, it searches in that subdirectory for a
   `.psd1` file with the same name as the script (or the value of the **FileName** parameter).
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-Expression.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-Expression.md
@@ -145,12 +145,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-You can pipe a string representing the expression to invoke to this cmdlet. Use the `$Input`
+You can pipe a string representing the expression to invoke to this cmdlet. Use the `$input`
 automatic variable to represent the input objects in the command.
 
 ### System.Management.Automation.PSObject
 
-You can pipe an object representing the expression to invoke to this cmdlet. Use the `$Input`
+You can pipe an object representing the expression to invoke to this cmdlet. Use the `$input`
 automatic variable to represent the input objects in the command.
 
 ## OUTPUTS

--- a/reference/7.4/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/New-Object.md
@@ -56,16 +56,16 @@ Major  Minor  Build  Revision
 
 This example creates two instances of the COM object that represents the Internet Explorer
 application. The first instance uses the **Property** parameter hash table to call the **Navigate2**
-method and set the **Visible** property of the object to `$True` to make the application visible.
+method and set the **Visible** property of the object to `$true` to make the application visible.
 The second instance gets the same results with individual commands.
 
 ```powershell
-$IE1 = New-Object -COMObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $True}
+$IE1 = New-Object -COMObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $true}
 
 # The following command gets the same results as the example above.
 $IE2 = New-Object -COMObject InternetExplorer.Application`
 $IE2.Navigate2("www.microsoft.com")`
-$IE2.Visible = $True`
+$IE2.Visible = $true`
 ```
 
 ### Example 3: Use the Strict parameter to generate a non-terminating error
@@ -74,7 +74,7 @@ This example demonstrates that adding the **Strict** parameter causes the `New-O
 generate a non-terminating error when the COM object uses an interop assembly.
 
 ```powershell
-$A = New-Object -COMObject Word.Application -Strict -Property @{Visible = $True}
+$A = New-Object -COMObject Word.Application -Strict -Property @{Visible = $true}
 ```
 
 ```Output

--- a/reference/7.5/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -79,7 +79,7 @@ they have the read-only attribute.
 
 ```powershell
 Export-Alias -Path "alias.ps1" -As Script
-Add-Content -Path $Profile -Value (Get-Content alias.ps1)
+Add-Content -Path $PROFILE -Value (Get-Content alias.ps1)
 $S = New-PSSession -ComputerName Server01
 Invoke-Command -Session $S -FilePath .\alias.ps1
 ```
@@ -91,7 +91,7 @@ parameter with a value of Script to generate a file that contains a Set-Alias co
 alias.
 
 The second command adds the aliases in the Alias.ps1 file to the CurrentUser-CurrentHost profile.
-The path to the profile is saved in the `$Profile` variable. The command uses the `Get-Content`
+The path to the profile is saved in the `$PROFILE` variable. The command uses the `Get-Content`
 cmdlet to get the aliases from the Alias.ps1 file and the `Add-Content` cmdlet to add them to the
 profile. For more information, see
 [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).

--- a/reference/7.5/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -84,9 +84,9 @@ In this example, given a credential that you've stored in the `$Credential` vari
 > array. This provides some obfuscation but does not provide encryption.
 
 ```powershell
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential | Export-Clixml $Credxmlpath
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential = Import-Clixml $Credxmlpath
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Format-List.md
@@ -49,7 +49,7 @@ default output cmdlet for display.
 These commands display information about the PS1XML files in the PowerShell directory as a list.
 
 ```powershell
-$A = Get-ChildItem $pshome\*.ps1xml
+$A = Get-ChildItem $PSHOME\*.ps1xml
 Format-List -InputObject $A
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-Culture.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-Culture.md
@@ -243,8 +243,8 @@ This cmdlet returns a **CultureInfo** object representing the current culture.
 
 ## NOTES
 
-You can also use the `$PsCulture` and `$PsUICulture` variables. The `$PsCulture` variable stores the
-name of the current culture and the `$PsUICulture` variable stores the name of the current UI
+You can also use the `$PSCulture` and `$PSUICulture` variables. The `$PSCulture` variable stores the
+name of the current culture and the `$PSUICulture` variable stores the name of the current UI
 culture.
 
 ## RELATED LINKS

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -116,7 +116,7 @@ Id  Name           State      HasMoreData  Location  Command
 ```
 
 ```powershell
-$Timer.Enabled = $True
+$Timer.Enabled = $true
 $Subscriber = Get-EventSubscriber -SourceIdentifier Timer.Random
 ($Subscriber.Action).GetType().FullName
 ```

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-Member.md
@@ -507,9 +507,9 @@ PowerShell includes the following aliases for `Get-Member`:
 You can get information about a collection object either using the **InputObject** parameter or by
 piping the object, preceded by a comma, to `Get-Member`.
 
-You can use the `$This` automatic variable in script blocks that define the values of new properties
-and methods. The `$This` variable refers to the instance of the object to which the properties and
-methods are being added. For more information about the `$This` variable, see
+You can use the `$this` automatic variable in script blocks that define the values of new properties
+and methods. The `$this` variable refers to the instance of the object to which the properties and
+methods are being added. For more information about the `$this` variable, see
 [about_Automatic_Variables](../Microsoft.PowerShell.Core/About/about_Automatic_Variables.md).
 
 If you pass an object representing a _type_, like a type literal such as `[int]`, `Get-Member`

--- a/reference/7.5/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -74,9 +74,9 @@ In this example, given a credential that you've stored in the `$Credential` vari
 > such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential | Export-Clixml $Credxmlpath
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential = Import-Clixml $Credxmlpath
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Import-LocalizedData.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Import-LocalizedData.md
@@ -55,7 +55,7 @@ Import-LocalizedData -BindingVariable "Messages"
 ```
 
 If the command is included in the Archives.ps1 script in the `C:\Test` directory, and the value of
-the `$PsUICulture` automatic variable is zh-CN, `Import-LocalizedData` imports the `Archives.psd1`
+the `$PSUICulture` automatic variable is zh-CN, `Import-LocalizedData` imports the `Archives.psd1`
 file in the `C:\test\zh-CN` directory into the `$Messages` variable.
 
 ### Example 2: Import localized data strings
@@ -160,13 +160,13 @@ command that converts the contents of the DATA section to a hashtable and stores
 
 The script also includes an `Import-LocalizedData` command, which imports a hashtable of translated
 text strings from the TestScript.psd1 file in the subdirectory specified by the value of the
-`$PsUICulture` variable. If the command finds the `.psd1` file, it saves the translated strings from
+`$PSUICulture` variable. If the command finds the `.psd1` file, it saves the translated strings from
 the file in the value of the same `$UserMessages` variable, overwriting the hashtable saved by the
 DATA section logic.
 
 The third command displays the first message in the `$UserMessages` variable.
 
-If the `Import-LocalizedData` command finds a `.psd1` file for the `$PsUICulture` language, the
+If the `Import-LocalizedData` command finds a `.psd1` file for the `$PSUICulture` language, the
 value of the `$UserMessages` variable contains the translated text strings. If the command fails for
 any reason, the command displays the default text strings defined in the DATA section of the script.
 
@@ -301,14 +301,14 @@ Accept wildcard characters: False
 
 ### -UICulture
 
-Specifies an alternate UI culture. The default is the value of the `$PsUICulture` automatic
+Specifies an alternate UI culture. The default is the value of the `$PSUICulture` automatic
 variable. Enter a UI culture in `<language>-<region>` format, such as `en-US`, `de-DE`, or `ar-SA`.
 
 The value of the **UICulture** parameter determines the language-specific subdirectory (within the
 base directory) from which `Import-LocalizedData` gets the `.psd1` file for the script.
 
 The cmdlet searches for a subdirectory with the same name as the value of the **UICulture**
-parameter or the `$PsUICulture` automatic variable, such as `de-DE` or `ar-SA`. If it can't find the
+parameter or the `$PSUICulture` automatic variable, such as `de-DE` or `ar-SA`. If it can't find the
 directory, or the directory doesn't contain a `.psd1` file for the script, it searches for a
 subdirectory with the name of the language code, such as de or ar. If it can't find the subdirectory
 or `.psd1` file, the command fails and the data is displayed in the default language specified in
@@ -363,7 +363,7 @@ parameter.
 
   `Import-LocalizedData` begins the search in the directory where the script file is located (or the
   value of the **BaseDirectory** parameter). It then searches within the base directory for a
-  subdirectory with the same name as the value of the `$PsUICulture` variable (or the value of the
+  subdirectory with the same name as the value of the `$PSUICulture` variable (or the value of the
   **UICulture** parameter), such as `de-DE` or `ar-SA`. Then, it searches in that subdirectory for a
   `.psd1` file with the same name as the script (or the value of the **FileName** parameter).
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Invoke-Expression.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Invoke-Expression.md
@@ -145,12 +145,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-You can pipe a string representing the expression to invoke to this cmdlet. Use the `$Input`
+You can pipe a string representing the expression to invoke to this cmdlet. Use the `$input`
 automatic variable to represent the input objects in the command.
 
 ### System.Management.Automation.PSObject
 
-You can pipe an object representing the expression to invoke to this cmdlet. Use the `$Input`
+You can pipe an object representing the expression to invoke to this cmdlet. Use the `$input`
 automatic variable to represent the input objects in the command.
 
 ## OUTPUTS

--- a/reference/7.5/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/New-Object.md
@@ -56,16 +56,16 @@ Major  Minor  Build  Revision
 
 This example creates two instances of the COM object that represents the Internet Explorer
 application. The first instance uses the **Property** parameter hash table to call the **Navigate2**
-method and set the **Visible** property of the object to `$True` to make the application visible.
+method and set the **Visible** property of the object to `$true` to make the application visible.
 The second instance gets the same results with individual commands.
 
 ```powershell
-$IE1 = New-Object -COMObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $True}
+$IE1 = New-Object -COMObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $true}
 
 # The following command gets the same results as the example above.
 $IE2 = New-Object -COMObject InternetExplorer.Application`
 $IE2.Navigate2("www.microsoft.com")`
-$IE2.Visible = $True`
+$IE2.Visible = $true`
 ```
 
 ### Example 3: Use the Strict parameter to generate a non-terminating error
@@ -74,7 +74,7 @@ This example demonstrates that adding the **Strict** parameter causes the `New-O
 generate a non-terminating error when the COM object uses an interop assembly.
 
 ```powershell
-$A = New-Object -COMObject Word.Application -Strict -Property @{Visible = $True}
+$A = New-Object -COMObject Word.Application -Strict -Property @{Visible = $true}
 ```
 
 ```Output

--- a/reference/7.6/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -79,7 +79,7 @@ they have the read-only attribute.
 
 ```powershell
 Export-Alias -Path "alias.ps1" -As Script
-Add-Content -Path $Profile -Value (Get-Content alias.ps1)
+Add-Content -Path $PROFILE -Value (Get-Content alias.ps1)
 $S = New-PSSession -ComputerName Server01
 Invoke-Command -Session $S -FilePath .\alias.ps1
 ```
@@ -91,7 +91,7 @@ parameter with a value of Script to generate a file that contains a Set-Alias co
 alias.
 
 The second command adds the aliases in the Alias.ps1 file to the CurrentUser-CurrentHost profile.
-The path to the profile is saved in the `$Profile` variable. The command uses the `Get-Content`
+The path to the profile is saved in the `$PROFILE` variable. The command uses the `Get-Content`
 cmdlet to get the aliases from the Alias.ps1 file and the `Add-Content` cmdlet to add them to the
 profile. For more information, see
 [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).

--- a/reference/7.6/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -84,9 +84,9 @@ In this example, given a credential that you've stored in the `$Credential` vari
 > array. This provides some obfuscation but does not provide encryption.
 
 ```powershell
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential | Export-Clixml $Credxmlpath
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential = Import-Clixml $Credxmlpath
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Format-List.md
@@ -48,7 +48,7 @@ default output cmdlet for display.
 These commands display information about the PS1XML files in the PowerShell directory as a list.
 
 ```powershell
-$A = Get-ChildItem $pshome\*.ps1xml
+$A = Get-ChildItem $PSHOME\*.ps1xml
 Format-List -InputObject $A
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-Culture.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-Culture.md
@@ -243,8 +243,8 @@ This cmdlet returns a **CultureInfo** object representing the current culture.
 
 ## NOTES
 
-You can also use the `$PsCulture` and `$PsUICulture` variables. The `$PsCulture` variable stores the
-name of the current culture and the `$PsUICulture` variable stores the name of the current UI
+You can also use the `$PSCulture` and `$PSUICulture` variables. The `$PSCulture` variable stores the
+name of the current culture and the `$PSUICulture` variable stores the name of the current UI
 culture.
 
 ## RELATED LINKS

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -111,7 +111,7 @@ Id  Name           State      HasMoreData  Location  Command
 ```
 
 ```powershell
-$Timer.Enabled = $True
+$Timer.Enabled = $true
 $Subscriber = Get-EventSubscriber -SourceIdentifier Timer.Random
 ($Subscriber.action).GetType().fullname
 ```

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-Member.md
@@ -507,9 +507,9 @@ PowerShell includes the following aliases for `Get-Member`:
 You can get information about a collection object either using the **InputObject** parameter or by
 piping the object, preceded by a comma, to `Get-Member`.
 
-You can use the `$This` automatic variable in script blocks that define the values of new properties
-and methods. The `$This` variable refers to the instance of the object to which the properties and
-methods are being added. For more information about the `$This` variable, see
+You can use the `$this` automatic variable in script blocks that define the values of new properties
+and methods. The `$this` variable refers to the instance of the object to which the properties and
+methods are being added. For more information about the `$this` variable, see
 [about_Automatic_Variables](../Microsoft.PowerShell.Core/About/about_Automatic_Variables.md).
 
 If you pass an object representing a _type_, like a type literal such as `[int]`, `Get-Member`

--- a/reference/7.6/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -74,9 +74,9 @@ In this example, given a credential that you've stored in the `$Credential` vari
 > such as macOS and Linux, credentials are exported in plain text.
 
 ```powershell
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential | Export-Clixml $Credxmlpath
-$Credxmlpath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credxmlpath = Join-Path (Split-Path $PROFILE) TestScript.ps1.credential
 $Credential = Import-Clixml $Credxmlpath
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Import-LocalizedData.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Import-LocalizedData.md
@@ -55,7 +55,7 @@ Import-LocalizedData -BindingVariable "Messages"
 ```
 
 If the command is included in the Archives.ps1 script in the `C:\Test` directory, and the value of
-the `$PsUICulture` automatic variable is zh-CN, `Import-LocalizedData` imports the `Archives.psd1`
+the `$PSUICulture` automatic variable is zh-CN, `Import-LocalizedData` imports the `Archives.psd1`
 file in the `C:\test\zh-CN` directory into the `$Messages` variable.
 
 ### Example 2: Import localized data strings
@@ -160,13 +160,13 @@ command that converts the contents of the DATA section to a hashtable and stores
 
 The script also includes an `Import-LocalizedData` command, which imports a hashtable of translated
 text strings from the TestScript.psd1 file in the subdirectory specified by the value of the
-`$PsUICulture` variable. If the command finds the `.psd1` file, it saves the translated strings from
+`$PSUICulture` variable. If the command finds the `.psd1` file, it saves the translated strings from
 the file in the value of the same `$UserMessages` variable, overwriting the hashtable saved by the
 DATA section logic.
 
 The third command displays the first message in the `$UserMessages` variable.
 
-If the `Import-LocalizedData` command finds a `.psd1` file for the `$PsUICulture` language, the
+If the `Import-LocalizedData` command finds a `.psd1` file for the `$PSUICulture` language, the
 value of the `$UserMessages` variable contains the translated text strings. If the command fails for
 any reason, the command displays the default text strings defined in the DATA section of the script.
 
@@ -301,14 +301,14 @@ Accept wildcard characters: False
 
 ### -UICulture
 
-Specifies an alternate UI culture. The default is the value of the `$PsUICulture` automatic
+Specifies an alternate UI culture. The default is the value of the `$PSUICulture` automatic
 variable. Enter a UI culture in `<language>-<region>` format, such as `en-US`, `de-DE`, or `ar-SA`.
 
 The value of the **UICulture** parameter determines the language-specific subdirectory (within the
 base directory) from which `Import-LocalizedData` gets the `.psd1` file for the script.
 
 The cmdlet searches for a subdirectory with the same name as the value of the **UICulture**
-parameter or the `$PsUICulture` automatic variable, such as `de-DE` or `ar-SA`. If it can't find the
+parameter or the `$PSUICulture` automatic variable, such as `de-DE` or `ar-SA`. If it can't find the
 directory, or the directory doesn't contain a `.psd1` file for the script, it searches for a
 subdirectory with the name of the language code, such as de or ar. If it can't find the subdirectory
 or `.psd1` file, the command fails and the data is displayed in the default language specified in
@@ -363,7 +363,7 @@ parameter.
 
   `Import-LocalizedData` begins the search in the directory where the script file is located (or the
   value of the **BaseDirectory** parameter). It then searches within the base directory for a
-  subdirectory with the same name as the value of the `$PsUICulture` variable (or the value of the
+  subdirectory with the same name as the value of the `$PSUICulture` variable (or the value of the
   **UICulture** parameter), such as `de-DE` or `ar-SA`. Then, it searches in that subdirectory for a
   `.psd1` file with the same name as the script (or the value of the **FileName** parameter).
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Invoke-Expression.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Invoke-Expression.md
@@ -145,12 +145,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-You can pipe a string representing the expression to invoke to this cmdlet. Use the `$Input`
+You can pipe a string representing the expression to invoke to this cmdlet. Use the `$input`
 automatic variable to represent the input objects in the command.
 
 ### System.Management.Automation.PSObject
 
-You can pipe an object representing the expression to invoke to this cmdlet. Use the `$Input`
+You can pipe an object representing the expression to invoke to this cmdlet. Use the `$input`
 automatic variable to represent the input objects in the command.
 
 ## OUTPUTS

--- a/reference/7.6/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/New-Object.md
@@ -56,16 +56,16 @@ Major  Minor  Build  Revision
 
 This example creates two instances of the COM object that represents the Internet Explorer
 application. The first instance uses the **Property** parameter hash table to call the **Navigate2**
-method and set the **Visible** property of the object to `$True` to make the application visible.
+method and set the **Visible** property of the object to `$true` to make the application visible.
 The second instance gets the same results with individual commands.
 
 ```powershell
-$IE1 = New-Object -COMObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $True}
+$IE1 = New-Object -COMObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $true}
 
 # The following command gets the same results as the example above.
 $IE2 = New-Object -COMObject InternetExplorer.Application`
 $IE2.Navigate2("www.microsoft.com")`
-$IE2.Visible = $True`
+$IE2.Visible = $true`
 ```
 
 ### Example 3: Use the Strict parameter to generate a non-terminating error
@@ -74,7 +74,7 @@ This example demonstrates that adding the **Strict** parameter causes the `New-O
 generate a non-terminating error when the COM object uses an interop assembly.
 
 ```powershell
-$A = New-Object -COMObject Word.Application -Strict -Property @{Visible = $True}
+$A = New-Object -COMObject Word.Application -Strict -Property @{Visible = $true}
 ```
 
 ```Output


### PR DESCRIPTION
# PR Summary

This PR fixes incorrect [automatic variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables) casing used in selected files. E.g., `$Args` (incorrect) -> `$args` (correct).

## Context

This is PR **_6/9_** in a series that ensures the correct case is consistently used for individual automatic variables, as documented in `about_Automatic_Variables` and verified by tab completion. As requested, the PRs are split into groups of ~40 files. Within each file, correct casing is applied to all referenced automatic variables.

Changes in scope:

- Variables with a `$` or `@` sigil.
- Variables referenced by name without a sigil.

Out of scope:

- Preference variables (separate PRs to follow).
- Misuse of an automatic variable (e.g., naming a function parameter as `$Input`).
- Reference to the variable's _value_ (e.g., `false`/`False`/`FALSE` when referring to the _value_ of `$false`).

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide