### PR TITLE
Fix incorrect case/capitalization in reference documents (3/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -203,8 +203,8 @@ class BookList {
     # Static method to initialize the list of books. Called in the other
     # static methods to avoid needing to explicit initialize the value.
     static [void] Initialize()             { [BookList]::Initialize($false) }
-    static [bool] Initialize([bool]$force) {
-        if ([BookList]::Books.Count -gt 0 -and -not $force) {
+    static [bool] Initialize([bool]$Force) {
+        if ([BookList]::Books.Count -gt 0 -and -not $Force) {
             return $false
         }
 
@@ -527,7 +527,7 @@ module is removed, so are the type accelerators.
 
 ## Manually importing classes from a PowerShell module
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes aren't imported.
 
 If a module defines classes and enumerations but doesn't add type accelerators

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes_Constructors.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes_Constructors.md
@@ -309,7 +309,7 @@ class BaseExample {
         Write-Verbose "[$($Type.Name)] static constructor"
     }
 
-    static [void] ParamMessage([type]$Type, [object]$Value) {
+    static [void] ParamMessage([type]$Type, [Object]$Value) {
         Write-Verbose "[$($Type.Name)] param constructor ($Value)"
     }
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes_Inheritance.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes_Inheritance.md
@@ -58,14 +58,14 @@ declaration.
 This example shows the basic PowerShell class inheritance syntax.
 
 ```powershell
-Class Derived : Base {...}
+class Derived : Base {...}
 ```
 
 This example shows inheritance with an interface declaration coming after the
 base class.
 
 ```powershell
-Class Derived : Base, Interface {...}
+class Derived : Base, Interface {...}
 ```
 
 ## Syntax
@@ -657,7 +657,7 @@ Kelvin. For any other format, the method should throw a
     }
     # If format provider isn't specified, use the current culture.
     if ($null -eq $FormatProvider) {
-        $FormatProvider = [CultureInfo]::CurrentCulture
+        $FormatProvider = [cultureinfo]::CurrentCulture
     }
     # Format the temperature.
     switch ($Format) {
@@ -748,7 +748,7 @@ class Temperature : System.IFormattable {
         }
         # If format provider isn't specified, use the current culture.
         if ($null -eq $FormatProvider) {
-            $FormatProvider = [CultureInfo]::CurrentCulture
+            $FormatProvider = [cultureinfo]::CurrentCulture
         }
         # Format the temperature.
         switch ($Format) {
@@ -815,7 +815,7 @@ To implement the interface, the class needs to inherit from
 method needs to have the following signature:
 
 ```powershell
-[bool] Equals([object]$Other) {
+[bool] Equals([Object]$Other) {
     # Implementation
 }
 ```
@@ -830,7 +830,7 @@ values to Kelvin, since temperatures can be equivalent even with different
 scales.
 
 ```powershell
-[bool] Equals([object]$Other) {
+[bool] Equals([Object]$Other) {
     # If the other object is null, we can't compare it.
     if ($null -eq $Other) {
         return $false
@@ -851,7 +851,7 @@ With the interface method implemented, the updated definition for
 **Temperature** is:
 
 ```powershell
-class Temperature : System.IFormattable, System.IEquatable[object] {
+class Temperature : System.IFormattable, System.IEquatable[Object] {
     [float]            $Degrees
     [TemperatureScale] $Scale
 
@@ -899,7 +899,7 @@ class Temperature : System.IFormattable, System.IEquatable[object] {
         }
         # If format provider isn't specified, use the current culture.
         if ($null -eq $FormatProvider) {
-            $FormatProvider = [CultureInfo]::CurrentCulture
+            $FormatProvider = [cultureinfo]::CurrentCulture
         }
         # Format the temperature.
         switch ($Format) {
@@ -927,7 +927,7 @@ class Temperature : System.IFormattable, System.IEquatable[object] {
         return $this.ToString($null, $null)
     }
 
-    [bool] Equals([object]$Other) {
+    [bool] Equals([Object]$Other) {
         # If the other object is null, we can't compare it.
         if ($null -eq $Other) {
             return $false
@@ -999,7 +999,7 @@ converted to a different scale, is a floating point number, the method can rely
 on the underlying type for the actual comparison.
 
 ```powershell
-[int] CompareTo([object]$Other) {
+[int] CompareTo([Object]$Other) {
     # If the other object's null, consider this instance "greater than" it
     if ($null -eq $Other) {
         return 1
@@ -1021,7 +1021,7 @@ The final definition for the **Temperature** class is:
 ```powershell
 class Temperature : System.IFormattable,
                     System.IComparable,
-                    System.IEquatable[object] {
+                    System.IEquatable[Object] {
     # Instance properties
     [float]            $Degrees
     [TemperatureScale] $Scale
@@ -1071,7 +1071,7 @@ class Temperature : System.IFormattable,
         }
         # If format provider isn't specified, use the current culture.
         if ($null -eq $FormatProvider) {
-            $FormatProvider = [CultureInfo]::CurrentCulture
+            $FormatProvider = [cultureinfo]::CurrentCulture
         }
         # Format the temperature.
         switch ($Format) {
@@ -1099,7 +1099,7 @@ class Temperature : System.IFormattable,
         return $this.ToString($null, $null)
     }
 
-    [bool] Equals([object]$Other) {
+    [bool] Equals([Object]$Other) {
         # If the other object is null, we can't compare it.
         if ($null -eq $Other) {
             return $false
@@ -1112,7 +1112,7 @@ class Temperature : System.IFormattable,
         # Compare the temperatures as Kelvin.
         return $this.ToKelvin() -eq $OtherTemperature.ToKelvin()
     }
-    [int] CompareTo([object]$Other) {
+    [int] CompareTo([Object]$Other) {
         # If the other object's null, consider this instance "greater than" it
         if ($null -eq $Other) {
             return 1
@@ -1182,7 +1182,7 @@ generic type as long as the type parameter is already defined at parse time.
 ```powershell
 class ExampleStringList : System.Collections.Generic.List[string] {}
 
-$List = [ExampleStringList]::New()
+$List = [ExampleStringList]::new()
 $List.AddRange([string[]]@('a','b','c'))
 $List.GetType() | Format-List -Property Name, BaseType
 $List
@@ -1243,7 +1243,7 @@ This time, PowerShell doesn't raise any errors. Both classes are now defined.
 Run the following code block to view the behavior of the new class.
 
 ```powershell
-$List = [ExampleItemList]::New()
+$List = [ExampleItemList]::new()
 $List.AddRange([ExampleItem[]]@(
     [ExampleItem]@{ Name = 'Foo' }
     [ExampleItem]@{ Name = 'Bar' }

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes_Methods.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Classes_Methods.md
@@ -602,17 +602,17 @@ class. The representation for **DerivedClassB** is different because it
 overrode the `ToString()` instance method.
 
 ```powershell
-"`$base = [BaseClass]::New()     => $($base = [BaseClass]::New(); $base)"
-"`$a    = [DerivedClassA]::New() => $($a = [DerivedClassA]::New(); $a)"
-"`$b    = [DerivedClassB]::New() => $($b = [DerivedClassB]::New(); $b)"
-"`$c    = [DerivedClassC]::New() => $($c = [DerivedClassC]::New(); $c)"
+"`$base = [BaseClass]::new()     => $($base = [BaseClass]::new(); $base)"
+"`$a    = [DerivedClassA]::new() => $($a = [DerivedClassA]::new(); $a)"
+"`$b    = [DerivedClassB]::new() => $($b = [DerivedClassB]::new(); $b)"
+"`$c    = [DerivedClassC]::new() => $($c = [DerivedClassC]::new(); $c)"
 ```
 
 ```Output
-$base = [BaseClass]::New()     => 11/6/2023 9:44:57 AM
-$a    = [DerivedClassA]::New() => 11/6/2023 9:44:57 AM
-$b    = [DerivedClassB]::New() => 2023-11-06
-$c    = [DerivedClassC]::New() => 11/6/2023 9:44:57 AM
+$base = [BaseClass]::new()     => 11/6/2023 9:44:57 AM
+$a    = [DerivedClassA]::new() => 11/6/2023 9:44:57 AM
+$b    = [DerivedClassB]::new() => 2023-11-06
+$c    = [DerivedClassC]::new() => 11/6/2023 9:44:57 AM
 ```
 
 The next block calls the `SetTimeStamp()` instance method for each instance,

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -38,7 +38,7 @@ C:\TechDocs\FindDocs.ps1
 You can run any executable command using its full path. As a security feature,
 PowerShell doesn't run executable commands, including PowerShell scripts and
 native commands, unless the command is located in a path listed in the
-`$env:Path` environment variable.
+`$Env:PATH` environment variable.
 
 To run an executable file that's in the current directory, specify the full
 path or use the relative path `.\` to represent the current directory.
@@ -58,7 +58,7 @@ when it runs commands.
 1. External executable files (including PowerShell script files)
 
 Therefore, if you type `help`, PowerShell first looks for an alias named
-`help`, then a function named `Help`, and finally a cmdlet named `Help`. It
+`help`, then a function named `help`, and finally a cmdlet named `help`. It
 runs the first `help` item that it finds.
 
 For example, if your session contains a cmdlet and a function, both named
@@ -247,7 +247,7 @@ For example, the following command saves the `Map` function in the `$myMap`
 variable and then uses the `Call` operator to run it.
 
 ```powershell
-$myMap = (Get-Command -Name map -CommandType function)
+$myMap = (Get-Command -Name map -CommandType Function)
 & ($myMap)
 ```
 
@@ -273,7 +273,7 @@ first module found alphabetically.
 
 If the cmdlet isn't loaded, PowerShell searches the installed modules and
 autoloads the first module that contains the cmdlet and runs that cmdlet.
-PowerShell searches for modules in each path defined in the `$env:PSModulePath`
+PowerShell searches for modules in each path defined in the `$Env:PSModulePath`
 environment variable. The paths are searched in the order that they're listed
 in the variable. Within each path, the modules are searched in alphabetical
 order. PowerShell uses the cmdlet from the first match it finds.
@@ -299,7 +299,7 @@ Import-Module -Name DateFunctions -Prefix ZZ
 
 ## Running external executables
 
-On Windows. PowerShell treats the file extensions listed in the `$env:PATHEXT`
+On Windows. PowerShell treats the file extensions listed in the `$Env:PATHEXT`
 environment variable as executable files. Files that aren't Windows executables
 are handed to Windows to process. Windows looks up the file association and
 executes the default Windows Shell verb for the extension. For Windows to
@@ -312,7 +312,7 @@ to register the file handler. For more information, see the documentation for
 the [ftype][04] command.
 
 For PowerShell to see a file extension as executable in the current session,
-you must add the extension to the `$env:PATHEXT` environment variable.
+you must add the extension to the `$Env:PATHEXT` environment variable.
 
 ## See also
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -70,12 +70,12 @@ Keywords define each section of comment-based help. Each comment-based help
 keyword is preceded by a dot `.`. The keywords can appear in any order. The
 keyword names aren't case-sensitive.
 
-For example, the `.Description` keyword precedes a description of a function or
+For example, the `.DESCRIPTION` keyword precedes a description of a function or
 script.
 
 ```powershell
 <#
-.Description
+.DESCRIPTION
 Get-Function displays the name and syntax of all functions in the session.
 #>
 ```
@@ -220,8 +220,8 @@ ignored.
 function Verb-Noun {
     [CmdletBinding()]
     param (
-        # This is the same as .Parameter
-        [string]$Computername
+        # This is the same as .PARAMETER
+        [string]$ComputerName
     )
     # Verb the Noun on the computer
 }
@@ -256,7 +256,7 @@ Repeat the `.LINK` keyword for each related topic.
 
 This content appears in the Related Links section of the help topic.
 
-The `.Link` keyword content can also include a Uniform Resource Identifier
+The `.LINK` keyword content can also include a Uniform Resource Identifier
 (URI) to an online version of the same help topic. The online version opens
 when you use the **Online** parameter of `Get-Help`. The URI must begin with
 "http" or "https".
@@ -290,7 +290,7 @@ provider.
 
 ### .FORWARDHELPCATEGORY
 
-Specifies the help category of the item in `.ForwardHelpTargetName`. Valid
+Specifies the help category of the item in `.FORWARDHELPTARGETNAME`. Valid
 values are `Alias`, `Cmdlet`, `HelpFile`, `Function`, `Provider`, `General`,
 `FAQ`, `Glossary`, `ScriptCommand`, `ExternalScript`, `Filter`, or `All`. Use
 this keyword to avoid conflicts when there are commands with the same name.
@@ -369,11 +369,11 @@ type, the **Object** type is inserted as the default value.
 ### Parameter List
 
 The parameter list in the help topic is generated from the function or script
-syntax and from the descriptions that you add by using the `.Parameter`
+syntax and from the descriptions that you add by using the `.PARAMETER`
 keyword. The function parameters appear in the **Parameters** section of the
 help topic in the same order that they appear in the function or script syntax.
 The spelling and capitalization of parameter names is also taken from the
-syntax. It isn't affected by the parameter name specified by the `.Parameter`
+syntax. It isn't affected by the parameter name specified by the `.PARAMETER`
 keyword.
 
 ### Common Parameters
@@ -408,8 +408,8 @@ The following sample function includes comment-based help:
 function Add-Extension
 {
 param ([string]$Name,[string]$Extension = "txt")
-$name = $name + "." + $extension
-$name
+$Name = $Name + "." + $Extension
+$Name
 
 <#
 .SYNOPSIS
@@ -438,17 +438,17 @@ or file name.
 
 .EXAMPLE
 
-PS> extension -name "File"
+PS> Add-Extension -Name "File"
 File.txt
 
 .EXAMPLE
 
-PS> extension -name "File" -extension "doc"
+PS> Add-Extension -Name "File" -Extension "doc"
 File.doc
 
 .EXAMPLE
 
-PS> extension "File" "doc"
+PS> Add-Extension "File" "doc"
 File.doc
 
 .LINK
@@ -511,7 +511,7 @@ Accept wildcard characters?
 This cmdlet supports the common parameters: -Verbose, -Debug,
 -ErrorAction, -ErrorVariable, -WarningAction, -WarningVariable,
 -OutBuffer and -OutVariable. For more information, type
-"get-help about_commonparameters".
+"Get-Help about_CommonParameters".
 
 INPUTS
 None. You can't pipe objects to Add-Extension.
@@ -523,17 +523,17 @@ file name.
 
 Example 1
 
-PS> extension -name "File"
+PS> Add-Extension -Name "File"
 File.txt
 
 Example 2
 
-PS> extension -name "File" -extension "doc"
+PS> Add-Extension -Name "File" -Extension "doc"
 File.doc
 
 Example 3
 
-PS> extension "File" "doc"
+PS> Add-Extension "File" "doc"
 File.doc
 
 RELATED LINKS
@@ -556,15 +556,15 @@ param
 
 [string]
 #Specifies the file name.
-$name,
+$Name,
 
 [string]
 #Specifies the file name extension. "Txt" is the default.
-$extension = "txt"
+$Extension = "txt"
 )
 
-$name = $name + "." + $extension
-$name
+$Name = $Name + "." + $Extension
+$Name
 
 <#
 .SYNOPSIS
@@ -587,17 +587,17 @@ file name.
 
 .EXAMPLE
 
-PS> extension -name "File"
+PS> Add-Extension -Name "File"
 File.txt
 
 .EXAMPLE
 
-PS> extension -name "File" -extension "doc"
+PS> Add-Extension -Name "File" -Extension "doc"
 File.doc
 
 .EXAMPLE
 
-PS> extension "File" "doc"
+PS> Add-Extension "File" "doc"
 File.doc
 
 .LINK
@@ -614,8 +614,8 @@ Set-Item
 ### Comment-based Help for a Script
 
 The following sample script includes comment-based help. Notice the blank lines
-between the closing `#>` and the `Param` statement. In a script that doesn't
-have a `Param` statement, there must be at least two blank lines between the
+between the closing `#>` and the `param` statement. In a script that doesn't
+have a `param` statement, there must be at least two blank lines between the
 final comment in the help topic and the first function declaration. Without
 these blank lines, `Get-Help` associates the help topic with the function, not
 the script.
@@ -653,22 +653,22 @@ PS> .\Update-Month.ps1
 
 .EXAMPLE
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv
 
 .EXAMPLE
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv -outputPath `
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv -OutputPath `
 C:\Reports\2009\January.csv
 #>
 
-param ([string]$InputPath, [string]$OutPutPath)
+param ([string]$InputPath, [string]$OutputPath)
 
 function Get-Data { }
 ...
 ```
 
 The following command gets the script help. Because the script isn't in a
-directory that's listed in the `$env:Path` environment variable, the
+directory that's listed in the `$Env:PATH` environment variable, the
 `Get-Help` command that gets the script help must specify the script path.
 
 ```powershell
@@ -720,7 +720,7 @@ Accept wildcard characters?
 This cmdlet supports the common parameters: -Verbose, -Debug,
 -ErrorAction, -ErrorVariable, -WarningAction, -WarningVariable,
 -OutBuffer and -OutVariable. For more information, type,
-"get-help about_commonparameters".
+"Get-Help about_CommonParameters".
 
 # INPUTS
 
@@ -736,11 +736,11 @@ PS> .\Update-Month.ps1
 
 Example 2
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv
 
 Example 3
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv -outputPath
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv -OutputPath
 C:\Reports\2009\January.csv
 
 # RELATED LINKS
@@ -762,7 +762,7 @@ the keyword. Any other placement is ineffective.
 ```powershell
 # .EXTERNALHELP C:\MyScripts\Update-Month-Help.xml
 
-param ([string]$InputPath, [string]$OutPutPath)
+param ([string]$InputPath, [string]$OutputPath)
 function Get-Data { }
 ...
 ```
@@ -774,17 +774,17 @@ keyword in a function.
 function Add-Extension {
     # .EXTERNALHELP C:\ps-test\Add-Extension.xml
 
-    param ([string] $name, [string]$extension = "txt")
-    $name = $name + "." + $extension
-    $name
+    param ([string] $Name, [string]$Extension = "txt")
+    $Name = $Name + "." + $Extension
+    $Name
 }
 ```
 
 ```powershell
 function Add-Extension {
-    param ([string] $name, [string]$extension = "txt")
-    $name = $name + "." + $extension
-    $name
+    param ([string] $Name, [string]$Extension = "txt")
+    $Name = $Name + "." + $Extension
+    $Name
 
     # .EXTERNALHELP C:\ps-test\Add-Extension.xml
 }
@@ -793,9 +793,9 @@ function Add-Extension {
 ```powershell
 # .EXTERNALHELP C:\ps-test\Add-Extension.xml
 function Add-Extension {
-    param ([string] $name, [string]$extension = "txt")
-    $name = $name + "." + $extension
-    $name
+    param ([string] $Name, [string]$Extension = "txt")
+    $Name = $Name + "." + $Extension
+    $Name
 }
 ```
 
@@ -804,7 +804,7 @@ function Add-Extension {
 The following code is an excerpt from the beginning of the built-in help
 function in PowerShell, which displays one screen of help text at a time.
 Because the help topic for the `Get-Help` cmdlet describes the help function,
-the help function uses the `.ForwardHelpTargetName` and `.ForwardHelpCategory`
+the help function uses the `.FORWARDHELPTARGETNAME` and `.FORWARDHELPCATEGORY`
 keywords to redirect the user to the `Get-Help` cmdlet help topic.
 
 ```powershell

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comments.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comments.md
@@ -162,7 +162,7 @@ before the script is executed.
 # SIG # End signature block
 ```
 
-For more information, see [about_signing][10].
+For more information, see [about_Signing][10].
 
 ### Code editor region markers
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -350,7 +350,7 @@ For example, the following command creates the `$out` variable and stores the
 process object in it:
 
 ```powershell
-Get-Process PowerShell -OutVariable out
+Get-Process powershell -OutVariable out
 ```
 
 The following command adds the process object to the `$out` variable:
@@ -419,13 +419,13 @@ Valid values are strings, the same as for any variable names.
 > a command after the blocking command.
 
 The following is an example of how **PipelineVariable** works. In this example,
-the **PipelineVariable** parameter is added to a `Foreach-Object` command to
+the **PipelineVariable** parameter is added to a `ForEach-Object` command to
 store the results of the command in variables. A range of numbers, 1 to 5, are
-piped into the first `Foreach-Object` command, the results of which are stored
+piped into the first `ForEach-Object` command, the results of which are stored
 in a variable named `$temp`.
 
-The results of the first `Foreach-Object` command are piped into a second
-`Foreach-Object` command, which displays the current values of `$temp` and
+The results of the first `ForEach-Object` command are piped into a second
+`ForEach-Object` command, which displays the current values of `$temp` and
 `$_`.
 
 ```powershell

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -162,8 +162,8 @@ The following example demonstrates the issue.
 
 ```powershell
 class MyFileInfoSet {
-    [String]$File
-    [Int64]$Size
+    [string]$File
+    [int64]$Size
 }
 $a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
 $b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
@@ -184,8 +184,8 @@ the File and Size properties of two **MyFileInfoSet** objects are the same.
 
 ```powershell
 class MyFileInfoSet : System.IEquatable[Object] {
-    [String]$File
-    [Int64]$Size
+    [string]$File
+    [int64]$Size
 
     [bool] Equals([Object] $obj) {
         return ($this.File -eq $obj.File) -and ($this.Size -eq $obj.Size)
@@ -319,7 +319,7 @@ Examples:
 
 ```powershell
 # Date comparison
-[DateTime]'2001-11-12' -lt [DateTime]'2020-08-01' # True
+[datetime]'2001-11-12' -lt [datetime]'2020-08-01' # True
 
 # Sorting order comparison
 'a' -lt 'z'           # True; 'a' comes before 'z'
@@ -505,7 +505,7 @@ such as renaming files. For example, the following command changes the file
 name extensions of all `.txt` files to `.log`:
 
 ```powershell
-Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
+Get-ChildItem *.txt | Rename-Item -NewName { $_.Name -replace '\.txt$','.log' }
 ```
 
 By default, the `-replace` operator is case-insensitive. To make it case
@@ -733,7 +733,7 @@ $a -isnot $b.GetType() # Output: True
 - [about_Regular_Expressions][10]
 - [about_Wildcards][11]
 - [Compare-Object][14]
-- [Foreach-Object][12]
+- [ForEach-Object][12]
 - [Where-Object][13]
 
 <!-- link references -->

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Core_Commands.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Core_Commands.md
@@ -19,7 +19,7 @@ PowerShell includes a set of cmdlets that are specifically designed to manage
 the items in the data stores that are exposed by Windows PowerShell providers.
 You can use these cmdlets in the same ways to manage all the different types
 of data that the providers make available to you. For more information about
-providers, type "get-help about_providers".
+providers, type "Get-Help about_Providers".
 
 For example, you can use the Get-ChildItem cmdlet to list the files in a file
 system directory, the keys under a registry key, or the items that are exposed
@@ -87,7 +87,7 @@ PSProvider cmdlets
 
 - Get-PSProvider
 
-For more information about a cmdlet, type `get-help <cmdlet-name>`.
+For more information about a cmdlet, type `Get-Help <cmdlet-name>`.
 
 ## See also
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -204,8 +204,8 @@ class BookList {
     # Static method to initialize the list of books. Called in the other
     # static methods to avoid needing to explicit initialize the value.
     static [void] Initialize()             { [BookList]::Initialize($false) }
-    static [bool] Initialize([bool]$force) {
-        if ([BookList]::Books.Count -gt 0 -and -not $force) {
+    static [bool] Initialize([bool]$Force) {
+        if ([BookList]::Books.Count -gt 0 -and -not $Force) {
             return $false
         }
 
@@ -369,8 +369,8 @@ an error, such as `Global scope cannot be removed`.
 ```powershell
 # Class definition with Runspace affinity (default behavior)
 class UnsafeClass {
-    static [object] ShowRunspaceId($val) {
-        return [PSCustomObject]@{
+    static [Object] ShowRunspaceId($Val) {
+        return [pscustomobject]@{
             ThreadId   = [Threading.Thread]::CurrentThread.ManagedThreadId
             RunspaceId = [runspace]::DefaultRunspace.Id
         }
@@ -382,7 +382,7 @@ $unsafe = [UnsafeClass]::new()
 while ($true) {
     1..10 | ForEach-Object -Parallel {
         Start-Sleep -ms 100
-        ($using:unsafe)::ShowRunspaceId($_)
+        ($Using:unsafe)::ShowRunspaceId($_)
     }
 }
 ```
@@ -398,8 +398,8 @@ Runspace ids.
 # Class definition with NoRunspaceAffinity attribute
 [NoRunspaceAffinity()]
 class SafeClass {
-    static [object] ShowRunspaceId($val) {
-        return [PSCustomObject]@{
+    static [Object] ShowRunspaceId($Val) {
+        return [pscustomobject]@{
             ThreadId   = [Threading.Thread]::CurrentThread.ManagedThreadId
             RunspaceId = [runspace]::DefaultRunspace.Id
         }
@@ -411,7 +411,7 @@ $safe = [SafeClass]::new()
 while ($true) {
     1..10 | ForEach-Object -Parallel {
         Start-Sleep -ms 100
-        ($using:safe)::ShowRunspaceId($_)
+        ($Using:safe)::ShowRunspaceId($_)
     }
 }
 ```
@@ -608,7 +608,7 @@ module is removed, so are the type accelerators.
 
 ## Manually importing classes from a PowerShell module
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes aren't imported.
 
 If a module defines classes and enumerations but doesn't add type accelerators

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Classes_Constructors.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Classes_Constructors.md
@@ -308,7 +308,7 @@ class BaseExample {
         Write-Verbose "[$($Type.Name)] static constructor"
     }
 
-    static [void] ParamMessage([type]$Type, [object]$Value) {
+    static [void] ParamMessage([type]$Type, [Object]$Value) {
         Write-Verbose "[$($Type.Name)] param constructor ($Value)"
     }
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Classes_Inheritance.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Classes_Inheritance.md
@@ -58,14 +58,14 @@ declaration.
 This example shows the basic PowerShell class inheritance syntax.
 
 ```powershell
-Class Derived : Base {...}
+class Derived : Base {...}
 ```
 
 This example shows inheritance with an interface declaration coming after the
 base class.
 
 ```powershell
-Class Derived : Base, Interface {...}
+class Derived : Base, Interface {...}
 ```
 
 ## Syntax
@@ -656,7 +656,7 @@ Kelvin. For any other format, the method should throw a
     }
     # If format provider isn't specified, use the current culture.
     if ($null -eq $FormatProvider) {
-        $FormatProvider = [CultureInfo]::CurrentCulture
+        $FormatProvider = [cultureinfo]::CurrentCulture
     }
     # Format the temperature.
     switch ($Format) {
@@ -747,7 +747,7 @@ class Temperature : System.IFormattable {
         }
         # If format provider isn't specified, use the current culture.
         if ($null -eq $FormatProvider) {
-            $FormatProvider = [CultureInfo]::CurrentCulture
+            $FormatProvider = [cultureinfo]::CurrentCulture
         }
         # Format the temperature.
         switch ($Format) {
@@ -814,7 +814,7 @@ To implement the interface, the class needs to inherit from
 method needs to have the following signature:
 
 ```powershell
-[bool] Equals([object]$Other) {
+[bool] Equals([Object]$Other) {
     # Implementation
 }
 ```
@@ -829,7 +829,7 @@ values to Kelvin, since temperatures can be equivalent even with different
 scales.
 
 ```powershell
-[bool] Equals([object]$Other) {
+[bool] Equals([Object]$Other) {
     # If the other object is null, we can't compare it.
     if ($null -eq $Other) {
         return $false
@@ -850,7 +850,7 @@ With the interface method implemented, the updated definition for
 **Temperature** is:
 
 ```powershell
-class Temperature : System.IFormattable, System.IEquatable[object] {
+class Temperature : System.IFormattable, System.IEquatable[Object] {
     [float]            $Degrees
     [TemperatureScale] $Scale
 
@@ -898,7 +898,7 @@ class Temperature : System.IFormattable, System.IEquatable[object] {
         }
         # If format provider isn't specified, use the current culture.
         if ($null -eq $FormatProvider) {
-            $FormatProvider = [CultureInfo]::CurrentCulture
+            $FormatProvider = [cultureinfo]::CurrentCulture
         }
         # Format the temperature.
         switch ($Format) {
@@ -926,7 +926,7 @@ class Temperature : System.IFormattable, System.IEquatable[object] {
         return $this.ToString($null, $null)
     }
 
-    [bool] Equals([object]$Other) {
+    [bool] Equals([Object]$Other) {
         # If the other object is null, we can't compare it.
         if ($null -eq $Other) {
             return $false
@@ -998,7 +998,7 @@ converted to a different scale, is a floating point number, the method can rely
 on the underlying type for the actual comparison.
 
 ```powershell
-[int] CompareTo([object]$Other) {
+[int] CompareTo([Object]$Other) {
     # If the other object's null, consider this instance "greater than" it
     if ($null -eq $Other) {
         return 1
@@ -1020,7 +1020,7 @@ The final definition for the **Temperature** class is:
 ```powershell
 class Temperature : System.IFormattable,
                     System.IComparable,
-                    System.IEquatable[object] {
+                    System.IEquatable[Object] {
     # Instance properties
     [float]            $Degrees
     [TemperatureScale] $Scale
@@ -1070,7 +1070,7 @@ class Temperature : System.IFormattable,
         }
         # If format provider isn't specified, use the current culture.
         if ($null -eq $FormatProvider) {
-            $FormatProvider = [CultureInfo]::CurrentCulture
+            $FormatProvider = [cultureinfo]::CurrentCulture
         }
         # Format the temperature.
         switch ($Format) {
@@ -1098,7 +1098,7 @@ class Temperature : System.IFormattable,
         return $this.ToString($null, $null)
     }
 
-    [bool] Equals([object]$Other) {
+    [bool] Equals([Object]$Other) {
         # If the other object is null, we can't compare it.
         if ($null -eq $Other) {
             return $false
@@ -1111,7 +1111,7 @@ class Temperature : System.IFormattable,
         # Compare the temperatures as Kelvin.
         return $this.ToKelvin() -eq $OtherTemperature.ToKelvin()
     }
-    [int] CompareTo([object]$Other) {
+    [int] CompareTo([Object]$Other) {
         # If the other object's null, consider this instance "greater than" it
         if ($null -eq $Other) {
             return 1
@@ -1181,7 +1181,7 @@ generic type as long as the type parameter is already defined at parse time.
 ```powershell
 class ExampleStringList : System.Collections.Generic.List[string] {}
 
-$List = [ExampleStringList]::New()
+$List = [ExampleStringList]::new()
 $List.AddRange([string[]]@('a','b','c'))
 $List.GetType() | Format-List -Property Name, BaseType
 $List
@@ -1239,7 +1239,7 @@ This time, PowerShell doesn't raise any errors. Both classes are now defined.
 Run the following code block to view the behavior of the new class.
 
 ```powershell
-$List = [ExampleItemList]::New()
+$List = [ExampleItemList]::new()
 $List.AddRange([ExampleItem[]]@(
     [ExampleItem]@{ Name = 'Foo' }
     [ExampleItem]@{ Name = 'Bar' }

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Classes_Methods.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Classes_Methods.md
@@ -603,17 +603,17 @@ class. The representation for **DerivedClassB** is different because it
 overrode the `ToString()` instance method.
 
 ```powershell
-"`$base = [BaseClass]::New()     => $($base = [BaseClass]::New(); $base)"
-"`$a    = [DerivedClassA]::New() => $($a = [DerivedClassA]::New(); $a)"
-"`$b    = [DerivedClassB]::New() => $($b = [DerivedClassB]::New(); $b)"
-"`$c    = [DerivedClassC]::New() => $($c = [DerivedClassC]::New(); $c)"
+"`$base = [BaseClass]::new()     => $($base = [BaseClass]::new(); $base)"
+"`$a    = [DerivedClassA]::new() => $($a = [DerivedClassA]::new(); $a)"
+"`$b    = [DerivedClassB]::new() => $($b = [DerivedClassB]::new(); $b)"
+"`$c    = [DerivedClassC]::new() => $($c = [DerivedClassC]::new(); $c)"
 ```
 
 ```Output
-$base = [BaseClass]::New()     => 11/6/2023 9:44:57 AM
-$a    = [DerivedClassA]::New() => 11/6/2023 9:44:57 AM
-$b    = [DerivedClassB]::New() => 2023-11-06
-$c    = [DerivedClassC]::New() => 11/6/2023 9:44:57 AM
+$base = [BaseClass]::new()     => 11/6/2023 9:44:57 AM
+$a    = [DerivedClassA]::new() => 11/6/2023 9:44:57 AM
+$b    = [DerivedClassB]::new() => 2023-11-06
+$c    = [DerivedClassC]::new() => 11/6/2023 9:44:57 AM
 ```
 
 The next block calls the `SetTimeStamp()` instance method for each instance,

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -38,7 +38,7 @@ C:\TechDocs\FindDocs.ps1
 You can run any executable command using its full path. As a security feature,
 PowerShell doesn't run executable commands, including PowerShell scripts and
 native commands, unless the command is located in a path listed in the
-`$env:Path` environment variable.
+`$Env:PATH` environment variable.
 
 To run an executable file that's in the current directory, specify the full
 path or use the relative path `.\` to represent the current directory.
@@ -58,7 +58,7 @@ when it runs commands.
 1. External executable files (including PowerShell script files)
 
 Therefore, if you type `help`, PowerShell first looks for an alias named
-`help`, then a function named `Help`, and finally a cmdlet named `Help`. It
+`help`, then a function named `help`, and finally a cmdlet named `help`. It
 runs the first `help` item that it finds.
 
 For example, if your session contains a cmdlet and a function, both named
@@ -247,7 +247,7 @@ For example, the following command saves the `Map` function in the `$myMap`
 variable and then uses the `Call` operator to run it.
 
 ```powershell
-$myMap = (Get-Command -Name map -CommandType function)
+$myMap = (Get-Command -Name map -CommandType Function)
 & ($myMap)
 ```
 
@@ -273,7 +273,7 @@ first module found alphabetically.
 
 If the cmdlet isn't loaded, PowerShell searches the installed modules and
 autoloads the first module that contains the cmdlet and runs that cmdlet.
-PowerShell searches for modules in each path defined in the `$env:PSModulePath`
+PowerShell searches for modules in each path defined in the `$Env:PSModulePath`
 environment variable. The paths are searched in the order that they're listed
 in the variable. Within each path, the modules are searched in alphabetical
 order. PowerShell uses the cmdlet from the first match it finds.
@@ -299,7 +299,7 @@ Import-Module -Name DateFunctions -Prefix ZZ
 
 ## Running external executables
 
-On Windows. PowerShell treats the file extensions listed in the `$env:PATHEXT`
+On Windows. PowerShell treats the file extensions listed in the `$Env:PATHEXT`
 environment variable as executable files. Files that aren't Windows executables
 are handed to Windows to process. Windows looks up the file association and
 executes the default Windows Shell verb for the extension. For Windows to
@@ -312,7 +312,7 @@ to register the file handler. For more information, see the documentation for
 the [ftype][04] command.
 
 For PowerShell to see a file extension as executable in the current session,
-you must add the extension to the `$env:PATHEXT` environment variable.
+you must add the extension to the `$Env:PATHEXT` environment variable.
 
 ## See also
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -70,12 +70,12 @@ Keywords define each section of comment-based help. Each comment-based help
 keyword is preceded by a dot `.`. The keywords can appear in any order. The
 keyword names aren't case-sensitive.
 
-For example, the `.Description` keyword precedes a description of a function or
+For example, the `.DESCRIPTION` keyword precedes a description of a function or
 script.
 
 ```powershell
 <#
-.Description
+.DESCRIPTION
 Get-Function displays the name and syntax of all functions in the session.
 #>
 ```
@@ -220,8 +220,8 @@ ignored.
 function Verb-Noun {
     [CmdletBinding()]
     param (
-        # This is the same as .Parameter
-        [string]$Computername
+        # This is the same as .PARAMETER
+        [string]$ComputerName
     )
     # Verb the Noun on the computer
 }
@@ -256,7 +256,7 @@ Repeat the `.LINK` keyword for each related topic.
 
 This content appears in the Related Links section of the help topic.
 
-The `.Link` keyword content can also include a Uniform Resource Identifier
+The `.LINK` keyword content can also include a Uniform Resource Identifier
 (URI) to an online version of the same help topic. The online version opens
 when you use the **Online** parameter of `Get-Help`. The URI must begin with
 "http" or "https".
@@ -290,7 +290,7 @@ provider.
 
 ### .FORWARDHELPCATEGORY
 
-Specifies the help category of the item in `.ForwardHelpTargetName`. Valid
+Specifies the help category of the item in `.FORWARDHELPTARGETNAME`. Valid
 values are `Alias`, `Cmdlet`, `HelpFile`, `Function`, `Provider`, `General`,
 `FAQ`, `Glossary`, `ScriptCommand`, `ExternalScript`, `Filter`, or `All`. Use
 this keyword to avoid conflicts when there are commands with the same name.
@@ -369,11 +369,11 @@ type, the **Object** type is inserted as the default value.
 ### Parameter List
 
 The parameter list in the help topic is generated from the function or script
-syntax and from the descriptions that you add by using the `.Parameter`
+syntax and from the descriptions that you add by using the `.PARAMETER`
 keyword. The function parameters appear in the **Parameters** section of the
 help topic in the same order that they appear in the function or script syntax.
 The spelling and capitalization of parameter names is also taken from the
-syntax. It isn't affected by the parameter name specified by the `.Parameter`
+syntax. It isn't affected by the parameter name specified by the `.PARAMETER`
 keyword.
 
 ### Common Parameters
@@ -408,8 +408,8 @@ The following sample function includes comment-based help:
 function Add-Extension
 {
 param ([string]$Name,[string]$Extension = "txt")
-$name = $name + "." + $extension
-$name
+$Name = $Name + "." + $Extension
+$Name
 
 <#
 .SYNOPSIS
@@ -438,17 +438,17 @@ or file name.
 
 .EXAMPLE
 
-PS> extension -name "File"
+PS> Add-Extension -Name "File"
 File.txt
 
 .EXAMPLE
 
-PS> extension -name "File" -extension "doc"
+PS> Add-Extension -Name "File" -Extension "doc"
 File.doc
 
 .EXAMPLE
 
-PS> extension "File" "doc"
+PS> Add-Extension "File" "doc"
 File.doc
 
 .LINK
@@ -511,7 +511,7 @@ Accept wildcard characters?
 This cmdlet supports the common parameters: -Verbose, -Debug,
 -ErrorAction, -ErrorVariable, -WarningAction, -WarningVariable,
 -OutBuffer and -OutVariable. For more information, type
-"get-help about_commonparameters".
+"Get-Help about_CommonParameters".
 
 INPUTS
 None. You can't pipe objects to Add-Extension.
@@ -523,17 +523,17 @@ file name.
 
 Example 1
 
-PS> extension -name "File"
+PS> Add-Extension -Name "File"
 File.txt
 
 Example 2
 
-PS> extension -name "File" -extension "doc"
+PS> Add-Extension -Name "File" -Extension "doc"
 File.doc
 
 Example 3
 
-PS> extension "File" "doc"
+PS> Add-Extension "File" "doc"
 File.doc
 
 RELATED LINKS
@@ -556,15 +556,15 @@ param
 
 [string]
 #Specifies the file name.
-$name,
+$Name,
 
 [string]
 #Specifies the file name extension. "Txt" is the default.
-$extension = "txt"
+$Extension = "txt"
 )
 
-$name = $name + "." + $extension
-$name
+$Name = $Name + "." + $Extension
+$Name
 
 <#
 .SYNOPSIS
@@ -587,17 +587,17 @@ file name.
 
 .EXAMPLE
 
-PS> extension -name "File"
+PS> Add-Extension -Name "File"
 File.txt
 
 .EXAMPLE
 
-PS> extension -name "File" -extension "doc"
+PS> Add-Extension -Name "File" -Extension "doc"
 File.doc
 
 .EXAMPLE
 
-PS> extension "File" "doc"
+PS> Add-Extension "File" "doc"
 File.doc
 
 .LINK
@@ -614,8 +614,8 @@ Set-Item
 ### Comment-based Help for a Script
 
 The following sample script includes comment-based help. Notice the blank lines
-between the closing `#>` and the `Param` statement. In a script that doesn't
-have a `Param` statement, there must be at least two blank lines between the
+between the closing `#>` and the `param` statement. In a script that doesn't
+have a `param` statement, there must be at least two blank lines between the
 final comment in the help topic and the first function declaration. Without
 these blank lines, `Get-Help` associates the help topic with the function, not
 the script.
@@ -653,22 +653,22 @@ PS> .\Update-Month.ps1
 
 .EXAMPLE
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv
 
 .EXAMPLE
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv -outputPath `
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv -OutputPath `
 C:\Reports\2009\January.csv
 #>
 
-param ([string]$InputPath, [string]$OutPutPath)
+param ([string]$InputPath, [string]$OutputPath)
 
 function Get-Data { }
 ...
 ```
 
 The following command gets the script help. Because the script isn't in a
-directory that's listed in the `$env:Path` environment variable, the
+directory that's listed in the `$Env:PATH` environment variable, the
 `Get-Help` command that gets the script help must specify the script path.
 
 ```powershell
@@ -720,7 +720,7 @@ Accept wildcard characters?
 This cmdlet supports the common parameters: -Verbose, -Debug,
 -ErrorAction, -ErrorVariable, -WarningAction, -WarningVariable,
 -OutBuffer and -OutVariable. For more information, type,
-"get-help about_commonparameters".
+"Get-Help about_CommonParameters".
 
 # INPUTS
 
@@ -736,11 +736,11 @@ PS> .\Update-Month.ps1
 
 Example 2
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv
 
 Example 3
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv -outputPath
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv -OutputPath
 C:\Reports\2009\January.csv
 
 # RELATED LINKS
@@ -762,7 +762,7 @@ the keyword. Any other placement is ineffective.
 ```powershell
 # .EXTERNALHELP C:\MyScripts\Update-Month-Help.xml
 
-param ([string]$InputPath, [string]$OutPutPath)
+param ([string]$InputPath, [string]$OutputPath)
 function Get-Data { }
 ...
 ```
@@ -774,17 +774,17 @@ keyword in a function.
 function Add-Extension {
     # .EXTERNALHELP C:\ps-test\Add-Extension.xml
 
-    param ([string] $name, [string]$extension = "txt")
-    $name = $name + "." + $extension
-    $name
+    param ([string] $Name, [string]$Extension = "txt")
+    $Name = $Name + "." + $Extension
+    $Name
 }
 ```
 
 ```powershell
 function Add-Extension {
-    param ([string] $name, [string]$extension = "txt")
-    $name = $name + "." + $extension
-    $name
+    param ([string] $Name, [string]$Extension = "txt")
+    $Name = $Name + "." + $Extension
+    $Name
 
     # .EXTERNALHELP C:\ps-test\Add-Extension.xml
 }
@@ -793,9 +793,9 @@ function Add-Extension {
 ```powershell
 # .EXTERNALHELP C:\ps-test\Add-Extension.xml
 function Add-Extension {
-    param ([string] $name, [string]$extension = "txt")
-    $name = $name + "." + $extension
-    $name
+    param ([string] $Name, [string]$Extension = "txt")
+    $Name = $Name + "." + $Extension
+    $Name
 }
 ```
 
@@ -804,7 +804,7 @@ function Add-Extension {
 The following code is an excerpt from the beginning of the built-in help
 function in PowerShell, which displays one screen of help text at a time.
 Because the help topic for the `Get-Help` cmdlet describes the help function,
-the help function uses the `.ForwardHelpTargetName` and `.ForwardHelpCategory`
+the help function uses the `.FORWARDHELPTARGETNAME` and `.FORWARDHELPCATEGORY`
 keywords to redirect the user to the `Get-Help` cmdlet help topic.
 
 ```powershell

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Comments.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Comments.md
@@ -162,7 +162,7 @@ before the script is executed.
 # SIG # End signature block
 ```
 
-For more information, see [about_signing][10].
+For more information, see [about_Signing][10].
 
 ### Shebang
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -341,7 +341,7 @@ For example, the following command creates the `$out` variable and stores the
 process object in it:
 
 ```powershell
-Get-Process PowerShell -OutVariable out
+Get-Process powershell -OutVariable out
 ```
 
 The following command adds the process object to the `$out` variable:
@@ -410,13 +410,13 @@ Valid values are strings, the same as for any variable names.
 > a command after the blocking command.
 
 The following is an example of how **PipelineVariable** works. In this example,
-the **PipelineVariable** parameter is added to a `Foreach-Object` command to
+the **PipelineVariable** parameter is added to a `ForEach-Object` command to
 store the results of the command in variables. A range of numbers, 1 to 5, are
-piped into the first `Foreach-Object` command, the results of which are stored
+piped into the first `ForEach-Object` command, the results of which are stored
 in a variable named `$temp`.
 
-The results of the first `Foreach-Object` command are piped into a second
-`Foreach-Object` command, which displays the current values of `$temp` and
+The results of the first `ForEach-Object` command are piped into a second
+`ForEach-Object` command, which displays the current values of `$temp` and
 `$_`.
 
 ```powershell

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -162,8 +162,8 @@ The following example demonstrates the issue.
 
 ```powershell
 class MyFileInfoSet {
-    [String]$File
-    [Int64]$Size
+    [string]$File
+    [int64]$Size
 }
 $a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
 $b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
@@ -184,8 +184,8 @@ the File and Size properties of two **MyFileInfoSet** objects are the same.
 
 ```powershell
 class MyFileInfoSet : System.IEquatable[Object] {
-    [String]$File
-    [Int64]$Size
+    [string]$File
+    [int64]$Size
 
     [bool] Equals([Object] $obj) {
         return ($this.File -eq $obj.File) -and ($this.Size -eq $obj.Size)
@@ -319,7 +319,7 @@ Examples:
 
 ```powershell
 # Date comparison
-[DateTime]'2001-11-12' -lt [DateTime]'2020-08-01' # True
+[datetime]'2001-11-12' -lt [datetime]'2020-08-01' # True
 
 # Sorting order comparison
 'a' -lt 'z'           # True; 'a' comes before 'z'
@@ -505,7 +505,7 @@ such as renaming files. For example, the following command changes the file
 name extensions of all `.txt` files to `.log`:
 
 ```powershell
-Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
+Get-ChildItem *.txt | Rename-Item -NewName { $_.Name -replace '\.txt$','.log' }
 ```
 
 By default, the `-replace` operator is case-insensitive. To make it case
@@ -783,7 +783,7 @@ $a -isnot $b.GetType() # Output: True
 - [about_Regular_Expressions][10]
 - [about_Wildcards][11]
 - [Compare-Object][14]
-- [Foreach-Object][12]
+- [ForEach-Object][12]
 - [Where-Object][13]
 
 <!-- link references -->

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Core_Commands.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Core_Commands.md
@@ -18,7 +18,7 @@ PowerShell includes a set of cmdlets that are specifically designed to manage
 the items in the data stores that are exposed by PowerShell providers.
 You can use these cmdlets in the same ways to manage all the different types
 of data that the providers make available to you. For more information about
-providers, type "get-help about_providers".
+providers, type "Get-Help about_Providers".
 
 For example, you can use the Get-ChildItem cmdlet to list the files in a file
 system directory, the keys under a registry key, or the items that are exposed
@@ -86,7 +86,7 @@ PSProvider cmdlets
 
 - Get-PSProvider
 
-For more information about a cmdlet, type `get-help <cmdlet-name>`.
+For more information about a cmdlet, type `Get-Help <cmdlet-name>`.
 
 ## See also
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -204,8 +204,8 @@ class BookList {
     # Static method to initialize the list of books. Called in the other
     # static methods to avoid needing to explicit initialize the value.
     static [void] Initialize()             { [BookList]::Initialize($false) }
-    static [bool] Initialize([bool]$force) {
-        if ([BookList]::Books.Count -gt 0 -and -not $force) {
+    static [bool] Initialize([bool]$Force) {
+        if ([BookList]::Books.Count -gt 0 -and -not $Force) {
             return $false
         }
 
@@ -369,8 +369,8 @@ an error, such as `Global scope cannot be removed`.
 ```powershell
 # Class definition with Runspace affinity (default behavior)
 class UnsafeClass {
-    static [object] ShowRunspaceId($val) {
-        return [PSCustomObject]@{
+    static [Object] ShowRunspaceId($Val) {
+        return [pscustomobject]@{
             ThreadId   = [Threading.Thread]::CurrentThread.ManagedThreadId
             RunspaceId = [runspace]::DefaultRunspace.Id
         }
@@ -382,7 +382,7 @@ $unsafe = [UnsafeClass]::new()
 while ($true) {
     1..10 | ForEach-Object -Parallel {
         Start-Sleep -ms 100
-        ($using:unsafe)::ShowRunspaceId($_)
+        ($Using:unsafe)::ShowRunspaceId($_)
     }
 }
 ```
@@ -398,8 +398,8 @@ Runspace ids.
 # Class definition with NoRunspaceAffinity attribute
 [NoRunspaceAffinity()]
 class SafeClass {
-    static [object] ShowRunspaceId($val) {
-        return [PSCustomObject]@{
+    static [Object] ShowRunspaceId($Val) {
+        return [pscustomobject]@{
             ThreadId   = [Threading.Thread]::CurrentThread.ManagedThreadId
             RunspaceId = [runspace]::DefaultRunspace.Id
         }
@@ -411,7 +411,7 @@ $safe = [SafeClass]::new()
 while ($true) {
     1..10 | ForEach-Object -Parallel {
         Start-Sleep -ms 100
-        ($using:safe)::ShowRunspaceId($_)
+        ($Using:safe)::ShowRunspaceId($_)
     }
 }
 ```
@@ -608,7 +608,7 @@ module is removed, so are the type accelerators.
 
 ## Manually importing classes from a PowerShell module
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes aren't imported.
 
 If a module defines classes and enumerations but doesn't add type accelerators

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Classes_Constructors.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Classes_Constructors.md
@@ -308,7 +308,7 @@ class BaseExample {
         Write-Verbose "[$($Type.Name)] static constructor"
     }
 
-    static [void] ParamMessage([type]$Type, [object]$Value) {
+    static [void] ParamMessage([type]$Type, [Object]$Value) {
         Write-Verbose "[$($Type.Name)] param constructor ($Value)"
     }
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Classes_Inheritance.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Classes_Inheritance.md
@@ -58,14 +58,14 @@ declaration.
 This example shows the basic PowerShell class inheritance syntax.
 
 ```powershell
-Class Derived : Base {...}
+class Derived : Base {...}
 ```
 
 This example shows inheritance with an interface declaration coming after the
 base class.
 
 ```powershell
-Class Derived : Base, Interface {...}
+class Derived : Base, Interface {...}
 ```
 
 ## Syntax
@@ -656,7 +656,7 @@ Kelvin. For any other format, the method should throw a
     }
     # If format provider isn't specified, use the current culture.
     if ($null -eq $FormatProvider) {
-        $FormatProvider = [CultureInfo]::CurrentCulture
+        $FormatProvider = [cultureinfo]::CurrentCulture
     }
     # Format the temperature.
     switch ($Format) {
@@ -747,7 +747,7 @@ class Temperature : System.IFormattable {
         }
         # If format provider isn't specified, use the current culture.
         if ($null -eq $FormatProvider) {
-            $FormatProvider = [CultureInfo]::CurrentCulture
+            $FormatProvider = [cultureinfo]::CurrentCulture
         }
         # Format the temperature.
         switch ($Format) {
@@ -814,7 +814,7 @@ To implement the interface, the class needs to inherit from
 method needs to have the following signature:
 
 ```powershell
-[bool] Equals([object]$Other) {
+[bool] Equals([Object]$Other) {
     # Implementation
 }
 ```
@@ -829,7 +829,7 @@ values to Kelvin, since temperatures can be equivalent even with different
 scales.
 
 ```powershell
-[bool] Equals([object]$Other) {
+[bool] Equals([Object]$Other) {
     # If the other object is null, we can't compare it.
     if ($null -eq $Other) {
         return $false
@@ -850,7 +850,7 @@ With the interface method implemented, the updated definition for
 **Temperature** is:
 
 ```powershell
-class Temperature : System.IFormattable, System.IEquatable[object] {
+class Temperature : System.IFormattable, System.IEquatable[Object] {
     [float]            $Degrees
     [TemperatureScale] $Scale
 
@@ -898,7 +898,7 @@ class Temperature : System.IFormattable, System.IEquatable[object] {
         }
         # If format provider isn't specified, use the current culture.
         if ($null -eq $FormatProvider) {
-            $FormatProvider = [CultureInfo]::CurrentCulture
+            $FormatProvider = [cultureinfo]::CurrentCulture
         }
         # Format the temperature.
         switch ($Format) {
@@ -926,7 +926,7 @@ class Temperature : System.IFormattable, System.IEquatable[object] {
         return $this.ToString($null, $null)
     }
 
-    [bool] Equals([object]$Other) {
+    [bool] Equals([Object]$Other) {
         # If the other object is null, we can't compare it.
         if ($null -eq $Other) {
             return $false
@@ -998,7 +998,7 @@ converted to a different scale, is a floating point number, the method can rely
 on the underlying type for the actual comparison.
 
 ```powershell
-[int] CompareTo([object]$Other) {
+[int] CompareTo([Object]$Other) {
     # If the other object's null, consider this instance "greater than" it
     if ($null -eq $Other) {
         return 1
@@ -1020,7 +1020,7 @@ The final definition for the **Temperature** class is:
 ```powershell
 class Temperature : System.IFormattable,
                     System.IComparable,
-                    System.IEquatable[object] {
+                    System.IEquatable[Object] {
     # Instance properties
     [float]            $Degrees
     [TemperatureScale] $Scale
@@ -1070,7 +1070,7 @@ class Temperature : System.IFormattable,
         }
         # If format provider isn't specified, use the current culture.
         if ($null -eq $FormatProvider) {
-            $FormatProvider = [CultureInfo]::CurrentCulture
+            $FormatProvider = [cultureinfo]::CurrentCulture
         }
         # Format the temperature.
         switch ($Format) {
@@ -1098,7 +1098,7 @@ class Temperature : System.IFormattable,
         return $this.ToString($null, $null)
     }
 
-    [bool] Equals([object]$Other) {
+    [bool] Equals([Object]$Other) {
         # If the other object is null, we can't compare it.
         if ($null -eq $Other) {
             return $false
@@ -1111,7 +1111,7 @@ class Temperature : System.IFormattable,
         # Compare the temperatures as Kelvin.
         return $this.ToKelvin() -eq $OtherTemperature.ToKelvin()
     }
-    [int] CompareTo([object]$Other) {
+    [int] CompareTo([Object]$Other) {
         # If the other object's null, consider this instance "greater than" it
         if ($null -eq $Other) {
             return 1
@@ -1181,7 +1181,7 @@ generic type as long as the type parameter is already defined at parse time.
 ```powershell
 class ExampleStringList : System.Collections.Generic.List[string] {}
 
-$List = [ExampleStringList]::New()
+$List = [ExampleStringList]::new()
 $List.AddRange([string[]]@('a','b','c'))
 $List.GetType() | Format-List -Property Name, BaseType
 $List
@@ -1239,7 +1239,7 @@ This time, PowerShell doesn't raise any errors. Both classes are now defined.
 Run the following code block to view the behavior of the new class.
 
 ```powershell
-$List = [ExampleItemList]::New()
+$List = [ExampleItemList]::new()
 $List.AddRange([ExampleItem[]]@(
     [ExampleItem]@{ Name = 'Foo' }
     [ExampleItem]@{ Name = 'Bar' }

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Classes_Methods.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Classes_Methods.md
@@ -603,17 +603,17 @@ class. The representation for **DerivedClassB** is different because it
 overrode the `ToString()` instance method.
 
 ```powershell
-"`$base = [BaseClass]::New()     => $($base = [BaseClass]::New(); $base)"
-"`$a    = [DerivedClassA]::New() => $($a = [DerivedClassA]::New(); $a)"
-"`$b    = [DerivedClassB]::New() => $($b = [DerivedClassB]::New(); $b)"
-"`$c    = [DerivedClassC]::New() => $($c = [DerivedClassC]::New(); $c)"
+"`$base = [BaseClass]::new()     => $($base = [BaseClass]::new(); $base)"
+"`$a    = [DerivedClassA]::new() => $($a = [DerivedClassA]::new(); $a)"
+"`$b    = [DerivedClassB]::new() => $($b = [DerivedClassB]::new(); $b)"
+"`$c    = [DerivedClassC]::new() => $($c = [DerivedClassC]::new(); $c)"
 ```
 
 ```Output
-$base = [BaseClass]::New()     => 11/6/2023 9:44:57 AM
-$a    = [DerivedClassA]::New() => 11/6/2023 9:44:57 AM
-$b    = [DerivedClassB]::New() => 2023-11-06
-$c    = [DerivedClassC]::New() => 11/6/2023 9:44:57 AM
+$base = [BaseClass]::new()     => 11/6/2023 9:44:57 AM
+$a    = [DerivedClassA]::new() => 11/6/2023 9:44:57 AM
+$b    = [DerivedClassB]::new() => 2023-11-06
+$c    = [DerivedClassC]::new() => 11/6/2023 9:44:57 AM
 ```
 
 The next block calls the `SetTimeStamp()` instance method for each instance,

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -38,7 +38,7 @@ C:\TechDocs\FindDocs.ps1
 You can run any executable command using its full path. As a security feature,
 PowerShell doesn't run executable commands, including PowerShell scripts and
 native commands, unless the command is located in a path listed in the
-`$env:Path` environment variable.
+`$Env:PATH` environment variable.
 
 To run an executable file that's in the current directory, specify the full
 path or use the relative path `.\` to represent the current directory.
@@ -58,7 +58,7 @@ when it runs commands.
 1. External executable files (including PowerShell script files)
 
 Therefore, if you type `help`, PowerShell first looks for an alias named
-`help`, then a function named `Help`, and finally a cmdlet named `Help`. It
+`help`, then a function named `help`, and finally a cmdlet named `help`. It
 runs the first `help` item that it finds.
 
 For example, if your session contains a cmdlet and a function, both named
@@ -247,7 +247,7 @@ For example, the following command saves the `Map` function in the `$myMap`
 variable and then uses the `Call` operator to run it.
 
 ```powershell
-$myMap = (Get-Command -Name map -CommandType function)
+$myMap = (Get-Command -Name map -CommandType Function)
 & ($myMap)
 ```
 
@@ -273,7 +273,7 @@ first module found alphabetically.
 
 If the cmdlet isn't loaded, PowerShell searches the installed modules and
 autoloads the first module that contains the cmdlet and runs that cmdlet.
-PowerShell searches for modules in each path defined in the `$env:PSModulePath`
+PowerShell searches for modules in each path defined in the `$Env:PSModulePath`
 environment variable. The paths are searched in the order that they're listed
 in the variable. Within each path, the modules are searched in alphabetical
 order. PowerShell uses the cmdlet from the first match it finds.
@@ -299,7 +299,7 @@ Import-Module -Name DateFunctions -Prefix ZZ
 
 ## Running external executables
 
-On Windows. PowerShell treats the file extensions listed in the `$env:PATHEXT`
+On Windows. PowerShell treats the file extensions listed in the `$Env:PATHEXT`
 environment variable as executable files. Files that aren't Windows executables
 are handed to Windows to process. Windows looks up the file association and
 executes the default Windows Shell verb for the extension. For Windows to
@@ -312,7 +312,7 @@ to register the file handler. For more information, see the documentation for
 the [ftype][04] command.
 
 For PowerShell to see a file extension as executable in the current session,
-you must add the extension to the `$env:PATHEXT` environment variable.
+you must add the extension to the `$Env:PATHEXT` environment variable.
 
 ## See also
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -70,12 +70,12 @@ Keywords define each section of comment-based help. Each comment-based help
 keyword is preceded by a dot `.`. The keywords can appear in any order. The
 keyword names aren't case-sensitive.
 
-For example, the `.Description` keyword precedes a description of a function or
+For example, the `.DESCRIPTION` keyword precedes a description of a function or
 script.
 
 ```powershell
 <#
-.Description
+.DESCRIPTION
 Get-Function displays the name and syntax of all functions in the session.
 #>
 ```
@@ -220,8 +220,8 @@ ignored.
 function Verb-Noun {
     [CmdletBinding()]
     param (
-        # This is the same as .Parameter
-        [string]$Computername
+        # This is the same as .PARAMETER
+        [string]$ComputerName
     )
     # Verb the Noun on the computer
 }
@@ -256,7 +256,7 @@ Repeat the `.LINK` keyword for each related topic.
 
 This content appears in the Related Links section of the help topic.
 
-The `.Link` keyword content can also include a Uniform Resource Identifier
+The `.LINK` keyword content can also include a Uniform Resource Identifier
 (URI) to an online version of the same help topic. The online version opens
 when you use the **Online** parameter of `Get-Help`. The URI must begin with
 "http" or "https".
@@ -290,7 +290,7 @@ provider.
 
 ### .FORWARDHELPCATEGORY
 
-Specifies the help category of the item in `.ForwardHelpTargetName`. Valid
+Specifies the help category of the item in `.FORWARDHELPTARGETNAME`. Valid
 values are `Alias`, `Cmdlet`, `HelpFile`, `Function`, `Provider`, `General`,
 `FAQ`, `Glossary`, `ScriptCommand`, `ExternalScript`, `Filter`, or `All`. Use
 this keyword to avoid conflicts when there are commands with the same name.
@@ -369,11 +369,11 @@ type, the **Object** type is inserted as the default value.
 ### Parameter List
 
 The parameter list in the help topic is generated from the function or script
-syntax and from the descriptions that you add by using the `.Parameter`
+syntax and from the descriptions that you add by using the `.PARAMETER`
 keyword. The function parameters appear in the **Parameters** section of the
 help topic in the same order that they appear in the function or script syntax.
 The spelling and capitalization of parameter names is also taken from the
-syntax. It isn't affected by the parameter name specified by the `.Parameter`
+syntax. It isn't affected by the parameter name specified by the `.PARAMETER`
 keyword.
 
 ### Common Parameters
@@ -408,8 +408,8 @@ The following sample function includes comment-based help:
 function Add-Extension
 {
 param ([string]$Name,[string]$Extension = "txt")
-$name = $name + "." + $extension
-$name
+$Name = $Name + "." + $Extension
+$Name
 
 <#
 .SYNOPSIS
@@ -438,17 +438,17 @@ or file name.
 
 .EXAMPLE
 
-PS> extension -name "File"
+PS> Add-Extension -Name "File"
 File.txt
 
 .EXAMPLE
 
-PS> extension -name "File" -extension "doc"
+PS> Add-Extension -Name "File" -Extension "doc"
 File.doc
 
 .EXAMPLE
 
-PS> extension "File" "doc"
+PS> Add-Extension "File" "doc"
 File.doc
 
 .LINK
@@ -511,7 +511,7 @@ Accept wildcard characters?
 This cmdlet supports the common parameters: -Verbose, -Debug,
 -ErrorAction, -ErrorVariable, -WarningAction, -WarningVariable,
 -OutBuffer and -OutVariable. For more information, type
-"get-help about_commonparameters".
+"Get-Help about_CommonParameters".
 
 INPUTS
 None. You can't pipe objects to Add-Extension.
@@ -523,17 +523,17 @@ file name.
 
 Example 1
 
-PS> extension -name "File"
+PS> Add-Extension -Name "File"
 File.txt
 
 Example 2
 
-PS> extension -name "File" -extension "doc"
+PS> Add-Extension -Name "File" -Extension "doc"
 File.doc
 
 Example 3
 
-PS> extension "File" "doc"
+PS> Add-Extension "File" "doc"
 File.doc
 
 RELATED LINKS
@@ -556,15 +556,15 @@ param
 
 [string]
 #Specifies the file name.
-$name,
+$Name,
 
 [string]
 #Specifies the file name extension. "Txt" is the default.
-$extension = "txt"
+$Extension = "txt"
 )
 
-$name = $name + "." + $extension
-$name
+$Name = $Name + "." + $Extension
+$Name
 
 <#
 .SYNOPSIS
@@ -587,17 +587,17 @@ file name.
 
 .EXAMPLE
 
-PS> extension -name "File"
+PS> Add-Extension -Name "File"
 File.txt
 
 .EXAMPLE
 
-PS> extension -name "File" -extension "doc"
+PS> Add-Extension -Name "File" -Extension "doc"
 File.doc
 
 .EXAMPLE
 
-PS> extension "File" "doc"
+PS> Add-Extension "File" "doc"
 File.doc
 
 .LINK
@@ -614,8 +614,8 @@ Set-Item
 ### Comment-based Help for a Script
 
 The following sample script includes comment-based help. Notice the blank lines
-between the closing `#>` and the `Param` statement. In a script that doesn't
-have a `Param` statement, there must be at least two blank lines between the
+between the closing `#>` and the `param` statement. In a script that doesn't
+have a `param` statement, there must be at least two blank lines between the
 final comment in the help topic and the first function declaration. Without
 these blank lines, `Get-Help` associates the help topic with the function, not
 the script.
@@ -653,22 +653,22 @@ PS> .\Update-Month.ps1
 
 .EXAMPLE
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv
 
 .EXAMPLE
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv -outputPath `
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv -OutputPath `
 C:\Reports\2009\January.csv
 #>
 
-param ([string]$InputPath, [string]$OutPutPath)
+param ([string]$InputPath, [string]$OutputPath)
 
 function Get-Data { }
 ...
 ```
 
 The following command gets the script help. Because the script isn't in a
-directory that's listed in the `$env:Path` environment variable, the
+directory that's listed in the `$Env:PATH` environment variable, the
 `Get-Help` command that gets the script help must specify the script path.
 
 ```powershell
@@ -720,7 +720,7 @@ Accept wildcard characters?
 This cmdlet supports the common parameters: -Verbose, -Debug,
 -ErrorAction, -ErrorVariable, -WarningAction, -WarningVariable,
 -OutBuffer and -OutVariable. For more information, type,
-"get-help about_commonparameters".
+"Get-Help about_CommonParameters".
 
 # INPUTS
 
@@ -736,11 +736,11 @@ PS> .\Update-Month.ps1
 
 Example 2
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv
 
 Example 3
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv -outputPath
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv -OutputPath
 C:\Reports\2009\January.csv
 
 # RELATED LINKS
@@ -762,7 +762,7 @@ the keyword. Any other placement is ineffective.
 ```powershell
 # .EXTERNALHELP C:\MyScripts\Update-Month-Help.xml
 
-param ([string]$InputPath, [string]$OutPutPath)
+param ([string]$InputPath, [string]$OutputPath)
 function Get-Data { }
 ...
 ```
@@ -774,17 +774,17 @@ keyword in a function.
 function Add-Extension {
     # .EXTERNALHELP C:\ps-test\Add-Extension.xml
 
-    param ([string] $name, [string]$extension = "txt")
-    $name = $name + "." + $extension
-    $name
+    param ([string] $Name, [string]$Extension = "txt")
+    $Name = $Name + "." + $Extension
+    $Name
 }
 ```
 
 ```powershell
 function Add-Extension {
-    param ([string] $name, [string]$extension = "txt")
-    $name = $name + "." + $extension
-    $name
+    param ([string] $Name, [string]$Extension = "txt")
+    $Name = $Name + "." + $Extension
+    $Name
 
     # .EXTERNALHELP C:\ps-test\Add-Extension.xml
 }
@@ -793,9 +793,9 @@ function Add-Extension {
 ```powershell
 # .EXTERNALHELP C:\ps-test\Add-Extension.xml
 function Add-Extension {
-    param ([string] $name, [string]$extension = "txt")
-    $name = $name + "." + $extension
-    $name
+    param ([string] $Name, [string]$Extension = "txt")
+    $Name = $Name + "." + $Extension
+    $Name
 }
 ```
 
@@ -804,7 +804,7 @@ function Add-Extension {
 The following code is an excerpt from the beginning of the built-in help
 function in PowerShell, which displays one screen of help text at a time.
 Because the help topic for the `Get-Help` cmdlet describes the help function,
-the help function uses the `.ForwardHelpTargetName` and `.ForwardHelpCategory`
+the help function uses the `.FORWARDHELPTARGETNAME` and `.FORWARDHELPCATEGORY`
 keywords to redirect the user to the `Get-Help` cmdlet help topic.
 
 ```powershell

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Comments.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Comments.md
@@ -162,7 +162,7 @@ before the script is executed.
 # SIG # End signature block
 ```
 
-For more information, see [about_signing][10].
+For more information, see [about_Signing][10].
 
 ### Shebang
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -341,7 +341,7 @@ For example, the following command creates the `$out` variable and stores the
 process object in it:
 
 ```powershell
-Get-Process PowerShell -OutVariable out
+Get-Process powershell -OutVariable out
 ```
 
 The following command adds the process object to the `$out` variable:
@@ -410,13 +410,13 @@ Valid values are strings, the same as for any variable names.
 > a command after the blocking command.
 
 The following is an example of how **PipelineVariable** works. In this example,
-the **PipelineVariable** parameter is added to a `Foreach-Object` command to
+the **PipelineVariable** parameter is added to a `ForEach-Object` command to
 store the results of the command in variables. A range of numbers, 1 to 5, are
-piped into the first `Foreach-Object` command, the results of which are stored
+piped into the first `ForEach-Object` command, the results of which are stored
 in a variable named `$temp`.
 
-The results of the first `Foreach-Object` command are piped into a second
-`Foreach-Object` command, which displays the current values of `$temp` and
+The results of the first `ForEach-Object` command are piped into a second
+`ForEach-Object` command, which displays the current values of `$temp` and
 `$_`.
 
 ```powershell

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -162,8 +162,8 @@ The following example demonstrates the issue.
 
 ```powershell
 class MyFileInfoSet {
-    [String]$File
-    [Int64]$Size
+    [string]$File
+    [int64]$Size
 }
 $a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
 $b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
@@ -184,8 +184,8 @@ the File and Size properties of two **MyFileInfoSet** objects are the same.
 
 ```powershell
 class MyFileInfoSet : System.IEquatable[Object] {
-    [String]$File
-    [Int64]$Size
+    [string]$File
+    [int64]$Size
 
     [bool] Equals([Object] $obj) {
         return ($this.File -eq $obj.File) -and ($this.Size -eq $obj.Size)
@@ -319,7 +319,7 @@ Examples:
 
 ```powershell
 # Date comparison
-[DateTime]'2001-11-12' -lt [DateTime]'2020-08-01' # True
+[datetime]'2001-11-12' -lt [datetime]'2020-08-01' # True
 
 # Sorting order comparison
 'a' -lt 'z'           # True; 'a' comes before 'z'
@@ -505,7 +505,7 @@ such as renaming files. For example, the following command changes the file
 name extensions of all `.txt` files to `.log`:
 
 ```powershell
-Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
+Get-ChildItem *.txt | Rename-Item -NewName { $_.Name -replace '\.txt$','.log' }
 ```
 
 By default, the `-replace` operator is case-insensitive. To make it case
@@ -783,7 +783,7 @@ $a -isnot $b.GetType() # Output: True
 - [about_Regular_Expressions][10]
 - [about_Wildcards][11]
 - [Compare-Object][14]
-- [Foreach-Object][12]
+- [ForEach-Object][12]
 - [Where-Object][13]
 
 <!-- link references -->

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Core_Commands.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Core_Commands.md
@@ -18,7 +18,7 @@ PowerShell includes a set of cmdlets that are specifically designed to manage
 the items in the data stores that are exposed by PowerShell providers.
 You can use these cmdlets in the same ways to manage all the different types
 of data that the providers make available to you. For more information about
-providers, type "get-help about_providers".
+providers, type "Get-Help about_Providers".
 
 For example, you can use the Get-ChildItem cmdlet to list the files in a file
 system directory, the keys under a registry key, or the items that are exposed
@@ -86,7 +86,7 @@ PSProvider cmdlets
 
 - Get-PSProvider
 
-For more information about a cmdlet, type `get-help <cmdlet-name>`.
+For more information about a cmdlet, type `Get-Help <cmdlet-name>`.
 
 ## See also
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -204,8 +204,8 @@ class BookList {
     # Static method to initialize the list of books. Called in the other
     # static methods to avoid needing to explicit initialize the value.
     static [void] Initialize()             { [BookList]::Initialize($false) }
-    static [bool] Initialize([bool]$force) {
-        if ([BookList]::Books.Count -gt 0 -and -not $force) {
+    static [bool] Initialize([bool]$Force) {
+        if ([BookList]::Books.Count -gt 0 -and -not $Force) {
             return $false
         }
 
@@ -369,8 +369,8 @@ an error, such as `Global scope cannot be removed`.
 ```powershell
 # Class definition with Runspace affinity (default behavior)
 class UnsafeClass {
-    static [object] ShowRunspaceId($val) {
-        return [PSCustomObject]@{
+    static [Object] ShowRunspaceId($Val) {
+        return [pscustomobject]@{
             ThreadId   = [Threading.Thread]::CurrentThread.ManagedThreadId
             RunspaceId = [runspace]::DefaultRunspace.Id
         }
@@ -382,7 +382,7 @@ $unsafe = [UnsafeClass]::new()
 while ($true) {
     1..10 | ForEach-Object -Parallel {
         Start-Sleep -ms 100
-        ($using:unsafe)::ShowRunspaceId($_)
+        ($Using:unsafe)::ShowRunspaceId($_)
     }
 }
 ```
@@ -398,8 +398,8 @@ Runspace ids.
 # Class definition with NoRunspaceAffinity attribute
 [NoRunspaceAffinity()]
 class SafeClass {
-    static [object] ShowRunspaceId($val) {
-        return [PSCustomObject]@{
+    static [Object] ShowRunspaceId($Val) {
+        return [pscustomobject]@{
             ThreadId   = [Threading.Thread]::CurrentThread.ManagedThreadId
             RunspaceId = [runspace]::DefaultRunspace.Id
         }
@@ -411,7 +411,7 @@ $safe = [SafeClass]::new()
 while ($true) {
     1..10 | ForEach-Object -Parallel {
         Start-Sleep -ms 100
-        ($using:safe)::ShowRunspaceId($_)
+        ($Using:safe)::ShowRunspaceId($_)
     }
 }
 ```
@@ -608,7 +608,7 @@ module is removed, so are the type accelerators.
 
 ## Manually importing classes from a PowerShell module
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes aren't imported.
 
 If a module defines classes and enumerations but doesn't add type accelerators

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Classes_Constructors.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Classes_Constructors.md
@@ -308,7 +308,7 @@ class BaseExample {
         Write-Verbose "[$($Type.Name)] static constructor"
     }
 
-    static [void] ParamMessage([type]$Type, [object]$Value) {
+    static [void] ParamMessage([type]$Type, [Object]$Value) {
         Write-Verbose "[$($Type.Name)] param constructor ($Value)"
     }
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Classes_Inheritance.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Classes_Inheritance.md
@@ -58,14 +58,14 @@ declaration.
 This example shows the basic PowerShell class inheritance syntax.
 
 ```powershell
-Class Derived : Base {...}
+class Derived : Base {...}
 ```
 
 This example shows inheritance with an interface declaration coming after the
 base class.
 
 ```powershell
-Class Derived : Base, Interface {...}
+class Derived : Base, Interface {...}
 ```
 
 ## Syntax
@@ -656,7 +656,7 @@ Kelvin. For any other format, the method should throw a
     }
     # If format provider isn't specified, use the current culture.
     if ($null -eq $FormatProvider) {
-        $FormatProvider = [CultureInfo]::CurrentCulture
+        $FormatProvider = [cultureinfo]::CurrentCulture
     }
     # Format the temperature.
     switch ($Format) {
@@ -747,7 +747,7 @@ class Temperature : System.IFormattable {
         }
         # If format provider isn't specified, use the current culture.
         if ($null -eq $FormatProvider) {
-            $FormatProvider = [CultureInfo]::CurrentCulture
+            $FormatProvider = [cultureinfo]::CurrentCulture
         }
         # Format the temperature.
         switch ($Format) {
@@ -814,7 +814,7 @@ To implement the interface, the class needs to inherit from
 method needs to have the following signature:
 
 ```powershell
-[bool] Equals([object]$Other) {
+[bool] Equals([Object]$Other) {
     # Implementation
 }
 ```
@@ -829,7 +829,7 @@ values to Kelvin, since temperatures can be equivalent even with different
 scales.
 
 ```powershell
-[bool] Equals([object]$Other) {
+[bool] Equals([Object]$Other) {
     # If the other object is null, we can't compare it.
     if ($null -eq $Other) {
         return $false
@@ -850,7 +850,7 @@ With the interface method implemented, the updated definition for
 **Temperature** is:
 
 ```powershell
-class Temperature : System.IFormattable, System.IEquatable[object] {
+class Temperature : System.IFormattable, System.IEquatable[Object] {
     [float]            $Degrees
     [TemperatureScale] $Scale
 
@@ -898,7 +898,7 @@ class Temperature : System.IFormattable, System.IEquatable[object] {
         }
         # If format provider isn't specified, use the current culture.
         if ($null -eq $FormatProvider) {
-            $FormatProvider = [CultureInfo]::CurrentCulture
+            $FormatProvider = [cultureinfo]::CurrentCulture
         }
         # Format the temperature.
         switch ($Format) {
@@ -926,7 +926,7 @@ class Temperature : System.IFormattable, System.IEquatable[object] {
         return $this.ToString($null, $null)
     }
 
-    [bool] Equals([object]$Other) {
+    [bool] Equals([Object]$Other) {
         # If the other object is null, we can't compare it.
         if ($null -eq $Other) {
             return $false
@@ -998,7 +998,7 @@ converted to a different scale, is a floating point number, the method can rely
 on the underlying type for the actual comparison.
 
 ```powershell
-[int] CompareTo([object]$Other) {
+[int] CompareTo([Object]$Other) {
     # If the other object's null, consider this instance "greater than" it
     if ($null -eq $Other) {
         return 1
@@ -1020,7 +1020,7 @@ The final definition for the **Temperature** class is:
 ```powershell
 class Temperature : System.IFormattable,
                     System.IComparable,
-                    System.IEquatable[object] {
+                    System.IEquatable[Object] {
     # Instance properties
     [float]            $Degrees
     [TemperatureScale] $Scale
@@ -1070,7 +1070,7 @@ class Temperature : System.IFormattable,
         }
         # If format provider isn't specified, use the current culture.
         if ($null -eq $FormatProvider) {
-            $FormatProvider = [CultureInfo]::CurrentCulture
+            $FormatProvider = [cultureinfo]::CurrentCulture
         }
         # Format the temperature.
         switch ($Format) {
@@ -1098,7 +1098,7 @@ class Temperature : System.IFormattable,
         return $this.ToString($null, $null)
     }
 
-    [bool] Equals([object]$Other) {
+    [bool] Equals([Object]$Other) {
         # If the other object is null, we can't compare it.
         if ($null -eq $Other) {
             return $false
@@ -1111,7 +1111,7 @@ class Temperature : System.IFormattable,
         # Compare the temperatures as Kelvin.
         return $this.ToKelvin() -eq $OtherTemperature.ToKelvin()
     }
-    [int] CompareTo([object]$Other) {
+    [int] CompareTo([Object]$Other) {
         # If the other object's null, consider this instance "greater than" it
         if ($null -eq $Other) {
             return 1
@@ -1181,7 +1181,7 @@ generic type as long as the type parameter is already defined at parse time.
 ```powershell
 class ExampleStringList : System.Collections.Generic.List[string] {}
 
-$List = [ExampleStringList]::New()
+$List = [ExampleStringList]::new()
 $List.AddRange([string[]]@('a','b','c'))
 $List.GetType() | Format-List -Property Name, BaseType
 $List
@@ -1239,7 +1239,7 @@ This time, PowerShell doesn't raise any errors. Both classes are now defined.
 Run the following code block to view the behavior of the new class.
 
 ```powershell
-$List = [ExampleItemList]::New()
+$List = [ExampleItemList]::new()
 $List.AddRange([ExampleItem[]]@(
     [ExampleItem]@{ Name = 'Foo' }
     [ExampleItem]@{ Name = 'Bar' }

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Classes_Methods.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Classes_Methods.md
@@ -603,17 +603,17 @@ class. The representation for **DerivedClassB** is different because it
 overrode the `ToString()` instance method.
 
 ```powershell
-"`$base = [BaseClass]::New()     => $($base = [BaseClass]::New(); $base)"
-"`$a    = [DerivedClassA]::New() => $($a = [DerivedClassA]::New(); $a)"
-"`$b    = [DerivedClassB]::New() => $($b = [DerivedClassB]::New(); $b)"
-"`$c    = [DerivedClassC]::New() => $($c = [DerivedClassC]::New(); $c)"
+"`$base = [BaseClass]::new()     => $($base = [BaseClass]::new(); $base)"
+"`$a    = [DerivedClassA]::new() => $($a = [DerivedClassA]::new(); $a)"
+"`$b    = [DerivedClassB]::new() => $($b = [DerivedClassB]::new(); $b)"
+"`$c    = [DerivedClassC]::new() => $($c = [DerivedClassC]::new(); $c)"
 ```
 
 ```Output
-$base = [BaseClass]::New()     => 11/6/2023 9:44:57 AM
-$a    = [DerivedClassA]::New() => 11/6/2023 9:44:57 AM
-$b    = [DerivedClassB]::New() => 2023-11-06
-$c    = [DerivedClassC]::New() => 11/6/2023 9:44:57 AM
+$base = [BaseClass]::new()     => 11/6/2023 9:44:57 AM
+$a    = [DerivedClassA]::new() => 11/6/2023 9:44:57 AM
+$b    = [DerivedClassB]::new() => 2023-11-06
+$c    = [DerivedClassC]::new() => 11/6/2023 9:44:57 AM
 ```
 
 The next block calls the `SetTimeStamp()` instance method for each instance,

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -38,7 +38,7 @@ C:\TechDocs\FindDocs.ps1
 You can run any executable command using its full path. As a security feature,
 PowerShell doesn't run executable commands, including PowerShell scripts and
 native commands, unless the command is located in a path listed in the
-`$env:Path` environment variable.
+`$Env:PATH` environment variable.
 
 To run an executable file that's in the current directory, specify the full
 path or use the relative path `.\` to represent the current directory.
@@ -58,7 +58,7 @@ when it runs commands.
 1. External executable files (including PowerShell script files)
 
 Therefore, if you type `help`, PowerShell first looks for an alias named
-`help`, then a function named `Help`, and finally a cmdlet named `Help`. It
+`help`, then a function named `help`, and finally a cmdlet named `help`. It
 runs the first `help` item that it finds.
 
 For example, if your session contains a cmdlet and a function, both named
@@ -247,7 +247,7 @@ For example, the following command saves the `Map` function in the `$myMap`
 variable and then uses the `Call` operator to run it.
 
 ```powershell
-$myMap = (Get-Command -Name map -CommandType function)
+$myMap = (Get-Command -Name map -CommandType Function)
 & ($myMap)
 ```
 
@@ -273,7 +273,7 @@ first module found alphabetically.
 
 If the cmdlet isn't loaded, PowerShell searches the installed modules and
 autoloads the first module that contains the cmdlet and runs that cmdlet.
-PowerShell searches for modules in each path defined in the `$env:PSModulePath`
+PowerShell searches for modules in each path defined in the `$Env:PSModulePath`
 environment variable. The paths are searched in the order that they're listed
 in the variable. Within each path, the modules are searched in alphabetical
 order. PowerShell uses the cmdlet from the first match it finds.
@@ -299,7 +299,7 @@ Import-Module -Name DateFunctions -Prefix ZZ
 
 ## Running external executables
 
-On Windows. PowerShell treats the file extensions listed in the `$env:PATHEXT`
+On Windows. PowerShell treats the file extensions listed in the `$Env:PATHEXT`
 environment variable as executable files. Files that aren't Windows executables
 are handed to Windows to process. Windows looks up the file association and
 executes the default Windows Shell verb for the extension. For Windows to
@@ -312,7 +312,7 @@ to register the file handler. For more information, see the documentation for
 the [ftype][04] command.
 
 For PowerShell to see a file extension as executable in the current session,
-you must add the extension to the `$env:PATHEXT` environment variable.
+you must add the extension to the `$Env:PATHEXT` environment variable.
 
 ## See also
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -70,12 +70,12 @@ Keywords define each section of comment-based help. Each comment-based help
 keyword is preceded by a dot `.`. The keywords can appear in any order. The
 keyword names aren't case-sensitive.
 
-For example, the `.Description` keyword precedes a description of a function or
+For example, the `.DESCRIPTION` keyword precedes a description of a function or
 script.
 
 ```powershell
 <#
-.Description
+.DESCRIPTION
 Get-Function displays the name and syntax of all functions in the session.
 #>
 ```
@@ -220,8 +220,8 @@ ignored.
 function Verb-Noun {
     [CmdletBinding()]
     param (
-        # This is the same as .Parameter
-        [string]$Computername
+        # This is the same as .PARAMETER
+        [string]$ComputerName
     )
     # Verb the Noun on the computer
 }
@@ -256,7 +256,7 @@ Repeat the `.LINK` keyword for each related topic.
 
 This content appears in the Related Links section of the help topic.
 
-The `.Link` keyword content can also include a Uniform Resource Identifier
+The `.LINK` keyword content can also include a Uniform Resource Identifier
 (URI) to an online version of the same help topic. The online version opens
 when you use the **Online** parameter of `Get-Help`. The URI must begin with
 "http" or "https".
@@ -290,7 +290,7 @@ provider.
 
 ### .FORWARDHELPCATEGORY
 
-Specifies the help category of the item in `.ForwardHelpTargetName`. Valid
+Specifies the help category of the item in `.FORWARDHELPTARGETNAME`. Valid
 values are `Alias`, `Cmdlet`, `HelpFile`, `Function`, `Provider`, `General`,
 `FAQ`, `Glossary`, `ScriptCommand`, `ExternalScript`, `Filter`, or `All`. Use
 this keyword to avoid conflicts when there are commands with the same name.
@@ -369,11 +369,11 @@ type, the **Object** type is inserted as the default value.
 ### Parameter List
 
 The parameter list in the help topic is generated from the function or script
-syntax and from the descriptions that you add by using the `.Parameter`
+syntax and from the descriptions that you add by using the `.PARAMETER`
 keyword. The function parameters appear in the **Parameters** section of the
 help topic in the same order that they appear in the function or script syntax.
 The spelling and capitalization of parameter names is also taken from the
-syntax. It isn't affected by the parameter name specified by the `.Parameter`
+syntax. It isn't affected by the parameter name specified by the `.PARAMETER`
 keyword.
 
 ### Common Parameters
@@ -408,8 +408,8 @@ The following sample function includes comment-based help:
 function Add-Extension
 {
 param ([string]$Name,[string]$Extension = "txt")
-$name = $name + "." + $extension
-$name
+$Name = $Name + "." + $Extension
+$Name
 
 <#
 .SYNOPSIS
@@ -438,17 +438,17 @@ or file name.
 
 .EXAMPLE
 
-PS> extension -name "File"
+PS> Add-Extension -Name "File"
 File.txt
 
 .EXAMPLE
 
-PS> extension -name "File" -extension "doc"
+PS> Add-Extension -Name "File" -Extension "doc"
 File.doc
 
 .EXAMPLE
 
-PS> extension "File" "doc"
+PS> Add-Extension "File" "doc"
 File.doc
 
 .LINK
@@ -511,7 +511,7 @@ Accept wildcard characters?
 This cmdlet supports the common parameters: -Verbose, -Debug,
 -ErrorAction, -ErrorVariable, -WarningAction, -WarningVariable,
 -OutBuffer and -OutVariable. For more information, type
-"get-help about_commonparameters".
+"Get-Help about_CommonParameters".
 
 INPUTS
 None. You can't pipe objects to Add-Extension.
@@ -523,17 +523,17 @@ file name.
 
 Example 1
 
-PS> extension -name "File"
+PS> Add-Extension -Name "File"
 File.txt
 
 Example 2
 
-PS> extension -name "File" -extension "doc"
+PS> Add-Extension -Name "File" -Extension "doc"
 File.doc
 
 Example 3
 
-PS> extension "File" "doc"
+PS> Add-Extension "File" "doc"
 File.doc
 
 RELATED LINKS
@@ -556,15 +556,15 @@ param
 
 [string]
 #Specifies the file name.
-$name,
+$Name,
 
 [string]
 #Specifies the file name extension. "Txt" is the default.
-$extension = "txt"
+$Extension = "txt"
 )
 
-$name = $name + "." + $extension
-$name
+$Name = $Name + "." + $Extension
+$Name
 
 <#
 .SYNOPSIS
@@ -587,17 +587,17 @@ file name.
 
 .EXAMPLE
 
-PS> extension -name "File"
+PS> Add-Extension -Name "File"
 File.txt
 
 .EXAMPLE
 
-PS> extension -name "File" -extension "doc"
+PS> Add-Extension -Name "File" -Extension "doc"
 File.doc
 
 .EXAMPLE
 
-PS> extension "File" "doc"
+PS> Add-Extension "File" "doc"
 File.doc
 
 .LINK
@@ -614,8 +614,8 @@ Set-Item
 ### Comment-based Help for a Script
 
 The following sample script includes comment-based help. Notice the blank lines
-between the closing `#>` and the `Param` statement. In a script that doesn't
-have a `Param` statement, there must be at least two blank lines between the
+between the closing `#>` and the `param` statement. In a script that doesn't
+have a `param` statement, there must be at least two blank lines between the
 final comment in the help topic and the first function declaration. Without
 these blank lines, `Get-Help` associates the help topic with the function, not
 the script.
@@ -653,22 +653,22 @@ PS> .\Update-Month.ps1
 
 .EXAMPLE
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv
 
 .EXAMPLE
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv -outputPath `
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv -OutputPath `
 C:\Reports\2009\January.csv
 #>
 
-param ([string]$InputPath, [string]$OutPutPath)
+param ([string]$InputPath, [string]$OutputPath)
 
 function Get-Data { }
 ...
 ```
 
 The following command gets the script help. Because the script isn't in a
-directory that's listed in the `$env:Path` environment variable, the
+directory that's listed in the `$Env:PATH` environment variable, the
 `Get-Help` command that gets the script help must specify the script path.
 
 ```powershell
@@ -720,7 +720,7 @@ Accept wildcard characters?
 This cmdlet supports the common parameters: -Verbose, -Debug,
 -ErrorAction, -ErrorVariable, -WarningAction, -WarningVariable,
 -OutBuffer and -OutVariable. For more information, type,
-"get-help about_commonparameters".
+"Get-Help about_CommonParameters".
 
 # INPUTS
 
@@ -736,11 +736,11 @@ PS> .\Update-Month.ps1
 
 Example 2
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv
 
 Example 3
 
-PS> .\Update-Month.ps1 -inputpath C:\Data\January.csv -outputPath
+PS> .\Update-Month.ps1 -InputPath C:\Data\January.csv -OutputPath
 C:\Reports\2009\January.csv
 
 # RELATED LINKS
@@ -762,7 +762,7 @@ the keyword. Any other placement is ineffective.
 ```powershell
 # .EXTERNALHELP C:\MyScripts\Update-Month-Help.xml
 
-param ([string]$InputPath, [string]$OutPutPath)
+param ([string]$InputPath, [string]$OutputPath)
 function Get-Data { }
 ...
 ```
@@ -774,17 +774,17 @@ keyword in a function.
 function Add-Extension {
     # .EXTERNALHELP C:\ps-test\Add-Extension.xml
 
-    param ([string] $name, [string]$extension = "txt")
-    $name = $name + "." + $extension
-    $name
+    param ([string] $Name, [string]$Extension = "txt")
+    $Name = $Name + "." + $Extension
+    $Name
 }
 ```
 
 ```powershell
 function Add-Extension {
-    param ([string] $name, [string]$extension = "txt")
-    $name = $name + "." + $extension
-    $name
+    param ([string] $Name, [string]$Extension = "txt")
+    $Name = $Name + "." + $Extension
+    $Name
 
     # .EXTERNALHELP C:\ps-test\Add-Extension.xml
 }
@@ -793,9 +793,9 @@ function Add-Extension {
 ```powershell
 # .EXTERNALHELP C:\ps-test\Add-Extension.xml
 function Add-Extension {
-    param ([string] $name, [string]$extension = "txt")
-    $name = $name + "." + $extension
-    $name
+    param ([string] $Name, [string]$Extension = "txt")
+    $Name = $Name + "." + $Extension
+    $Name
 }
 ```
 
@@ -804,7 +804,7 @@ function Add-Extension {
 The following code is an excerpt from the beginning of the built-in help
 function in PowerShell, which displays one screen of help text at a time.
 Because the help topic for the `Get-Help` cmdlet describes the help function,
-the help function uses the `.ForwardHelpTargetName` and `.ForwardHelpCategory`
+the help function uses the `.FORWARDHELPTARGETNAME` and `.FORWARDHELPCATEGORY`
 keywords to redirect the user to the `Get-Help` cmdlet help topic.
 
 ```powershell

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Comments.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Comments.md
@@ -162,7 +162,7 @@ before the script is executed.
 # SIG # End signature block
 ```
 
-For more information, see [about_signing][10].
+For more information, see [about_Signing][10].
 
 ### Shebang
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -341,7 +341,7 @@ For example, the following command creates the `$out` variable and stores the
 process object in it:
 
 ```powershell
-Get-Process PowerShell -OutVariable out
+Get-Process powershell -OutVariable out
 ```
 
 The following command adds the process object to the `$out` variable:
@@ -410,13 +410,13 @@ Valid values are strings, the same as for any variable names.
 > a command after the blocking command.
 
 The following is an example of how **PipelineVariable** works. In this example,
-the **PipelineVariable** parameter is added to a `Foreach-Object` command to
+the **PipelineVariable** parameter is added to a `ForEach-Object` command to
 store the results of the command in variables. A range of numbers, 1 to 5, are
-piped into the first `Foreach-Object` command, the results of which are stored
+piped into the first `ForEach-Object` command, the results of which are stored
 in a variable named `$temp`.
 
-The results of the first `Foreach-Object` command are piped into a second
-`Foreach-Object` command, which displays the current values of `$temp` and
+The results of the first `ForEach-Object` command are piped into a second
+`ForEach-Object` command, which displays the current values of `$temp` and
 `$_`.
 
 ```powershell

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -162,8 +162,8 @@ The following example demonstrates the issue.
 
 ```powershell
 class MyFileInfoSet {
-    [String]$File
-    [Int64]$Size
+    [string]$File
+    [int64]$Size
 }
 $a = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
 $b = [MyFileInfoSet]@{File = "C:\Windows\explorer.exe"; Size = 4651032}
@@ -184,8 +184,8 @@ the File and Size properties of two **MyFileInfoSet** objects are the same.
 
 ```powershell
 class MyFileInfoSet : System.IEquatable[Object] {
-    [String]$File
-    [Int64]$Size
+    [string]$File
+    [int64]$Size
 
     [bool] Equals([Object] $obj) {
         return ($this.File -eq $obj.File) -and ($this.Size -eq $obj.Size)
@@ -319,7 +319,7 @@ Examples:
 
 ```powershell
 # Date comparison
-[DateTime]'2001-11-12' -lt [DateTime]'2020-08-01' # True
+[datetime]'2001-11-12' -lt [datetime]'2020-08-01' # True
 
 # Sorting order comparison
 'a' -lt 'z'           # True; 'a' comes before 'z'
@@ -505,7 +505,7 @@ such as renaming files. For example, the following command changes the file
 name extensions of all `.txt` files to `.log`:
 
 ```powershell
-Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
+Get-ChildItem *.txt | Rename-Item -NewName { $_.Name -replace '\.txt$','.log' }
 ```
 
 By default, the `-replace` operator is case-insensitive. To make it case
@@ -783,7 +783,7 @@ $a -isnot $b.GetType() # Output: True
 - [about_Regular_Expressions][10]
 - [about_Wildcards][11]
 - [Compare-Object][14]
-- [Foreach-Object][12]
+- [ForEach-Object][12]
 - [Where-Object][13]
 
 <!-- link references -->

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Core_Commands.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Core_Commands.md
@@ -18,7 +18,7 @@ PowerShell includes a set of cmdlets that are specifically designed to manage
 the items in the data stores that are exposed by PowerShell providers.
 You can use these cmdlets in the same ways to manage all the different types
 of data that the providers make available to you. For more information about
-providers, type "get-help about_providers".
+providers, type "Get-Help about_Providers".
 
 For example, you can use the Get-ChildItem cmdlet to list the files in a file
 system directory, the keys under a registry key, or the items that are exposed
@@ -86,7 +86,7 @@ PSProvider cmdlets
 
 - Get-PSProvider
 
-For more information about a cmdlet, type `get-help <cmdlet-name>`.
+For more information about a cmdlet, type `Get-Help <cmdlet-name>`.
 
 ## See also
 


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide