### PR TITLE
Fix incorrect case/capitalization in reference documents (6/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Hidden.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Hidden.md
@@ -48,7 +48,7 @@ PowerShell 5.0.
 ## EXAMPLE
 
 The following example shows how to use the `hidden` keyword in a class
-definition. The **Car** class method, **Drive**, has a property, **rides**,
+definition. The **Car** class method, **Drive**, has a property, **Rides**,
 that does not need to be viewed or changed as it merely tallies the number of
 times that **Drive** is called on the **Car** class. That metric that is not
 important to users of the class (consider, for example, that when you are
@@ -68,20 +68,20 @@ later to identify all members that you have hidden.
 class Car
 {
    # Properties
-   [String] $Color
-   [String] $ModelYear
+   [string] $Color
+   [string] $ModelYear
    [int] $Distance
 
    # Method
-   [int] Drive ([int]$miles)
+   [int] Drive ([int]$Miles)
    {
-      $this.Distance += $miles
-      $this.rides++
+      $this.Distance += $Miles
+      $this.Rides++
       return $this.Distance
    }
 
    # Hidden property of the Drive method
-    hidden [int] $rides = 0
+    hidden [int] $Rides = 0
 }
 ```
 
@@ -93,7 +93,7 @@ $TestCar = [Car]::new()
 ```
 
 After you create the new instance, pipe the contents of the `$TestCar` variable
-to `Get-Member`. Observe that the **rides** property is not among the members
+to `Get-Member`. Observe that the **Rides** property is not among the members
 listed in the `Get-Member` command results.
 
 ```output
@@ -103,7 +103,7 @@ PS C:\Windows\system32> $TestCar | Get-Member
 
 Name        MemberType Definition
 ----        ---------- ----------
-Drive       Method     int Drive(int miles)
+Drive       Method     int Drive(int Miles)
 Equals      Method     bool Equals(System.Object obj)
 GetHashCode Method     int GetHashCode()
 GetType     Method     type GetType()
@@ -115,7 +115,7 @@ ModelYear   Property   string ModelYear {get;set;}
 ```
 
 Now, try running `Get-Member` again, but this time, add the `-Force` parameter.
-Note that the results contain the hidden **rides** property, among other
+Note that the results contain the hidden **Rides** property, among other
 members that are hidden by default.
 
 ```output
@@ -130,23 +130,23 @@ psadapted     MemberSet    psadapted {Color, ModelYear, Distance,
 psbase        MemberSet    psbase {Color, ModelYear, Distance,...
 psextended    MemberSet    psextended {}
 psobject      MemberSet    psobject {BaseObject, Members,...
-Drive         Method       int Drive(int miles)
+Drive         Method       int Drive(int Miles)
 Equals        Method       bool Equals(System.Object obj)
 GetHashCode   Method       int GetHashCode()
 GetType       Method       type GetType()
 get_Color     Method       string get_Color()
 get_Distance  Method       int get_Distance()
 get_ModelYear Method       string get_ModelYear()
-get_rides     Method       int get_rides()
+get_Rides     Method       int get_Rides()
 set_Color     Method       void set_Color(string )
 set_Distance  Method       void set_Distance(int )
 set_ModelYear Method       void set_ModelYear(string )
-set_rides     Method       void set_rides(int )
+set_Rides     Method       void set_Rides(int )
 ToString      Method       string ToString()
 Color         Property     string Color {get;set;}
 Distance      Property     int Distance {get;set;}
 ModelYear     Property     string ModelYear {get;set;}
-rides         Property     int rides {get;set;}
+Rides         Property     int Rides {get;set;}
 
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_If.md
@@ -48,7 +48,7 @@ statement. If both `<test1>` and `<test2>` evaluate to false, the
 You can use multiple `elseif` statements to chain a series of conditional
 tests. Each test is run only if all the previous tests are false. If you need
 to create an `if` statement that contains many `elseif` statements, consider
-using a Switch statement instead.
+using a `switch` statement instead.
 
 Examples:
 
@@ -67,7 +67,7 @@ evaluates to true, and the statement list runs. However, if `$a` is less than
 or equal to `2` or isn't an existing variable, the `if` statement doesn't
 display a message.
 
-By adding an Else statement, a message is displayed when $a is less than or
+By adding an `else` statement, a message is displayed when $a is less than or
 equal to 2. As the next example shows:
 
 ```powershell

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
@@ -211,7 +211,7 @@ For more information, see [about_Operators][03].
 
 ## New() method for types
 
-Beginning in PowerShell 5.0, PowerShell adds a static `New()` method for all
+Beginning in PowerShell 5.0, PowerShell adds a static `new()` method for all
 .NET types. The following examples produce the same result.
 
 ```powershell

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -84,7 +84,7 @@ other cmdlets might work differently.
 
 The child jobs are stored in the **ChildJobs** property of the parent job
 object. The **ChildJobs** property can contain one or many child job objects.
-The child job objects have a **Name**, **ID**, and **InstanceId** that differ
+The child job objects have a **Name**, **Id**, and **InstanceId** that differ
 from the parent job so that you can manage the parent and child jobs
 individually or as a unit.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Jobs.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Jobs.md
@@ -248,11 +248,11 @@ is completed and all results are available.
 
 You can also use the `Wait-Job` cmdlet to wait for any or all of the results of
 the job. `Wait-Job` lets you wait for one or more specific job or for all jobs.
-The following command uses the `Wait-Job` cmdlet to wait for a job with **ID**
+The following command uses the `Wait-Job` cmdlet to wait for a job with **Id**
 10.
 
 ```powershell
-Wait-Job -ID 10
+Wait-Job -Id 10
 ```
 
 As a result, the PowerShell prompt is suppressed until the job is completed.
@@ -262,7 +262,7 @@ You can also wait for a predetermined period of time. This command uses the
 the command prompt returns, but the job continues to run in the background.
 
 ```powershell
-Wait-Job -ID 10 -Timeout 120
+Wait-Job -Id 10 -Timeout 120
 ```
 
 ## Stopping a job

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Join.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Join.md
@@ -1,5 +1,5 @@
 ---
-description: Describes how the join operator (-join) combines multiple strings into a single string.
+description: Describes how the join operator (`-join`) combines multiple strings into a single string.
 Locale: en-US
 ms.date: 06/09/2017
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_join?view=powershell-5.1&WT.mc_id=ps-gethelp
@@ -11,7 +11,7 @@ title: about_Join
 
 ## Short description
 
-Describes how the join operator (-join) combines multiple strings into a
+Describes how the join operator (`-join`) combines multiple strings into a
 single string.
 
 ## Long description
@@ -38,7 +38,7 @@ concatenated strings. The default is no delimiter ("").
 
 Remarks
 
-The unary join operator (-join <string[]>) has higher precedence than a
+The unary join operator (`-join <string[]>`) has higher precedence than a
 comma. As a result, if you submit a comma-separated list of strings to the
 unary join operator, only the first string (before the first comma) is
 submitted to the join operator.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -35,12 +35,12 @@ about topic for the keyword and the information that follows the table.
 | `filter`       | [about_Functions][18]                                              |
 | `finally`      | [about_Try_Catch_Finally][26]                                      |
 | `for`          | [about_For][13]                                                    |
-| `foreach`      | [about_ForEach][14]                                                |
+| `foreach`      | [about_Foreach][14]                                                |
 | `from`         | Reserved for future use                                            |
 | `function`     | [about_Functions][18], [about_Functions_Advanced][17]              |
 | `hidden`       | [about_Hidden][19]                                                 |
 | `if`           | [about_If][20]                                                     |
-| `in`           | [about_ForEach][14]                                                |
+| `in`           | [about_Foreach][14]                                                |
 | `param`        | [about_Functions][18]                                              |
 | `process`      | [about_Functions][18], [about_Functions_Advanced][17]              |
 | `return`       | [about_Return][21]                                                 |
@@ -155,7 +155,7 @@ also include `if` statements and some limited commands.
 Syntax:
 
 ```Syntax
-data <variable> [-supportedCommand <cmdlet-name>] {<permitted content>}
+data <variable> [-SupportedCommand <cmdlet-name>] {<permitted content>}
 ```
 
 ## `do`
@@ -281,7 +281,7 @@ C:\scripts\test>type test.ps1
 3
 exit 4
 
-C:\scripts\test>powershell -file ./test.ps1
+C:\scripts\test>powershell -File ./test.ps1
 1
 2
 3
@@ -358,7 +358,7 @@ Syntax:
 
 ```Syntax
 function [<scope:>]<name> {
-   param ([type]<$pname1> [, [type]<$pname2>])
+   param ([type]<$PName1> [, [type]<$PName2>])
    dynamicparam {<statement list>}
    begin {<statement list>}
    process {<statement list>}
@@ -372,7 +372,7 @@ statement list after the function name.
 Syntax:
 
 ```Syntax
-function [<scope:>]<name> [([type]<$pname1>, [[type]<$pname2>])] {
+function [<scope:>]<name> [([type]<$PName1>, [[type]<$PName2>])] {
    dynamicparam {<statement list>}
    begin {<statement list>}
    process {<statement list>}
@@ -420,7 +420,7 @@ Syntax:
 
 ```Syntax
 function [<scope:>]<name> {
-   param ([type]<$pname1>[, [[type]<$pname2>]])
+   param ([type]<$PName1>[, [[type]<$PName2>]])
    <statement list>
 }
 ```
@@ -554,7 +554,7 @@ include classes from modules.
 Namespace syntax:
 
 ```Syntax
-using namespace <.Net-framework-namespace>
+using namespace <.NET-Framework-namespace>
 ```
 
 Module syntax:
@@ -567,7 +567,7 @@ Assembly syntax:
 
 ```Syntax
 using assembly <.NET-assembly-path>
-using assembly <.NET-framework-namespace>
+using assembly <.NET-Framework-namespace>
 ```
 
 For more information, see [about_Using][27].
@@ -614,7 +614,7 @@ do {<statement list>} while (<condition>)
 [11]: about_Do.md
 [12]: about_Enum.md
 [13]: about_For.md
-[14]: about_ForEach.md
+[14]: about_Foreach.md
 [15]: about_Functions_Advanced_Methods.md
 [16]: about_Functions_Advanced_Parameters.md
 [17]: about_Functions_Advanced.md

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -176,7 +176,7 @@ additional variables:
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
-- Any environment variables, like `$ENV:TEMP`
+- Any environment variables, like `$Env:TEMP`
 
 Only the following comparison operators are permitted:
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
@@ -60,8 +60,8 @@ of FALSE. All other integers have a value of TRUE.
 The syntax of the logical operators is as follows:
 
 ```Syntax
-<statement> {-AND | -OR | -XOR} <statement>
-{! | -NOT} <statement>
+<statement> {-and | -or | -xor} <statement>
+{! | -not} <statement>
 ```
 
 Statements that use the logical operators return Boolean (TRUE or FALSE)
@@ -72,7 +72,7 @@ determine the truth value of the statement. If the left operand in a statement
 that contains the and operator is FALSE, the right operand isn't evaluated. If
 the left operand in a statement that contains the or statement is TRUE, the
 right operand isn't evaluated. As a result, you can use these statements in
-the same way that you would use the `If` statement.
+the same way that you would use the `if` statement.
 
 ## See also
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Member-Access_Enumeration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Member-Access_Enumeration.md
@@ -230,7 +230,7 @@ PS> $CapitalizedProperty = @{
     Value      = { $this.ToUpper() }
     PassThru   = $true
 }
-PS> [System.Collections.Generic.List[object]]$MixedCollection = @(
+PS> [System.Collections.Generic.List[Object]]$MixedCollection = @(
     'a'
     ('b' | Add-Member @CapitalizedProperty)
     ('c' | Add-Member @CapitalizedProperty)
@@ -284,7 +284,7 @@ successful method calls isn't returned. Terminating error conditions include:
 Consider the following example:
 
 ```powershell
-class Class1 { [object] Foo() { return 'Bar' } }
+class Class1 { [Object] Foo() { return 'Bar' } }
 class Class2 { [void] Foo() { throw 'Error' } }
 class Class3 {}
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Hidden.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Hidden.md
@@ -48,7 +48,7 @@ PowerShell 5.0.
 ## EXAMPLE
 
 The following example shows how to use the `hidden` keyword in a class
-definition. The **Car** class method, **Drive**, has a property, **rides**,
+definition. The **Car** class method, **Drive**, has a property, **Rides**,
 that does not need to be viewed or changed as it merely tallies the number of
 times that **Drive** is called on the **Car** class. That metric that is not
 important to users of the class (consider, for example, that when you are
@@ -68,20 +68,20 @@ later to identify all members that you have hidden.
 class Car
 {
    # Properties
-   [String] $Color
-   [String] $ModelYear
+   [string] $Color
+   [string] $ModelYear
    [int] $Distance
 
    # Method
-   [int] Drive ([int]$miles)
+   [int] Drive ([int]$Miles)
    {
-      $this.Distance += $miles
-      $this.rides++
+      $this.Distance += $Miles
+      $this.Rides++
       return $this.Distance
    }
 
    # Hidden property of the Drive method
-    hidden [int] $rides = 0
+    hidden [int] $Rides = 0
 }
 ```
 
@@ -93,7 +93,7 @@ $TestCar = [Car]::new()
 ```
 
 After you create the new instance, pipe the contents of the `$TestCar` variable
-to `Get-Member`. Observe that the **rides** property is not among the members
+to `Get-Member`. Observe that the **Rides** property is not among the members
 listed in the `Get-Member` command results.
 
 ```output
@@ -103,7 +103,7 @@ PS C:\Windows\system32> $TestCar | Get-Member
 
 Name        MemberType Definition
 ----        ---------- ----------
-Drive       Method     int Drive(int miles)
+Drive       Method     int Drive(int Miles)
 Equals      Method     bool Equals(System.Object obj)
 GetHashCode Method     int GetHashCode()
 GetType     Method     type GetType()
@@ -115,7 +115,7 @@ ModelYear   Property   string ModelYear {get;set;}
 ```
 
 Now, try running `Get-Member` again, but this time, add the `-Force` parameter.
-Note that the results contain the hidden **rides** property, among other
+Note that the results contain the hidden **Rides** property, among other
 members that are hidden by default.
 
 ```output
@@ -130,23 +130,23 @@ psadapted     MemberSet    psadapted {Color, ModelYear, Distance,
 psbase        MemberSet    psbase {Color, ModelYear, Distance,...
 psextended    MemberSet    psextended {}
 psobject      MemberSet    psobject {BaseObject, Members,...
-Drive         Method       int Drive(int miles)
+Drive         Method       int Drive(int Miles)
 Equals        Method       bool Equals(System.Object obj)
 GetHashCode   Method       int GetHashCode()
 GetType       Method       type GetType()
 get_Color     Method       string get_Color()
 get_Distance  Method       int get_Distance()
 get_ModelYear Method       string get_ModelYear()
-get_rides     Method       int get_rides()
+get_Rides     Method       int get_Rides()
 set_Color     Method       void set_Color(string )
 set_Distance  Method       void set_Distance(int )
 set_ModelYear Method       void set_ModelYear(string )
-set_rides     Method       void set_rides(int )
+set_Rides     Method       void set_Rides(int )
 ToString      Method       string ToString()
 Color         Property     string Color {get;set;}
 Distance      Property     int Distance {get;set;}
 ModelYear     Property     string ModelYear {get;set;}
-rides         Property     int rides {get;set;}
+Rides         Property     int Rides {get;set;}
 
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_If.md
@@ -48,7 +48,7 @@ statement. If both `<test1>` and `<test2>` evaluate to false, the
 You can use multiple `elseif` statements to chain a series of conditional
 tests. Each test is run only if all the previous tests are false. If you need
 to create an `if` statement that contains many `elseif` statements, consider
-using a Switch statement instead.
+using a `switch` statement instead.
 
 Examples:
 
@@ -67,7 +67,7 @@ evaluates to true, and the statement list runs. However, if `$a` is less than
 or equal to `2` or isn't an existing variable, the `if` statement doesn't
 display a message.
 
-By adding an Else statement, a message is displayed when $a is less than or
+By adding an `else` statement, a message is displayed when $a is less than or
 equal to 2. As the next example shows:
 
 ```powershell

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
@@ -211,7 +211,7 @@ For more information, see [about_Operators][03].
 
 ## New() method for types
 
-Beginning in PowerShell 5.0, PowerShell adds a static `New()` method for all
+Beginning in PowerShell 5.0, PowerShell adds a static `new()` method for all
 .NET types. The following examples produce the same result.
 
 ```powershell

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -84,7 +84,7 @@ other cmdlets might work differently.
 
 The child jobs are stored in the **ChildJobs** property of the parent job
 object. The **ChildJobs** property can contain one or many child job objects.
-The child job objects have a **Name**, **ID**, and **InstanceId** that differ
+The child job objects have a **Name**, **Id**, and **InstanceId** that differ
 from the parent job so that you can manage the parent and child jobs
 individually or as a unit.
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Jobs.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Jobs.md
@@ -259,11 +259,11 @@ is completed and all results are available.
 
 You can also use the `Wait-Job` cmdlet to wait for any or all of the results of
 the job. `Wait-Job` lets you wait for one or more specific job or for all jobs.
-The following command uses the `Wait-Job` cmdlet to wait for a job with **ID**
+The following command uses the `Wait-Job` cmdlet to wait for a job with **Id**
 10.
 
 ```powershell
-Wait-Job -ID 10
+Wait-Job -Id 10
 ```
 
 As a result, the PowerShell prompt is suppressed until the job is completed.
@@ -273,7 +273,7 @@ You can also wait for a predetermined period of time. This command uses the
 the command prompt returns, but the job continues to run in the background.
 
 ```powershell
-Wait-Job -ID 10 -Timeout 120
+Wait-Job -Id 10 -Timeout 120
 ```
 
 ## Stopping a job

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Join.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Join.md
@@ -1,5 +1,5 @@
 ---
-description: Describes how the join operator (-join) combines multiple strings into a single string.
+description: Describes how the join operator (`-join`) combines multiple strings into a single string.
 Locale: en-US
 ms.date: 06/09/2017
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_join?view=powershell-7.4&WT.mc_id=ps-gethelp
@@ -10,7 +10,7 @@ title: about_Join
 
 ## Short description
 
-Describes how the join operator (-join) combines multiple strings into a
+Describes how the join operator (`-join`) combines multiple strings into a
 single string.
 
 ## Long description
@@ -37,7 +37,7 @@ concatenated strings. The default is no delimiter ("").
 
 Remarks
 
-The unary join operator (-join <string[]>) has higher precedence than a
+The unary join operator (`-join <string[]>`) has higher precedence than a
 comma. As a result, if you submit a comma-separated list of strings to the
 unary join operator, only the first string (before the first comma) is
 submitted to the join operator.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -37,12 +37,12 @@ about topic for the keyword and the information that follows the table.
 | `filter`       | [about_Functions][14]                                              |
 | `finally`      | [about_Try_Catch_Finally][22]                                      |
 | `for`          | [about_For][09]                                                    |
-| `foreach`      | [about_ForEach][10]                                                |
+| `foreach`      | [about_Foreach][10]                                                |
 | `from`         | Reserved for future use                                            |
 | `function`     | [about_Functions][14], [about_Functions_Advanced][13]              |
 | `hidden`       | [about_Hidden][15]                                                 |
 | `if`           | [about_If][16]                                                     |
-| `in`           | [about_ForEach][10]                                                |
+| `in`           | [about_Foreach][10]                                                |
 | `param`        | [about_Functions][14]                                              |
 | `process`      | [about_Functions][14], [about_Functions_Advanced][13]              |
 | `return`       | [about_Return][17]                                                 |
@@ -162,7 +162,7 @@ also include `if` statements and some limited commands.
 Syntax:
 
 ```Syntax
-data <variable> [-supportedCommand <cmdlet-name>] {<permitted content>}
+data <variable> [-SupportedCommand <cmdlet-name>] {<permitted content>}
 ```
 
 ## `do`
@@ -294,7 +294,7 @@ C:\scripts\test>type test.ps1
 3
 exit 4
 
-C:\scripts\test>pwsh -file ./test.ps1
+C:\scripts\test>pwsh -File ./test.ps1
 1
 2
 3
@@ -371,7 +371,7 @@ Syntax:
 
 ```Syntax
 function [<scope:>]<name> {
-   param ([type]<$pname1> [, [type]<$pname2>])
+   param ([type]<$PName1> [, [type]<$PName2>])
    dynamicparam {<statement list>}
    begin {<statement list>}
    process {<statement list>}
@@ -385,7 +385,7 @@ statement list after the function name.
 Syntax:
 
 ```Syntax
-function [<scope:>]<name> [([type]<$pname1>, [[type]<$pname2>])] {
+function [<scope:>]<name> [([type]<$PName1>, [[type]<$PName2>])] {
    dynamicparam {<statement list>}
    begin {<statement list>}
    process {<statement list>}
@@ -433,7 +433,7 @@ Syntax:
 
 ```Syntax
 function [<scope:>]<name> {
-   param ([type]<$pname1>[, [[type]<$pname2>]])
+   param ([type]<$PName1>[, [[type]<$PName2>]])
    <statement list>
 }
 ```
@@ -567,7 +567,7 @@ include classes from modules.
 Namespace syntax:
 
 ```Syntax
-using namespace <.Net-namespace>
+using namespace <.NET-namespace>
 ```
 
 Module syntax:
@@ -622,7 +622,7 @@ do {<statement list>} while (<condition>)
 [07]: about_Do.md
 [08]: about_Enum.md
 [09]: about_For.md
-[10]: about_ForEach.md
+[10]: about_Foreach.md
 [11]: about_Functions_Advanced_Methods.md
 [12]: about_Functions_Advanced_Parameters.md
 [13]: about_Functions_Advanced.md

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -179,7 +179,7 @@ additional variables:
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
-- Any environment variables, like `$ENV:TEMP`
+- Any environment variables, like `$Env:TEMP`
 
 Only the following comparison operators are permitted:
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
@@ -60,8 +60,8 @@ of FALSE. All other integers have a value of TRUE.
 The syntax of the logical operators is as follows:
 
 ```Syntax
-<statement> {-AND | -OR | -XOR} <statement>
-{! | -NOT} <statement>
+<statement> {-and | -or | -xor} <statement>
+{! | -not} <statement>
 ```
 
 Statements that use the logical operators return Boolean (TRUE or FALSE)
@@ -72,7 +72,7 @@ determine the truth value of the statement. If the left operand in a statement
 that contains the and operator is FALSE, the right operand isn't evaluated. If
 the left operand in a statement that contains the or statement is TRUE, the
 right operand isn't evaluated. As a result, you can use these statements in
-the same way that you would use the `If` statement.
+the same way that you would use the `if` statement.
 
 ## See also
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Member-Access_Enumeration.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Member-Access_Enumeration.md
@@ -225,7 +225,7 @@ PS> $CapitalizedProperty = @{
     Value      = { $this.ToUpper() }
     PassThru   = $true
 }
-PS> [System.Collections.Generic.List[object]]$MixedCollection = @(
+PS> [System.Collections.Generic.List[Object]]$MixedCollection = @(
     'a'
     ('b' | Add-Member @CapitalizedProperty)
     ('c' | Add-Member @CapitalizedProperty)
@@ -279,7 +279,7 @@ successful method calls isn't returned. Terminating error conditions include:
 Consider the following example:
 
 ```powershell
-class Class1 { [object] Foo() { return 'Bar' } }
+class Class1 { [Object] Foo() { return 'Bar' } }
 class Class2 { [void] Foo() { throw 'Error' } }
 class Class3 {}
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Hidden.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Hidden.md
@@ -48,7 +48,7 @@ PowerShell 5.0.
 ## EXAMPLE
 
 The following example shows how to use the `hidden` keyword in a class
-definition. The **Car** class method, **Drive**, has a property, **rides**,
+definition. The **Car** class method, **Drive**, has a property, **Rides**,
 that does not need to be viewed or changed as it merely tallies the number of
 times that **Drive** is called on the **Car** class. That metric that is not
 important to users of the class (consider, for example, that when you are
@@ -68,20 +68,20 @@ later to identify all members that you have hidden.
 class Car
 {
    # Properties
-   [String] $Color
-   [String] $ModelYear
+   [string] $Color
+   [string] $ModelYear
    [int] $Distance
 
    # Method
-   [int] Drive ([int]$miles)
+   [int] Drive ([int]$Miles)
    {
-      $this.Distance += $miles
-      $this.rides++
+      $this.Distance += $Miles
+      $this.Rides++
       return $this.Distance
    }
 
    # Hidden property of the Drive method
-    hidden [int] $rides = 0
+    hidden [int] $Rides = 0
 }
 ```
 
@@ -93,7 +93,7 @@ $TestCar = [Car]::new()
 ```
 
 After you create the new instance, pipe the contents of the `$TestCar` variable
-to `Get-Member`. Observe that the **rides** property is not among the members
+to `Get-Member`. Observe that the **Rides** property is not among the members
 listed in the `Get-Member` command results.
 
 ```output
@@ -103,7 +103,7 @@ PS C:\Windows\system32> $TestCar | Get-Member
 
 Name        MemberType Definition
 ----        ---------- ----------
-Drive       Method     int Drive(int miles)
+Drive       Method     int Drive(int Miles)
 Equals      Method     bool Equals(System.Object obj)
 GetHashCode Method     int GetHashCode()
 GetType     Method     type GetType()
@@ -115,7 +115,7 @@ ModelYear   Property   string ModelYear {get;set;}
 ```
 
 Now, try running `Get-Member` again, but this time, add the `-Force` parameter.
-Note that the results contain the hidden **rides** property, among other
+Note that the results contain the hidden **Rides** property, among other
 members that are hidden by default.
 
 ```output
@@ -130,23 +130,23 @@ psadapted     MemberSet    psadapted {Color, ModelYear, Distance,
 psbase        MemberSet    psbase {Color, ModelYear, Distance,...
 psextended    MemberSet    psextended {}
 psobject      MemberSet    psobject {BaseObject, Members,...
-Drive         Method       int Drive(int miles)
+Drive         Method       int Drive(int Miles)
 Equals        Method       bool Equals(System.Object obj)
 GetHashCode   Method       int GetHashCode()
 GetType       Method       type GetType()
 get_Color     Method       string get_Color()
 get_Distance  Method       int get_Distance()
 get_ModelYear Method       string get_ModelYear()
-get_rides     Method       int get_rides()
+get_Rides     Method       int get_Rides()
 set_Color     Method       void set_Color(string )
 set_Distance  Method       void set_Distance(int )
 set_ModelYear Method       void set_ModelYear(string )
-set_rides     Method       void set_rides(int )
+set_Rides     Method       void set_Rides(int )
 ToString      Method       string ToString()
 Color         Property     string Color {get;set;}
 Distance      Property     int Distance {get;set;}
 ModelYear     Property     string ModelYear {get;set;}
-rides         Property     int rides {get;set;}
+Rides         Property     int Rides {get;set;}
 
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_If.md
@@ -49,7 +49,7 @@ statement. If both `<test1>` and `<test2>` evaluate to false, the
 You can use multiple `elseif` statements to chain a series of conditional
 tests. Each test is run only if all the previous tests are false. If you need
 to create an `if` statement that contains many `elseif` statements, consider
-using a Switch statement instead.
+using a `switch` statement instead.
 
 Examples:
 
@@ -68,7 +68,7 @@ evaluates to true, and the statement list runs. However, if `$a` is less than
 or equal to `2` or isn't an existing variable, the `if` statement doesn't
 display a message.
 
-By adding an Else statement, a message is displayed when $a is less than or
+By adding an `else` statement, a message is displayed when $a is less than or
 equal to 2. As the next example shows:
 
 ```powershell

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
@@ -211,7 +211,7 @@ For more information, see [about_Operators][03].
 
 ## New() method for types
 
-Beginning in PowerShell 5.0, PowerShell adds a static `New()` method for all
+Beginning in PowerShell 5.0, PowerShell adds a static `new()` method for all
 .NET types. The following examples produce the same result.
 
 ```powershell

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -85,7 +85,7 @@ other cmdlets might work differently.
 
 The child jobs are stored in the **ChildJobs** property of the parent job
 object. The **ChildJobs** property can contain one or many child job objects.
-The child job objects have a **Name**, **ID**, and **InstanceId** that differ
+The child job objects have a **Name**, **Id**, and **InstanceId** that differ
 from the parent job so that you can manage the parent and child jobs
 individually or as a unit.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Jobs.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Jobs.md
@@ -259,11 +259,11 @@ is completed and all results are available.
 
 You can also use the `Wait-Job` cmdlet to wait for any or all of the results of
 the job. `Wait-Job` lets you wait for one or more specific job or for all jobs.
-The following command uses the `Wait-Job` cmdlet to wait for a job with **ID**
+The following command uses the `Wait-Job` cmdlet to wait for a job with **Id**
 10.
 
 ```powershell
-Wait-Job -ID 10
+Wait-Job -Id 10
 ```
 
 As a result, the PowerShell prompt is suppressed until the job is completed.
@@ -273,7 +273,7 @@ You can also wait for a predetermined period of time. This command uses the
 the command prompt returns, but the job continues to run in the background.
 
 ```powershell
-Wait-Job -ID 10 -Timeout 120
+Wait-Job -Id 10 -Timeout 120
 ```
 
 ## Stopping a job

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Join.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Join.md
@@ -1,5 +1,5 @@
 ---
-description: Describes how the join operator (-join) combines multiple strings into a single string.
+description: Describes how the join operator (`-join`) combines multiple strings into a single string.
 Locale: en-US
 ms.date: 06/09/2017
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_join?view=powershell-7.5&WT.mc_id=ps-gethelp
@@ -11,7 +11,7 @@ title: about_Join
 
 ## Short description
 
-Describes how the join operator (-join) combines multiple strings into a
+Describes how the join operator (`-join`) combines multiple strings into a
 single string.
 
 ## Long description
@@ -38,7 +38,7 @@ concatenated strings. The default is no delimiter ("").
 
 Remarks
 
-The unary join operator (-join <string[]>) has higher precedence than a
+The unary join operator (`-join <string[]>`) has higher precedence than a
 comma. As a result, if you submit a comma-separated list of strings to the
 unary join operator, only the first string (before the first comma) is
 submitted to the join operator.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -37,12 +37,12 @@ about topic for the keyword and the information that follows the table.
 | `filter`       | [about_Functions][14]                                              |
 | `finally`      | [about_Try_Catch_Finally][22]                                      |
 | `for`          | [about_For][09]                                                    |
-| `foreach`      | [about_ForEach][10]                                                |
+| `foreach`      | [about_Foreach][10]                                                |
 | `from`         | Reserved for future use                                            |
 | `function`     | [about_Functions][14], [about_Functions_Advanced][13]              |
 | `hidden`       | [about_Hidden][15]                                                 |
 | `if`           | [about_If][16]                                                     |
-| `in`           | [about_ForEach][10]                                                |
+| `in`           | [about_Foreach][10]                                                |
 | `param`        | [about_Functions][14]                                              |
 | `process`      | [about_Functions][14], [about_Functions_Advanced][13]              |
 | `return`       | [about_Return][17]                                                 |
@@ -162,7 +162,7 @@ also include `if` statements and some limited commands.
 Syntax:
 
 ```Syntax
-data <variable> [-supportedCommand <cmdlet-name>] {<permitted content>}
+data <variable> [-SupportedCommand <cmdlet-name>] {<permitted content>}
 ```
 
 ## `do`
@@ -294,7 +294,7 @@ C:\scripts\test>type test.ps1
 3
 exit 4
 
-C:\scripts\test>pwsh -file ./test.ps1
+C:\scripts\test>pwsh -File ./test.ps1
 1
 2
 3
@@ -371,7 +371,7 @@ Syntax:
 
 ```Syntax
 function [<scope:>]<name> {
-   param ([type]<$pname1> [, [type]<$pname2>])
+   param ([type]<$PName1> [, [type]<$PName2>])
    dynamicparam {<statement list>}
    begin {<statement list>}
    process {<statement list>}
@@ -385,7 +385,7 @@ statement list after the function name.
 Syntax:
 
 ```Syntax
-function [<scope:>]<name> [([type]<$pname1>, [[type]<$pname2>])] {
+function [<scope:>]<name> [([type]<$PName1>, [[type]<$PName2>])] {
    dynamicparam {<statement list>}
    begin {<statement list>}
    process {<statement list>}
@@ -433,7 +433,7 @@ Syntax:
 
 ```Syntax
 function [<scope:>]<name> {
-   param ([type]<$pname1>[, [[type]<$pname2>]])
+   param ([type]<$PName1>[, [[type]<$PName2>]])
    <statement list>
 }
 ```
@@ -567,7 +567,7 @@ include classes from modules.
 Namespace syntax:
 
 ```Syntax
-using namespace <.Net-namespace>
+using namespace <.NET-namespace>
 ```
 
 Module syntax:
@@ -622,7 +622,7 @@ do {<statement list>} while (<condition>)
 [07]: about_Do.md
 [08]: about_Enum.md
 [09]: about_For.md
-[10]: about_ForEach.md
+[10]: about_Foreach.md
 [11]: about_Functions_Advanced_Methods.md
 [12]: about_Functions_Advanced_Parameters.md
 [13]: about_Functions_Advanced.md

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -179,7 +179,7 @@ additional variables:
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
-- Any environment variables, like `$ENV:TEMP`
+- Any environment variables, like `$Env:TEMP`
 
 Only the following comparison operators are permitted:
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
@@ -61,8 +61,8 @@ of FALSE. All other integers have a value of TRUE.
 The syntax of the logical operators is as follows:
 
 ```Syntax
-<statement> {-AND | -OR | -XOR} <statement>
-{! | -NOT} <statement>
+<statement> {-and | -or | -xor} <statement>
+{! | -not} <statement>
 ```
 
 Statements that use the logical operators return Boolean (TRUE or FALSE)
@@ -73,7 +73,7 @@ determine the truth value of the statement. If the left operand in a statement
 that contains the and operator is FALSE, the right operand isn't evaluated. If
 the left operand in a statement that contains the or statement is TRUE, the
 right operand isn't evaluated. As a result, you can use these statements in
-the same way that you would use the `If` statement.
+the same way that you would use the `if` statement.
 
 ## See also
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Member-Access_Enumeration.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Member-Access_Enumeration.md
@@ -225,7 +225,7 @@ PS> $CapitalizedProperty = @{
     Value      = { $this.ToUpper() }
     PassThru   = $true
 }
-PS> [System.Collections.Generic.List[object]]$MixedCollection = @(
+PS> [System.Collections.Generic.List[Object]]$MixedCollection = @(
     'a'
     ('b' | Add-Member @CapitalizedProperty)
     ('c' | Add-Member @CapitalizedProperty)
@@ -279,7 +279,7 @@ successful method calls isn't returned. Terminating error conditions include:
 Consider the following example:
 
 ```powershell
-class Class1 { [object] Foo() { return 'Bar' } }
+class Class1 { [Object] Foo() { return 'Bar' } }
 class Class2 { [void] Foo() { throw 'Error' } }
 class Class3 {}
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Hidden.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Hidden.md
@@ -48,7 +48,7 @@ PowerShell 5.0.
 ## EXAMPLE
 
 The following example shows how to use the `hidden` keyword in a class
-definition. The **Car** class method, **Drive**, has a property, **rides**,
+definition. The **Car** class method, **Drive**, has a property, **Rides**,
 that does not need to be viewed or changed as it merely tallies the number of
 times that **Drive** is called on the **Car** class. That metric that is not
 important to users of the class (consider, for example, that when you are
@@ -68,20 +68,20 @@ later to identify all members that you have hidden.
 class Car
 {
    # Properties
-   [String] $Color
-   [String] $ModelYear
+   [string] $Color
+   [string] $ModelYear
    [int] $Distance
 
    # Method
-   [int] Drive ([int]$miles)
+   [int] Drive ([int]$Miles)
    {
-      $this.Distance += $miles
-      $this.rides++
+      $this.Distance += $Miles
+      $this.Rides++
       return $this.Distance
    }
 
    # Hidden property of the Drive method
-    hidden [int] $rides = 0
+    hidden [int] $Rides = 0
 }
 ```
 
@@ -93,7 +93,7 @@ $TestCar = [Car]::new()
 ```
 
 After you create the new instance, pipe the contents of the `$TestCar` variable
-to `Get-Member`. Observe that the **rides** property is not among the members
+to `Get-Member`. Observe that the **Rides** property is not among the members
 listed in the `Get-Member` command results.
 
 ```output
@@ -103,7 +103,7 @@ PS C:\Windows\system32> $TestCar | Get-Member
 
 Name        MemberType Definition
 ----        ---------- ----------
-Drive       Method     int Drive(int miles)
+Drive       Method     int Drive(int Miles)
 Equals      Method     bool Equals(System.Object obj)
 GetHashCode Method     int GetHashCode()
 GetType     Method     type GetType()
@@ -115,7 +115,7 @@ ModelYear   Property   string ModelYear {get;set;}
 ```
 
 Now, try running `Get-Member` again, but this time, add the `-Force` parameter.
-Note that the results contain the hidden **rides** property, among other
+Note that the results contain the hidden **Rides** property, among other
 members that are hidden by default.
 
 ```output
@@ -130,23 +130,23 @@ psadapted     MemberSet    psadapted {Color, ModelYear, Distance,
 psbase        MemberSet    psbase {Color, ModelYear, Distance,...
 psextended    MemberSet    psextended {}
 psobject      MemberSet    psobject {BaseObject, Members,...
-Drive         Method       int Drive(int miles)
+Drive         Method       int Drive(int Miles)
 Equals        Method       bool Equals(System.Object obj)
 GetHashCode   Method       int GetHashCode()
 GetType       Method       type GetType()
 get_Color     Method       string get_Color()
 get_Distance  Method       int get_Distance()
 get_ModelYear Method       string get_ModelYear()
-get_rides     Method       int get_rides()
+get_Rides     Method       int get_Rides()
 set_Color     Method       void set_Color(string )
 set_Distance  Method       void set_Distance(int )
 set_ModelYear Method       void set_ModelYear(string )
-set_rides     Method       void set_rides(int )
+set_Rides     Method       void set_Rides(int )
 ToString      Method       string ToString()
 Color         Property     string Color {get;set;}
 Distance      Property     int Distance {get;set;}
 ModelYear     Property     string ModelYear {get;set;}
-rides         Property     int rides {get;set;}
+Rides         Property     int Rides {get;set;}
 
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_If.md
@@ -49,7 +49,7 @@ statement. If both `<test1>` and `<test2>` evaluate to false, the
 You can use multiple `elseif` statements to chain a series of conditional
 tests. Each test is run only if all the previous tests are false. If you need
 to create an `if` statement that contains many `elseif` statements, consider
-using a Switch statement instead.
+using a `switch` statement instead.
 
 Examples:
 
@@ -68,7 +68,7 @@ evaluates to true, and the statement list runs. However, if `$a` is less than
 or equal to `2` or isn't an existing variable, the `if` statement doesn't
 display a message.
 
-By adding an Else statement, a message is displayed when $a is less than or
+By adding an `else` statement, a message is displayed when $a is less than or
 equal to 2. As the next example shows:
 
 ```powershell

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md
@@ -211,7 +211,7 @@ For more information, see [about_Operators][03].
 
 ## New() method for types
 
-Beginning in PowerShell 5.0, PowerShell adds a static `New()` method for all
+Beginning in PowerShell 5.0, PowerShell adds a static `new()` method for all
 .NET types. The following examples produce the same result.
 
 ```powershell

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -85,7 +85,7 @@ other cmdlets might work differently.
 
 The child jobs are stored in the **ChildJobs** property of the parent job
 object. The **ChildJobs** property can contain one or many child job objects.
-The child job objects have a **Name**, **ID**, and **InstanceId** that differ
+The child job objects have a **Name**, **Id**, and **InstanceId** that differ
 from the parent job so that you can manage the parent and child jobs
 individually or as a unit.
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Jobs.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Jobs.md
@@ -259,11 +259,11 @@ is completed and all results are available.
 
 You can also use the `Wait-Job` cmdlet to wait for any or all of the results of
 the job. `Wait-Job` lets you wait for one or more specific job or for all jobs.
-The following command uses the `Wait-Job` cmdlet to wait for a job with **ID**
+The following command uses the `Wait-Job` cmdlet to wait for a job with **Id**
 10.
 
 ```powershell
-Wait-Job -ID 10
+Wait-Job -Id 10
 ```
 
 As a result, the PowerShell prompt is suppressed until the job is completed.
@@ -273,7 +273,7 @@ You can also wait for a predetermined period of time. This command uses the
 the command prompt returns, but the job continues to run in the background.
 
 ```powershell
-Wait-Job -ID 10 -Timeout 120
+Wait-Job -Id 10 -Timeout 120
 ```
 
 ## Stopping a job

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Join.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Join.md
@@ -1,5 +1,5 @@
 ---
-description: Describes how the join operator (-join) combines multiple strings into a single string.
+description: Describes how the join operator (`-join`) combines multiple strings into a single string.
 Locale: en-US
 ms.date: 06/09/2017
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_join?view=powershell-7.6&WT.mc_id=ps-gethelp
@@ -10,7 +10,7 @@ title: about_Join
 
 ## Short description
 
-Describes how the join operator (-join) combines multiple strings into a
+Describes how the join operator (`-join`) combines multiple strings into a
 single string.
 
 ## Long description
@@ -37,7 +37,7 @@ concatenated strings. The default is no delimiter ("").
 
 Remarks
 
-The unary join operator (-join <string[]>) has higher precedence than a
+The unary join operator (`-join <string[]>`) has higher precedence than a
 comma. As a result, if you submit a comma-separated list of strings to the
 unary join operator, only the first string (before the first comma) is
 submitted to the join operator.

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -37,12 +37,12 @@ about topic for the keyword and the information that follows the table.
 | `filter`       | [about_Functions][14]                                              |
 | `finally`      | [about_Try_Catch_Finally][22]                                      |
 | `for`          | [about_For][09]                                                    |
-| `foreach`      | [about_ForEach][10]                                                |
+| `foreach`      | [about_Foreach][10]                                                |
 | `from`         | Reserved for future use                                            |
 | `function`     | [about_Functions][14], [about_Functions_Advanced][13]              |
 | `hidden`       | [about_Hidden][15]                                                 |
 | `if`           | [about_If][16]                                                     |
-| `in`           | [about_ForEach][10]                                                |
+| `in`           | [about_Foreach][10]                                                |
 | `param`        | [about_Functions][14]                                              |
 | `process`      | [about_Functions][14], [about_Functions_Advanced][13]              |
 | `return`       | [about_Return][17]                                                 |
@@ -162,7 +162,7 @@ also include `if` statements and some limited commands.
 Syntax:
 
 ```Syntax
-data <variable> [-supportedCommand <cmdlet-name>] {<permitted content>}
+data <variable> [-SupportedCommand <cmdlet-name>] {<permitted content>}
 ```
 
 ## `do`
@@ -294,7 +294,7 @@ C:\scripts\test>type test.ps1
 3
 exit 4
 
-C:\scripts\test>pwsh -file ./test.ps1
+C:\scripts\test>pwsh -File ./test.ps1
 1
 2
 3
@@ -371,7 +371,7 @@ Syntax:
 
 ```Syntax
 function [<scope:>]<name> {
-   param ([type]<$pname1> [, [type]<$pname2>])
+   param ([type]<$PName1> [, [type]<$PName2>])
    dynamicparam {<statement list>}
    begin {<statement list>}
    process {<statement list>}
@@ -385,7 +385,7 @@ statement list after the function name.
 Syntax:
 
 ```Syntax
-function [<scope:>]<name> [([type]<$pname1>, [[type]<$pname2>])] {
+function [<scope:>]<name> [([type]<$PName1>, [[type]<$PName2>])] {
    dynamicparam {<statement list>}
    begin {<statement list>}
    process {<statement list>}
@@ -433,7 +433,7 @@ Syntax:
 
 ```Syntax
 function [<scope:>]<name> {
-   param ([type]<$pname1>[, [[type]<$pname2>]])
+   param ([type]<$PName1>[, [[type]<$PName2>]])
    <statement list>
 }
 ```
@@ -567,7 +567,7 @@ include classes from modules.
 Namespace syntax:
 
 ```Syntax
-using namespace <.Net-namespace>
+using namespace <.NET-namespace>
 ```
 
 Module syntax:
@@ -622,7 +622,7 @@ do {<statement list>} while (<condition>)
 [07]: about_Do.md
 [08]: about_Enum.md
 [09]: about_For.md
-[10]: about_ForEach.md
+[10]: about_Foreach.md
 [11]: about_Functions_Advanced_Methods.md
 [12]: about_Functions_Advanced_Parameters.md
 [13]: about_Functions_Advanced.md

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -179,7 +179,7 @@ additional variables:
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
-- Any environment variables, like `$ENV:TEMP`
+- Any environment variables, like `$Env:TEMP`
 
 Only the following comparison operators are permitted:
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Logical_Operators.md
@@ -61,8 +61,8 @@ of FALSE. All other integers have a value of TRUE.
 The syntax of the logical operators is as follows:
 
 ```Syntax
-<statement> {-AND | -OR | -XOR} <statement>
-{! | -NOT} <statement>
+<statement> {-and | -or | -xor} <statement>
+{! | -not} <statement>
 ```
 
 Statements that use the logical operators return Boolean (TRUE or FALSE)
@@ -73,7 +73,7 @@ determine the truth value of the statement. If the left operand in a statement
 that contains the and operator is FALSE, the right operand isn't evaluated. If
 the left operand in a statement that contains the or statement is TRUE, the
 right operand isn't evaluated. As a result, you can use these statements in
-the same way that you would use the `If` statement.
+the same way that you would use the `if` statement.
 
 ## See also
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Member-Access_Enumeration.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Member-Access_Enumeration.md
@@ -225,7 +225,7 @@ PS> $CapitalizedProperty = @{
     Value      = { $this.ToUpper() }
     PassThru   = $true
 }
-PS> [System.Collections.Generic.List[object]]$MixedCollection = @(
+PS> [System.Collections.Generic.List[Object]]$MixedCollection = @(
     'a'
     ('b' | Add-Member @CapitalizedProperty)
     ('c' | Add-Member @CapitalizedProperty)
@@ -279,7 +279,7 @@ successful method calls isn't returned. Terminating error conditions include:
 Consider the following example:
 
 ```powershell
-class Class1 { [object] Foo() { return 'Bar' } }
+class Class1 { [Object] Foo() { return 'Bar' } }
 class Class2 { [void] Foo() { throw 'Error' } }
 class Class3 {}
 


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide