### PR TITLE
Fix incorrect case/capitalization in reference documents (5/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Foreach.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Foreach.md
@@ -81,7 +81,7 @@ foreach ($file in Get-ChildItem)
 ```
 
 In this example, the `foreach` loop uses a property of the `$file` variable to
-perform a comparison operation (`$file.length -gt 100KB`). The `$file` variable
+perform a comparison operation (`$file.Length -gt 100KB`). The `$file` variable
 has all the properties of the object returned by the `Get-ChildItem`.
 
 In the next example, the script displays the length and the last access time

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -431,7 +431,7 @@ digital signature. For more information, see
 
 The following sample creates a `Format-Table` custom view for the
 **System.IO.DirectoryInfo** and **System.IO.FileInfo** objects created by
-`Get-ChildItem`. The custom view is named **mygciview** and adds the
+`Get-ChildItem`. The custom view is named **MyGciView** and adds the
 **CreationTime** column to the table.
 
 The custom view is created from an edited version of the
@@ -500,7 +500,7 @@ Update-FormatData -PrependPath $PSHOME\Format\MyFileSystem.Format.ps1xml
 </Controls>
 <ViewDefinitions>
     <View>
-    <Name>mygciview</Name>
+    <Name>MyGciView</Name>
     <ViewSelectedBy>
         <SelectionSetName>FileSystemTypes</SelectionSetName>
     </ViewSelectedBy>
@@ -541,14 +541,14 @@ Update-FormatData -PrependPath $PSHOME\Format\MyFileSystem.Format.ps1xml
                         </TableColumnItem>
                         <TableColumnItem>
                             <ScriptBlock>
-                                [String]::Format("{0,10}  {1,8}",
+                                [string]::Format("{0,10}  {1,8}",
                                     $_.LastWriteTime.ToString("d"),
                                     $_.LastWriteTime.ToString("t"))
                             </ScriptBlock>
                         </TableColumnItem>
                         <TableColumnItem>
                             <ScriptBlock>
-                                [String]::Format("{0,10}  {1,8}",
+                                [string]::Format("{0,10}  {1,8}",
                                     $_.CreationTime.ToString("d"),
                                     $_.LastWriteTime.ToString("t"))
                             </ScriptBlock>

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Function_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Function_Provider.md
@@ -101,21 +101,21 @@ You can retrieve a function's definition by accessing the **Definition**
 property, as shown below.
 
 ```powershell
-(Get-Item -Path function:more).Definition
+(Get-Item -Path Function:more).Definition
 ```
 
 You can also retrieve a function's definition using its provider path prefixed
 by the dollar sign (`$`).
 
 ```powershell
-$function:more
+$Function:more
 ```
 
 To retrieve the definition for a function that has a dash (`-`) in the name,
 wrap the value after the dollar sign in curly braces.
 
 ```powershell
-${function:Clear-Host}
+${Function:Clear-Host}
 ```
 
 ### Getting selected functions
@@ -132,7 +132,7 @@ Get-Item -Path man | Format-Table -Wrap -AutoSize
 
 ### Working with Function provider paths
 
-These commands both get the function named `c:`. The first command can be used
+These commands both get the function named `C:`. The first command can be used
 in any drive. The second command is used in the `Function:` drive. Because the
 name ends in a colon, which is the syntax for a drive, you must qualify the
 path with the drive name. Within the `Function:` drive, you can use either
@@ -160,7 +160,7 @@ function, it is available only in the scope in which it was created. To make a
 function available, use a scope modifier when you create the function. For more
 information, see [about_Scopes][15].
 
-The following example uses the `global:` scope modifier to create a function in
+The following example uses the `Global:` scope modifier to create a function in
 the global scope.
 
 ```powershell
@@ -170,14 +170,14 @@ function New-Function {
         [scriptblock] $Script
     )
 
-    $lp = "Function:\global:$($name)"
-    Set-Item -LiteralPath $lp -Value $script -PassThru -Force
+    $lp = "Function:\Global:$($Name)"
+    Set-Item -LiteralPath $lp -Value $Script -PassThru -Force
 }
 
 New-Function -Name 'Win32:' -Script { Set-Location C:\Windows\System32 }
 ```
 
-Without the `global:` scope modifier, the function would be created in the
+Without the `Global:` scope modifier, the function would be created in the
 local scope. When `New-Function` exits the newly created function would no
 longer exist.
 
@@ -269,7 +269,7 @@ Get-Help Get-ChildItem
 ```
 
 ```powershell
-Get-Help Get-ChildItem -Path function:
+Get-Help Get-ChildItem -Path Function:
 ```
 
 ## See also

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -22,7 +22,7 @@ run as if you had typed them at the command prompt.
 Functions can be as simple as:
 
 ```powershell
-function Get-PowerShellProcess { Get-Process PowerShell }
+function Get-PowerShellProcess { Get-Process powershell }
 ```
 
 Once a function is defined, you can use it like the built-in cmdlets. For
@@ -71,7 +71,7 @@ like a cmdlet without using `C#` programming. For more information, see
 The following are the syntax for a function:
 
 ```Syntax
-function [<scope:>]<name> [([type]$parameter1[,[type]$parameter2])]
+function [<scope:>]<name> [([type]$Parameter1[,[type]$Parameter2])]
 {
   begin {<statement list>}
   process {<statement list>}
@@ -82,7 +82,7 @@ function [<scope:>]<name> [([type]$parameter1[,[type]$parameter2])]
 ```Syntax
 function [<scope:>]<name>
 {
-  param([type]$parameter1 [,[type]$parameter2])
+  param([type]$Parameter1 [,[type]$Parameter2])
   dynamicparam {<statement list>}
   begin {<statement list>}
   process {<statement list>}
@@ -120,7 +120,7 @@ processing, and an `end` block for one-time post-processing.
 Function Test-ScriptCmdlet
 {
 [CmdletBinding(SupportsShouldProcess=$true)]
-    Param ($Parameter1)
+    param ($Parameter1)
     begin{}
     process{}
     end{}
@@ -188,11 +188,11 @@ For example, the following function finds all `.jpg` files in the current
 user's directories that were changed after the start date.
 
 ```powershell
-function Get-NewPix
+function Get-NewPicture
 {
   $start = Get-Date -Month 1 -Day 1 -Year 2010
-  $allpix = Get-ChildItem -Path $env:UserProfile\*.jpg -Recurse
-  $allpix | Where-Object {$_.LastWriteTime -gt $Start}
+  $allPics = Get-ChildItem -Path $Env:USERPROFILE\*.jpg -Recurse
+  $allPics | Where-Object {$_.LastWriteTime -gt $Start}
 }
 ```
 
@@ -234,16 +234,16 @@ in the following sample syntax:
 
 ```Syntax
 function <name> {
-  param ([type]$parameter1 [,[type]$parameter2])
+  param ([type]$Parameter1 [,[type]$Parameter2])
   <statement list>
 }
 ```
 
-You can also define parameters outside the braces without the `Param` keyword,
+You can also define parameters outside the braces without the `param` keyword,
 as shown in the following sample syntax:
 
 ```Syntax
-function <name> [([type]$parameter1[,[type]$parameter2])] {
+function <name> [([type]$Parameter1[,[type]$Parameter2])] {
   <statement list>
 }
 ```
@@ -251,8 +251,8 @@ function <name> [([type]$parameter1[,[type]$parameter2])] {
 Below is an example of this alternative syntax.
 
 ```powershell
-function Add-Numbers([int]$one, [int]$two) {
-    $one + $two
+function Add-Numbers([int]$One, [int]$Two) {
+    $One + $Two
 }
 ```
 
@@ -269,7 +269,7 @@ the value of the `$Size` parameter, and it excludes directories:
 
 ```powershell
 function Get-SmallFiles {
-  Param($Size)
+  param ($Size)
   Get-ChildItem $HOME | Where-Object {
     $_.Length -lt $Size -and !$_.PSIsContainer
   }
@@ -369,8 +369,8 @@ name, as shown in the following example:
 
 ```powershell
 function Switch-Item {
-  param ([switch]$on)
-  if ($on) { "Switch on" }
+  param ([switch]$On)
+  if ($On) { "Switch on" }
   else { "Switch off" }
 }
 ```
@@ -379,7 +379,7 @@ When you type the `On` switch parameter after the function name, the function
 displays `Switch on`. Without the switch parameter, it displays `Switch off`.
 
 ```powershell
-Switch-Item -on
+Switch-Item -On
 ```
 
 ```Output
@@ -398,7 +398,7 @@ You can also assign a **Boolean** value to a switch when you run the function,
 as shown in the following example:
 
 ```powershell
-Switch-Item -on:$true
+Switch-Item -On:$true
 ```
 
 ```Output
@@ -406,7 +406,7 @@ Switch on
 ```
 
 ```powershell
-Switch-Item -on:$false
+Switch-Item -On:$false
 ```
 
 ```Output
@@ -607,7 +607,7 @@ You can specify the scope of a function. For example, the function is added to
 the global scope in the following example:
 
 ```powershell
-function global:Get-DependentSvs {
+function Global:Get-DependentSvs {
   Get-Service | Where-Object {$_.DependentServices}
 }
 ```
@@ -633,7 +633,7 @@ The following command displays all the functions in the current session of
 PowerShell:
 
 ```powershell
-Get-ChildItem function:
+Get-ChildItem Function:
 ```
 
 The commands in the function are stored as a script block in the definition
@@ -641,13 +641,13 @@ property of the function. For example, to display the commands in the Help
 function that comes with PowerShell, type:
 
 ```powershell
-(Get-ChildItem function:help).Definition
+(Get-ChildItem Function:help).Definition
 ```
 
 You can also use the following syntax.
 
 ```powershell
-$function:help
+$Function:help
 ```
 
 For more information about the `Function:` drive, see the help topic for the

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -137,7 +137,7 @@ function.
 This method is called to request confirmation from the user before the function
 performs an action that would change the system. The function can continue
 based on the Boolean value returned by the method. This method can only be
-called only from within the `Process{}` block of the function. The
+called only from within the `process {}` block of the function. The
 `CmdletBinding` attribute must also declare that the function supports
 `ShouldProcess` (as shown in the previous example).
 
@@ -160,7 +160,7 @@ Functions can call two different methods when errors occur. When a
 non-terminating error occurs, the function should call the `WriteError` method,
 which is described in the `Write` methods section. When a terminating error
 occurs and the function can't continue, it should call the
-`ThrowTerminatingError` method. You can also use the `Throw` statement for
+`ThrowTerminatingError` method. You can also use the `throw` statement for
 terminating errors and the [Write-Error][22] cmdlet for non-terminating errors.
 
 For more information, see

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -128,14 +128,14 @@ As shown above, cmdlets use culture-sensitive parsing to convert the string.
 # Define an equivalent function.
 function Get-Date_Func {
   param(
-    [DateTime] $Date
+    [datetime] $Date
   )
   process {
     $Date
   }
 }
 
-[CultureInfo]::CurrentCulture = 'de-DE'
+[cultureinfo]::CurrentCulture = 'de-DE'
 
 # This German-format date string doesn't work with the invariant culture.
 # E.g., [datetime] '19-06-2018' breaks.
@@ -302,7 +302,7 @@ function Get-Sample {
       $attributeCollection.Add($parameterAttribute)
 
       $dynParam1 = [System.Management.Automation.RuntimeDefinedParameter]::new(
-        'KeyCount', [Int32], $attributeCollection
+        'KeyCount', [int32], $attributeCollection
       )
 
       $paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
@@ -724,7 +724,7 @@ function TestDefaultValue {
 Use `Get-Help` to see the default value information.
 
 ```powershell
-Get-Help TestDefaultValue -Parameter name
+Get-Help TestDefaultValue -Parameter Name
 ```
 
 ```Output
@@ -1004,7 +1004,7 @@ between zero and ten.
 param(
     [Parameter(Mandatory)]
     [ValidateRange(0,10)]
-    [Int]$Attempts
+    [int]$Attempts
 )
 ```
 
@@ -1033,7 +1033,7 @@ greater than or equal to the current date.
 param(
     [Parameter(Mandatory)]
     [ValidateScript({$_ -ge (Get-Date)})]
-    [DateTime]$EventDate
+    [datetime]$EventDate
 )
 ```
 
@@ -1041,7 +1041,7 @@ In the following example, the value of the variable `$date` must be less than
 or equal to the current date and time.
 
 ```powershell
-[ValidateScript({$_ -le (Get-Date)})] [DateTime]$date = (Get-Date)
+[ValidateScript({$_ -le (Get-Date)})] [datetime]$date = (Get-Date)
 ```
 
 > [!NOTE]
@@ -1103,18 +1103,18 @@ more information, see [about_Tab_Expansion][18].
 
 #### Dynamic ValidateSet values using classes
 
-You can use a **Class** to dynamically generate the values for **ValidateSet**
+You can use a `class` to dynamically generate the values for **ValidateSet**
 at runtime. In the following example, the valid values for the variable
-`$Sound` are generated via a **Class** named **SoundNames** that checks three
+`$Sound` are generated via a `class` named **SoundNames** that checks three
 filesystem paths for available sound files:
 
 ```powershell
-Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
+class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
     [string[]] GetValidValues() {
         $SoundPaths = '/System/Library/Sounds/',
             '/Library/Sounds','~/Library/Sounds'
-        $SoundNames = ForEach ($SoundPath in $SoundPaths) {
-            If (Test-Path $SoundPath) {
+        $SoundNames = foreach ($SoundPath in $SoundPaths) {
+            if (Test-Path $SoundPath) {
                 (Get-ChildItem $SoundPath).BaseName
             }
         }
@@ -1148,13 +1148,13 @@ that implicitly converts a null value, such as a **string**, the null value is
 converted to an empty string even when using the **ValidateNotNull** attribute.
 For this scenario use the **ValidateNotNullOrEmpty** attribute.
 
-In the following example, the value of the **ID** parameter can't be `$null`.
+In the following example, the value of the **Id** parameter can't be `$null`.
 
 ```powershell
 param(
     [Parameter()]
     [ValidateNotNull()]
-    $ID
+    $Id
 )
 ```
 
@@ -1235,7 +1235,7 @@ You can define `User` drive in Just Enough Administration (JEA) session
 configurations. For this example, we create the User: drive.
 
 ```powershell
-New-PSDrive -Name 'User' -PSProvider FileSystem -Root $env:HOMEPATH
+New-PSDrive -Name 'User' -PSProvider FileSystem -Root $Env:HOMEPATH
 ```
 
 ```Output

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Argument_Completion.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Argument_Completion.md
@@ -4,7 +4,7 @@ Locale: en-US
 ms.date: 01/04/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_Functions_Argument_Completion?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
-title: About_functions_argument_completion
+title: about_Functions_Argument_Completion
 ---
 # about_Functions_Argument_Completion
 
@@ -37,7 +37,7 @@ example, the value of the **Fruit** parameter can only be **Apple**,
 **Banana**, or **Pear**.
 
 ```powershell
-Param(
+param (
     [Parameter(Mandatory=$true)]
     [ValidateSet('Apple', 'Banana', 'Pear')]
     [string[]]$Fruit
@@ -57,7 +57,7 @@ The validation occurs whenever that variable is assigned even within the
 script.
 
 ```powershell
-Param(
+param (
     [ValidateSet('hello', 'world')]
     [string]$Message
 )
@@ -77,19 +77,19 @@ For more information about tab expansion, see
 
 ### Dynamic ValidateSet values using classes
 
-You can use a **Class** to dynamically generate the values for **ValidateSet**
+You can use a `class` to dynamically generate the values for **ValidateSet**
 at runtime. In the following example, the valid values for the variable
-`$Sound` are generated via a **Class** named **SoundNames** that checks three
+`$Sound` are generated via a `class` named **SoundNames** that checks three
 filesystem paths for available sound files:
 
 ```powershell
-Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
+class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
     [string[]] GetValidValues() {
         $SoundPaths = '/System/Library/Sounds/',
                       '/Library/Sounds',
                       '~/Library/Sounds'
-        $SoundNames = ForEach ($SoundPath in $SoundPaths) {
-            If (Test-Path $SoundPath) {
+        $SoundNames = foreach ($SoundPath in $SoundPaths) {
+            if (Test-Path $SoundPath) {
                 (Get-ChildItem $SoundPath).BaseName
             }
         }
@@ -102,7 +102,7 @@ The `[SoundNames]` class is then implemented as a dynamic **ValidateSet** value
 as follows:
 
 ```powershell
-Param(
+param (
     [ValidateSet([SoundNames])]
     [string]$Sound
 )
@@ -126,7 +126,7 @@ The syntax is as follows:
 
 ```powershell
 function MyArgumentCompleter {
-    Param(
+    param (
         [Parameter(Mandatory)]
         [ArgumentCompleter( {
             param ( $commandName,

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -44,15 +44,15 @@ each argument follows this example.
 {
     [CmdletBinding(ConfirmImpact=<String>,
     DefaultParameterSetName=<String>,
-    HelpURI=<URI>,
+    HelpUri=<URI>,
     SupportsPaging=<Boolean>,
     SupportsShouldProcess=<Boolean>,
     PositionalBinding=<Boolean>)]
 
-    Param ($Parameter1)
-    Begin{}
-    Process{}
-    End{}
+    param ($Parameter1)
+    begin {}
+    process {}
+    end {}
 }
 ```
 
@@ -65,10 +65,10 @@ value to `$true` or just list the argument by name. For example, the following
 {
     [CmdletBinding(SupportsPaging=$true)]
 
-    Param ($Parameter1)
-    Begin{}
-    Process{}
-    End{}
+    param ($Parameter1)
+    begin {}
+    process {}
+    end {}
 }
 
 # Boolean arguments can be defined using this shorthand syntax
@@ -76,10 +76,10 @@ value to `$true` or just list the argument by name. For example, the following
 {
     [CmdletBinding(SupportsPaging)]
 
-    Param ($Parameter1)
-    Begin{}
-    Process{}
-    End{}
+    param ($Parameter1)
+    begin {}
+    process {}
+    end {}
 }
 ```
 
@@ -103,22 +103,22 @@ set that PowerShell will attempt to use when it cannot determine which
 parameter set to use. You can avoid this issue by making the unique parameter
 of each parameter set a mandatory parameter.
 
-## HelpURI
+## HelpUri
 
-The **HelpURI** argument specifies the internet address of the online version
-of the help topic that describes the function. The value of the **HelpURI**
+The **HelpUri** argument specifies the internet address of the online version
+of the help topic that describes the function. The value of the **HelpUri**
 argument must begin with "http" or "https".
 
-The **HelpURI** argument value is used for the value of the **HelpURI**
+The **HelpUri** argument value is used for the value of the **HelpUri**
 property of the **CommandInfo** object that `Get-Command` returns for the
 function.
 
 However, when help files are installed on the computer and the value of the
 first link in the **RelatedLinks** section of the help file is a URI, or the
-value of the first `.Link` directive in comment-based help is a URI, the URI in
+value of the first `.LINK` keyword in comment-based help is a URI, the URI in
 the help file is used as the value of the **HelpUri** property of the function.
 
-The `Get-Help` cmdlet uses the value of the **HelpURI** property to locate the
+The `Get-Help` cmdlet uses the value of the **HelpUri** property to locate the
 online version of the function help topic when the **Online** parameter of
 `Get-Help` is specified in a command.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
@@ -55,7 +55,7 @@ parameter sets return different types.
 ```
 
 Place the **OutputType** attribute statements in the attributes list that
-precedes the `Param` statement.
+precedes the `param` statement.
 
 The following example shows the placement of the **OutputType** attribute in a
 simple function.
@@ -64,7 +64,7 @@ simple function.
 function SimpleFunction2
 {
   [OutputType([<Type>])]
-  Param ($Parameter1)
+  param ($Parameter1)
 
   <function body>
 }
@@ -77,9 +77,9 @@ advanced functions.
 function AdvancedFunction1
 {
   [OutputType([<Type>])]
-  Param (
-    [parameter(Mandatory=$true)]
-    [String[]]
+  param (
+    [Parameter(Mandatory=$true)]
+    [string[]]
     $Parameter1
   )
 
@@ -90,9 +90,9 @@ function AdvancedFunction2
 {
   [CmdletBinding(SupportsShouldProcess=<Boolean>)]
   [OutputType([<Type>])]
-  Param (
-    [parameter(Mandatory=$true)]
-    [String[]]
+  param (
+    [Parameter(Mandatory=$true)]
+    [string[]]
     $Parameter1
   )
 
@@ -107,8 +107,8 @@ function AdvancedFunction2
 ```powershell
 function Send-Greeting
 {
-  [OutputType([String])]
-  Param ($Name)
+  [OutputType([string])]
+  param ($Name)
 
   "Hello, $Name"
 }
@@ -138,15 +138,15 @@ function Get-User
   [CmdletBinding(DefaultParameterSetName="ID")]
 
   [OutputType("System.Int32", ParameterSetName="ID")]
-  [OutputType([String], ParameterSetName="Name")]
+  [OutputType([string], ParameterSetName="Name")]
 
-  Param (
-    [parameter(Mandatory=$true, ParameterSetName="ID")]
-    [Int[]]
+  param (
+    [Parameter(Mandatory=$true, ParameterSetName="ID")]
+    [int]
     $UserID,
 
-    [parameter(Mandatory=$true, ParameterSetName="Name")]
-    [String[]]
+    [Parameter(Mandatory=$true, ParameterSetName="Name")]
+    [string[]]
     $UserName
   )
 
@@ -166,10 +166,10 @@ that it returns a **System.DateTime** object.
 ```powershell
 function Get-Time
 {
-  [OutputType([DateTime])]
-  Param (
-    [parameter(Mandatory=$true)]
-    [Datetime]$DateTime
+  [OutputType([datetime])]
+  param (
+    [Parameter(Mandatory=$true)]
+    [datetime]$DateTime
   )
 
   $DateTime.ToShortTimeString()
@@ -209,7 +209,7 @@ but not return anything.
 function Invoke-Notepad
 {
   [OutputType([System.Void])]
-  Param ()
+  param ()
   & notepad.exe | Out-Null
 }
 ```

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -128,10 +128,10 @@ If you place the ordered attribute before the variable name, the command fails
 with the following error message.
 
 ```powershell
-[ordered]$orderedhash = @{}
+[ordered]$orderedHash = @{}
 ParserError:
 Line |
-   1 |  [ordered]$orderedhash = @{}
+   1 |  [ordered]$orderedHash = @{}
      |  ~~~~~~~~~~~~~~
      | The ordered attribute can be specified only on a hash literal node.
 ```
@@ -139,19 +139,19 @@ Line |
 To correct the expression, move the [ordered] attribute.
 
 ```powershell
-$orderedhash = [ordered]@{}
+$orderedHash = [ordered]@{}
 ```
 
 You can cast an ordered dictionary to a hashtable, but you can't guarantee the
 order of the members.
 
 ```powershell
-[hashtable]$newhash = [ordered]@{
+[hashtable]$newHash = [ordered]@{
     Number = 1
     Shape = "Square"
     Color = "Blue"
 }
-$newhash
+$newHash
 ```
 
 ```Output
@@ -297,7 +297,7 @@ member notation or array index notation.
   two
   PS> ([array]$dictionary.Values)[1]
   two
-  PS> $dictionary[[object]1]
+  PS> $dictionary[[Object]1]
   one
   PS> $dictionary['three']
   3
@@ -305,7 +305,7 @@ member notation or array index notation.
 
   In this example, the array value `[1]` is an index into the collection of
   values using the `Item(int index)` parameterized property overload. The array
-  value `[[object]1]` isn't an index but a key value using the
+  value `[[Object]1]` isn't an index but a key value using the
   `Item(System.Object key)` overload.
 
   > [!NOTE]
@@ -455,7 +455,7 @@ object values and saves it in the `$p` variable.
 
 ```powershell
 $p = @{
-    "PowerShell" = (Get-Process PowerShell)
+    "PowerShell" = (Get-Process powershell)
     "Notepad" = (Get-Process notepad)
 }
 ```
@@ -565,7 +565,7 @@ For example, the following commands enumerate the keys and values in the
 hashtable in the `$p` variable and then sort the keys in alphabetical order.
 
 ```powershell
-PS> $p.GetEnumerator() | Sort-Object -Property key
+PS> $p.GetEnumerator() | Sort-Object -Property Key
 
 Name                           Value
 ----                           -----

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Foreach.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Foreach.md
@@ -81,7 +81,7 @@ foreach ($file in Get-ChildItem)
 ```
 
 In this example, the `foreach` loop uses a property of the `$file` variable to
-perform a comparison operation (`$file.length -gt 100KB`). The `$file` variable
+perform a comparison operation (`$file.Length -gt 100KB`). The `$file` variable
 has all the properties of the object returned by the `Get-ChildItem`.
 
 In the next example, the script displays the length and the last access time

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -318,7 +318,7 @@ digital signature. For more information, see [about_Signing][07].
 
 The following XML sample creates a `Format-Table` custom view for the
 **System.IO.DirectoryInfo** and **System.IO.FileInfo** objects created by
-`Get-ChildItem`. The custom view is named **mygciview** and adds the
+`Get-ChildItem`. The custom view is named **MyGciView** and adds the
 **CreationTime** column to the table.
 
 To create the custom view, use the `Get-FormatData` and `Export-FormatData`
@@ -335,7 +335,7 @@ For this example, the custom view must use the table format, otherwise,
 `Format-Table` fails.
 
 Use `Format-Table` with the **View** parameter to specify the custom view's
-name, **mygciview**, and format the table's output with the **CreationTime**
+name, **MyGciView**, and format the table's output with the **CreationTime**
 column. For an example of how the command is run, see [Format-Table][08].
 
 > [!NOTE]
@@ -349,8 +349,8 @@ specific PowerShell version.
 
 ```powershell
 Get-FormatData -PowerShellVersion 5.1 -TypeName System.IO.DirectoryInfo |
-   Export-FormatData -Path ./Mygciview.Format.ps1xml
-Update-FormatData -AppendPath ./Mygciview.Format.ps1xml
+   Export-FormatData -Path ./MyGciView.Format.ps1xml
+Update-FormatData -AppendPath ./MyGciView.Format.ps1xml
 ```
 
 ```xml
@@ -358,7 +358,7 @@ Update-FormatData -AppendPath ./Mygciview.Format.ps1xml
 <Configuration>
   <ViewDefinitions>
     <View>
-      <Name>mygciview</Name>
+      <Name>MyGciView</Name>
       <ViewSelectedBy>
         <TypeName>System.IO.DirectoryInfo</TypeName>
         <TypeName>System.IO.FileInfo</TypeName>

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Function_Provider.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Function_Provider.md
@@ -101,21 +101,21 @@ You can retrieve a function's definition by accessing the **Definition**
 property, as shown below.
 
 ```powershell
-(Get-Item -Path function:more).Definition
+(Get-Item -Path Function:more).Definition
 ```
 
 You can also retrieve a function's definition using its provider path prefixed
 by the dollar sign (`$`).
 
 ```powershell
-$function:more
+$Function:more
 ```
 
 To retrieve the definition for a function that has a dash (`-`) in the name,
 wrap the value after the dollar sign in curly braces.
 
 ```powershell
-${function:Clear-Host}
+${Function:Clear-Host}
 ```
 
 ### Getting selected functions
@@ -132,7 +132,7 @@ Get-Item -Path man | Format-Table -Wrap -AutoSize
 
 ### Working with Function provider paths
 
-These commands both get the function named `c:`. The first command can be used
+These commands both get the function named `C:`. The first command can be used
 in any drive. The second command is used in the `Function:` drive. Because the
 name ends in a colon, which is the syntax for a drive, you must qualify the
 path with the drive name. Within the `Function:` drive, you can use either
@@ -160,7 +160,7 @@ function, it is available only in the scope in which it was created. To make a
 function available, use a scope modifier when you create the function. For more
 information, see [about_Scopes][15].
 
-The following example uses the `global:` scope modifier to create a function in
+The following example uses the `Global:` scope modifier to create a function in
 the global scope.
 
 ```powershell
@@ -170,14 +170,14 @@ function New-Function {
         [scriptblock] $Script
     )
 
-    $lp = "Function:\global:$($name)"
-    Set-Item -LiteralPath $lp -Value $script -PassThru -Force
+    $lp = "Function:\Global:$($Name)"
+    Set-Item -LiteralPath $lp -Value $Script -PassThru -Force
 }
 
 New-Function -Name 'Win32:' -Script { Set-Location C:\Windows\System32 }
 ```
 
-Without the `global:` scope modifier, the function would be created in the
+Without the `Global:` scope modifier, the function would be created in the
 local scope. When `New-Function` exits the newly created function would no
 longer exist.
 
@@ -269,7 +269,7 @@ Get-Help Get-ChildItem
 ```
 
 ```powershell
-Get-Help Get-ChildItem -Path function:
+Get-Help Get-ChildItem -Path Function:
 ```
 
 ## See also

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -71,7 +71,7 @@ like a cmdlet without using `C#` programming. For more information, see
 The following are the syntax for a function:
 
 ```Syntax
-function [<scope:>]<name> [([type]$parameter1[,[type]$parameter2])]
+function [<scope:>]<name> [([type]$Parameter1[,[type]$Parameter2])]
 {
   begin {<statement list>}
   process {<statement list>}
@@ -83,7 +83,7 @@ function [<scope:>]<name> [([type]$parameter1[,[type]$parameter2])]
 ```Syntax
 function [<scope:>]<name>
 {
-  param([type]$parameter1 [,[type]$parameter2])
+  param([type]$Parameter1 [,[type]$Parameter2])
   dynamicparam {<statement list>}
   begin {<statement list>}
   process {<statement list>}
@@ -123,7 +123,7 @@ processing, and an `end` block for one-time post-processing.
 Function Test-ScriptCmdlet
 {
 [CmdletBinding(SupportsShouldProcess=$true)]
-    Param ($Parameter1)
+    param ($Parameter1)
     begin{}
     process{}
     end{}
@@ -215,11 +215,11 @@ For example, the following function finds all `.jpg` files in the current
 user's directories that were changed after the start date.
 
 ```powershell
-function Get-NewPix
+function Get-NewPicture
 {
   $start = Get-Date -Month 1 -Day 1 -Year 2010
-  $allpix = Get-ChildItem -Path $env:UserProfile\*.jpg -Recurse
-  $allpix | Where-Object {$_.LastWriteTime -gt $Start}
+  $allPics = Get-ChildItem -Path $Env:USERPROFILE\*.jpg -Recurse
+  $allPics | Where-Object {$_.LastWriteTime -gt $Start}
 }
 ```
 
@@ -261,16 +261,16 @@ in the following sample syntax:
 
 ```Syntax
 function <name> {
-  param ([type]$parameter1 [,[type]$parameter2])
+  param ([type]$Parameter1 [,[type]$Parameter2])
   <statement list>
 }
 ```
 
-You can also define parameters outside the braces without the `Param` keyword,
+You can also define parameters outside the braces without the `param` keyword,
 as shown in the following sample syntax:
 
 ```Syntax
-function <name> [([type]$parameter1[,[type]$parameter2])] {
+function <name> [([type]$Parameter1[,[type]$Parameter2])] {
   <statement list>
 }
 ```
@@ -278,8 +278,8 @@ function <name> [([type]$parameter1[,[type]$parameter2])] {
 Below is an example of this alternative syntax.
 
 ```powershell
-function Add-Numbers([int]$one, [int]$two) {
-    $one + $two
+function Add-Numbers([int]$One, [int]$Two) {
+    $One + $Two
 }
 ```
 
@@ -296,7 +296,7 @@ the value of the `$Size` parameter, and it excludes directories:
 
 ```powershell
 function Get-SmallFiles {
-  Param($Size)
+  param ($Size)
   Get-ChildItem $HOME | Where-Object {
     $_.Length -lt $Size -and !$_.PSIsContainer
   }
@@ -396,8 +396,8 @@ name, as shown in the following example:
 
 ```powershell
 function Switch-Item {
-  param ([switch]$on)
-  if ($on) { "Switch on" }
+  param ([switch]$On)
+  if ($On) { "Switch on" }
   else { "Switch off" }
 }
 ```
@@ -406,7 +406,7 @@ When you type the `On` switch parameter after the function name, the function
 displays `Switch on`. Without the switch parameter, it displays `Switch off`.
 
 ```powershell
-Switch-Item -on
+Switch-Item -On
 ```
 
 ```Output
@@ -425,7 +425,7 @@ You can also assign a **Boolean** value to a switch when you run the function,
 as shown in the following example:
 
 ```powershell
-Switch-Item -on:$true
+Switch-Item -On:$true
 ```
 
 ```Output
@@ -433,7 +433,7 @@ Switch on
 ```
 
 ```powershell
-Switch-Item -on:$false
+Switch-Item -On:$false
 ```
 
 ```Output
@@ -653,7 +653,7 @@ You can specify the scope of a function. For example, the function is added to
 the global scope in the following example:
 
 ```powershell
-function global:Get-DependentSvs {
+function Global:Get-DependentSvs {
   Get-Service | Where-Object {$_.DependentServices}
 }
 ```
@@ -679,7 +679,7 @@ The following command displays all the functions in the current session of
 PowerShell:
 
 ```powershell
-Get-ChildItem function:
+Get-ChildItem Function:
 ```
 
 The commands in the function are stored as a script block in the definition
@@ -687,13 +687,13 @@ property of the function. For example, to display the commands in the Help
 function that comes with PowerShell, type:
 
 ```powershell
-(Get-ChildItem function:help).Definition
+(Get-ChildItem Function:help).Definition
 ```
 
 You can also use the following syntax.
 
 ```powershell
-$function:help
+$Function:help
 ```
 
 For more information about the `Function:` drive, see the help topic for the

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -163,7 +163,7 @@ The clean block discards any output that's written to the **Success** stream.
 This method is called to request confirmation from the user before the function
 performs an action that would change the system. The function can continue
 based on the Boolean value returned by the method. This method can only be
-called only from within the `Process{}` block of the function. The
+called only from within the `process {}` block of the function. The
 `CmdletBinding` attribute must also declare that the function supports
 `ShouldProcess` (as shown in the previous example).
 
@@ -186,7 +186,7 @@ Functions can call two different methods when errors occur. When a
 non-terminating error occurs, the function should call the `WriteError` method,
 which is described in the `Write` methods section. When a terminating error
 occurs and the function can't continue, it should call the
-`ThrowTerminatingError` method. You can also use the `Throw` statement for
+`ThrowTerminatingError` method. You can also use the `throw` statement for
 terminating errors and the [Write-Error][22] cmdlet for non-terminating errors.
 
 For more information, see

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -128,14 +128,14 @@ As shown above, cmdlets use culture-sensitive parsing to convert the string.
 # Define an equivalent function.
 function Get-Date_Func {
   param(
-    [DateTime] $Date
+    [datetime] $Date
   )
   process {
     $Date
   }
 }
 
-[CultureInfo]::CurrentCulture = 'de-DE'
+[cultureinfo]::CurrentCulture = 'de-DE'
 
 # This German-format date string doesn't work with the invariant culture.
 # E.g., [datetime] '19-06-2018' breaks.
@@ -297,7 +297,7 @@ function Get-Sample {
       $attributeCollection.Add($parameterAttribute)
 
       $dynParam1 = [System.Management.Automation.RuntimeDefinedParameter]::new(
-        'KeyCount', [Int32], $attributeCollection
+        'KeyCount', [int32], $attributeCollection
       )
 
       $paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
@@ -718,7 +718,7 @@ function TestDefaultValue {
 Use `Get-Help` to see the default value information.
 
 ```powershell
-Get-Help TestDefaultValue -Parameter name
+Get-Help TestDefaultValue -Parameter Name
 ```
 
 ```Output
@@ -1014,7 +1014,7 @@ between zero and ten.
 param(
     [Parameter(Mandatory)]
     [ValidateRange(0,10)]
-    [Int]$Attempts
+    [int]$Attempts
 )
 ```
 
@@ -1050,7 +1050,7 @@ greater than or equal to the current date.
 param(
     [Parameter(Mandatory)]
     [ValidateScript({$_ -ge (Get-Date)})]
-    [DateTime]$EventDate
+    [datetime]$EventDate
 )
 ```
 
@@ -1058,7 +1058,7 @@ In the following example, the value of the variable `$date` must be less than
 or equal to the current date and time.
 
 ```powershell
-[ValidateScript({$_ -le (Get-Date)})] [DateTime]$date = (Get-Date)
+[ValidateScript({$_ -le (Get-Date)})] [datetime]$date = (Get-Date)
 ```
 
 > [!NOTE]
@@ -1085,7 +1085,7 @@ param(
         {$_ -ge (Get-Date)},
         ErrorMessage = "{0} isn't a future date. Specify a later date."
     )]
-    [DateTime]$EventDate
+    [datetime]$EventDate
 )
 ```
 
@@ -1110,7 +1110,7 @@ param(
         {$_ -ge (Get-Date).Date},
         ErrorMessage = "{0:d} isn't a future date. Specify a later date."
     )]
-    [DateTime]$EventDate
+    [datetime]$EventDate
 )
 ```
 
@@ -1169,18 +1169,18 @@ more information, see [about_Tab_Expansion][18].
 
 #### Dynamic ValidateSet values using classes
 
-You can use a **Class** to dynamically generate the values for **ValidateSet**
+You can use a `class` to dynamically generate the values for **ValidateSet**
 at runtime. In the following example, the valid values for the variable
-`$Sound` are generated via a **Class** named **SoundNames** that checks three
+`$Sound` are generated via a `class` named **SoundNames** that checks three
 filesystem paths for available sound files:
 
 ```powershell
-Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
+class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
     [string[]] GetValidValues() {
         $SoundPaths = '/System/Library/Sounds/',
             '/Library/Sounds','~/Library/Sounds'
-        $SoundNames = ForEach ($SoundPath in $SoundPaths) {
-            If (Test-Path $SoundPath) {
+        $SoundNames = foreach ($SoundPath in $SoundPaths) {
+            if (Test-Path $SoundPath) {
                 (Get-ChildItem $SoundPath).BaseName
             }
         }
@@ -1214,13 +1214,13 @@ that implicitly converts a null value, such as a **string**, the null value is
 converted to an empty string even when using the **ValidateNotNull** attribute.
 For this scenario use the **ValidateNotNullOrEmpty** attribute.
 
-In the following example, the value of the **ID** parameter can't be `$null`.
+In the following example, the value of the **Id** parameter can't be `$null`.
 
 ```powershell
 param(
     [Parameter()]
     [ValidateNotNull()]
-    $ID
+    $Id
 )
 ```
 
@@ -1324,7 +1324,7 @@ You can define `User` drive in Just Enough Administration (JEA) session
 configurations. For this example, we create the User: drive.
 
 ```powershell
-New-PSDrive -Name 'User' -PSProvider FileSystem -Root $env:HOMEPATH
+New-PSDrive -Name 'User' -PSProvider FileSystem -Root $Env:HOMEPATH
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Argument_Completion.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_Argument_Completion.md
@@ -4,7 +4,7 @@ Locale: en-US
 ms.date: 10/22/2021
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_argument_completion?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
-title: About_functions_argument_completion
+title: about_Functions_Argument_Completion
 ---
 # about_Functions_Argument_Completion
 
@@ -37,7 +37,7 @@ example, the value of the **Fruit** parameter can only be **Apple**,
 **Banana**, or **Pear**.
 
 ```powershell
-Param(
+param (
     [Parameter(Mandatory=$true)]
     [ValidateSet('Apple', 'Banana', 'Pear')]
     [string[]]$Fruit
@@ -57,7 +57,7 @@ The validation occurs whenever that variable is assigned even within the
 script.
 
 ```powershell
-Param(
+param (
     [ValidateSet('hello', 'world')]
     [string]$Message
 )
@@ -77,19 +77,19 @@ For more information about tab expansion, see
 
 ### Dynamic ValidateSet values using classes
 
-You can use a **Class** to dynamically generate the values for **ValidateSet**
+You can use a `class` to dynamically generate the values for **ValidateSet**
 at runtime. In the following example, the valid values for the variable
-`$Sound` are generated via a **Class** named **SoundNames** that checks three
+`$Sound` are generated via a `class` named **SoundNames** that checks three
 filesystem paths for available sound files:
 
 ```powershell
-Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
+class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
     [string[]] GetValidValues() {
         $SoundPaths = '/System/Library/Sounds/',
                       '/Library/Sounds',
                       '~/Library/Sounds'
-        $SoundNames = ForEach ($SoundPath in $SoundPaths) {
-            If (Test-Path $SoundPath) {
+        $SoundNames = foreach ($SoundPath in $SoundPaths) {
+            if (Test-Path $SoundPath) {
                 (Get-ChildItem $SoundPath).BaseName
             }
         }
@@ -102,7 +102,7 @@ The `[SoundNames]` class is then implemented as a dynamic **ValidateSet** value
 as follows:
 
 ```powershell
-Param(
+param (
     [ValidateSet([SoundNames])]
     [string]$Sound
 )
@@ -167,7 +167,7 @@ The syntax is as follows:
 
 ```powershell
 function MyArgumentCompleter {
-    Param(
+    param (
         [Parameter(Mandatory)]
         [ArgumentCompleter( {
             param ( $commandName,
@@ -301,8 +301,8 @@ class NumberCompleter : IArgumentCompleter {
         [IDictionary] $fakeBoundParameters) {
 
         $resultList = [List[CompletionResult]]::new()
-        $local:to = $this.To
-        $local:step = $this.Step
+        $Local:to = $this.To
+        $Local:step = $this.Step
         for ($i = $this.From; $i -lt $to; $i += $step) {
             $resultList.Add([CompletionResult]::new($i.ToString()))
         }

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -44,15 +44,15 @@ each argument follows this example.
 {
     [CmdletBinding(ConfirmImpact=<String>,
     DefaultParameterSetName=<String>,
-    HelpURI=<URI>,
+    HelpUri=<URI>,
     SupportsPaging=<Boolean>,
     SupportsShouldProcess=<Boolean>,
     PositionalBinding=<Boolean>)]
 
-    Param ($Parameter1)
-    Begin{}
-    Process{}
-    End{}
+    param ($Parameter1)
+    begin {}
+    process {}
+    end {}
 }
 ```
 
@@ -65,10 +65,10 @@ value to `$true` or just list the argument by name. For example, the following
 {
     [CmdletBinding(SupportsPaging=$true)]
 
-    Param ($Parameter1)
-    Begin{}
-    Process{}
-    End{}
+    param ($Parameter1)
+    begin {}
+    process {}
+    end {}
 }
 
 # Boolean arguments can be defined using this shorthand syntax
@@ -76,10 +76,10 @@ value to `$true` or just list the argument by name. For example, the following
 {
     [CmdletBinding(SupportsPaging)]
 
-    Param ($Parameter1)
-    Begin{}
-    Process{}
-    End{}
+    param ($Parameter1)
+    begin {}
+    process {}
+    end {}
 }
 ```
 
@@ -103,22 +103,22 @@ set that PowerShell will attempt to use when it cannot determine which
 parameter set to use. You can avoid this issue by making the unique parameter
 of each parameter set a mandatory parameter.
 
-## HelpURI
+## HelpUri
 
-The **HelpURI** argument specifies the internet address of the online version
-of the help topic that describes the function. The value of the **HelpURI**
+The **HelpUri** argument specifies the internet address of the online version
+of the help topic that describes the function. The value of the **HelpUri**
 argument must begin with "http" or "https".
 
-The **HelpURI** argument value is used for the value of the **HelpURI**
+The **HelpUri** argument value is used for the value of the **HelpUri**
 property of the **CommandInfo** object that `Get-Command` returns for the
 function.
 
 However, when help files are installed on the computer and the value of the
 first link in the **RelatedLinks** section of the help file is a URI, or the
-value of the first `.Link` directive in comment-based help is a URI, the URI in
+value of the first `.LINK` keyword in comment-based help is a URI, the URI in
 the help file is used as the value of the **HelpUri** property of the function.
 
-The `Get-Help` cmdlet uses the value of the **HelpURI** property to locate the
+The `Get-Help` cmdlet uses the value of the **HelpUri** property to locate the
 online version of the function help topic when the **Online** parameter of
 `Get-Help` is specified in a command.
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
@@ -55,7 +55,7 @@ parameter sets return different types.
 ```
 
 Place the **OutputType** attribute statements in the attributes list that
-precedes the `Param` statement.
+precedes the `param` statement.
 
 The following example shows the placement of the **OutputType** attribute in a
 simple function.
@@ -64,7 +64,7 @@ simple function.
 function SimpleFunction2
 {
   [OutputType([<Type>])]
-  Param ($Parameter1)
+  param ($Parameter1)
 
   <function body>
 }
@@ -77,9 +77,9 @@ advanced functions.
 function AdvancedFunction1
 {
   [OutputType([<Type>])]
-  Param (
-    [parameter(Mandatory=$true)]
-    [String[]]
+  param (
+    [Parameter(Mandatory=$true)]
+    [string[]]
     $Parameter1
   )
 
@@ -90,9 +90,9 @@ function AdvancedFunction2
 {
   [CmdletBinding(SupportsShouldProcess=<Boolean>)]
   [OutputType([<Type>])]
-  Param (
-    [parameter(Mandatory=$true)]
-    [String[]]
+  param (
+    [Parameter(Mandatory=$true)]
+    [string[]]
     $Parameter1
   )
 
@@ -107,8 +107,8 @@ function AdvancedFunction2
 ```powershell
 function Send-Greeting
 {
-  [OutputType([String])]
-  Param ($Name)
+  [OutputType([string])]
+  param ($Name)
 
   "Hello, $Name"
 }
@@ -138,15 +138,15 @@ function Get-User
   [CmdletBinding(DefaultParameterSetName="ID")]
 
   [OutputType("System.Int32", ParameterSetName="ID")]
-  [OutputType([String], ParameterSetName="Name")]
+  [OutputType([string], ParameterSetName="Name")]
 
-  Param (
-    [parameter(Mandatory=$true, ParameterSetName="ID")]
-    [Int[]]
+  param (
+    [Parameter(Mandatory=$true, ParameterSetName="ID")]
+    [int]
     $UserID,
 
-    [parameter(Mandatory=$true, ParameterSetName="Name")]
-    [String[]]
+    [Parameter(Mandatory=$true, ParameterSetName="Name")]
+    [string[]]
     $UserName
   )
 
@@ -166,10 +166,10 @@ that it returns a **System.DateTime** object.
 ```powershell
 function Get-Time
 {
-  [OutputType([DateTime])]
-  Param (
-    [parameter(Mandatory=$true)]
-    [Datetime]$DateTime
+  [OutputType([datetime])]
+  param (
+    [Parameter(Mandatory=$true)]
+    [datetime]$DateTime
   )
 
   $DateTime.ToShortTimeString()
@@ -209,7 +209,7 @@ but not return anything.
 function Invoke-Notepad
 {
   [OutputType([System.Void])]
-  Param ()
+  param ()
   & notepad.exe | Out-Null
 }
 ```

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -128,10 +128,10 @@ If you place the ordered attribute before the variable name, the command fails
 with the following error message.
 
 ```powershell
-[ordered]$orderedhash = @{}
+[ordered]$orderedHash = @{}
 ParserError:
 Line |
-   1 |  [ordered]$orderedhash = @{}
+   1 |  [ordered]$orderedHash = @{}
      |  ~~~~~~~~~~~~~~
      | The ordered attribute can be specified only on a hash literal node.
 ```
@@ -139,19 +139,19 @@ Line |
 To correct the expression, move the [ordered] attribute.
 
 ```powershell
-$orderedhash = [ordered]@{}
+$orderedHash = [ordered]@{}
 ```
 
 You can cast an ordered dictionary to a hashtable, but you can't guarantee the
 order of the members.
 
 ```powershell
-[hashtable]$newhash = [ordered]@{
+[hashtable]$newHash = [ordered]@{
     Number = 1
     Shape = "Square"
     Color = "Blue"
 }
-$newhash
+$newHash
 ```
 
 ```Output
@@ -297,7 +297,7 @@ member notation or array index notation.
   two
   PS> ([array]$dictionary.Values)[1]
   two
-  PS> $dictionary[[object]1]
+  PS> $dictionary[[Object]1]
   one
   PS> $dictionary['three']
   3
@@ -305,7 +305,7 @@ member notation or array index notation.
 
   In this example, the array value `[1]` is an index into the collection of
   values using the `Item(int index)` parameterized property overload. The array
-  value `[[object]1]` isn't an index but a key value using the
+  value `[[Object]1]` isn't an index but a key value using the
   `Item(System.Object key)` overload.
 
   > [!NOTE]
@@ -455,7 +455,7 @@ object values and saves it in the `$p` variable.
 
 ```powershell
 $p = @{
-    "PowerShell" = (Get-Process PowerShell)
+    "PowerShell" = (Get-Process powershell)
     "Notepad" = (Get-Process notepad)
 }
 ```
@@ -565,7 +565,7 @@ For example, the following commands enumerate the keys and values in the
 hashtable in the `$p` variable and then sort the keys in alphabetical order.
 
 ```powershell
-PS> $p.GetEnumerator() | Sort-Object -Property key
+PS> $p.GetEnumerator() | Sort-Object -Property Key
 
 Name                           Value
 ----                           -----

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Foreach.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Foreach.md
@@ -81,7 +81,7 @@ foreach ($file in Get-ChildItem)
 ```
 
 In this example, the `foreach` loop uses a property of the `$file` variable to
-perform a comparison operation (`$file.length -gt 100KB`). The `$file` variable
+perform a comparison operation (`$file.Length -gt 100KB`). The `$file` variable
 has all the properties of the object returned by the `Get-ChildItem`.
 
 In the next example, the script displays the length and the last access time

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -318,7 +318,7 @@ digital signature. For more information, see [about_Signing][07].
 
 The following XML sample creates a `Format-Table` custom view for the
 **System.IO.DirectoryInfo** and **System.IO.FileInfo** objects created by
-`Get-ChildItem`. The custom view is named **mygciview** and adds the
+`Get-ChildItem`. The custom view is named **MyGciView** and adds the
 **CreationTime** column to the table.
 
 To create the custom view, use the `Get-FormatData` and `Export-FormatData`
@@ -335,7 +335,7 @@ For this example, the custom view must use the table format, otherwise,
 `Format-Table` fails.
 
 Use `Format-Table` with the **View** parameter to specify the custom view's
-name, **mygciview**, and format the table's output with the **CreationTime**
+name, **MyGciView**, and format the table's output with the **CreationTime**
 column. For an example of how the command is run, see [Format-Table][08].
 
 > [!NOTE]
@@ -349,8 +349,8 @@ specific PowerShell version.
 
 ```powershell
 Get-FormatData -PowerShellVersion 5.1 -TypeName System.IO.DirectoryInfo |
-   Export-FormatData -Path ./Mygciview.Format.ps1xml
-Update-FormatData -AppendPath ./Mygciview.Format.ps1xml
+   Export-FormatData -Path ./MyGciView.Format.ps1xml
+Update-FormatData -AppendPath ./MyGciView.Format.ps1xml
 ```
 
 ```xml
@@ -358,7 +358,7 @@ Update-FormatData -AppendPath ./Mygciview.Format.ps1xml
 <Configuration>
   <ViewDefinitions>
     <View>
-      <Name>mygciview</Name>
+      <Name>MyGciView</Name>
       <ViewSelectedBy>
         <TypeName>System.IO.DirectoryInfo</TypeName>
         <TypeName>System.IO.FileInfo</TypeName>

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Function_Provider.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Function_Provider.md
@@ -101,21 +101,21 @@ You can retrieve a function's definition by accessing the **Definition**
 property, as shown below.
 
 ```powershell
-(Get-Item -Path function:more).Definition
+(Get-Item -Path Function:more).Definition
 ```
 
 You can also retrieve a function's definition using its provider path prefixed
 by the dollar sign (`$`).
 
 ```powershell
-$function:more
+$Function:more
 ```
 
 To retrieve the definition for a function that has a dash (`-`) in the name,
 wrap the value after the dollar sign in curly braces.
 
 ```powershell
-${function:Clear-Host}
+${Function:Clear-Host}
 ```
 
 ### Getting selected functions
@@ -132,7 +132,7 @@ Get-Item -Path man | Format-Table -Wrap -AutoSize
 
 ### Working with Function provider paths
 
-These commands both get the function named `c:`. The first command can be used
+These commands both get the function named `C:`. The first command can be used
 in any drive. The second command is used in the `Function:` drive. Because the
 name ends in a colon, which is the syntax for a drive, you must qualify the
 path with the drive name. Within the `Function:` drive, you can use either
@@ -160,7 +160,7 @@ function, it is available only in the scope in which it was created. To make a
 function available, use a scope modifier when you create the function. For more
 information, see [about_Scopes][15].
 
-The following example uses the `global:` scope modifier to create a function in
+The following example uses the `Global:` scope modifier to create a function in
 the global scope.
 
 ```powershell
@@ -170,14 +170,14 @@ function New-Function {
         [scriptblock] $Script
     )
 
-    $lp = "Function:\global:$($name)"
-    Set-Item -LiteralPath $lp -Value $script -PassThru -Force
+    $lp = "Function:\Global:$($Name)"
+    Set-Item -LiteralPath $lp -Value $Script -PassThru -Force
 }
 
 New-Function -Name 'Win32:' -Script { Set-Location C:\Windows\System32 }
 ```
 
-Without the `global:` scope modifier, the function would be created in the
+Without the `Global:` scope modifier, the function would be created in the
 local scope. When `New-Function` exits the newly created function would no
 longer exist.
 
@@ -269,7 +269,7 @@ Get-Help Get-ChildItem
 ```
 
 ```powershell
-Get-Help Get-ChildItem -Path function:
+Get-Help Get-ChildItem -Path Function:
 ```
 
 ## See also

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -71,7 +71,7 @@ like a cmdlet without using `C#` programming. For more information, see
 The following are the syntax for a function:
 
 ```Syntax
-function [<scope:>]<name> [([type]$parameter1[,[type]$parameter2])]
+function [<scope:>]<name> [([type]$Parameter1[,[type]$Parameter2])]
 {
   begin {<statement list>}
   process {<statement list>}
@@ -83,7 +83,7 @@ function [<scope:>]<name> [([type]$parameter1[,[type]$parameter2])]
 ```Syntax
 function [<scope:>]<name>
 {
-  param([type]$parameter1 [,[type]$parameter2])
+  param([type]$Parameter1 [,[type]$Parameter2])
   dynamicparam {<statement list>}
   begin {<statement list>}
   process {<statement list>}
@@ -123,7 +123,7 @@ processing, and an `end` block for one-time post-processing.
 Function Test-ScriptCmdlet
 {
 [CmdletBinding(SupportsShouldProcess=$true)]
-    Param ($Parameter1)
+    param ($Parameter1)
     begin{}
     process{}
     end{}
@@ -215,11 +215,11 @@ For example, the following function finds all `.jpg` files in the current
 user's directories that were changed after the start date.
 
 ```powershell
-function Get-NewPix
+function Get-NewPicture
 {
   $start = Get-Date -Month 1 -Day 1 -Year 2010
-  $allpix = Get-ChildItem -Path $env:UserProfile\*.jpg -Recurse
-  $allpix | Where-Object {$_.LastWriteTime -gt $Start}
+  $allPics = Get-ChildItem -Path $Env:USERPROFILE\*.jpg -Recurse
+  $allPics | Where-Object {$_.LastWriteTime -gt $Start}
 }
 ```
 
@@ -261,16 +261,16 @@ in the following sample syntax:
 
 ```Syntax
 function <name> {
-  param ([type]$parameter1 [,[type]$parameter2])
+  param ([type]$Parameter1 [,[type]$Parameter2])
   <statement list>
 }
 ```
 
-You can also define parameters outside the braces without the `Param` keyword,
+You can also define parameters outside the braces without the `param` keyword,
 as shown in the following sample syntax:
 
 ```Syntax
-function <name> [([type]$parameter1[,[type]$parameter2])] {
+function <name> [([type]$Parameter1[,[type]$Parameter2])] {
   <statement list>
 }
 ```
@@ -278,8 +278,8 @@ function <name> [([type]$parameter1[,[type]$parameter2])] {
 Below is an example of this alternative syntax.
 
 ```powershell
-function Add-Numbers([int]$one, [int]$two) {
-    $one + $two
+function Add-Numbers([int]$One, [int]$Two) {
+    $One + $Two
 }
 ```
 
@@ -296,7 +296,7 @@ the value of the `$Size` parameter, and it excludes directories:
 
 ```powershell
 function Get-SmallFiles {
-  Param($Size)
+  param ($Size)
   Get-ChildItem $HOME | Where-Object {
     $_.Length -lt $Size -and !$_.PSIsContainer
   }
@@ -396,8 +396,8 @@ name, as shown in the following example:
 
 ```powershell
 function Switch-Item {
-  param ([switch]$on)
-  if ($on) { "Switch on" }
+  param ([switch]$On)
+  if ($On) { "Switch on" }
   else { "Switch off" }
 }
 ```
@@ -406,7 +406,7 @@ When you type the `On` switch parameter after the function name, the function
 displays `Switch on`. Without the switch parameter, it displays `Switch off`.
 
 ```powershell
-Switch-Item -on
+Switch-Item -On
 ```
 
 ```Output
@@ -425,7 +425,7 @@ You can also assign a **Boolean** value to a switch when you run the function,
 as shown in the following example:
 
 ```powershell
-Switch-Item -on:$true
+Switch-Item -On:$true
 ```
 
 ```Output
@@ -433,7 +433,7 @@ Switch on
 ```
 
 ```powershell
-Switch-Item -on:$false
+Switch-Item -On:$false
 ```
 
 ```Output
@@ -653,7 +653,7 @@ You can specify the scope of a function. For example, the function is added to
 the global scope in the following example:
 
 ```powershell
-function global:Get-DependentSvs {
+function Global:Get-DependentSvs {
   Get-Service | Where-Object {$_.DependentServices}
 }
 ```
@@ -679,7 +679,7 @@ The following command displays all the functions in the current session of
 PowerShell:
 
 ```powershell
-Get-ChildItem function:
+Get-ChildItem Function:
 ```
 
 The commands in the function are stored as a script block in the definition
@@ -687,13 +687,13 @@ property of the function. For example, to display the commands in the Help
 function that comes with PowerShell, type:
 
 ```powershell
-(Get-ChildItem function:help).Definition
+(Get-ChildItem Function:help).Definition
 ```
 
 You can also use the following syntax.
 
 ```powershell
-$function:help
+$Function:help
 ```
 
 For more information about the `Function:` drive, see the help topic for the

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -163,7 +163,7 @@ The clean block discards any output that's written to the **Success** stream.
 This method is called to request confirmation from the user before the function
 performs an action that would change the system. The function can continue
 based on the Boolean value returned by the method. This method can only be
-called only from within the `Process{}` block of the function. The
+called only from within the `process {}` block of the function. The
 `CmdletBinding` attribute must also declare that the function supports
 `ShouldProcess` (as shown in the previous example).
 
@@ -186,7 +186,7 @@ Functions can call two different methods when errors occur. When a
 non-terminating error occurs, the function should call the `WriteError` method,
 which is described in the `Write` methods section. When a terminating error
 occurs and the function can't continue, it should call the
-`ThrowTerminatingError` method. You can also use the `Throw` statement for
+`ThrowTerminatingError` method. You can also use the `throw` statement for
 terminating errors and the [Write-Error][22] cmdlet for non-terminating errors.
 
 For more information, see

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -128,14 +128,14 @@ As shown above, cmdlets use culture-sensitive parsing to convert the string.
 # Define an equivalent function.
 function Get-Date_Func {
   param(
-    [DateTime] $Date
+    [datetime] $Date
   )
   process {
     $Date
   }
 }
 
-[CultureInfo]::CurrentCulture = 'de-DE'
+[cultureinfo]::CurrentCulture = 'de-DE'
 
 # This German-format date string doesn't work with the invariant culture.
 # E.g., [datetime] '19-06-2018' breaks.
@@ -297,7 +297,7 @@ function Get-Sample {
       $attributeCollection.Add($parameterAttribute)
 
       $dynParam1 = [System.Management.Automation.RuntimeDefinedParameter]::new(
-        'KeyCount', [Int32], $attributeCollection
+        'KeyCount', [int32], $attributeCollection
       )
 
       $paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
@@ -718,7 +718,7 @@ function TestDefaultValue {
 Use `Get-Help` to see the default value information.
 
 ```powershell
-Get-Help TestDefaultValue -Parameter name
+Get-Help TestDefaultValue -Parameter Name
 ```
 
 ```Output
@@ -1014,7 +1014,7 @@ between zero and ten.
 param(
     [Parameter(Mandatory)]
     [ValidateRange(0,10)]
-    [Int]$Attempts
+    [int]$Attempts
 )
 ```
 
@@ -1050,7 +1050,7 @@ greater than or equal to the current date.
 param(
     [Parameter(Mandatory)]
     [ValidateScript({$_ -ge (Get-Date)})]
-    [DateTime]$EventDate
+    [datetime]$EventDate
 )
 ```
 
@@ -1058,7 +1058,7 @@ In the following example, the value of the variable `$date` must be less than
 or equal to the current date and time.
 
 ```powershell
-[ValidateScript({$_ -le (Get-Date)})] [DateTime]$date = (Get-Date)
+[ValidateScript({$_ -le (Get-Date)})] [datetime]$date = (Get-Date)
 ```
 
 > [!NOTE]
@@ -1085,7 +1085,7 @@ param(
         {$_ -ge (Get-Date)},
         ErrorMessage = "{0} isn't a future date. Specify a later date."
     )]
-    [DateTime]$EventDate
+    [datetime]$EventDate
 )
 ```
 
@@ -1110,7 +1110,7 @@ param(
         {$_ -ge (Get-Date).Date},
         ErrorMessage = "{0:d} isn't a future date. Specify a later date."
     )]
-    [DateTime]$EventDate
+    [datetime]$EventDate
 )
 ```
 
@@ -1169,18 +1169,18 @@ more information, see [about_Tab_Expansion][18].
 
 #### Dynamic ValidateSet values using classes
 
-You can use a **Class** to dynamically generate the values for **ValidateSet**
+You can use a `class` to dynamically generate the values for **ValidateSet**
 at runtime. In the following example, the valid values for the variable
-`$Sound` are generated via a **Class** named **SoundNames** that checks three
+`$Sound` are generated via a `class` named **SoundNames** that checks three
 filesystem paths for available sound files:
 
 ```powershell
-Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
+class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
     [string[]] GetValidValues() {
         $SoundPaths = '/System/Library/Sounds/',
             '/Library/Sounds','~/Library/Sounds'
-        $SoundNames = ForEach ($SoundPath in $SoundPaths) {
-            If (Test-Path $SoundPath) {
+        $SoundNames = foreach ($SoundPath in $SoundPaths) {
+            if (Test-Path $SoundPath) {
                 (Get-ChildItem $SoundPath).BaseName
             }
         }
@@ -1214,13 +1214,13 @@ that implicitly converts a null value, such as a **string**, the null value is
 converted to an empty string even when using the **ValidateNotNull** attribute.
 For this scenario use the **ValidateNotNullOrEmpty** attribute.
 
-In the following example, the value of the **ID** parameter can't be `$null`.
+In the following example, the value of the **Id** parameter can't be `$null`.
 
 ```powershell
 param(
     [Parameter()]
     [ValidateNotNull()]
-    $ID
+    $Id
 )
 ```
 
@@ -1324,7 +1324,7 @@ You can define `User` drive in Just Enough Administration (JEA) session
 configurations. For this example, we create the User: drive.
 
 ```powershell
-New-PSDrive -Name 'User' -PSProvider FileSystem -Root $env:HOMEPATH
+New-PSDrive -Name 'User' -PSProvider FileSystem -Root $Env:HOMEPATH
 ```
 
 ```Output

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Argument_Completion.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_Argument_Completion.md
@@ -4,7 +4,7 @@ Locale: en-US
 ms.date: 01/04/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_argument_completion?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
-title: About_functions_argument_completion
+title: about_Functions_Argument_Completion
 ---
 # about_Functions_Argument_Completion
 
@@ -37,7 +37,7 @@ example, the value of the **Fruit** parameter can only be **Apple**,
 **Banana**, or **Pear**.
 
 ```powershell
-Param(
+param (
     [Parameter(Mandatory=$true)]
     [ValidateSet('Apple', 'Banana', 'Pear')]
     [string[]]$Fruit
@@ -57,7 +57,7 @@ The validation occurs whenever that variable is assigned even within the
 script.
 
 ```powershell
-Param(
+param (
     [ValidateSet('hello', 'world')]
     [string]$Message
 )
@@ -77,19 +77,19 @@ For more information about tab expansion, see
 
 ### Dynamic ValidateSet values using classes
 
-You can use a **Class** to dynamically generate the values for **ValidateSet**
+You can use a `class` to dynamically generate the values for **ValidateSet**
 at runtime. In the following example, the valid values for the variable
-`$Sound` are generated via a **Class** named **SoundNames** that checks three
+`$Sound` are generated via a `class` named **SoundNames** that checks three
 filesystem paths for available sound files:
 
 ```powershell
-Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
+class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
     [string[]] GetValidValues() {
         $SoundPaths = '/System/Library/Sounds/',
                       '/Library/Sounds',
                       '~/Library/Sounds'
-        $SoundNames = ForEach ($SoundPath in $SoundPaths) {
-            If (Test-Path $SoundPath) {
+        $SoundNames = foreach ($SoundPath in $SoundPaths) {
+            if (Test-Path $SoundPath) {
                 (Get-ChildItem $SoundPath).BaseName
             }
         }
@@ -102,7 +102,7 @@ The `[SoundNames]` class is then implemented as a dynamic **ValidateSet** value
 as follows:
 
 ```powershell
-Param(
+param (
     [ValidateSet([SoundNames])]
     [string]$Sound
 )
@@ -167,7 +167,7 @@ The syntax is as follows:
 
 ```powershell
 function MyArgumentCompleter {
-    Param(
+    param (
         [Parameter(Mandatory)]
         [ArgumentCompleter( {
             param ( $commandName,
@@ -301,8 +301,8 @@ class NumberCompleter : IArgumentCompleter {
         [IDictionary] $fakeBoundParameters) {
 
         $resultList = [List[CompletionResult]]::new()
-        $local:to = $this.To
-        $local:step = $this.Step
+        $Local:to = $this.To
+        $Local:step = $this.Step
         for ($i = $this.From; $i -lt $to; $i += $step) {
             $resultList.Add([CompletionResult]::new($i.ToString()))
         }

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -45,15 +45,15 @@ each argument follows this example.
 {
     [CmdletBinding(ConfirmImpact=<String>,
     DefaultParameterSetName=<String>,
-    HelpURI=<URI>,
+    HelpUri=<URI>,
     SupportsPaging=<Boolean>,
     SupportsShouldProcess=<Boolean>,
     PositionalBinding=<Boolean>)]
 
-    Param ($Parameter1)
-    Begin{}
-    Process{}
-    End{}
+    param ($Parameter1)
+    begin {}
+    process {}
+    end {}
 }
 ```
 
@@ -66,10 +66,10 @@ value to `$true` or just list the argument by name. For example, the following
 {
     [CmdletBinding(SupportsPaging=$true)]
 
-    Param ($Parameter1)
-    Begin{}
-    Process{}
-    End{}
+    param ($Parameter1)
+    begin {}
+    process {}
+    end {}
 }
 
 # Boolean arguments can be defined using this shorthand syntax
@@ -77,10 +77,10 @@ value to `$true` or just list the argument by name. For example, the following
 {
     [CmdletBinding(SupportsPaging)]
 
-    Param ($Parameter1)
-    Begin{}
-    Process{}
-    End{}
+    param ($Parameter1)
+    begin {}
+    process {}
+    end {}
 }
 ```
 
@@ -104,22 +104,22 @@ set that PowerShell will attempt to use when it cannot determine which
 parameter set to use. You can avoid this issue by making the unique parameter
 of each parameter set a mandatory parameter.
 
-## HelpURI
+## HelpUri
 
-The **HelpURI** argument specifies the internet address of the online version
-of the help topic that describes the function. The value of the **HelpURI**
+The **HelpUri** argument specifies the internet address of the online version
+of the help topic that describes the function. The value of the **HelpUri**
 argument must begin with "http" or "https".
 
-The **HelpURI** argument value is used for the value of the **HelpURI**
+The **HelpUri** argument value is used for the value of the **HelpUri**
 property of the **CommandInfo** object that `Get-Command` returns for the
 function.
 
 However, when help files are installed on the computer and the value of the
 first link in the **RelatedLinks** section of the help file is a URI, or the
-value of the first `.Link` directive in comment-based help is a URI, the URI in
+value of the first `.LINK` keyword in comment-based help is a URI, the URI in
 the help file is used as the value of the **HelpUri** property of the function.
 
-The `Get-Help` cmdlet uses the value of the **HelpURI** property to locate the
+The `Get-Help` cmdlet uses the value of the **HelpUri** property to locate the
 online version of the function help topic when the **Online** parameter of
 `Get-Help` is specified in a command.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
@@ -56,7 +56,7 @@ parameter sets return different types.
 ```
 
 Place the **OutputType** attribute statements in the attributes list that
-precedes the `Param` statement.
+precedes the `param` statement.
 
 The following example shows the placement of the **OutputType** attribute in a
 simple function.
@@ -65,7 +65,7 @@ simple function.
 function SimpleFunction2
 {
   [OutputType([<Type>])]
-  Param ($Parameter1)
+  param ($Parameter1)
 
   <function body>
 }
@@ -78,9 +78,9 @@ advanced functions.
 function AdvancedFunction1
 {
   [OutputType([<Type>])]
-  Param (
-    [parameter(Mandatory=$true)]
-    [String[]]
+  param (
+    [Parameter(Mandatory=$true)]
+    [string[]]
     $Parameter1
   )
 
@@ -91,9 +91,9 @@ function AdvancedFunction2
 {
   [CmdletBinding(SupportsShouldProcess=<Boolean>)]
   [OutputType([<Type>])]
-  Param (
-    [parameter(Mandatory=$true)]
-    [String[]]
+  param (
+    [Parameter(Mandatory=$true)]
+    [string[]]
     $Parameter1
   )
 
@@ -108,8 +108,8 @@ function AdvancedFunction2
 ```powershell
 function Send-Greeting
 {
-  [OutputType([String])]
-  Param ($Name)
+  [OutputType([string])]
+  param ($Name)
 
   "Hello, $Name"
 }
@@ -139,15 +139,15 @@ function Get-User
   [CmdletBinding(DefaultParameterSetName="ID")]
 
   [OutputType("System.Int32", ParameterSetName="ID")]
-  [OutputType([String], ParameterSetName="Name")]
+  [OutputType([string], ParameterSetName="Name")]
 
-  Param (
-    [parameter(Mandatory=$true, ParameterSetName="ID")]
-    [Int[]]
+  param (
+    [Parameter(Mandatory=$true, ParameterSetName="ID")]
+    [int]
     $UserID,
 
-    [parameter(Mandatory=$true, ParameterSetName="Name")]
-    [String[]]
+    [Parameter(Mandatory=$true, ParameterSetName="Name")]
+    [string[]]
     $UserName
   )
 
@@ -167,10 +167,10 @@ that it returns a **System.DateTime** object.
 ```powershell
 function Get-Time
 {
-  [OutputType([DateTime])]
-  Param (
-    [parameter(Mandatory=$true)]
-    [Datetime]$DateTime
+  [OutputType([datetime])]
+  param (
+    [Parameter(Mandatory=$true)]
+    [datetime]$DateTime
   )
 
   $DateTime.ToShortTimeString()
@@ -210,7 +210,7 @@ but not return anything.
 function Invoke-Notepad
 {
   [OutputType([System.Void])]
-  Param ()
+  param ()
   & notepad.exe | Out-Null
 }
 ```

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -128,10 +128,10 @@ If you place the ordered attribute before the variable name, the command fails
 with the following error message.
 
 ```powershell
-[ordered]$orderedhash = @{}
+[ordered]$orderedHash = @{}
 ParserError:
 Line |
-   1 |  [ordered]$orderedhash = @{}
+   1 |  [ordered]$orderedHash = @{}
      |  ~~~~~~~~~~~~~~
      | The ordered attribute can be specified only on a hash literal node.
 ```
@@ -139,19 +139,19 @@ Line |
 To correct the expression, move the [ordered] attribute.
 
 ```powershell
-$orderedhash = [ordered]@{}
+$orderedHash = [ordered]@{}
 ```
 
 You can cast an ordered dictionary to a hashtable, but you can't guarantee the
 order of the members.
 
 ```powershell
-[hashtable]$newhash = [ordered]@{
+[hashtable]$newHash = [ordered]@{
     Number = 1
     Shape = "Square"
     Color = "Blue"
 }
-$newhash
+$newHash
 ```
 
 ```Output
@@ -297,7 +297,7 @@ member notation or array index notation.
   two
   PS> ([array]$dictionary.Values)[1]
   two
-  PS> $dictionary[[object]1]
+  PS> $dictionary[[Object]1]
   one
   PS> $dictionary['three']
   3
@@ -305,7 +305,7 @@ member notation or array index notation.
 
   In this example, the array value `[1]` is an index into the collection of
   values using the `Item(int index)` parameterized property overload. The array
-  value `[[object]1]` isn't an index but a key value using the
+  value `[[Object]1]` isn't an index but a key value using the
   `Item(System.Object key)` overload.
 
   > [!NOTE]
@@ -455,7 +455,7 @@ object values and saves it in the `$p` variable.
 
 ```powershell
 $p = @{
-    "PowerShell" = (Get-Process PowerShell)
+    "PowerShell" = (Get-Process powershell)
     "Notepad" = (Get-Process notepad)
 }
 ```
@@ -565,7 +565,7 @@ For example, the following commands enumerate the keys and values in the
 hashtable in the `$p` variable and then sort the keys in alphabetical order.
 
 ```powershell
-PS> $p.GetEnumerator() | Sort-Object -Property key
+PS> $p.GetEnumerator() | Sort-Object -Property Key
 
 Name                           Value
 ----                           -----

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Foreach.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Foreach.md
@@ -81,7 +81,7 @@ foreach ($file in Get-ChildItem)
 ```
 
 In this example, the `foreach` loop uses a property of the `$file` variable to
-perform a comparison operation (`$file.length -gt 100KB`). The `$file` variable
+perform a comparison operation (`$file.Length -gt 100KB`). The `$file` variable
 has all the properties of the object returned by the `Get-ChildItem`.
 
 In the next example, the script displays the length and the last access time

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -318,7 +318,7 @@ digital signature. For more information, see [about_Signing][07].
 
 The following XML sample creates a `Format-Table` custom view for the
 **System.IO.DirectoryInfo** and **System.IO.FileInfo** objects created by
-`Get-ChildItem`. The custom view is named **mygciview** and adds the
+`Get-ChildItem`. The custom view is named **MyGciView** and adds the
 **CreationTime** column to the table.
 
 To create the custom view, use the `Get-FormatData` and `Export-FormatData`
@@ -335,7 +335,7 @@ For this example, the custom view must use the table format, otherwise,
 `Format-Table` fails.
 
 Use `Format-Table` with the **View** parameter to specify the custom view's
-name, **mygciview**, and format the table's output with the **CreationTime**
+name, **MyGciView**, and format the table's output with the **CreationTime**
 column. For an example of how the command is run, see [Format-Table][08].
 
 > [!NOTE]
@@ -349,8 +349,8 @@ specific PowerShell version.
 
 ```powershell
 Get-FormatData -PowerShellVersion 5.1 -TypeName System.IO.DirectoryInfo |
-   Export-FormatData -Path ./Mygciview.Format.ps1xml
-Update-FormatData -AppendPath ./Mygciview.Format.ps1xml
+   Export-FormatData -Path ./MyGciView.Format.ps1xml
+Update-FormatData -AppendPath ./MyGciView.Format.ps1xml
 ```
 
 ```xml
@@ -358,7 +358,7 @@ Update-FormatData -AppendPath ./Mygciview.Format.ps1xml
 <Configuration>
   <ViewDefinitions>
     <View>
-      <Name>mygciview</Name>
+      <Name>MyGciView</Name>
       <ViewSelectedBy>
         <TypeName>System.IO.DirectoryInfo</TypeName>
         <TypeName>System.IO.FileInfo</TypeName>

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Function_Provider.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Function_Provider.md
@@ -101,21 +101,21 @@ You can retrieve a function's definition by accessing the **Definition**
 property, as shown below.
 
 ```powershell
-(Get-Item -Path function:more).Definition
+(Get-Item -Path Function:more).Definition
 ```
 
 You can also retrieve a function's definition using its provider path prefixed
 by the dollar sign (`$`).
 
 ```powershell
-$function:more
+$Function:more
 ```
 
 To retrieve the definition for a function that has a dash (`-`) in the name,
 wrap the value after the dollar sign in curly braces.
 
 ```powershell
-${function:Clear-Host}
+${Function:Clear-Host}
 ```
 
 ### Getting selected functions
@@ -132,7 +132,7 @@ Get-Item -Path man | Format-Table -Wrap -AutoSize
 
 ### Working with Function provider paths
 
-These commands both get the function named `c:`. The first command can be used
+These commands both get the function named `C:`. The first command can be used
 in any drive. The second command is used in the `Function:` drive. Because the
 name ends in a colon, which is the syntax for a drive, you must qualify the
 path with the drive name. Within the `Function:` drive, you can use either
@@ -160,7 +160,7 @@ function, it is available only in the scope in which it was created. To make a
 function available, use a scope modifier when you create the function. For more
 information, see [about_Scopes][15].
 
-The following example uses the `global:` scope modifier to create a function in
+The following example uses the `Global:` scope modifier to create a function in
 the global scope.
 
 ```powershell
@@ -170,14 +170,14 @@ function New-Function {
         [scriptblock] $Script
     )
 
-    $lp = "Function:\global:$($name)"
-    Set-Item -LiteralPath $lp -Value $script -PassThru -Force
+    $lp = "Function:\Global:$($Name)"
+    Set-Item -LiteralPath $lp -Value $Script -PassThru -Force
 }
 
 New-Function -Name 'Win32:' -Script { Set-Location C:\Windows\System32 }
 ```
 
-Without the `global:` scope modifier, the function would be created in the
+Without the `Global:` scope modifier, the function would be created in the
 local scope. When `New-Function` exits the newly created function would no
 longer exist.
 
@@ -269,7 +269,7 @@ Get-Help Get-ChildItem
 ```
 
 ```powershell
-Get-Help Get-ChildItem -Path function:
+Get-Help Get-ChildItem -Path Function:
 ```
 
 ## See also

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -71,7 +71,7 @@ like a cmdlet without using `C#` programming. For more information, see
 The following are the syntax for a function:
 
 ```Syntax
-function [<scope:>]<name> [([type]$parameter1[,[type]$parameter2])]
+function [<scope:>]<name> [([type]$Parameter1[,[type]$Parameter2])]
 {
   begin {<statement list>}
   process {<statement list>}
@@ -83,7 +83,7 @@ function [<scope:>]<name> [([type]$parameter1[,[type]$parameter2])]
 ```Syntax
 function [<scope:>]<name>
 {
-  param([type]$parameter1 [,[type]$parameter2])
+  param([type]$Parameter1 [,[type]$Parameter2])
   dynamicparam {<statement list>}
   begin {<statement list>}
   process {<statement list>}
@@ -123,7 +123,7 @@ processing, and an `end` block for one-time post-processing.
 Function Test-ScriptCmdlet
 {
 [CmdletBinding(SupportsShouldProcess=$true)]
-    Param ($Parameter1)
+    param ($Parameter1)
     begin{}
     process{}
     end{}
@@ -215,11 +215,11 @@ For example, the following function finds all `.jpg` files in the current
 user's directories that were changed after the start date.
 
 ```powershell
-function Get-NewPix
+function Get-NewPicture
 {
   $start = Get-Date -Month 1 -Day 1 -Year 2010
-  $allpix = Get-ChildItem -Path $env:UserProfile\*.jpg -Recurse
-  $allpix | Where-Object {$_.LastWriteTime -gt $Start}
+  $allPics = Get-ChildItem -Path $Env:USERPROFILE\*.jpg -Recurse
+  $allPics | Where-Object {$_.LastWriteTime -gt $Start}
 }
 ```
 
@@ -261,16 +261,16 @@ in the following sample syntax:
 
 ```Syntax
 function <name> {
-  param ([type]$parameter1 [,[type]$parameter2])
+  param ([type]$Parameter1 [,[type]$Parameter2])
   <statement list>
 }
 ```
 
-You can also define parameters outside the braces without the `Param` keyword,
+You can also define parameters outside the braces without the `param` keyword,
 as shown in the following sample syntax:
 
 ```Syntax
-function <name> [([type]$parameter1[,[type]$parameter2])] {
+function <name> [([type]$Parameter1[,[type]$Parameter2])] {
   <statement list>
 }
 ```
@@ -278,8 +278,8 @@ function <name> [([type]$parameter1[,[type]$parameter2])] {
 Below is an example of this alternative syntax.
 
 ```powershell
-function Add-Numbers([int]$one, [int]$two) {
-    $one + $two
+function Add-Numbers([int]$One, [int]$Two) {
+    $One + $Two
 }
 ```
 
@@ -296,7 +296,7 @@ the value of the `$Size` parameter, and it excludes directories:
 
 ```powershell
 function Get-SmallFiles {
-  Param($Size)
+  param ($Size)
   Get-ChildItem $HOME | Where-Object {
     $_.Length -lt $Size -and !$_.PSIsContainer
   }
@@ -396,8 +396,8 @@ name, as shown in the following example:
 
 ```powershell
 function Switch-Item {
-  param ([switch]$on)
-  if ($on) { "Switch on" }
+  param ([switch]$On)
+  if ($On) { "Switch on" }
   else { "Switch off" }
 }
 ```
@@ -406,7 +406,7 @@ When you type the `On` switch parameter after the function name, the function
 displays `Switch on`. Without the switch parameter, it displays `Switch off`.
 
 ```powershell
-Switch-Item -on
+Switch-Item -On
 ```
 
 ```Output
@@ -425,7 +425,7 @@ You can also assign a **Boolean** value to a switch when you run the function,
 as shown in the following example:
 
 ```powershell
-Switch-Item -on:$true
+Switch-Item -On:$true
 ```
 
 ```Output
@@ -433,7 +433,7 @@ Switch on
 ```
 
 ```powershell
-Switch-Item -on:$false
+Switch-Item -On:$false
 ```
 
 ```Output
@@ -653,7 +653,7 @@ You can specify the scope of a function. For example, the function is added to
 the global scope in the following example:
 
 ```powershell
-function global:Get-DependentSvs {
+function Global:Get-DependentSvs {
   Get-Service | Where-Object {$_.DependentServices}
 }
 ```
@@ -679,7 +679,7 @@ The following command displays all the functions in the current session of
 PowerShell:
 
 ```powershell
-Get-ChildItem function:
+Get-ChildItem Function:
 ```
 
 The commands in the function are stored as a script block in the definition
@@ -687,13 +687,13 @@ property of the function. For example, to display the commands in the Help
 function that comes with PowerShell, type:
 
 ```powershell
-(Get-ChildItem function:help).Definition
+(Get-ChildItem Function:help).Definition
 ```
 
 You can also use the following syntax.
 
 ```powershell
-$function:help
+$Function:help
 ```
 
 For more information about the `Function:` drive, see the help topic for the

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -163,7 +163,7 @@ The clean block discards any output that's written to the **Success** stream.
 This method is called to request confirmation from the user before the function
 performs an action that would change the system. The function can continue
 based on the Boolean value returned by the method. This method can only be
-called only from within the `Process{}` block of the function. The
+called only from within the `process {}` block of the function. The
 `CmdletBinding` attribute must also declare that the function supports
 `ShouldProcess` (as shown in the previous example).
 
@@ -186,7 +186,7 @@ Functions can call two different methods when errors occur. When a
 non-terminating error occurs, the function should call the `WriteError` method,
 which is described in the `Write` methods section. When a terminating error
 occurs and the function can't continue, it should call the
-`ThrowTerminatingError` method. You can also use the `Throw` statement for
+`ThrowTerminatingError` method. You can also use the `throw` statement for
 terminating errors and the [Write-Error][22] cmdlet for non-terminating errors.
 
 For more information, see

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -128,14 +128,14 @@ As shown above, cmdlets use culture-sensitive parsing to convert the string.
 # Define an equivalent function.
 function Get-Date_Func {
   param(
-    [DateTime] $Date
+    [datetime] $Date
   )
   process {
     $Date
   }
 }
 
-[CultureInfo]::CurrentCulture = 'de-DE'
+[cultureinfo]::CurrentCulture = 'de-DE'
 
 # This German-format date string doesn't work with the invariant culture.
 # E.g., [datetime] '19-06-2018' breaks.
@@ -297,7 +297,7 @@ function Get-Sample {
       $attributeCollection.Add($parameterAttribute)
 
       $dynParam1 = [System.Management.Automation.RuntimeDefinedParameter]::new(
-        'KeyCount', [Int32], $attributeCollection
+        'KeyCount', [int32], $attributeCollection
       )
 
       $paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
@@ -718,7 +718,7 @@ function TestDefaultValue {
 Use `Get-Help` to see the default value information.
 
 ```powershell
-Get-Help TestDefaultValue -Parameter name
+Get-Help TestDefaultValue -Parameter Name
 ```
 
 ```Output
@@ -1014,7 +1014,7 @@ between zero and ten.
 param(
     [Parameter(Mandatory)]
     [ValidateRange(0,10)]
-    [Int]$Attempts
+    [int]$Attempts
 )
 ```
 
@@ -1050,7 +1050,7 @@ greater than or equal to the current date.
 param(
     [Parameter(Mandatory)]
     [ValidateScript({$_ -ge (Get-Date)})]
-    [DateTime]$EventDate
+    [datetime]$EventDate
 )
 ```
 
@@ -1058,7 +1058,7 @@ In the following example, the value of the variable `$date` must be less than
 or equal to the current date and time.
 
 ```powershell
-[ValidateScript({$_ -le (Get-Date)})] [DateTime]$date = (Get-Date)
+[ValidateScript({$_ -le (Get-Date)})] [datetime]$date = (Get-Date)
 ```
 
 > [!NOTE]
@@ -1085,7 +1085,7 @@ param(
         {$_ -ge (Get-Date)},
         ErrorMessage = "{0} isn't a future date. Specify a later date."
     )]
-    [DateTime]$EventDate
+    [datetime]$EventDate
 )
 ```
 
@@ -1110,7 +1110,7 @@ param(
         {$_ -ge (Get-Date).Date},
         ErrorMessage = "{0:d} isn't a future date. Specify a later date."
     )]
-    [DateTime]$EventDate
+    [datetime]$EventDate
 )
 ```
 
@@ -1169,18 +1169,18 @@ more information, see [about_Tab_Expansion][18].
 
 #### Dynamic ValidateSet values using classes
 
-You can use a **Class** to dynamically generate the values for **ValidateSet**
+You can use a `class` to dynamically generate the values for **ValidateSet**
 at runtime. In the following example, the valid values for the variable
-`$Sound` are generated via a **Class** named **SoundNames** that checks three
+`$Sound` are generated via a `class` named **SoundNames** that checks three
 filesystem paths for available sound files:
 
 ```powershell
-Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
+class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
     [string[]] GetValidValues() {
         $SoundPaths = '/System/Library/Sounds/',
             '/Library/Sounds','~/Library/Sounds'
-        $SoundNames = ForEach ($SoundPath in $SoundPaths) {
-            If (Test-Path $SoundPath) {
+        $SoundNames = foreach ($SoundPath in $SoundPaths) {
+            if (Test-Path $SoundPath) {
                 (Get-ChildItem $SoundPath).BaseName
             }
         }
@@ -1214,13 +1214,13 @@ that implicitly converts a null value, such as a **string**, the null value is
 converted to an empty string even when using the **ValidateNotNull** attribute.
 For this scenario use the **ValidateNotNullOrEmpty** attribute.
 
-In the following example, the value of the **ID** parameter can't be `$null`.
+In the following example, the value of the **Id** parameter can't be `$null`.
 
 ```powershell
 param(
     [Parameter()]
     [ValidateNotNull()]
-    $ID
+    $Id
 )
 ```
 
@@ -1324,7 +1324,7 @@ You can define `User` drive in Just Enough Administration (JEA) session
 configurations. For this example, we create the User: drive.
 
 ```powershell
-New-PSDrive -Name 'User' -PSProvider FileSystem -Root $env:HOMEPATH
+New-PSDrive -Name 'User' -PSProvider FileSystem -Root $Env:HOMEPATH
 ```
 
 ```Output

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Argument_Completion.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_Argument_Completion.md
@@ -4,7 +4,7 @@ Locale: en-US
 ms.date: 10/22/2021
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_argument_completion?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
-title: About_functions_argument_completion
+title: about_Functions_Argument_Completion
 ---
 # about_Functions_Argument_Completion
 
@@ -37,7 +37,7 @@ example, the value of the **Fruit** parameter can only be **Apple**,
 **Banana**, or **Pear**.
 
 ```powershell
-Param(
+param (
     [Parameter(Mandatory=$true)]
     [ValidateSet('Apple', 'Banana', 'Pear')]
     [string[]]$Fruit
@@ -57,7 +57,7 @@ The validation occurs whenever that variable is assigned even within the
 script.
 
 ```powershell
-Param(
+param (
     [ValidateSet('hello', 'world')]
     [string]$Message
 )
@@ -77,19 +77,19 @@ For more information about tab expansion, see
 
 ### Dynamic ValidateSet values using classes
 
-You can use a **Class** to dynamically generate the values for **ValidateSet**
+You can use a `class` to dynamically generate the values for **ValidateSet**
 at runtime. In the following example, the valid values for the variable
-`$Sound` are generated via a **Class** named **SoundNames** that checks three
+`$Sound` are generated via a `class` named **SoundNames** that checks three
 filesystem paths for available sound files:
 
 ```powershell
-Class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
+class SoundNames : System.Management.Automation.IValidateSetValuesGenerator {
     [string[]] GetValidValues() {
         $SoundPaths = '/System/Library/Sounds/',
                       '/Library/Sounds',
                       '~/Library/Sounds'
-        $SoundNames = ForEach ($SoundPath in $SoundPaths) {
-            If (Test-Path $SoundPath) {
+        $SoundNames = foreach ($SoundPath in $SoundPaths) {
+            if (Test-Path $SoundPath) {
                 (Get-ChildItem $SoundPath).BaseName
             }
         }
@@ -102,7 +102,7 @@ The `[SoundNames]` class is then implemented as a dynamic **ValidateSet** value
 as follows:
 
 ```powershell
-Param(
+param (
     [ValidateSet([SoundNames])]
     [string]$Sound
 )
@@ -167,7 +167,7 @@ The syntax is as follows:
 
 ```powershell
 function MyArgumentCompleter {
-    Param(
+    param (
         [Parameter(Mandatory)]
         [ArgumentCompleter( {
             param ( $commandName,
@@ -301,8 +301,8 @@ class NumberCompleter : IArgumentCompleter {
         [IDictionary] $fakeBoundParameters) {
 
         $resultList = [List[CompletionResult]]::new()
-        $local:to = $this.To
-        $local:step = $this.Step
+        $Local:to = $this.To
+        $Local:step = $this.Step
         for ($i = $this.From; $i -lt $to; $i += $step) {
             $resultList.Add([CompletionResult]::new($i.ToString()))
         }

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -45,15 +45,15 @@ each argument follows this example.
 {
     [CmdletBinding(ConfirmImpact=<String>,
     DefaultParameterSetName=<String>,
-    HelpURI=<URI>,
+    HelpUri=<URI>,
     SupportsPaging=<Boolean>,
     SupportsShouldProcess=<Boolean>,
     PositionalBinding=<Boolean>)]
 
-    Param ($Parameter1)
-    Begin{}
-    Process{}
-    End{}
+    param ($Parameter1)
+    begin {}
+    process {}
+    end {}
 }
 ```
 
@@ -66,10 +66,10 @@ value to `$true` or just list the argument by name. For example, the following
 {
     [CmdletBinding(SupportsPaging=$true)]
 
-    Param ($Parameter1)
-    Begin{}
-    Process{}
-    End{}
+    param ($Parameter1)
+    begin {}
+    process {}
+    end {}
 }
 
 # Boolean arguments can be defined using this shorthand syntax
@@ -77,10 +77,10 @@ value to `$true` or just list the argument by name. For example, the following
 {
     [CmdletBinding(SupportsPaging)]
 
-    Param ($Parameter1)
-    Begin{}
-    Process{}
-    End{}
+    param ($Parameter1)
+    begin {}
+    process {}
+    end {}
 }
 ```
 
@@ -104,22 +104,22 @@ set that PowerShell will attempt to use when it cannot determine which
 parameter set to use. You can avoid this issue by making the unique parameter
 of each parameter set a mandatory parameter.
 
-## HelpURI
+## HelpUri
 
-The **HelpURI** argument specifies the internet address of the online version
-of the help topic that describes the function. The value of the **HelpURI**
+The **HelpUri** argument specifies the internet address of the online version
+of the help topic that describes the function. The value of the **HelpUri**
 argument must begin with "http" or "https".
 
-The **HelpURI** argument value is used for the value of the **HelpURI**
+The **HelpUri** argument value is used for the value of the **HelpUri**
 property of the **CommandInfo** object that `Get-Command` returns for the
 function.
 
 However, when help files are installed on the computer and the value of the
 first link in the **RelatedLinks** section of the help file is a URI, or the
-value of the first `.Link` directive in comment-based help is a URI, the URI in
+value of the first `.LINK` keyword in comment-based help is a URI, the URI in
 the help file is used as the value of the **HelpUri** property of the function.
 
-The `Get-Help` cmdlet uses the value of the **HelpURI** property to locate the
+The `Get-Help` cmdlet uses the value of the **HelpUri** property to locate the
 online version of the function help topic when the **Online** parameter of
 `Get-Help` is specified in a command.
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
@@ -56,7 +56,7 @@ parameter sets return different types.
 ```
 
 Place the **OutputType** attribute statements in the attributes list that
-precedes the `Param` statement.
+precedes the `param` statement.
 
 The following example shows the placement of the **OutputType** attribute in a
 simple function.
@@ -65,7 +65,7 @@ simple function.
 function SimpleFunction2
 {
   [OutputType([<Type>])]
-  Param ($Parameter1)
+  param ($Parameter1)
 
   <function body>
 }
@@ -78,9 +78,9 @@ advanced functions.
 function AdvancedFunction1
 {
   [OutputType([<Type>])]
-  Param (
-    [parameter(Mandatory=$true)]
-    [String[]]
+  param (
+    [Parameter(Mandatory=$true)]
+    [string[]]
     $Parameter1
   )
 
@@ -91,9 +91,9 @@ function AdvancedFunction2
 {
   [CmdletBinding(SupportsShouldProcess=<Boolean>)]
   [OutputType([<Type>])]
-  Param (
-    [parameter(Mandatory=$true)]
-    [String[]]
+  param (
+    [Parameter(Mandatory=$true)]
+    [string[]]
     $Parameter1
   )
 
@@ -108,8 +108,8 @@ function AdvancedFunction2
 ```powershell
 function Send-Greeting
 {
-  [OutputType([String])]
-  Param ($Name)
+  [OutputType([string])]
+  param ($Name)
 
   "Hello, $Name"
 }
@@ -139,15 +139,15 @@ function Get-User
   [CmdletBinding(DefaultParameterSetName="ID")]
 
   [OutputType("System.Int32", ParameterSetName="ID")]
-  [OutputType([String], ParameterSetName="Name")]
+  [OutputType([string], ParameterSetName="Name")]
 
-  Param (
-    [parameter(Mandatory=$true, ParameterSetName="ID")]
-    [Int[]]
+  param (
+    [Parameter(Mandatory=$true, ParameterSetName="ID")]
+    [int]
     $UserID,
 
-    [parameter(Mandatory=$true, ParameterSetName="Name")]
-    [String[]]
+    [Parameter(Mandatory=$true, ParameterSetName="Name")]
+    [string[]]
     $UserName
   )
 
@@ -167,10 +167,10 @@ that it returns a **System.DateTime** object.
 ```powershell
 function Get-Time
 {
-  [OutputType([DateTime])]
-  Param (
-    [parameter(Mandatory=$true)]
-    [Datetime]$DateTime
+  [OutputType([datetime])]
+  param (
+    [Parameter(Mandatory=$true)]
+    [datetime]$DateTime
   )
 
   $DateTime.ToShortTimeString()
@@ -210,7 +210,7 @@ but not return anything.
 function Invoke-Notepad
 {
   [OutputType([System.Void])]
-  Param ()
+  param ()
   & notepad.exe | Out-Null
 }
 ```

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -128,10 +128,10 @@ If you place the ordered attribute before the variable name, the command fails
 with the following error message.
 
 ```powershell
-[ordered]$orderedhash = @{}
+[ordered]$orderedHash = @{}
 ParserError:
 Line |
-   1 |  [ordered]$orderedhash = @{}
+   1 |  [ordered]$orderedHash = @{}
      |  ~~~~~~~~~~~~~~
      | The ordered attribute can be specified only on a hash literal node.
 ```
@@ -139,19 +139,19 @@ Line |
 To correct the expression, move the [ordered] attribute.
 
 ```powershell
-$orderedhash = [ordered]@{}
+$orderedHash = [ordered]@{}
 ```
 
 You can cast an ordered dictionary to a hashtable, but you can't guarantee the
 order of the members.
 
 ```powershell
-[hashtable]$newhash = [ordered]@{
+[hashtable]$newHash = [ordered]@{
     Number = 1
     Shape = "Square"
     Color = "Blue"
 }
-$newhash
+$newHash
 ```
 
 ```Output
@@ -297,7 +297,7 @@ member notation or array index notation.
   two
   PS> ([array]$dictionary.Values)[1]
   two
-  PS> $dictionary[[object]1]
+  PS> $dictionary[[Object]1]
   one
   PS> $dictionary['three']
   3
@@ -305,7 +305,7 @@ member notation or array index notation.
 
   In this example, the array value `[1]` is an index into the collection of
   values using the `Item(int index)` parameterized property overload. The array
-  value `[[object]1]` isn't an index but a key value using the
+  value `[[Object]1]` isn't an index but a key value using the
   `Item(System.Object key)` overload.
 
   > [!NOTE]
@@ -455,7 +455,7 @@ object values and saves it in the `$p` variable.
 
 ```powershell
 $p = @{
-    "PowerShell" = (Get-Process PowerShell)
+    "PowerShell" = (Get-Process powershell)
     "Notepad" = (Get-Process notepad)
 }
 ```
@@ -565,7 +565,7 @@ For example, the following commands enumerate the keys and values in the
 hashtable in the `$p` variable and then sort the keys in alphabetical order.
 
 ```powershell
-PS> $p.GetEnumerator() | Sort-Object -Property key
+PS> $p.GetEnumerator() | Sort-Object -Property Key
 
 Name                           Value
 ----                           -----


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide