### PR TITLE
Fix automatic variable case (7/9)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-File.md
@@ -147,7 +147,7 @@ function DemoDefaultOutFileWidth() {
     try {
         $PSDefaultParameterValues['out-file:width'] = 2000
 
-        $logFile = "$pwd\logfile.txt"
+        $logFile = "$PWD\logfile.txt"
 
         Get-ChildItem Env:\ > $logFile
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -85,7 +85,7 @@ Register-EngineEvent -SourceIdentifier MyEventSource -Action {
 }
 
 Start-Job -Name TestJob -ScriptBlock {
-    While ($True) {
+    While ($true) {
         Register-EngineEvent -SourceIdentifier MyEventSource -Forward
         Start-Sleep -seconds 2
         "Doing some work..."

--- a/reference/5.1/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -106,7 +106,7 @@ function  Enable-ProcessCreationEvent {
         EventName = 'EventArrived'
         SourceIdentifier = 'WMI.ProcessCreated'
         MessageData = 'Test'
-        Forward = $True
+        Forward = $true
     }
     Register-ObjectEvent @objectEventArgs
 }
@@ -141,7 +141,7 @@ variable.
 ```powershell
 $Timer = New-Object Timers.Timer
 $Timer.Interval = 500
-$Timer.Enabled = $True
+$Timer.Enabled = $true
 $objectEventArgs = @{
     InputObject = $Timer
     EventName = 'Elapsed'

--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -61,7 +61,7 @@ the XPath statement from the `Types.ps1xml` file. The command uses a pipeline op
 **Node** object and returns its **Name** and **ReferencedMemberName** properties.
 
 ```powershell
-$Path = "$Pshome\Types.ps1xml"
+$Path = "$PSHOME\Types.ps1xml"
 $XPath = "/Types/Type/Members/AliasProperty"
 Select-Xml -Path $Path -XPath $Xpath | Select-Object -ExpandProperty Node
 ```
@@ -103,7 +103,7 @@ the **Xml** parameter to specify the XML content in the `$Types` variable and th
 parameter to specify the path to the **MethodName** node.
 
 ```powershell
-[xml]$Types = Get-Content $Pshome\Types.ps1xml
+[xml]$Types = Get-Content $PSHOME\Types.ps1xml
 Select-Xml -Xml $Types -XPath "//MethodName"
 ```
 
@@ -138,7 +138,7 @@ $Namespace = @{
     dev = "http://schemas.microsoft.com/maml/dev/2004/10"
 }
 
-$Path = "$Pshome\en-us\*dll-Help.xml"
+$Path = "$PSHOME\en-us\*dll-Help.xml"
 $Xml = Select-Xml -Path $Path -Namespace $Namespace -XPath "//command:name"
 $Xml | Format-Table @{Label="Name"; Expression= {($_.node.innerxml).trim()}}, Path -AutoSize
 ```

--- a/reference/5.1/Microsoft.PowerShell.Utility/Show-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Show-Command.md
@@ -95,7 +95,7 @@ the **Height**, **Width**, and **ErrorPopup** parameters of the `Show-Command` c
 $PSDefaultParameterValues = @{
     "Show-Command:Height" = 700
     "Show-Command:Width" = 1000
-    "Show-Command:ErrorPopup" = $True
+    "Show-Command:ErrorPopup" = $true
 }
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -190,7 +190,7 @@ hash table to specify the property names and sort orders. The **Property** param
 two properties, **Status** in descending order and **DisplayName** in ascending order.
 
 **Status** is an enumerated property. **Stopped** has a value of **1** and **Running** has a value
-of **4**. The **Descending** parameter is set to `$True` so that **Running** processes are displayed
+of **4**. The **Descending** parameter is set to `$true` so that **Running** processes are displayed
 before **Stopped** processes. **DisplayName** sets the **Descending** parameter to `$false` to sort
 the display names in alphabetical order.
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -61,7 +61,7 @@ processes a `Get-Alias` expression that takes input from the pipeline.
 
 ```powershell
 $A = "i*"
-Trace-Command ParameterBinding {Get-Alias $Input} -PSHost -InputObject $A
+Trace-Command ParameterBinding {Get-Alias $input} -PSHost -InputObject $A
 ```
 
 In `Trace-Command`, the **InputObject** parameter passes an object to the expression that's being
@@ -71,7 +71,7 @@ The first command stores the string `i*` in the `$A` variable. The second comman
 `Trace-Command` cmdlet with the ParameterBinding trace source. The **PSHost** parameter sends the
 output to the console.
 
-The expression being processed is `Get-Alias $Input`, where the `$Input` variable is associated with
+The expression being processed is `Get-Alias $input`, where the `$input` variable is associated with
 the **InputObject** parameter. The **InputObject** parameter passes the variable `$A` to the
 expression. In effect, the command being processed during the trace is
 `Get-Alias -InputObject $A" or "$A | Get-Alias`.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -492,11 +492,11 @@ Accept wildcard characters: False
 ### -InheritPropertySerializationSet
 
 Indicates whether the set of properties that are serialized is inherited. The default value is
-`$Null`. The acceptable values for this parameter are:
+`$null`. The acceptable values for this parameter are:
 
-- `$True`. The property set is inherited.
+- `$true`. The property set is inherited.
 - `$false`. The property set is not inherited.
-- `$Null`. Inheritance is not defined.
+- `$null`. Inheritance is not defined.
 
 This parameter is valid only when the value of the **SerializationMethod** parameter is
 `SpecificProperties`. When the value of this parameter is `$false`, the **PropertySerializationSet**

--- a/reference/5.1/Microsoft.PowerShell.Utility/Wait-Event.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Wait-Event.md
@@ -63,7 +63,7 @@ $objectEventArgs = @{
 Register-ObjectEvent @objectEventArgs
 $Timer.Interval = 2000
 $Timer.Autoreset = $false
-$Timer.Enabled = $True
+$Timer.Enabled = $true
 Wait-Event Timer.Elapsed
 ```
 

--- a/reference/5.1/Microsoft.WSMan.Management/Enable-WSManCredSSP.md
+++ b/reference/5.1/Microsoft.WSMan.Management/Enable-WSManCredSSP.md
@@ -133,7 +133,7 @@ the WSMan provider must be set to true.
 
 ```powershell
 Connect-WSMan -ComputerName "server02"
-Set-Item -Path "WSMan:\server02\service\auth\credSSP" -Value $True
+Set-Item -Path "WSMan:\server02\service\auth\credSSP" -Value $true
 ```
 
 `Connect-WSMan` creates a connection to the remote computer, server02. `Set-Item` uses the **Path**

--- a/reference/7.4/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Out-File.md
@@ -150,7 +150,7 @@ function DemoDefaultOutFileWidth() {
     try {
         $PSDefaultParameterValues['out-file:width'] = 2000
 
-        $logFile = "$pwd\logfile.txt"
+        $logFile = "$PWD\logfile.txt"
 
         Get-ChildItem Env:\ > $logFile
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -85,7 +85,7 @@ Register-EngineEvent -SourceIdentifier MyEventSource -Action {
 }
 
 Start-Job -Name TestJob -ScriptBlock {
-    While ($True) {
+    While ($true) {
         Register-EngineEvent -SourceIdentifier MyEventSource -Forward
         Start-Sleep -seconds 2
         "Doing some work..."

--- a/reference/7.4/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -106,7 +106,7 @@ function  Enable-ProcessCreationEvent {
         EventName = 'EventArrived'
         SourceIdentifier = 'WMI.ProcessCreated'
         MessageData = 'Test'
-        Forward = $True
+        Forward = $true
     }
     Register-ObjectEvent @objectEventArgs
 }
@@ -141,7 +141,7 @@ variable.
 ```powershell
 $Timer = New-Object Timers.Timer
 $Timer.Interval = 500
-$Timer.Enabled = $True
+$Timer.Enabled = $true
 $objectEventArgs = @{
     InputObject = $Timer
     EventName = 'Elapsed'

--- a/reference/7.4/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -61,7 +61,7 @@ the XPath statement from the `Types.ps1xml` file. The command uses a pipeline op
 **Node** object and returns its **Name** and **ReferencedMemberName** properties.
 
 ```powershell
-$Path = "$Pshome\Types.ps1xml"
+$Path = "$PSHOME\Types.ps1xml"
 $XPath = "/Types/Type/Members/AliasProperty"
 Select-Xml -Path $Path -XPath $Xpath | Select-Object -ExpandProperty Node
 ```
@@ -103,7 +103,7 @@ the **Xml** parameter to specify the XML content in the `$Types` variable and th
 parameter to specify the path to the **MethodName** node.
 
 ```powershell
-[xml]$Types = Get-Content $Pshome\Types.ps1xml
+[xml]$Types = Get-Content $PSHOME\Types.ps1xml
 Select-Xml -Xml $Types -XPath "//MethodName"
 ```
 
@@ -138,7 +138,7 @@ $Namespace = @{
     dev = "http://schemas.microsoft.com/maml/dev/2004/10"
 }
 
-$Path = "$Pshome\en-us\*dll-Help.xml"
+$Path = "$PSHOME\en-us\*dll-Help.xml"
 $Xml = Select-Xml -Path $Path -Namespace $Namespace -XPath "//command:name"
 $Xml | Format-Table @{Label="Name"; Expression= {($_.node.innerxml).trim()}}, Path -AutoSize
 ```

--- a/reference/7.4/Microsoft.PowerShell.Utility/Show-Command.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Show-Command.md
@@ -97,7 +97,7 @@ the **Height**, **Width**, and **ErrorPopup** parameters of the `Show-Command` c
 $PSDefaultParameterValues = @{
     "Show-Command:Height" = 700
     "Show-Command:Width" = 1000
-    "Show-Command:ErrorPopup" = $True
+    "Show-Command:ErrorPopup" = $true
 }
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -208,7 +208,7 @@ hash table to specify the property names and sort orders. The **Property** param
 two properties, **Status** in descending order and **DisplayName** in ascending order.
 
 **Status** is an enumerated property. **Stopped** has a value of **1** and **Running** has a value
-of **4**. The **Descending** parameter is set to `$True` so that **Running** processes are displayed
+of **4**. The **Descending** parameter is set to `$true` so that **Running** processes are displayed
 before **Stopped** processes. **DisplayName** sets the **Descending** parameter to `$false` to sort
 the display names in alphabetical order.
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -61,7 +61,7 @@ processes a `Get-Alias` expression that takes input from the pipeline.
 
 ```powershell
 $A = "i*"
-Trace-Command ParameterBinding {Get-Alias $Input} -PSHost -InputObject $A
+Trace-Command ParameterBinding {Get-Alias $input} -PSHost -InputObject $A
 ```
 
 In `Trace-Command`, the **InputObject** parameter passes an object to the expression that's being
@@ -71,7 +71,7 @@ The first command stores the string `i*` in the `$A` variable. The second comman
 `Trace-Command` cmdlet with the ParameterBinding trace source. The **PSHost** parameter sends the
 output to the console.
 
-The expression being processed is `Get-Alias $Input`, where the `$Input` variable is associated with
+The expression being processed is `Get-Alias $input`, where the `$input` variable is associated with
 the **InputObject** parameter. The **InputObject** parameter passes the variable `$A` to the
 expression. In effect, the command being processed during the trace is
 `Get-Alias -InputObject $A" or "$A | Get-Alias`.

--- a/reference/7.4/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -500,11 +500,11 @@ Accept wildcard characters: False
 ### -InheritPropertySerializationSet
 
 Indicates whether the set of properties that are serialized is inherited. The default value is
-`$Null`. The acceptable values for this parameter are:
+`$null`. The acceptable values for this parameter are:
 
-- `$True`. The property set is inherited.
+- `$true`. The property set is inherited.
 - `$false`. The property set is not inherited.
-- `$Null`. Inheritance is not defined.
+- `$null`. Inheritance is not defined.
 
 This parameter is valid only when the value of the **SerializationMethod** parameter is
 `SpecificProperties`. When the value of this parameter is `$false`, the **PropertySerializationSet**

--- a/reference/7.4/Microsoft.PowerShell.Utility/Wait-Event.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Wait-Event.md
@@ -63,7 +63,7 @@ $objectEventArgs = @{
 Register-ObjectEvent @objectEventArgs
 $Timer.Interval = 2000
 $Timer.Autoreset = $false
-$Timer.Enabled = $True
+$Timer.Enabled = $true
 Wait-Event Timer.Elapsed
 ```
 

--- a/reference/7.4/Microsoft.WSMan.Management/Enable-WSManCredSSP.md
+++ b/reference/7.4/Microsoft.WSMan.Management/Enable-WSManCredSSP.md
@@ -135,7 +135,7 @@ the WSMan provider must be set to true.
 
 ```powershell
 Connect-WSMan -ComputerName "server02"
-Set-Item -Path "WSMan:\server02\service\auth\credSSP" -Value $True
+Set-Item -Path "WSMan:\server02\service\auth\credSSP" -Value $true
 ```
 
 `Connect-WSMan` creates a connection to the remote computer, server02. `Set-Item` uses the **Path**

--- a/reference/7.5/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Out-File.md
@@ -150,7 +150,7 @@ function DemoDefaultOutFileWidth() {
     try {
         $PSDefaultParameterValues['out-file:width'] = 2000
 
-        $logFile = "$pwd\logfile.txt"
+        $logFile = "$PWD\logfile.txt"
 
         Get-ChildItem Env:\ > $logFile
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -85,7 +85,7 @@ Register-EngineEvent -SourceIdentifier MyEventSource -Action {
 }
 
 Start-Job -Name TestJob -ScriptBlock {
-    While ($True) {
+    While ($true) {
         Register-EngineEvent -SourceIdentifier MyEventSource -Forward
         Start-Sleep -seconds 2
         "Doing some work..."

--- a/reference/7.5/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -106,7 +106,7 @@ function  Enable-ProcessCreationEvent {
         EventName = 'EventArrived'
         SourceIdentifier = 'WMI.ProcessCreated'
         MessageData = 'Test'
-        Forward = $True
+        Forward = $true
     }
     Register-ObjectEvent @objectEventArgs
 }
@@ -141,7 +141,7 @@ variable.
 ```powershell
 $Timer = New-Object Timers.Timer
 $Timer.Interval = 500
-$Timer.Enabled = $True
+$Timer.Enabled = $true
 $objectEventArgs = @{
     InputObject = $Timer
     EventName = 'Elapsed'

--- a/reference/7.5/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -61,7 +61,7 @@ the XPath statement from the `Types.ps1xml` file. The command uses a pipeline op
 **Node** object and returns its **Name** and **ReferencedMemberName** properties.
 
 ```powershell
-$Path = "$Pshome\Types.ps1xml"
+$Path = "$PSHOME\Types.ps1xml"
 $XPath = "/Types/Type/Members/AliasProperty"
 Select-Xml -Path $Path -XPath $Xpath | Select-Object -ExpandProperty Node
 ```
@@ -103,7 +103,7 @@ the **Xml** parameter to specify the XML content in the `$Types` variable and th
 parameter to specify the path to the **MethodName** node.
 
 ```powershell
-[xml]$Types = Get-Content $Pshome\Types.ps1xml
+[xml]$Types = Get-Content $PSHOME\Types.ps1xml
 Select-Xml -Xml $Types -XPath "//MethodName"
 ```
 
@@ -138,7 +138,7 @@ $Namespace = @{
     dev = "http://schemas.microsoft.com/maml/dev/2004/10"
 }
 
-$Path = "$Pshome\en-us\*dll-Help.xml"
+$Path = "$PSHOME\en-us\*dll-Help.xml"
 $Xml = Select-Xml -Path $Path -Namespace $Namespace -XPath "//command:name"
 $Xml | Format-Table @{Label="Name"; Expression= {($_.Node.InnerXml).trim()}}, Path -AutoSize
 ```

--- a/reference/7.5/Microsoft.PowerShell.Utility/Show-Command.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Show-Command.md
@@ -97,7 +97,7 @@ the **Height**, **Width**, and **ErrorPopup** parameters of the `Show-Command` c
 $PSDefaultParameterValues = @{
     "Show-Command:Height" = 700
     "Show-Command:Width" = 1000
-    "Show-Command:ErrorPopup" = $True
+    "Show-Command:ErrorPopup" = $true
 }
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -208,7 +208,7 @@ hash table to specify the property names and sort orders. The **Property** param
 two properties, **Status** in descending order and **DisplayName** in ascending order.
 
 **Status** is an enumerated property. **Stopped** has a value of **1** and **Running** has a value
-of **4**. The **Descending** parameter is set to `$True` so that **Running** processes are displayed
+of **4**. The **Descending** parameter is set to `$true` so that **Running** processes are displayed
 before **Stopped** processes. **DisplayName** sets the **Descending** parameter to `$false` to sort
 the display names in alphabetical order.
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -61,7 +61,7 @@ processes a `Get-Alias` expression that takes input from the pipeline.
 
 ```powershell
 $A = "i*"
-Trace-Command ParameterBinding {Get-Alias $Input} -PSHost -InputObject $A
+Trace-Command ParameterBinding {Get-Alias $input} -PSHost -InputObject $A
 ```
 
 In `Trace-Command`, the **InputObject** parameter passes an object to the expression that's being
@@ -71,7 +71,7 @@ The first command stores the string `i*` in the `$A` variable. The second comman
 `Trace-Command` cmdlet with the ParameterBinding trace source. The **PSHost** parameter sends the
 output to the console.
 
-The expression being processed is `Get-Alias $Input`, where the `$Input` variable is associated with
+The expression being processed is `Get-Alias $input`, where the `$input` variable is associated with
 the **InputObject** parameter. The **InputObject** parameter passes the variable `$A` to the
 expression. In effect, the command being processed during the trace is
 `Get-Alias -InputObject $A" or "$A | Get-Alias`.

--- a/reference/7.5/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -500,11 +500,11 @@ Accept wildcard characters: False
 ### -InheritPropertySerializationSet
 
 Indicates whether the set of properties that are serialized is inherited. The default value is
-`$Null`. The acceptable values for this parameter are:
+`$null`. The acceptable values for this parameter are:
 
-- `$True`. The property set is inherited.
+- `$true`. The property set is inherited.
 - `$false`. The property set is not inherited.
-- `$Null`. Inheritance is not defined.
+- `$null`. Inheritance is not defined.
 
 This parameter is valid only when the value of the **SerializationMethod** parameter is
 `SpecificProperties`. When the value of this parameter is `$false`, the **PropertySerializationSet**

--- a/reference/7.5/Microsoft.PowerShell.Utility/Wait-Event.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Wait-Event.md
@@ -63,7 +63,7 @@ $objectEventArgs = @{
 Register-ObjectEvent @objectEventArgs
 $Timer.Interval = 2000
 $Timer.AutoReset = $false
-$Timer.Enabled = $True
+$Timer.Enabled = $true
 Wait-Event Timer.Elapsed
 ```
 

--- a/reference/7.5/Microsoft.WSMan.Management/Enable-WSManCredSSP.md
+++ b/reference/7.5/Microsoft.WSMan.Management/Enable-WSManCredSSP.md
@@ -135,7 +135,7 @@ the WSMan provider must be set to true.
 
 ```powershell
 Connect-WSMan -ComputerName "server02"
-Set-Item -Path "WSMan:\server02\service\auth\credSSP" -Value $True
+Set-Item -Path "WSMan:\server02\service\auth\credSSP" -Value $true
 ```
 
 `Connect-WSMan` creates a connection to the remote computer, server02. `Set-Item` uses the **Path**

--- a/reference/7.6/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Out-File.md
@@ -150,7 +150,7 @@ function DemoDefaultOutFileWidth() {
     try {
         $PSDefaultParameterValues['out-file:width'] = 2000
 
-        $logFile = "$pwd\logfile.txt"
+        $logFile = "$PWD\logfile.txt"
 
         Get-ChildItem Env:\ > $logFile
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -85,7 +85,7 @@ Register-EngineEvent -SourceIdentifier MyEventSource -Action {
 }
 
 Start-Job -Name TestJob -ScriptBlock {
-    While ($True) {
+    While ($true) {
         Register-EngineEvent -SourceIdentifier MyEventSource -Forward
         Start-Sleep -seconds 2
         "Doing some work..."

--- a/reference/7.6/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -106,7 +106,7 @@ function  Enable-ProcessCreationEvent {
         EventName = 'EventArrived'
         SourceIdentifier = 'WMI.ProcessCreated'
         MessageData = 'Test'
-        Forward = $True
+        Forward = $true
     }
     Register-ObjectEvent @objectEventArgs
 }
@@ -141,7 +141,7 @@ variable.
 ```powershell
 $Timer = New-Object Timers.Timer
 $Timer.Interval = 500
-$Timer.Enabled = $True
+$Timer.Enabled = $true
 $objectEventArgs = @{
     InputObject = $Timer
     EventName = 'Elapsed'

--- a/reference/7.6/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -61,7 +61,7 @@ the XPath statement from the `Types.ps1xml` file. The command uses a pipeline op
 **Node** object and returns its **Name** and **ReferencedMemberName** properties.
 
 ```powershell
-$Path = "$Pshome\Types.ps1xml"
+$Path = "$PSHOME\Types.ps1xml"
 $XPath = "/Types/Type/Members/AliasProperty"
 Select-Xml -Path $Path -XPath $Xpath | Select-Object -ExpandProperty Node
 ```
@@ -103,7 +103,7 @@ the **Xml** parameter to specify the XML content in the `$Types` variable and th
 parameter to specify the path to the **MethodName** node.
 
 ```powershell
-[xml]$Types = Get-Content $Pshome\Types.ps1xml
+[xml]$Types = Get-Content $PSHOME\Types.ps1xml
 Select-Xml -Xml $Types -XPath "//MethodName"
 ```
 
@@ -138,7 +138,7 @@ $Namespace = @{
     dev = "http://schemas.microsoft.com/maml/dev/2004/10"
 }
 
-$Path = "$Pshome\en-us\*dll-Help.xml"
+$Path = "$PSHOME\en-us\*dll-Help.xml"
 $Xml = Select-Xml -Path $Path -Namespace $Namespace -XPath "//command:name"
 $Xml | Format-Table @{Label="Name"; Expression= {($_.Node.InnerXml).trim()}}, Path -AutoSize
 ```

--- a/reference/7.6/Microsoft.PowerShell.Utility/Show-Command.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Show-Command.md
@@ -97,7 +97,7 @@ the **Height**, **Width**, and **ErrorPopup** parameters of the `Show-Command` c
 $PSDefaultParameterValues = @{
     "Show-Command:Height" = 700
     "Show-Command:Width" = 1000
-    "Show-Command:ErrorPopup" = $True
+    "Show-Command:ErrorPopup" = $true
 }
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -208,7 +208,7 @@ hash table to specify the property names and sort orders. The **Property** param
 two properties, **Status** in descending order and **DisplayName** in ascending order.
 
 **Status** is an enumerated property. **Stopped** has a value of **1** and **Running** has a value
-of **4**. The **Descending** parameter is set to `$True` so that **Running** processes are displayed
+of **4**. The **Descending** parameter is set to `$true` so that **Running** processes are displayed
 before **Stopped** processes. **DisplayName** sets the **Descending** parameter to `$false` to sort
 the display names in alphabetical order.
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -61,7 +61,7 @@ processes a `Get-Alias` expression that takes input from the pipeline.
 
 ```powershell
 $A = "i*"
-Trace-Command ParameterBinding {Get-Alias $Input} -PSHost -InputObject $A
+Trace-Command ParameterBinding {Get-Alias $input} -PSHost -InputObject $A
 ```
 
 In `Trace-Command`, the **InputObject** parameter passes an object to the expression that's being
@@ -71,7 +71,7 @@ The first command stores the string `i*` in the `$A` variable. The second comman
 `Trace-Command` cmdlet with the ParameterBinding trace source. The **PSHost** parameter sends the
 output to the console.
 
-The expression being processed is `Get-Alias $Input`, where the `$Input` variable is associated with
+The expression being processed is `Get-Alias $input`, where the `$input` variable is associated with
 the **InputObject** parameter. The **InputObject** parameter passes the variable `$A` to the
 expression. In effect, the command being processed during the trace is
 `Get-Alias -InputObject $A" or "$A | Get-Alias`.

--- a/reference/7.6/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -500,11 +500,11 @@ Accept wildcard characters: False
 ### -InheritPropertySerializationSet
 
 Indicates whether the set of properties that are serialized is inherited. The default value is
-`$Null`. The acceptable values for this parameter are:
+`$null`. The acceptable values for this parameter are:
 
-- `$True`. The property set is inherited.
+- `$true`. The property set is inherited.
 - `$false`. The property set is not inherited.
-- `$Null`. Inheritance is not defined.
+- `$null`. Inheritance is not defined.
 
 This parameter is valid only when the value of the **SerializationMethod** parameter is
 `SpecificProperties`. When the value of this parameter is `$false`, the **PropertySerializationSet**

--- a/reference/7.6/Microsoft.PowerShell.Utility/Wait-Event.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Wait-Event.md
@@ -63,7 +63,7 @@ $objectEventArgs = @{
 Register-ObjectEvent @objectEventArgs
 $Timer.Interval = 2000
 $Timer.AutoReset = $false
-$Timer.Enabled = $True
+$Timer.Enabled = $true
 Wait-Event Timer.Elapsed
 ```
 

--- a/reference/7.6/Microsoft.WSMan.Management/Enable-WSManCredSSP.md
+++ b/reference/7.6/Microsoft.WSMan.Management/Enable-WSManCredSSP.md
@@ -135,7 +135,7 @@ the WSMan provider must be set to true.
 
 ```powershell
 Connect-WSMan -ComputerName "server02"
-Set-Item -Path "WSMan:\server02\service\auth\credSSP" -Value $True
+Set-Item -Path "WSMan:\server02\service\auth\credSSP" -Value $true
 ```
 
 `Connect-WSMan` creates a connection to the remote computer, server02. `Set-Item` uses the **Path**


### PR DESCRIPTION
# PR Summary

This PR fixes incorrect [automatic variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables) casing used in selected files. E.g., `$Args` (incorrect) -> `$args` (correct).

## Context

This is PR **_7/9_** in a series that ensures the correct case is consistently used for individual automatic variables, as documented in `about_Automatic_Variables` and verified by tab completion. As requested, the PRs are split into groups of ~40 files. Within each file, correct casing is applied to all referenced automatic variables.

Changes in scope:

- Variables with a `$` or `@` sigil.
- Variables referenced by name without a sigil.

Out of scope:

- Preference variables (separate PRs to follow).
- Misuse of an automatic variable (e.g., naming a function parameter as `$Input`).
- Reference to the variable's _value_ (e.g., `false`/`False`/`FALSE` when referring to the _value_ of `$false`).

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide