### PR TITLE
Fix incorrect case/capitalization in reference documents (8/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PSConsoleHostReadLine.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PSConsoleHostReadLine.md
@@ -27,7 +27,7 @@ the user creates:
 
 ```powershell
 function PSConsoleHostReadLine {
-  $inputFile = Join-Path $env:TEMP PSConsoleHostReadLine
+  $inputFile = Join-Path $Env:TEMP PSConsoleHostReadLine
   Set-Content $inputFile "PS > "
 
   # Notepad opens. Enter your command in it, save the file, and then exit.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
@@ -23,7 +23,7 @@ properties and values was more complicated. Originally, you had to use
 example:
 
 ```powershell
-PS> $object1 = New-Object -TypeName PSObject
+PS> $object1 = New-Object -TypeName psobject
 PS> Add-Member -InputObject $object1 -MemberType NoteProperty -Name one -Value 1
 PS> Add-Member -InputObject $object1 -MemberType NoteProperty -Name two -Value 2
 PS> $object1 | Get-Member
@@ -50,7 +50,7 @@ Later, you could use the **Property** parameter of `New-Object` to pass a
 **Hashtable** containing the members and values. For example:
 
 ```powershell
-PS> $object2 = New-Object -TypeName PSObject -Property @{one=1; two=2}
+PS> $object2 = New-Object -TypeName psobject -Property @{one=1; two=2}
 PS> $object2 | Get-Member
 
    TypeName: System.Management.Automation.PSCustomObject
@@ -191,11 +191,11 @@ have subtle side effects.
 - Wrapped objects match their original type and the `[psobject]` type.
 
   ```powershell
-  PS> 1 -is [Int32]
+  PS> 1 -is [int32]
   True
   PS> 1 -is [psobject]
   False
-  PS> ([psobject] 1) -is [Int32]
+  PS> ([psobject] 1) -is [int32]
   True
   PS> ([psobject] 1) -is [psobject]
   True
@@ -248,7 +248,7 @@ When that hashtable is cast to a `[pscustomobject]`, the case of the name of
 first key is used, but that value of the last matching key name is used.
 
 ```powershell
-[PSCustomObject]$OrderedHashTable
+[pscustomobject]$OrderedHashTable
 ```
 
 ```Output
@@ -266,7 +266,7 @@ Attempting to access these members returns `$null`.
 For example:
 
 ```powershell
-PS> $object = [PSCustomObject]@{key = 'value'}
+PS> $object = [pscustomobject]@{key = 'value'}
 PS> $object
 
 key

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PSItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PSItem.md
@@ -189,7 +189,7 @@ parameters that take input from the pipeline.
 function Write-JsonLog {
     [CmdletBinding()]
     param(
-        [parameter(ValueFromPipelineByPropertyName)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [string]$Message
     )
     begin {

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Parsing.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Parsing.md
@@ -59,7 +59,7 @@ Variable expressions carry the value of the variable they reference:
 
 ```powershell
 $x
-$script:path
+$Script:path
 ```
 
 Operators combine other expressions for evaluation:
@@ -352,7 +352,7 @@ arguments to the executable. You can use this tool to verify that you have
 properly escaped the characters in your arguments.
 
 ```powershell
-TestExe -echoargs """""${env:ProgramFiles(x86)}\Microsoft\\"""""
+TestExe -echoargs """""${Env:ProgramFiles(x86)}\Microsoft\\"""""
 TestExe -echoargs """""C:\Program Files (x86)\Microsoft\\"""""
 TestExe -echoargs --% ""\""C:\Program Files (x86)\Microsoft\\""
 TestExe -echoargs --% """C:\Program Files (x86)\Microsoft\\""
@@ -390,7 +390,7 @@ Unlike the stop-parsing (`--%`) token, any values following the `--` token can
 be interpreted as expressions by PowerShell.
 
 ```powershell
-Write-Output -- -InputObject $env:PROCESSOR_ARCHITECTURE
+Write-Output -- -InputObject $Env:PROCESSOR_ARCHITECTURE
 ```
 
 ```Output

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Pipelines.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Pipelines.md
@@ -50,7 +50,7 @@ Get-Process notepad | Stop-Process
 The first command uses the `Get-Process` cmdlet to get an object representing
 the Notepad process. It uses a pipeline operator (`|`) to send the process
 object to the `Stop-Process` cmdlet, which stops the Notepad process. Notice
-that the `Stop-Process` command doesn't have a **Name** or **ID** parameter to
+that the `Stop-Process` command doesn't have a **Name** or **Id** parameter to
 specify the process, because the specified process is submitted through the
 pipeline.
 
@@ -60,9 +60,9 @@ displays the name and length of each file in a table.
 
 ```powershell
 Get-ChildItem -Path *.txt |
-  Where-Object {$_.length -gt 10000} |
-    Sort-Object -Property length |
-      Format-Table -Property name, length
+  Where-Object {$_.Length -gt 10000} |
+    Sort-Object -Property Length |
+      Format-Table -Property Name, Length
 ```
 
 This pipeline consists of four commands in the specified order. The following
@@ -73,7 +73,7 @@ command in the pipeline.
 Get-ChildItem -Path *.txt
 | (FileInfo objects for *.txt)
 V
-Where-Object {$_.length -gt 10000}
+Where-Object {$_.Length -gt 10000}
 | (FileInfo objects for *.txt)
 | (      Length > 10000      )
 V
@@ -82,7 +82,7 @@ Sort-Object -Property Length
 | (      Length > 10000      )
 | (     Sorted by length     )
 V
-Format-Table -Property name, length
+Format-Table -Property Name, Length
 | (FileInfo objects for *.txt)
 | (      Length > 10000      )
 | (     Sorted by length     )
@@ -110,7 +110,7 @@ Get-Service wmi | Start-Service
 ```
 
 For another example, you can pipe the output of `Get-Item` or `Get-ChildItem`
-within the PowerShell registry provider to the `New-ItemProperty` cmdlet. This
+within the PowerShell Registry provider to the `New-ItemProperty` cmdlet. This
 example adds a new registry entry, **NoOfEmployees**, with a value of **8124**,
 to the **MyCompany** registry key.
 
@@ -126,11 +126,11 @@ how to sort all the processes on the computer by the number of open handles in
 each process.
 
 ```powershell
-Get-Process | Sort-Object -Property handles
+Get-Process | Sort-Object -Property Handles
 ```
 
 You can pipe objects to the formatting, export, and output cmdlets, such as
-`Format-List`, `Format-Table`, `Export-Clixml`, `Export-CSV`, and `Out-File`.
+`Format-List`, `Format-Table`, `Export-Clixml`, `Export-Csv`, and `Out-File`.
 
 This example shows how to use the `Format-List` cmdlet to display a list of
 properties for a process object.
@@ -391,7 +391,7 @@ use that to count the number of processes running on the computer.
 For example,
 
 ```powershell
-(Get-Process).count
+(Get-Process).Count
 ```
 
 It's important to remember that objects sent down the pipeline are delivered
@@ -564,7 +564,7 @@ enhances readability.
 - [about_Objects][05]
 - [about_Parameters][06]
 - [about_Command_Syntax][03]
-- [about_ForEach][04]
+- [about_Foreach][04]
 
 <!-- link references -->
 [02]: #investigating-pipeline-errors

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -62,8 +62,8 @@ PowerShell includes the following environment variables that store user
 preferences. For more information about these environment variables, see
 [about_Environment_Variables][30].
 
-- `$env:PSExecutionPolicyPreference`
-- `$env:PSModulePath`
+- `$Env:PSExecutionPolicyPreference`
+- `$Env:PSModulePath`
 
 > [!NOTE]
 > Changes to preference variables apply only in the scope they are made
@@ -549,7 +549,7 @@ ObjectNotFound: (C:\nofile.txt:String) [Get-ChildItem], ItemNotFoundException
 This example demonstrates that the value of `$ErrorView` only affects the error
 display. It doesn't change the structure of the error object that's stored in
 the `$Error` automatic variable. For information about the `$Error` automatic
-variable, see [about_automatic_variables][28].
+variable, see [about_Automatic_Variables][28].
 
 The following command takes the **ErrorRecord** object associated with the most
 recent error in the error array, **element 0**, and formats the properties of
@@ -739,14 +739,14 @@ To enable a **Log*Event**, type the variable with a value of `$true`, for
 example:
 
 ```powershell
-$LogCommandLifeCycleEvent = $true
+$LogCommandLifecycleEvent = $true
 ```
 
 To disable an event type, type the variable with a value of `$false`, for
 example:
 
 ```powershell
-$LogCommandLifeCycleEvent = $false
+$LogCommandLifecycleEvent = $false
 ```
 
 The events that you enable are effective only for the current PowerShell
@@ -766,7 +766,7 @@ value is **4096** and that should be enough for most uses. You can adjust
 To count the aliases on your system, type:
 
 ```powershell
-(Get-Alias).count
+(Get-Alias).Count
 ```
 
 ## $MaximumDriveCount
@@ -782,7 +782,7 @@ providers and appear as drives, such as the `Alias:` and `HKLM:` drives.
 To count the aliases on your system, type:
 
 ```powershell
-(Get-PSDrive).count
+(Get-PSDrive).Count
 ```
 
 ## $MaximumErrorCount
@@ -801,7 +801,7 @@ To count the errors on your system, use the `$Error` array's **Count**
 property.
 
 ```powershell
-$Error.count
+$Error.Count
 ```
 
 To display a specific error, use the `[0]` array notation to see the most
@@ -1016,7 +1016,7 @@ try {
     $buffer = [byte[]]::new(1024)
     $read = $inputStream.Read($buffer, 0, $buffer.Length)
     $actual = [byte[]]::new($read)
-    [Array]::Copy($buffer, $actual, $read)
+    [array]::Copy($buffer, $actual, $read)
     Format-Hex -InputObject $actual
 } finally {
     $inputStream.Dispose()
@@ -1093,16 +1093,16 @@ Specifies the default email server that's used to send email messages. This
 preference variable is used by cmdlets that send email, such as the
 [Send-MailMessage][49] cmdlet.
 
-## $PSModuleAutoloadingPreference
+## $PSModuleAutoLoadingPreference
 
 Enables and disables automatic importing of modules in the session. The
-`$PSModuleAutoloadingPreference` variable doesn't exist by default. The default
+`$PSModuleAutoLoadingPreference` variable doesn't exist by default. The default
 behavior when the variable isn't defined is the same as
-`$PSModuleAutoloadingPreference = 'All'`.
+`$PSModuleAutoLoadingPreference = 'All'`.
 
 To automatically import a module, get or use a command contained in the module.
 
-The `$PSModuleAutoloadingPreference` variable takes one of the
+The `$PSModuleAutoLoadingPreference` variable takes one of the
 [`PSModuleAutoLoadingPreference`][58] enumeration values:
 
 - `All`: Modules are imported automatically on first-use.
@@ -1700,7 +1700,7 @@ At line:1 char:1
 
 ## See also
 
-- [about_automatic_variables][28]
+- [about_Automatic_Variables][28]
 - [about_CommonParameters][29]
 - [about_Environment_Variables][30]
 - [about_Profiles][36]

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -205,9 +205,9 @@ Here are a few suggestions to get you started.
 ### Add a function that lists aliases for any cmdlet
 
 ```powershell
-function Get-CmdletAlias ($cmdletname) {
+function Get-CmdletAlias ($cmdletName) {
   Get-Alias |
-    Where-Object -FilterScript {$_.Definition -like "$cmdletname"} |
+    Where-Object -FilterScript {$_.Definition -like "$cmdletName"} |
       Format-Table -Property Definition, Name -AutoSize
 }
 ```
@@ -216,9 +216,9 @@ function Get-CmdletAlias ($cmdletname) {
 
 ```powershell
 function CustomizeConsole {
-  $hosttime = (Get-ChildItem -Path $PSHOME\PowerShell.exe).CreationTime
-  $hostversion="$($Host.Version.Major)`.$($Host.Version.Minor)"
-  $Host.UI.RawUI.WindowTitle = "PowerShell $hostversion ($hosttime)"
+  $hostTime = (Get-ChildItem -Path $PSHOME\powershell.exe).CreationTime
+  $hostVersion="$($Host.Version.Major)`.$($Host.Version.Minor)"
+  $Host.UI.RawUI.WindowTitle = "PowerShell $hostVersion ($hostTime)"
   Clear-Host
 }
 CustomizeConsole
@@ -227,8 +227,8 @@ CustomizeConsole
 ### Add a customized PowerShell prompt
 
 ```powershell
-function Prompt {
-    $env:COMPUTERNAME + "\" + (Get-Location) + "> "
+function prompt {
+    $Env:COMPUTERNAME + "\" + (Get-Location) + "> "
 }
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -1,5 +1,5 @@
 ---
-description: Describes the `Prompt` function and demonstrates how to create a custom `Prompt` function.
+description: Describes the `prompt` function and demonstrates how to create a custom `prompt` function.
 Locale: en-US
 ms.date: 08/21/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_prompts?view=powershell-5.1&WT.mc_id=ps-gethelp
@@ -9,8 +9,8 @@ title: about_Prompts
 # about_Prompts
 
 ## Short description
-Describes the `Prompt` function and demonstrates how to create a custom
-`Prompt` function.
+Describes the `prompt` function and demonstrates how to create a custom
+`prompt` function.
 
 ## Long description
 
@@ -21,26 +21,26 @@ command:
 PS C:\>
 ```
 
-PowerShell has a built-in `Prompt` function. You can define your own customized
-`Prompt` function in your PowerShell profile script.
+PowerShell has a built-in `prompt` function. You can define your own customized
+`prompt` function in your PowerShell profile script.
 
-## About the Prompt function
+## About the `prompt` function
 
-The `Prompt` function determines the appearance of the PowerShell prompt.
-PowerShell comes with a built-in `Prompt` function, but you can override it by
-defining your own `Prompt` function.
+The `prompt` function determines the appearance of the PowerShell prompt.
+PowerShell comes with a built-in `prompt` function, but you can override it by
+defining your own `prompt` function.
 
-The `Prompt` function has the following syntax:
+The `prompt` function has the following syntax:
 
 ```powershell
-function Prompt { <function-body> }
+function prompt { <function-body> }
 ```
 
-The `Prompt` function must return an object. As a best practice, return a
+The `prompt` function must return an object. As a best practice, return a
 string or an object that's formatted as a string. The maximum recommended
 length is 80 characters.
 
-For example, the following `Prompt` function returns a "Hello, World" string
+For example, the following `prompt` function returns a "Hello, World" string
 followed by a  right angle bracket (`>`).
 
 ```powershell
@@ -48,15 +48,15 @@ PS C:\> function prompt {"Hello, World > "}
 Hello, World >
 ```
 
-### Getting the Prompt function
+### Getting the `prompt` function
 
-To get the `Prompt` function, use the `Get-Command` cmdlet or use the
+To get the `prompt` function, use the `Get-Command` cmdlet or use the
 `Get-Item` cmdlet in the Function drive.
 
 For example:
 
 ```powershell
-PS C:\> Get-Command Prompt
+PS C:\> Get-Command prompt
 
 CommandType     Name      ModuleName
 -----------     ----      ----------
@@ -64,12 +64,12 @@ Function        prompt
 ```
 
 To get the script that sets the value of the prompt, use the dot method to get
-the **ScriptBlock** property of the `Prompt` function.
+the **ScriptBlock** property of the `prompt` function.
 
 For example:
 
 ```powershell
-(Get-Command Prompt).ScriptBlock
+(Get-Command prompt).ScriptBlock
 ```
 
 ```Output
@@ -79,16 +79,16 @@ For example:
 # .ExternalHelp System.Management.Automation.dll-help.xml
 ```
 
-Like all functions, the `Prompt` function is stored in the `Function:` drive.
-To display the script that creates the current `Prompt` function, type:
+Like all functions, the `prompt` function is stored in the `Function:` drive.
+To display the script that creates the current `prompt` function, type:
 
 ```powershell
-(Get-Item function:prompt).ScriptBlock
+(Get-Item Function:prompt).ScriptBlock
 ```
 
 ### The default prompt
 
-The default prompt appears only when the `Prompt` function generates an error
+The default prompt appears only when the `prompt` function generates an error
 or doesn't return an object.
 
 The default PowerShell prompt is:
@@ -97,7 +97,7 @@ The default PowerShell prompt is:
 PS>
 ```
 
-For example, the following command sets the `Prompt` function to `$null`, which
+For example, the following command sets the `prompt` function to `$null`, which
 is invalid. As a result, the default prompt appears.
 
 ```powershell
@@ -110,7 +110,7 @@ default prompt.
 
 ### Built-in prompt
 
-PowerShell includes a built-in `Prompt` function.
+PowerShell includes a built-in `prompt` function.
 
 ```powershell
 function prompt {
@@ -153,7 +153,7 @@ the following prompt:
 ### Changes to the prompt
 
 The `Enter-PSSession` cmdlet prepends the name of the remote computer to the
-current `Prompt` function. When you use the `Enter-PSSession` cmdlet to start a
+current `prompt` function. When you use the `Enter-PSSession` cmdlet to start a
 session with a remote computer, the command prompt changes to include the name
 of the remote computer. For example:
 
@@ -170,10 +170,10 @@ automatic variables, see [about_Automatic_Variables][01].
 
 ### How to customize the prompt
 
-To customize the prompt, write a new `Prompt` function. The function isn't
+To customize the prompt, write a new `prompt` function. The function isn't
 protected, so you can overwrite it.
 
-To write a `Prompt` function, type the following:
+To write a `prompt` function, type the following:
 
 ```powershell
 function prompt { }
@@ -185,7 +185,7 @@ prompt.
 For example, the following prompt includes your computer name:
 
 ```powershell
-function prompt {"PS [$env:COMPUTERNAME]> "}
+function prompt {"PS [$Env:COMPUTERNAME]> "}
 ```
 
 On the Server01 computer, the prompt resembles the following prompt:
@@ -194,7 +194,7 @@ On the Server01 computer, the prompt resembles the following prompt:
 PS [Server01] >
 ```
 
-The following `Prompt` function includes the current date and time:
+The following `prompt` function includes the current date and time:
 
 ```powershell
 function prompt {"$(Get-Date)> "}
@@ -206,9 +206,9 @@ The prompt resembles the following prompt:
 03/15/2012 17:49:47>
 ```
 
-You can also change the default `Prompt` function:
+You can also change the default `prompt` function:
 
-For example, the following modified `Prompt` function adds `[ADMIN]:` to the
+For example, the following modified `prompt` function adds `[ADMIN]:` to the
 built-in PowerShell prompt when running in an elevated session.
 
 ```powershell
@@ -217,7 +217,7 @@ function prompt {
   $principal = [Security.Principal.WindowsPrincipal] $identity
   $adminRole = [Security.Principal.WindowsBuiltInRole]::Administrator
 
-  $(if (Test-Path variable:/PSDebugContext) { '[DBG]: ' }
+  $(if (Test-Path Variable:/PSDebugContext) { '[DBG]: ' }
     elseif($principal.IsInRole($adminRole)) { "[ADMIN]: " }
     else { '' }
   ) + 'PS ' + $(Get-Location) +
@@ -232,7 +232,7 @@ that resembles the following prompt appears:
 [ADMIN]: PS C:\ps-test>
 ```
 
-The following `Prompt` function displays the history ID of the next command. To
+The following `prompt` function displays the history ID of the next command. To
 view the command history, use the `Get-History` cmdlet.
 
 ```powershell
@@ -254,21 +254,21 @@ function prompt {
 The following prompt uses the `Write-Host` and `Get-Random` cmdlets to create a
 prompt that changes color randomly. Because `Write-Host` writes to the current
 host application but doesn't return an object, this function includes a
-`Return` statement. Without it, PowerShell uses the default prompt, `PS>`.
+`return` statement. Without it, PowerShell uses the default prompt, `PS>`.
 
 ```powershell
 function prompt {
     $color = Get-Random -Min 1 -Max 16
-    Write-Host ("PS " + $(Get-Location) +">") -NoNewLine `
+    Write-Host ("PS " + $(Get-Location) +">") -NoNewline `
      -ForegroundColor $Color
     return " "
 }
 ```
 
-### Saving the Prompt function
+### Saving the `prompt` function
 
-Like any function, the `Prompt` function exists only in the current session. To
-save the `Prompt` function for future sessions, add it to your PowerShell
+Like any function, the `prompt` function exists only in the current session. To
+save the `prompt` function for future sessions, add it to your PowerShell
 profiles. For more information about profiles, see [about_Profiles][04].
 
 ## See also

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -262,7 +262,7 @@ PS> $collection = @(
 $collection.Length
 2
 
-# Get the length property of each item in the collection.
+# Get the Length property of each item in the collection.
 PS> $collection.GetEnumerator().Length
 foo
 bar

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -192,7 +192,7 @@ cmdlets. Type the drive name followed by a colon (`:`). For example, to view
 the contents of the `Alias:` drive, type:
 
 ```powershell
-Get-Item alias:
+Get-Item Alias:
 ```
 
 You can view and manage the data in any drive from another drive by including
@@ -208,7 +208,7 @@ specify the drive path. For example, to change your location to the root
 directory of the `Cert:` drive, type:
 
 ```powershell
-Set-Location cert:
+Set-Location Cert:
 ```
 
 Then, to view the contents of the `Cert:` drive, type:
@@ -302,7 +302,7 @@ Cert:\> Set-Location ~
 
 ```Output
 Set-Location : Home location for this provider isn't set. To set the home
-location, call "(get-psprovider 'Certificate').Home = 'path'".
+location, call "(Get-PSProvider 'Certificate').Home = 'path'".
 At line:1 char:1
 + Set-Location ~
 + ~~~~~~~~~~~~~~
@@ -331,7 +331,7 @@ Get-Help <provider-name>
 For example:
 
 ```powershell
-Get-Help certificate
+Get-Help Certificate
 ```
 
 ## Learning about providers
@@ -350,7 +350,7 @@ Get-Help <ProviderName>
 For example:
 
 ```powershell
-Get-Help registry
+Get-Help Registry
 ```
 
 For a list of Help topics about the providers, type:

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_PSConsoleHostReadLine.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_PSConsoleHostReadLine.md
@@ -27,7 +27,7 @@ the user creates:
 
 ```powershell
 function PSConsoleHostReadLine {
-  $inputFile = Join-Path $env:TEMP PSConsoleHostReadLine
+  $inputFile = Join-Path $Env:TEMP PSConsoleHostReadLine
   Set-Content $inputFile "PS > "
 
   # Notepad opens. Enter your command in it, save the file, and then exit.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
@@ -23,7 +23,7 @@ properties and values was more complicated. Originally, you had to use
 example:
 
 ```powershell
-PS> $object1 = New-Object -TypeName PSObject
+PS> $object1 = New-Object -TypeName psobject
 PS> Add-Member -InputObject $object1 -MemberType NoteProperty -Name one -Value 1
 PS> Add-Member -InputObject $object1 -MemberType NoteProperty -Name two -Value 2
 PS> $object1 | Get-Member
@@ -50,7 +50,7 @@ Later, you could use the **Property** parameter of `New-Object` to pass a
 **Hashtable** containing the members and values. For example:
 
 ```powershell
-PS> $object2 = New-Object -TypeName PSObject -Property @{one=1; two=2}
+PS> $object2 = New-Object -TypeName psobject -Property @{one=1; two=2}
 PS> $object2 | Get-Member
 
    TypeName: System.Management.Automation.PSCustomObject
@@ -190,11 +190,11 @@ have subtle side effects.
 - Wrapped objects match their original type and the `[psobject]` type.
 
   ```powershell
-  PS> 1 -is [Int32]
+  PS> 1 -is [int32]
   True
   PS> 1 -is [psobject]
   False
-  PS> ([psobject] 1) -is [Int32]
+  PS> ([psobject] 1) -is [int32]
   True
   PS> ([psobject] 1) -is [psobject]
   True
@@ -253,7 +253,7 @@ When that hashtable is cast to a `[pscustomobject]`, the case of the name of
 first key is used, but that value of the last matching key name is used.
 
 ```powershell
-[PSCustomObject]$OrderedHashTable
+[pscustomobject]$OrderedHashTable
 ```
 
 ```Output
@@ -271,7 +271,7 @@ Attempting to access these members returns `$null`.
 For example:
 
 ```powershell
-PS> $object = [PSCustomObject]@{key = 'value'}
+PS> $object = [pscustomobject]@{key = 'value'}
 PS> $object
 
 key

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_PSItem.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_PSItem.md
@@ -190,7 +190,7 @@ parameters that take input from the pipeline.
 function Write-JsonLog {
     [CmdletBinding()]
     param(
-        [parameter(ValueFromPipelineByPropertyName)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [string]$Message
     )
     begin {
@@ -378,9 +378,9 @@ was included, verify that the path is correct and try again.
 For more examples, see the _Accessing exception information_ section in
 [about_Try_Catch_Finally][14].
 
-## The -replace operator's substitution scriptblock
+## The `-replace` operator's substitution scriptblock
 
-Starting in PowerShell 6, you can use `$PSItem` when calling the [replace][04]
+Starting in PowerShell 6, you can use `$PSItem` when calling the [-replace][04]
 operator and defining a [substitution scriptblock][05]. When you do, the value
 of `$PSItem` is the value of the current match.
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Parsing.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Parsing.md
@@ -59,7 +59,7 @@ Variable expressions carry the value of the variable they reference:
 
 ```powershell
 $x
-$script:path
+$Script:path
 ```
 
 Operators combine other expressions for evaluation:
@@ -391,7 +391,7 @@ In `Windows` or `Standard` mode, the following examples produce the expected
 results:
 
 ```powershell
-TestExe -echoargs """${env:ProgramFiles(x86)}\Microsoft\"""
+TestExe -echoargs """${Env:ProgramFiles(x86)}\Microsoft\"""
 TestExe -echoargs '"C:\Program Files (x86)\Microsoft\"'
 ```
 
@@ -399,7 +399,7 @@ To get the same results in `Legacy` mode, you must escape the quotes or use the
 stop-parsing token (`--%`):
 
 ```powershell
-TestExe -echoargs """""${env:ProgramFiles(x86)}\Microsoft\\"""""
+TestExe -echoargs """""${Env:ProgramFiles(x86)}\Microsoft\\"""""
 TestExe -echoargs "\""C:\Program Files (x86)\Microsoft\\"""
 TestExe -echoargs --% ""\""C:\Program Files (x86)\Microsoft\\"\"""
 TestExe -echoargs --% """C:\Program Files (x86)\Microsoft\\""
@@ -439,7 +439,7 @@ Unlike the stop-parsing (`--%`) token, any values following the `--` token can
 be interpreted as expressions by PowerShell.
 
 ```powershell
-Write-Output -- -InputObject $env:PROCESSOR_ARCHITECTURE
+Write-Output -- -InputObject $Env:PROCESSOR_ARCHITECTURE
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Pipelines.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Pipelines.md
@@ -50,7 +50,7 @@ Get-Process notepad | Stop-Process
 The first command uses the `Get-Process` cmdlet to get an object representing
 the Notepad process. It uses a pipeline operator (`|`) to send the process
 object to the `Stop-Process` cmdlet, which stops the Notepad process. Notice
-that the `Stop-Process` command doesn't have a **Name** or **ID** parameter to
+that the `Stop-Process` command doesn't have a **Name** or **Id** parameter to
 specify the process, because the specified process is submitted through the
 pipeline.
 
@@ -60,9 +60,9 @@ displays the name and length of each file in a table.
 
 ```powershell
 Get-ChildItem -Path *.txt |
-  Where-Object {$_.length -gt 10000} |
-    Sort-Object -Property length |
-      Format-Table -Property name, length
+  Where-Object {$_.Length -gt 10000} |
+    Sort-Object -Property Length |
+      Format-Table -Property Name, Length
 ```
 
 This pipeline consists of four commands in the specified order. The following
@@ -73,7 +73,7 @@ command in the pipeline.
 Get-ChildItem -Path *.txt
 | (FileInfo objects for *.txt)
 V
-Where-Object {$_.length -gt 10000}
+Where-Object {$_.Length -gt 10000}
 | (FileInfo objects for *.txt)
 | (      Length > 10000      )
 V
@@ -82,7 +82,7 @@ Sort-Object -Property Length
 | (      Length > 10000      )
 | (     Sorted by length     )
 V
-Format-Table -Property name, length
+Format-Table -Property Name, Length
 | (FileInfo objects for *.txt)
 | (      Length > 10000      )
 | (     Sorted by length     )
@@ -110,7 +110,7 @@ Get-Service wmi | Start-Service
 ```
 
 For another example, you can pipe the output of `Get-Item` or `Get-ChildItem`
-within the PowerShell registry provider to the `New-ItemProperty` cmdlet. This
+within the PowerShell Registry provider to the `New-ItemProperty` cmdlet. This
 example adds a new registry entry, **NoOfEmployees**, with a value of **8124**,
 to the **MyCompany** registry key.
 
@@ -126,11 +126,11 @@ how to sort all the processes on the computer by the number of open handles in
 each process.
 
 ```powershell
-Get-Process | Sort-Object -Property handles
+Get-Process | Sort-Object -Property Handles
 ```
 
 You can pipe objects to the formatting, export, and output cmdlets, such as
-`Format-List`, `Format-Table`, `Export-Clixml`, `Export-CSV`, and `Out-File`.
+`Format-List`, `Format-Table`, `Export-Clixml`, `Export-Csv`, and `Out-File`.
 
 This example shows how to use the `Format-List` cmdlet to display a list of
 properties for a process object.
@@ -391,7 +391,7 @@ use that to count the number of processes running on the computer.
 For example,
 
 ```powershell
-(Get-Process).count
+(Get-Process).Count
 ```
 
 It's important to remember that objects sent down the pipeline are delivered
@@ -604,13 +604,13 @@ use this new functionality.
 ```powershell
 # Wrapping with a pipe at the beginning of a line (no backtick required)
 Get-Process | Where-Object CPU | Where-Object Path
-    | Get-Item | Where-Object FullName -match "AppData"
+    | Get-Item | Where-Object FullName -Match "AppData"
     | Sort-Object FullName -Unique
 
 # Wrapping with a pipe on a line by itself
 Get-Process | Where-Object CPU | Where-Object Path
     |
-    Get-Item | Where-Object FullName -match "AppData"
+    Get-Item | Where-Object FullName -Match "AppData"
     |
     Sort-Object FullName -Unique
 ```
@@ -627,7 +627,7 @@ Get-Process | Where-Object CPU | Where-Object Path
 - [about_Objects][05]
 - [about_Parameters][06]
 - [about_Command_Syntax][03]
-- [about_ForEach][04]
+- [about_Foreach][04]
 
 <!-- link references -->
 [02]: #investigating-pipeline-errors

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -60,8 +60,8 @@ PowerShell includes the following environment variables that store user
 preferences. For more information about these environment variables, see
 [about_Environment_Variables][30].
 
-- `$env:PSExecutionPolicyPreference`
-- `$env:PSModulePath`
+- `$Env:PSExecutionPolicyPreference`
+- `$Env:PSModulePath`
 
 > [!NOTE]
 > Changes to preference variables apply only in the scope they are made
@@ -549,7 +549,7 @@ default, **ConciseView**. `Get-ChildItem` is used to find a non-existent
 directory.
 
 ```powershell
-Get-ChildItem -path 'C:\NoRealDirectory'
+Get-ChildItem -Path 'C:\NoRealDirectory'
 ```
 
 ```Output
@@ -599,7 +599,7 @@ ObjectNotFound: (C:\nofile.txt:String) [Get-ChildItem], ItemNotFoundException
 This example demonstrates that the value of `$ErrorView` only affects the error
 display. It doesn't change the structure of the error object that's stored in
 the `$Error` automatic variable. For information about the `$Error` automatic
-variable, see [about_automatic_variables][28].
+variable, see [about_Automatic_Variables][28].
 
 The following command takes the **ErrorRecord** object associated with the most
 recent error in the error array, **element 0**, and formats the properties of
@@ -785,14 +785,14 @@ To enable a **Log*Event**, type the variable with a value of `$true`, for
 example:
 
 ```powershell
-$LogCommandLifeCycleEvent = $true
+$LogCommandLifecycleEvent = $true
 ```
 
 To disable an event type, type the variable with a value of `$false`, for
 example:
 
 ```powershell
-$LogCommandLifeCycleEvent = $false
+$LogCommandLifecycleEvent = $false
 ```
 
 The events that you enable are effective only for the current PowerShell
@@ -988,16 +988,16 @@ Specifies the default email server that's used to send email messages. This
 preference variable is used by cmdlets that send email, such as the
 [Send-MailMessage][48] cmdlet.
 
-## $PSModuleAutoloadingPreference
+## $PSModuleAutoLoadingPreference
 
 Enables and disables automatic importing of modules in the session. The
-`$PSModuleAutoloadingPreference` variable doesn't exist by default. The default
+`$PSModuleAutoLoadingPreference` variable doesn't exist by default. The default
 behavior when the variable isn't defined is the same as
-`$PSModuleAutoloadingPreference = 'All'`.
+`$PSModuleAutoLoadingPreference = 'All'`.
 
 To automatically import a module, get or use a command contained in the module.
 
-The `$PSModuleAutoloadingPreference` variable takes one of the
+The `$PSModuleAutoLoadingPreference` variable takes one of the
 [`PSModuleAutoLoadingPreference`][58] enumeration values:
 
 - `All`: Modules are imported automatically on first-use.
@@ -1687,7 +1687,7 @@ At line:1 char:1
 
 ## See also
 
-- [about_automatic_variables][28]
+- [about_Automatic_Variables][28]
 - [about_CommonParameters][29]
 - [about_Environment_Variables][30]
 - [about_Profiles][36]

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -216,9 +216,9 @@ Here are a few suggestions to get you started.
 ### Add a function that lists aliases for any cmdlet
 
 ```powershell
-function Get-CmdletAlias ($cmdletname) {
+function Get-CmdletAlias ($cmdletName) {
   Get-Alias |
-    Where-Object -FilterScript {$_.Definition -like "$cmdletname"} |
+    Where-Object -FilterScript {$_.Definition -like "$cmdletName"} |
       Format-Table -Property Definition, Name -AutoSize
 }
 ```
@@ -227,9 +227,9 @@ function Get-CmdletAlias ($cmdletname) {
 
 ```powershell
 function CustomizeConsole {
-  $hosttime = (Get-ChildItem -Path $PSHOME\pwsh.exe).CreationTime
-  $hostversion="$($Host.Version.Major)`.$($Host.Version.Minor)"
-  $Host.UI.RawUI.WindowTitle = "PowerShell $hostversion ($hosttime)"
+  $hostTime = (Get-ChildItem -Path $PSHOME\pwsh.exe).CreationTime
+  $hostVersion="$($Host.Version.Major)`.$($Host.Version.Minor)"
+  $Host.UI.RawUI.WindowTitle = "PowerShell $hostVersion ($hostTime)"
   Clear-Host
 }
 CustomizeConsole
@@ -238,8 +238,8 @@ CustomizeConsole
 ### Add a customized PowerShell prompt
 
 ```powershell
-function Prompt {
-    $env:COMPUTERNAME + "\" + (Get-Location) + "> "
+function prompt {
+    $Env:COMPUTERNAME + "\" + (Get-Location) + "> "
 }
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -1,5 +1,5 @@
 ---
-description: Describes the `Prompt` function and demonstrates how to create a custom `Prompt` function.
+description: Describes the `prompt` function and demonstrates how to create a custom `prompt` function.
 Locale: en-US
 ms.date: 08/21/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_prompts?view=powershell-7.4&WT.mc_id=ps-gethelp
@@ -9,8 +9,8 @@ title: about_Prompts
 # about_Prompts
 
 ## Short description
-Describes the `Prompt` function and demonstrates how to create a custom
-`Prompt` function.
+Describes the `prompt` function and demonstrates how to create a custom
+`prompt` function.
 
 ## Long description
 
@@ -21,26 +21,26 @@ command:
 PS C:\>
 ```
 
-PowerShell has a built-in `Prompt` function. You can define your own customized
-`Prompt` function in your PowerShell profile script.
+PowerShell has a built-in `prompt` function. You can define your own customized
+`prompt` function in your PowerShell profile script.
 
-## About the Prompt function
+## About the `prompt` function
 
-The `Prompt` function determines the appearance of the PowerShell prompt.
-PowerShell comes with a built-in `Prompt` function, but you can override it by
-defining your own `Prompt` function.
+The `prompt` function determines the appearance of the PowerShell prompt.
+PowerShell comes with a built-in `prompt` function, but you can override it by
+defining your own `prompt` function.
 
-The `Prompt` function has the following syntax:
+The `prompt` function has the following syntax:
 
 ```powershell
-function Prompt { <function-body> }
+function prompt { <function-body> }
 ```
 
-The `Prompt` function must return an object. As a best practice, return a
+The `prompt` function must return an object. As a best practice, return a
 string or an object that's formatted as a string. The maximum recommended
 length is 80 characters.
 
-For example, the following `Prompt` function returns a "Hello, World" string
+For example, the following `prompt` function returns a "Hello, World" string
 followed by a  right angle bracket (`>`).
 
 ```powershell
@@ -48,15 +48,15 @@ PS C:\> function prompt {"Hello, World > "}
 Hello, World >
 ```
 
-### Getting the Prompt function
+### Getting the `prompt` function
 
-To get the `Prompt` function, use the `Get-Command` cmdlet or use the
+To get the `prompt` function, use the `Get-Command` cmdlet or use the
 `Get-Item` cmdlet in the Function drive.
 
 For example:
 
 ```powershell
-PS C:\> Get-Command Prompt
+PS C:\> Get-Command prompt
 
 CommandType     Name      ModuleName
 -----------     ----      ----------
@@ -64,12 +64,12 @@ Function        prompt
 ```
 
 To get the script that sets the value of the prompt, use the dot method to get
-the **ScriptBlock** property of the `Prompt` function.
+the **ScriptBlock** property of the `prompt` function.
 
 For example:
 
 ```powershell
-(Get-Command Prompt).ScriptBlock
+(Get-Command prompt).ScriptBlock
 ```
 
 ```Output
@@ -79,16 +79,16 @@ For example:
 # .ExternalHelp System.Management.Automation.dll-help.xml
 ```
 
-Like all functions, the `Prompt` function is stored in the `Function:` drive.
-To display the script that creates the current `Prompt` function, type:
+Like all functions, the `prompt` function is stored in the `Function:` drive.
+To display the script that creates the current `prompt` function, type:
 
 ```powershell
-(Get-Item function:prompt).ScriptBlock
+(Get-Item Function:prompt).ScriptBlock
 ```
 
 ### The default prompt
 
-The default prompt appears only when the `Prompt` function generates an error
+The default prompt appears only when the `prompt` function generates an error
 or doesn't return an object.
 
 The default PowerShell prompt is:
@@ -97,7 +97,7 @@ The default PowerShell prompt is:
 PS>
 ```
 
-For example, the following command sets the `Prompt` function to `$null`, which
+For example, the following command sets the `prompt` function to `$null`, which
 is invalid. As a result, the default prompt appears.
 
 ```powershell
@@ -110,7 +110,7 @@ default prompt.
 
 ### Built-in prompt
 
-PowerShell includes a built-in `Prompt` function.
+PowerShell includes a built-in `prompt` function.
 
 ```powershell
 function prompt {
@@ -153,7 +153,7 @@ the following prompt:
 ### Changes to the prompt
 
 The `Enter-PSSession` cmdlet prepends the name of the remote computer to the
-current `Prompt` function. When you use the `Enter-PSSession` cmdlet to start a
+current `prompt` function. When you use the `Enter-PSSession` cmdlet to start a
 session with a remote computer, the command prompt changes to include the name
 of the remote computer. For example:
 
@@ -170,10 +170,10 @@ automatic variables, see [about_Automatic_Variables][01].
 
 ### How to customize the prompt
 
-To customize the prompt, write a new `Prompt` function. The function isn't
+To customize the prompt, write a new `prompt` function. The function isn't
 protected, so you can overwrite it.
 
-To write a `Prompt` function, type the following:
+To write a `prompt` function, type the following:
 
 ```powershell
 function prompt { }
@@ -185,7 +185,7 @@ prompt.
 For example, the following prompt includes your computer name:
 
 ```powershell
-function prompt {"PS [$env:COMPUTERNAME]> "}
+function prompt {"PS [$Env:COMPUTERNAME]> "}
 ```
 
 On the Server01 computer, the prompt resembles the following prompt:
@@ -194,7 +194,7 @@ On the Server01 computer, the prompt resembles the following prompt:
 PS [Server01] >
 ```
 
-The following `Prompt` function includes the current date and time:
+The following `prompt` function includes the current date and time:
 
 ```powershell
 function prompt {"$(Get-Date)> "}
@@ -206,9 +206,9 @@ The prompt resembles the following prompt:
 03/15/2012 17:49:47>
 ```
 
-You can also change the default `Prompt` function:
+You can also change the default `prompt` function:
 
-For example, the following modified `Prompt` function adds `[ADMIN]:` to the
+For example, the following modified `prompt` function adds `[ADMIN]:` to the
 built-in PowerShell prompt when running in an elevated session.
 
 ```powershell
@@ -217,7 +217,7 @@ function prompt {
   $principal = [Security.Principal.WindowsPrincipal] $identity
   $adminRole = [Security.Principal.WindowsBuiltInRole]::Administrator
 
-  $(if (Test-Path variable:/PSDebugContext) { '[DBG]: ' }
+  $(if (Test-Path Variable:/PSDebugContext) { '[DBG]: ' }
     elseif($principal.IsInRole($adminRole)) { "[ADMIN]: " }
     else { '' }
   ) + 'PS ' + $(Get-Location) +
@@ -232,7 +232,7 @@ that resembles the following prompt appears:
 [ADMIN]: PS C:\ps-test>
 ```
 
-The following `Prompt` function displays the history ID of the next command. To
+The following `prompt` function displays the history ID of the next command. To
 view the command history, use the `Get-History` cmdlet.
 
 ```powershell
@@ -254,21 +254,21 @@ function prompt {
 The following prompt uses the `Write-Host` and `Get-Random` cmdlets to create a
 prompt that changes color randomly. Because `Write-Host` writes to the current
 host application but doesn't return an object, this function includes a
-`Return` statement. Without it, PowerShell uses the default prompt, `PS>`.
+`return` statement. Without it, PowerShell uses the default prompt, `PS>`.
 
 ```powershell
 function prompt {
     $color = Get-Random -Min 1 -Max 16
-    Write-Host ("PS " + $(Get-Location) +">") -NoNewLine `
+    Write-Host ("PS " + $(Get-Location) +">") -NoNewline `
      -ForegroundColor $Color
     return " "
 }
 ```
 
-### Saving the Prompt function
+### Saving the `prompt` function
 
-Like any function, the `Prompt` function exists only in the current session. To
-save the `Prompt` function for future sessions, add it to your PowerShell
+Like any function, the `prompt` function exists only in the current session. To
+save the `prompt` function for future sessions, add it to your PowerShell
 profiles. For more information about profiles, see [about_Profiles][04].
 
 ## See also

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -265,7 +265,7 @@ PS> $collection = @(
 $collection.Length
 2
 
-# Get the length property of each item in the collection.
+# Get the Length property of each item in the collection.
 PS> $collection.GetEnumerator().Length
 foo
 bar

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -196,7 +196,7 @@ cmdlets. Type the drive name followed by a colon (`:`). For example, to view
 the contents of the `Alias:` drive, type:
 
 ```powershell
-Get-Item alias:
+Get-Item Alias:
 ```
 
 You can view and manage the data in any drive from another drive by including
@@ -212,7 +212,7 @@ specify the drive path. For example, to change your location to the root
 directory of the `Cert:` drive, type:
 
 ```powershell
-Set-Location cert:
+Set-Location Cert:
 ```
 
 Then, to view the contents of the `Cert:` drive, type:
@@ -306,7 +306,7 @@ Cert:\> Set-Location ~
 
 ```Output
 Set-Location : Home location for this provider isn't set. To set the home
-location, call "(get-psprovider 'Certificate').Home = 'path'".
+location, call "(Get-PSProvider 'Certificate').Home = 'path'".
 At line:1 char:1
 + Set-Location ~
 + ~~~~~~~~~~~~~~
@@ -335,7 +335,7 @@ Get-Help <provider-name>
 For example:
 
 ```powershell
-Get-Help certificate
+Get-Help Certificate
 ```
 
 ## Learning about providers
@@ -354,7 +354,7 @@ Get-Help <ProviderName>
 For example:
 
 ```powershell
-Get-Help registry
+Get-Help Registry
 ```
 
 For a list of Help topics about the providers, type:

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_PSConsoleHostReadLine.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_PSConsoleHostReadLine.md
@@ -27,7 +27,7 @@ the user creates:
 
 ```powershell
 function PSConsoleHostReadLine {
-  $inputFile = Join-Path $env:TEMP PSConsoleHostReadLine
+  $inputFile = Join-Path $Env:TEMP PSConsoleHostReadLine
   Set-Content $inputFile "PS > "
 
   # Notepad opens. Enter your command in it, save the file, and then exit.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
@@ -23,7 +23,7 @@ properties and values was more complicated. Originally, you had to use
 example:
 
 ```powershell
-PS> $object1 = New-Object -TypeName PSObject
+PS> $object1 = New-Object -TypeName psobject
 PS> Add-Member -InputObject $object1 -MemberType NoteProperty -Name one -Value 1
 PS> Add-Member -InputObject $object1 -MemberType NoteProperty -Name two -Value 2
 PS> $object1 | Get-Member
@@ -50,7 +50,7 @@ Later, you could use the **Property** parameter of `New-Object` to pass a
 **Hashtable** containing the members and values. For example:
 
 ```powershell
-PS> $object2 = New-Object -TypeName PSObject -Property @{one=1; two=2}
+PS> $object2 = New-Object -TypeName psobject -Property @{one=1; two=2}
 PS> $object2 | Get-Member
 
    TypeName: System.Management.Automation.PSCustomObject
@@ -190,11 +190,11 @@ have subtle side effects.
 - Wrapped objects match their original type and the `[psobject]` type.
 
   ```powershell
-  PS> 1 -is [Int32]
+  PS> 1 -is [int32]
   True
   PS> 1 -is [psobject]
   False
-  PS> ([psobject] 1) -is [Int32]
+  PS> ([psobject] 1) -is [int32]
   True
   PS> ([psobject] 1) -is [psobject]
   True
@@ -253,7 +253,7 @@ When that hashtable is cast to a `[pscustomobject]`, the case of the name of
 first key is used, but that value of the last matching key name is used.
 
 ```powershell
-[PSCustomObject]$OrderedHashTable
+[pscustomobject]$OrderedHashTable
 ```
 
 ```Output
@@ -271,7 +271,7 @@ Attempting to access these members returns `$null`.
 For example:
 
 ```powershell
-PS> $object = [PSCustomObject]@{key = 'value'}
+PS> $object = [pscustomobject]@{key = 'value'}
 PS> $object
 
 key

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_PSItem.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_PSItem.md
@@ -190,7 +190,7 @@ parameters that take input from the pipeline.
 function Write-JsonLog {
     [CmdletBinding()]
     param(
-        [parameter(ValueFromPipelineByPropertyName)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [string]$Message
     )
     begin {
@@ -378,9 +378,9 @@ was included, verify that the path is correct and try again.
 For more examples, see the _Accessing exception information_ section in
 [about_Try_Catch_Finally][14].
 
-## The -replace operator's substitution scriptblock
+## The `-replace` operator's substitution scriptblock
 
-Starting in PowerShell 6, you can use `$PSItem` when calling the [replace][04]
+Starting in PowerShell 6, you can use `$PSItem` when calling the [-replace][04]
 operator and defining a [substitution scriptblock][05]. When you do, the value
 of `$PSItem` is the value of the current match.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Parsing.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Parsing.md
@@ -59,7 +59,7 @@ Variable expressions carry the value of the variable they reference:
 
 ```powershell
 $x
-$script:path
+$Script:path
 ```
 
 Operators combine other expressions for evaluation:
@@ -391,7 +391,7 @@ In `Windows` or `Standard` mode, the following examples produce the expected
 results:
 
 ```powershell
-TestExe -echoargs """${env:ProgramFiles(x86)}\Microsoft\"""
+TestExe -echoargs """${Env:ProgramFiles(x86)}\Microsoft\"""
 TestExe -echoargs '"C:\Program Files (x86)\Microsoft\"'
 ```
 
@@ -399,7 +399,7 @@ To get the same results in `Legacy` mode, you must escape the quotes or use the
 stop-parsing token (`--%`):
 
 ```powershell
-TestExe -echoargs """""${env:ProgramFiles(x86)}\Microsoft\\"""""
+TestExe -echoargs """""${Env:ProgramFiles(x86)}\Microsoft\\"""""
 TestExe -echoargs "\""C:\Program Files (x86)\Microsoft\\"""
 TestExe -echoargs --% ""\""C:\Program Files (x86)\Microsoft\\"\"""
 TestExe -echoargs --% """C:\Program Files (x86)\Microsoft\\""
@@ -439,7 +439,7 @@ Unlike the stop-parsing (`--%`) token, any values following the `--` token can
 be interpreted as expressions by PowerShell.
 
 ```powershell
-Write-Output -- -InputObject $env:PROCESSOR_ARCHITECTURE
+Write-Output -- -InputObject $Env:PROCESSOR_ARCHITECTURE
 ```
 
 ```Output
@@ -521,13 +521,13 @@ using `Trace-Command`.
 
 ```powershell
 Trace-Command -Name ParameterBinding -Expression {
-    findstr /c:"foo" ~\repocache.clixml
+    findstr /C:\foo" ~\repocache.clixml
 } -PSHost
 ```
 
 ```Output
 DEBUG: 2024-05-06 15:13:46.8268 ParameterBinding Information: 0 : BIND NAMED native application line args [C:\Windows\system32\findstr.exe]
-DEBUG: 2024-05-06 15:13:46.8270 ParameterBinding Information: 0 :     BIND cmd line arg [/c:foo] to position [0]
+DEBUG: 2024-05-06 15:13:46.8270 ParameterBinding Information: 0 :     BIND cmd line arg [/C:\oo] to position [0]
 DEBUG: 2024-05-06 15:13:46.8271 ParameterBinding Information: 0 :     BIND cmd line arg [C:\Users\user2\repocache.clixml] to position [1]
 DEBUG: 2024-05-06 15:13:46.8322 ParameterBinding Information: 0 : CALLING BeginProcessing
 ```

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Pipelines.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Pipelines.md
@@ -50,7 +50,7 @@ Get-Process notepad | Stop-Process
 The first command uses the `Get-Process` cmdlet to get an object representing
 the Notepad process. It uses a pipeline operator (`|`) to send the process
 object to the `Stop-Process` cmdlet, which stops the Notepad process. Notice
-that the `Stop-Process` command doesn't have a **Name** or **ID** parameter to
+that the `Stop-Process` command doesn't have a **Name** or **Id** parameter to
 specify the process, because the specified process is submitted through the
 pipeline.
 
@@ -60,9 +60,9 @@ displays the name and length of each file in a table.
 
 ```powershell
 Get-ChildItem -Path *.txt |
-  Where-Object {$_.length -gt 10000} |
-    Sort-Object -Property length |
-      Format-Table -Property name, length
+  Where-Object {$_.Length -gt 10000} |
+    Sort-Object -Property Length |
+      Format-Table -Property Name, Length
 ```
 
 This pipeline consists of four commands in the specified order. The following
@@ -73,7 +73,7 @@ command in the pipeline.
 Get-ChildItem -Path *.txt
 | (FileInfo objects for *.txt)
 V
-Where-Object {$_.length -gt 10000}
+Where-Object {$_.Length -gt 10000}
 | (FileInfo objects for *.txt)
 | (      Length > 10000      )
 V
@@ -82,7 +82,7 @@ Sort-Object -Property Length
 | (      Length > 10000      )
 | (     Sorted by length     )
 V
-Format-Table -Property name, length
+Format-Table -Property Name, Length
 | (FileInfo objects for *.txt)
 | (      Length > 10000      )
 | (     Sorted by length     )
@@ -110,7 +110,7 @@ Get-Service wmi | Start-Service
 ```
 
 For another example, you can pipe the output of `Get-Item` or `Get-ChildItem`
-within the PowerShell registry provider to the `New-ItemProperty` cmdlet. This
+within the PowerShell Registry provider to the `New-ItemProperty` cmdlet. This
 example adds a new registry entry, **NoOfEmployees**, with a value of **8124**,
 to the **MyCompany** registry key.
 
@@ -126,11 +126,11 @@ how to sort all the processes on the computer by the number of open handles in
 each process.
 
 ```powershell
-Get-Process | Sort-Object -Property handles
+Get-Process | Sort-Object -Property Handles
 ```
 
 You can pipe objects to the formatting, export, and output cmdlets, such as
-`Format-List`, `Format-Table`, `Export-Clixml`, `Export-CSV`, and `Out-File`.
+`Format-List`, `Format-Table`, `Export-Clixml`, `Export-Csv`, and `Out-File`.
 
 This example shows how to use the `Format-List` cmdlet to display a list of
 properties for a process object.
@@ -391,7 +391,7 @@ use that to count the number of processes running on the computer.
 For example,
 
 ```powershell
-(Get-Process).count
+(Get-Process).Count
 ```
 
 It's important to remember that objects sent down the pipeline are delivered
@@ -604,13 +604,13 @@ use this new functionality.
 ```powershell
 # Wrapping with a pipe at the beginning of a line (no backtick required)
 Get-Process | Where-Object CPU | Where-Object Path
-    | Get-Item | Where-Object FullName -match "AppData"
+    | Get-Item | Where-Object FullName -Match "AppData"
     | Sort-Object FullName -Unique
 
 # Wrapping with a pipe on a line by itself
 Get-Process | Where-Object CPU | Where-Object Path
     |
-    Get-Item | Where-Object FullName -match "AppData"
+    Get-Item | Where-Object FullName -Match "AppData"
     |
     Sort-Object FullName -Unique
 ```
@@ -627,7 +627,7 @@ Get-Process | Where-Object CPU | Where-Object Path
 - [about_Objects][05]
 - [about_Parameters][06]
 - [about_Command_Syntax][03]
-- [about_ForEach][04]
+- [about_Foreach][04]
 
 <!-- link references -->
 [02]: #investigating-pipeline-errors

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -60,8 +60,8 @@ PowerShell includes the following environment variables that store user
 preferences. For more information about these environment variables, see
 [about_Environment_Variables][30].
 
-- `$env:PSExecutionPolicyPreference`
-- `$env:PSModulePath`
+- `$Env:PSExecutionPolicyPreference`
+- `$Env:PSModulePath`
 
 > [!NOTE]
 > Changes to preference variables apply only in the scope they are made
@@ -549,7 +549,7 @@ default, **ConciseView**. `Get-ChildItem` is used to find a non-existent
 directory.
 
 ```powershell
-Get-ChildItem -path 'C:\NoRealDirectory'
+Get-ChildItem -Path 'C:\NoRealDirectory'
 ```
 
 ```Output
@@ -599,7 +599,7 @@ ObjectNotFound: (C:\nofile.txt:String) [Get-ChildItem], ItemNotFoundException
 This example demonstrates that the value of `$ErrorView` only affects the error
 display. It doesn't change the structure of the error object that's stored in
 the `$Error` automatic variable. For information about the `$Error` automatic
-variable, see [about_automatic_variables][28].
+variable, see [about_Automatic_Variables][28].
 
 The following command takes the **ErrorRecord** object associated with the most
 recent error in the error array, **element 0**, and formats the properties of
@@ -785,14 +785,14 @@ To enable a **Log*Event**, type the variable with a value of `$true`, for
 example:
 
 ```powershell
-$LogCommandLifeCycleEvent = $true
+$LogCommandLifecycleEvent = $true
 ```
 
 To disable an event type, type the variable with a value of `$false`, for
 example:
 
 ```powershell
-$LogCommandLifeCycleEvent = $false
+$LogCommandLifecycleEvent = $false
 ```
 
 The events that you enable are effective only for the current PowerShell
@@ -988,16 +988,16 @@ Specifies the default email server that's used to send email messages. This
 preference variable is used by cmdlets that send email, such as the
 [Send-MailMessage][48] cmdlet.
 
-## $PSModuleAutoloadingPreference
+## $PSModuleAutoLoadingPreference
 
 Enables and disables automatic importing of modules in the session. The
-`$PSModuleAutoloadingPreference` variable doesn't exist by default. The default
+`$PSModuleAutoLoadingPreference` variable doesn't exist by default. The default
 behavior when the variable isn't defined is the same as
-`$PSModuleAutoloadingPreference = 'All'`.
+`$PSModuleAutoLoadingPreference = 'All'`.
 
 To automatically import a module, get or use a command contained in the module.
 
-The `$PSModuleAutoloadingPreference` variable takes one of the
+The `$PSModuleAutoLoadingPreference` variable takes one of the
 [`PSModuleAutoLoadingPreference`][58] enumeration values:
 
 - `All`: Modules are imported automatically on first-use.
@@ -1687,7 +1687,7 @@ At line:1 char:1
 
 ## See also
 
-- [about_automatic_variables][28]
+- [about_Automatic_Variables][28]
 - [about_CommonParameters][29]
 - [about_Environment_Variables][30]
 - [about_Profiles][36]

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -217,9 +217,9 @@ Here are a few suggestions to get you started.
 ### Add a function that lists aliases for any cmdlet
 
 ```powershell
-function Get-CmdletAlias ($cmdletname) {
+function Get-CmdletAlias ($cmdletName) {
   Get-Alias |
-    Where-Object -FilterScript {$_.Definition -like "$cmdletname"} |
+    Where-Object -FilterScript {$_.Definition -like "$cmdletName"} |
       Format-Table -Property Definition, Name -AutoSize
 }
 ```
@@ -228,9 +228,9 @@ function Get-CmdletAlias ($cmdletname) {
 
 ```powershell
 function CustomizeConsole {
-  $hosttime = (Get-ChildItem -Path $PSHOME\pwsh.exe).CreationTime
-  $hostversion="$($Host.Version.Major)`.$($Host.Version.Minor)"
-  $Host.UI.RawUI.WindowTitle = "PowerShell $hostversion ($hosttime)"
+  $hostTime = (Get-ChildItem -Path $PSHOME\pwsh.exe).CreationTime
+  $hostVersion="$($Host.Version.Major)`.$($Host.Version.Minor)"
+  $Host.UI.RawUI.WindowTitle = "PowerShell $hostVersion ($hostTime)"
   Clear-Host
 }
 CustomizeConsole
@@ -239,8 +239,8 @@ CustomizeConsole
 ### Add a customized PowerShell prompt
 
 ```powershell
-function Prompt {
-    $env:COMPUTERNAME + "\" + (Get-Location) + "> "
+function prompt {
+    $Env:COMPUTERNAME + "\" + (Get-Location) + "> "
 }
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -1,5 +1,5 @@
 ---
-description: Describes the `Prompt` function and demonstrates how to create a custom `Prompt` function.
+description: Describes the `prompt` function and demonstrates how to create a custom `prompt` function.
 Locale: en-US
 ms.date: 08/21/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_prompts?view=powershell-7.5&WT.mc_id=ps-gethelp
@@ -10,8 +10,8 @@ title: about_Prompts
 
 ## Short description
 
-Describes the `Prompt` function and demonstrates how to create a custom
-`Prompt` function.
+Describes the `prompt` function and demonstrates how to create a custom
+`prompt` function.
 
 ## Long description
 
@@ -22,26 +22,26 @@ command:
 PS C:\>
 ```
 
-PowerShell has a built-in `Prompt` function. You can define your own customized
-`Prompt` function in your PowerShell profile script.
+PowerShell has a built-in `prompt` function. You can define your own customized
+`prompt` function in your PowerShell profile script.
 
-## About the Prompt function
+## About the `prompt` function
 
-The `Prompt` function determines the appearance of the PowerShell prompt.
-PowerShell comes with a built-in `Prompt` function, but you can override it by
-defining your own `Prompt` function.
+The `prompt` function determines the appearance of the PowerShell prompt.
+PowerShell comes with a built-in `prompt` function, but you can override it by
+defining your own `prompt` function.
 
-The `Prompt` function has the following syntax:
+The `prompt` function has the following syntax:
 
 ```powershell
-function Prompt { <function-body> }
+function prompt { <function-body> }
 ```
 
-The `Prompt` function must return an object. As a best practice, return a
+The `prompt` function must return an object. As a best practice, return a
 string or an object that's formatted as a string. The maximum recommended
 length is 80 characters.
 
-For example, the following `Prompt` function returns a "Hello, World" string
+For example, the following `prompt` function returns a "Hello, World" string
 followed by a  right angle bracket (`>`).
 
 ```powershell
@@ -49,15 +49,15 @@ PS C:\> function prompt {"Hello, World > "}
 Hello, World >
 ```
 
-### Getting the Prompt function
+### Getting the `prompt` function
 
-To get the `Prompt` function, use the `Get-Command` cmdlet or use the
+To get the `prompt` function, use the `Get-Command` cmdlet or use the
 `Get-Item` cmdlet in the Function drive.
 
 For example:
 
 ```powershell
-PS C:\> Get-Command Prompt
+PS C:\> Get-Command prompt
 
 CommandType     Name      ModuleName
 -----------     ----      ----------
@@ -65,12 +65,12 @@ Function        prompt
 ```
 
 To get the script that sets the value of the prompt, use the dot method to get
-the **ScriptBlock** property of the `Prompt` function.
+the **ScriptBlock** property of the `prompt` function.
 
 For example:
 
 ```powershell
-(Get-Command Prompt).ScriptBlock
+(Get-Command prompt).ScriptBlock
 ```
 
 ```Output
@@ -80,16 +80,16 @@ For example:
 # .ExternalHelp System.Management.Automation.dll-help.xml
 ```
 
-Like all functions, the `Prompt` function is stored in the `Function:` drive.
-To display the script that creates the current `Prompt` function, type:
+Like all functions, the `prompt` function is stored in the `Function:` drive.
+To display the script that creates the current `prompt` function, type:
 
 ```powershell
-(Get-Item function:prompt).ScriptBlock
+(Get-Item Function:prompt).ScriptBlock
 ```
 
 ### The default prompt
 
-The default prompt appears only when the `Prompt` function generates an error
+The default prompt appears only when the `prompt` function generates an error
 or doesn't return an object.
 
 The default PowerShell prompt is:
@@ -98,7 +98,7 @@ The default PowerShell prompt is:
 PS>
 ```
 
-For example, the following command sets the `Prompt` function to `$null`, which
+For example, the following command sets the `prompt` function to `$null`, which
 is invalid. As a result, the default prompt appears.
 
 ```powershell
@@ -111,7 +111,7 @@ default prompt.
 
 ### Built-in prompt
 
-PowerShell includes a built-in `Prompt` function.
+PowerShell includes a built-in `prompt` function.
 
 ```powershell
 function prompt {
@@ -154,7 +154,7 @@ the following prompt:
 ### Changes to the prompt
 
 The `Enter-PSSession` cmdlet prepends the name of the remote computer to the
-current `Prompt` function. When you use the `Enter-PSSession` cmdlet to start a
+current `prompt` function. When you use the `Enter-PSSession` cmdlet to start a
 session with a remote computer, the command prompt changes to include the name
 of the remote computer. For example:
 
@@ -171,10 +171,10 @@ automatic variables, see [about_Automatic_Variables][01].
 
 ### How to customize the prompt
 
-To customize the prompt, write a new `Prompt` function. The function isn't
+To customize the prompt, write a new `prompt` function. The function isn't
 protected, so you can overwrite it.
 
-To write a `Prompt` function, type the following:
+To write a `prompt` function, type the following:
 
 ```powershell
 function prompt { }
@@ -186,7 +186,7 @@ prompt.
 For example, the following prompt includes your computer name:
 
 ```powershell
-function prompt {"PS [$env:COMPUTERNAME]> "}
+function prompt {"PS [$Env:COMPUTERNAME]> "}
 ```
 
 On the Server01 computer, the prompt resembles the following prompt:
@@ -195,7 +195,7 @@ On the Server01 computer, the prompt resembles the following prompt:
 PS [Server01] >
 ```
 
-The following `Prompt` function includes the current date and time:
+The following `prompt` function includes the current date and time:
 
 ```powershell
 function prompt {"$(Get-Date)> "}
@@ -207,9 +207,9 @@ The prompt resembles the following prompt:
 03/15/2012 17:49:47>
 ```
 
-You can also change the default `Prompt` function:
+You can also change the default `prompt` function:
 
-For example, the following modified `Prompt` function adds `[ADMIN]:` to the
+For example, the following modified `prompt` function adds `[ADMIN]:` to the
 built-in PowerShell prompt when running in an elevated session.
 
 ```powershell
@@ -218,7 +218,7 @@ function prompt {
   $principal = [Security.Principal.WindowsPrincipal] $identity
   $adminRole = [Security.Principal.WindowsBuiltInRole]::Administrator
 
-  $(if (Test-Path variable:/PSDebugContext) { '[DBG]: ' }
+  $(if (Test-Path Variable:/PSDebugContext) { '[DBG]: ' }
     elseif($principal.IsInRole($adminRole)) { "[ADMIN]: " }
     else { '' }
   ) + 'PS ' + $(Get-Location) +
@@ -233,7 +233,7 @@ that resembles the following prompt appears:
 [ADMIN]: PS C:\ps-test>
 ```
 
-The following `Prompt` function displays the history ID of the next command. To
+The following `prompt` function displays the history ID of the next command. To
 view the command history, use the `Get-History` cmdlet.
 
 ```powershell
@@ -255,21 +255,21 @@ function prompt {
 The following prompt uses the `Write-Host` and `Get-Random` cmdlets to create a
 prompt that changes color randomly. Because `Write-Host` writes to the current
 host application but doesn't return an object, this function includes a
-`Return` statement. Without it, PowerShell uses the default prompt, `PS>`.
+`return` statement. Without it, PowerShell uses the default prompt, `PS>`.
 
 ```powershell
 function prompt {
     $color = Get-Random -Min 1 -Max 16
-    Write-Host ("PS " + $(Get-Location) +">") -NoNewLine `
+    Write-Host ("PS " + $(Get-Location) +">") -NoNewline `
      -ForegroundColor $Color
     return " "
 }
 ```
 
-### Saving the Prompt function
+### Saving the `prompt` function
 
-Like any function, the `Prompt` function exists only in the current session. To
-save the `Prompt` function for future sessions, add it to your PowerShell
+Like any function, the `prompt` function exists only in the current session. To
+save the `prompt` function for future sessions, add it to your PowerShell
 profiles. For more information about profiles, see [about_Profiles][04].
 
 ## See also

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -264,7 +264,7 @@ PS> $collection = @(
 $collection.Length
 2
 
-# Get the length property of each item in the collection.
+# Get the Length property of each item in the collection.
 PS> $collection.GetEnumerator().Length
 foo
 bar

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -197,7 +197,7 @@ cmdlets. Type the drive name followed by a colon (`:`). For example, to view
 the contents of the `Alias:` drive, type:
 
 ```powershell
-Get-Item alias:
+Get-Item Alias:
 ```
 
 You can view and manage the data in any drive from another drive by including
@@ -213,7 +213,7 @@ specify the drive path. For example, to change your location to the root
 directory of the `Cert:` drive, type:
 
 ```powershell
-Set-Location cert:
+Set-Location Cert:
 ```
 
 Then, to view the contents of the `Cert:` drive, type:
@@ -307,7 +307,7 @@ Cert:\> Set-Location ~
 
 ```Output
 Set-Location : Home location for this provider isn't set. To set the home
-location, call "(get-psprovider 'Certificate').Home = 'path'".
+location, call "(Get-PSProvider 'Certificate').Home = 'path'".
 At line:1 char:1
 + Set-Location ~
 + ~~~~~~~~~~~~~~
@@ -336,7 +336,7 @@ Get-Help <provider-name>
 For example:
 
 ```powershell
-Get-Help certificate
+Get-Help Certificate
 ```
 
 ## Learning about providers
@@ -355,7 +355,7 @@ Get-Help <ProviderName>
 For example:
 
 ```powershell
-Get-Help registry
+Get-Help Registry
 ```
 
 For a list of Help topics about the providers, type:

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_PSConsoleHostReadLine.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_PSConsoleHostReadLine.md
@@ -27,7 +27,7 @@ the user creates:
 
 ```powershell
 function PSConsoleHostReadLine {
-  $inputFile = Join-Path $env:TEMP PSConsoleHostReadLine
+  $inputFile = Join-Path $Env:TEMP PSConsoleHostReadLine
   Set-Content $inputFile "PS > "
 
   # Notepad opens. Enter your command in it, save the file, and then exit.

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_PSCustomObject.md
@@ -23,7 +23,7 @@ properties and values was more complicated. Originally, you had to use
 example:
 
 ```powershell
-PS> $object1 = New-Object -TypeName PSObject
+PS> $object1 = New-Object -TypeName psobject
 PS> Add-Member -InputObject $object1 -MemberType NoteProperty -Name one -Value 1
 PS> Add-Member -InputObject $object1 -MemberType NoteProperty -Name two -Value 2
 PS> $object1 | Get-Member
@@ -50,7 +50,7 @@ Later, you could use the **Property** parameter of `New-Object` to pass a
 **Hashtable** containing the members and values. For example:
 
 ```powershell
-PS> $object2 = New-Object -TypeName PSObject -Property @{one=1; two=2}
+PS> $object2 = New-Object -TypeName psobject -Property @{one=1; two=2}
 PS> $object2 | Get-Member
 
    TypeName: System.Management.Automation.PSCustomObject
@@ -190,11 +190,11 @@ have subtle side effects.
 - Wrapped objects match their original type and the `[psobject]` type.
 
   ```powershell
-  PS> 1 -is [Int32]
+  PS> 1 -is [int32]
   True
   PS> 1 -is [psobject]
   False
-  PS> ([psobject] 1) -is [Int32]
+  PS> ([psobject] 1) -is [int32]
   True
   PS> ([psobject] 1) -is [psobject]
   True
@@ -253,7 +253,7 @@ When that hashtable is cast to a `[pscustomobject]`, the case of the name of
 first key is used, but that value of the last matching key name is used.
 
 ```powershell
-[PSCustomObject]$OrderedHashTable
+[pscustomobject]$OrderedHashTable
 ```
 
 ```Output
@@ -271,7 +271,7 @@ Attempting to access these members returns `$null`.
 For example:
 
 ```powershell
-PS> $object = [PSCustomObject]@{key = 'value'}
+PS> $object = [pscustomobject]@{key = 'value'}
 PS> $object
 
 key

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_PSItem.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_PSItem.md
@@ -190,7 +190,7 @@ parameters that take input from the pipeline.
 function Write-JsonLog {
     [CmdletBinding()]
     param(
-        [parameter(ValueFromPipelineByPropertyName)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [string]$Message
     )
     begin {
@@ -378,9 +378,9 @@ was included, verify that the path is correct and try again.
 For more examples, see the _Accessing exception information_ section in
 [about_Try_Catch_Finally][14].
 
-## The -replace operator's substitution scriptblock
+## The `-replace` operator's substitution scriptblock
 
-Starting in PowerShell 6, you can use `$PSItem` when calling the [replace][04]
+Starting in PowerShell 6, you can use `$PSItem` when calling the [-replace][04]
 operator and defining a [substitution scriptblock][05]. When you do, the value
 of `$PSItem` is the value of the current match.
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Parsing.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Parsing.md
@@ -59,7 +59,7 @@ Variable expressions carry the value of the variable they reference:
 
 ```powershell
 $x
-$script:path
+$Script:path
 ```
 
 Operators combine other expressions for evaluation:
@@ -391,7 +391,7 @@ In `Windows` or `Standard` mode, the following examples produce the expected
 results:
 
 ```powershell
-TestExe -echoargs """${env:ProgramFiles(x86)}\Microsoft\"""
+TestExe -echoargs """${Env:ProgramFiles(x86)}\Microsoft\"""
 TestExe -echoargs '"C:\Program Files (x86)\Microsoft\"'
 ```
 
@@ -399,7 +399,7 @@ To get the same results in `Legacy` mode, you must escape the quotes or use the
 stop-parsing token (`--%`):
 
 ```powershell
-TestExe -echoargs """""${env:ProgramFiles(x86)}\Microsoft\\"""""
+TestExe -echoargs """""${Env:ProgramFiles(x86)}\Microsoft\\"""""
 TestExe -echoargs "\""C:\Program Files (x86)\Microsoft\\"""
 TestExe -echoargs --% ""\""C:\Program Files (x86)\Microsoft\\"\"""
 TestExe -echoargs --% """C:\Program Files (x86)\Microsoft\\""
@@ -439,7 +439,7 @@ Unlike the stop-parsing (`--%`) token, any values following the `--` token can
 be interpreted as expressions by PowerShell.
 
 ```powershell
-Write-Output -- -InputObject $env:PROCESSOR_ARCHITECTURE
+Write-Output -- -InputObject $Env:PROCESSOR_ARCHITECTURE
 ```
 
 ```Output
@@ -521,13 +521,13 @@ using `Trace-Command`.
 
 ```powershell
 Trace-Command -Name ParameterBinding -Expression {
-    findstr /c:"foo" ~\repocache.clixml
+    findstr /C:\foo" ~\repocache.clixml
 } -PSHost
 ```
 
 ```Output
 DEBUG: 2024-05-06 15:13:46.8268 ParameterBinding Information: 0 : BIND NAMED native application line args [C:\Windows\system32\findstr.exe]
-DEBUG: 2024-05-06 15:13:46.8270 ParameterBinding Information: 0 :     BIND cmd line arg [/c:foo] to position [0]
+DEBUG: 2024-05-06 15:13:46.8270 ParameterBinding Information: 0 :     BIND cmd line arg [/C:\oo] to position [0]
 DEBUG: 2024-05-06 15:13:46.8271 ParameterBinding Information: 0 :     BIND cmd line arg [C:\Users\user2\repocache.clixml] to position [1]
 DEBUG: 2024-05-06 15:13:46.8322 ParameterBinding Information: 0 : CALLING BeginProcessing
 ```

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Pipelines.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Pipelines.md
@@ -50,7 +50,7 @@ Get-Process notepad | Stop-Process
 The first command uses the `Get-Process` cmdlet to get an object representing
 the Notepad process. It uses a pipeline operator (`|`) to send the process
 object to the `Stop-Process` cmdlet, which stops the Notepad process. Notice
-that the `Stop-Process` command doesn't have a **Name** or **ID** parameter to
+that the `Stop-Process` command doesn't have a **Name** or **Id** parameter to
 specify the process, because the specified process is submitted through the
 pipeline.
 
@@ -60,9 +60,9 @@ displays the name and length of each file in a table.
 
 ```powershell
 Get-ChildItem -Path *.txt |
-  Where-Object {$_.length -gt 10000} |
-    Sort-Object -Property length |
-      Format-Table -Property name, length
+  Where-Object {$_.Length -gt 10000} |
+    Sort-Object -Property Length |
+      Format-Table -Property Name, Length
 ```
 
 This pipeline consists of four commands in the specified order. The following
@@ -73,7 +73,7 @@ command in the pipeline.
 Get-ChildItem -Path *.txt
 | (FileInfo objects for *.txt)
 V
-Where-Object {$_.length -gt 10000}
+Where-Object {$_.Length -gt 10000}
 | (FileInfo objects for *.txt)
 | (      Length > 10000      )
 V
@@ -82,7 +82,7 @@ Sort-Object -Property Length
 | (      Length > 10000      )
 | (     Sorted by length     )
 V
-Format-Table -Property name, length
+Format-Table -Property Name, Length
 | (FileInfo objects for *.txt)
 | (      Length > 10000      )
 | (     Sorted by length     )
@@ -110,7 +110,7 @@ Get-Service wmi | Start-Service
 ```
 
 For another example, you can pipe the output of `Get-Item` or `Get-ChildItem`
-within the PowerShell registry provider to the `New-ItemProperty` cmdlet. This
+within the PowerShell Registry provider to the `New-ItemProperty` cmdlet. This
 example adds a new registry entry, **NoOfEmployees**, with a value of **8124**,
 to the **MyCompany** registry key.
 
@@ -126,11 +126,11 @@ how to sort all the processes on the computer by the number of open handles in
 each process.
 
 ```powershell
-Get-Process | Sort-Object -Property handles
+Get-Process | Sort-Object -Property Handles
 ```
 
 You can pipe objects to the formatting, export, and output cmdlets, such as
-`Format-List`, `Format-Table`, `Export-Clixml`, `Export-CSV`, and `Out-File`.
+`Format-List`, `Format-Table`, `Export-Clixml`, `Export-Csv`, and `Out-File`.
 
 This example shows how to use the `Format-List` cmdlet to display a list of
 properties for a process object.
@@ -391,7 +391,7 @@ use that to count the number of processes running on the computer.
 For example,
 
 ```powershell
-(Get-Process).count
+(Get-Process).Count
 ```
 
 It's important to remember that objects sent down the pipeline are delivered
@@ -604,13 +604,13 @@ use this new functionality.
 ```powershell
 # Wrapping with a pipe at the beginning of a line (no backtick required)
 Get-Process | Where-Object CPU | Where-Object Path
-    | Get-Item | Where-Object FullName -match "AppData"
+    | Get-Item | Where-Object FullName -Match "AppData"
     | Sort-Object FullName -Unique
 
 # Wrapping with a pipe on a line by itself
 Get-Process | Where-Object CPU | Where-Object Path
     |
-    Get-Item | Where-Object FullName -match "AppData"
+    Get-Item | Where-Object FullName -Match "AppData"
     |
     Sort-Object FullName -Unique
 ```
@@ -627,7 +627,7 @@ Get-Process | Where-Object CPU | Where-Object Path
 - [about_Objects][05]
 - [about_Parameters][06]
 - [about_Command_Syntax][03]
-- [about_ForEach][04]
+- [about_Foreach][04]
 
 <!-- link references -->
 [02]: #investigating-pipeline-errors

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -60,8 +60,8 @@ PowerShell includes the following environment variables that store user
 preferences. For more information about these environment variables, see
 [about_Environment_Variables][30].
 
-- `$env:PSExecutionPolicyPreference`
-- `$env:PSModulePath`
+- `$Env:PSExecutionPolicyPreference`
+- `$Env:PSModulePath`
 
 > [!NOTE]
 > Changes to preference variables apply only in the scope they are made
@@ -549,7 +549,7 @@ default, **ConciseView**. `Get-ChildItem` is used to find a non-existent
 directory.
 
 ```powershell
-Get-ChildItem -path 'C:\NoRealDirectory'
+Get-ChildItem -Path 'C:\NoRealDirectory'
 ```
 
 ```Output
@@ -599,7 +599,7 @@ ObjectNotFound: (C:\nofile.txt:String) [Get-ChildItem], ItemNotFoundException
 This example demonstrates that the value of `$ErrorView` only affects the error
 display. It doesn't change the structure of the error object that's stored in
 the `$Error` automatic variable. For information about the `$Error` automatic
-variable, see [about_automatic_variables][28].
+variable, see [about_Automatic_variables][28].
 
 The following command takes the **ErrorRecord** object associated with the most
 recent error in the error array, **element 0**, and formats the properties of
@@ -785,14 +785,14 @@ To enable a **Log*Event**, type the variable with a value of `$true`, for
 example:
 
 ```powershell
-$LogCommandLifeCycleEvent = $true
+$LogCommandLifecycleEvent = $true
 ```
 
 To disable an event type, type the variable with a value of `$false`, for
 example:
 
 ```powershell
-$LogCommandLifeCycleEvent = $false
+$LogCommandLifecycleEvent = $false
 ```
 
 The events that you enable are effective only for the current PowerShell
@@ -988,16 +988,16 @@ Specifies the default email server that's used to send email messages. This
 preference variable is used by cmdlets that send email, such as the
 [Send-MailMessage][48] cmdlet.
 
-## $PSModuleAutoloadingPreference
+## $PSModuleAutoLoadingPreference
 
 Enables and disables automatic importing of modules in the session. The
-`$PSModuleAutoloadingPreference` variable doesn't exist by default. The default
+`$PSModuleAutoLoadingPreference` variable doesn't exist by default. The default
 behavior when the variable isn't defined is the same as
-`$PSModuleAutoloadingPreference = 'All'`.
+`$PSModuleAutoLoadingPreference = 'All'`.
 
 To automatically import a module, get or use a command contained in the module.
 
-The `$PSModuleAutoloadingPreference` variable takes one of the
+The `$PSModuleAutoLoadingPreference` variable takes one of the
 [`PSModuleAutoLoadingPreference`][58] enumeration values:
 
 - `All`: Modules are imported automatically on first-use.
@@ -1687,7 +1687,7 @@ At line:1 char:1
 
 ## See also
 
-- [about_automatic_variables][28]
+- [about_Automatic_Variables][28]
 - [about_CommonParameters][29]
 - [about_Environment_Variables][30]
 - [about_Profiles][36]

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -217,9 +217,9 @@ Here are a few suggestions to get you started.
 ### Add a function that lists aliases for any cmdlet
 
 ```powershell
-function Get-CmdletAlias ($cmdletname) {
+function Get-CmdletAlias ($cmdletName) {
   Get-Alias |
-    Where-Object -FilterScript {$_.Definition -like "$cmdletname"} |
+    Where-Object -FilterScript {$_.Definition -like "$cmdletName"} |
       Format-Table -Property Definition, Name -AutoSize
 }
 ```
@@ -228,9 +228,9 @@ function Get-CmdletAlias ($cmdletname) {
 
 ```powershell
 function CustomizeConsole {
-  $hosttime = (Get-ChildItem -Path $PSHOME\pwsh.exe).CreationTime
-  $hostversion="$($Host.Version.Major)`.$($Host.Version.Minor)"
-  $Host.UI.RawUI.WindowTitle = "PowerShell $hostversion ($hosttime)"
+  $hostTime = (Get-ChildItem -Path $PSHOME\pwsh.exe).CreationTime
+  $hostVersion="$($Host.Version.Major)`.$($Host.Version.Minor)"
+  $Host.UI.RawUI.WindowTitle = "PowerShell $hostVersion ($hostTime)"
   Clear-Host
 }
 CustomizeConsole
@@ -239,8 +239,8 @@ CustomizeConsole
 ### Add a customized PowerShell prompt
 
 ```powershell
-function Prompt {
-    $env:COMPUTERNAME + "\" + (Get-Location) + "> "
+function prompt {
+    $Env:COMPUTERNAME + "\" + (Get-Location) + "> "
 }
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -1,5 +1,5 @@
 ---
-description: Describes the `Prompt` function and demonstrates how to create a custom `Prompt` function.
+description: Describes the `prompt` function and demonstrates how to create a custom `prompt` function.
 Locale: en-US
 ms.date: 08/21/2023
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_prompts?view=powershell-7.6&WT.mc_id=ps-gethelp
@@ -10,8 +10,8 @@ title: about_Prompts
 
 ## Short description
 
-Describes the `Prompt` function and demonstrates how to create a custom
-`Prompt` function.
+Describes the `prompt` function and demonstrates how to create a custom
+`prompt` function.
 
 ## Long description
 
@@ -22,26 +22,26 @@ command:
 PS C:\>
 ```
 
-PowerShell has a built-in `Prompt` function. You can define your own customized
-`Prompt` function in your PowerShell profile script.
+PowerShell has a built-in `prompt` function. You can define your own customized
+`prompt` function in your PowerShell profile script.
 
-## About the Prompt function
+## About the `prompt` function
 
-The `Prompt` function determines the appearance of the PowerShell prompt.
-PowerShell comes with a built-in `Prompt` function, but you can override it by
-defining your own `Prompt` function.
+The `prompt` function determines the appearance of the PowerShell prompt.
+PowerShell comes with a built-in `prompt` function, but you can override it by
+defining your own `prompt` function.
 
-The `Prompt` function has the following syntax:
+The `prompt` function has the following syntax:
 
 ```powershell
-function Prompt { <function-body> }
+function prompt { <function-body> }
 ```
 
-The `Prompt` function must return an object. As a best practice, return a
+The `prompt` function must return an object. As a best practice, return a
 string or an object that's formatted as a string. The maximum recommended
 length is 80 characters.
 
-For example, the following `Prompt` function returns a "Hello, World" string
+For example, the following `prompt` function returns a "Hello, World" string
 followed by a  right angle bracket (`>`).
 
 ```powershell
@@ -49,15 +49,15 @@ PS C:\> function prompt {"Hello, World > "}
 Hello, World >
 ```
 
-### Getting the Prompt function
+### Getting the `prompt` function
 
-To get the `Prompt` function, use the `Get-Command` cmdlet or use the
+To get the `prompt` function, use the `Get-Command` cmdlet or use the
 `Get-Item` cmdlet in the Function drive.
 
 For example:
 
 ```powershell
-PS C:\> Get-Command Prompt
+PS C:\> Get-Command prompt
 
 CommandType     Name      ModuleName
 -----------     ----      ----------
@@ -65,12 +65,12 @@ Function        prompt
 ```
 
 To get the script that sets the value of the prompt, use the dot method to get
-the **ScriptBlock** property of the `Prompt` function.
+the **ScriptBlock** property of the `prompt` function.
 
 For example:
 
 ```powershell
-(Get-Command Prompt).ScriptBlock
+(Get-Command prompt).ScriptBlock
 ```
 
 ```Output
@@ -80,16 +80,16 @@ For example:
 # .ExternalHelp System.Management.Automation.dll-help.xml
 ```
 
-Like all functions, the `Prompt` function is stored in the `Function:` drive.
-To display the script that creates the current `Prompt` function, type:
+Like all functions, the `prompt` function is stored in the `Function:` drive.
+To display the script that creates the current `prompt` function, type:
 
 ```powershell
-(Get-Item function:prompt).ScriptBlock
+(Get-Item Function:prompt).ScriptBlock
 ```
 
 ### The default prompt
 
-The default prompt appears only when the `Prompt` function generates an error
+The default prompt appears only when the `prompt` function generates an error
 or doesn't return an object.
 
 The default PowerShell prompt is:
@@ -98,7 +98,7 @@ The default PowerShell prompt is:
 PS>
 ```
 
-For example, the following command sets the `Prompt` function to `$null`, which
+For example, the following command sets the `prompt` function to `$null`, which
 is invalid. As a result, the default prompt appears.
 
 ```powershell
@@ -111,7 +111,7 @@ default prompt.
 
 ### Built-in prompt
 
-PowerShell includes a built-in `Prompt` function.
+PowerShell includes a built-in `prompt` function.
 
 ```powershell
 function prompt {
@@ -154,7 +154,7 @@ the following prompt:
 ### Changes to the prompt
 
 The `Enter-PSSession` cmdlet prepends the name of the remote computer to the
-current `Prompt` function. When you use the `Enter-PSSession` cmdlet to start a
+current `prompt` function. When you use the `Enter-PSSession` cmdlet to start a
 session with a remote computer, the command prompt changes to include the name
 of the remote computer. For example:
 
@@ -171,10 +171,10 @@ automatic variables, see [about_Automatic_Variables][01].
 
 ### How to customize the prompt
 
-To customize the prompt, write a new `Prompt` function. The function isn't
+To customize the prompt, write a new `prompt` function. The function isn't
 protected, so you can overwrite it.
 
-To write a `Prompt` function, type the following:
+To write a `prompt` function, type the following:
 
 ```powershell
 function prompt { }
@@ -186,7 +186,7 @@ prompt.
 For example, the following prompt includes your computer name:
 
 ```powershell
-function prompt {"PS [$env:COMPUTERNAME]> "}
+function prompt {"PS [$Env:COMPUTERNAME]> "}
 ```
 
 On the Server01 computer, the prompt resembles the following prompt:
@@ -195,7 +195,7 @@ On the Server01 computer, the prompt resembles the following prompt:
 PS [Server01] >
 ```
 
-The following `Prompt` function includes the current date and time:
+The following `prompt` function includes the current date and time:
 
 ```powershell
 function prompt {"$(Get-Date)> "}
@@ -207,9 +207,9 @@ The prompt resembles the following prompt:
 03/15/2012 17:49:47>
 ```
 
-You can also change the default `Prompt` function:
+You can also change the default `prompt` function:
 
-For example, the following modified `Prompt` function adds `[ADMIN]:` to the
+For example, the following modified `prompt` function adds `[ADMIN]:` to the
 built-in PowerShell prompt when running in an elevated session.
 
 ```powershell
@@ -218,7 +218,7 @@ function prompt {
   $principal = [Security.Principal.WindowsPrincipal] $identity
   $adminRole = [Security.Principal.WindowsBuiltInRole]::Administrator
 
-  $(if (Test-Path variable:/PSDebugContext) { '[DBG]: ' }
+  $(if (Test-Path Variable:/PSDebugContext) { '[DBG]: ' }
     elseif($principal.IsInRole($adminRole)) { "[ADMIN]: " }
     else { '' }
   ) + 'PS ' + $(Get-Location) +
@@ -233,7 +233,7 @@ that resembles the following prompt appears:
 [ADMIN]: PS C:\ps-test>
 ```
 
-The following `Prompt` function displays the history ID of the next command. To
+The following `prompt` function displays the history ID of the next command. To
 view the command history, use the `Get-History` cmdlet.
 
 ```powershell
@@ -255,21 +255,21 @@ function prompt {
 The following prompt uses the `Write-Host` and `Get-Random` cmdlets to create a
 prompt that changes color randomly. Because `Write-Host` writes to the current
 host application but doesn't return an object, this function includes a
-`Return` statement. Without it, PowerShell uses the default prompt, `PS>`.
+`return` statement. Without it, PowerShell uses the default prompt, `PS>`.
 
 ```powershell
 function prompt {
     $color = Get-Random -Min 1 -Max 16
-    Write-Host ("PS " + $(Get-Location) +">") -NoNewLine `
+    Write-Host ("PS " + $(Get-Location) +">") -NoNewline `
      -ForegroundColor $Color
     return " "
 }
 ```
 
-### Saving the Prompt function
+### Saving the `prompt` function
 
-Like any function, the `Prompt` function exists only in the current session. To
-save the `Prompt` function for future sessions, add it to your PowerShell
+Like any function, the `prompt` function exists only in the current session. To
+save the `prompt` function for future sessions, add it to your PowerShell
 profiles. For more information about profiles, see [about_Profiles][04].
 
 ## See also

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -264,7 +264,7 @@ PS> $collection = @(
 $collection.Length
 2
 
-# Get the length property of each item in the collection.
+# Get the Length property of each item in the collection.
 PS> $collection.GetEnumerator().Length
 foo
 bar

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -197,7 +197,7 @@ cmdlets. Type the drive name followed by a colon (`:`). For example, to view
 the contents of the `Alias:` drive, type:
 
 ```powershell
-Get-Item alias:
+Get-Item Alias:
 ```
 
 You can view and manage the data in any drive from another drive by including
@@ -213,7 +213,7 @@ specify the drive path. For example, to change your location to the root
 directory of the `Cert:` drive, type:
 
 ```powershell
-Set-Location cert:
+Set-Location Cert:
 ```
 
 Then, to view the contents of the `Cert:` drive, type:
@@ -307,7 +307,7 @@ Cert:\> Set-Location ~
 
 ```Output
 Set-Location : Home location for this provider isn't set. To set the home
-location, call "(get-psprovider 'Certificate').Home = 'path'".
+location, call "(Get-PSProvider 'Certificate').Home = 'path'".
 At line:1 char:1
 + Set-Location ~
 + ~~~~~~~~~~~~~~
@@ -336,7 +336,7 @@ Get-Help <provider-name>
 For example:
 
 ```powershell
-Get-Help certificate
+Get-Help Certificate
 ```
 
 ## Learning about providers
@@ -355,7 +355,7 @@ Get-Help <ProviderName>
 For example:
 
 ```powershell
-Get-Help registry
+Get-Help Registry
 ```
 
 For a list of Help topics about the providers, type:


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide