### PR TITLE
Fix incorrect case/capitalization in reference documents (7/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Methods.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Methods.md
@@ -119,7 +119,7 @@ following example uses the first `CopyTo` method to copy the `Final.txt` file
 to the `C:\Bin` directory.
 
 ```powershell
-(Get-ChildItem c:\final.txt).CopyTo("c:\bin\final.txt")
+(Get-ChildItem C:\final.txt).CopyTo("C:\bin\final.txt")
 ```
 
 > [!NOTE]
@@ -138,7 +138,7 @@ The following example uses the second `CopyTo` method to copy the `Final.txt`
 file to the `C:\Bin` directory, and to overwrite existing files.
 
 ```powershell
-(Get-ChildItem c:\final.txt).CopyTo("c:\bin\final.txt", $true)
+(Get-ChildItem C:\final.txt).CopyTo("C:\bin\final.txt", $true)
 ```
 
 ## Member-access enumeration
@@ -190,7 +190,7 @@ At line:1 char:12
 l.Commands.GetProcessCommand
 ```
 
-This example is functionally equivalent to using the `Foreach-Object` cmdlet to
+This example is functionally equivalent to using the `ForEach-Object` cmdlet to
 run the method on each object in the collection.
 
 ```powershell
@@ -203,7 +203,7 @@ Beginning in PowerShell 4.0, collection filtering using a method syntax is
 supported. This allows use of two new methods when dealing with collections
 `ForEach` and `Where`.
 
-You can read more about these methods in [about_arrays](about_arrays.md)
+You can read more about these methods in [about_Arrays](about_arrays.md)
 
 ## Calling a specific method when multiple overloads exist
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
@@ -99,7 +99,7 @@ Allowed variables
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
-- Any environment variables, like `$ENV:TEMP`
+- Any environment variables, like `$Env:TEMP`
 
 For more information, see [about_Language_Modes][08].
 
@@ -1416,7 +1416,7 @@ For example, this manifest defines the **PublishedDate** key in
 Cmdlets in the module can access this value with the `$MyInvocation` variable.
 
 ```powershell
-Function Get-Stale {
+function Get-Stale {
     [CmdletBinding()]
     param()
 
@@ -1428,7 +1428,7 @@ Function Get-Stale {
     } catch {
         # The date was set in the manifest, set to an invalid value, or
         # the script module was directly imported without the manifest.
-        Throw "Unable to determine published date. Check the module manifest."
+        throw "Unable to determine published date. Check the module manifest."
     }
 
     if ($CurrentDate -gt $PublishedDate.AddDays(30)) {

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -23,7 +23,7 @@ A module is a self-contained, reusable unit that can include cmdlets,
 providers, functions, variables, and other resources. By default, PowerShell
 automatically loads an installed module the first time you use a command from
 the module. You can configure automatic module loading behavior using the
-variable `$PSModuleAutoloadingPreference`. For more information, see
+variable `$PSModuleAutoLoadingPreference`. For more information, see
 [about_Preference_Variables][08].
 
 You can also manually load or unload modules during a PowerShell session. To
@@ -49,7 +49,7 @@ to create PowerShell modules, see [Writing a PowerShell Module][02].
 
 PowerShell stores modules in the following default locations:
 
-  - All users scope - `$env:ProgramFiles\WindowsPowerShell\Modules`
+  - All users scope - `$Env:ProgramFiles\WindowsPowerShell\Modules`
   - Current user scope - `$HOME\Documents\WindowsPowerShell\Modules`
   - Modules shipped with PowerShell - `$PSHOME\Modules`
 
@@ -64,7 +64,7 @@ Use the following command to create a `Modules` folder for the current user:
 $folder = New-Item -Type Directory -Path $HOME\Documents\WindowsPowerShell\Modules
 ```
 
-These locations are automatically included in the `$env:PSModulePath`
+These locations are automatically included in the `$Env:PSModulePath`
 environment variable. For more information about the default module locations,
 see [about_PSModulePath][10].
 
@@ -72,7 +72,7 @@ see [about_PSModulePath][10].
 
 The first time that you run a command from an installed module, PowerShell
 automatically imports (loads) that module. The module must be stored in the
-locations specified in the `$env:PSModulePath` environment variable.
+locations specified in the `$Env:PSModulePath` environment variable.
 
 Module autoloading allows you to use commands in a module without any setup or
 profile configuration. Each of the following examples causes the **CimCmdlets**
@@ -103,7 +103,7 @@ modules that you might not need in your session.
 ## Manually import a module
 
 Manually importing a module is required when a module isn't installed in the
-locations specified by the `$env:PSModulePath` environment variable, or when
+locations specified by the `$Env:PSModulePath` environment variable, or when
 the module is provided as a standalone `.dll` or `.psm1` file, rather than a
 packaged module.
 
@@ -127,7 +127,7 @@ session.
 Import-Module BitsTransfer
 ```
 
-To import a module that isn't in your `$env:PSModulePath`, use the fully
+To import a module that isn't in your `$Env:PSModulePath`, use the fully
 qualified path to the module folder. For example, to add the **TestCmdlets**
 module in the `C:\ps-test` directory to your session, type:
 
@@ -187,7 +187,7 @@ For more information, see [PowerShellGet Overview][01].
 You can manually install a module by copying the module contents from another
 folder. That folder can be in another location on the local machine or
 installed on another machine. To install a module manually, copy the entire
-module folder into a new location included in your `$env:PSModulePath`.
+module folder into a new location included in your `$Env:PSModulePath`.
 
 In PowerShell use the `Copy-Item` cmdlet. For example, run the following
 command to copy the `MyModule` folder from `C:\PSTest`:
@@ -210,16 +210,16 @@ Get-Module
 ```
 
 The modules listed can include modules that were imported from any location,
-not just from `$env:PSModulePath`.
+not just from `$Env:PSModulePath`.
 
 Use the following command to list modules that are installed in the
-`$env:PSModulePath`:
+`$Env:PSModulePath`:
 
 ```powershell
 Get-Module -ListAvailable
 ```
 
-This command gets all modules that are installed in `$env:PSModulePath`, not
+This command gets all modules that are installed in `$Env:PSModulePath`, not
 just the modules that are imported into the current session. This command
 doesn't list modules that are installed in other locations.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Numeric_Literals.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Numeric_Literals.md
@@ -133,14 +133,14 @@ PowerShell supports the following type accelerators:
 | ----------- | -------------------- | -------------------------------- |
 | `[byte]`    |                      | Byte (unsigned)                  |
 | `[sbyte]`   |                      | Byte (signed)                    |
-| `[Int16]`   |                      | 16-bit integer                   |
-| `[UInt16]`  |                      | 16-bit integer (unsigned)        |
-| `[Int32]`   |                      | 32-bit integer                   |
+| `[int16]`   |                      | 16-bit integer                   |
+| `[uint16]`  |                      | 16-bit integer (unsigned)        |
+| `[int32]`   |                      | 32-bit integer                   |
 | `[int]`     | alias for `[int32]`  | 32-bit integer                   |
-| `[UInt32]`  |                      | 32-bit integer (unsigned)        |
-| `[Int64]`   |                      | 64-bit integer                   |
+| `[uint32]`  |                      | 32-bit integer (unsigned)        |
+| `[int64]`   |                      | 64-bit integer                   |
 | `[long]`    | alias for `[int64]`  | 64-bit integer                   |
-| `[UInt64]`  |                      | 64-bit integer (unsigned)        |
+| `[uint64]`  |                      | 64-bit integer (unsigned)        |
 | `[bigint]`  |                      | See [BigInteger Struct][bigint]  |
 | `[single]`  |                      | Single precision floating point  |
 | `[float]`   | alias for `[single]` | Single precision floating point  |

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Object_Creation.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Object_Creation.md
@@ -21,7 +21,7 @@ There are many ways to create objects, this list is not definitive:
 
 - [New-Object][16]: Creates an instance of a .NET Framework object or COM
   object.
-- [Import-Csv][15] / [ConvertFrom-CSV][11]: Creates custom objects
+- [Import-Csv][15] / [ConvertFrom-Csv][11]: Creates custom objects
   (**PSCustomObject**) from the items defined as character separated values.
 - [ConvertFrom-Json][12]: Creates custom objects defined in JavaScript Object
   Notation (JSON).
@@ -173,17 +173,17 @@ the example section of the `Update-Help` cmdlet help topic.
 ```powershell
 function Test-Object {
   $ModuleName = "PSScheduledJob"
-  $HelpCulture = "en-us"
+  $HelpCulture = "en-US"
   $HelpVersion = "3.1.0.0"
-  [PSCustomObject]@{
+  [pscustomobject]@{
     "ModuleName"=$ModuleName
     "UICulture"=$HelpCulture
     "Version"=$HelpVersion
   }
   $ModuleName = "PSWorkflow"
-  $HelpCulture = "en-us"
+  $HelpCulture = "en-US"
   $HelpVersion = "3.0.0.0"
-  [PSCustomObject]@{
+  [pscustomobject]@{
     "ModuleName"=$ModuleName
     "UICulture"=$HelpCulture
     "Version"=$HelpVersion
@@ -198,8 +198,8 @@ table by default.
 ```Output
 ModuleName        UICulture      Version
 ---------         ---------      -------
-PSScheduledJob    en-us          3.1.0.0
-PSWorkflow        en-us          3.0.0.0
+PSScheduledJob    en-US          3.1.0.0
+PSWorkflow        en-US          3.0.0.0
 ```
 
 Users can manage the properties of the custom objects just as they do with

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Objects.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Objects.md
@@ -54,18 +54,18 @@ The following example demonstrates how objects are passed from one
 command to the next:
 
 ```powershell
-Get-ChildItem C: | where { $_.PsIsContainer -eq $false } | Format-List
+Get-ChildItem C: | where { $_.PSIsContainer -eq $false } | Format-List
 ```
 
 The first command `Get-ChildItem C:` returns a file or directory object
 for each item in the root directory of the file system. The file and
 directory objects are passed down the pipeline to the second command.
 
-The second command `where { $_.PsIsContainer -eq $false }` uses the
-**PsIsContainer** property of all file system objects to select only
-files, which have a value of False (`$false`) in their **PsIsContainer**
+The second command `where { $_.PSIsContainer -eq $false }` uses the
+**PSIsContainer** property of all file system objects to select only
+files, which have a value of False (`$false`) in their **PSIsContainer**
 property. Folders, which are containers and, thus, have a value of
-True (`$true`) in their **PsIsContainer** property, are not selected.
+True (`$true`) in their **PSIsContainer** property, are not selected.
 
 The second command passes only the file objects to the third command
 `Format-List`, which displays the file objects in a list.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -34,7 +34,7 @@ precedence.
 
 The Operator column lists the operators. The Reference column lists the
 PowerShell Help topic in which the operator is described. To display the topic,
-type `get-help <topic-name>`.
+type `Get-Help <topic-name>`.
 
 |          OPERATOR           |              REFERENCE               |
 | --------------------------- | ------------------------------------ |
@@ -66,7 +66,7 @@ and explicitly case-insensitive variants have the same precedence.
 | `-like -notlike`          | [about_Comparison_Operators][compare] |
 | `-match -notmatch`        | [about_Comparison_Operators][compare] |
 | `-in -notIn`              | [about_Comparison_Operators][compare] |
-| `-contains -notContains`  | [about_Comparison_Operators][compare] |
+| `-contains -notcontains`  | [about_Comparison_Operators][compare] |
 | `-replace`                | [about_Comparison_Operators][compare] |
 
 The list resumes here with the following operators in precedence
@@ -110,13 +110,13 @@ The following example gets the read-only text files from the local directory
 and saves them in the `$read_only` variable.
 
 ```powershell
-$read_only = Get-ChildItem *.txt | Where-Object {$_.isReadOnly}
+$read_only = Get-ChildItem *.txt | Where-Object {$_.IsReadOnly}
 ```
 
 It is equivalent to the following example.
 
 ```powershell
-$read_only = ( Get-ChildItem *.txt | Where-Object {$_.isReadOnly} )
+$read_only = ( Get-ChildItem *.txt | Where-Object {$_.IsReadOnly} )
 ```
 
 Because the pipeline operator (`|`) has a higher precedence than the assignment

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -224,7 +224,7 @@ of command in a string expression.
 PS> "Today is $(Get-Date)"
 Today is 12/02/2019 13:15:20
 
-PS> "Folder list: $((dir c:\ -dir).Name -join ', ')"
+PS> "Folder list: $((dir C:\ -Dir).Name -join ', ')"
 Folder list: Program Files, Program Files (x86), Users, Windows
 ```
 
@@ -243,7 +243,7 @@ True     True     Object[]                                 System.Array
 
 PS> $list.Count
 20
-PS> $list = @(Get-Service | Where-Object Status -eq Starting )
+PS> $list = @(Get-Service | Where-Object Status -EQ Starting )
 PS> $list.GetType()
 
 IsPublic IsSerial Name                                     BaseType
@@ -348,7 +348,7 @@ Converts or limits objects to the specified type. If the objects can't be
 converted, PowerShell generates an error.
 
 ```powershell
-[DateTime] '2/20/88' - [DateTime] '1/20/88' -eq [TimeSpan] '31'
+[datetime] '2/20/88' - [datetime] '1/20/88' -eq [timespan] '31'
 ```
 
 A cast can also be performed when a variable is assigned to using
@@ -378,7 +378,7 @@ for which no value has been given become variables with no value. However, the
 automatic variable `$args` is preserved.
 
 ```powershell
-. c:\scripts\sample.ps1 1 2 -Also:3
+. C:\scripts\sample.ps1 1 2 -Also:3
 ```
 
 > [!NOTE]
@@ -414,7 +414,7 @@ Enter the composite format string on the left side of the operator and the
 objects to be formatted on the right side of the operator.
 
 ```powershell
-"{0} {1,-10} {2:N}" -f 1,"hello",[math]::pi
+"{0} {1,-10} {2:N}" -f 1,"hello",[Math]::PI
 ```
 
 ```Output
@@ -467,7 +467,7 @@ PS> $a[2, 1, 0]
 ```
 
 ```powershell
-(Get-HotFix | Sort-Object installedOn)[-1]
+(Get-HotFix | Sort-Object InstalledOn)[-1]
 ```
 
 ```powershell
@@ -576,9 +576,9 @@ Accesses the properties and methods of an object. The member name may be an
 expression.
 
 ```powershell
-$myProcess.peakWorkingSet
-(Get-Process PowerShell).Kill()
-'OS', 'Platform' | Foreach-Object { $PSVersionTable. $_ }
+$myProcess.PeakWorkingSet
+(Get-Process powershell).Kill()
+'OS', 'Platform' | ForEach-Object { $PSVersionTable. $_ }
 ```
 
 Starting PowerShell 3.0, when you use the operator on a list collection object
@@ -594,7 +594,7 @@ properties and methods of an object, use the Static parameter of the
 
 ```powershell
 [datetime]::Now
-'MinValue', 'MaxValue' | Foreach-Object { [int]:: $_ }
+'MinValue', 'MaxValue' | ForEach-Object { [int]:: $_ }
 ```
 
 ## See also

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -134,7 +134,7 @@ function Measure-Lines {
 
             if ($Words) {
                 $wc = 0
-                foreach ($line in $content) { $wc += $line.split(' ').Length }
+                foreach ($line in $content) { $wc += $line.Split(' ').Length }
                 $result.Add('Words', $wc)
             }
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameters.md
@@ -131,10 +131,10 @@ As a result of the `Position` settings for these two parameters, you can use
 any of the following commands:
 
 ```powershell
-Get-ChildItem -Path c:\techdocs -Exclude *.ppt
-Get-ChildItem c:\techdocs -Exclude *.ppt
-Get-ChildItem -Exclude *.ppt -Path c:\techdocs
-Get-ChildItem -Exclude *.ppt c:\techdocs
+Get-ChildItem -Path C:\techdocs -Exclude *.ppt
+Get-ChildItem C:\techdocs -Exclude *.ppt
+Get-ChildItem -Exclude *.ppt -Path C:\techdocs
+Get-ChildItem -Exclude *.ppt C:\techdocs
 ```
 
 If you were to include another positional parameter without including the
@@ -237,7 +237,7 @@ information about common parameters, see
 
 ## See also
 
-- [about_Command_syntax](about_Command_syntax.md)
+- [about_Command_Syntax](about_Command_Syntax.md)
 - [about_Comment_Based_Help](about_Comment_Based_Help.md)
 - [about_Functions_Advanced](about_Functions_Advanced.md)
 - [about_Parameters_Default_Values](about_Parameters_Default_Values.md)

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Methods.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Methods.md
@@ -119,7 +119,7 @@ following example uses the first `CopyTo` method to copy the `Final.txt` file
 to the `C:\Bin` directory.
 
 ```powershell
-(Get-ChildItem c:\final.txt).CopyTo("c:\bin\final.txt")
+(Get-ChildItem C:\final.txt).CopyTo("C:\bin\final.txt")
 ```
 
 > [!NOTE]
@@ -138,7 +138,7 @@ The following example uses the second `CopyTo` method to copy the `Final.txt`
 file to the `C:\Bin` directory, and to overwrite existing files.
 
 ```powershell
-(Get-ChildItem c:\final.txt).CopyTo("c:\bin\final.txt", $true)
+(Get-ChildItem C:\final.txt).CopyTo("C:\bin\final.txt", $true)
 ```
 
 ## Member-access enumeration
@@ -190,7 +190,7 @@ At line:1 char:12
 l.Commands.GetProcessCommand
 ```
 
-This example is functionally equivalent to using the `Foreach-Object` cmdlet to
+This example is functionally equivalent to using the `ForEach-Object` cmdlet to
 run the method on each object in the collection.
 
 ```powershell
@@ -203,7 +203,7 @@ Beginning in PowerShell 4.0, collection filtering using a method syntax is
 supported. This allows use of two new methods when dealing with collections
 `ForEach` and `Where`.
 
-You can read more about these methods in [about_arrays](about_arrays.md)
+You can read more about these methods in [about_Arrays](about_arrays.md)
 
 ## Calling a specific method when multiple overloads exist
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
@@ -99,7 +99,7 @@ Allowed variables
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
-- Any environment variables, like `$ENV:TEMP`
+- Any environment variables, like `$Env:TEMP`
 
 For more information, see [about_Language_Modes][08].
 
@@ -1416,7 +1416,7 @@ For example, this manifest defines the **PublishedDate** key in
 Cmdlets in the module can access this value with the `$MyInvocation` variable.
 
 ```powershell
-Function Get-Stale {
+function Get-Stale {
     [CmdletBinding()]
     param()
 
@@ -1428,7 +1428,7 @@ Function Get-Stale {
     } catch {
         # The date was set in the manifest, set to an invalid value, or
         # the script module was directly imported without the manifest.
-        Throw "Unable to determine published date. Check the module manifest."
+        throw "Unable to determine published date. Check the module manifest."
     }
 
     if ($CurrentDate -gt $PublishedDate.AddDays(30)) {
@@ -1562,7 +1562,7 @@ imported as `Get-ExampleItem`.
 [06]: about_Experimental_Features.md#declaring-experimental-features-in-modules-written-in-powershell
 [07]: about_Format.ps1xml.md
 [08]: about_Language_Modes.md
-[09]: about_Powershell_Editions.md
+[09]: about_PowerShell_Editions.md
 [10]: about_Types.ps1xml.md
 [11]: about_Updatable_Help.md
 [13]: xref:Microsoft.PowerShell.Core.New-ModuleManifest

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -23,7 +23,7 @@ A module is a self-contained, reusable unit that can include cmdlets,
 providers, functions, variables, and other resources. By default, PowerShell
 automatically loads an installed module the first time you use a command from
 the module. You can configure automatic module loading behavior using the
-variable `$PSModuleAutoloadingPreference`. For more information, see
+variable `$PSModuleAutoLoadingPreference`. For more information, see
 [about_Preference_Variables][08].
 
 You can also manually load or unload modules during a PowerShell session. To
@@ -50,7 +50,7 @@ to create PowerShell modules, see [Writing a PowerShell Module][02].
 PowerShell stores modules in the following default locations:
 
 - On Windows
-  - All users scope - `$env:ProgramFiles\PowerShell\Modules`
+  - All users scope - `$Env:ProgramFiles\PowerShell\Modules`
   - Current user scope - `$HOME\Documents\PowerShell\Modules`
   - Modules shipped with PowerShell - `$PSHOME\Modules`
 - On Linux and macOS
@@ -69,7 +69,7 @@ Use the following command to create a `Modules` folder for the current user:
 $folder = New-Item -Type Directory -Path $HOME\Documents\PowerShell\Modules
 ```
 
-These locations are automatically included in the `$env:PSModulePath`
+These locations are automatically included in the `$Env:PSModulePath`
 environment variable. For more information about the default module locations,
 see [about_PSModulePath][10].
 
@@ -77,7 +77,7 @@ see [about_PSModulePath][10].
 
 The first time that you run a command from an installed module, PowerShell
 automatically imports (loads) that module. The module must be stored in the
-locations specified in the `$env:PSModulePath` environment variable.
+locations specified in the `$Env:PSModulePath` environment variable.
 
 Module autoloading allows you to use commands in a module without any setup or
 profile configuration. Each of the following examples causes the **CimCmdlets**
@@ -108,7 +108,7 @@ modules that you might not need in your session.
 ## Manually import a module
 
 Manually importing a module is required when a module isn't installed in the
-locations specified by the `$env:PSModulePath` environment variable, or when
+locations specified by the `$Env:PSModulePath` environment variable, or when
 the module is provided as a standalone `.dll` or `.psm1` file, rather than a
 packaged module.
 
@@ -132,7 +132,7 @@ session.
 Import-Module BitsTransfer
 ```
 
-To import a module that isn't in your `$env:PSModulePath`, use the fully
+To import a module that isn't in your `$Env:PSModulePath`, use the fully
 qualified path to the module folder. For example, to add the **TestCmdlets**
 module in the `C:\ps-test` directory to your session, type:
 
@@ -192,7 +192,7 @@ For more information, see [PowerShellGet Overview][01].
 You can manually install a module by copying the module contents from another
 folder. That folder can be in another location on the local machine or
 installed on another machine. To install a module manually, copy the entire
-module folder into a new location included in your `$env:PSModulePath`.
+module folder into a new location included in your `$Env:PSModulePath`.
 
 In PowerShell use the `Copy-Item` cmdlet. For example, run the following
 command to copy the `MyModule` folder from `C:\PSTest`:
@@ -215,16 +215,16 @@ Get-Module
 ```
 
 The modules listed can include modules that were imported from any location,
-not just from `$env:PSModulePath`.
+not just from `$Env:PSModulePath`.
 
 Use the following command to list modules that are installed in the
-`$env:PSModulePath`:
+`$Env:PSModulePath`:
 
 ```powershell
 Get-Module -ListAvailable
 ```
 
-This command gets all modules that are installed in `$env:PSModulePath`, not
+This command gets all modules that are installed in `$Env:PSModulePath`, not
 just the modules that are imported into the current session. This command
 doesn't list modules that are installed in other locations.
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Numeric_Literals.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Numeric_Literals.md
@@ -147,17 +147,17 @@ PowerShell supports the following type accelerators:
 | ----------- | -------------------- | ------------------------------- |
 | `[byte]`    |                      | Byte (unsigned)                 |
 | `[sbyte]`   |                      | Byte (signed)                   |
-| `[Int16]`   |                      | 16-bit integer                  |
+| `[int16]`   |                      | 16-bit integer                  |
 | `[short]`   | alias for `[int16]`  | 16-bit integer                  |
-| `[UInt16]`  |                      | 16-bit integer (unsigned)       |
+| `[uint16]`  |                      | 16-bit integer (unsigned)       |
 | `[ushort]`  | alias for `[uint16]` | 16-bit integer (unsigned)       |
-| `[Int32]`   |                      | 32-bit integer                  |
+| `[int32]`   |                      | 32-bit integer                  |
 | `[int]`     | alias for `[int32]`  | 32-bit integer                  |
-| `[UInt32]`  |                      | 32-bit integer (unsigned)       |
+| `[uint32]`  |                      | 32-bit integer (unsigned)       |
 | `[uint]`    | alias for `[uint32]` | 32-bit integer (unsigned)       |
-| `[Int64]`   |                      | 64-bit integer                  |
+| `[int64]`   |                      | 64-bit integer                  |
 | `[long]`    | alias for `[int64]`  | 64-bit integer                  |
-| `[UInt64]`  |                      | 64-bit integer (unsigned)       |
+| `[uint64]`  |                      | 64-bit integer (unsigned)       |
 | `[ulong]`   | alias for `[uint64]` | 64-bit integer (unsigned)       |
 | `[bigint]`  |                      | See [BigInteger Struct][bigint] |
 | `[single]`  |                      | Single precision floating point |
@@ -314,20 +314,20 @@ If the literal contains a decimal point or the e-notation, the literal string
 is parsed as a real number.
 
 - If the decimal-suffix is present then directly into `[decimal]`.
-- Else, parse as `[Double]` and apply multiplier to the value. Then check the
+- Else, parse as `[double]` and apply multiplier to the value. Then check the
   type suffixes and attempt to cast into appropriate type.
-- If the string has no type suffix, then parse as `[Double]`.
+- If the string has no type suffix, then parse as `[double]`.
 
 ### Parsing integer numeric literals
 
 Integer type literals are parsed using the following steps:
 
 1. Determine the radix format
-   - For binary formats, parse into `[BigInteger]`.
-   - For hexadecimal formats, parse into `[BigInteger]` using special cases to
+   - For binary formats, parse into `[bigint]`.
+   - For hexadecimal formats, parse into `[bigint]` using special cases to
      retain original behaviors when the value is in the `[int]` or `[long]`
      range.
-   - If neither binary nor hex, parse normally as a `[BigInteger]`.
+   - If neither binary nor hex, parse normally as a `[bigint]`.
 1. Apply the multiplier value before attempting any casts to ensure type bounds
    can be appropriately checked without overflows.
 1. Check type suffixes.
@@ -373,7 +373,7 @@ PS> 111111111111111111111111111111111111111111111111111111n
 
 Also values between `[ulong]::MaxValue` and `[decimal]::MaxValue` should be
 denoted using the decimal-suffix `D` to maintain accuracy. Without the suffix,
-these values are parsed as `[Double]` using the real-parsing mode.
+these values are parsed as `[double]` using the real-parsing mode.
 
 <!-- reference links -->
 [bigint]: /dotnet/api/system.numerics.biginteger

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Object_Creation.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Object_Creation.md
@@ -21,7 +21,7 @@ There are many ways to create objects, this list is not definitive:
 
 - [New-Object][14]: Creates an instance of a .NET Framework object or COM
   object.
-- [Import-Csv][13]/[ConvertFrom-CSV][10]: Creates custom objects
+- [Import-Csv][13]/[ConvertFrom-Csv][10]: Creates custom objects
   (**PSCustomObject**) from the items defined as character separated values.
 - [ConvertFrom-Json][11]: Creates custom objects defined in JavaScript Object
   Notation (JSON).
@@ -170,17 +170,17 @@ the example section of the `Update-Help` cmdlet help topic.
 ```powershell
 function Test-Object {
   $ModuleName = "PSScheduledJob"
-  $HelpCulture = "en-us"
+  $HelpCulture = "en-US"
   $HelpVersion = "3.1.0.0"
-  [PSCustomObject]@{
+  [pscustomobject]@{
     "ModuleName"=$ModuleName
     "UICulture"=$HelpCulture
     "Version"=$HelpVersion
   }
   $ModuleName = "PSWorkflow"
-  $HelpCulture = "en-us"
+  $HelpCulture = "en-US"
   $HelpVersion = "3.0.0.0"
-  [PSCustomObject]@{
+  [pscustomobject]@{
     "ModuleName"=$ModuleName
     "UICulture"=$HelpCulture
     "Version"=$HelpVersion
@@ -195,8 +195,8 @@ table by default.
 ```Output
 ModuleName        UICulture      Version
 ---------         ---------      -------
-PSScheduledJob    en-us          3.1.0.0
-PSWorkflow        en-us          3.0.0.0
+PSScheduledJob    en-US          3.1.0.0
+PSWorkflow        en-US          3.0.0.0
 ```
 
 Users can manage the properties of the custom objects just as they do with

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Objects.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Objects.md
@@ -53,18 +53,18 @@ The following example demonstrates how objects are passed from one
 command to the next:
 
 ```powershell
-Get-ChildItem C: | where { $_.PsIsContainer -eq $false } | Format-List
+Get-ChildItem C: | where { $_.PSIsContainer -eq $false } | Format-List
 ```
 
 The first command `Get-ChildItem C:` returns a file or directory object
 for each item in the root directory of the file system. The file and
 directory objects are passed down the pipeline to the second command.
 
-The second command `where { $_.PsIsContainer -eq $false }` uses the
-**PsIsContainer** property of all file system objects to select only
-files, which have a value of False (`$false`) in their **PsIsContainer**
+The second command `where { $_.PSIsContainer -eq $false }` uses the
+**PSIsContainer** property of all file system objects to select only
+files, which have a value of False (`$false`) in their **PSIsContainer**
 property. Folders, which are containers and, thus, have a value of
-True (`$true`) in their **PsIsContainer** property, are not selected.
+True (`$true`) in their **PSIsContainer** property, are not selected.
 
 The second command passes only the file objects to the third command
 `Format-List`, which displays the file objects in a list.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -34,7 +34,7 @@ precedence.
 
 The Operator column lists the operators. The Reference column lists the
 PowerShell Help topic in which the operator is described. To display the topic,
-type `get-help <topic-name>`.
+type `Get-Help <topic-name>`.
 
 |          OPERATOR           |              REFERENCE               |
 | --------------------------- | ------------------------------------ |
@@ -66,7 +66,7 @@ and explicitly case-insensitive variants have the same precedence.
 | `-like -notlike`          | [about_Comparison_Operators][compare] |
 | `-match -notmatch`        | [about_Comparison_Operators][compare] |
 | `-in -notIn`              | [about_Comparison_Operators][compare] |
-| `-contains -notContains`  | [about_Comparison_Operators][compare] |
+| `-contains -notcontains`  | [about_Comparison_Operators][compare] |
 | `-replace`                | [about_Comparison_Operators][compare] |
 
 The list resumes here with the following operators in precedence
@@ -110,13 +110,13 @@ The following example gets the read-only text files from the local directory
 and saves them in the `$read_only` variable.
 
 ```powershell
-$read_only = Get-ChildItem *.txt | Where-Object {$_.isReadOnly}
+$read_only = Get-ChildItem *.txt | Where-Object {$_.IsReadOnly}
 ```
 
 It is equivalent to the following example.
 
 ```powershell
-$read_only = ( Get-ChildItem *.txt | Where-Object {$_.isReadOnly} )
+$read_only = ( Get-ChildItem *.txt | Where-Object {$_.IsReadOnly} )
 ```
 
 Because the pipeline operator (`|`) has a higher precedence than the assignment

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -202,7 +202,7 @@ of command in a string expression.
 PS> "Today is $(Get-Date)"
 Today is 12/02/2019 13:15:20
 
-PS> "Folder list: $((dir c:\ -dir).Name -join ', ')"
+PS> "Folder list: $((dir C:\ -Dir).Name -join ', ')"
 Folder list: Program Files, Program Files (x86), Users, Windows
 ```
 
@@ -221,7 +221,7 @@ True     True     Object[]                                 System.Array
 
 PS> $list.Count
 20
-PS> $list = @(Get-Service | Where-Object Status -eq Starting )
+PS> $list = @(Get-Service | Where-Object Status -EQ Starting )
 PS> $list.GetType()
 
 IsPublic IsSerial Name                                     BaseType
@@ -314,7 +314,7 @@ For more about script blocks, see [about_Script_Blocks][20].
 ### Background operator `&`
 
 Runs the pipeline before it in the background, in a PowerShell job. This
-operator acts similarly to the UNIX control operator ampersand (`&`), which
+operator acts similarly to the Unix control operator ampersand (`&`), which
 runs the command before it asynchronously in subshell as a job.
 
 This operator is functionally equivalent to `Start-Job`. By default, the
@@ -355,7 +355,7 @@ Receive-Job $job -Wait
 Remove-Job $job
 ```
 
-The `&` background operator is also a statement terminator, just like the UNIX
+The `&` background operator is also a statement terminator, just like the Unix
 control operator ampersand (`&`). This allows you to invoke additional commands
 after the `&` background operator. The following example demonstrates the
 invocation of additional commands after the `&` background operator.
@@ -396,7 +396,7 @@ Converts or limits objects to the specified type. If the objects can't be
 converted, PowerShell generates an error.
 
 ```powershell
-[DateTime] '2/20/88' - [DateTime] '1/20/88' -eq [TimeSpan] '31'
+[datetime] '2/20/88' - [datetime] '1/20/88' -eq [timespan] '31'
 ```
 
 A cast can also be performed when a variable is assigned to using
@@ -426,7 +426,7 @@ for which no value has been given become variables with no value. However, the
 automatic variable `$args` is preserved.
 
 ```powershell
-. c:\scripts\sample.ps1 1 2 -Also:3
+. C:\scripts\sample.ps1 1 2 -Also:3
 ```
 
 > [!NOTE]
@@ -462,7 +462,7 @@ Enter the composite format string on the left side of the operator and the
 objects to be formatted on the right side of the operator.
 
 ```powershell
-"{0} {1,-10} {2:N}" -f 1,"hello",[math]::pi
+"{0} {1,-10} {2:N}" -f 1,"hello",[Math]::PI
 ```
 
 ```Output
@@ -515,7 +515,7 @@ PS> $a[2, 1, 0]
 ```
 
 ```powershell
-(Get-HotFix | Sort-Object installedOn)[-1]
+(Get-HotFix | Sort-Object InstalledOn)[-1]
 ```
 
 ```powershell
@@ -706,9 +706,9 @@ Accesses the properties and methods of an object. The member name may be an
 expression.
 
 ```powershell
-$myProcess.peakWorkingSet
-(Get-Process PowerShell).Kill()
-'OS', 'Platform' | Foreach-Object { $PSVersionTable. $_ }
+$myProcess.PeakWorkingSet
+(Get-Process powershell).Kill()
+'OS', 'Platform' | ForEach-Object { $PSVersionTable. $_ }
 ```
 
 Starting PowerShell 3.0, when you use the operator on a list collection object
@@ -724,7 +724,7 @@ properties and methods of an object, use the Static parameter of the
 
 ```powershell
 [datetime]::Now
-'MinValue', 'MaxValue' | Foreach-Object { [int]:: $_ }
+'MinValue', 'MaxValue' | ForEach-Object { [int]:: $_ }
 ```
 
 ### Ternary operator `? <if-true> : <if-false>`

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -134,7 +134,7 @@ function Measure-Lines {
 
             if ($Words) {
                 $wc = 0
-                foreach ($line in $content) { $wc += $line.split(' ').Length }
+                foreach ($line in $content) { $wc += $line.Split(' ').Length }
                 $result.Add('Words', $wc)
             }
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Parameters.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Parameters.md
@@ -131,10 +131,10 @@ As a result of the `Position` settings for these two parameters, you can use
 any of the following commands:
 
 ```powershell
-Get-ChildItem -Path c:\techdocs -Exclude *.ppt
-Get-ChildItem c:\techdocs -Exclude *.ppt
-Get-ChildItem -Exclude *.ppt -Path c:\techdocs
-Get-ChildItem -Exclude *.ppt c:\techdocs
+Get-ChildItem -Path C:\techdocs -Exclude *.ppt
+Get-ChildItem C:\techdocs -Exclude *.ppt
+Get-ChildItem -Exclude *.ppt -Path C:\techdocs
+Get-ChildItem -Exclude *.ppt C:\techdocs
 ```
 
 If you were to include another positional parameter without including the
@@ -237,7 +237,7 @@ information about common parameters, see
 
 ## See also
 
-- [about_Command_syntax](about_Command_syntax.md)
+- [about_Command_Syntax](about_Command_Syntax.md)
 - [about_Comment_Based_Help](about_Comment_Based_Help.md)
 - [about_Functions_Advanced](about_Functions_Advanced.md)
 - [about_Parameters_Default_Values](about_Parameters_Default_Values.md)

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Methods.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Methods.md
@@ -119,7 +119,7 @@ following example uses the first `CopyTo` method to copy the `Final.txt` file
 to the `C:\Bin` directory.
 
 ```powershell
-(Get-ChildItem c:\final.txt).CopyTo("c:\bin\final.txt")
+(Get-ChildItem C:\final.txt).CopyTo("C:\bin\final.txt")
 ```
 
 > [!NOTE]
@@ -138,7 +138,7 @@ The following example uses the second `CopyTo` method to copy the `Final.txt`
 file to the `C:\Bin` directory, and to overwrite existing files.
 
 ```powershell
-(Get-ChildItem c:\final.txt).CopyTo("c:\bin\final.txt", $true)
+(Get-ChildItem C:\final.txt).CopyTo("C:\bin\final.txt", $true)
 ```
 
 ## Member-access enumeration
@@ -190,7 +190,7 @@ At line:1 char:12
 l.Commands.GetProcessCommand
 ```
 
-This example is functionally equivalent to using the `Foreach-Object` cmdlet to
+This example is functionally equivalent to using the `ForEach-Object` cmdlet to
 run the method on each object in the collection.
 
 ```powershell
@@ -203,7 +203,7 @@ Beginning in PowerShell 4.0, collection filtering using a method syntax is
 supported. This allows use of two new methods when dealing with collections
 `ForEach` and `Where`.
 
-You can read more about these methods in [about_arrays](about_arrays.md)
+You can read more about these methods in [about_Arrays](about_arrays.md)
 
 ## Calling a specific method when multiple overloads exist
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
@@ -99,7 +99,7 @@ Allowed variables
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
-- Any environment variables, like `$ENV:TEMP`
+- Any environment variables, like `$Env:TEMP`
 
 For more information, see [about_Language_Modes][08].
 
@@ -1416,7 +1416,7 @@ For example, this manifest defines the **PublishedDate** key in
 Cmdlets in the module can access this value with the `$MyInvocation` variable.
 
 ```powershell
-Function Get-Stale {
+function Get-Stale {
     [CmdletBinding()]
     param()
 
@@ -1428,7 +1428,7 @@ Function Get-Stale {
     } catch {
         # The date was set in the manifest, set to an invalid value, or
         # the script module was directly imported without the manifest.
-        Throw "Unable to determine published date. Check the module manifest."
+        throw "Unable to determine published date. Check the module manifest."
     }
 
     if ($CurrentDate -gt $PublishedDate.AddDays(30)) {
@@ -1562,7 +1562,7 @@ imported as `Get-ExampleItem`.
 [06]: about_Experimental_Features.md#declaring-experimental-features-in-modules-written-in-powershell
 [07]: about_Format.ps1xml.md
 [08]: about_Language_Modes.md
-[09]: about_Powershell_Editions.md
+[09]: about_PowerShell_Editions.md
 [10]: about_Types.ps1xml.md
 [11]: about_Updatable_Help.md
 [13]: xref:Microsoft.PowerShell.Core.New-ModuleManifest

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -23,7 +23,7 @@ A module is a self-contained, reusable unit that can include cmdlets,
 providers, functions, variables, and other resources. By default, PowerShell
 automatically loads an installed module the first time you use a command from
 the module. You can configure automatic module loading behavior using the
-variable `$PSModuleAutoloadingPreference`. For more information, see
+variable `$PSModuleAutoLoadingPreference`. For more information, see
 [about_Preference_Variables][08].
 
 You can also manually load or unload modules during a PowerShell session. To
@@ -50,7 +50,7 @@ to create PowerShell modules, see [Writing a PowerShell Module][02].
 PowerShell stores modules in the following default locations:
 
 - On Windows
-  - All users scope - `$env:ProgramFiles\PowerShell\Modules`
+  - All users scope - `$Env:ProgramFiles\PowerShell\Modules`
   - Current user scope - `$HOME\Documents\PowerShell\Modules`
   - Modules shipped with PowerShell - `$PSHOME\Modules`
 - On Linux and macOS
@@ -69,7 +69,7 @@ Use the following command to create a `Modules` folder for the current user:
 $folder = New-Item -Type Directory -Path $HOME\Documents\PowerShell\Modules
 ```
 
-These locations are automatically included in the `$env:PSModulePath`
+These locations are automatically included in the `$Env:PSModulePath`
 environment variable. For more information about the default module locations,
 see [about_PSModulePath][10].
 
@@ -77,7 +77,7 @@ see [about_PSModulePath][10].
 
 The first time that you run a command from an installed module, PowerShell
 automatically imports (loads) that module. The module must be stored in the
-locations specified in the `$env:PSModulePath` environment variable.
+locations specified in the `$Env:PSModulePath` environment variable.
 
 Module autoloading allows you to use commands in a module without any setup or
 profile configuration. Each of the following examples causes the **CimCmdlets**
@@ -108,7 +108,7 @@ modules that you might not need in your session.
 ## Manually import a module
 
 Manually importing a module is required when a module isn't installed in the
-locations specified by the `$env:PSModulePath` environment variable, or when
+locations specified by the `$Env:PSModulePath` environment variable, or when
 the module is provided as a standalone `.dll` or `.psm1` file, rather than a
 packaged module.
 
@@ -132,7 +132,7 @@ session.
 Import-Module BitsTransfer
 ```
 
-To import a module that isn't in your `$env:PSModulePath`, use the fully
+To import a module that isn't in your `$Env:PSModulePath`, use the fully
 qualified path to the module folder. For example, to add the **TestCmdlets**
 module in the `C:\ps-test` directory to your session, type:
 
@@ -192,7 +192,7 @@ For more information, see [PowerShellGet Overview][01].
 You can manually install a module by copying the module contents from another
 folder. That folder can be in another location on the local machine or
 installed on another machine. To install a module manually, copy the entire
-module folder into a new location included in your `$env:PSModulePath`.
+module folder into a new location included in your `$Env:PSModulePath`.
 
 In PowerShell use the `Copy-Item` cmdlet. For example, run the following
 command to copy the `MyModule` folder from `C:\PSTest`:
@@ -215,16 +215,16 @@ Get-Module
 ```
 
 The modules listed can include modules that were imported from any location,
-not just from `$env:PSModulePath`.
+not just from `$Env:PSModulePath`.
 
 Use the following command to list modules that are installed in the
-`$env:PSModulePath`:
+`$Env:PSModulePath`:
 
 ```powershell
 Get-Module -ListAvailable
 ```
 
-This command gets all modules that are installed in `$env:PSModulePath`, not
+This command gets all modules that are installed in `$Env:PSModulePath`, not
 just the modules that are imported into the current session. This command
 doesn't list modules that are installed in other locations.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Numeric_Literals.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Numeric_Literals.md
@@ -149,17 +149,17 @@ PowerShell supports the following type accelerators:
 | ----------- | -------------------- | ------------------------------- |
 | `[byte]`    |                      | Byte (unsigned)                 |
 | `[sbyte]`   |                      | Byte (signed)                   |
-| `[Int16]`   |                      | 16-bit integer                  |
+| `[int16]`   |                      | 16-bit integer                  |
 | `[short]`   | alias for `[int16]`  | 16-bit integer                  |
-| `[UInt16]`  |                      | 16-bit integer (unsigned)       |
+| `[uint16]`  |                      | 16-bit integer (unsigned)       |
 | `[ushort]`  | alias for `[uint16]` | 16-bit integer (unsigned)       |
-| `[Int32]`   |                      | 32-bit integer                  |
+| `[int32]`   |                      | 32-bit integer                  |
 | `[int]`     | alias for `[int32]`  | 32-bit integer                  |
-| `[UInt32]`  |                      | 32-bit integer (unsigned)       |
+| `[uint32]`  |                      | 32-bit integer (unsigned)       |
 | `[uint]`    | alias for `[uint32]` | 32-bit integer (unsigned)       |
-| `[Int64]`   |                      | 64-bit integer                  |
+| `[int64]`   |                      | 64-bit integer                  |
 | `[long]`    | alias for `[int64]`  | 64-bit integer                  |
-| `[UInt64]`  |                      | 64-bit integer (unsigned)       |
+| `[uint64]`  |                      | 64-bit integer (unsigned)       |
 | `[ulong]`   | alias for `[uint64]` | 64-bit integer (unsigned)       |
 | `[bigint]`  |                      | See [BigInteger Struct][bigint] |
 | `[single]`  |                      | Single precision floating point |
@@ -316,20 +316,20 @@ If the literal contains a decimal point or the e-notation, the literal string
 is parsed as a real number.
 
 - If the decimal-suffix is present then directly into `[decimal]`.
-- Else, parse as `[Double]` and apply multiplier to the value. Then check the
+- Else, parse as `[double]` and apply multiplier to the value. Then check the
   type suffixes and attempt to cast into appropriate type.
-- If the string has no type suffix, then parse as `[Double]`.
+- If the string has no type suffix, then parse as `[double]`.
 
 ### Parsing integer numeric literals
 
 Integer type literals are parsed using the following steps:
 
 1. Determine the radix format
-   - For binary formats, parse into `[BigInteger]`.
-   - For hexadecimal formats, parse into `[BigInteger]` using special cases to
+   - For binary formats, parse into `[bigint]`.
+   - For hexadecimal formats, parse into `[bigint]` using special cases to
      retain original behaviors when the value is in the `[int]` or `[long]`
      range.
-   - If neither binary nor hex, parse normally as a `[BigInteger]`.
+   - If neither binary nor hex, parse normally as a `[bigint]`.
 1. Apply the multiplier value before attempting any casts to ensure type bounds
    can be appropriately checked without overflows.
 1. Check type suffixes.
@@ -375,7 +375,7 @@ PS> 111111111111111111111111111111111111111111111111111111n
 
 Also values between `[ulong]::MaxValue` and `[decimal]::MaxValue` should be
 denoted using the decimal-suffix `D` to maintain accuracy. Without the suffix,
-these values are parsed as `[Double]` using the real-parsing mode.
+these values are parsed as `[double]` using the real-parsing mode.
 
 <!-- reference links -->
 [bigint]: /dotnet/api/system.numerics.biginteger

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Object_Creation.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Object_Creation.md
@@ -21,7 +21,7 @@ There are many ways to create objects, this list is not definitive:
 
 - [New-Object][14]: Creates an instance of a .NET Framework object or COM
   object.
-- [Import-Csv][13]/[ConvertFrom-CSV][10]: Creates custom objects
+- [Import-Csv][13]/[ConvertFrom-Csv][10]: Creates custom objects
   (**PSCustomObject**) from the items defined as character separated values.
 - [ConvertFrom-Json][11]: Creates custom objects defined in JavaScript Object
   Notation (JSON).
@@ -170,17 +170,17 @@ the example section of the `Update-Help` cmdlet help topic.
 ```powershell
 function Test-Object {
   $ModuleName = "PSScheduledJob"
-  $HelpCulture = "en-us"
+  $HelpCulture = "en-US"
   $HelpVersion = "3.1.0.0"
-  [PSCustomObject]@{
+  [pscustomobject]@{
     "ModuleName"=$ModuleName
     "UICulture"=$HelpCulture
     "Version"=$HelpVersion
   }
   $ModuleName = "PSWorkflow"
-  $HelpCulture = "en-us"
+  $HelpCulture = "en-US"
   $HelpVersion = "3.0.0.0"
-  [PSCustomObject]@{
+  [pscustomobject]@{
     "ModuleName"=$ModuleName
     "UICulture"=$HelpCulture
     "Version"=$HelpVersion
@@ -195,8 +195,8 @@ table by default.
 ```Output
 ModuleName        UICulture      Version
 ---------         ---------      -------
-PSScheduledJob    en-us          3.1.0.0
-PSWorkflow        en-us          3.0.0.0
+PSScheduledJob    en-US          3.1.0.0
+PSWorkflow        en-US          3.0.0.0
 ```
 
 Users can manage the properties of the custom objects just as they do with

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Objects.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Objects.md
@@ -54,18 +54,18 @@ The following example demonstrates how objects are passed from one
 command to the next:
 
 ```powershell
-Get-ChildItem C: | where { $_.PsIsContainer -eq $false } | Format-List
+Get-ChildItem C: | where { $_.PSIsContainer -eq $false } | Format-List
 ```
 
 The first command `Get-ChildItem C:` returns a file or directory object
 for each item in the root directory of the file system. The file and
 directory objects are passed down the pipeline to the second command.
 
-The second command `where { $_.PsIsContainer -eq $false }` uses the
-**PsIsContainer** property of all file system objects to select only
-files, which have a value of False (`$false`) in their **PsIsContainer**
+The second command `where { $_.PSIsContainer -eq $false }` uses the
+**PSIsContainer** property of all file system objects to select only
+files, which have a value of False (`$false`) in their **PSIsContainer**
 property. Folders, which are containers and, thus, have a value of
-True (`$true`) in their **PsIsContainer** property, are not selected.
+True (`$true`) in their **PSIsContainer** property, are not selected.
 
 The second command passes only the file objects to the third command
 `Format-List`, which displays the file objects in a list.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -34,7 +34,7 @@ precedence.
 
 The Operator column lists the operators. The Reference column lists the
 PowerShell Help topic in which the operator is described. To display the topic,
-type `get-help <topic-name>`.
+type `Get-Help <topic-name>`.
 
 |          OPERATOR           |              REFERENCE               |
 | --------------------------- | ------------------------------------ |
@@ -66,7 +66,7 @@ and explicitly case-insensitive variants have the same precedence.
 | `-like -notlike`          | [about_Comparison_Operators][compare] |
 | `-match -notmatch`        | [about_Comparison_Operators][compare] |
 | `-in -notIn`              | [about_Comparison_Operators][compare] |
-| `-contains -notContains`  | [about_Comparison_Operators][compare] |
+| `-contains -notcontains`  | [about_Comparison_Operators][compare] |
 | `-replace`                | [about_Comparison_Operators][compare] |
 
 The list resumes here with the following operators in precedence
@@ -110,13 +110,13 @@ The following example gets the read-only text files from the local directory
 and saves them in the `$read_only` variable.
 
 ```powershell
-$read_only = Get-ChildItem *.txt | Where-Object {$_.isReadOnly}
+$read_only = Get-ChildItem *.txt | Where-Object {$_.IsReadOnly}
 ```
 
 It is equivalent to the following example.
 
 ```powershell
-$read_only = ( Get-ChildItem *.txt | Where-Object {$_.isReadOnly} )
+$read_only = ( Get-ChildItem *.txt | Where-Object {$_.IsReadOnly} )
 ```
 
 Because the pipeline operator (`|`) has a higher precedence than the assignment

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -202,7 +202,7 @@ of command in a string expression.
 PS> "Today is $(Get-Date)"
 Today is 12/02/2019 13:15:20
 
-PS> "Folder list: $((dir c:\ -dir).Name -join ', ')"
+PS> "Folder list: $((dir C:\ -Dir).Name -join ', ')"
 Folder list: Program Files, Program Files (x86), Users, Windows
 ```
 
@@ -221,7 +221,7 @@ True     True     Object[]                                 System.Array
 
 PS> $list.Count
 20
-PS> $list = @(Get-Service | Where-Object Status -eq Starting )
+PS> $list = @(Get-Service | Where-Object Status -EQ Starting )
 PS> $list.GetType()
 
 IsPublic IsSerial Name                                     BaseType
@@ -314,7 +314,7 @@ For more about script blocks, see [about_Script_Blocks][20].
 ### Background operator `&`
 
 Runs the pipeline before it in the background, in a PowerShell job. This
-operator acts similarly to the UNIX control operator ampersand (`&`), which
+operator acts similarly to the Unix control operator ampersand (`&`), which
 runs the command before it asynchronously in subshell as a job.
 
 This operator is functionally equivalent to `Start-Job`. By default, the
@@ -355,7 +355,7 @@ Receive-Job $job -Wait
 Remove-Job $job
 ```
 
-The `&` background operator is also a statement terminator, just like the UNIX
+The `&` background operator is also a statement terminator, just like the Unix
 control operator ampersand (`&`). This allows you to invoke additional commands
 after the `&` background operator. The following example demonstrates the
 invocation of additional commands after the `&` background operator.
@@ -396,7 +396,7 @@ Converts or limits objects to the specified type. If the objects can't be
 converted, PowerShell generates an error.
 
 ```powershell
-[DateTime] '2/20/88' - [DateTime] '1/20/88' -eq [TimeSpan] '31'
+[datetime] '2/20/88' - [datetime] '1/20/88' -eq [timespan] '31'
 ```
 
 A cast can also be performed when a variable is assigned to using
@@ -426,7 +426,7 @@ for which no value has been given become variables with no value. However, the
 automatic variable `$args` is preserved.
 
 ```powershell
-. c:\scripts\sample.ps1 1 2 -Also:3
+. C:\scripts\sample.ps1 1 2 -Also:3
 ```
 
 > [!NOTE]
@@ -462,7 +462,7 @@ Enter the composite format string on the left side of the operator and the
 objects to be formatted on the right side of the operator.
 
 ```powershell
-"{0} {1,-10} {2:N}" -f 1,"hello",[math]::pi
+"{0} {1,-10} {2:N}" -f 1,"hello",[Math]::PI
 ```
 
 ```Output
@@ -515,7 +515,7 @@ PS> $a[2, 1, 0]
 ```
 
 ```powershell
-(Get-HotFix | Sort-Object installedOn)[-1]
+(Get-HotFix | Sort-Object InstalledOn)[-1]
 ```
 
 ```powershell
@@ -706,9 +706,9 @@ Accesses the properties and methods of an object. The member name may be an
 expression.
 
 ```powershell
-$myProcess.peakWorkingSet
-(Get-Process PowerShell).Kill()
-'OS', 'Platform' | Foreach-Object { $PSVersionTable. $_ }
+$myProcess.PeakWorkingSet
+(Get-Process powershell).Kill()
+'OS', 'Platform' | ForEach-Object { $PSVersionTable. $_ }
 ```
 
 Starting PowerShell 3.0, when you use the operator on a list collection object
@@ -724,7 +724,7 @@ properties and methods of an object, use the Static parameter of the
 
 ```powershell
 [datetime]::Now
-'MinValue', 'MaxValue' | Foreach-Object { [int]:: $_ }
+'MinValue', 'MaxValue' | ForEach-Object { [int]:: $_ }
 ```
 
 ### Ternary operator `? <if-true> : <if-false>`

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -134,7 +134,7 @@ function Measure-Lines {
 
             if ($Words) {
                 $wc = 0
-                foreach ($line in $content) { $wc += $line.split(' ').Length }
+                foreach ($line in $content) { $wc += $line.Split(' ').Length }
                 $result.Add('Words', $wc)
             }
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameters.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Parameters.md
@@ -131,10 +131,10 @@ As a result of the `Position` settings for these two parameters, you can use
 any of the following commands:
 
 ```powershell
-Get-ChildItem -Path c:\techdocs -Exclude *.ppt
-Get-ChildItem c:\techdocs -Exclude *.ppt
-Get-ChildItem -Exclude *.ppt -Path c:\techdocs
-Get-ChildItem -Exclude *.ppt c:\techdocs
+Get-ChildItem -Path C:\techdocs -Exclude *.ppt
+Get-ChildItem C:\techdocs -Exclude *.ppt
+Get-ChildItem -Exclude *.ppt -Path C:\techdocs
+Get-ChildItem -Exclude *.ppt C:\techdocs
 ```
 
 If you were to include another positional parameter without including the
@@ -237,7 +237,7 @@ information about common parameters, see
 
 ## See also
 
-- [about_Command_syntax](about_Command_syntax.md)
+- [about_Command_Syntax](about_Command_Syntax.md)
 - [about_Comment_Based_Help](about_Comment_Based_Help.md)
 - [about_Functions_Advanced](about_Functions_Advanced.md)
 - [about_Parameters_Default_Values](about_Parameters_Default_Values.md)

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Methods.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Methods.md
@@ -119,7 +119,7 @@ following example uses the first `CopyTo` method to copy the `Final.txt` file
 to the `C:\Bin` directory.
 
 ```powershell
-(Get-ChildItem c:\final.txt).CopyTo("c:\bin\final.txt")
+(Get-ChildItem C:\final.txt).CopyTo("C:\bin\final.txt")
 ```
 
 > [!NOTE]
@@ -138,7 +138,7 @@ The following example uses the second `CopyTo` method to copy the `Final.txt`
 file to the `C:\Bin` directory, and to overwrite existing files.
 
 ```powershell
-(Get-ChildItem c:\final.txt).CopyTo("c:\bin\final.txt", $true)
+(Get-ChildItem C:\final.txt).CopyTo("C:\bin\final.txt", $true)
 ```
 
 ## Member-access enumeration
@@ -190,7 +190,7 @@ At line:1 char:12
 l.Commands.GetProcessCommand
 ```
 
-This example is functionally equivalent to using the `Foreach-Object` cmdlet to
+This example is functionally equivalent to using the `ForEach-Object` cmdlet to
 run the method on each object in the collection.
 
 ```powershell
@@ -203,7 +203,7 @@ Beginning in PowerShell 4.0, collection filtering using a method syntax is
 supported. This allows use of two new methods when dealing with collections
 `ForEach` and `Where`.
 
-You can read more about these methods in [about_arrays](about_arrays.md)
+You can read more about these methods in [about_Arrays](about_arrays.md)
 
 ## Calling a specific method when multiple overloads exist
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Module_Manifests.md
@@ -99,7 +99,7 @@ Allowed variables
 - `$PSScriptRoot`
 - `$PSEdition`
 - `$EnabledExperimentalFeatures`
-- Any environment variables, like `$ENV:TEMP`
+- Any environment variables, like `$Env:TEMP`
 
 For more information, see [about_Language_Modes][08].
 
@@ -1416,7 +1416,7 @@ For example, this manifest defines the **PublishedDate** key in
 Cmdlets in the module can access this value with the `$MyInvocation` variable.
 
 ```powershell
-Function Get-Stale {
+function Get-Stale {
     [CmdletBinding()]
     param()
 
@@ -1428,7 +1428,7 @@ Function Get-Stale {
     } catch {
         # The date was set in the manifest, set to an invalid value, or
         # the script module was directly imported without the manifest.
-        Throw "Unable to determine published date. Check the module manifest."
+        throw "Unable to determine published date. Check the module manifest."
     }
 
     if ($CurrentDate -gt $PublishedDate.AddDays(30)) {
@@ -1562,7 +1562,7 @@ imported as `Get-ExampleItem`.
 [06]: about_Experimental_Features.md#declaring-experimental-features-in-modules-written-in-powershell
 [07]: about_Format.ps1xml.md
 [08]: about_Language_Modes.md
-[09]: about_Powershell_Editions.md
+[09]: about_PowerShell_Editions.md
 [10]: about_Types.ps1xml.md
 [11]: about_Updatable_Help.md
 [13]: xref:Microsoft.PowerShell.Core.New-ModuleManifest

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -23,7 +23,7 @@ A module is a self-contained, reusable unit that can include cmdlets,
 providers, functions, variables, and other resources. By default, PowerShell
 automatically loads an installed module the first time you use a command from
 the module. You can configure automatic module loading behavior using the
-variable `$PSModuleAutoloadingPreference`. For more information, see
+variable `$PSModuleAutoLoadingPreference`. For more information, see
 [about_Preference_Variables][08].
 
 You can also manually load or unload modules during a PowerShell session. To
@@ -50,7 +50,7 @@ to create PowerShell modules, see [Writing a PowerShell Module][02].
 PowerShell stores modules in the following default locations:
 
 - On Windows
-  - All users scope - `$env:ProgramFiles\PowerShell\Modules`
+  - All users scope - `$Env:ProgramFiles\PowerShell\Modules`
   - Current user scope - `$HOME\Documents\PowerShell\Modules`
   - Modules shipped with PowerShell - `$PSHOME\Modules`
 - On Linux and macOS
@@ -69,7 +69,7 @@ Use the following command to create a `Modules` folder for the current user:
 $folder = New-Item -Type Directory -Path $HOME\Documents\PowerShell\Modules
 ```
 
-These locations are automatically included in the `$env:PSModulePath`
+These locations are automatically included in the `$Env:PSModulePath`
 environment variable. For more information about the default module locations,
 see [about_PSModulePath][10].
 
@@ -77,7 +77,7 @@ see [about_PSModulePath][10].
 
 The first time that you run a command from an installed module, PowerShell
 automatically imports (loads) that module. The module must be stored in the
-locations specified in the `$env:PSModulePath` environment variable.
+locations specified in the `$Env:PSModulePath` environment variable.
 
 Module autoloading allows you to use commands in a module without any setup or
 profile configuration. Each of the following examples causes the **CimCmdlets**
@@ -108,7 +108,7 @@ modules that you might not need in your session.
 ## Manually import a module
 
 Manually importing a module is required when a module isn't installed in the
-locations specified by the `$env:PSModulePath` environment variable, or when
+locations specified by the `$Env:PSModulePath` environment variable, or when
 the module is provided as a standalone `.dll` or `.psm1` file, rather than a
 packaged module.
 
@@ -132,7 +132,7 @@ session.
 Import-Module BitsTransfer
 ```
 
-To import a module that isn't in your `$env:PSModulePath`, use the fully
+To import a module that isn't in your `$Env:PSModulePath`, use the fully
 qualified path to the module folder. For example, to add the **TestCmdlets**
 module in the `C:\ps-test` directory to your session, type:
 
@@ -192,7 +192,7 @@ For more information, see [PowerShellGet Overview][01].
 You can manually install a module by copying the module contents from another
 folder. That folder can be in another location on the local machine or
 installed on another machine. To install a module manually, copy the entire
-module folder into a new location included in your `$env:PSModulePath`.
+module folder into a new location included in your `$Env:PSModulePath`.
 
 In PowerShell use the `Copy-Item` cmdlet. For example, run the following
 command to copy the `MyModule` folder from `C:\PSTest`:
@@ -215,16 +215,16 @@ Get-Module
 ```
 
 The modules listed can include modules that were imported from any location,
-not just from `$env:PSModulePath`.
+not just from `$Env:PSModulePath`.
 
 Use the following command to list modules that are installed in the
-`$env:PSModulePath`:
+`$Env:PSModulePath`:
 
 ```powershell
 Get-Module -ListAvailable
 ```
 
-This command gets all modules that are installed in `$env:PSModulePath`, not
+This command gets all modules that are installed in `$Env:PSModulePath`, not
 just the modules that are imported into the current session. This command
 doesn't list modules that are installed in other locations.
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Numeric_Literals.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Numeric_Literals.md
@@ -149,17 +149,17 @@ PowerShell supports the following type accelerators:
 | ----------- | -------------------- | ------------------------------- |
 | `[byte]`    |                      | Byte (unsigned)                 |
 | `[sbyte]`   |                      | Byte (signed)                   |
-| `[Int16]`   |                      | 16-bit integer                  |
+| `[int16]`   |                      | 16-bit integer                  |
 | `[short]`   | alias for `[int16]`  | 16-bit integer                  |
-| `[UInt16]`  |                      | 16-bit integer (unsigned)       |
+| `[uint16]`  |                      | 16-bit integer (unsigned)       |
 | `[ushort]`  | alias for `[uint16]` | 16-bit integer (unsigned)       |
-| `[Int32]`   |                      | 32-bit integer                  |
+| `[int32]`   |                      | 32-bit integer                  |
 | `[int]`     | alias for `[int32]`  | 32-bit integer                  |
-| `[UInt32]`  |                      | 32-bit integer (unsigned)       |
+| `[uint32]`  |                      | 32-bit integer (unsigned)       |
 | `[uint]`    | alias for `[uint32]` | 32-bit integer (unsigned)       |
-| `[Int64]`   |                      | 64-bit integer                  |
+| `[int64]`   |                      | 64-bit integer                  |
 | `[long]`    | alias for `[int64]`  | 64-bit integer                  |
-| `[UInt64]`  |                      | 64-bit integer (unsigned)       |
+| `[uint64]`  |                      | 64-bit integer (unsigned)       |
 | `[ulong]`   | alias for `[uint64]` | 64-bit integer (unsigned)       |
 | `[bigint]`  |                      | See [BigInteger Struct][bigint] |
 | `[single]`  |                      | Single precision floating point |
@@ -316,20 +316,20 @@ If the literal contains a decimal point or the e-notation, the literal string
 is parsed as a real number.
 
 - If the decimal-suffix is present then directly into `[decimal]`.
-- Else, parse as `[Double]` and apply multiplier to the value. Then check the
+- Else, parse as `[double]` and apply multiplier to the value. Then check the
   type suffixes and attempt to cast into appropriate type.
-- If the string has no type suffix, then parse as `[Double]`.
+- If the string has no type suffix, then parse as `[double]`.
 
 ### Parsing integer numeric literals
 
 Integer type literals are parsed using the following steps:
 
 1. Determine the radix format
-   - For binary formats, parse into `[BigInteger]`.
-   - For hexadecimal formats, parse into `[BigInteger]` using special cases to
+   - For binary formats, parse into `[bigint]`.
+   - For hexadecimal formats, parse into `[bigint]` using special cases to
      retain original behaviors when the value is in the `[int]` or `[long]`
      range.
-   - If neither binary nor hex, parse normally as a `[BigInteger]`.
+   - If neither binary nor hex, parse normally as a `[bigint]`.
 1. Apply the multiplier value before attempting any casts to ensure type bounds
    can be appropriately checked without overflows.
 1. Check type suffixes.
@@ -375,7 +375,7 @@ PS> 111111111111111111111111111111111111111111111111111111n
 
 Also values between `[ulong]::MaxValue` and `[decimal]::MaxValue` should be
 denoted using the decimal-suffix `D` to maintain accuracy. Without the suffix,
-these values are parsed as `[Double]` using the real-parsing mode.
+these values are parsed as `[double]` using the real-parsing mode.
 
 <!-- reference links -->
 [bigint]: /dotnet/api/system.numerics.biginteger

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Object_Creation.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Object_Creation.md
@@ -21,7 +21,7 @@ There are many ways to create objects, this list is not definitive:
 
 - [New-Object][14]: Creates an instance of a .NET Framework object or COM
   object.
-- [Import-Csv][13]/[ConvertFrom-CSV][10]: Creates custom objects
+- [Import-Csv][13]/[ConvertFrom-Csv][10]: Creates custom objects
   (**PSCustomObject**) from the items defined as character separated values.
 - [ConvertFrom-Json][11]: Creates custom objects defined in JavaScript Object
   Notation (JSON).
@@ -170,17 +170,17 @@ the example section of the `Update-Help` cmdlet help topic.
 ```powershell
 function Test-Object {
   $ModuleName = "PSScheduledJob"
-  $HelpCulture = "en-us"
+  $HelpCulture = "en-US"
   $HelpVersion = "3.1.0.0"
-  [PSCustomObject]@{
+  [pscustomobject]@{
     "ModuleName"=$ModuleName
     "UICulture"=$HelpCulture
     "Version"=$HelpVersion
   }
   $ModuleName = "PSWorkflow"
-  $HelpCulture = "en-us"
+  $HelpCulture = "en-US"
   $HelpVersion = "3.0.0.0"
-  [PSCustomObject]@{
+  [pscustomobject]@{
     "ModuleName"=$ModuleName
     "UICulture"=$HelpCulture
     "Version"=$HelpVersion
@@ -195,8 +195,8 @@ table by default.
 ```Output
 ModuleName        UICulture      Version
 ---------         ---------      -------
-PSScheduledJob    en-us          3.1.0.0
-PSWorkflow        en-us          3.0.0.0
+PSScheduledJob    en-US          3.1.0.0
+PSWorkflow        en-US          3.0.0.0
 ```
 
 Users can manage the properties of the custom objects just as they do with

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Objects.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Objects.md
@@ -53,18 +53,18 @@ The following example demonstrates how objects are passed from one
 command to the next:
 
 ```powershell
-Get-ChildItem C: | where { $_.PsIsContainer -eq $false } | Format-List
+Get-ChildItem C: | where { $_.PSIsContainer -eq $false } | Format-List
 ```
 
 The first command `Get-ChildItem C:` returns a file or directory object
 for each item in the root directory of the file system. The file and
 directory objects are passed down the pipeline to the second command.
 
-The second command `where { $_.PsIsContainer -eq $false }` uses the
-**PsIsContainer** property of all file system objects to select only
-files, which have a value of False (`$false`) in their **PsIsContainer**
+The second command `where { $_.PSIsContainer -eq $false }` uses the
+**PSIsContainer** property of all file system objects to select only
+files, which have a value of False (`$false`) in their **PSIsContainer**
 property. Folders, which are containers and, thus, have a value of
-True (`$true`) in their **PsIsContainer** property, are not selected.
+True (`$true`) in their **PSIsContainer** property, are not selected.
 
 The second command passes only the file objects to the third command
 `Format-List`, which displays the file objects in a list.

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -34,7 +34,7 @@ precedence.
 
 The Operator column lists the operators. The Reference column lists the
 PowerShell Help topic in which the operator is described. To display the topic,
-type `get-help <topic-name>`.
+type `Get-Help <topic-name>`.
 
 |          OPERATOR           |              REFERENCE               |
 | --------------------------- | ------------------------------------ |
@@ -66,7 +66,7 @@ and explicitly case-insensitive variants have the same precedence.
 | `-like -notlike`          | [about_Comparison_Operators][compare] |
 | `-match -notmatch`        | [about_Comparison_Operators][compare] |
 | `-in -notIn`              | [about_Comparison_Operators][compare] |
-| `-contains -notContains`  | [about_Comparison_Operators][compare] |
+| `-contains -notcontains`  | [about_Comparison_Operators][compare] |
 | `-replace`                | [about_Comparison_Operators][compare] |
 
 The list resumes here with the following operators in precedence
@@ -110,13 +110,13 @@ The following example gets the read-only text files from the local directory
 and saves them in the `$read_only` variable.
 
 ```powershell
-$read_only = Get-ChildItem *.txt | Where-Object {$_.isReadOnly}
+$read_only = Get-ChildItem *.txt | Where-Object {$_.IsReadOnly}
 ```
 
 It is equivalent to the following example.
 
 ```powershell
-$read_only = ( Get-ChildItem *.txt | Where-Object {$_.isReadOnly} )
+$read_only = ( Get-ChildItem *.txt | Where-Object {$_.IsReadOnly} )
 ```
 
 Because the pipeline operator (`|`) has a higher precedence than the assignment

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -202,7 +202,7 @@ of command in a string expression.
 PS> "Today is $(Get-Date)"
 Today is 12/02/2019 13:15:20
 
-PS> "Folder list: $((dir c:\ -dir).Name -join ', ')"
+PS> "Folder list: $((dir C:\ -Dir).Name -join ', ')"
 Folder list: Program Files, Program Files (x86), Users, Windows
 ```
 
@@ -221,7 +221,7 @@ True     True     Object[]                                 System.Array
 
 PS> $list.Count
 20
-PS> $list = @(Get-Service | Where-Object Status -eq Starting )
+PS> $list = @(Get-Service | Where-Object Status -EQ Starting )
 PS> $list.GetType()
 
 IsPublic IsSerial Name                                     BaseType
@@ -314,7 +314,7 @@ For more about script blocks, see [about_Script_Blocks][20].
 ### Background operator `&`
 
 Runs the pipeline before it in the background, in a PowerShell job. This
-operator acts similarly to the UNIX control operator ampersand (`&`), which
+operator acts similarly to the Unix control operator ampersand (`&`), which
 runs the command before it asynchronously in subshell as a job.
 
 This operator is functionally equivalent to `Start-Job`. By default, the
@@ -355,7 +355,7 @@ Receive-Job $job -Wait
 Remove-Job $job
 ```
 
-The `&` background operator is also a statement terminator, just like the UNIX
+The `&` background operator is also a statement terminator, just like the Unix
 control operator ampersand (`&`). This allows you to invoke additional commands
 after the `&` background operator. The following example demonstrates the
 invocation of additional commands after the `&` background operator.
@@ -396,7 +396,7 @@ Converts or limits objects to the specified type. If the objects can't be
 converted, PowerShell generates an error.
 
 ```powershell
-[DateTime] '2/20/88' - [DateTime] '1/20/88' -eq [TimeSpan] '31'
+[datetime] '2/20/88' - [datetime] '1/20/88' -eq [timespan] '31'
 ```
 
 A cast can also be performed when a variable is assigned to using
@@ -426,7 +426,7 @@ for which no value has been given become variables with no value. However, the
 automatic variable `$args` is preserved.
 
 ```powershell
-. c:\scripts\sample.ps1 1 2 -Also:3
+. C:\scripts\sample.ps1 1 2 -Also:3
 ```
 
 > [!NOTE]
@@ -462,7 +462,7 @@ Enter the composite format string on the left side of the operator and the
 objects to be formatted on the right side of the operator.
 
 ```powershell
-"{0} {1,-10} {2:N}" -f 1,"hello",[math]::pi
+"{0} {1,-10} {2:N}" -f 1,"hello",[Math]::PI
 ```
 
 ```Output
@@ -515,7 +515,7 @@ PS> $a[2, 1, 0]
 ```
 
 ```powershell
-(Get-HotFix | Sort-Object installedOn)[-1]
+(Get-HotFix | Sort-Object InstalledOn)[-1]
 ```
 
 ```powershell
@@ -706,9 +706,9 @@ Accesses the properties and methods of an object. The member name may be an
 expression.
 
 ```powershell
-$myProcess.peakWorkingSet
-(Get-Process PowerShell).Kill()
-'OS', 'Platform' | Foreach-Object { $PSVersionTable. $_ }
+$myProcess.PeakWorkingSet
+(Get-Process powershell).Kill()
+'OS', 'Platform' | ForEach-Object { $PSVersionTable. $_ }
 ```
 
 Starting PowerShell 3.0, when you use the operator on a list collection object
@@ -724,7 +724,7 @@ properties and methods of an object, use the Static parameter of the
 
 ```powershell
 [datetime]::Now
-'MinValue', 'MaxValue' | Foreach-Object { [int]:: $_ }
+'MinValue', 'MaxValue' | ForEach-Object { [int]:: $_ }
 ```
 
 ### Ternary operator `? <if-true> : <if-false>`

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Parameter_Sets.md
@@ -134,7 +134,7 @@ function Measure-Lines {
 
             if ($Words) {
                 $wc = 0
-                foreach ($line in $content) { $wc += $line.split(' ').Length }
+                foreach ($line in $content) { $wc += $line.Split(' ').Length }
                 $result.Add('Words', $wc)
             }
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Parameters.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Parameters.md
@@ -131,10 +131,10 @@ As a result of the `Position` settings for these two parameters, you can use
 any of the following commands:
 
 ```powershell
-Get-ChildItem -Path c:\techdocs -Exclude *.ppt
-Get-ChildItem c:\techdocs -Exclude *.ppt
-Get-ChildItem -Exclude *.ppt -Path c:\techdocs
-Get-ChildItem -Exclude *.ppt c:\techdocs
+Get-ChildItem -Path C:\techdocs -Exclude *.ppt
+Get-ChildItem C:\techdocs -Exclude *.ppt
+Get-ChildItem -Exclude *.ppt -Path C:\techdocs
+Get-ChildItem -Exclude *.ppt C:\techdocs
 ```
 
 If you were to include another positional parameter without including the
@@ -237,7 +237,7 @@ information about common parameters, see
 
 ## See also
 
-- [about_Command_syntax](about_Command_syntax.md)
+- [about_Command_Syntax](about_Command_Syntax.md)
 - [about_Comment_Based_Help](about_Comment_Based_Help.md)
 - [about_Functions_Advanced](about_Functions_Advanced.md)
 - [about_Parameters_Default_Values](about_Parameters_Default_Values.md)


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide