### PR TITLE
Fix incorrect case/capitalization in reference documents (4/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Files.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Files.md
@@ -1,5 +1,5 @@
 ---
-description: Describes how to use PowerShell data (.psd1) files.
+description: Describes how to use PowerShell data (`.psd1`) files.
 Locale: en-US
 ms.date: 01/19/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_data_files?view=powershell-5.1&WT.mc_id=ps-gethelp
@@ -55,7 +55,7 @@ you aren't limited to storing string data and don't have to use the data for
 localized output.
 
 The data in the file isn't limited to hashtables. It can be in any format
-supported by the PowerShell syntax, such as `DATA` sections.
+supported by the PowerShell syntax, such as `data` sections.
 
 For more information, see [about_Data_Sections][01].
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -10,14 +10,14 @@ title: about_Data_Sections
 
 ## Short description
 
-Explains `DATA` sections, which isolate text strings and other read-only
+Explains `data` sections, which isolate text strings and other read-only
 data from script logic.
 
 ## Long description
 
-Scripts that are designed for PowerShell can have one or more `DATA` sections
-that contain only data. You can include one or more `DATA` sections in any
-script, function, or advanced function. The content of the `DATA` section is
+Scripts that are designed for PowerShell can have one or more `data` sections
+that contain only data. You can include one or more `data` sections in any
+script, function, or advanced function. The content of the `data` section is
 restricted to a specified subset of the PowerShell scripting language.
 
 Separating data from code logic makes it easier to identify and manage both
@@ -25,27 +25,27 @@ logic and data. It lets you have separate string resource files for text, such
 as error messages and Help strings. It also isolates the code logic, which
 facilitates security and validation tests.
 
-In PowerShell, you can use the `DATA` section to support script
-internationalization. You can use `DATA` sections to make it easier to isolate,
+In PowerShell, you can use the `data` section to support script
+internationalization. You can use `data` sections to make it easier to isolate,
 locate, and process strings that can be translated into other languages.
 
-The `DATA` section was added in PowerShell 2.0 feature.
+The `data` section was added in PowerShell 2.0 feature.
 
 ### Syntax
 
-The syntax for a `DATA` section is as follows:
+The syntax for a `data` section is as follows:
 
 ```Syntax
-DATA [<variable-name>] [-supportedCommand <cmdlet-name>] {
+data [<variable-name>] [-SupportedCommand <cmdlet-name>] {
     <Permitted content>
 }
 ```
 
-The `DATA` keyword is required. It isn't case-sensitive. The permitted content
+The `data` keyword is required. It isn't case-sensitive. The permitted content
 is limited to the following elements:
 
 - All PowerShell operators, except `-match`
-- `If`, `Else`, and `ElseIf` statements
+- `if`, `else`, and `elseif` statements
 - The following automatic variables: `$PSCulture`, `$PSUICulture`, `$true`,
   `$false`, and `$null`
 - Comments
@@ -60,17 +60,17 @@ is limited to the following elements:
   "PowerShell 2.0"
   @( "red", "green", "blue" )
   @{ a = 0x1; b = "great"; c ="script" }
-  [XML] @'
+  [xml] @'
   <p> Hello, World </p>
   '@
   ```
 
-- Cmdlets that are permitted in a `DATA` section. By default, only the
+- Cmdlets that are permitted in a `data` section. By default, only the
   `ConvertFrom-StringData` cmdlet is permitted.
-- Cmdlets that you permit in a `DATA` section by using the `-SupportedCommand`
+- Cmdlets that you permit in a `data` section by using the `-SupportedCommand`
   parameter.
 
-When you use the `ConvertFrom-StringData` cmdlet in a `DATA` section, you can
+When you use the `ConvertFrom-StringData` cmdlet in a `data` section, you can
 enclose the key-value pairs in single-quoted or double-quoted strings or in
 single-quoted or double-quoted here-strings. However, strings that contain
 variables and subexpressions must be enclosed in single-quoted strings or in
@@ -81,34 +81,34 @@ subexpressions aren't executable.
 
 The **SupportedCommand** parameter allows you to indicate that a cmdlet or
 function generates only data. It's designed to allow users to include cmdlets
-and functions in a `DATA` section that they have written or tested.
+and functions in a `data` section that they have written or tested.
 
 The value of **SupportedCommand** is a comma-separated list of one or more
 cmdlet or function names.
 
-For example, the following `DATA` section includes a user-written cmdlet,
+For example, the following `data` section includes a user-written cmdlet,
 `Format-Xml`, that formats data in an XML file:
 
 ```powershell
-DATA -supportedCommand Format-Xml
+data -SupportedCommand Format-Xml
 {
     Format-Xml -Strings string1, string2, string3
 }
 ```
 
-### Using a `DATA` Section
+### Using a `data` Section
 
-To use the content of a `DATA` section, assign it to a variable and use
+To use the content of a `data` section, assign it to a variable and use
 variable notation to access the content.
 
-For example, the following `DATA` section contains a `ConvertFrom-StringData`
+For example, the following `data` section contains a `ConvertFrom-StringData`
 command that converts the here-string into a hash table. The hash table is
 assigned to the `$TextMsgs` variable.
 
-The `$TextMsgs` variable isn't part of the `DATA` section.
+The `$TextMsgs` variable isn't part of the `data` section.
 
 ```powershell
-$TextMsgs = DATA {
+$TextMsgs = data {
     ConvertFrom-StringData -StringData @'
 Text001 = Windows 7
 Text002 = Windows Server 2008 R2
@@ -124,11 +124,11 @@ $TextMsgs.Text001
 $TextMsgs.Text002
 ```
 
-Alternately, you can put the variable name in the definition of the `DATA`
+Alternately, you can put the variable name in the definition of the `data`
 section. For example:
 
 ```powershell
-DATA TextMsgs {
+data TextMsgs {
     ConvertFrom-StringData -StringData @'
 Text001 = Windows 7
 Text002 = Windows Server 2008 R2
@@ -152,7 +152,7 @@ Text002                        Windows Server 2008 R2
 Simple data strings.
 
 ```powershell
-DATA {
+data {
     "Thank you for using my PowerShell Organize.pst script."
     "It is provided free of charge to the community."
     "I appreciate your comments and feedback."
@@ -162,9 +162,9 @@ DATA {
 Strings that include permitted variables.
 
 ```powershell
-DATA {
+data {
     if ($null) {
-        "To get help for this cmdlet, type get-help new-dictionary."
+        "To get help for this cmdlet, type Get-Help New-Dictionary."
     }
 }
 ```
@@ -172,7 +172,7 @@ DATA {
 A single-quoted here-string that uses the `ConvertFrom-StringData` cmdlet:
 
 ```powershell
-DATA {
+data {
     ConvertFrom-StringData -StringData @'
 Text001 = Windows 7
 Text002 = Windows Server 2008 R2
@@ -183,7 +183,7 @@ Text002 = Windows Server 2008 R2
 A double-quoted here-string that uses the `ConvertFrom-StringData` cmdlet:
 
 ```powershell
-DATA  {
+data {
     ConvertFrom-StringData -StringData @"
 Msg1 = To start, press any key.
 Msg2 = To exit, type "quit".
@@ -194,7 +194,7 @@ Msg2 = To exit, type "quit".
 A data section that includes a user-written cmdlet that generates data:
 
 ```powershell
-DATA -supportedCommand Format-XML {
+data -SupportedCommand Format-Xml {
     Format-Xml -Strings string1, string2, string3
 }
 ```

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -96,7 +96,7 @@ menu.
   you are debugging a job by running the `Debug-Job` cmdlet, the `Exit` command
   detaches the debugger, and allows the job to continue running.
 
-- `k`, `Get-PsCallStack`: Displays the current call stack.
+- `k`, `Get-PSCallStack`: Displays the current call stack.
 
 - `<Enter>`: Repeats the last command if it was `Step` (`s`), `StepOver` (`v`),
   or `List` (`l`). Otherwise, represents a submit action.
@@ -308,7 +308,7 @@ sections, the debugger breaks at the first line of each section.
 For example:
 
 ```powershell
-function test-cmdlet {
+function Test-Cmdlet {
     begin {
         Write-Output "Begin"
     }
@@ -320,32 +320,32 @@ function test-cmdlet {
     }
 }
 
-C:\PS> Set-PSBreakpoint -Command test-cmdlet
+C:\PS> Set-PSBreakpoint -Command Test-Cmdlet
 
-C:\PS> test-cmdlet
+C:\PS> Test-Cmdlet
 
 Begin
 Entering debug mode. Use h or ? for help.
 
-Hit Command breakpoint on 'prompt:test-cmdlet'
+Hit Command breakpoint on 'prompt:Test-Cmdlet'
 
-test-cmdlet
+Test-Cmdlet
 
 [DBG]: C:\PS> c
 Process
 Entering debug mode. Use h or ? for help.
 
-Hit Command breakpoint on 'prompt:test-cmdlet'
+Hit Command breakpoint on 'prompt:Test-Cmdlet'
 
-test-cmdlet
+Test-Cmdlet
 
 [DBG]: C:\PS> c
 End
 Entering debug mode. Use h or ? for help.
 
-Hit Command breakpoint on 'prompt:test-cmdlet'
+Hit Command breakpoint on 'prompt:Test-Cmdlet'
 
-test-cmdlet
+Test-Cmdlet
 
 [DBG]: C:\PS>
 ```
@@ -436,7 +436,7 @@ function psversion {
     "Upgrade to PowerShell 7!"
   }
   else {
-    "Have you run a background job today (start-job)?"
+    "Have you run a background job today (Start-Job)?"
   }
 }
 
@@ -545,7 +545,7 @@ steps to the next statement in the script.
 ```powershell
 DBG> o
 Windows PowerShell 2.0
-Have you run a background job today (start-job)?
+Have you run a background job today (Start-Job)?
 test.ps1:13  "Done $scriptName"
 ```
 
@@ -562,9 +562,9 @@ indicates that the debugger has exited and returned control to the command
 processor.
 
 Now, run the debugger again. First, to delete the current breakpoint, use the
-`Get-PsBreakpoint` and `Remove-PsBreakpoint` cmdlets. (If you think you might
-reuse the breakpoint, use the `Disable-PsBreakpoint` cmdlet instead of
-`Remove-PsBreakpoint`.)
+`Get-PSBreakpoint` and `Remove-PSBreakpoint` cmdlets. (If you think you might
+reuse the breakpoint, use the `Disable-PSBreakpoint` cmdlet instead of
+`Remove-PSBreakpoint`.)
 
 ```powershell
 PS C:\ps-test> Get-PSBreakpoint | Remove-PSBreakpoint
@@ -638,7 +638,7 @@ displayed, but it isn't executed.
 ```powershell
 DBG> v
 Windows PowerShell 2.0
-Have you run a background job today (start-job)?
+Have you run a background job today (Start-Job)?
 test.ps1:13  "Done $scriptName"
 ```
 
@@ -652,7 +652,7 @@ the standard command prompt.
 C:\ps-test>
 ```
 
-To delete the breakpoints, use the `Get-PsBreakpoint` and `Remove-PsBreakpoint`
+To delete the breakpoints, use the `Get-PSBreakpoint` and `Remove-PSBreakpoint`
 cmdlets.
 
 ```powershell
@@ -688,13 +688,13 @@ the breakpoint or to perform preparatory or diagnostic tasks, such as starting
 a log or invoking a diagnostic or security script.
 
 To set an action, use a Continue command (c) to exit the script, and a
-`Remove-PsBreakpoint` command to delete the current breakpoint. (Breakpoints
+`Remove-PSBreakpoint` command to delete the current breakpoint. (Breakpoints
 are read-only, so you can't add an action to the current breakpoint.)
 
 ```powershell
 DBG> c
 Windows PowerShell 2.0
-Have you run a background job today (start-job)?
+Have you run a background job today (Start-Job)?
 Done C:\ps-test\test.ps1
 
 PS C:\ps-test> Get-PSBreakpoint | Remove-PSBreakpoint
@@ -741,7 +741,7 @@ Because the execution policy is set to **RemoteSigned**, execution stops at the
 function call.
 
 At this point, you might want to check the call stack. Use the
-`Get-PsCallStack` cmdlet or the `Get-PsCallStack` debugger command (`k`). The
+`Get-PSCallStack` cmdlet or the `Get-PSCallStack` debugger command (`k`). The
 following command gets the current call stack.
 
 ```powershell

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Do.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Do.md
@@ -1,5 +1,5 @@
 ---
-description: Runs a statement list one or more times, subject to a While or Until condition.
+description: Runs a statement list one or more times, subject to a `while` or `until` condition.
 Locale: en-US
 ms.date: 06/10/2021
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_do?view=powershell-5.1&WT.mc_id=ps-gethelp
@@ -9,24 +9,24 @@ title: about_Do
 # about_Do
 
 ## Short description
-Runs a statement list one or more times, subject to a `While` or `Until`
+Runs a statement list one or more times, subject to a `while` or `until`
 condition.
 
 ## Long description
 
-The `Do` keyword works with the `While` keyword or the `Until` keyword to run
+The `do` keyword works with the `while` keyword or the `until` keyword to run
 the statements in a script block, subject to a condition. Unlike the related
-`While` loop, the script block in a `Do` loop always runs at least once.
+`while` loop, the script block in a `do` loop always runs at least once.
 
-A **Do-While** loop is a variety of the `While` loop. In a **Do-While** loop,
-the condition is evaluated after the script block has run. As in a While loop,
-the script block is repeated as long as the condition evaluates to true.
+A **Do-While** loop is a variety of the `while` loop. In a **Do-While** loop,
+the condition is evaluated after the script block has run. As in a `while`
+loop, the script block is repeated as long as the condition evaluates to true.
 
 Like a **Do-While** loop, a **Do-Until** loop always runs at least once
 before the condition is evaluated. However, the script block runs only
 while the condition is false.
 
-The `Continue` and `Break` flow control keywords can be used in a **Do-While**
+The `continue` and `break` flow control keywords can be used in a **Do-While**
 loop or in a **Do-Until** loop.
 
 ### Syntax
@@ -52,7 +52,7 @@ information about how booleans are evaluated, see
 
 ### Example
 
-The following example of a `Do` statement counts the items in an array until it
+The following example of a `do` statement counts the items in an array until it
 reaches an item with a value of 0.
 
 ```powershell
@@ -62,7 +62,7 @@ PS> $count
 3
 ```
 
-The following example uses the `Until` keyword. Notice that the not equal to
+The following example uses the `until` keyword. Notice that the not equal to
 operator (`-ne`) is replaced by the equal to operator (`-eq`).
 
 ```powershell

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -45,7 +45,7 @@ Enumerations use the following syntaxes:
 ### Flag enumeration definition syntax
 
 ```Syntax
-[[<attribute>]...] [Flag()] enum <enum-name>[ : <underlying-type-name>] {
+[[<attribute>]...] [Flags()] enum <enum-name>[ : <underlying-type-name>] {
     <label 0> [= 1]
     <label 1> [= 2]
     <label 2> [= 4]
@@ -400,11 +400,11 @@ You can use the static method on the **System.Enum** base class type or a
 specific enumeration type.
 
 ```Syntax
-[System.Enum]::format([<enum-name>], <value>, <format-string>)
+[System.Enum]::Format([<enum-name>], <value>, <format-string>)
 ```
 
 ```Syntax
-[<enum-name>]::format([<enum-name>], <value>, <format-string>)
+[<enum-name>]::Format([<enum-name>], <value>, <format-string>)
 ```
 
 The valid format strings are `G` or `g`, `D` or `d`, `X` or `x`, and `F` or
@@ -712,7 +712,7 @@ enum Shade {
     Black
 }
 
-[Shade].GetEnumValues() | Foreach-Object -Process {
+[Shade].GetEnumValues() | ForEach-Object -Process {
     [pscustomobject]@{
         EnumValue    = $_
         StringValue  = $_.ToString()
@@ -1010,7 +1010,7 @@ module is removed, so are the type accelerators.
 
 ## Manually importing enumerations from a PowerShell module
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Enumerations aren't imported.
 
 If a module defines classes and enumerations but doesn't add type accelerators

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Provider.md
@@ -78,16 +78,16 @@ drive. To reference an environment variable from another location, use the
 drive name `Env:` in the path.
 
 The **Environment** provider also exposes environment variables using a
-variable prefix of `$env:`.  The following command views the contents of the
-**ProgramFiles** environment variable. The `$env:` variable prefix can
+variable prefix of `$Env:`.  The following command views the contents of the
+**ProgramFiles** environment variable. The `$Env:` variable prefix can
 be used from any PowerShell drive.
 
 ```
-PS C:\> $env:ProgramFiles
+PS C:\> $Env:ProgramFiles
 C:\Program Files
 ```
 
-You can also change the value of an environment variable using the `$env:`
+You can also change the value of an environment variable using the `$Env:`
 variable prefix.  Any changes made only pertain to the current PowerShell
 session for as long as it is active.
 
@@ -116,7 +116,7 @@ Get-ChildItem -Path Env:
 
 ### Get a selected environment variable
 
-This command gets the `WINDIR` environment Variable.
+This command gets the `windir` environment Variable.
 
 ```powershell
 Get-ChildItem -Path Env:windir
@@ -125,7 +125,7 @@ Get-ChildItem -Path Env:windir
 You can also use the variable prefix format as well.
 
 ```powershell
-$env:windir
+$Env:windir
 ```
 
 ## Create an environment variable
@@ -210,7 +210,7 @@ Get-Help Get-ChildItem
 ```
 
 ```powershell
-Get-Help Get-ChildItem -Path env:
+Get-Help Get-ChildItem -Path Env:
 ```
 
 ## See also

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -25,7 +25,7 @@ For full descriptions of these variables, see the
 ## Long description
 
 PowerShell can access and manage environment variables in any of the supported
-operating system platforms. The PowerShell environment provider lets you get,
+operating system platforms. The PowerShell Environment provider lets you get,
 add, change, clear, and delete environment variables in the current console.
 
 Environment variables, unlike other types of variables in PowerShell, are
@@ -47,7 +47,7 @@ _User_ scopes.
 
 When you change environment variables in PowerShell, the change affects only
 the current session. This behavior resembles the behavior of the `set` command
-in the Windows Command Shell and the `setenv` command in UNIX-based
+in the Windows Command Shell and the `setenv` command in Unix-based
 environments. To change values in the Machine or User scopes, you must use the
 methods of the **System.Environment** class.
 
@@ -71,7 +71,7 @@ following syntax:
 $Env:<variable-name>
 ```
 
-For example, to display the value of the `WINDIR` environment variable:
+For example, to display the value of the `windir` environment variable:
 
 ```powershell
 $Env:windir
@@ -125,7 +125,7 @@ $Env:Foo | Get-Member -MemberType Properties
 ```Output
 Get-Member : You must specify an object for the Get-Member cmdlet.
 At line:1 char:12
-+ $env:foo | Get-Member
++ $Env:foo | Get-Member
 +            ~~~~~~~~~~
     + CategoryInfo          : CloseError: (:) [Get-Member], InvalidOperationException
     + FullyQualifiedErrorId : NoObjectInGetMember,Microsoft.PowerShell.Commands.GetMemberCommand
@@ -251,12 +251,12 @@ available in any session that loads your profile. This method works for any
 version of PowerShell on any supported platform.
 
 For example, to create the `CompanyUri` environment variable and update the
-`Path` environment variable to include the `C:\Tools` folder, add the following
+`PATH` environment variable to include the `C:\Tools` folder, add the following
 lines to your PowerShell profile:
 
 ```powershell
 $Env:CompanyUri = 'https://internal.contoso.com'
-$Env:Path += ';C:\Tools'
+$Env:PATH += ';C:\Tools'
 ```
 
 You can get the path to your PowerShell profile with the `$PROFILE` automatic
@@ -328,10 +328,10 @@ The environment variables that store preferences include:
 
 - `PSModulePath`
 
-  The `$env:PSModulePath` environment variable contains a list of folder
+  The `$Env:PSModulePath` environment variable contains a list of folder
   locations that are searched to find modules and resources.
 
-  By default, the effective locations assigned to `$env:PSModulePath` are:
+  By default, the effective locations assigned to `$Env:PSModulePath` are:
 
   - System-wide locations: These folders contain modules that ship with
     PowerShell. The modules are store in the `$PSHOME\Modules` location. Also,
@@ -344,11 +344,11 @@ The environment variables that store preferences include:
 
     - On Windows, the location of the user-specific **CurrentUser** scope is
       the `$HOME\Documents\PowerShell\Modules` folder. The location of the
-      **AllUsers** scope is `$env:ProgramFiles\PowerShell\Modules`.
+      **AllUsers** scope is `$Env:ProgramFiles\PowerShell\Modules`.
 
   In addition, setup programs that install modules in other directories, such
   as the Program Files directory, can append their locations to the value of
-  `$env:PSModulePath`.
+  `$Env:PSModulePath`.
 
   For more information, see [about_PSModulePath][08].
 
@@ -361,7 +361,7 @@ The environment variables that store preferences include:
 
   The default location of the cache is:
 
-  - `$env:LOCALAPPDATA\Microsoft\Windows\PowerShell`
+  - `$Env:LOCALAPPDATA\Microsoft\Windows\PowerShell`
 
   The default filename for the cache is `ModuleAnalysisCache`.
 
@@ -383,7 +383,7 @@ The environment variables that store preferences include:
 
   ```powershell
   # `NUL` here is a special device on Windows that can't be written to
-  $env:PSModuleAnalysisCachePath = 'NUL'
+  $Env:PSModuleAnalysisCachePath = 'NUL'
   ```
 
   This sets the path to the **NUL** device. PowerShell can't write to the
@@ -415,13 +415,13 @@ The environment variables that store preferences include:
 
 - `PATH`
 
-  The `$env:PATH` environment variable contains a list of folder locations that
+  The `$Env:PATH` environment variable contains a list of folder locations that
   the operating system searches for executable files. On Windows, the list of
   folder locations is separated by the semi-colon (`;`) character.
 
 - `PATHEXT`
 
-  The `$env:PATHEXT` variable contains a list of file extensions that Windows
+  The `$Env:PATHEXT` variable contains a list of file extensions that Windows
   considers to be executable files. When a script file with one of the listed
   extensions is executed from PowerShell, the script runs in the current
   console or terminal session. If the file extension isn't listed, the script
@@ -437,7 +437,7 @@ The environment variables that store preferences include:
   documentation for the [ftype][02] command.
 
   PowerShell scripts always start in the current console session. You don't
-  need to add the `.PS1` extension.
+  need to add the `.ps1` extension.
 
 ## See also
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
@@ -127,7 +127,7 @@ The PowerShell execution policies are as follows:
 
   The **Process** scope only affects the current PowerShell session. The
   execution policy is saved in the environment variable
-  `$env:PSExecutionPolicyPreference`, rather than the registry. When the
+  `$Env:PSExecutionPolicyPreference`, rather than the registry. When the
   PowerShell session is closed, the variable and value are deleted.
 
 - CurrentUser
@@ -272,7 +272,7 @@ powershell.exe -ExecutionPolicy AllSigned
 ```
 
 The execution policy that you set isn't stored in the registry. Instead, it's
-stored in the `$env:PSExecutionPolicyPreference` environment variable. The
+stored in the `$Env:PSExecutionPolicyPreference` environment variable. The
 variable is deleted when you close the session in which the policy is set. You
 cannot change the policy by editing the variable value.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
@@ -206,7 +206,7 @@ the dollar sign (`$`). The path must be enclosed in curly braces due to
 variable naming restrictions. For more information, see [about_Variables][09].
 
 ```powershell
-${C:\Windows\System32\Drivers\etc\hosts}
+${C:\Windows\System32\drivers\etc\hosts}
 ```
 
 ### Add content to a file
@@ -254,7 +254,7 @@ For more information about `Get-Content` cmdlet, see the help topic for the
 For more information about arrays, see [about_Arrays][07].
 
 ```powershell
-$e = Get-Content c:\test\employees.txt -Delimited "End Of Employee Record"
+$e = Get-Content C:\test\employees.txt -Delimited "End Of Employee Record"
 $e[0]
 ```
 
@@ -278,7 +278,7 @@ For more information about this object, pipe the command to the
 This command creates the `logfiles` directory on the `C` drive:
 
 ```powershell
-New-Item -Path c:\ -Name logfiles -Type directory
+New-Item -Path C:\ -Name logfiles -Type Directory
 ```
 
 PowerShell also includes a `mkdir` function (alias `md`) that uses the
@@ -290,7 +290,7 @@ This command creates the `log2.txt` file in the `C:\logfiles` directory and
 then adds the "test log" string to the file:
 
 ```powershell
-New-Item -Path c:\logfiles -Name log2.txt -Type file
+New-Item -Path C:\logfiles -Name log2.txt -Type File
 ```
 
 ### Create a file with content
@@ -299,7 +299,7 @@ Creates a file called `log2.txt` in the `C:\logfiles` directory and adds the
 string "test log" to the file.
 
 ```powershell
-New-Item -Path c:\logfiles -Name log2.txt -Type file -Value "test log"
+New-Item -Path C:\logfiles -Name log2.txt -Type File -Value "test log"
 ```
 
 ## Renaming files and directories
@@ -309,7 +309,7 @@ New-Item -Path c:\logfiles -Name log2.txt -Type file -Value "test log"
 This command renames the `a.txt` file in the `C:\a` directory to `b.txt`:
 
 ```powershell
-Rename-Item -Path c:\a\a.txt -NewName b.txt
+Rename-Item -Path C:\a\a.txt -NewName b.txt
 ```
 
 ### Rename a directory
@@ -317,7 +317,7 @@ Rename-Item -Path c:\a\a.txt -NewName b.txt
 This command renames the `C:\a\cc` directory to `C:\a\dd`:
 
 ```powershell
-Rename-Item -Path c:\a\cc -NewName dd
+Rename-Item -Path C:\a\cc -NewName dd
 ```
 
 ## Deleting files and directories
@@ -382,7 +382,7 @@ which gets hidden files, and `!Directory`, which gets all other files.
 Get-ChildItem -Attributes !Directory,!Directory+Hidden
 ```
 
-`dir -att !d,!d+h` is the equivalent of this command.
+`dir -Att !d,!d+h` is the equivalent of this command.
 
 ### Get Compressed and Encrypted files
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_For.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_For.md
@@ -15,17 +15,17 @@ conditional test.
 
 ## Long description
 
-The `For` statement (also known as a `For` loop) is a language construct you
+The `for` statement (also known as a `for` loop) is a language construct you
 can use to create a loop that runs commands in a command block while a
 specified condition evaluates to `$true`.
 
-A typical use of the `For` loop is to iterate an array of values and to operate
+A typical use of the `for` loop is to iterate an array of values and to operate
 on a subset of these values. In most cases, if you want to iterate all the
-values in an array, consider using a `Foreach` statement.
+values in an array, consider using a `foreach` statement.
 
 ### Syntax
 
-The following shows the `For` statement syntax.
+The following shows the `for` statement syntax.
 
 ```
 for (<Init>; <Condition>; <Repeat>)
@@ -39,11 +39,11 @@ the loop begins. You typically use the **Init** portion of the statement to
 create and initialize a variable with a starting value.
 
 This variable will then be the basis for the condition to be tested in the next
-portion of the `For` statement.
+portion of the `for` statement.
 
-The **Condition** placeholder represents the portion of the `For` statement
+The **Condition** placeholder represents the portion of the `for` statement
 that resolves to a `$true` or `$false` **Boolean** value. PowerShell evaluates
-the condition each time the `For` loop runs. If the statement is `$true`, the
+the condition each time the `for` loop runs. If the statement is `$true`, the
 commands in the command block run, and the statement is evaluated again. If the
 condition is still `$true`, the commands in the **Statement list** run again.
 The loop is repeated until the condition becomes `$false`.
@@ -122,14 +122,14 @@ For more information, see [about_Logical_Operators][01].
 
 ### Syntax examples
 
-At a minimum, a `For` statement requires the parenthesis surrounding the
+At a minimum, a `for` statement requires the parenthesis surrounding the
 **Init**, **Condition**, and **Repeat** part of the statement and a command
 surrounded by braces in the **Statement list** part of the statement.
 
-Note that the upcoming examples intentionally show code outside the `For`
-statement. In later examples, code is integrated into the `For` statement.
+Note that the upcoming examples intentionally show code outside the `for`
+statement. In later examples, code is integrated into the `for` statement.
 
-For example, the following `For` statement continually displays the value of
+For example, the following `for` statement continually displays the value of
 the `$i` variable until you manually break out of the command by pressing
 CTRL+C.
 
@@ -156,7 +156,7 @@ continually display the value of the `$i` variable as it is incremented by 1
 each time the loop is run.
 
 Rather than change the value of the variable in the statement list part of the
-`For` statement, you can use the **Repeat** portion of the `For` statement
+`for` statement, you can use the **Repeat** portion of the `for` statement
 instead, as follows.
 
 ```powershell
@@ -170,11 +170,11 @@ for (;;$i++)
 This statement will still repeat indefinitely until you break out of the
 command by pressing CTRL+C.
 
-You can terminate the `For` loop using a **condition**. You can place a
-condition using the **Condition** portion of the `For` statement. The `For`
+You can terminate the `for` loop using a **condition**. You can place a
+condition using the **Condition** portion of the `for` statement. The `for`
 loop terminates when the condition evaluates to `$false`.
 
-In the following example, the `For` loop runs while the value of `$i` is less
+In the following example, the `for` loop runs while the value of `$i` is less
 than or equal to 10.
 
 ```powershell
@@ -185,17 +185,17 @@ for(;$i -le 10;$i++)
 }
 ```
 
-Instead of creating and initializing the variable outside the `For` statement,
-you can perform this task inside the `For` loop by using the **Init** portion
-of the `For` statement.
+Instead of creating and initializing the variable outside the `for` statement,
+you can perform this task inside the `for` loop by using the **Init** portion
+of the `for` statement.
 
 ```powershell
 for($i=1; $i -le 10; $i++){Write-Host $i}
 ```
 
 You can use carriage returns instead of semicolons to delimit the **Init**,
-**Condition**, and **Repeat** portions of the `For` statement. The following
-example shows a `For` that uses this alternative syntax.
+**Condition**, and **Repeat** portions of the `for` statement. The following
+example shows a `for` that uses this alternative syntax.
 
 ```powershell
 for ($i = 0
@@ -205,15 +205,15 @@ for ($i = 0
 }
 ```
 
-This alternative form of the `For` statement works in PowerShell script files
-and at the PowerShell command prompt. However, it is easier to use the `For`
+This alternative form of the `for` statement works in PowerShell script files
+and at the PowerShell command prompt. However, it is easier to use the `for`
 statement syntax with semicolons when you enter interactive commands at the
 command prompt.
 
-The `For` loop is more flexible than the `Foreach` loop because it allows you
+The `for` loop is more flexible than the `foreach` loop because it allows you
 to increment values in an array or collection by using patterns. In the
 following example, the `$i` variable is incremented by 2 in the **Repeat**
-portion of the `For` statement.
+portion of the `for` statement.
 
 ```powershell
 for ($i = 0; $i -le 20; $i += 2)
@@ -222,7 +222,7 @@ for ($i = 0; $i -le 20; $i += 2)
 }
 ```
 
-The `For` loop can also be written on one line as in the following example.
+The `for` loop can also be written on one line as in the following example.
 
 ```powershell
 for ($i = 0; $i -lt 10; $i++){Write-Host $i}
@@ -230,7 +230,7 @@ for ($i = 0; $i -lt 10; $i++){Write-Host $i}
 
 ### Functional example
 
-The following example demonstrates how you can use a `For` loop to iterate over
+The following example demonstrates how you can use a `for` loop to iterate over
 an array of files and rename them. The files in the `work_items` folder have
 their work item ID as the filename. The loop iterates through the files
 to ensure that the ID number is zero-padded to five digits.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Data_Files.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Data_Files.md
@@ -1,5 +1,5 @@
 ---
-description: Describes how to use PowerShell data (.psd1) files.
+description: Describes how to use PowerShell data (`.psd1`) files.
 Locale: en-US
 ms.date: 01/19/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_data_files?view=powershell-7.4&WT.mc_id=ps-gethelp
@@ -55,7 +55,7 @@ you aren't limited to storing string data and don't have to use the data for
 localized output.
 
 The data in the file isn't limited to hashtables. It can be in any format
-supported by the PowerShell syntax, such as `DATA` sections.
+supported by the PowerShell syntax, such as `data` sections.
 
 For more information, see [about_Data_Sections][01].
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -10,14 +10,14 @@ title: about_Data_Sections
 
 ## Short description
 
-Explains `DATA` sections, which isolate text strings and other read-only
+Explains `data` sections, which isolate text strings and other read-only
 data from script logic.
 
 ## Long description
 
-Scripts that are designed for PowerShell can have one or more `DATA` sections
-that contain only data. You can include one or more `DATA` sections in any
-script, function, or advanced function. The content of the `DATA` section is
+Scripts that are designed for PowerShell can have one or more `data` sections
+that contain only data. You can include one or more `data` sections in any
+script, function, or advanced function. The content of the `data` section is
 restricted to a specified subset of the PowerShell scripting language.
 
 Separating data from code logic makes it easier to identify and manage both
@@ -25,27 +25,27 @@ logic and data. It lets you have separate string resource files for text, such
 as error messages and Help strings. It also isolates the code logic, which
 facilitates security and validation tests.
 
-In PowerShell, you can use the `DATA` section to support script
-internationalization. You can use `DATA` sections to make it easier to isolate,
+In PowerShell, you can use the `data` section to support script
+internationalization. You can use `data` sections to make it easier to isolate,
 locate, and process strings that can be translated into other languages.
 
-The `DATA` section was added in PowerShell 2.0 feature.
+The `data` section was added in PowerShell 2.0 feature.
 
 ### Syntax
 
-The syntax for a `DATA` section is as follows:
+The syntax for a `data` section is as follows:
 
 ```Syntax
-DATA [<variable-name>] [-supportedCommand <cmdlet-name>] {
+data [<variable-name>] [-SupportedCommand <cmdlet-name>] {
     <Permitted content>
 }
 ```
 
-The `DATA` keyword is required. It isn't case-sensitive. The permitted content
+The `data` keyword is required. It isn't case-sensitive. The permitted content
 is limited to the following elements:
 
 - All PowerShell operators, except `-match`
-- `If`, `Else`, and `ElseIf` statements
+- `if`, `else`, and `elseif` statements
 - The following automatic variables: `$PSCulture`, `$PSUICulture`, `$true`,
   `$false`, and `$null`
 - Comments
@@ -60,17 +60,17 @@ is limited to the following elements:
   "PowerShell 2.0"
   @( "red", "green", "blue" )
   @{ a = 0x1; b = "great"; c ="script" }
-  [XML] @'
+  [xml] @'
   <p> Hello, World </p>
   '@
   ```
 
-- Cmdlets that are permitted in a `DATA` section. By default, only the
+- Cmdlets that are permitted in a `data` section. By default, only the
   `ConvertFrom-StringData` cmdlet is permitted.
-- Cmdlets that you permit in a `DATA` section by using the `-SupportedCommand`
+- Cmdlets that you permit in a `data` section by using the `-SupportedCommand`
   parameter.
 
-When you use the `ConvertFrom-StringData` cmdlet in a `DATA` section, you can
+When you use the `ConvertFrom-StringData` cmdlet in a `data` section, you can
 enclose the key-value pairs in single-quoted or double-quoted strings or in
 single-quoted or double-quoted here-strings. However, strings that contain
 variables and subexpressions must be enclosed in single-quoted strings or in
@@ -81,34 +81,34 @@ subexpressions aren't executable.
 
 The **SupportedCommand** parameter allows you to indicate that a cmdlet or
 function generates only data. It's designed to allow users to include cmdlets
-and functions in a `DATA` section that they have written or tested.
+and functions in a `data` section that they have written or tested.
 
 The value of **SupportedCommand** is a comma-separated list of one or more
 cmdlet or function names.
 
-For example, the following `DATA` section includes a user-written cmdlet,
+For example, the following `data` section includes a user-written cmdlet,
 `Format-Xml`, that formats data in an XML file:
 
 ```powershell
-DATA -supportedCommand Format-Xml
+data -SupportedCommand Format-Xml
 {
     Format-Xml -Strings string1, string2, string3
 }
 ```
 
-### Using a `DATA` Section
+### Using a `data` Section
 
-To use the content of a `DATA` section, assign it to a variable and use
+To use the content of a `data` section, assign it to a variable and use
 variable notation to access the content.
 
-For example, the following `DATA` section contains a `ConvertFrom-StringData`
+For example, the following `data` section contains a `ConvertFrom-StringData`
 command that converts the here-string into a hash table. The hash table is
 assigned to the `$TextMsgs` variable.
 
-The `$TextMsgs` variable isn't part of the `DATA` section.
+The `$TextMsgs` variable isn't part of the `data` section.
 
 ```powershell
-$TextMsgs = DATA {
+$TextMsgs = data {
     ConvertFrom-StringData -StringData @'
 Text001 = Windows 7
 Text002 = Windows Server 2008 R2
@@ -124,11 +124,11 @@ $TextMsgs.Text001
 $TextMsgs.Text002
 ```
 
-Alternately, you can put the variable name in the definition of the `DATA`
+Alternately, you can put the variable name in the definition of the `data`
 section. For example:
 
 ```powershell
-DATA TextMsgs {
+data TextMsgs {
     ConvertFrom-StringData -StringData @'
 Text001 = Windows 7
 Text002 = Windows Server 2008 R2
@@ -152,7 +152,7 @@ Text002                        Windows Server 2008 R2
 Simple data strings.
 
 ```powershell
-DATA {
+data {
     "Thank you for using my PowerShell Organize.pst script."
     "It is provided free of charge to the community."
     "I appreciate your comments and feedback."
@@ -162,9 +162,9 @@ DATA {
 Strings that include permitted variables.
 
 ```powershell
-DATA {
+data {
     if ($null) {
-        "To get help for this cmdlet, type get-help new-dictionary."
+        "To get help for this cmdlet, type Get-Help New-Dictionary."
     }
 }
 ```
@@ -172,7 +172,7 @@ DATA {
 A single-quoted here-string that uses the `ConvertFrom-StringData` cmdlet:
 
 ```powershell
-DATA {
+data {
     ConvertFrom-StringData -StringData @'
 Text001 = Windows 7
 Text002 = Windows Server 2008 R2
@@ -183,7 +183,7 @@ Text002 = Windows Server 2008 R2
 A double-quoted here-string that uses the `ConvertFrom-StringData` cmdlet:
 
 ```powershell
-DATA  {
+data {
     ConvertFrom-StringData -StringData @"
 Msg1 = To start, press any key.
 Msg2 = To exit, type "quit".
@@ -194,7 +194,7 @@ Msg2 = To exit, type "quit".
 A data section that includes a user-written cmdlet that generates data:
 
 ```powershell
-DATA -supportedCommand Format-XML {
+data -SupportedCommand Format-Xml {
     Format-Xml -Strings string1, string2, string3
 }
 ```

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -96,7 +96,7 @@ menu.
   you are debugging a job by running the `Debug-Job` cmdlet, the `Exit` command
   detaches the debugger, and allows the job to continue running.
 
-- `k`, `Get-PsCallStack`: Displays the current call stack.
+- `k`, `Get-PSCallStack`: Displays the current call stack.
 
 - `<Enter>`: Repeats the last command if it was `Step` (`s`), `StepOver` (`v`),
   or `List` (`l`). Otherwise, represents a submit action.
@@ -223,7 +223,7 @@ sections, the debugger breaks at the first line of each section.
 For example:
 
 ```powershell
-function test-cmdlet {
+function Test-Cmdlet {
     begin {
         Write-Output "Begin"
     }
@@ -235,32 +235,32 @@ function test-cmdlet {
     }
 }
 
-C:\PS> Set-PSBreakpoint -Command test-cmdlet
+C:\PS> Set-PSBreakpoint -Command Test-Cmdlet
 
-C:\PS> test-cmdlet
+C:\PS> Test-Cmdlet
 
 Begin
 Entering debug mode. Use h or ? for help.
 
-Hit Command breakpoint on 'prompt:test-cmdlet'
+Hit Command breakpoint on 'prompt:Test-Cmdlet'
 
-test-cmdlet
+Test-Cmdlet
 
 [DBG]: C:\PS> c
 Process
 Entering debug mode. Use h or ? for help.
 
-Hit Command breakpoint on 'prompt:test-cmdlet'
+Hit Command breakpoint on 'prompt:Test-Cmdlet'
 
-test-cmdlet
+Test-Cmdlet
 
 [DBG]: C:\PS> c
 End
 Entering debug mode. Use h or ? for help.
 
-Hit Command breakpoint on 'prompt:test-cmdlet'
+Hit Command breakpoint on 'prompt:Test-Cmdlet'
 
-test-cmdlet
+Test-Cmdlet
 
 [DBG]: C:\PS>
 ```
@@ -351,7 +351,7 @@ function psversion {
     "Upgrade to PowerShell 7!"
   }
   else {
-    "Have you run a background job today (start-job)?"
+    "Have you run a background job today (Start-Job)?"
   }
 }
 
@@ -460,7 +460,7 @@ steps to the next statement in the script.
 ```powershell
 DBG> o
 Windows PowerShell 2.0
-Have you run a background job today (start-job)?
+Have you run a background job today (Start-Job)?
 test.ps1:13  "Done $scriptName"
 ```
 
@@ -477,9 +477,9 @@ indicates that the debugger has exited and returned control to the command
 processor.
 
 Now, run the debugger again. First, to delete the current breakpoint, use the
-`Get-PsBreakpoint` and `Remove-PsBreakpoint` cmdlets. (If you think you might
-reuse the breakpoint, use the `Disable-PsBreakpoint` cmdlet instead of
-`Remove-PsBreakpoint`.)
+`Get-PSBreakpoint` and `Remove-PSBreakpoint` cmdlets. (If you think you might
+reuse the breakpoint, use the `Disable-PSBreakpoint` cmdlet instead of
+`Remove-PSBreakpoint`.)
 
 ```powershell
 PS C:\ps-test> Get-PSBreakpoint | Remove-PSBreakpoint
@@ -553,7 +553,7 @@ displayed, but it isn't executed.
 ```powershell
 DBG> v
 Windows PowerShell 2.0
-Have you run a background job today (start-job)?
+Have you run a background job today (Start-Job)?
 test.ps1:13  "Done $scriptName"
 ```
 
@@ -567,7 +567,7 @@ the standard command prompt.
 C:\ps-test>
 ```
 
-To delete the breakpoints, use the `Get-PsBreakpoint` and `Remove-PsBreakpoint`
+To delete the breakpoints, use the `Get-PSBreakpoint` and `Remove-PSBreakpoint`
 cmdlets.
 
 ```powershell
@@ -603,13 +603,13 @@ the breakpoint or to perform preparatory or diagnostic tasks, such as starting
 a log or invoking a diagnostic or security script.
 
 To set an action, use a Continue command (c) to exit the script, and a
-`Remove-PsBreakpoint` command to delete the current breakpoint. (Breakpoints
+`Remove-PSBreakpoint` command to delete the current breakpoint. (Breakpoints
 are read-only, so you can't add an action to the current breakpoint.)
 
 ```powershell
 DBG> c
 Windows PowerShell 2.0
-Have you run a background job today (start-job)?
+Have you run a background job today (Start-Job)?
 Done C:\ps-test\test.ps1
 
 PS C:\ps-test> Get-PSBreakpoint | Remove-PSBreakpoint
@@ -656,7 +656,7 @@ Because the execution policy is set to **RemoteSigned**, execution stops at the
 function call.
 
 At this point, you might want to check the call stack. Use the
-`Get-PsCallStack` cmdlet or the `Get-PsCallStack` debugger command (`k`). The
+`Get-PSCallStack` cmdlet or the `Get-PSCallStack` debugger command (`k`). The
 following command gets the current call stack.
 
 ```powershell

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Do.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Do.md
@@ -1,5 +1,5 @@
 ---
-description: Runs a statement list one or more times, subject to a While or Until condition.
+description: Runs a statement list one or more times, subject to a `while` or `until` condition.
 Locale: en-US
 ms.date: 06/10/2021
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_do?view=powershell-7.4&WT.mc_id=ps-gethelp
@@ -10,24 +10,24 @@ title: about_Do
 
 ## Short description
 
-Runs a statement list one or more times, subject to a `While` or `Until`
+Runs a statement list one or more times, subject to a `while` or `until`
 condition.
 
 ## Long description
 
-The `Do` keyword works with the `While` keyword or the `Until` keyword to run
+The `do` keyword works with the `while` keyword or the `until` keyword to run
 the statements in a script block, subject to a condition. Unlike the related
-`While` loop, the script block in a `Do` loop always runs at least once.
+`while` loop, the script block in a `do` loop always runs at least once.
 
-A **Do-While** loop is a variety of the `While` loop. In a **Do-While** loop,
-the condition is evaluated after the script block has run. As in a While loop,
-the script block is repeated as long as the condition evaluates to true.
+A **Do-While** loop is a variety of the `while` loop. In a **Do-While** loop,
+the condition is evaluated after the script block has run. As in a `while`
+loop, the script block is repeated as long as the condition evaluates to true.
 
 Like a **Do-While** loop, a **Do-Until** loop always runs at least once
 before the condition is evaluated. However, the script block runs only
 while the condition is false.
 
-The `Continue` and `Break` flow control keywords can be used in a **Do-While**
+The `continue` and `break` flow control keywords can be used in a **Do-While**
 loop or in a **Do-Until** loop.
 
 ### Syntax
@@ -53,7 +53,7 @@ information about how booleans are evaluated, see
 
 ### Example
 
-The following example of a `Do` statement counts the items in an array until it
+The following example of a `do` statement counts the items in an array until it
 reaches an item with a value of 0.
 
 ```powershell
@@ -63,7 +63,7 @@ PS> $count
 3
 ```
 
-The following example uses the `Until` keyword. Notice that the not equal to
+The following example uses the `until` keyword. Notice that the not equal to
 operator (`-ne`) is replaced by the equal to operator (`-eq`).
 
 ```powershell

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -54,7 +54,7 @@ Enumerations use the following syntaxes:
 ### Flag enumeration definition syntax
 
 ```Syntax
-[[<attribute>]...] [Flag()] enum <enum-name>[ : <underlying-type-name>] {
+[[<attribute>]...] [Flags()] enum <enum-name>[ : <underlying-type-name>] {
     <label 0> [= 1]
     <label 1> [= 2]
     <label 2> [= 4]
@@ -493,11 +493,11 @@ You can use the static method on the **System.Enum** base class type or a
 specific enumeration type.
 
 ```Syntax
-[System.Enum]::format([<enum-name>], <value>, <format-string>)
+[System.Enum]::Format([<enum-name>], <value>, <format-string>)
 ```
 
 ```Syntax
-[<enum-name>]::format([<enum-name>], <value>, <format-string>)
+[<enum-name>]::Format([<enum-name>], <value>, <format-string>)
 ```
 
 The valid format strings are `G` or `g`, `D` or `d`, `X` or `x`, and `F` or
@@ -843,7 +843,7 @@ enum Shade {
     Black
 }
 
-[Shade].GetEnumValues() | Foreach-Object -Process {
+[Shade].GetEnumValues() | ForEach-Object -Process {
     [pscustomobject]@{
         EnumValue    = $_
         StringValue  = $_.ToString()
@@ -1181,7 +1181,7 @@ module is removed, so are the type accelerators.
 
 ## Manually importing enumerations from a PowerShell module
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Enumerations aren't imported.
 
 If a module defines classes and enumerations but doesn't add type accelerators

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Environment_Provider.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Environment_Provider.md
@@ -78,16 +78,16 @@ drive. To reference an environment variable from another location, use the
 drive name `Env:` in the path.
 
 The **Environment** provider also exposes environment variables using a
-variable prefix of `$env:`.  The following command views the contents of the
-**ProgramFiles** environment variable. The `$env:` variable prefix can
+variable prefix of `$Env:`.  The following command views the contents of the
+**ProgramFiles** environment variable. The `$Env:` variable prefix can
 be used from any PowerShell drive.
 
 ```
-PS C:\> $env:ProgramFiles
+PS C:\> $Env:ProgramFiles
 C:\Program Files
 ```
 
-You can also change the value of an environment variable using the `$env:`
+You can also change the value of an environment variable using the `$Env:`
 variable prefix.  Any changes made only pertain to the current PowerShell
 session for as long as it is active.
 
@@ -116,7 +116,7 @@ Get-ChildItem -Path Env:
 
 ### Get a selected environment variable
 
-This command gets the `WINDIR` environment Variable.
+This command gets the `windir` environment Variable.
 
 ```powershell
 Get-ChildItem -Path Env:windir
@@ -125,7 +125,7 @@ Get-ChildItem -Path Env:windir
 You can also use the variable prefix format as well.
 
 ```powershell
-$env:windir
+$Env:windir
 ```
 
 ## Create an environment variable
@@ -210,7 +210,7 @@ Get-Help Get-ChildItem
 ```
 
 ```powershell
-Get-Help Get-ChildItem -Path env:
+Get-Help Get-ChildItem -Path Env:
 ```
 
 ## See also

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -29,12 +29,12 @@ For full descriptions of these variables, see the
 ## Long description
 
 PowerShell can access and manage environment variables in any of the supported
-operating system platforms. The PowerShell environment provider lets you get,
+operating system platforms. The PowerShell Environment provider lets you get,
 add, change, clear, and delete environment variables in the current console.
 
 > [!NOTE]
 > Unlike Windows, environment variable names on macOS and Linux are
-> case-sensitive. For example, `$env:Path` and `$env:PATH` are different
+> case-sensitive. For example, `$Env:Path` and `$Env:PATH` are different
 > environment variables on non-Windows platforms.
 
 Environment variables, unlike other types of variables in PowerShell, are
@@ -56,7 +56,7 @@ _User_ scopes.
 
 When you change environment variables in PowerShell, the change affects only
 the current session. This behavior resembles the behavior of the `set` command
-in the Windows Command Shell and the `setenv` command in UNIX-based
+in the Windows Command Shell and the `setenv` command in Unix-based
 environments. To change values in the Machine or User scopes, you must use the
 methods of the **System.Environment** class.
 
@@ -80,7 +80,7 @@ following syntax:
 $Env:<variable-name>
 ```
 
-For example, to display the value of the `WINDIR` environment variable:
+For example, to display the value of the `windir` environment variable:
 
 ```powershell
 $Env:windir
@@ -134,7 +134,7 @@ $Env:Foo | Get-Member -MemberType Properties
 ```Output
 Get-Member : You must specify an object for the Get-Member cmdlet.
 At line:1 char:12
-+ $env:foo | Get-Member
++ $Env:foo | Get-Member
 +            ~~~~~~~~~~
     + CategoryInfo          : CloseError: (:) [Get-Member], InvalidOperationException
     + FullyQualifiedErrorId : NoObjectInGetMember,Microsoft.PowerShell.Commands.GetMemberCommand
@@ -260,12 +260,12 @@ available in any session that loads your profile. This method works for any
 version of PowerShell on any supported platform.
 
 For example, to create the `CompanyUri` environment variable and update the
-`Path` environment variable to include the `C:\Tools` folder, add the following
+`PATH` environment variable to include the `C:\Tools` folder, add the following
 lines to your PowerShell profile:
 
 ```powershell
 $Env:CompanyUri = 'https://internal.contoso.com'
-$Env:Path += ';C:\Tools'
+$Env:PATH += ';C:\Tools'
 ```
 
 > [!NOTE]
@@ -396,13 +396,13 @@ The environment variables that store preferences include:
 
 - `PSModulePath`
 
-  The `$env:PSModulePath` environment variable contains a list of folder
+  The `$Env:PSModulePath` environment variable contains a list of folder
   locations that are searched to find modules and resources. On Windows, the
   list of folder locations is separated by the semi-colon (`;`) character. On
   non-Windows platforms, the colon (`:`) separates the folder locations in the
   environment variable.
 
-  By default, the effective locations assigned to `$env:PSModulePath` are:
+  By default, the effective locations assigned to `$Env:PSModulePath` are:
 
   - System-wide locations: These folders contain modules that ship with
     PowerShell. The modules are store in the `$PSHOME\Modules` location. Also,
@@ -415,14 +415,14 @@ The environment variables that store preferences include:
 
     - On Windows, the location of the user-specific **CurrentUser** scope is
       the `$HOME\Documents\PowerShell\Modules` folder. The location of the
-      **AllUsers** scope is `$env:ProgramFiles\PowerShell\Modules`.
+      **AllUsers** scope is `$Env:ProgramFiles\PowerShell\Modules`.
     - On non-Windows systems, the location of the user-specific **CurrentUser**
       scope is the `$HOME/.local/share/powershell/Modules` folder. The location
       of the **AllUsers** scope is `/usr/local/share/powershell/Modules`.
 
   In addition, setup programs that install modules in other directories, such
   as the Program Files directory, can append their locations to the value of
-  `$env:PSModulePath`.
+  `$Env:PSModulePath`.
 
   For more information, see [about_PSModulePath][08].
 
@@ -435,8 +435,8 @@ The environment variables that store preferences include:
 
   The default location of the cache is:
 
-  - Windows PowerShell 5.1: `$env:LOCALAPPDATA\Microsoft\Windows\PowerShell`
-  - PowerShell 6.0 and higher: `$env:LOCALAPPDATA\Microsoft\PowerShell`
+  - Windows PowerShell 5.1: `$Env:LOCALAPPDATA\Microsoft\Windows\PowerShell`
+  - PowerShell 6.0 and higher: `$Env:LOCALAPPDATA\Microsoft\PowerShell`
   - Non-Windows default: `~/.cache/powershell`
 
   The default filename for the cache is `ModuleAnalysisCache`. When you have
@@ -462,7 +462,7 @@ The environment variables that store preferences include:
   ```powershell
   # `NUL` here is a special device on Windows that can't be written to,
   # on non-Windows you would use `/dev/null`
-  $env:PSModuleAnalysisCachePath = 'NUL'
+  $Env:PSModuleAnalysisCachePath = 'NUL'
   ```
 
   This sets the path to the **NUL** device. PowerShell can't write to the
@@ -494,7 +494,7 @@ The environment variables that store preferences include:
 
 - `PATH`
 
-  The `$env:PATH` environment variable contains a list of folder locations that
+  The `$Env:PATH` environment variable contains a list of folder locations that
   the operating system searches for executable files. On Windows, the list of
   folder locations is separated by the semi-colon (`;`) character. On
   non-Windows platforms, the colon (`:`) separates the folder locations in the
@@ -502,7 +502,7 @@ The environment variables that store preferences include:
 
 - `PATHEXT`
 
-  The `$env:PATHEXT` variable contains a list of file extensions that Windows
+  The `$Env:PATHEXT` variable contains a list of file extensions that Windows
   considers to be executable files. When a script file with one of the listed
   extensions is executed from PowerShell, the script runs in the current
   console or terminal session. If the file extension isn't listed, the script
@@ -518,7 +518,7 @@ The environment variables that store preferences include:
   documentation for the [ftype][02] command.
 
   PowerShell scripts always start in the current console session. You don't
-  need to add the `.PS1` extension.
+  need to add the `.ps1` extension.
 
 - `XDG` variables
 
@@ -538,7 +538,7 @@ or `NO_COLOR` environment variables.
 
 - `TERM`
 
-  The following values of `$env:TERM` change the behavior as follows:
+  The following values of `$Env:TERM` change the behavior as follows:
 
   - `dumb` - sets `$Host.UI.SupportsVirtualTerminal = $false`
   - `xterm-mono` - sets `$PSStyle.OutputRendering = PlainText`
@@ -546,7 +546,7 @@ or `NO_COLOR` environment variables.
 
 - `NO_COLOR`
 
-  If `$env:NO_COLOR` exists, then `$PSStyle.OutputRendering` is set to
+  If `$Env:NO_COLOR` exists, then `$PSStyle.OutputRendering` is set to
   `PlainText`. For more information about the `NO_COLOR` environment
   variable, see [https://no-color.org/][12].
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
@@ -135,7 +135,7 @@ execution policies are as follows:
 
   The **Process** scope only affects the current PowerShell session. The
   execution policy is saved in the environment variable
-  `$env:PSExecutionPolicyPreference`, rather than the configuration file. When
+  `$Env:PSExecutionPolicyPreference`, rather than the configuration file. When
   the PowerShell session is closed, the variable and value are deleted.
 
 - CurrentUser
@@ -279,7 +279,7 @@ pwsh.exe -ExecutionPolicy AllSigned
 ```
 
 The execution policy that you set isn't stored in the configuration file.
-Instead, it's stored in the `$env:PSExecutionPolicyPreference` environment
+Instead, it's stored in the `$Env:PSExecutionPolicyPreference` environment
 variable. The variable is deleted when you close the session in which the
 policy is set. You cannot change the policy by editing the variable value.
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
@@ -33,11 +33,11 @@ The **FileSystem** drives are a hierarchical namespace containing the
 directories and files on your computer. A **FileSystem** drive can be a logical
 or physical drive, directory, or mapped network share.
 
-Beginning in PowerShell Version 7.0, a drive called `TEMP:` is mapped to the
+Beginning in PowerShell Version 7.0, a drive called `Temp:` is mapped to the
 user's temporary directory path. PowerShell uses the .NET [GetTempPath()][05]
 method to determine the location of the temporary folder. On Windows, the
-location is the same as `$env:TEMP`. On non-Windows systems, the location is
-the same as `$env:TMPDIR` or `/tmp` if the environment variable isn't defined.
+location is the same as `$Env:TEMP`. On non-Windows systems, the location is
+the same as `$Env:TMPDIR` or `/tmp` if the environment variable isn't defined.
 
 The **FileSystem** provider supports the following cmdlets, which are covered
 in this article.
@@ -212,7 +212,7 @@ the dollar sign (`$`). The path must be enclosed in curly braces due to
 variable naming restrictions. For more information, see [about_Variables][09].
 
 ```powershell
-${C:\Windows\System32\Drivers\etc\hosts}
+${C:\Windows\System32\drivers\etc\hosts}
 ```
 
 ### Add content to a file
@@ -260,7 +260,7 @@ For more information about `Get-Content` cmdlet, see the help topic for the
 For more information about arrays, see [about_Arrays][07].
 
 ```powershell
-$e = Get-Content c:\test\employees.txt -Delimited "End Of Employee Record"
+$e = Get-Content C:\test\employees.txt -Delimited "End Of Employee Record"
 $e[0]
 ```
 
@@ -284,7 +284,7 @@ For more information about this object, pipe the command to the
 This command creates the `logfiles` directory on the `C` drive:
 
 ```powershell
-New-Item -Path c:\ -Name logfiles -Type directory
+New-Item -Path C:\ -Name logfiles -Type Directory
 ```
 
 PowerShell also includes a `mkdir` function (alias `md`) that uses the
@@ -296,7 +296,7 @@ This command creates the `log2.txt` file in the `C:\logfiles` directory and
 then adds the "test log" string to the file:
 
 ```powershell
-New-Item -Path c:\logfiles -Name log2.txt -Type file
+New-Item -Path C:\logfiles -Name log2.txt -Type File
 ```
 
 ### Create a file with content
@@ -305,7 +305,7 @@ Creates a file called `log2.txt` in the `C:\logfiles` directory and adds the
 string "test log" to the file.
 
 ```powershell
-New-Item -Path c:\logfiles -Name log2.txt -Type file -Value "test log"
+New-Item -Path C:\logfiles -Name log2.txt -Type File -Value "test log"
 ```
 
 ## Renaming files and directories
@@ -315,7 +315,7 @@ New-Item -Path c:\logfiles -Name log2.txt -Type file -Value "test log"
 This command renames the `a.txt` file in the `C:\a` directory to `b.txt`:
 
 ```powershell
-Rename-Item -Path c:\a\a.txt -NewName b.txt
+Rename-Item -Path C:\a\a.txt -NewName b.txt
 ```
 
 ### Rename a directory
@@ -323,7 +323,7 @@ Rename-Item -Path c:\a\a.txt -NewName b.txt
 This command renames the `C:\a\cc` directory to `C:\a\dd`:
 
 ```powershell
-Rename-Item -Path c:\a\cc -NewName dd
+Rename-Item -Path C:\a\cc -NewName dd
 ```
 
 ## Deleting files and directories
@@ -388,7 +388,7 @@ which gets hidden files, and `!Directory`, which gets all other files.
 Get-ChildItem -Attributes !Directory,!Directory+Hidden
 ```
 
-`dir -att !d,!d+h` is the equivalent of this command.
+`dir -Att !d,!d+h` is the equivalent of this command.
 
 ### Get Compressed and Encrypted files
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_For.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_For.md
@@ -15,17 +15,17 @@ conditional test.
 
 ## Long description
 
-The `For` statement (also known as a `For` loop) is a language construct you
+The `for` statement (also known as a `for` loop) is a language construct you
 can use to create a loop that runs commands in a command block while a
 specified condition evaluates to `$true`.
 
-A typical use of the `For` loop is to iterate an array of values and to operate
+A typical use of the `for` loop is to iterate an array of values and to operate
 on a subset of these values. In most cases, if you want to iterate all the
-values in an array, consider using a `Foreach` statement.
+values in an array, consider using a `foreach` statement.
 
 ### Syntax
 
-The following shows the `For` statement syntax.
+The following shows the `for` statement syntax.
 
 ```
 for (<Init>; <Condition>; <Repeat>)
@@ -39,11 +39,11 @@ the loop begins. You typically use the **Init** portion of the statement to
 create and initialize a variable with a starting value.
 
 This variable will then be the basis for the condition to be tested in the next
-portion of the `For` statement.
+portion of the `for` statement.
 
-The **Condition** placeholder represents the portion of the `For` statement
+The **Condition** placeholder represents the portion of the `for` statement
 that resolves to a `$true` or `$false` **Boolean** value. PowerShell evaluates
-the condition each time the `For` loop runs. If the statement is `$true`, the
+the condition each time the `for` loop runs. If the statement is `$true`, the
 commands in the command block run, and the statement is evaluated again. If the
 condition is still `$true`, the commands in the **Statement list** run again.
 The loop is repeated until the condition becomes `$false`.
@@ -122,14 +122,14 @@ For more information, see [about_Logical_Operators][01].
 
 ### Syntax examples
 
-At a minimum, a `For` statement requires the parenthesis surrounding the
+At a minimum, a `for` statement requires the parenthesis surrounding the
 **Init**, **Condition**, and **Repeat** part of the statement and a command
 surrounded by braces in the **Statement list** part of the statement.
 
-Note that the upcoming examples intentionally show code outside the `For`
-statement. In later examples, code is integrated into the `For` statement.
+Note that the upcoming examples intentionally show code outside the `for`
+statement. In later examples, code is integrated into the `for` statement.
 
-For example, the following `For` statement continually displays the value of
+For example, the following `for` statement continually displays the value of
 the `$i` variable until you manually break out of the command by pressing
 CTRL+C.
 
@@ -156,7 +156,7 @@ continually display the value of the `$i` variable as it is incremented by 1
 each time the loop is run.
 
 Rather than change the value of the variable in the statement list part of the
-`For` statement, you can use the **Repeat** portion of the `For` statement
+`for` statement, you can use the **Repeat** portion of the `for` statement
 instead, as follows.
 
 ```powershell
@@ -170,11 +170,11 @@ for (;;$i++)
 This statement will still repeat indefinitely until you break out of the
 command by pressing CTRL+C.
 
-You can terminate the `For` loop using a **condition**. You can place a
-condition using the **Condition** portion of the `For` statement. The `For`
+You can terminate the `for` loop using a **condition**. You can place a
+condition using the **Condition** portion of the `for` statement. The `for`
 loop terminates when the condition evaluates to `$false`.
 
-In the following example, the `For` loop runs while the value of `$i` is less
+In the following example, the `for` loop runs while the value of `$i` is less
 than or equal to 10.
 
 ```powershell
@@ -185,17 +185,17 @@ for(;$i -le 10;$i++)
 }
 ```
 
-Instead of creating and initializing the variable outside the `For` statement,
-you can perform this task inside the `For` loop by using the **Init** portion
-of the `For` statement.
+Instead of creating and initializing the variable outside the `for` statement,
+you can perform this task inside the `for` loop by using the **Init** portion
+of the `for` statement.
 
 ```powershell
 for($i=1; $i -le 10; $i++){Write-Host $i}
 ```
 
 You can use carriage returns instead of semicolons to delimit the **Init**,
-**Condition**, and **Repeat** portions of the `For` statement. The following
-example shows a `For` that uses this alternative syntax.
+**Condition**, and **Repeat** portions of the `for` statement. The following
+example shows a `for` that uses this alternative syntax.
 
 ```powershell
 for ($i = 0
@@ -205,15 +205,15 @@ for ($i = 0
 }
 ```
 
-This alternative form of the `For` statement works in PowerShell script files
-and at the PowerShell command prompt. However, it is easier to use the `For`
+This alternative form of the `for` statement works in PowerShell script files
+and at the PowerShell command prompt. However, it is easier to use the `for`
 statement syntax with semicolons when you enter interactive commands at the
 command prompt.
 
-The `For` loop is more flexible than the `Foreach` loop because it allows you
+The `for` loop is more flexible than the `foreach` loop because it allows you
 to increment values in an array or collection by using patterns. In the
 following example, the `$i` variable is incremented by 2 in the **Repeat**
-portion of the `For` statement.
+portion of the `for` statement.
 
 ```powershell
 for ($i = 0; $i -le 20; $i += 2)
@@ -222,7 +222,7 @@ for ($i = 0; $i -le 20; $i += 2)
 }
 ```
 
-The `For` loop can also be written on one line as in the following example.
+The `for` loop can also be written on one line as in the following example.
 
 ```powershell
 for ($i = 0; $i -lt 10; $i++){Write-Host $i}
@@ -230,7 +230,7 @@ for ($i = 0; $i -lt 10; $i++){Write-Host $i}
 
 ### Functional example
 
-The following example demonstrates how you can use a `For` loop to iterate over
+The following example demonstrates how you can use a `for` loop to iterate over
 an array of files and rename them. The files in the `work_items` folder have
 their work item ID as the filename. The loop iterates through the files
 to ensure that the ID number is zero-padded to five digits.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Data_Files.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Data_Files.md
@@ -1,5 +1,5 @@
 ---
-description: Describes how to use PowerShell data (.psd1) files.
+description: Describes how to use PowerShell data (`.psd1`) files.
 Locale: en-US
 ms.date: 01/19/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_data_files?view=powershell-7.5&WT.mc_id=ps-gethelp
@@ -55,7 +55,7 @@ you aren't limited to storing string data and don't have to use the data for
 localized output.
 
 The data in the file isn't limited to hashtables. It can be in any format
-supported by the PowerShell syntax, such as `DATA` sections.
+supported by the PowerShell syntax, such as `data` sections.
 
 For more information, see [about_Data_Sections][01].
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -10,14 +10,14 @@ title: about_Data_Sections
 
 ## Short description
 
-Explains `DATA` sections, which isolate text strings and other read-only
+Explains `data` sections, which isolate text strings and other read-only
 data from script logic.
 
 ## Long description
 
-Scripts that are designed for PowerShell can have one or more `DATA` sections
-that contain only data. You can include one or more `DATA` sections in any
-script, function, or advanced function. The content of the `DATA` section is
+Scripts that are designed for PowerShell can have one or more `data` sections
+that contain only data. You can include one or more `data` sections in any
+script, function, or advanced function. The content of the `data` section is
 restricted to a specified subset of the PowerShell scripting language.
 
 Separating data from code logic makes it easier to identify and manage both
@@ -25,27 +25,27 @@ logic and data. It lets you have separate string resource files for text, such
 as error messages and Help strings. It also isolates the code logic, which
 facilitates security and validation tests.
 
-In PowerShell, you can use the `DATA` section to support script
-internationalization. You can use `DATA` sections to make it easier to isolate,
+In PowerShell, you can use the `data` section to support script
+internationalization. You can use `data` sections to make it easier to isolate,
 locate, and process strings that can be translated into other languages.
 
-The `DATA` section was added in PowerShell 2.0 feature.
+The `data` section was added in PowerShell 2.0 feature.
 
 ### Syntax
 
-The syntax for a `DATA` section is as follows:
+The syntax for a `data` section is as follows:
 
 ```Syntax
-DATA [<variable-name>] [-supportedCommand <cmdlet-name>] {
+data [<variable-name>] [-SupportedCommand <cmdlet-name>] {
     <Permitted content>
 }
 ```
 
-The `DATA` keyword is required. It isn't case-sensitive. The permitted content
+The `data` keyword is required. It isn't case-sensitive. The permitted content
 is limited to the following elements:
 
 - All PowerShell operators, except `-match`
-- `If`, `Else`, and `ElseIf` statements
+- `if`, `else`, and `elseif` statements
 - The following automatic variables: `$PSCulture`, `$PSUICulture`, `$true`,
   `$false`, and `$null`
 - Comments
@@ -60,17 +60,17 @@ is limited to the following elements:
   "PowerShell 2.0"
   @( "red", "green", "blue" )
   @{ a = 0x1; b = "great"; c ="script" }
-  [XML] @'
+  [xml] @'
   <p> Hello, World </p>
   '@
   ```
 
-- Cmdlets that are permitted in a `DATA` section. By default, only the
+- Cmdlets that are permitted in a `data` section. By default, only the
   `ConvertFrom-StringData` cmdlet is permitted.
-- Cmdlets that you permit in a `DATA` section by using the `-SupportedCommand`
+- Cmdlets that you permit in a `data` section by using the `-SupportedCommand`
   parameter.
 
-When you use the `ConvertFrom-StringData` cmdlet in a `DATA` section, you can
+When you use the `ConvertFrom-StringData` cmdlet in a `data` section, you can
 enclose the key-value pairs in single-quoted or double-quoted strings or in
 single-quoted or double-quoted here-strings. However, strings that contain
 variables and subexpressions must be enclosed in single-quoted strings or in
@@ -81,34 +81,34 @@ subexpressions aren't executable.
 
 The **SupportedCommand** parameter allows you to indicate that a cmdlet or
 function generates only data. It's designed to allow users to include cmdlets
-and functions in a `DATA` section that they have written or tested.
+and functions in a `data` section that they have written or tested.
 
 The value of **SupportedCommand** is a comma-separated list of one or more
 cmdlet or function names.
 
-For example, the following `DATA` section includes a user-written cmdlet,
+For example, the following `data` section includes a user-written cmdlet,
 `Format-Xml`, that formats data in an XML file:
 
 ```powershell
-DATA -supportedCommand Format-Xml
+data -SupportedCommand Format-Xml
 {
     Format-Xml -Strings string1, string2, string3
 }
 ```
 
-### Using a `DATA` Section
+### Using a `data` Section
 
-To use the content of a `DATA` section, assign it to a variable and use
+To use the content of a `data` section, assign it to a variable and use
 variable notation to access the content.
 
-For example, the following `DATA` section contains a `ConvertFrom-StringData`
+For example, the following `data` section contains a `ConvertFrom-StringData`
 command that converts the here-string into a hash table. The hash table is
 assigned to the `$TextMsgs` variable.
 
-The `$TextMsgs` variable isn't part of the `DATA` section.
+The `$TextMsgs` variable isn't part of the `data` section.
 
 ```powershell
-$TextMsgs = DATA {
+$TextMsgs = data {
     ConvertFrom-StringData -StringData @'
 Text001 = Windows 7
 Text002 = Windows Server 2008 R2
@@ -124,11 +124,11 @@ $TextMsgs.Text001
 $TextMsgs.Text002
 ```
 
-Alternately, you can put the variable name in the definition of the `DATA`
+Alternately, you can put the variable name in the definition of the `data`
 section. For example:
 
 ```powershell
-DATA TextMsgs {
+data TextMsgs {
     ConvertFrom-StringData -StringData @'
 Text001 = Windows 7
 Text002 = Windows Server 2008 R2
@@ -152,7 +152,7 @@ Text002                        Windows Server 2008 R2
 Simple data strings.
 
 ```powershell
-DATA {
+data {
     "Thank you for using my PowerShell Organize.pst script."
     "It is provided free of charge to the community."
     "I appreciate your comments and feedback."
@@ -162,9 +162,9 @@ DATA {
 Strings that include permitted variables.
 
 ```powershell
-DATA {
+data {
     if ($null) {
-        "To get help for this cmdlet, type get-help new-dictionary."
+        "To get help for this cmdlet, type Get-Help New-Dictionary."
     }
 }
 ```
@@ -172,7 +172,7 @@ DATA {
 A single-quoted here-string that uses the `ConvertFrom-StringData` cmdlet:
 
 ```powershell
-DATA {
+data {
     ConvertFrom-StringData -StringData @'
 Text001 = Windows 7
 Text002 = Windows Server 2008 R2
@@ -183,7 +183,7 @@ Text002 = Windows Server 2008 R2
 A double-quoted here-string that uses the `ConvertFrom-StringData` cmdlet:
 
 ```powershell
-DATA  {
+data {
     ConvertFrom-StringData -StringData @"
 Msg1 = To start, press any key.
 Msg2 = To exit, type "quit".
@@ -194,7 +194,7 @@ Msg2 = To exit, type "quit".
 A data section that includes a user-written cmdlet that generates data:
 
 ```powershell
-DATA -supportedCommand Format-XML {
+data -SupportedCommand Format-Xml {
     Format-Xml -Strings string1, string2, string3
 }
 ```

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -96,7 +96,7 @@ menu.
   you are debugging a job by running the `Debug-Job` cmdlet, the `Exit` command
   detaches the debugger, and allows the job to continue running.
 
-- `k`, `Get-PsCallStack`: Displays the current call stack.
+- `k`, `Get-PSCallStack`: Displays the current call stack.
 
 - `<Enter>`: Repeats the last command if it was `Step` (`s`), `StepOver` (`v`),
   or `List` (`l`). Otherwise, represents a submit action.
@@ -223,7 +223,7 @@ sections, the debugger breaks at the first line of each section.
 For example:
 
 ```powershell
-function test-cmdlet {
+function Test-Cmdlet {
     begin {
         Write-Output "Begin"
     }
@@ -235,32 +235,32 @@ function test-cmdlet {
     }
 }
 
-C:\PS> Set-PSBreakpoint -Command test-cmdlet
+C:\PS> Set-PSBreakpoint -Command Test-Cmdlet
 
-C:\PS> test-cmdlet
+C:\PS> Test-Cmdlet
 
 Begin
 Entering debug mode. Use h or ? for help.
 
-Hit Command breakpoint on 'prompt:test-cmdlet'
+Hit Command breakpoint on 'prompt:Test-Cmdlet'
 
-test-cmdlet
+Test-Cmdlet
 
 [DBG]: C:\PS> c
 Process
 Entering debug mode. Use h or ? for help.
 
-Hit Command breakpoint on 'prompt:test-cmdlet'
+Hit Command breakpoint on 'prompt:Test-Cmdlet'
 
-test-cmdlet
+Test-Cmdlet
 
 [DBG]: C:\PS> c
 End
 Entering debug mode. Use h or ? for help.
 
-Hit Command breakpoint on 'prompt:test-cmdlet'
+Hit Command breakpoint on 'prompt:Test-Cmdlet'
 
-test-cmdlet
+Test-Cmdlet
 
 [DBG]: C:\PS>
 ```
@@ -351,7 +351,7 @@ function psversion {
     "Upgrade to PowerShell 7!"
   }
   else {
-    "Have you run a background job today (start-job)?"
+    "Have you run a background job today (Start-Job)?"
   }
 }
 
@@ -460,7 +460,7 @@ steps to the next statement in the script.
 ```powershell
 DBG> o
 Windows PowerShell 2.0
-Have you run a background job today (start-job)?
+Have you run a background job today (Start-Job)?
 test.ps1:13  "Done $scriptName"
 ```
 
@@ -477,9 +477,9 @@ indicates that the debugger has exited and returned control to the command
 processor.
 
 Now, run the debugger again. First, to delete the current breakpoint, use the
-`Get-PsBreakpoint` and `Remove-PsBreakpoint` cmdlets. (If you think you might
-reuse the breakpoint, use the `Disable-PsBreakpoint` cmdlet instead of
-`Remove-PsBreakpoint`.)
+`Get-PSBreakpoint` and `Remove-PSBreakpoint` cmdlets. (If you think you might
+reuse the breakpoint, use the `Disable-PSBreakpoint` cmdlet instead of
+`Remove-PSBreakpoint`.)
 
 ```powershell
 PS C:\ps-test> Get-PSBreakpoint | Remove-PSBreakpoint
@@ -553,7 +553,7 @@ displayed, but it isn't executed.
 ```powershell
 DBG> v
 Windows PowerShell 2.0
-Have you run a background job today (start-job)?
+Have you run a background job today (Start-Job)?
 test.ps1:13  "Done $scriptName"
 ```
 
@@ -567,7 +567,7 @@ the standard command prompt.
 C:\ps-test>
 ```
 
-To delete the breakpoints, use the `Get-PsBreakpoint` and `Remove-PsBreakpoint`
+To delete the breakpoints, use the `Get-PSBreakpoint` and `Remove-PSBreakpoint`
 cmdlets.
 
 ```powershell
@@ -603,13 +603,13 @@ the breakpoint or to perform preparatory or diagnostic tasks, such as starting
 a log or invoking a diagnostic or security script.
 
 To set an action, use a Continue command (c) to exit the script, and a
-`Remove-PsBreakpoint` command to delete the current breakpoint. (Breakpoints
+`Remove-PSBreakpoint` command to delete the current breakpoint. (Breakpoints
 are read-only, so you can't add an action to the current breakpoint.)
 
 ```powershell
 DBG> c
 Windows PowerShell 2.0
-Have you run a background job today (start-job)?
+Have you run a background job today (Start-Job)?
 Done C:\ps-test\test.ps1
 
 PS C:\ps-test> Get-PSBreakpoint | Remove-PSBreakpoint
@@ -656,7 +656,7 @@ Because the execution policy is set to **RemoteSigned**, execution stops at the
 function call.
 
 At this point, you might want to check the call stack. Use the
-`Get-PsCallStack` cmdlet or the `Get-PsCallStack` debugger command (`k`). The
+`Get-PSCallStack` cmdlet or the `Get-PSCallStack` debugger command (`k`). The
 following command gets the current call stack.
 
 ```powershell

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Do.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Do.md
@@ -1,5 +1,5 @@
 ---
-description: Runs a statement list one or more times, subject to a While or Until condition.
+description: Runs a statement list one or more times, subject to a `while` or `until` condition.
 Locale: en-US
 ms.date: 06/10/2021
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_do?view=powershell-7.5&WT.mc_id=ps-gethelp
@@ -10,24 +10,24 @@ title: about_Do
 
 ## Short description
 
-Runs a statement list one or more times, subject to a `While` or `Until`
+Runs a statement list one or more times, subject to a `while` or `until`
 condition.
 
 ## Long description
 
-The `Do` keyword works with the `While` keyword or the `Until` keyword to run
+The `do` keyword works with the `while` keyword or the `until` keyword to run
 the statements in a script block, subject to a condition. Unlike the related
-`While` loop, the script block in a `Do` loop always runs at least once.
+`while` loop, the script block in a `do` loop always runs at least once.
 
-A **Do-While** loop is a variety of the `While` loop. In a **Do-While** loop,
-the condition is evaluated after the script block has run. As in a While loop,
-the script block is repeated as long as the condition evaluates to true.
+A **Do-While** loop is a variety of the `while` loop. In a **Do-While** loop,
+the condition is evaluated after the script block has run. As in a `while`
+loop, the script block is repeated as long as the condition evaluates to true.
 
 Like a **Do-While** loop, a **Do-Until** loop always runs at least once
 before the condition is evaluated. However, the script block runs only
 while the condition is false.
 
-The `Continue` and `Break` flow control keywords can be used in a **Do-While**
+The `continue` and `break` flow control keywords can be used in a **Do-While**
 loop or in a **Do-Until** loop.
 
 ### Syntax
@@ -53,7 +53,7 @@ information about how booleans are evaluated, see
 
 ### Example
 
-The following example of a `Do` statement counts the items in an array until it
+The following example of a `do` statement counts the items in an array until it
 reaches an item with a value of 0.
 
 ```powershell
@@ -63,7 +63,7 @@ PS> $count
 3
 ```
 
-The following example uses the `Until` keyword. Notice that the not equal to
+The following example uses the `until` keyword. Notice that the not equal to
 operator (`-ne`) is replaced by the equal to operator (`-eq`).
 
 ```powershell

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -54,7 +54,7 @@ Enumerations use the following syntaxes:
 ### Flag enumeration definition syntax
 
 ```Syntax
-[[<attribute>]...] [Flag()] enum <enum-name>[ : <underlying-type-name>] {
+[[<attribute>]...] [Flags()] enum <enum-name>[ : <underlying-type-name>] {
     <label 0> [= 1]
     <label 1> [= 2]
     <label 2> [= 4]
@@ -493,11 +493,11 @@ You can use the static method on the **System.Enum** base class type or a
 specific enumeration type.
 
 ```Syntax
-[System.Enum]::format([<enum-name>], <value>, <format-string>)
+[System.Enum]::Format([<enum-name>], <value>, <format-string>)
 ```
 
 ```Syntax
-[<enum-name>]::format([<enum-name>], <value>, <format-string>)
+[<enum-name>]::Format([<enum-name>], <value>, <format-string>)
 ```
 
 The valid format strings are `G` or `g`, `D` or `d`, `X` or `x`, and `F` or
@@ -843,7 +843,7 @@ enum Shade {
     Black
 }
 
-[Shade].GetEnumValues() | Foreach-Object -Process {
+[Shade].GetEnumValues() | ForEach-Object -Process {
     [pscustomobject]@{
         EnumValue    = $_
         StringValue  = $_.ToString()
@@ -1181,7 +1181,7 @@ module is removed, so are the type accelerators.
 
 ## Manually importing enumerations from a PowerShell module
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Enumerations aren't imported.
 
 If a module defines classes and enumerations but doesn't add type accelerators

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Environment_Provider.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Environment_Provider.md
@@ -78,16 +78,16 @@ drive. To reference an environment variable from another location, use the
 drive name `Env:` in the path.
 
 The **Environment** provider also exposes environment variables using a
-variable prefix of `$env:`.  The following command views the contents of the
-**ProgramFiles** environment variable. The `$env:` variable prefix can
+variable prefix of `$Env:`.  The following command views the contents of the
+**ProgramFiles** environment variable. The `$Env:` variable prefix can
 be used from any PowerShell drive.
 
 ```
-PS C:\> $env:ProgramFiles
+PS C:\> $Env:ProgramFiles
 C:\Program Files
 ```
 
-You can also change the value of an environment variable using the `$env:`
+You can also change the value of an environment variable using the `$Env:`
 variable prefix.  Any changes made only pertain to the current PowerShell
 session for as long as it is active.
 
@@ -116,7 +116,7 @@ Get-ChildItem -Path Env:
 
 ### Get a selected environment variable
 
-This command gets the `WINDIR` environment Variable.
+This command gets the `windir` environment Variable.
 
 ```powershell
 Get-ChildItem -Path Env:windir
@@ -125,7 +125,7 @@ Get-ChildItem -Path Env:windir
 You can also use the variable prefix format as well.
 
 ```powershell
-$env:windir
+$Env:windir
 ```
 
 ## Create an environment variable
@@ -210,7 +210,7 @@ Get-Help Get-ChildItem
 ```
 
 ```powershell
-Get-Help Get-ChildItem -Path env:
+Get-Help Get-ChildItem -Path Env:
 ```
 
 ## See also

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -29,12 +29,12 @@ For full descriptions of these variables, see the
 ## Long description
 
 PowerShell can access and manage environment variables in any of the supported
-operating system platforms. The PowerShell environment provider lets you get,
+operating system platforms. The PowerShell Environment provider lets you get,
 add, change, clear, and delete environment variables in the current console.
 
 > [!NOTE]
 > Unlike Windows, environment variable names on macOS and Linux are
-> case-sensitive. For example, `$env:Path` and `$env:PATH` are different
+> case-sensitive. For example, `$Env:Path` and `$Env:PATH` are different
 > environment variables on non-Windows platforms.
 
 Environment variables, unlike other types of variables in PowerShell, are
@@ -56,7 +56,7 @@ _User_ scopes.
 
 When you change environment variables in PowerShell, the change affects only
 the current session. This behavior resembles the behavior of the `set` command
-in the Windows Command Shell and the `setenv` command in UNIX-based
+in the Windows Command Shell and the `setenv` command in Unix-based
 environments. To change values in the Machine or User scopes, you must use the
 methods of the **System.Environment** class.
 
@@ -80,7 +80,7 @@ following syntax:
 $Env:<variable-name>
 ```
 
-For example, to display the value of the `WINDIR` environment variable:
+For example, to display the value of the `windir` environment variable:
 
 ```powershell
 $Env:windir
@@ -134,7 +134,7 @@ $Env:Foo | Get-Member -MemberType Properties
 ```Output
 Get-Member : You must specify an object for the Get-Member cmdlet.
 At line:1 char:12
-+ $env:foo | Get-Member
++ $Env:foo | Get-Member
 +            ~~~~~~~~~~
     + CategoryInfo          : CloseError: (:) [Get-Member], InvalidOperationException
     + FullyQualifiedErrorId : NoObjectInGetMember,Microsoft.PowerShell.Commands.GetMemberCommand
@@ -260,12 +260,12 @@ available in any session that loads your profile. This method works for any
 version of PowerShell on any supported platform.
 
 For example, to create the `CompanyUri` environment variable and update the
-`Path` environment variable to include the `C:\Tools` folder, add the following
+`PATH` environment variable to include the `C:\Tools` folder, add the following
 lines to your PowerShell profile:
 
 ```powershell
 $Env:CompanyUri = 'https://internal.contoso.com'
-$Env:Path += ';C:\Tools'
+$Env:PATH += ';C:\Tools'
 ```
 
 > [!NOTE]
@@ -396,13 +396,13 @@ The environment variables that store preferences include:
 
 - `PSModulePath`
 
-  The `$env:PSModulePath` environment variable contains a list of folder
+  The `$Env:PSModulePath` environment variable contains a list of folder
   locations that are searched to find modules and resources. On Windows, the
   list of folder locations is separated by the semi-colon (`;`) character. On
   non-Windows platforms, the colon (`:`) separates the folder locations in the
   environment variable.
 
-  By default, the effective locations assigned to `$env:PSModulePath` are:
+  By default, the effective locations assigned to `$Env:PSModulePath` are:
 
   - System-wide locations: These folders contain modules that ship with
     PowerShell. The modules are store in the `$PSHOME\Modules` location. Also,
@@ -415,14 +415,14 @@ The environment variables that store preferences include:
 
     - On Windows, the location of the user-specific **CurrentUser** scope is
       the `$HOME\Documents\PowerShell\Modules` folder. The location of the
-      **AllUsers** scope is `$env:ProgramFiles\PowerShell\Modules`.
+      **AllUsers** scope is `$Env:ProgramFiles\PowerShell\Modules`.
     - On non-Windows systems, the location of the user-specific **CurrentUser**
       scope is the `$HOME/.local/share/powershell/Modules` folder. The location
       of the **AllUsers** scope is `/usr/local/share/powershell/Modules`.
 
   In addition, setup programs that install modules in other directories, such
   as the Program Files directory, can append their locations to the value of
-  `$env:PSModulePath`.
+  `$Env:PSModulePath`.
 
   For more information, see [about_PSModulePath][08].
 
@@ -435,8 +435,8 @@ The environment variables that store preferences include:
 
   The default location of the cache is:
 
-  - Windows PowerShell 5.1: `$env:LOCALAPPDATA\Microsoft\Windows\PowerShell`
-  - PowerShell 6.0 and higher: `$env:LOCALAPPDATA\Microsoft\PowerShell`
+  - Windows PowerShell 5.1: `$Env:LOCALAPPDATA\Microsoft\Windows\PowerShell`
+  - PowerShell 6.0 and higher: `$Env:LOCALAPPDATA\Microsoft\PowerShell`
   - Non-Windows default: `~/.cache/powershell`
 
   The default filename for the cache is `ModuleAnalysisCache`. When you have
@@ -462,7 +462,7 @@ The environment variables that store preferences include:
   ```powershell
   # `NUL` here is a special device on Windows that can't be written to,
   # on non-Windows you would use `/dev/null`
-  $env:PSModuleAnalysisCachePath = 'NUL'
+  $Env:PSModuleAnalysisCachePath = 'NUL'
   ```
 
   This sets the path to the **NUL** device. PowerShell can't write to the
@@ -494,7 +494,7 @@ The environment variables that store preferences include:
 
 - `PATH`
 
-  The `$env:PATH` environment variable contains a list of folder locations that
+  The `$Env:PATH` environment variable contains a list of folder locations that
   the operating system searches for executable files. On Windows, the list of
   folder locations is separated by the semi-colon (`;`) character. On
   non-Windows platforms, the colon (`:`) separates the folder locations in the
@@ -502,7 +502,7 @@ The environment variables that store preferences include:
 
 - `PATHEXT`
 
-  The `$env:PATHEXT` variable contains a list of file extensions that Windows
+  The `$Env:PATHEXT` variable contains a list of file extensions that Windows
   considers to be executable files. When a script file with one of the listed
   extensions is executed from PowerShell, the script runs in the current
   console or terminal session. If the file extension isn't listed, the script
@@ -518,7 +518,7 @@ The environment variables that store preferences include:
   documentation for the [ftype][02] command.
 
   PowerShell scripts always start in the current console session. You don't
-  need to add the `.PS1` extension.
+  need to add the `.ps1` extension.
 
 - `XDG` variables
 
@@ -538,7 +538,7 @@ or `NO_COLOR` environment variables.
 
 - `TERM`
 
-  The following values of `$env:TERM` change the behavior as follows:
+  The following values of `$Env:TERM` change the behavior as follows:
 
   - `dumb` - sets `$Host.UI.SupportsVirtualTerminal = $false`
   - `xterm-mono` - sets `$PSStyle.OutputRendering = PlainText`
@@ -546,7 +546,7 @@ or `NO_COLOR` environment variables.
 
 - `NO_COLOR`
 
-  If `$env:NO_COLOR` exists, then `$PSStyle.OutputRendering` is set to
+  If `$Env:NO_COLOR` exists, then `$PSStyle.OutputRendering` is set to
   `PlainText`. For more information about the `NO_COLOR` environment
   variable, see [https://no-color.org/][12].
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
@@ -135,7 +135,7 @@ execution policies are as follows:
 
   The **Process** scope only affects the current PowerShell session. The
   execution policy is saved in the environment variable
-  `$env:PSExecutionPolicyPreference`, rather than the configuration file. When
+  `$Env:PSExecutionPolicyPreference`, rather than the configuration file. When
   the PowerShell session is closed, the variable and value are deleted.
 
 - CurrentUser
@@ -279,7 +279,7 @@ pwsh.exe -ExecutionPolicy AllSigned
 ```
 
 The execution policy that you set isn't stored in the configuration file.
-Instead, it's stored in the `$env:PSExecutionPolicyPreference` environment
+Instead, it's stored in the `$Env:PSExecutionPolicyPreference` environment
 variable. The variable is deleted when you close the session in which the
 policy is set. You cannot change the policy by editing the variable value.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
@@ -33,11 +33,11 @@ The **FileSystem** drives are a hierarchical namespace containing the
 directories and files on your computer. A **FileSystem** drive can be a logical
 or physical drive, directory, or mapped network share.
 
-Beginning in PowerShell Version 7.0, a drive called `TEMP:` is mapped to the
+Beginning in PowerShell Version 7.0, a drive called `Temp:` is mapped to the
 user's temporary directory path. PowerShell uses the .NET [GetTempPath()][05]
 method to determine the location of the temporary folder. On Windows, the
-location is the same as `$env:TEMP`. On non-Windows systems, the location is
-the same as `$env:TMPDIR` or `/tmp` if the environment variable isn't defined.
+location is the same as `$Env:TEMP`. On non-Windows systems, the location is
+the same as `$Env:TMPDIR` or `/tmp` if the environment variable isn't defined.
 
 The **FileSystem** provider supports the following cmdlets, which are covered
 in this article.
@@ -212,7 +212,7 @@ the dollar sign (`$`). The path must be enclosed in curly braces due to
 variable naming restrictions. For more information, see [about_Variables][09].
 
 ```powershell
-${C:\Windows\System32\Drivers\etc\hosts}
+${C:\Windows\System32\drivers\etc\hosts}
 ```
 
 ### Add content to a file
@@ -260,7 +260,7 @@ For more information about `Get-Content` cmdlet, see the help topic for the
 For more information about arrays, see [about_Arrays][07].
 
 ```powershell
-$e = Get-Content c:\test\employees.txt -Delimited "End Of Employee Record"
+$e = Get-Content C:\test\employees.txt -Delimited "End Of Employee Record"
 $e[0]
 ```
 
@@ -284,7 +284,7 @@ For more information about this object, pipe the command to the
 This command creates the `logfiles` directory on the `C` drive:
 
 ```powershell
-New-Item -Path c:\ -Name logfiles -Type directory
+New-Item -Path C:\ -Name logfiles -Type Directory
 ```
 
 PowerShell also includes a `mkdir` function (alias `md`) that uses the
@@ -296,7 +296,7 @@ This command creates the `log2.txt` file in the `C:\logfiles` directory and
 then adds the "test log" string to the file:
 
 ```powershell
-New-Item -Path c:\logfiles -Name log2.txt -Type file
+New-Item -Path C:\logfiles -Name log2.txt -Type File
 ```
 
 ### Create a file with content
@@ -305,7 +305,7 @@ Creates a file called `log2.txt` in the `C:\logfiles` directory and adds the
 string "test log" to the file.
 
 ```powershell
-New-Item -Path c:\logfiles -Name log2.txt -Type file -Value "test log"
+New-Item -Path C:\logfiles -Name log2.txt -Type File -Value "test log"
 ```
 
 ## Renaming files and directories
@@ -315,7 +315,7 @@ New-Item -Path c:\logfiles -Name log2.txt -Type file -Value "test log"
 This command renames the `a.txt` file in the `C:\a` directory to `b.txt`:
 
 ```powershell
-Rename-Item -Path c:\a\a.txt -NewName b.txt
+Rename-Item -Path C:\a\a.txt -NewName b.txt
 ```
 
 ### Rename a directory
@@ -323,7 +323,7 @@ Rename-Item -Path c:\a\a.txt -NewName b.txt
 This command renames the `C:\a\cc` directory to `C:\a\dd`:
 
 ```powershell
-Rename-Item -Path c:\a\cc -NewName dd
+Rename-Item -Path C:\a\cc -NewName dd
 ```
 
 ## Deleting files and directories
@@ -388,7 +388,7 @@ which gets hidden files, and `!Directory`, which gets all other files.
 Get-ChildItem -Attributes !Directory,!Directory+Hidden
 ```
 
-`dir -att !d,!d+h` is the equivalent of this command.
+`dir -Att !d,!d+h` is the equivalent of this command.
 
 ### Get Compressed and Encrypted files
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_For.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_For.md
@@ -15,17 +15,17 @@ conditional test.
 
 ## Long description
 
-The `For` statement (also known as a `For` loop) is a language construct you
+The `for` statement (also known as a `for` loop) is a language construct you
 can use to create a loop that runs commands in a command block while a
 specified condition evaluates to `$true`.
 
-A typical use of the `For` loop is to iterate an array of values and to operate
+A typical use of the `for` loop is to iterate an array of values and to operate
 on a subset of these values. In most cases, if you want to iterate all the
-values in an array, consider using a `Foreach` statement.
+values in an array, consider using a `foreach` statement.
 
 ### Syntax
 
-The following shows the `For` statement syntax.
+The following shows the `for` statement syntax.
 
 ```
 for (<Init>; <Condition>; <Repeat>)
@@ -39,11 +39,11 @@ the loop begins. You typically use the **Init** portion of the statement to
 create and initialize a variable with a starting value.
 
 This variable will then be the basis for the condition to be tested in the next
-portion of the `For` statement.
+portion of the `for` statement.
 
-The **Condition** placeholder represents the portion of the `For` statement
+The **Condition** placeholder represents the portion of the `for` statement
 that resolves to a `$true` or `$false` **Boolean** value. PowerShell evaluates
-the condition each time the `For` loop runs. If the statement is `$true`, the
+the condition each time the `for` loop runs. If the statement is `$true`, the
 commands in the command block run, and the statement is evaluated again. If the
 condition is still `$true`, the commands in the **Statement list** run again.
 The loop is repeated until the condition becomes `$false`.
@@ -122,14 +122,14 @@ For more information, see [about_Logical_Operators][01].
 
 ### Syntax examples
 
-At a minimum, a `For` statement requires the parenthesis surrounding the
+At a minimum, a `for` statement requires the parenthesis surrounding the
 **Init**, **Condition**, and **Repeat** part of the statement and a command
 surrounded by braces in the **Statement list** part of the statement.
 
-Note that the upcoming examples intentionally show code outside the `For`
-statement. In later examples, code is integrated into the `For` statement.
+Note that the upcoming examples intentionally show code outside the `for`
+statement. In later examples, code is integrated into the `for` statement.
 
-For example, the following `For` statement continually displays the value of
+For example, the following `for` statement continually displays the value of
 the `$i` variable until you manually break out of the command by pressing
 CTRL+C.
 
@@ -156,7 +156,7 @@ continually display the value of the `$i` variable as it is incremented by 1
 each time the loop is run.
 
 Rather than change the value of the variable in the statement list part of the
-`For` statement, you can use the **Repeat** portion of the `For` statement
+`for` statement, you can use the **Repeat** portion of the `for` statement
 instead, as follows.
 
 ```powershell
@@ -170,11 +170,11 @@ for (;;$i++)
 This statement will still repeat indefinitely until you break out of the
 command by pressing CTRL+C.
 
-You can terminate the `For` loop using a **condition**. You can place a
-condition using the **Condition** portion of the `For` statement. The `For`
+You can terminate the `for` loop using a **condition**. You can place a
+condition using the **Condition** portion of the `for` statement. The `for`
 loop terminates when the condition evaluates to `$false`.
 
-In the following example, the `For` loop runs while the value of `$i` is less
+In the following example, the `for` loop runs while the value of `$i` is less
 than or equal to 10.
 
 ```powershell
@@ -185,17 +185,17 @@ for(;$i -le 10;$i++)
 }
 ```
 
-Instead of creating and initializing the variable outside the `For` statement,
-you can perform this task inside the `For` loop by using the **Init** portion
-of the `For` statement.
+Instead of creating and initializing the variable outside the `for` statement,
+you can perform this task inside the `for` loop by using the **Init** portion
+of the `for` statement.
 
 ```powershell
 for($i=1; $i -le 10; $i++){Write-Host $i}
 ```
 
 You can use carriage returns instead of semicolons to delimit the **Init**,
-**Condition**, and **Repeat** portions of the `For` statement. The following
-example shows a `For` that uses this alternative syntax.
+**Condition**, and **Repeat** portions of the `for` statement. The following
+example shows a `for` that uses this alternative syntax.
 
 ```powershell
 for ($i = 0
@@ -205,15 +205,15 @@ for ($i = 0
 }
 ```
 
-This alternative form of the `For` statement works in PowerShell script files
-and at the PowerShell command prompt. However, it is easier to use the `For`
+This alternative form of the `for` statement works in PowerShell script files
+and at the PowerShell command prompt. However, it is easier to use the `for`
 statement syntax with semicolons when you enter interactive commands at the
 command prompt.
 
-The `For` loop is more flexible than the `Foreach` loop because it allows you
+The `for` loop is more flexible than the `foreach` loop because it allows you
 to increment values in an array or collection by using patterns. In the
 following example, the `$i` variable is incremented by 2 in the **Repeat**
-portion of the `For` statement.
+portion of the `for` statement.
 
 ```powershell
 for ($i = 0; $i -le 20; $i += 2)
@@ -222,7 +222,7 @@ for ($i = 0; $i -le 20; $i += 2)
 }
 ```
 
-The `For` loop can also be written on one line as in the following example.
+The `for` loop can also be written on one line as in the following example.
 
 ```powershell
 for ($i = 0; $i -lt 10; $i++){Write-Host $i}
@@ -230,7 +230,7 @@ for ($i = 0; $i -lt 10; $i++){Write-Host $i}
 
 ### Functional example
 
-The following example demonstrates how you can use a `For` loop to iterate over
+The following example demonstrates how you can use a `for` loop to iterate over
 an array of files and rename them. The files in the `work_items` folder have
 their work item ID as the filename. The loop iterates through the files
 to ensure that the ID number is zero-padded to five digits.

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Data_Files.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Data_Files.md
@@ -1,5 +1,5 @@
 ---
-description: Describes how to use PowerShell data (.psd1) files.
+description: Describes how to use PowerShell data (`.psd1`) files.
 Locale: en-US
 ms.date: 01/19/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_data_files?view=powershell-7.6&WT.mc_id=ps-gethelp
@@ -55,7 +55,7 @@ you aren't limited to storing string data and don't have to use the data for
 localized output.
 
 The data in the file isn't limited to hashtables. It can be in any format
-supported by the PowerShell syntax, such as `DATA` sections.
+supported by the PowerShell syntax, such as `data` sections.
 
 For more information, see [about_Data_Sections][01].
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -10,14 +10,14 @@ title: about_Data_Sections
 
 ## Short description
 
-Explains `DATA` sections, which isolate text strings and other read-only
+Explains `data` sections, which isolate text strings and other read-only
 data from script logic.
 
 ## Long description
 
-Scripts that are designed for PowerShell can have one or more `DATA` sections
-that contain only data. You can include one or more `DATA` sections in any
-script, function, or advanced function. The content of the `DATA` section is
+Scripts that are designed for PowerShell can have one or more `data` sections
+that contain only data. You can include one or more `data` sections in any
+script, function, or advanced function. The content of the `data` section is
 restricted to a specified subset of the PowerShell scripting language.
 
 Separating data from code logic makes it easier to identify and manage both
@@ -25,27 +25,27 @@ logic and data. It lets you have separate string resource files for text, such
 as error messages and Help strings. It also isolates the code logic, which
 facilitates security and validation tests.
 
-In PowerShell, you can use the `DATA` section to support script
-internationalization. You can use `DATA` sections to make it easier to isolate,
+In PowerShell, you can use the `data` section to support script
+internationalization. You can use `data` sections to make it easier to isolate,
 locate, and process strings that can be translated into other languages.
 
-The `DATA` section was added in PowerShell 2.0 feature.
+The `data` section was added in PowerShell 2.0 feature.
 
 ### Syntax
 
-The syntax for a `DATA` section is as follows:
+The syntax for a `data` section is as follows:
 
 ```Syntax
-DATA [<variable-name>] [-supportedCommand <cmdlet-name>] {
+data [<variable-name>] [-SupportedCommand <cmdlet-name>] {
     <Permitted content>
 }
 ```
 
-The `DATA` keyword is required. It isn't case-sensitive. The permitted content
+The `data` keyword is required. It isn't case-sensitive. The permitted content
 is limited to the following elements:
 
 - All PowerShell operators, except `-match`
-- `If`, `Else`, and `ElseIf` statements
+- `if`, `else`, and `elseif` statements
 - The following automatic variables: `$PSCulture`, `$PSUICulture`, `$true`,
   `$false`, and `$null`
 - Comments
@@ -60,17 +60,17 @@ is limited to the following elements:
   "PowerShell 2.0"
   @( "red", "green", "blue" )
   @{ a = 0x1; b = "great"; c ="script" }
-  [XML] @'
+  [xml] @'
   <p> Hello, World </p>
   '@
   ```
 
-- Cmdlets that are permitted in a `DATA` section. By default, only the
+- Cmdlets that are permitted in a `data` section. By default, only the
   `ConvertFrom-StringData` cmdlet is permitted.
-- Cmdlets that you permit in a `DATA` section by using the `-SupportedCommand`
+- Cmdlets that you permit in a `data` section by using the `-SupportedCommand`
   parameter.
 
-When you use the `ConvertFrom-StringData` cmdlet in a `DATA` section, you can
+When you use the `ConvertFrom-StringData` cmdlet in a `data` section, you can
 enclose the key-value pairs in single-quoted or double-quoted strings or in
 single-quoted or double-quoted here-strings. However, strings that contain
 variables and subexpressions must be enclosed in single-quoted strings or in
@@ -81,34 +81,34 @@ subexpressions aren't executable.
 
 The **SupportedCommand** parameter allows you to indicate that a cmdlet or
 function generates only data. It's designed to allow users to include cmdlets
-and functions in a `DATA` section that they have written or tested.
+and functions in a `data` section that they have written or tested.
 
 The value of **SupportedCommand** is a comma-separated list of one or more
 cmdlet or function names.
 
-For example, the following `DATA` section includes a user-written cmdlet,
+For example, the following `data` section includes a user-written cmdlet,
 `Format-Xml`, that formats data in an XML file:
 
 ```powershell
-DATA -supportedCommand Format-Xml
+data -SupportedCommand Format-Xml
 {
     Format-Xml -Strings string1, string2, string3
 }
 ```
 
-### Using a `DATA` Section
+### Using a `data` Section
 
-To use the content of a `DATA` section, assign it to a variable and use
+To use the content of a `data` section, assign it to a variable and use
 variable notation to access the content.
 
-For example, the following `DATA` section contains a `ConvertFrom-StringData`
+For example, the following `data` section contains a `ConvertFrom-StringData`
 command that converts the here-string into a hash table. The hash table is
 assigned to the `$TextMsgs` variable.
 
-The `$TextMsgs` variable isn't part of the `DATA` section.
+The `$TextMsgs` variable isn't part of the `data` section.
 
 ```powershell
-$TextMsgs = DATA {
+$TextMsgs = data {
     ConvertFrom-StringData -StringData @'
 Text001 = Windows 7
 Text002 = Windows Server 2008 R2
@@ -124,11 +124,11 @@ $TextMsgs.Text001
 $TextMsgs.Text002
 ```
 
-Alternately, you can put the variable name in the definition of the `DATA`
+Alternately, you can put the variable name in the definition of the `data`
 section. For example:
 
 ```powershell
-DATA TextMsgs {
+data TextMsgs {
     ConvertFrom-StringData -StringData @'
 Text001 = Windows 7
 Text002 = Windows Server 2008 R2
@@ -152,7 +152,7 @@ Text002                        Windows Server 2008 R2
 Simple data strings.
 
 ```powershell
-DATA {
+data {
     "Thank you for using my PowerShell Organize.pst script."
     "It is provided free of charge to the community."
     "I appreciate your comments and feedback."
@@ -162,9 +162,9 @@ DATA {
 Strings that include permitted variables.
 
 ```powershell
-DATA {
+data {
     if ($null) {
-        "To get help for this cmdlet, type get-help new-dictionary."
+        "To get help for this cmdlet, type Get-Help New-Dictionary."
     }
 }
 ```
@@ -172,7 +172,7 @@ DATA {
 A single-quoted here-string that uses the `ConvertFrom-StringData` cmdlet:
 
 ```powershell
-DATA {
+data {
     ConvertFrom-StringData -StringData @'
 Text001 = Windows 7
 Text002 = Windows Server 2008 R2
@@ -183,7 +183,7 @@ Text002 = Windows Server 2008 R2
 A double-quoted here-string that uses the `ConvertFrom-StringData` cmdlet:
 
 ```powershell
-DATA  {
+data {
     ConvertFrom-StringData -StringData @"
 Msg1 = To start, press any key.
 Msg2 = To exit, type "quit".
@@ -194,7 +194,7 @@ Msg2 = To exit, type "quit".
 A data section that includes a user-written cmdlet that generates data:
 
 ```powershell
-DATA -supportedCommand Format-XML {
+data -SupportedCommand Format-Xml {
     Format-Xml -Strings string1, string2, string3
 }
 ```

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -96,7 +96,7 @@ menu.
   you are debugging a job by running the `Debug-Job` cmdlet, the `Exit` command
   detaches the debugger, and allows the job to continue running.
 
-- `k`, `Get-PsCallStack`: Displays the current call stack.
+- `k`, `Get-PSCallStack`: Displays the current call stack.
 
 - `<Enter>`: Repeats the last command if it was `Step` (`s`), `StepOver` (`v`),
   or `List` (`l`). Otherwise, represents a submit action.
@@ -223,7 +223,7 @@ sections, the debugger breaks at the first line of each section.
 For example:
 
 ```powershell
-function test-cmdlet {
+function Test-Cmdlet {
     begin {
         Write-Output "Begin"
     }
@@ -235,32 +235,32 @@ function test-cmdlet {
     }
 }
 
-C:\PS> Set-PSBreakpoint -Command test-cmdlet
+C:\PS> Set-PSBreakpoint -Command Test-Cmdlet
 
-C:\PS> test-cmdlet
+C:\PS> Test-Cmdlet
 
 Begin
 Entering debug mode. Use h or ? for help.
 
-Hit Command breakpoint on 'prompt:test-cmdlet'
+Hit Command breakpoint on 'prompt:Test-Cmdlet'
 
-test-cmdlet
+Test-Cmdlet
 
 [DBG]: C:\PS> c
 Process
 Entering debug mode. Use h or ? for help.
 
-Hit Command breakpoint on 'prompt:test-cmdlet'
+Hit Command breakpoint on 'prompt:Test-Cmdlet'
 
-test-cmdlet
+Test-Cmdlet
 
 [DBG]: C:\PS> c
 End
 Entering debug mode. Use h or ? for help.
 
-Hit Command breakpoint on 'prompt:test-cmdlet'
+Hit Command breakpoint on 'prompt:Test-Cmdlet'
 
-test-cmdlet
+Test-Cmdlet
 
 [DBG]: C:\PS>
 ```
@@ -351,7 +351,7 @@ function psversion {
     "Upgrade to PowerShell 7!"
   }
   else {
-    "Have you run a background job today (start-job)?"
+    "Have you run a background job today (Start-Job)?"
   }
 }
 
@@ -460,7 +460,7 @@ steps to the next statement in the script.
 ```powershell
 DBG> o
 Windows PowerShell 2.0
-Have you run a background job today (start-job)?
+Have you run a background job today (Start-Job)?
 test.ps1:13  "Done $scriptName"
 ```
 
@@ -477,9 +477,9 @@ indicates that the debugger has exited and returned control to the command
 processor.
 
 Now, run the debugger again. First, to delete the current breakpoint, use the
-`Get-PsBreakpoint` and `Remove-PsBreakpoint` cmdlets. (If you think you might
-reuse the breakpoint, use the `Disable-PsBreakpoint` cmdlet instead of
-`Remove-PsBreakpoint`.)
+`Get-PSBreakpoint` and `Remove-PSBreakpoint` cmdlets. (If you think you might
+reuse the breakpoint, use the `Disable-PSBreakpoint` cmdlet instead of
+`Remove-PSBreakpoint`.)
 
 ```powershell
 PS C:\ps-test> Get-PSBreakpoint | Remove-PSBreakpoint
@@ -553,7 +553,7 @@ displayed, but it isn't executed.
 ```powershell
 DBG> v
 Windows PowerShell 2.0
-Have you run a background job today (start-job)?
+Have you run a background job today (Start-Job)?
 test.ps1:13  "Done $scriptName"
 ```
 
@@ -567,7 +567,7 @@ the standard command prompt.
 C:\ps-test>
 ```
 
-To delete the breakpoints, use the `Get-PsBreakpoint` and `Remove-PsBreakpoint`
+To delete the breakpoints, use the `Get-PSBreakpoint` and `Remove-PSBreakpoint`
 cmdlets.
 
 ```powershell
@@ -603,13 +603,13 @@ the breakpoint or to perform preparatory or diagnostic tasks, such as starting
 a log or invoking a diagnostic or security script.
 
 To set an action, use a Continue command (c) to exit the script, and a
-`Remove-PsBreakpoint` command to delete the current breakpoint. (Breakpoints
+`Remove-PSBreakpoint` command to delete the current breakpoint. (Breakpoints
 are read-only, so you can't add an action to the current breakpoint.)
 
 ```powershell
 DBG> c
 Windows PowerShell 2.0
-Have you run a background job today (start-job)?
+Have you run a background job today (Start-Job)?
 Done C:\ps-test\test.ps1
 
 PS C:\ps-test> Get-PSBreakpoint | Remove-PSBreakpoint
@@ -656,7 +656,7 @@ Because the execution policy is set to **RemoteSigned**, execution stops at the
 function call.
 
 At this point, you might want to check the call stack. Use the
-`Get-PsCallStack` cmdlet or the `Get-PsCallStack` debugger command (`k`). The
+`Get-PSCallStack` cmdlet or the `Get-PSCallStack` debugger command (`k`). The
 following command gets the current call stack.
 
 ```powershell

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Do.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Do.md
@@ -1,5 +1,5 @@
 ---
-description: Runs a statement list one or more times, subject to a While or Until condition.
+description: Runs a statement list one or more times, subject to a `while` or `until` condition.
 Locale: en-US
 ms.date: 06/10/2021
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_do?view=powershell-7.6&WT.mc_id=ps-gethelp
@@ -10,24 +10,24 @@ title: about_Do
 
 ## Short description
 
-Runs a statement list one or more times, subject to a `While` or `Until`
+Runs a statement list one or more times, subject to a `while` or `until`
 condition.
 
 ## Long description
 
-The `Do` keyword works with the `While` keyword or the `Until` keyword to run
+The `do` keyword works with the `while` keyword or the `until` keyword to run
 the statements in a script block, subject to a condition. Unlike the related
-`While` loop, the script block in a `Do` loop always runs at least once.
+`while` loop, the script block in a `do` loop always runs at least once.
 
-A **Do-While** loop is a variety of the `While` loop. In a **Do-While** loop,
-the condition is evaluated after the script block has run. As in a While loop,
-the script block is repeated as long as the condition evaluates to true.
+A **Do-While** loop is a variety of the `while` loop. In a **Do-While** loop,
+the condition is evaluated after the script block has run. As in a `while`
+loop, the script block is repeated as long as the condition evaluates to true.
 
 Like a **Do-While** loop, a **Do-Until** loop always runs at least once
 before the condition is evaluated. However, the script block runs only
 while the condition is false.
 
-The `Continue` and `Break` flow control keywords can be used in a **Do-While**
+The `continue` and `break` flow control keywords can be used in a **Do-While**
 loop or in a **Do-Until** loop.
 
 ### Syntax
@@ -53,7 +53,7 @@ information about how booleans are evaluated, see
 
 ### Example
 
-The following example of a `Do` statement counts the items in an array until it
+The following example of a `do` statement counts the items in an array until it
 reaches an item with a value of 0.
 
 ```powershell
@@ -63,7 +63,7 @@ PS> $count
 3
 ```
 
-The following example uses the `Until` keyword. Notice that the not equal to
+The following example uses the `until` keyword. Notice that the not equal to
 operator (`-ne`) is replaced by the equal to operator (`-eq`).
 
 ```powershell

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Enum.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Enum.md
@@ -54,7 +54,7 @@ Enumerations use the following syntaxes:
 ### Flag enumeration definition syntax
 
 ```Syntax
-[[<attribute>]...] [Flag()] enum <enum-name>[ : <underlying-type-name>] {
+[[<attribute>]...] [Flags()] enum <enum-name>[ : <underlying-type-name>] {
     <label 0> [= 1]
     <label 1> [= 2]
     <label 2> [= 4]
@@ -493,11 +493,11 @@ You can use the static method on the **System.Enum** base class type or a
 specific enumeration type.
 
 ```Syntax
-[System.Enum]::format([<enum-name>], <value>, <format-string>)
+[System.Enum]::Format([<enum-name>], <value>, <format-string>)
 ```
 
 ```Syntax
-[<enum-name>]::format([<enum-name>], <value>, <format-string>)
+[<enum-name>]::Format([<enum-name>], <value>, <format-string>)
 ```
 
 The valid format strings are `G` or `g`, `D` or `d`, `X` or `x`, and `F` or
@@ -843,7 +843,7 @@ enum Shade {
     Black
 }
 
-[Shade].GetEnumValues() | Foreach-Object -Process {
+[Shade].GetEnumValues() | ForEach-Object -Process {
     [pscustomobject]@{
         EnumValue    = $_
         StringValue  = $_.ToString()
@@ -1181,7 +1181,7 @@ module is removed, so are the type accelerators.
 
 ## Manually importing enumerations from a PowerShell module
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Enumerations aren't imported.
 
 If a module defines classes and enumerations but doesn't add type accelerators

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Environment_Provider.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Environment_Provider.md
@@ -78,16 +78,16 @@ drive. To reference an environment variable from another location, use the
 drive name `Env:` in the path.
 
 The **Environment** provider also exposes environment variables using a
-variable prefix of `$env:`.  The following command views the contents of the
-**ProgramFiles** environment variable. The `$env:` variable prefix can
+variable prefix of `$Env:`.  The following command views the contents of the
+**ProgramFiles** environment variable. The `$Env:` variable prefix can
 be used from any PowerShell drive.
 
 ```
-PS C:\> $env:ProgramFiles
+PS C:\> $Env:ProgramFiles
 C:\Program Files
 ```
 
-You can also change the value of an environment variable using the `$env:`
+You can also change the value of an environment variable using the `$Env:`
 variable prefix.  Any changes made only pertain to the current PowerShell
 session for as long as it is active.
 
@@ -116,7 +116,7 @@ Get-ChildItem -Path Env:
 
 ### Get a selected environment variable
 
-This command gets the `WINDIR` environment Variable.
+This command gets the `windir` environment Variable.
 
 ```powershell
 Get-ChildItem -Path Env:windir
@@ -125,7 +125,7 @@ Get-ChildItem -Path Env:windir
 You can also use the variable prefix format as well.
 
 ```powershell
-$env:windir
+$Env:windir
 ```
 
 ## Create an environment variable
@@ -210,7 +210,7 @@ Get-Help Get-ChildItem
 ```
 
 ```powershell
-Get-Help Get-ChildItem -Path env:
+Get-Help Get-ChildItem -Path Env:
 ```
 
 ## See also

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -29,12 +29,12 @@ For full descriptions of these variables, see the
 ## Long description
 
 PowerShell can access and manage environment variables in any of the supported
-operating system platforms. The PowerShell environment provider lets you get,
+operating system platforms. The PowerShell Environment provider lets you get,
 add, change, clear, and delete environment variables in the current console.
 
 > [!NOTE]
 > Unlike Windows, environment variable names on macOS and Linux are
-> case-sensitive. For example, `$env:Path` and `$env:PATH` are different
+> case-sensitive. For example, `$Env:Path` and `$Env:PATH` are different
 > environment variables on non-Windows platforms.
 
 Environment variables, unlike other types of variables in PowerShell, are
@@ -56,7 +56,7 @@ _User_ scopes.
 
 When you change environment variables in PowerShell, the change affects only
 the current session. This behavior resembles the behavior of the `set` command
-in the Windows Command Shell and the `setenv` command in UNIX-based
+in the Windows Command Shell and the `setenv` command in Unix-based
 environments. To change values in the Machine or User scopes, you must use the
 methods of the **System.Environment** class.
 
@@ -80,7 +80,7 @@ following syntax:
 $Env:<variable-name>
 ```
 
-For example, to display the value of the `WINDIR` environment variable:
+For example, to display the value of the `windir` environment variable:
 
 ```powershell
 $Env:windir
@@ -134,7 +134,7 @@ $Env:Foo | Get-Member -MemberType Properties
 ```Output
 Get-Member : You must specify an object for the Get-Member cmdlet.
 At line:1 char:12
-+ $env:foo | Get-Member
++ $Env:foo | Get-Member
 +            ~~~~~~~~~~
     + CategoryInfo          : CloseError: (:) [Get-Member], InvalidOperationException
     + FullyQualifiedErrorId : NoObjectInGetMember,Microsoft.PowerShell.Commands.GetMemberCommand
@@ -260,12 +260,12 @@ available in any session that loads your profile. This method works for any
 version of PowerShell on any supported platform.
 
 For example, to create the `CompanyUri` environment variable and update the
-`Path` environment variable to include the `C:\Tools` folder, add the following
+`PATH` environment variable to include the `C:\Tools` folder, add the following
 lines to your PowerShell profile:
 
 ```powershell
 $Env:CompanyUri = 'https://internal.contoso.com'
-$Env:Path += ';C:\Tools'
+$Env:PATH += ';C:\Tools'
 ```
 
 > [!NOTE]
@@ -396,13 +396,13 @@ The environment variables that store preferences include:
 
 - `PSModulePath`
 
-  The `$env:PSModulePath` environment variable contains a list of folder
+  The `$Env:PSModulePath` environment variable contains a list of folder
   locations that are searched to find modules and resources. On Windows, the
   list of folder locations is separated by the semi-colon (`;`) character. On
   non-Windows platforms, the colon (`:`) separates the folder locations in the
   environment variable.
 
-  By default, the effective locations assigned to `$env:PSModulePath` are:
+  By default, the effective locations assigned to `$Env:PSModulePath` are:
 
   - System-wide locations: These folders contain modules that ship with
     PowerShell. The modules are store in the `$PSHOME\Modules` location. Also,
@@ -415,14 +415,14 @@ The environment variables that store preferences include:
 
     - On Windows, the location of the user-specific **CurrentUser** scope is
       the `$HOME\Documents\PowerShell\Modules` folder. The location of the
-      **AllUsers** scope is `$env:ProgramFiles\PowerShell\Modules`.
+      **AllUsers** scope is `$Env:ProgramFiles\PowerShell\Modules`.
     - On non-Windows systems, the location of the user-specific **CurrentUser**
       scope is the `$HOME/.local/share/powershell/Modules` folder. The location
       of the **AllUsers** scope is `/usr/local/share/powershell/Modules`.
 
   In addition, setup programs that install modules in other directories, such
   as the Program Files directory, can append their locations to the value of
-  `$env:PSModulePath`.
+  `$Env:PSModulePath`.
 
   For more information, see [about_PSModulePath][08].
 
@@ -435,8 +435,8 @@ The environment variables that store preferences include:
 
   The default location of the cache is:
 
-  - Windows PowerShell 5.1: `$env:LOCALAPPDATA\Microsoft\Windows\PowerShell`
-  - PowerShell 6.0 and higher: `$env:LOCALAPPDATA\Microsoft\PowerShell`
+  - Windows PowerShell 5.1: `$Env:LOCALAPPDATA\Microsoft\Windows\PowerShell`
+  - PowerShell 6.0 and higher: `$Env:LOCALAPPDATA\Microsoft\PowerShell`
   - Non-Windows default: `~/.cache/powershell`
 
   The default filename for the cache is `ModuleAnalysisCache`. When you have
@@ -462,7 +462,7 @@ The environment variables that store preferences include:
   ```powershell
   # `NUL` here is a special device on Windows that can't be written to,
   # on non-Windows you would use `/dev/null`
-  $env:PSModuleAnalysisCachePath = 'NUL'
+  $Env:PSModuleAnalysisCachePath = 'NUL'
   ```
 
   This sets the path to the **NUL** device. PowerShell can't write to the
@@ -494,7 +494,7 @@ The environment variables that store preferences include:
 
 - `PATH`
 
-  The `$env:PATH` environment variable contains a list of folder locations that
+  The `$Env:PATH` environment variable contains a list of folder locations that
   the operating system searches for executable files. On Windows, the list of
   folder locations is separated by the semi-colon (`;`) character. On
   non-Windows platforms, the colon (`:`) separates the folder locations in the
@@ -502,7 +502,7 @@ The environment variables that store preferences include:
 
 - `PATHEXT`
 
-  The `$env:PATHEXT` variable contains a list of file extensions that Windows
+  The `$Env:PATHEXT` variable contains a list of file extensions that Windows
   considers to be executable files. When a script file with one of the listed
   extensions is executed from PowerShell, the script runs in the current
   console or terminal session. If the file extension isn't listed, the script
@@ -518,7 +518,7 @@ The environment variables that store preferences include:
   documentation for the [ftype][02] command.
 
   PowerShell scripts always start in the current console session. You don't
-  need to add the `.PS1` extension.
+  need to add the `.ps1` extension.
 
 - `XDG` variables
 
@@ -538,7 +538,7 @@ or `NO_COLOR` environment variables.
 
 - `TERM`
 
-  The following values of `$env:TERM` change the behavior as follows:
+  The following values of `$Env:TERM` change the behavior as follows:
 
   - `dumb` - sets `$Host.UI.SupportsVirtualTerminal = $false`
   - `xterm-mono` - sets `$PSStyle.OutputRendering = PlainText`
@@ -546,7 +546,7 @@ or `NO_COLOR` environment variables.
 
 - `NO_COLOR`
 
-  If `$env:NO_COLOR` exists, then `$PSStyle.OutputRendering` is set to
+  If `$Env:NO_COLOR` exists, then `$PSStyle.OutputRendering` is set to
   `PlainText`. For more information about the `NO_COLOR` environment
   variable, see [https://no-color.org/][12].
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
@@ -135,7 +135,7 @@ execution policies are as follows:
 
   The **Process** scope only affects the current PowerShell session. The
   execution policy is saved in the environment variable
-  `$env:PSExecutionPolicyPreference`, rather than the configuration file. When
+  `$Env:PSExecutionPolicyPreference`, rather than the configuration file. When
   the PowerShell session is closed, the variable and value are deleted.
 
 - CurrentUser
@@ -279,7 +279,7 @@ pwsh.exe -ExecutionPolicy AllSigned
 ```
 
 The execution policy that you set isn't stored in the configuration file.
-Instead, it's stored in the `$env:PSExecutionPolicyPreference` environment
+Instead, it's stored in the `$Env:PSExecutionPolicyPreference` environment
 variable. The variable is deleted when you close the session in which the
 policy is set. You cannot change the policy by editing the variable value.
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md
@@ -33,11 +33,11 @@ The **FileSystem** drives are a hierarchical namespace containing the
 directories and files on your computer. A **FileSystem** drive can be a logical
 or physical drive, directory, or mapped network share.
 
-Beginning in PowerShell Version 7.0, a drive called `TEMP:` is mapped to the
+Beginning in PowerShell Version 7.0, a drive called `Temp:` is mapped to the
 user's temporary directory path. PowerShell uses the .NET [GetTempPath()][05]
 method to determine the location of the temporary folder. On Windows, the
-location is the same as `$env:TEMP`. On non-Windows systems, the location is
-the same as `$env:TMPDIR` or `/tmp` if the environment variable isn't defined.
+location is the same as `$Env:TEMP`. On non-Windows systems, the location is
+the same as `$Env:TMPDIR` or `/tmp` if the environment variable isn't defined.
 
 The **FileSystem** provider supports the following cmdlets, which are covered
 in this article.
@@ -212,7 +212,7 @@ the dollar sign (`$`). The path must be enclosed in curly braces due to
 variable naming restrictions. For more information, see [about_Variables][09].
 
 ```powershell
-${C:\Windows\System32\Drivers\etc\hosts}
+${C:\Windows\System32\drivers\etc\hosts}
 ```
 
 ### Add content to a file
@@ -260,7 +260,7 @@ For more information about `Get-Content` cmdlet, see the help topic for the
 For more information about arrays, see [about_Arrays][07].
 
 ```powershell
-$e = Get-Content c:\test\employees.txt -Delimited "End Of Employee Record"
+$e = Get-Content C:\test\employees.txt -Delimited "End Of Employee Record"
 $e[0]
 ```
 
@@ -284,7 +284,7 @@ For more information about this object, pipe the command to the
 This command creates the `logfiles` directory on the `C` drive:
 
 ```powershell
-New-Item -Path c:\ -Name logfiles -Type directory
+New-Item -Path C:\ -Name logfiles -Type Directory
 ```
 
 PowerShell also includes a `mkdir` function (alias `md`) that uses the
@@ -296,7 +296,7 @@ This command creates the `log2.txt` file in the `C:\logfiles` directory and
 then adds the "test log" string to the file:
 
 ```powershell
-New-Item -Path c:\logfiles -Name log2.txt -Type file
+New-Item -Path C:\logfiles -Name log2.txt -Type File
 ```
 
 ### Create a file with content
@@ -305,7 +305,7 @@ Creates a file called `log2.txt` in the `C:\logfiles` directory and adds the
 string "test log" to the file.
 
 ```powershell
-New-Item -Path c:\logfiles -Name log2.txt -Type file -Value "test log"
+New-Item -Path C:\logfiles -Name log2.txt -Type File -Value "test log"
 ```
 
 ## Renaming files and directories
@@ -315,7 +315,7 @@ New-Item -Path c:\logfiles -Name log2.txt -Type file -Value "test log"
 This command renames the `a.txt` file in the `C:\a` directory to `b.txt`:
 
 ```powershell
-Rename-Item -Path c:\a\a.txt -NewName b.txt
+Rename-Item -Path C:\a\a.txt -NewName b.txt
 ```
 
 ### Rename a directory
@@ -323,7 +323,7 @@ Rename-Item -Path c:\a\a.txt -NewName b.txt
 This command renames the `C:\a\cc` directory to `C:\a\dd`:
 
 ```powershell
-Rename-Item -Path c:\a\cc -NewName dd
+Rename-Item -Path C:\a\cc -NewName dd
 ```
 
 ## Deleting files and directories
@@ -388,7 +388,7 @@ which gets hidden files, and `!Directory`, which gets all other files.
 Get-ChildItem -Attributes !Directory,!Directory+Hidden
 ```
 
-`dir -att !d,!d+h` is the equivalent of this command.
+`dir -Att !d,!d+h` is the equivalent of this command.
 
 ### Get Compressed and Encrypted files
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_For.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_For.md
@@ -15,17 +15,17 @@ conditional test.
 
 ## Long description
 
-The `For` statement (also known as a `For` loop) is a language construct you
+The `for` statement (also known as a `for` loop) is a language construct you
 can use to create a loop that runs commands in a command block while a
 specified condition evaluates to `$true`.
 
-A typical use of the `For` loop is to iterate an array of values and to operate
+A typical use of the `for` loop is to iterate an array of values and to operate
 on a subset of these values. In most cases, if you want to iterate all the
-values in an array, consider using a `Foreach` statement.
+values in an array, consider using a `foreach` statement.
 
 ### Syntax
 
-The following shows the `For` statement syntax.
+The following shows the `for` statement syntax.
 
 ```
 for (<Init>; <Condition>; <Repeat>)
@@ -39,11 +39,11 @@ the loop begins. You typically use the **Init** portion of the statement to
 create and initialize a variable with a starting value.
 
 This variable will then be the basis for the condition to be tested in the next
-portion of the `For` statement.
+portion of the `for` statement.
 
-The **Condition** placeholder represents the portion of the `For` statement
+The **Condition** placeholder represents the portion of the `for` statement
 that resolves to a `$true` or `$false` **Boolean** value. PowerShell evaluates
-the condition each time the `For` loop runs. If the statement is `$true`, the
+the condition each time the `for` loop runs. If the statement is `$true`, the
 commands in the command block run, and the statement is evaluated again. If the
 condition is still `$true`, the commands in the **Statement list** run again.
 The loop is repeated until the condition becomes `$false`.
@@ -122,14 +122,14 @@ For more information, see [about_Logical_Operators][01].
 
 ### Syntax examples
 
-At a minimum, a `For` statement requires the parenthesis surrounding the
+At a minimum, a `for` statement requires the parenthesis surrounding the
 **Init**, **Condition**, and **Repeat** part of the statement and a command
 surrounded by braces in the **Statement list** part of the statement.
 
-Note that the upcoming examples intentionally show code outside the `For`
-statement. In later examples, code is integrated into the `For` statement.
+Note that the upcoming examples intentionally show code outside the `for`
+statement. In later examples, code is integrated into the `for` statement.
 
-For example, the following `For` statement continually displays the value of
+For example, the following `for` statement continually displays the value of
 the `$i` variable until you manually break out of the command by pressing
 CTRL+C.
 
@@ -156,7 +156,7 @@ continually display the value of the `$i` variable as it is incremented by 1
 each time the loop is run.
 
 Rather than change the value of the variable in the statement list part of the
-`For` statement, you can use the **Repeat** portion of the `For` statement
+`for` statement, you can use the **Repeat** portion of the `for` statement
 instead, as follows.
 
 ```powershell
@@ -170,11 +170,11 @@ for (;;$i++)
 This statement will still repeat indefinitely until you break out of the
 command by pressing CTRL+C.
 
-You can terminate the `For` loop using a **condition**. You can place a
-condition using the **Condition** portion of the `For` statement. The `For`
+You can terminate the `for` loop using a **condition**. You can place a
+condition using the **Condition** portion of the `for` statement. The `for`
 loop terminates when the condition evaluates to `$false`.
 
-In the following example, the `For` loop runs while the value of `$i` is less
+In the following example, the `for` loop runs while the value of `$i` is less
 than or equal to 10.
 
 ```powershell
@@ -185,17 +185,17 @@ for(;$i -le 10;$i++)
 }
 ```
 
-Instead of creating and initializing the variable outside the `For` statement,
-you can perform this task inside the `For` loop by using the **Init** portion
-of the `For` statement.
+Instead of creating and initializing the variable outside the `for` statement,
+you can perform this task inside the `for` loop by using the **Init** portion
+of the `for` statement.
 
 ```powershell
 for($i=1; $i -le 10; $i++){Write-Host $i}
 ```
 
 You can use carriage returns instead of semicolons to delimit the **Init**,
-**Condition**, and **Repeat** portions of the `For` statement. The following
-example shows a `For` that uses this alternative syntax.
+**Condition**, and **Repeat** portions of the `for` statement. The following
+example shows a `for` that uses this alternative syntax.
 
 ```powershell
 for ($i = 0
@@ -205,15 +205,15 @@ for ($i = 0
 }
 ```
 
-This alternative form of the `For` statement works in PowerShell script files
-and at the PowerShell command prompt. However, it is easier to use the `For`
+This alternative form of the `for` statement works in PowerShell script files
+and at the PowerShell command prompt. However, it is easier to use the `for`
 statement syntax with semicolons when you enter interactive commands at the
 command prompt.
 
-The `For` loop is more flexible than the `Foreach` loop because it allows you
+The `for` loop is more flexible than the `foreach` loop because it allows you
 to increment values in an array or collection by using patterns. In the
 following example, the `$i` variable is incremented by 2 in the **Repeat**
-portion of the `For` statement.
+portion of the `for` statement.
 
 ```powershell
 for ($i = 0; $i -le 20; $i += 2)
@@ -222,7 +222,7 @@ for ($i = 0; $i -le 20; $i += 2)
 }
 ```
 
-The `For` loop can also be written on one line as in the following example.
+The `for` loop can also be written on one line as in the following example.
 
 ```powershell
 for ($i = 0; $i -lt 10; $i++){Write-Host $i}
@@ -230,7 +230,7 @@ for ($i = 0; $i -lt 10; $i++){Write-Host $i}
 
 ### Functional example
 
-The following example demonstrates how you can use a `For` loop to iterate over
+The following example demonstrates how you can use a `for` loop to iterate over
 an array of files and rename them. The files in the `work_items` folder have
 their work item ID as the filename. The loop iterates through the files
 to ensure that the ID number is zero-padded to five digits.


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide