### PR TITLE
Fix incorrect case/capitalization in reference documents (10/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -49,17 +49,17 @@ Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $ps}
 You can use local variables in remote commands, but the variable must be
 defined in the local session.
 
-Beginning in PowerShell 3.0, you can use the `Using` scope modifier to identify
-a local variable in a remote command.
+Beginning in PowerShell 3.0, you can use the `Using:` scope modifier to
+identify a local variable in a remote command.
 
-The syntax of `Using` is as follows:
+The syntax of `Using:` is as follows:
 
 ```
 $Using:<VariableName>
 ```
 
 In the following example, the `$ps` variable is created in the local session,
-but is used in the session in which the command runs. The `Using` scope
+but is used in the session in which the command runs. The `Using:` scope
 modifier identifies `$ps` as a local variable.
 
 ```powershell
@@ -69,7 +69,7 @@ Invoke-Command -ComputerName S1 -ScriptBlock {
 }
 ```
 
-The `Using` scope modifier can be used in a **PSSession**.
+The `Using:` scope modifier can be used in a **PSSession**.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
@@ -77,9 +77,9 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-A variable reference such as `$using:var` expands to the value of variable
+A variable reference such as `$Using:var` expands to the value of variable
 `$var` from the caller's context. You do not get access to the caller's
-variable object. The `Using` scope modifier cannot be used to modify a local
+variable object. The `Using:` scope modifier cannot be used to modify a local
 variable within the **PSSession**. For example, the following code does not
 work:
 
@@ -89,7 +89,7 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {$Using:ps = 'Cannot assign new value'}
 ```
 
-For more information about `Using`, see [about_Scopes](./about_Scopes.md)
+For more information about `Using:`, see [about_Scopes](./about_Scopes.md)
 
 ### Using splatting
 
@@ -98,7 +98,7 @@ command. For more information, see [about_Splatting](about_Splatting.md).
 
 In this example, the splatting variable, `$Splat` is a hash table that is set
 up on the local computer. The `Invoke-Command` connects to a remote computer
-session. The **ScriptBlock** uses the `Using` scope modifier with the At (`@`)
+session. The **ScriptBlock** uses the `Using:` scope modifier with the At (`@`)
 symbol to represent the splatted variable.
 
 ```powershell
@@ -106,12 +106,12 @@ $Splat = @{ Name = "Win*"; Include = "WinRM" }
 Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
 ```
 
-### Other situations where the 'Using' scope modifier is needed
+### Other situations where the `Using:` scope modifier is needed
 
-For any script or command that executes out of session, you need the `Using`
+For any script or command that executes out of session, you need the `Using:`
 scope modifier to embed variable values from the calling session scope, so that
-out of session code can access them. The `Using` scope modifier is supported in
-the following contexts:
+out of session code can access them. The `Using:` scope modifier is supported
+in the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
   **ComputerName** or **Session** parameter (remote session)
@@ -138,7 +138,7 @@ It has the type properties and methods. For simple types, such as
 imperfect. For example, rehydrated certificate objects do not include the
 private key.
 
-Instances of all other types are **PSObject** instances. The **PSTypeNames**
+Instances of all other types are **PSObject** instances. The **pstypenames**
 property contains the original type name prefixed with **Deserialized**, for
 example, **Deserialized.System.Data.DataTable**
 
@@ -158,14 +158,14 @@ cmdlet to specify the local variable as the parameter value.
   the local variable as the parameter value.
 
 For example, the following commands define the `$ps` variable in the local
-session and then use it in a remote command. The command uses `$log` as the
+session and then use it in a remote command. The command uses `$Log` as the
 parameter name and the local variable, `$ps`, as its value.
 
 ```powershell
 $ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
-  param($log)
-  Get-WinEvent -LogName $log
+  param($Log)
+  Get-WinEvent -LogName $Log
 } -ArgumentList $ps
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -232,10 +232,10 @@ specified in both statements aren't met, the script doesn't run. Each
 ```powershell
 #Requires -Modules PSWorkflow
 #Requires -Version 3
-Param
+param
 (
-    [parameter(Mandatory=$true)]
-    [String[]]
+    [Parameter(Mandatory=$true)]
+    [string[]]
     $Path
 )
 ...

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
@@ -49,7 +49,7 @@ their own help articles. To view them, type `Get-Help about_` and add the
 keyword. For example, to get information about the `foreach` statement, type:
 
 ```powershell
-Get-Help about_ForEach
+Get-Help about_Foreach
 ```
 
 For information about the `filter` statement or the `return` statement syntax,

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Return.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Return.md
@@ -22,7 +22,7 @@ Users who are familiar with languages like C or C\# might want to use the
 `return` keyword to make the logic of leaving a scope explicit.
 
 In PowerShell, the results of each statement are returned as output, even
-without a statement that contains the Return keyword. Languages like C or C\#
+without a statement that contains the `return` keyword. Languages like C or C\#
 return only the value or values that are specified by the `return` keyword.
 
 > [!NOTE]
@@ -58,10 +58,10 @@ because the return statement exits before that statement can execute.
 ```powershell
 function MultiplyEven
 {
-    param($number)
+    param($Number)
 
-    if ($number % 2) { return "$number is not even" }
-    $number * 2
+    if ($Number % 2) { return "$Number is not even" }
+    $Number * 2
 }
 
 1..10 | ForEach-Object {MultiplyEven -Number $_}
@@ -99,15 +99,15 @@ The following example includes a statement intended to let the user know that
 the function is performing a calculation:
 
 ```powershell
-function calculation {
-    param ($value)
+function Calculation {
+    param ($Value)
 
     "Please wait. Working on calculation..."
-    $value += 73
-    return $value
+    $Value += 73
+    return $Value
 }
 
-$a = calculation 14
+$a = Calculation 14
 ```
 
 The "Please wait. Working on calculation..." string is not displayed. Instead,
@@ -128,12 +128,12 @@ the above example using the `Write-Information` cmdlet with a
 **InformationAction** set to `Continue`.
 
 ```powershell
-function calculation {
-    param ($value)
+function Calculation {
+    param ($Value)
 
     Write-Information "Please wait. Working on calculation..." -InformationAction Continue
-    $value += 73
-    return $value
+    $Value += 73
+    return $Value
 }
 ```
 
@@ -141,7 +141,7 @@ Now the information message to display in the host and not assigned to the
 variable.
 
 ```powershell
-PS> $a = calculation 14
+PS> $a = Calculation 14
 Please wait. Working on calculation...
 PS> $a
 87
@@ -152,7 +152,7 @@ PS> $a
 When you return a collection from your script block or function, PowerShell
 automatically unrolls the members and passes them one at a time through the
 pipeline. This is due to PowerShell's one-at-a-time processing. For more
-information, see [about_pipelines](about_pipelines.md).
+information, see [about_Pipelines](about_pipelines.md).
 
 This concept is illustrated by the following sample function that returns an
 array of numbers. The output from the function is piped to the `Measure-Object`

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -78,13 +78,13 @@ To find the items in a particular scope, use the Scope parameter of
 For example, to get all the variables in the local scope, type:
 
 ```powershell
-Get-Variable -Scope local
+Get-Variable -Scope Local
 ```
 
 To get all the variables in the global scope, type:
 
 ```powershell
-Get-Variable -Scope global
+Get-Variable -Scope Global
 ```
 
 When a reference is made to a variable, alias, or function, PowerShell searches
@@ -122,22 +122,22 @@ scope.
 A variable, alias, or function name can include any one of the following
 optional scope modifiers:
 
-- `global:` - Specifies that the name exists in the **Global** scope.
-- `local:` - Specifies that the name exists in the **Local** scope. The current
+- `Global:` - Specifies that the name exists in the **Global** scope.
+- `Local:` - Specifies that the name exists in the **Local** scope. The current
   scope is always the **Local** scope.
-- `private:` - Specifies that the name is **Private** and only visible to the
+- `Private:` - Specifies that the name is **Private** and only visible to the
   current scope.
 
   > [!NOTE]
-  > `private:` isn't a scope. It's an [option][04] that changes the
+  > `Private:` isn't a scope. It's an [option][04] that changes the
   > accessibility of an item outside of the scope in which it's defined.
 
-- `script:` - Specifies that the name exists in the **Script** scope.
+- `Script:` - Specifies that the name exists in the **Script** scope.
   **Script** scope is the nearest ancestor script file's scope or **Global** if
   there is no nearest ancestor script file.
-- `using:` - Used to access variables defined in another scope while running
+- `Using:` - Used to access variables defined in another scope while running
   in remote sessions, background jobs, or thread jobs.
-- `workflow:` - Specifies that the name exists within a workflow. Note:
+- `Workflow:` - Specifies that the name exists within a workflow. Note:
   Workflows aren't supported in PowerShell v6 and higher.
 - `<variable-namespace>` - A modifier created by a PowerShell **PSDrive**
   provider. For example:
@@ -177,11 +177,11 @@ in the current or **local** scope:
 $a = "one"
 ```
 
-To create the same variable in the **global** scope, use the scope `global:`
+To create the same variable in the **global** scope, use the scope `Global:`
 modifier:
 
 ```powershell
-$global:a = "one"
+$Global:a = "one"
 Get-Variable a | Format-List *
 ```
 
@@ -201,11 +201,11 @@ Attributes  : {}
 Compare that to a private variable:
 
 ```powershell
-$private:pVar = 'Private variable'
+$Private:pVar = 'Private variable'
 Get-Variable pVar | Format-List *
 ```
 
-Using the `private` scope modifier sets the **Options** property to `Private`.
+Using the `Private:` scope modifier sets the **Options** property to `Private`.
 
 ```Output
 Name        : pVar
@@ -218,18 +218,18 @@ Options     : Private
 Attributes  : {}
 ```
 
-To create the same variable in the **script** scope, use the `script:` scope
+To create the same variable in the **script** scope, use the `Script:` scope
 modifier:
 
 ```powershell
-$script:a = "one"
+$Script:a = "one"
 ```
 
 You can also use a scope modifier with functions. The following function
 definition creates a function in the **global** scope:
 
 ```powershell
-function global:Hello {
+function Global:Hello {
   Write-Host "Hello, World"
 }
 ```
@@ -240,21 +240,21 @@ and then in the global scope:
 
 ```powershell
 $test
-$global:test
+$Global:test
 ```
 
-### The `using:` scope modifier
+### The `Using:` scope modifier
 
 Using is a special scope modifier that identifies a local variable in a remote
 command. Without a modifier, PowerShell expects variables in remote commands to
 be defined in the remote session.
 
-The `using` scope modifier is introduced in PowerShell 3.0.
+The `Using:` scope modifier was introduced in PowerShell 3.0.
 
-For any script or command that executes out of session, you need the `using`
+For any script or command that executes out of session, you need the `Using:`
 scope modifier to embed variable values from the calling session scope, so that
-out of session code can access them. The `using` scope modifier is supported in
-the following contexts:
+out of session code can access them. The `Using:` scope modifier is supported
+in the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
   **ComputerName**, **HostName**, **SSHConnection** or **Session** parameters
@@ -268,7 +268,7 @@ out-of-process sessions, they're always independent copies.
 
 For more information, see [about_Remote_Variables][08].
 
-A `$using:` reference only expands to a variable's value. If you want to change
+A `$Using:` reference only expands to a variable's value. If you want to change
 the value of a variable in the caller's scope, you must have a reference to the
 variable itself. You can create a reference to a variable by getting the
 **PSVariable** instance of the variable. The following example show how to
@@ -279,7 +279,7 @@ $Count = 1
 $refOfCount = Get-Variable Count
 
 Start-ThreadJob {
-    ($using:refOfCount).Value = 2
+    ($Using:refOfCount).Value = 2
 } | Receive-Job -Wait -AutoRemoveJob
 
 $Count
@@ -310,7 +310,7 @@ It has the type properties and methods. For simple types, such as
 imperfect. For example, rehydrated certificate objects don't include the
 private key.
 
-Instances of all other types are **PSObject** instances. The **PSTypeNames**
+Instances of all other types are **PSObject** instances. The **pstypenames**
 property contains the original type name prefixed with **Deserialized**, for
 example, **Deserialized.System.Data.DataTable**
 
@@ -332,7 +332,7 @@ change) items in a particular scope. Use the following command to find all the
 cmdlets in your session that have a **Scope** parameter:
 
 ```powershell
-Get-Help * -Parameter scope
+Get-Help * -Parameter Scope
 ```
 
 To find the variables that are visible in a particular scope, use the `Scope`
@@ -343,7 +343,7 @@ For example, the following command gets the variables that are visible in the
 local scope:
 
 ```powershell
-Get-Variable -Scope local
+Get-Variable -Scope Local
 ```
 
 To create a variable in a particular scope, use a scope modifier or the
@@ -351,7 +351,7 @@ To create a variable in a particular scope, use a scope modifier or the
 in the global scope:
 
 ```powershell
-New-Variable -Scope global -Name a -Value "One"
+New-Variable -Scope Global -Name a -Value "One"
 ```
 
 You can also use the Scope parameter of the `New-Alias`, `Set-Alias`, or
@@ -359,7 +359,7 @@ You can also use the Scope parameter of the `New-Alias`, `Set-Alias`, or
 alias in the global scope:
 
 ```powershell
-New-Alias -Scope global -Name np -Value Notepad.exe
+New-Alias -Scope Global -Name np -Value Notepad.exe
 ```
 
 To get the functions in a particular scope, use the `Get-Item` cmdlet when you
@@ -389,7 +389,7 @@ the script scope (the default for scripts), just enter the full path to the
 script file on the command line.
 
 ```powershell
-c:\scripts\sample.ps1
+C:\scripts\sample.ps1
 ```
 
 A script file must have a `.ps1` file extension to be executable. Files that
@@ -402,7 +402,7 @@ Using the call operator to run a function or script runs it in script scope.
 Using the call operator is no different than running the script by name.
 
 ```powershell
-& c:\scripts\sample.ps1
+& C:\scripts\sample.ps1
 ```
 
 You can read more about the call operator in [about_Operators][07].
@@ -411,7 +411,7 @@ To run the `Sample.ps1` script in the local scope type a dot and a space (`. `)
 before the path to the script:
 
 ```powershell
-. c:\scripts\sample.ps1
+. C:\scripts\sample.ps1
 ```
 
 Now, any functions, aliases, or variables defined in the script are added to
@@ -459,7 +459,7 @@ $a = "Hello"
 
 function foo {
     "`$a = $a"
-    "`$global:a = $global:a"
+    "`$Global:a = $Global:a"
 }
 ```
 
@@ -476,7 +476,7 @@ The module declares the variable `$a` in the module scope then the function
 
 ```Output
 $a = Hello
-$global:a = Goodbye
+$Global:a = Goodbye
 ```
 
 Modules create parallel scope containers linked to the scope in which they were
@@ -488,10 +488,10 @@ module's scope container.
 
 If you load **Module2** from _within_ **Module1**, **Module2** is loaded into
 the scope container of Module1. Any exports from **Module2** are placed in the
-current module scope of **Module1**. If you use `Import-Module -Scope local`,
+current module scope of **Module1**. If you use `Import-Module -Scope Local`,
 then the exports are placed into the current scope object rather than at the
 top level. If you are _in a module_ and load another module using
-`Import-Module -Scope global` (or `Import-Module -Global`), that module and its
+`Import-Module -Scope Global` (or `Import-Module -Global`), that module and its
 exports are loaded into the global scope instead of the module's local scope.
 The **WindowsCompatibility** feature does this to import proxy modules into the
 global session state.
@@ -514,8 +514,8 @@ that scope.
 
 For example, if you create a variable that has a private option in the global
 scope and then run a script, `Get-Variable` commands in the script don't
-display the private variable. Using the global scope modifier in this instance
-doesn't display the private variable.
+display the private variable. Using the `Global:` scope modifier in this
+instance doesn't display the private variable.
 
 You can use the **Option** parameter of the `New-Variable`, `Set-Variable`,
 `New-Alias`, and `Set-Alias` cmdlets to set the value of the Option property to
@@ -605,7 +605,7 @@ In `Sample.ps1`:
 ```powershell
 $test = "Local"
 "The local value of `$test is $test."
-"The global value of `$test is $global:test."
+"The global value of `$test is $Global:test."
 ```
 
 When you run `Sample.ps1`, the output should resemble the following output:
@@ -641,8 +641,8 @@ the `$test` variable.
 In Sample.ps1:
 
 ```powershell
-$global:test = "Local"
-"The global value of `$test is $global:test."
+$Global:test = "Local"
+"The global value of `$test is $Global:test."
 ```
 
 When the script is complete, the global value of `$test` is changed.
@@ -654,7 +654,7 @@ Local
 
 ### Example 4: Creating a private variable
 
-A variable can be made private by using the `private:` scope modifier or by
+A variable can be made private by using the `Private:` scope modifier or by
 creating the variable with the **Option** property set to `Private`. Private
 variables can only be viewed or changed in the scope in which they were
 created.
@@ -675,7 +675,7 @@ function funcA {
 
 function funcB {
     "In funcB before set -> '$funcAVar1'"
-    $private:funcAVar1 = "Locally overwrite the value - child scopes can't see me!"
+    $Private:funcAVar1 = "Locally overwrite the value - child scopes can't see me!"
     "In funcB after set  -> '$funcAVar1'"
     funcC
 }
@@ -732,14 +732,14 @@ scopes using `Get-Variable` and specifying a scope number.
 
 ### Example 5: Using a local variable in a remote command
 
-For variables in a remote command created in the local session, use the `using`
-scope modifier. PowerShell assumes that the variables in remote commands were
-created in the remote session.
+For variables in a remote command created in the local session, use the
+`Using:` scope modifier. PowerShell assumes that the variables in remote
+commands were created in the remote session.
 
 The syntax is:
 
 ```
-$using:<VariableName>
+$Using:<VariableName>
 ```
 
 For example, the following commands create a `$Cred` variable in the local
@@ -747,10 +747,10 @@ session and then use the `$Cred` variable in a remote command:
 
 ```powershell
 $Cred = Get-Credential
-Invoke-Command $s {Remove-Item .\Test*.ps1 -Credential $using:Cred}
+Invoke-Command $s {Remove-Item .\Test*.ps1 -Credential $Using:Cred}
 ```
 
-The `using` scope modifier was introduced in PowerShell 3.0.
+The `Using:` scope modifier was introduced in PowerShell 3.0.
 
 ## See also
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -36,12 +36,12 @@ keyword doesn't affect or suppress other output returned from your script
 block. However, the `return` keyword exits the script block at that line. For
 more information, see [about_Return][04].
 
-Like functions, a script block can include parameters. Use the Param
+Like functions, a script block can include parameters. Use the `param`
 keyword to assign named parameters, as shown in the following syntax:
 
 ```
 {
-    Param([type]$Parameter1 [,[type]$Parameter2])
+    param ([type]$Parameter1 [,[type]$Parameter2])
     <statement list>
 }
 ```
@@ -50,8 +50,8 @@ keyword to assign named parameters, as shown in the following syntax:
 > In a script block, unlike a function, you can't specify parameters outside
 > the braces.
 
-Like functions, script blocks can include the `DynamicParam`, `Begin`,
-`Process`, and `End` keywords. For more information, see [about_Functions][02]
+Like functions, script blocks can include the `dynamicparam`, `begin`,
+`process`, and `end` keywords. For more information, see [about_Functions][02]
 and [about_Functions_Advanced][01].
 
 ## Using Script Blocks
@@ -174,7 +174,7 @@ Notes on delay-bind script blocks as parameters:
 - You must explicitly specify any parameter names you use with delay-bind
   script blocks.
 - The parameter must not be untyped, and the parameter's type can't be
-  `[scriptblock]` or `[object]`.
+  `[scriptblock]` or `[Object]`.
 - You receive an error if you use a delay-bind script block without providing
   pipeline input.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -68,7 +68,7 @@ the English-United States (en-US) set of prompt messages for a script. The
 stores them in the `$msgtable` variable.
 
 ```powershell
-$msgTable = Data {
+$msgTable = data {
     #culture="en-US"
     ConvertFrom-StringData @'
     helloWorld = Hello, World.
@@ -186,7 +186,7 @@ are defined in the Data section.
 The remaining commands load the strings into an array and display them.
 
 ```powershell
-$Day = Data {
+$Day = data {
 #culture="en-US"
 ConvertFrom-StringData -StringData @'
     messageDate = Today is

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -133,7 +133,7 @@ Invoke-Command @invokeCommandSplat
 The Get-Help cmdlet gets the help topics for scripts as well as for cmdlets
 and other types of commands. To get the help topic for a script, type
 `Get-Help` followed by the path and filename of the script. If the script
-path is in your `Path` environment variable, you can omit the path.
+path is in your `PATH` environment variable, you can omit the path.
 
 For example, to get help for the ServicesLog.ps1 script, type:
 
@@ -144,8 +144,8 @@ Get-Help C:\admin\scripts\ServicesLog.ps1
 ## How to write a script
 
 A script can contain any valid PowerShell commands, including single commands,
-commands that use the pipeline, functions, and control structures such as If
-statements and For loops.
+commands that use the pipeline, functions, and control structures such as `if`
+statements and `for` loops.
 
 To write a script, open a new file in a text editor, type the commands, and
 save them in a file with a valid filename with the `.ps1` file extension.
@@ -164,9 +164,9 @@ commands, and then save them in a file named `ServiceLog.ps1`.
 
 ### Parameters in scripts
 
-To define parameters in a script, use a Param statement. The `Param` statement
-must be the first statement in a script, except for comments and any
-`#Require` statements.
+To define parameters in a script, use a `param` statement. The `param`
+statement must be the first statement in a script, except for comments and any
+`#Requires` statements.
 
 Script parameters work like function parameters. The parameter values are
 available to all of the commands in the script. All of the features of
@@ -185,7 +185,7 @@ param ($ComputerName = $(throw "ComputerName parameter is required."))
 
 function CanPing {
    $Error.Clear()
-   $tmp = Test-Connection $computername -ErrorAction SilentlyContinue
+   $tmp = Test-Connection $ComputerName -ErrorAction SilentlyContinue
 
    if (!$?)
        {Write-Host "Ping failed: $ComputerName."; return $false}
@@ -194,7 +194,7 @@ function CanPing {
 }
 
 function CanRemote {
-    $s = New-PSSession $computername -ErrorAction SilentlyContinue
+    $s = New-PSSession $ComputerName -ErrorAction SilentlyContinue
 
     if ($s -is [System.Management.Automation.Runspaces.PSSession])
         {Write-Host "Remote test succeeded: $ComputerName."}
@@ -202,7 +202,7 @@ function CanRemote {
         {Write-Host "Remote test failed: $ComputerName."}
 }
 
-if (CanPing $computername) {CanRemote $computername}
+if (CanPing $ComputerName) {CanRemote $ComputerName}
 ```
 
 To run this script, type the parameter name after the script name. For example:
@@ -214,8 +214,8 @@ Ping succeeded: Server01
 Remote test failed: Server01
 ```
 
-For more information about the Param statement and the function parameters, see
-[about_Functions][04] and [about_Functions_Advanced_Parameters][05].
+For more information about the `param` statement and the function parameters,
+see [about_Functions][04] and [about_Functions_Advanced_Parameters][05].
 
 ### Writing help for scripts
 
@@ -235,11 +235,11 @@ methods:
   for cmdlets. XML-based Help is required if you are translating Help topics
   into multiple languages.
 
-To associate the script with the XML-based Help topic, use the .ExternalHelp
-Help comment keyword. For more information about the ExternalHelp keyword, see
-[about_Comment_Based_Help][06]. For more information about XML-based help, see
-[How to Write Cmdlet Help][07].
-[How to Write Cmdlet Help](/powershell/scripting/developer/help/writing-help-for-windows-powershell-cmdlets).
+To associate the script with the XML-based Help topic, use the `.EXTERNALHELP`
+Help comment keyword. For more information, see:
+
+- [about_Comment_Based_Help][06]
+- [How to Write Cmdlet Help][07]
 
 ### Returning an exit value
 
@@ -307,7 +307,7 @@ function New-Profile
   if (Test-Path $PROFILE)
     {Write-Error "Profile $profileName already exists on this computer."}
   else
-    {New-Item -Type file -Path $PROFILE -Force }
+    {New-Item -Type File -Path $PROFILE -Force }
 }
 ```
 
@@ -320,11 +320,11 @@ removed, as shown in the following example.
 C:\PS> .\UtilityFunctions.ps1
 
 C:\PS> New-Profile
-The term 'new-profile' is not recognized as a cmdlet, function, operable
+The term 'New-Profile' is not recognized as a cmdlet, function, operable
 program, or script file. Verify the term and try again.
 At line:1 char:12
-+ new-profile <<<<
-   + CategoryInfo          : ObjectNotFound: (new-profile:String) [],
++ New-Profile <<<<
+   + CategoryInfo          : ObjectNotFound: (New-Profile:String) [],
    + FullyQualifiedErrorId : CommandNotFoundException
 
 C:\PS> $profileName
@@ -362,7 +362,7 @@ get code from trusted sources.
 
 You can include scripts in your modules, or you can create a script module,
 which is a module that consists entirely or primarily of a script and
-supporting resources. A script module is just a script with a .psm1 file
+supporting resources. A script module is just a script with a `.psm1` file
 extension.
 
 For more information about modules, see [about_Modules][09].

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -17,11 +17,11 @@ sessions that use the session configuration.
 
 ## Long description
 
-A "session configuration file" is a text file with a .pssc file name extension
-that contains a hash table of session configuration properties and values. You
-can use a session configuration file to set the properties of a session
-configuration. Doing so defines the environment of any PowerShell sessions that
-use that session configuration.
+A "session configuration file" is a text file with a `.pssc` file name
+extension that contains a hash table of session configuration properties and
+values. You can use a session configuration file to set the properties of a
+session configuration. Doing so defines the environment of any PowerShell
+sessions that use that session configuration.
 
 Session configuration files make it easy to create custom session
 configurations without using complex C# assemblies or scripts.
@@ -138,7 +138,7 @@ later time.
 To include a session configuration file when creating a session configuration,
 use the Path parameter of the `Register-PSSessionConfiguration` cmdlet.
 
-For example, the following command uses the NoLanguage.pssc file when it
+For example, the following command uses the `NoLanguage.pssc` file when it
 creates a NoLanguage session configuration.
 
 ```powershell
@@ -155,7 +155,7 @@ new sessions created with the specified session configuration. Note that the
 `Set-PSSessionConfiguration` cmdlet changes the session itself and does not
 modify the session configuration file.
 
-For example, the following command adds the NoLanguage.pssc file to the
+For example, the following command adds the `NoLanguage.pssc` file to the
 LockedDown session configuration.
 
 ```powershell
@@ -224,7 +224,7 @@ C:\WINDOWS\System32\WindowsPowerShell\v1.0\SessionConfig\
 NoLanguage_0c115179-ff2a-4f66-a5eb-e56e5692ba22.pssc
 ```
 
-You can edit the .pssc file in any text editor. After the file is saved it
+You can edit the `.pssc` file in any text editor. After the file is saved it
 will be employed by any new sessions that use the session configuration.
 
 If you need to modify the RunAsVirtualAccount or the RunAsVirtualAccountGroups
@@ -321,7 +321,7 @@ lang                          NoteProperty   System.String lang=e...
 LanguageMode                  NoteProperty   System.String Langua...
 MaxConcurrentCommandsPerShell NoteProperty   System.String MaxCon...
 MaxConcurrentUsers            NoteProperty   System.String MaxCon...
-MaxIdleTimeoutms              NoteProperty   System.String MaxIdl...
+MaxIdleTimeoutMs              NoteProperty   System.String MaxIdl...
 MaxMemoryPerShellMB           NoteProperty   System.String MaxMem...
 MaxProcessesPerShell          NoteProperty   System.String MaxPro...
 MaxShells                     NoteProperty   System.String MaxShells

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -124,9 +124,9 @@ PS C:> Get-PSSessionConfiguration | Format-List -Property *
 ```
 
 You can also use the WSMan provider in PowerShell to view session
-configurations. The WSMan provider creates a WSMAN: drive in your session.
+configurations. The WSMan provider creates a WSMan: drive in your session.
 
-In the WSMAN: drive, session configurations are in the Plugin node. (All
+In the WSMan: drive, session configurations are in the Plugin node. (All
 session configurations are in the Plugin node, but there are items in the
 Plugin node that are not session configurations.)
 
@@ -134,7 +134,7 @@ For example, to view the session configurations on the local computer,
 type:
 
 ```powershell
-PS C:> dir wsman:\localhost\plugin\microsoft*
+PS C:> dir WSMan:\localhost\plugin\microsoft*
 
 WSManConfig: Microsoft.WSMan.Management\WSMan::localhost\Plugin
 
@@ -149,11 +149,11 @@ Container  {Name=microsoft.powershell32}     microsoft.powershell32
 
 To view the session configurations on a remote computer, use the
 `Connect-WSMan` cmdlet to add a note for the remote computer to the
-WSMAN: drive on your local computer, and then use the WSMAN: drive to view the
+WSMan: drive on your local computer, and then use the WSMan: drive to view the
 session configurations.
 
 For example, the following command adds a node for the Server01 remote
-computer to the WSMAN: drive on the local computer.
+computer to the WSMan: drive on the local computer.
 
 ```powershell
 PS C:> Connect-WSMan server01.corp.fabrikam.com
@@ -165,7 +165,7 @@ computer to view the session configurations.
 For example:
 
 ```powershell
-PS C:> cd wsman:
+PS C:> cd WSMan:
 
 PS WSMan:> dir
 
@@ -272,7 +272,7 @@ Register-PSSessionConfiguration @registerPSSessionConfigurationSplat
 ```
 
 When you create a session configuration, you can manage it by using the other
-session configuration cmdlets, and it appears in the WSMAN: drive.
+session configuration cmdlets, and it appears in the WSMan: drive.
 
 For more information, see `Register-PSSessionConfiguration`.
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -49,17 +49,17 @@ Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $ps}
 You can use local variables in remote commands, but the variable must be
 defined in the local session.
 
-Beginning in PowerShell 3.0, you can use the `Using` scope modifier to identify
-a local variable in a remote command.
+Beginning in PowerShell 3.0, you can use the `Using:` scope modifier to
+identify a local variable in a remote command.
 
-The syntax of `Using` is as follows:
+The syntax of `Using:` is as follows:
 
 ```
 $Using:<VariableName>
 ```
 
 In the following example, the `$ps` variable is created in the local session,
-but is used in the session in which the command runs. The `Using` scope
+but is used in the session in which the command runs. The `Using:` scope
 modifier identifies `$ps` as a local variable.
 
 ```powershell
@@ -69,7 +69,7 @@ Invoke-Command -ComputerName S1 -ScriptBlock {
 }
 ```
 
-The `Using` scope modifier can be used in a **PSSession**.
+The `Using:` scope modifier can be used in a **PSSession**.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
@@ -77,9 +77,9 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-A variable reference such as `$using:var` expands to the value of variable
+A variable reference such as `$Using:var` expands to the value of variable
 `$var` from the caller's context. You do not get access to the caller's
-variable object. The `Using` scope modifier cannot be used to modify a local
+variable object. The `Using:` scope modifier cannot be used to modify a local
 variable within the **PSSession**. For example, the following code does not
 work:
 
@@ -89,7 +89,7 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {$Using:ps = 'Cannot assign new value'}
 ```
 
-For more information about `Using`, see [about_Scopes](./about_Scopes.md)
+For more information about `Using:`, see [about_Scopes](./about_Scopes.md)
 
 ### Using splatting
 
@@ -98,7 +98,7 @@ command. For more information, see [about_Splatting](about_Splatting.md).
 
 In this example, the splatting variable, `$Splat` is a hash table that is set
 up on the local computer. The `Invoke-Command` connects to a remote computer
-session. The **ScriptBlock** uses the `Using` scope modifier with the At (`@`)
+session. The **ScriptBlock** uses the `Using:` scope modifier with the At (`@`)
 symbol to represent the splatted variable.
 
 ```powershell
@@ -106,12 +106,12 @@ $Splat = @{ Name = "Win*"; Include = "WinRM" }
 Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
 ```
 
-### Other situations where the 'Using' scope modifier is needed
+### Other situations where the `Using:` scope modifier is needed
 
-For any script or command that executes out of session, you need the `Using`
+For any script or command that executes out of session, you need the `Using:`
 scope modifier to embed variable values from the calling session scope, so that
-out of session code can access them. The `Using` scope modifier is supported in
-the following contexts:
+out of session code can access them. The `Using:` scope modifier is supported
+in the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
   **ComputerName**, **HostName**, **SSHConnection** or **Session** parameters
@@ -140,7 +140,7 @@ It has the type properties and methods. For simple types, such as
 imperfect. For example, rehydrated certificate objects do not include the
 private key.
 
-Instances of all other types are **PSObject** instances. The **PSTypeNames**
+Instances of all other types are **PSObject** instances. The **pstypenames**
 property contains the original type name prefixed with **Deserialized**, for
 example, **Deserialized.System.Data.DataTable**
 
@@ -160,14 +160,14 @@ cmdlet to specify the local variable as the parameter value.
   the local variable as the parameter value.
 
 For example, the following commands define the `$ps` variable in the local
-session and then use it in a remote command. The command uses `$log` as the
+session and then use it in a remote command. The command uses `$Log` as the
 parameter name and the local variable, `$ps`, as its value.
 
 ```powershell
 $ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
-  param($log)
-  Get-WinEvent -LogName $log
+  param($Log)
+  Get-WinEvent -LogName $Log
 } -ArgumentList $ps
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -204,10 +204,10 @@ specified in both statements aren't met, the script doesn't run. Each
 ```powershell
 #Requires -Modules AzureRM.Netcore
 #Requires -Version 6.0
-Param
+param
 (
-    [parameter(Mandatory=$true)]
-    [String[]]
+    [Parameter(Mandatory=$true)]
+    [string[]]
     $Path
 )
 ...

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
@@ -49,7 +49,7 @@ their own help articles. To view them, type `Get-Help about_` and add the
 keyword. For example, to get information about the `foreach` statement, type:
 
 ```powershell
-Get-Help about_ForEach
+Get-Help about_Foreach
 ```
 
 For information about the `filter` statement or the `return` statement syntax,

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Return.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Return.md
@@ -22,7 +22,7 @@ Users who are familiar with languages like C or C\# might want to use the
 `return` keyword to make the logic of leaving a scope explicit.
 
 In PowerShell, the results of each statement are returned as output, even
-without a statement that contains the Return keyword. Languages like C or C\#
+without a statement that contains the `return` keyword. Languages like C or C\#
 return only the value or values that are specified by the `return` keyword.
 
 > [!NOTE]
@@ -58,10 +58,10 @@ because the return statement exits before that statement can execute.
 ```powershell
 function MultiplyEven
 {
-    param($number)
+    param($Number)
 
-    if ($number % 2) { return "$number is not even" }
-    $number * 2
+    if ($Number % 2) { return "$Number is not even" }
+    $Number * 2
 }
 
 1..10 | ForEach-Object {MultiplyEven -Number $_}
@@ -99,15 +99,15 @@ The following example includes a statement intended to let the user know that
 the function is performing a calculation:
 
 ```powershell
-function calculation {
-    param ($value)
+function Calculation {
+    param ($Value)
 
     "Please wait. Working on calculation..."
-    $value += 73
-    return $value
+    $Value += 73
+    return $Value
 }
 
-$a = calculation 14
+$a = Calculation 14
 ```
 
 The "Please wait. Working on calculation..." string is not displayed. Instead,
@@ -128,12 +128,12 @@ the above example using the `Write-Information` cmdlet with a
 **InformationAction** set to `Continue`.
 
 ```powershell
-function calculation {
-    param ($value)
+function Calculation {
+    param ($Value)
 
     Write-Information "Please wait. Working on calculation..." -InformationAction Continue
-    $value += 73
-    return $value
+    $Value += 73
+    return $Value
 }
 ```
 
@@ -141,7 +141,7 @@ Now the information message to display in the host and not assigned to the
 variable.
 
 ```powershell
-PS> $a = calculation 14
+PS> $a = Calculation 14
 Please wait. Working on calculation...
 PS> $a
 87
@@ -152,7 +152,7 @@ PS> $a
 When you return a collection from your script block or function, PowerShell
 automatically unrolls the members and passes them one at a time through the
 pipeline. This is due to PowerShell's one-at-a-time processing. For more
-information, see [about_pipelines](about_pipelines.md).
+information, see [about_Pipelines](about_pipelines.md).
 
 This concept is illustrated by the following sample function that returns an
 array of numbers. The output from the function is piped to the `Measure-Object`

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -78,13 +78,13 @@ To find the items in a particular scope, use the Scope parameter of
 For example, to get all the variables in the local scope, type:
 
 ```powershell
-Get-Variable -Scope local
+Get-Variable -Scope Local
 ```
 
 To get all the variables in the global scope, type:
 
 ```powershell
-Get-Variable -Scope global
+Get-Variable -Scope Global
 ```
 
 When a reference is made to a variable, alias, or function, PowerShell searches
@@ -122,22 +122,22 @@ scope.
 A variable, alias, or function name can include any one of the following
 optional scope modifiers:
 
-- `global:` - Specifies that the name exists in the **Global** scope.
-- `local:` - Specifies that the name exists in the **Local** scope. The current
+- `Global:` - Specifies that the name exists in the **Global** scope.
+- `Local:` - Specifies that the name exists in the **Local** scope. The current
   scope is always the **Local** scope.
-- `private:` - Specifies that the name is **Private** and only visible to the
+- `Private:` - Specifies that the name is **Private** and only visible to the
   current scope.
 
   > [!NOTE]
-  > `private:` isn't a scope. It's an [option][04] that changes the
+  > `Private:` isn't a scope. It's an [option][04] that changes the
   > accessibility of an item outside of the scope in which it's defined.
 
-- `script:` - Specifies that the name exists in the **Script** scope.
+- `Script:` - Specifies that the name exists in the **Script** scope.
   **Script** scope is the nearest ancestor script file's scope or **Global** if
   there is no nearest ancestor script file.
-- `using:` - Used to access variables defined in another scope while running
+- `Using:` - Used to access variables defined in another scope while running
   in remote sessions, background jobs, or thread jobs.
-- `workflow:` - Specifies that the name exists within a workflow. Note:
+- `Workflow:` - Specifies that the name exists within a workflow. Note:
   Workflows aren't supported in PowerShell v6 and higher.
 - `<variable-namespace>` - A modifier created by a PowerShell **PSDrive**
   provider. For example:
@@ -177,11 +177,11 @@ in the current or **local** scope:
 $a = "one"
 ```
 
-To create the same variable in the **global** scope, use the scope `global:`
+To create the same variable in the **global** scope, use the scope `Global:`
 modifier:
 
 ```powershell
-$global:a = "one"
+$Global:a = "one"
 Get-Variable a | Format-List *
 ```
 
@@ -201,11 +201,11 @@ Attributes  : {}
 Compare that to a private variable:
 
 ```powershell
-$private:pVar = 'Private variable'
+$Private:pVar = 'Private variable'
 Get-Variable pVar | Format-List *
 ```
 
-Using the `private` scope modifier sets the **Options** property to `Private`.
+Using the `Private:` scope modifier sets the **Options** property to `Private`.
 
 ```Output
 Name        : pVar
@@ -218,18 +218,18 @@ Options     : Private
 Attributes  : {}
 ```
 
-To create the same variable in the **script** scope, use the `script:` scope
+To create the same variable in the **script** scope, use the `Script:` scope
 modifier:
 
 ```powershell
-$script:a = "one"
+$Script:a = "one"
 ```
 
 You can also use a scope modifier with functions. The following function
 definition creates a function in the **global** scope:
 
 ```powershell
-function global:Hello {
+function Global:Hello {
   Write-Host "Hello, World"
 }
 ```
@@ -240,21 +240,21 @@ and then in the global scope:
 
 ```powershell
 $test
-$global:test
+$Global:test
 ```
 
-### The `using:` scope modifier
+### The `Using:` scope modifier
 
 Using is a special scope modifier that identifies a local variable in a remote
 command. Without a modifier, PowerShell expects variables in remote commands to
 be defined in the remote session.
 
-The `using` scope modifier is introduced in PowerShell 3.0.
+The `Using:` scope modifier was introduced in PowerShell 3.0.
 
-For any script or command that executes out of session, you need the `using`
+For any script or command that executes out of session, you need the `Using:`
 scope modifier to embed variable values from the calling session scope, so that
-out of session code can access them. The `using` scope modifier is supported in
-the following contexts:
+out of session code can access them. The `Using:` scope modifier is supported
+in the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
   **ComputerName**, **HostName**, **SSHConnection** or **Session** parameters
@@ -269,7 +269,7 @@ out-of-process sessions, they're always independent copies.
 
 For more information, see [about_Remote_Variables][08].
 
-A `$using:` reference only expands to a variable's value. If you want to change
+A `$Using:` reference only expands to a variable's value. If you want to change
 the value of a variable in the caller's scope, you must have a reference to the
 variable itself. You can create a reference to a variable by getting the
 **PSVariable** instance of the variable. The following example show how to
@@ -280,7 +280,7 @@ $Count = 1
 $refOfCount = Get-Variable Count
 
 Start-ThreadJob {
-    ($using:refOfCount).Value = 2
+    ($Using:refOfCount).Value = 2
 } | Receive-Job -Wait -AutoRemoveJob
 
 $Count
@@ -311,7 +311,7 @@ It has the type properties and methods. For simple types, such as
 imperfect. For example, rehydrated certificate objects don't include the
 private key.
 
-Instances of all other types are **PSObject** instances. The **PSTypeNames**
+Instances of all other types are **PSObject** instances. The **pstypenames**
 property contains the original type name prefixed with **Deserialized**, for
 example, **Deserialized.System.Data.DataTable**
 
@@ -333,7 +333,7 @@ change) items in a particular scope. Use the following command to find all the
 cmdlets in your session that have a **Scope** parameter:
 
 ```powershell
-Get-Help * -Parameter scope
+Get-Help * -Parameter Scope
 ```
 
 To find the variables that are visible in a particular scope, use the `Scope`
@@ -344,7 +344,7 @@ For example, the following command gets the variables that are visible in the
 local scope:
 
 ```powershell
-Get-Variable -Scope local
+Get-Variable -Scope Local
 ```
 
 To create a variable in a particular scope, use a scope modifier or the
@@ -352,7 +352,7 @@ To create a variable in a particular scope, use a scope modifier or the
 in the global scope:
 
 ```powershell
-New-Variable -Scope global -Name a -Value "One"
+New-Variable -Scope Global -Name a -Value "One"
 ```
 
 You can also use the Scope parameter of the `New-Alias`, `Set-Alias`, or
@@ -360,7 +360,7 @@ You can also use the Scope parameter of the `New-Alias`, `Set-Alias`, or
 alias in the global scope:
 
 ```powershell
-New-Alias -Scope global -Name np -Value Notepad.exe
+New-Alias -Scope Global -Name np -Value Notepad.exe
 ```
 
 To get the functions in a particular scope, use the `Get-Item` cmdlet when you
@@ -390,7 +390,7 @@ the script scope (the default for scripts), just enter the full path to the
 script file on the command line.
 
 ```powershell
-c:\scripts\sample.ps1
+C:\scripts\sample.ps1
 ```
 
 A script file must have a `.ps1` file extension to be executable. Files that
@@ -403,7 +403,7 @@ Using the call operator to run a function or script runs it in script scope.
 Using the call operator is no different than running the script by name.
 
 ```powershell
-& c:\scripts\sample.ps1
+& C:\scripts\sample.ps1
 ```
 
 You can read more about the call operator in [about_Operators][07].
@@ -412,7 +412,7 @@ To run the `Sample.ps1` script in the local scope type a dot and a space (`. `)
 before the path to the script:
 
 ```powershell
-. c:\scripts\sample.ps1
+. C:\scripts\sample.ps1
 ```
 
 Now, any functions, aliases, or variables defined in the script are added to
@@ -460,7 +460,7 @@ $a = "Hello"
 
 function foo {
     "`$a = $a"
-    "`$global:a = $global:a"
+    "`$Global:a = $Global:a"
 }
 ```
 
@@ -477,7 +477,7 @@ The module declares the variable `$a` in the module scope then the function
 
 ```Output
 $a = Hello
-$global:a = Goodbye
+$Global:a = Goodbye
 ```
 
 Modules create parallel scope containers linked to the scope in which they were
@@ -489,10 +489,10 @@ module's scope container.
 
 If you load **Module2** from _within_ **Module1**, **Module2** is loaded into
 the scope container of Module1. Any exports from **Module2** are placed in the
-current module scope of **Module1**. If you use `Import-Module -Scope local`,
+current module scope of **Module1**. If you use `Import-Module -Scope Local`,
 then the exports are placed into the current scope object rather than at the
 top level. If you are _in a module_ and load another module using
-`Import-Module -Scope global` (or `Import-Module -Global`), that module and its
+`Import-Module -Scope Global` (or `Import-Module -Global`), that module and its
 exports are loaded into the global scope instead of the module's local scope.
 The **WindowsCompatibility** feature does this to import proxy modules into the
 global session state.
@@ -515,8 +515,8 @@ that scope.
 
 For example, if you create a variable that has a private option in the global
 scope and then run a script, `Get-Variable` commands in the script don't
-display the private variable. Using the global scope modifier in this instance
-doesn't display the private variable.
+display the private variable. Using the `Global:` scope modifier in this
+instance doesn't display the private variable.
 
 You can use the **Option** parameter of the `New-Variable`, `Set-Variable`,
 `New-Alias`, and `Set-Alias` cmdlets to set the value of the Option property to
@@ -606,7 +606,7 @@ In `Sample.ps1`:
 ```powershell
 $test = "Local"
 "The local value of `$test is $test."
-"The global value of `$test is $global:test."
+"The global value of `$test is $Global:test."
 ```
 
 When you run `Sample.ps1`, the output should resemble the following output:
@@ -642,8 +642,8 @@ the `$test` variable.
 In Sample.ps1:
 
 ```powershell
-$global:test = "Local"
-"The global value of `$test is $global:test."
+$Global:test = "Local"
+"The global value of `$test is $Global:test."
 ```
 
 When the script is complete, the global value of `$test` is changed.
@@ -655,7 +655,7 @@ Local
 
 ### Example 4: Creating a private variable
 
-A variable can be made private by using the `private:` scope modifier or by
+A variable can be made private by using the `Private:` scope modifier or by
 creating the variable with the **Option** property set to `Private`. Private
 variables can only be viewed or changed in the scope in which they were
 created.
@@ -676,7 +676,7 @@ function funcA {
 
 function funcB {
     "In funcB before set -> '$funcAVar1'"
-    $private:funcAVar1 = "Locally overwrite the value - child scopes can't see me!"
+    $Private:funcAVar1 = "Locally overwrite the value - child scopes can't see me!"
     "In funcB after set  -> '$funcAVar1'"
     funcC
 }
@@ -733,14 +733,14 @@ scopes using `Get-Variable` and specifying a scope number.
 
 ### Example 5: Using a local variable in a remote command
 
-For variables in a remote command created in the local session, use the `using`
-scope modifier. PowerShell assumes that the variables in remote commands were
-created in the remote session.
+For variables in a remote command created in the local session, use the
+`Using:` scope modifier. PowerShell assumes that the variables in remote
+commands were created in the remote session.
 
 The syntax is:
 
 ```
-$using:<VariableName>
+$Using:<VariableName>
 ```
 
 For example, the following commands create a `$Cred` variable in the local
@@ -748,10 +748,10 @@ session and then use the `$Cred` variable in a remote command:
 
 ```powershell
 $Cred = Get-Credential
-Invoke-Command $s {Remove-Item .\Test*.ps1 -Credential $using:Cred}
+Invoke-Command $s {Remove-Item .\Test*.ps1 -Credential $Using:Cred}
 ```
 
-The `using` scope modifier was introduced in PowerShell 3.0.
+The `Using:` scope modifier was introduced in PowerShell 3.0.
 
 ## See also
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -36,12 +36,12 @@ keyword doesn't affect or suppress other output returned from your script
 block. However, the `return` keyword exits the script block at that line. For
 more information, see [about_Return][04].
 
-Like functions, a script block can include parameters. Use the Param
+Like functions, a script block can include parameters. Use the `param`
 keyword to assign named parameters, as shown in the following syntax:
 
 ```
 {
-    Param([type]$Parameter1 [,[type]$Parameter2])
+    param ([type]$Parameter1 [,[type]$Parameter2])
     <statement list>
 }
 ```
@@ -174,7 +174,7 @@ Notes on delay-bind script blocks as parameters:
 - You must explicitly specify any parameter names you use with delay-bind
   script blocks.
 - The parameter must not be untyped, and the parameter's type can't be
-  `[scriptblock]` or `[object]`.
+  `[scriptblock]` or `[Object]`.
 - You receive an error if you use a delay-bind script block without providing
   pipeline input.
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -68,7 +68,7 @@ the English-United States (en-US) set of prompt messages for a script. The
 stores them in the `$msgtable` variable.
 
 ```powershell
-$msgTable = Data {
+$msgTable = data {
     #culture="en-US"
     ConvertFrom-StringData @'
     helloWorld = Hello, World.
@@ -186,7 +186,7 @@ are defined in the Data section.
 The remaining commands load the strings into an array and display them.
 
 ```powershell
-$Day = Data {
+$Day = data {
 #culture="en-US"
 ConvertFrom-StringData -StringData @'
     messageDate = Today is

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -133,7 +133,7 @@ Invoke-Command @invokeCommandSplat
 The Get-Help cmdlet gets the help topics for scripts as well as for cmdlets
 and other types of commands. To get the help topic for a script, type
 `Get-Help` followed by the path and filename of the script. If the script
-path is in your `Path` environment variable, you can omit the path.
+path is in your `PATH` environment variable, you can omit the path.
 
 For example, to get help for the ServicesLog.ps1 script, type:
 
@@ -144,8 +144,8 @@ Get-Help C:\admin\scripts\ServicesLog.ps1
 ## How to write a script
 
 A script can contain any valid PowerShell commands, including single commands,
-commands that use the pipeline, functions, and control structures such as If
-statements and For loops.
+commands that use the pipeline, functions, and control structures such as `if`
+statements and `for` loops.
 
 To write a script, open a new file in a text editor, type the commands, and
 save them in a file with a valid filename with the `.ps1` file extension.
@@ -164,9 +164,9 @@ commands, and then save them in a file named `ServiceLog.ps1`.
 
 ### Parameters in scripts
 
-To define parameters in a script, use a Param statement. The `Param` statement
-must be the first statement in a script, except for comments and any
-`#Require` statements.
+To define parameters in a script, use a `param` statement. The `param`
+statement must be the first statement in a script, except for comments and any
+`#Requires` statements.
 
 Script parameters work like function parameters. The parameter values are
 available to all of the commands in the script. All of the features of
@@ -185,7 +185,7 @@ param ($ComputerName = $(throw "ComputerName parameter is required."))
 
 function CanPing {
    $Error.Clear()
-   $tmp = Test-Connection $computername -ErrorAction SilentlyContinue
+   $tmp = Test-Connection $ComputerName -ErrorAction SilentlyContinue
 
    if (!$?)
        {Write-Host "Ping failed: $ComputerName."; return $false}
@@ -194,7 +194,7 @@ function CanPing {
 }
 
 function CanRemote {
-    $s = New-PSSession $computername -ErrorAction SilentlyContinue
+    $s = New-PSSession $ComputerName -ErrorAction SilentlyContinue
 
     if ($s -is [System.Management.Automation.Runspaces.PSSession])
         {Write-Host "Remote test succeeded: $ComputerName."}
@@ -202,7 +202,7 @@ function CanRemote {
         {Write-Host "Remote test failed: $ComputerName."}
 }
 
-if (CanPing $computername) {CanRemote $computername}
+if (CanPing $ComputerName) {CanRemote $ComputerName}
 ```
 
 To run this script, type the parameter name after the script name. For example:
@@ -214,8 +214,8 @@ Ping succeeded: Server01
 Remote test failed: Server01
 ```
 
-For more information about the Param statement and the function parameters, see
-[about_Functions][04] and [about_Functions_Advanced_Parameters][05].
+For more information about the `param` statement and the function parameters,
+see [about_Functions][04] and [about_Functions_Advanced_Parameters][05].
 
 ### Writing help for scripts
 
@@ -235,10 +235,11 @@ methods:
   for cmdlets. XML-based Help is required if you are translating Help topics
   into multiple languages.
 
-To associate the script with the XML-based Help topic, use the .ExternalHelp
-Help comment keyword. For more information about the ExternalHelp keyword, see
-[about_Comment_Based_Help][06]. For more information about XML-based help, see
-[How to Write Cmdlet Help][07].
+To associate the script with the XML-based Help topic, use the `.EXTERNALHELP`
+Help comment keyword. For more information, see:
+
+- [about_Comment_Based_Help][06]
+- [How to Write Cmdlet Help][07]
 
 ### Returning an exit value
 
@@ -310,7 +311,7 @@ function New-Profile
   if (Test-Path $PROFILE)
     {Write-Error "Profile $profileName already exists on this computer."}
   else
-    {New-Item -Type file -Path $PROFILE -Force }
+    {New-Item -Type File -Path $PROFILE -Force }
 }
 ```
 
@@ -323,11 +324,11 @@ removed, as shown in the following example.
 C:\PS> .\UtilityFunctions.ps1
 
 C:\PS> New-Profile
-The term 'new-profile' is not recognized as a cmdlet, function, operable
+The term 'New-Profile' is not recognized as a cmdlet, function, operable
 program, or script file. Verify the term and try again.
 At line:1 char:12
-+ new-profile <<<<
-   + CategoryInfo          : ObjectNotFound: (new-profile:String) [],
++ New-Profile <<<<
+   + CategoryInfo          : ObjectNotFound: (New-Profile:String) [],
    + FullyQualifiedErrorId : CommandNotFoundException
 
 C:\PS> $profileName
@@ -365,7 +366,7 @@ get code from trusted sources.
 
 You can include scripts in your modules, or you can create a script module,
 which is a module that consists entirely or primarily of a script and
-supporting resources. A script module is just a script with a .psm1 file
+supporting resources. A script module is just a script with a `.psm1` file
 extension.
 
 For more information about modules, see [about_Modules][09].

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -18,11 +18,11 @@ sessions that use the session configuration.
 
 > This information only applies to PowerShell running on Windows.
 
-A "session configuration file" is a text file with a .pssc file name extension
-that contains a hash table of session configuration properties and values. You
-can use a session configuration file to set the properties of a session
-configuration. Doing so defines the environment of any PowerShell sessions that
-use that session configuration.
+A "session configuration file" is a text file with a `.pssc` file name
+extension that contains a hash table of session configuration properties and
+values. You can use a session configuration file to set the properties of a
+session configuration. Doing so defines the environment of any PowerShell
+sessions that use that session configuration.
 
 Session configuration files make it easy to create custom session
 configurations without using complex C# assemblies or scripts.
@@ -139,7 +139,7 @@ later time.
 To include a session configuration file when creating a session configuration,
 use the Path parameter of the `Register-PSSessionConfiguration` cmdlet.
 
-For example, the following command uses the NoLanguage.pssc file when it
+For example, the following command uses the `NoLanguage.pssc` file when it
 creates a NoLanguage session configuration.
 
 ```powershell
@@ -156,7 +156,7 @@ new sessions created with the specified session configuration. Note that the
 `Set-PSSessionConfiguration` cmdlet changes the session itself and does not
 modify the session configuration file.
 
-For example, the following command adds the NoLanguage.pssc file to the
+For example, the following command adds the `NoLanguage.pssc` file to the
 LockedDown session configuration.
 
 ```powershell
@@ -225,7 +225,7 @@ C:\WINDOWS\System32\WindowsPowerShell\v1.0\SessionConfig\
 NoLanguage_0c115179-ff2a-4f66-a5eb-e56e5692ba22.pssc
 ```
 
-You can edit the .pssc file in any text editor. After the file is saved it
+You can edit the `.pssc` file in any text editor. After the file is saved it
 will be employed by any new sessions that use the session configuration.
 
 If you need to modify the RunAsVirtualAccount or the RunAsVirtualAccountGroups
@@ -322,7 +322,7 @@ lang                          NoteProperty   System.String lang=e...
 LanguageMode                  NoteProperty   System.String Langua...
 MaxConcurrentCommandsPerShell NoteProperty   System.String MaxCon...
 MaxConcurrentUsers            NoteProperty   System.String MaxCon...
-MaxIdleTimeoutms              NoteProperty   System.String MaxIdl...
+MaxIdleTimeoutMs              NoteProperty   System.String MaxIdl...
 MaxMemoryPerShellMB           NoteProperty   System.String MaxMem...
 MaxProcessesPerShell          NoteProperty   System.String MaxPro...
 MaxShells                     NoteProperty   System.String MaxShells

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -124,9 +124,9 @@ PS C:> Get-PSSessionConfiguration | Format-List -Property *
 ```
 
 You can also use the WSMan provider in PowerShell to view session
-configurations. The WSMan provider creates a WSMAN: drive in your session.
+configurations. The WSMan provider creates a WSMan: drive in your session.
 
-In the WSMAN: drive, session configurations are in the Plugin node. (All
+In the WSMan: drive, session configurations are in the Plugin node. (All
 session configurations are in the Plugin node, but there are items in the
 Plugin node that are not session configurations.)
 
@@ -134,7 +134,7 @@ For example, to view the session configurations on the local computer,
 type:
 
 ```powershell
-PS C:> dir wsman:\localhost\plugin\microsoft*
+PS C:> dir WSMan:\localhost\plugin\microsoft*
 
 WSManConfig: Microsoft.WSMan.Management\WSMan::localhost\Plugin
 
@@ -149,11 +149,11 @@ Container  {Name=microsoft.powershell32}     microsoft.powershell32
 
 To view the session configurations on a remote computer, use the
 `Connect-WSMan` cmdlet to add a note for the remote computer to the
-WSMAN: drive on your local computer, and then use the WSMAN: drive to view the
+WSMan: drive on your local computer, and then use the WSMan: drive to view the
 session configurations.
 
 For example, the following command adds a node for the Server01 remote
-computer to the WSMAN: drive on the local computer.
+computer to the WSMan: drive on the local computer.
 
 ```powershell
 PS C:> Connect-WSMan server01.corp.fabrikam.com
@@ -165,7 +165,7 @@ computer to view the session configurations.
 For example:
 
 ```powershell
-PS C:> cd wsman:
+PS C:> cd WSMan:
 
 PS WSMan:> dir
 
@@ -275,7 +275,7 @@ Register-PSSessionConfiguration @registerPSSessionConfigurationSplat
 ```
 
 When you create a session configuration, you can manage it by using the other
-session configuration cmdlets, and it appears in the WSMAN: drive.
+session configuration cmdlets, and it appears in the WSMan: drive.
 
 For more information, see `Register-PSSessionConfiguration`.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -49,17 +49,17 @@ Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $ps}
 You can use local variables in remote commands, but the variable must be
 defined in the local session.
 
-Beginning in PowerShell 3.0, you can use the `Using` scope modifier to identify
-a local variable in a remote command.
+Beginning in PowerShell 3.0, you can use the `Using:` scope modifier to
+identify a local variable in a remote command.
 
-The syntax of `Using` is as follows:
+The syntax of `Using:` is as follows:
 
 ```
 $Using:<VariableName>
 ```
 
 In the following example, the `$ps` variable is created in the local session,
-but is used in the session in which the command runs. The `Using` scope
+but is used in the session in which the command runs. The `Using:` scope
 modifier identifies `$ps` as a local variable.
 
 ```powershell
@@ -69,7 +69,7 @@ Invoke-Command -ComputerName S1 -ScriptBlock {
 }
 ```
 
-The `Using` scope modifier can be used in a **PSSession**.
+The `Using:` scope modifier can be used in a **PSSession**.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
@@ -77,9 +77,9 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-A variable reference such as `$using:var` expands to the value of variable
+A variable reference such as `$Using:var` expands to the value of variable
 `$var` from the caller's context. You do not get access to the caller's
-variable object. The `Using` scope modifier cannot be used to modify a local
+variable object. The `Using:` scope modifier cannot be used to modify a local
 variable within the **PSSession**. For example, the following code does not
 work:
 
@@ -89,7 +89,7 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {$Using:ps = 'Cannot assign new value'}
 ```
 
-For more information about `Using`, see [about_Scopes](./about_Scopes.md)
+For more information about `Using:`, see [about_Scopes](./about_Scopes.md)
 
 ### Using splatting
 
@@ -98,7 +98,7 @@ command. For more information, see [about_Splatting](about_Splatting.md).
 
 In this example, the splatting variable, `$Splat` is a hash table that is set
 up on the local computer. The `Invoke-Command` connects to a remote computer
-session. The **ScriptBlock** uses the `Using` scope modifier with the At (`@`)
+session. The **ScriptBlock** uses the `Using:` scope modifier with the At (`@`)
 symbol to represent the splatted variable.
 
 ```powershell
@@ -106,12 +106,12 @@ $Splat = @{ Name = "Win*"; Include = "WinRM" }
 Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
 ```
 
-### Other situations where the 'Using' scope modifier is needed
+### Other situations where the `Using:` scope modifier is needed
 
-For any script or command that executes out of session, you need the `Using`
+For any script or command that executes out of session, you need the `Using:`
 scope modifier to embed variable values from the calling session scope, so that
-out of session code can access them. The `Using` scope modifier is supported in
-the following contexts:
+out of session code can access them. The `Using:` scope modifier is supported
+in the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
   **ComputerName**, **HostName**, **SSHConnection** or **Session** parameters
@@ -140,7 +140,7 @@ It has the type properties and methods. For simple types, such as
 imperfect. For example, rehydrated certificate objects do not include the
 private key.
 
-Instances of all other types are **PSObject** instances. The **PSTypeNames**
+Instances of all other types are **PSObject** instances. The **pstypenames**
 property contains the original type name prefixed with **Deserialized**, for
 example, **Deserialized.System.Data.DataTable**
 
@@ -160,14 +160,14 @@ cmdlet to specify the local variable as the parameter value.
   the local variable as the parameter value.
 
 For example, the following commands define the `$ps` variable in the local
-session and then use it in a remote command. The command uses `$log` as the
+session and then use it in a remote command. The command uses `$Log` as the
 parameter name and the local variable, `$ps`, as its value.
 
 ```powershell
 $ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
-  param($log)
-  Get-WinEvent -LogName $log
+  param($Log)
+  Get-WinEvent -LogName $Log
 } -ArgumentList $ps
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -204,10 +204,10 @@ specified in both statements aren't met, the script doesn't run. Each
 ```powershell
 #Requires -Modules AzureRM.Netcore
 #Requires -Version 6.0
-Param
+param
 (
-    [parameter(Mandatory=$true)]
-    [String[]]
+    [Parameter(Mandatory=$true)]
+    [string[]]
     $Path
 )
 ...

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
@@ -50,7 +50,7 @@ their own help articles. To view them, type `Get-Help about_` and add the
 keyword. For example, to get information about the `foreach` statement, type:
 
 ```powershell
-Get-Help about_ForEach
+Get-Help about_Foreach
 ```
 
 For information about the `filter` statement or the `return` statement syntax,

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Return.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Return.md
@@ -22,7 +22,7 @@ Users who are familiar with languages like C or C\# might want to use the
 `return` keyword to make the logic of leaving a scope explicit.
 
 In PowerShell, the results of each statement are returned as output, even
-without a statement that contains the Return keyword. Languages like C or C\#
+without a statement that contains the `return` keyword. Languages like C or C\#
 return only the value or values that are specified by the `return` keyword.
 
 > [!NOTE]
@@ -58,10 +58,10 @@ because the return statement exits before that statement can execute.
 ```powershell
 function MultiplyEven
 {
-    param($number)
+    param($Number)
 
-    if ($number % 2) { return "$number is not even" }
-    $number * 2
+    if ($Number % 2) { return "$Number is not even" }
+    $Number * 2
 }
 
 1..10 | ForEach-Object {MultiplyEven -Number $_}
@@ -99,15 +99,15 @@ The following example includes a statement intended to let the user know that
 the function is performing a calculation:
 
 ```powershell
-function calculation {
-    param ($value)
+function Calculation {
+    param ($Value)
 
     "Please wait. Working on calculation..."
-    $value += 73
-    return $value
+    $Value += 73
+    return $Value
 }
 
-$a = calculation 14
+$a = Calculation 14
 ```
 
 The "Please wait. Working on calculation..." string is not displayed. Instead,
@@ -128,12 +128,12 @@ the above example using the `Write-Information` cmdlet with a
 **InformationAction** set to `Continue`.
 
 ```powershell
-function calculation {
-    param ($value)
+function Calculation {
+    param ($Value)
 
     Write-Information "Please wait. Working on calculation..." -InformationAction Continue
-    $value += 73
-    return $value
+    $Value += 73
+    return $Value
 }
 ```
 
@@ -141,7 +141,7 @@ Now the information message to display in the host and not assigned to the
 variable.
 
 ```powershell
-PS> $a = calculation 14
+PS> $a = Calculation 14
 Please wait. Working on calculation...
 PS> $a
 87
@@ -152,7 +152,7 @@ PS> $a
 When you return a collection from your script block or function, PowerShell
 automatically unrolls the members and passes them one at a time through the
 pipeline. This is due to PowerShell's one-at-a-time processing. For more
-information, see [about_pipelines](about_pipelines.md).
+information, see [about_Pipelines](about_pipelines.md).
 
 This concept is illustrated by the following sample function that returns an
 array of numbers. The output from the function is piped to the `Measure-Object`

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -78,13 +78,13 @@ To find the items in a particular scope, use the Scope parameter of
 For example, to get all the variables in the local scope, type:
 
 ```powershell
-Get-Variable -Scope local
+Get-Variable -Scope Local
 ```
 
 To get all the variables in the global scope, type:
 
 ```powershell
-Get-Variable -Scope global
+Get-Variable -Scope Global
 ```
 
 When a reference is made to a variable, alias, or function, PowerShell searches
@@ -122,22 +122,22 @@ scope.
 A variable, alias, or function name can include any one of the following
 optional scope modifiers:
 
-- `global:` - Specifies that the name exists in the **Global** scope.
-- `local:` - Specifies that the name exists in the **Local** scope. The current
+- `Global:` - Specifies that the name exists in the **Global** scope.
+- `Local:` - Specifies that the name exists in the **Local** scope. The current
   scope is always the **Local** scope.
-- `private:` - Specifies that the name is **Private** and only visible to the
+- `Private:` - Specifies that the name is **Private** and only visible to the
   current scope.
 
   > [!NOTE]
-  > `private:` isn't a scope. It's an [option][04] that changes the
+  > `Private:` isn't a scope. It's an [option][04] that changes the
   > accessibility of an item outside of the scope in which it's defined.
 
-- `script:` - Specifies that the name exists in the **Script** scope.
+- `Script:` - Specifies that the name exists in the **Script** scope.
   **Script** scope is the nearest ancestor script file's scope or **Global** if
   there is no nearest ancestor script file.
-- `using:` - Used to access variables defined in another scope while running
+- `Using:` - Used to access variables defined in another scope while running
   in remote sessions, background jobs, or thread jobs.
-- `workflow:` - Specifies that the name exists within a workflow. Note:
+- `Workflow:` - Specifies that the name exists within a workflow. Note:
   Workflows aren't supported in PowerShell v6 and higher.
 - `<variable-namespace>` - A modifier created by a PowerShell **PSDrive**
   provider. For example:
@@ -177,11 +177,11 @@ in the current or **local** scope:
 $a = "one"
 ```
 
-To create the same variable in the **global** scope, use the scope `global:`
+To create the same variable in the **global** scope, use the scope `Global:`
 modifier:
 
 ```powershell
-$global:a = "one"
+$Global:a = "one"
 Get-Variable a | Format-List *
 ```
 
@@ -201,11 +201,11 @@ Attributes  : {}
 Compare that to a private variable:
 
 ```powershell
-$private:pVar = 'Private variable'
+$Private:pVar = 'Private variable'
 Get-Variable pVar | Format-List *
 ```
 
-Using the `private` scope modifier sets the **Options** property to `Private`.
+Using the `Private:` scope modifier sets the **Options** property to `Private`.
 
 ```Output
 Name        : pVar
@@ -218,18 +218,18 @@ Options     : Private
 Attributes  : {}
 ```
 
-To create the same variable in the **script** scope, use the `script:` scope
+To create the same variable in the **script** scope, use the `Script:` scope
 modifier:
 
 ```powershell
-$script:a = "one"
+$Script:a = "one"
 ```
 
 You can also use a scope modifier with functions. The following function
 definition creates a function in the **global** scope:
 
 ```powershell
-function global:Hello {
+function Global:Hello {
   Write-Host "Hello, World"
 }
 ```
@@ -240,21 +240,21 @@ and then in the global scope:
 
 ```powershell
 $test
-$global:test
+$Global:test
 ```
 
-### The `using:` scope modifier
+### The `Using:` scope modifier
 
 Using is a special scope modifier that identifies a local variable in a remote
 command. Without a modifier, PowerShell expects variables in remote commands to
 be defined in the remote session.
 
-The `using` scope modifier is introduced in PowerShell 3.0.
+The `Using:` scope modifier was introduced in PowerShell 3.0.
 
-For any script or command that executes out of session, you need the `using`
+For any script or command that executes out of session, you need the `Using:`
 scope modifier to embed variable values from the calling session scope, so that
-out of session code can access them. The `using` scope modifier is supported in
-the following contexts:
+out of session code can access them. The `Using:` scope modifier is supported
+in the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
   **ComputerName**, **HostName**, **SSHConnection** or **Session** parameters
@@ -269,7 +269,7 @@ out-of-process sessions, they're always independent copies.
 
 For more information, see [about_Remote_Variables][08].
 
-A `$using:` reference only expands to a variable's value. If you want to change
+A `$Using:` reference only expands to a variable's value. If you want to change
 the value of a variable in the caller's scope, you must have a reference to the
 variable itself. You can create a reference to a variable by getting the
 **PSVariable** instance of the variable. The following example show how to
@@ -280,7 +280,7 @@ $Count = 1
 $refOfCount = Get-Variable Count
 
 Start-ThreadJob {
-    ($using:refOfCount).Value = 2
+    ($Using:refOfCount).Value = 2
 } | Receive-Job -Wait -AutoRemoveJob
 
 $Count
@@ -311,7 +311,7 @@ It has the type properties and methods. For simple types, such as
 imperfect. For example, rehydrated certificate objects don't include the
 private key.
 
-Instances of all other types are **PSObject** instances. The **PSTypeNames**
+Instances of all other types are **PSObject** instances. The **pstypenames**
 property contains the original type name prefixed with **Deserialized**, for
 example, **Deserialized.System.Data.DataTable**
 
@@ -333,7 +333,7 @@ change) items in a particular scope. Use the following command to find all the
 cmdlets in your session that have a **Scope** parameter:
 
 ```powershell
-Get-Help * -Parameter scope
+Get-Help * -Parameter Scope
 ```
 
 To find the variables that are visible in a particular scope, use the `Scope`
@@ -344,7 +344,7 @@ For example, the following command gets the variables that are visible in the
 local scope:
 
 ```powershell
-Get-Variable -Scope local
+Get-Variable -Scope Local
 ```
 
 To create a variable in a particular scope, use a scope modifier or the
@@ -352,7 +352,7 @@ To create a variable in a particular scope, use a scope modifier or the
 in the global scope:
 
 ```powershell
-New-Variable -Scope global -Name a -Value "One"
+New-Variable -Scope Global -Name a -Value "One"
 ```
 
 You can also use the Scope parameter of the `New-Alias`, `Set-Alias`, or
@@ -360,7 +360,7 @@ You can also use the Scope parameter of the `New-Alias`, `Set-Alias`, or
 alias in the global scope:
 
 ```powershell
-New-Alias -Scope global -Name np -Value Notepad.exe
+New-Alias -Scope Global -Name np -Value Notepad.exe
 ```
 
 To get the functions in a particular scope, use the `Get-Item` cmdlet when you
@@ -390,7 +390,7 @@ the script scope (the default for scripts), just enter the full path to the
 script file on the command line.
 
 ```powershell
-c:\scripts\sample.ps1
+C:\scripts\sample.ps1
 ```
 
 A script file must have a `.ps1` file extension to be executable. Files that
@@ -403,7 +403,7 @@ Using the call operator to run a function or script runs it in script scope.
 Using the call operator is no different than running the script by name.
 
 ```powershell
-& c:\scripts\sample.ps1
+& C:\scripts\sample.ps1
 ```
 
 You can read more about the call operator in [about_Operators][07].
@@ -412,7 +412,7 @@ To run the `Sample.ps1` script in the local scope type a dot and a space (`. `)
 before the path to the script:
 
 ```powershell
-. c:\scripts\sample.ps1
+. C:\scripts\sample.ps1
 ```
 
 Now, any functions, aliases, or variables defined in the script are added to
@@ -460,7 +460,7 @@ $a = "Hello"
 
 function foo {
     "`$a = $a"
-    "`$global:a = $global:a"
+    "`$Global:a = $Global:a"
 }
 ```
 
@@ -477,7 +477,7 @@ The module declares the variable `$a` in the module scope then the function
 
 ```Output
 $a = Hello
-$global:a = Goodbye
+$Global:a = Goodbye
 ```
 
 Modules create parallel scope containers linked to the scope in which they were
@@ -489,10 +489,10 @@ module's scope container.
 
 If you load **Module2** from _within_ **Module1**, **Module2** is loaded into
 the scope container of Module1. Any exports from **Module2** are placed in the
-current module scope of **Module1**. If you use `Import-Module -Scope local`,
+current module scope of **Module1**. If you use `Import-Module -Scope Local`,
 then the exports are placed into the current scope object rather than at the
 top level. If you are _in a module_ and load another module using
-`Import-Module -Scope global` (or `Import-Module -Global`), that module and its
+`Import-Module -Scope Global` (or `Import-Module -Global`), that module and its
 exports are loaded into the global scope instead of the module's local scope.
 The **WindowsCompatibility** feature does this to import proxy modules into the
 global session state.
@@ -515,8 +515,8 @@ that scope.
 
 For example, if you create a variable that has a private option in the global
 scope and then run a script, `Get-Variable` commands in the script don't
-display the private variable. Using the global scope modifier in this instance
-doesn't display the private variable.
+display the private variable. Using the `Global:` scope modifier in this
+instance doesn't display the private variable.
 
 You can use the **Option** parameter of the `New-Variable`, `Set-Variable`,
 `New-Alias`, and `Set-Alias` cmdlets to set the value of the Option property to
@@ -606,7 +606,7 @@ In `Sample.ps1`:
 ```powershell
 $test = "Local"
 "The local value of `$test is $test."
-"The global value of `$test is $global:test."
+"The global value of `$test is $Global:test."
 ```
 
 When you run `Sample.ps1`, the output should resemble the following output:
@@ -642,8 +642,8 @@ the `$test` variable.
 In Sample.ps1:
 
 ```powershell
-$global:test = "Local"
-"The global value of `$test is $global:test."
+$Global:test = "Local"
+"The global value of `$test is $Global:test."
 ```
 
 When the script is complete, the global value of `$test` is changed.
@@ -655,7 +655,7 @@ Local
 
 ### Example 4: Creating a private variable
 
-A variable can be made private by using the `private:` scope modifier or by
+A variable can be made private by using the `Private:` scope modifier or by
 creating the variable with the **Option** property set to `Private`. Private
 variables can only be viewed or changed in the scope in which they were
 created.
@@ -676,7 +676,7 @@ function funcA {
 
 function funcB {
     "In funcB before set -> '$funcAVar1'"
-    $private:funcAVar1 = "Locally overwrite the value - child scopes can't see me!"
+    $Private:funcAVar1 = "Locally overwrite the value - child scopes can't see me!"
     "In funcB after set  -> '$funcAVar1'"
     funcC
 }
@@ -733,14 +733,14 @@ scopes using `Get-Variable` and specifying a scope number.
 
 ### Example 5: Using a local variable in a remote command
 
-For variables in a remote command created in the local session, use the `using`
-scope modifier. PowerShell assumes that the variables in remote commands were
-created in the remote session.
+For variables in a remote command created in the local session, use the
+`Using:` scope modifier. PowerShell assumes that the variables in remote
+commands were created in the remote session.
 
 The syntax is:
 
 ```
-$using:<VariableName>
+$Using:<VariableName>
 ```
 
 For example, the following commands create a `$Cred` variable in the local
@@ -748,10 +748,10 @@ session and then use the `$Cred` variable in a remote command:
 
 ```powershell
 $Cred = Get-Credential
-Invoke-Command $s {Remove-Item .\Test*.ps1 -Credential $using:Cred}
+Invoke-Command $s {Remove-Item .\Test*.ps1 -Credential $Using:Cred}
 ```
 
-The `using` scope modifier was introduced in PowerShell 3.0.
+The `Using:` scope modifier was introduced in PowerShell 3.0.
 
 ## See also
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -36,12 +36,12 @@ keyword doesn't affect or suppress other output returned from your script
 block. However, the `return` keyword exits the script block at that line. For
 more information, see [about_Return][04].
 
-Like functions, a script block can include parameters. Use the Param
+Like functions, a script block can include parameters. Use the `param`
 keyword to assign named parameters, as shown in the following syntax:
 
 ```
 {
-    Param([type]$Parameter1 [,[type]$Parameter2])
+    param ([type]$Parameter1 [,[type]$Parameter2])
     <statement list>
 }
 ```
@@ -50,8 +50,8 @@ keyword to assign named parameters, as shown in the following syntax:
 > In a script block, unlike a function, you can't specify parameters outside
 > the braces.
 
-Like functions, script blocks can include the `DynamicParam`, `Begin`,
-`Process`, and `End` keywords. For more information, see [about_Functions][02]
+Like functions, script blocks can include the `dynamicparam`, `begin`,
+`process`, and `end` keywords. For more information, see [about_Functions][02]
 and [about_Functions_Advanced][01].
 
 ## Using Script Blocks
@@ -174,7 +174,7 @@ Notes on delay-bind script blocks as parameters:
 - You must explicitly specify any parameter names you use with delay-bind
   script blocks.
 - The parameter must not be untyped, and the parameter's type can't be
-  `[scriptblock]` or `[object]`.
+  `[scriptblock]` or `[Object]`.
 - You receive an error if you use a delay-bind script block without providing
   pipeline input.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -68,7 +68,7 @@ the English-United States (en-US) set of prompt messages for a script. The
 stores them in the `$msgtable` variable.
 
 ```powershell
-$msgTable = Data {
+$msgTable = data {
     #culture="en-US"
     ConvertFrom-StringData @'
     helloWorld = Hello, World.
@@ -186,7 +186,7 @@ are defined in the Data section.
 The remaining commands load the strings into an array and display them.
 
 ```powershell
-$Day = Data {
+$Day = data {
 #culture="en-US"
 ConvertFrom-StringData -StringData @'
     messageDate = Today is

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -133,7 +133,7 @@ Invoke-Command @invokeCommandSplat
 The Get-Help cmdlet gets the help topics for scripts as well as for cmdlets
 and other types of commands. To get the help topic for a script, type
 `Get-Help` followed by the path and filename of the script. If the script
-path is in your `Path` environment variable, you can omit the path.
+path is in your `PATH` environment variable, you can omit the path.
 
 For example, to get help for the ServicesLog.ps1 script, type:
 
@@ -145,7 +145,7 @@ Get-Help C:\admin\scripts\ServicesLog.ps1
 
 A script can contain any valid PowerShell commands, including single commands,
 commands that use the pipeline, functions, and control structures such as If
-statements and For loops.
+statements and `for` loops.
 
 To write a script, open a new file in a text editor, type the commands, and
 save them in a file with a valid filename with the `.ps1` file extension.
@@ -164,9 +164,9 @@ commands, and then save them in a file named `ServiceLog.ps1`.
 
 ### Parameters in scripts
 
-To define parameters in a script, use a Param statement. The `Param` statement
-must be the first statement in a script, except for comments and any
-`#Require` statements.
+To define parameters in a script, use a `param` statement. The `param`
+statement must be the first statement in a script, except for comments and any
+`#Requires` statements.
 
 Script parameters work like function parameters. The parameter values are
 available to all of the commands in the script. All of the features of
@@ -185,7 +185,7 @@ param ($ComputerName = $(throw "ComputerName parameter is required."))
 
 function CanPing {
    $Error.Clear()
-   $tmp = Test-Connection $computername -ErrorAction SilentlyContinue
+   $tmp = Test-Connection $ComputerName -ErrorAction SilentlyContinue
 
    if (!$?)
        {Write-Host "Ping failed: $ComputerName."; return $false}
@@ -194,7 +194,7 @@ function CanPing {
 }
 
 function CanRemote {
-    $s = New-PSSession $computername -ErrorAction SilentlyContinue
+    $s = New-PSSession $ComputerName -ErrorAction SilentlyContinue
 
     if ($s -is [System.Management.Automation.Runspaces.PSSession])
         {Write-Host "Remote test succeeded: $ComputerName."}
@@ -202,7 +202,7 @@ function CanRemote {
         {Write-Host "Remote test failed: $ComputerName."}
 }
 
-if (CanPing $computername) {CanRemote $computername}
+if (CanPing $ComputerName) {CanRemote $ComputerName}
 ```
 
 To run this script, type the parameter name after the script name. For example:
@@ -214,8 +214,8 @@ Ping succeeded: Server01
 Remote test failed: Server01
 ```
 
-For more information about the Param statement and the function parameters, see
-[about_Functions][04] and [about_Functions_Advanced_Parameters][05].
+For more information about the `param` statement and the function parameters,
+see [about_Functions][04] and [about_Functions_Advanced_Parameters][05].
 
 ### Writing help for scripts
 
@@ -235,10 +235,11 @@ methods:
   for cmdlets. XML-based Help is required if you are translating Help topics
   into multiple languages.
 
-To associate the script with the XML-based Help topic, use the .ExternalHelp
-Help comment keyword. For more information about the ExternalHelp keyword, see
-[about_Comment_Based_Help][06]. For more information about XML-based help, see
-[How to Write Cmdlet Help][07].
+To associate the script with the XML-based Help topic, use the `.EXTERNALHELP`
+Help comment keyword. For more information, see:
+
+- [about_Comment_Based_Help][06]
+- [How to Write Cmdlet Help][07]
 
 ### Returning an exit value
 
@@ -310,7 +311,7 @@ function New-Profile
   if (Test-Path $PROFILE)
     {Write-Error "Profile $profileName already exists on this computer."}
   else
-    {New-Item -Type file -Path $PROFILE -Force }
+    {New-Item -Type File -Path $PROFILE -Force }
 }
 ```
 
@@ -323,11 +324,11 @@ removed, as shown in the following example.
 C:\PS> .\UtilityFunctions.ps1
 
 C:\PS> New-Profile
-The term 'new-profile' is not recognized as a cmdlet, function, operable
+The term 'New-Profile' is not recognized as a cmdlet, function, operable
 program, or script file. Verify the term and try again.
 At line:1 char:12
-+ new-profile <<<<
-   + CategoryInfo          : ObjectNotFound: (new-profile:String) [],
++ New-Profile <<<<
+   + CategoryInfo          : ObjectNotFound: (New-Profile:String) [],
    + FullyQualifiedErrorId : CommandNotFoundException
 
 C:\PS> $profileName
@@ -365,7 +366,7 @@ get code from trusted sources.
 
 You can include scripts in your modules, or you can create a script module,
 which is a module that consists entirely or primarily of a script and
-supporting resources. A script module is just a script with a .psm1 file
+supporting resources. A script module is just a script with a `.psm1` file
 extension.
 
 For more information about modules, see [about_Modules][09].

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -19,11 +19,11 @@ sessions that use the session configuration.
 
 > This information only applies to PowerShell running on Windows.
 
-A "session configuration file" is a text file with a .pssc file name extension
-that contains a hash table of session configuration properties and values. You
-can use a session configuration file to set the properties of a session
-configuration. Doing so defines the environment of any PowerShell sessions that
-use that session configuration.
+A "session configuration file" is a text file with a `.pssc` file name
+extension that contains a hash table of session configuration properties and
+values. You can use a session configuration file to set the properties of a
+session configuration. Doing so defines the environment of any PowerShell
+sessions that use that session configuration.
 
 Session configuration files make it easy to create custom session
 configurations without using complex C# assemblies or scripts.
@@ -140,7 +140,7 @@ later time.
 To include a session configuration file when creating a session configuration,
 use the Path parameter of the `Register-PSSessionConfiguration` cmdlet.
 
-For example, the following command uses the NoLanguage.pssc file when it
+For example, the following command uses the `NoLanguage.pssc` file when it
 creates a NoLanguage session configuration.
 
 ```powershell
@@ -157,7 +157,7 @@ new sessions created with the specified session configuration. Note that the
 `Set-PSSessionConfiguration` cmdlet changes the session itself and does not
 modify the session configuration file.
 
-For example, the following command adds the NoLanguage.pssc file to the
+For example, the following command adds the `NoLanguage.pssc` file to the
 LockedDown session configuration.
 
 ```powershell
@@ -226,7 +226,7 @@ C:\WINDOWS\System32\WindowsPowerShell\v1.0\SessionConfig\
 NoLanguage_0c115179-ff2a-4f66-a5eb-e56e5692ba22.pssc
 ```
 
-You can edit the .pssc file in any text editor. After the file is saved it
+You can edit the `.pssc` file in any text editor. After the file is saved it
 will be employed by any new sessions that use the session configuration.
 
 If you need to modify the RunAsVirtualAccount or the RunAsVirtualAccountGroups
@@ -323,7 +323,7 @@ lang                          NoteProperty   System.String lang=e...
 LanguageMode                  NoteProperty   System.String Langua...
 MaxConcurrentCommandsPerShell NoteProperty   System.String MaxCon...
 MaxConcurrentUsers            NoteProperty   System.String MaxCon...
-MaxIdleTimeoutms              NoteProperty   System.String MaxIdl...
+MaxIdleTimeoutMs              NoteProperty   System.String MaxIdl...
 MaxMemoryPerShellMB           NoteProperty   System.String MaxMem...
 MaxProcessesPerShell          NoteProperty   System.String MaxPro...
 MaxShells                     NoteProperty   System.String MaxShells

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -124,9 +124,9 @@ PS C:> Get-PSSessionConfiguration | Format-List -Property *
 ```
 
 You can also use the WSMan provider in PowerShell to view session
-configurations. The WSMan provider creates a WSMAN: drive in your session.
+configurations. The WSMan provider creates a WSMan: drive in your session.
 
-In the WSMAN: drive, session configurations are in the Plugin node. (All
+In the WSMan: drive, session configurations are in the Plugin node. (All
 session configurations are in the Plugin node, but there are items in the
 Plugin node that are not session configurations.)
 
@@ -134,7 +134,7 @@ For example, to view the session configurations on the local computer,
 type:
 
 ```powershell
-PS C:> dir wsman:\localhost\plugin\microsoft*
+PS C:> dir WSMan:\localhost\plugin\microsoft*
 
 WSManConfig: Microsoft.WSMan.Management\WSMan::localhost\Plugin
 
@@ -149,11 +149,11 @@ Container  {Name=microsoft.powershell32}     microsoft.powershell32
 
 To view the session configurations on a remote computer, use the
 `Connect-WSMan` cmdlet to add a note for the remote computer to the
-WSMAN: drive on your local computer, and then use the WSMAN: drive to view the
+WSMan: drive on your local computer, and then use the WSMan: drive to view the
 session configurations.
 
 For example, the following command adds a node for the Server01 remote
-computer to the WSMAN: drive on the local computer.
+computer to the WSMan: drive on the local computer.
 
 ```powershell
 PS C:> Connect-WSMan server01.corp.fabrikam.com
@@ -165,7 +165,7 @@ computer to view the session configurations.
 For example:
 
 ```powershell
-PS C:> cd wsman:
+PS C:> cd WSMan:
 
 PS WSMan:> dir
 
@@ -275,7 +275,7 @@ Register-PSSessionConfiguration @registerPSSessionConfigurationSplat
 ```
 
 When you create a session configuration, you can manage it by using the other
-session configuration cmdlets, and it appears in the WSMAN: drive.
+session configuration cmdlets, and it appears in the WSMan: drive.
 
 For more information, see `Register-PSSessionConfiguration`.
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -49,17 +49,17 @@ Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $ps}
 You can use local variables in remote commands, but the variable must be
 defined in the local session.
 
-Beginning in PowerShell 3.0, you can use the `Using` scope modifier to identify
-a local variable in a remote command.
+Beginning in PowerShell 3.0, you can use the `Using:` scope modifier to
+identify a local variable in a remote command.
 
-The syntax of `Using` is as follows:
+The syntax of `Using:` is as follows:
 
 ```
 $Using:<VariableName>
 ```
 
 In the following example, the `$ps` variable is created in the local session,
-but is used in the session in which the command runs. The `Using` scope
+but is used in the session in which the command runs. The `Using:` scope
 modifier identifies `$ps` as a local variable.
 
 ```powershell
@@ -69,7 +69,7 @@ Invoke-Command -ComputerName S1 -ScriptBlock {
 }
 ```
 
-The `Using` scope modifier can be used in a **PSSession**.
+The `Using:` scope modifier can be used in a **PSSession**.
 
 ```powershell
 $s = New-PSSession -ComputerName S1
@@ -77,9 +77,9 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
-A variable reference such as `$using:var` expands to the value of variable
+A variable reference such as `$Using:var` expands to the value of variable
 `$var` from the caller's context. You do not get access to the caller's
-variable object. The `Using` scope modifier cannot be used to modify a local
+variable object. The `Using:` scope modifier cannot be used to modify a local
 variable within the **PSSession**. For example, the following code does not
 work:
 
@@ -89,7 +89,7 @@ $ps = "*PowerShell*"
 Invoke-Command -Session $s -ScriptBlock {$Using:ps = 'Cannot assign new value'}
 ```
 
-For more information about `Using`, see [about_Scopes](./about_Scopes.md)
+For more information about `Using:`, see [about_Scopes](./about_Scopes.md)
 
 ### Using splatting
 
@@ -98,7 +98,7 @@ command. For more information, see [about_Splatting](about_Splatting.md).
 
 In this example, the splatting variable, `$Splat` is a hash table that is set
 up on the local computer. The `Invoke-Command` connects to a remote computer
-session. The **ScriptBlock** uses the `Using` scope modifier with the At (`@`)
+session. The **ScriptBlock** uses the `Using:` scope modifier with the At (`@`)
 symbol to represent the splatted variable.
 
 ```powershell
@@ -106,12 +106,12 @@ $Splat = @{ Name = "Win*"; Include = "WinRM" }
 Invoke-Command -Session $s -ScriptBlock { Get-Service @Using:Splat }
 ```
 
-### Other situations where the 'Using' scope modifier is needed
+### Other situations where the `Using:` scope modifier is needed
 
-For any script or command that executes out of session, you need the `Using`
+For any script or command that executes out of session, you need the `Using:`
 scope modifier to embed variable values from the calling session scope, so that
-out of session code can access them. The `Using` scope modifier is supported in
-the following contexts:
+out of session code can access them. The `Using:` scope modifier is supported
+in the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
   **ComputerName**, **HostName**, **SSHConnection** or **Session** parameters
@@ -140,7 +140,7 @@ It has the type properties and methods. For simple types, such as
 imperfect. For example, rehydrated certificate objects do not include the
 private key.
 
-Instances of all other types are **PSObject** instances. The **PSTypeNames**
+Instances of all other types are **PSObject** instances. The **pstypenames**
 property contains the original type name prefixed with **Deserialized**, for
 example, **Deserialized.System.Data.DataTable**
 
@@ -160,14 +160,14 @@ cmdlet to specify the local variable as the parameter value.
   the local variable as the parameter value.
 
 For example, the following commands define the `$ps` variable in the local
-session and then use it in a remote command. The command uses `$log` as the
+session and then use it in a remote command. The command uses `$Log` as the
 parameter name and the local variable, `$ps`, as its value.
 
 ```powershell
 $ps = "*PowerShell*"
 Invoke-Command -ComputerName S1 -ScriptBlock {
-  param($log)
-  Get-WinEvent -LogName $log
+  param($Log)
+  Get-WinEvent -LogName $Log
 } -ArgumentList $ps
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -204,10 +204,10 @@ specified in both statements aren't met, the script doesn't run. Each
 ```powershell
 #Requires -Modules AzureRM.Netcore
 #Requires -Version 6.0
-Param
+param
 (
-    [parameter(Mandatory=$true)]
-    [String[]]
+    [Parameter(Mandatory=$true)]
+    [string[]]
     $Path
 )
 ...

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
@@ -50,7 +50,7 @@ their own help articles. To view them, type `Get-Help about_` and add the
 keyword. For example, to get information about the `foreach` statement, type:
 
 ```powershell
-Get-Help about_ForEach
+Get-Help about_Foreach
 ```
 
 For information about the `filter` statement or the `return` statement syntax,

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Return.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Return.md
@@ -22,7 +22,7 @@ Users who are familiar with languages like C or C\# might want to use the
 `return` keyword to make the logic of leaving a scope explicit.
 
 In PowerShell, the results of each statement are returned as output, even
-without a statement that contains the Return keyword. Languages like C or C\#
+without a statement that contains the `return` keyword. Languages like C or C\#
 return only the value or values that are specified by the `return` keyword.
 
 > [!NOTE]
@@ -58,10 +58,10 @@ because the return statement exits before that statement can execute.
 ```powershell
 function MultiplyEven
 {
-    param($number)
+    param($Number)
 
-    if ($number % 2) { return "$number is not even" }
-    $number * 2
+    if ($Number % 2) { return "$Number is not even" }
+    $Number * 2
 }
 
 1..10 | ForEach-Object {MultiplyEven -Number $_}
@@ -99,15 +99,15 @@ The following example includes a statement intended to let the user know that
 the function is performing a calculation:
 
 ```powershell
-function calculation {
-    param ($value)
+function Calculation {
+    param ($Value)
 
     "Please wait. Working on calculation..."
-    $value += 73
-    return $value
+    $Value += 73
+    return $Value
 }
 
-$a = calculation 14
+$a = Calculation 14
 ```
 
 The "Please wait. Working on calculation..." string is not displayed. Instead,
@@ -128,12 +128,12 @@ the above example using the `Write-Information` cmdlet with a
 **InformationAction** set to `Continue`.
 
 ```powershell
-function calculation {
-    param ($value)
+function Calculation {
+    param ($Value)
 
     Write-Information "Please wait. Working on calculation..." -InformationAction Continue
-    $value += 73
-    return $value
+    $Value += 73
+    return $Value
 }
 ```
 
@@ -141,7 +141,7 @@ Now the information message to display in the host and not assigned to the
 variable.
 
 ```powershell
-PS> $a = calculation 14
+PS> $a = Calculation 14
 Please wait. Working on calculation...
 PS> $a
 87
@@ -152,7 +152,7 @@ PS> $a
 When you return a collection from your script block or function, PowerShell
 automatically unrolls the members and passes them one at a time through the
 pipeline. This is due to PowerShell's one-at-a-time processing. For more
-information, see [about_pipelines](about_pipelines.md).
+information, see [about_Pipelines](about_pipelines.md).
 
 This concept is illustrated by the following sample function that returns an
 array of numbers. The output from the function is piped to the `Measure-Object`

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -78,13 +78,13 @@ To find the items in a particular scope, use the Scope parameter of
 For example, to get all the variables in the local scope, type:
 
 ```powershell
-Get-Variable -Scope local
+Get-Variable -Scope Local
 ```
 
 To get all the variables in the global scope, type:
 
 ```powershell
-Get-Variable -Scope global
+Get-Variable -Scope Global
 ```
 
 When a reference is made to a variable, alias, or function, PowerShell searches
@@ -122,22 +122,22 @@ scope.
 A variable, alias, or function name can include any one of the following
 optional scope modifiers:
 
-- `global:` - Specifies that the name exists in the **Global** scope.
-- `local:` - Specifies that the name exists in the **Local** scope. The current
+- `Global:` - Specifies that the name exists in the **Global** scope.
+- `Local:` - Specifies that the name exists in the **Local** scope. The current
   scope is always the **Local** scope.
-- `private:` - Specifies that the name is **Private** and only visible to the
+- `Private:` - Specifies that the name is **Private** and only visible to the
   current scope.
 
   > [!NOTE]
-  > `private:` isn't a scope. It's an [option][04] that changes the
+  > `Private:` isn't a scope. It's an [option][04] that changes the
   > accessibility of an item outside of the scope in which it's defined.
 
-- `script:` - Specifies that the name exists in the **Script** scope.
+- `Script:` - Specifies that the name exists in the **Script** scope.
   **Script** scope is the nearest ancestor script file's scope or **Global** if
   there is no nearest ancestor script file.
-- `using:` - Used to access variables defined in another scope while running
+- `Using:` - Used to access variables defined in another scope while running
   in remote sessions, background jobs, or thread jobs.
-- `workflow:` - Specifies that the name exists within a workflow. Note:
+- `Workflow:` - Specifies that the name exists within a workflow. Note:
   Workflows aren't supported in PowerShell v6 and higher.
 - `<variable-namespace>` - A modifier created by a PowerShell **PSDrive**
   provider. For example:
@@ -177,11 +177,11 @@ in the current or **local** scope:
 $a = "one"
 ```
 
-To create the same variable in the **global** scope, use the scope `global:`
+To create the same variable in the **global** scope, use the scope `Global:`
 modifier:
 
 ```powershell
-$global:a = "one"
+$Global:a = "one"
 Get-Variable a | Format-List *
 ```
 
@@ -201,11 +201,11 @@ Attributes  : {}
 Compare that to a private variable:
 
 ```powershell
-$private:pVar = 'Private variable'
+$Private:pVar = 'Private variable'
 Get-Variable pVar | Format-List *
 ```
 
-Using the `private` scope modifier sets the **Options** property to `Private`.
+Using the `Private:` scope modifier sets the **Options** property to `Private`.
 
 ```Output
 Name        : pVar
@@ -218,18 +218,18 @@ Options     : Private
 Attributes  : {}
 ```
 
-To create the same variable in the **script** scope, use the `script:` scope
+To create the same variable in the **script** scope, use the `Script:` scope
 modifier:
 
 ```powershell
-$script:a = "one"
+$Script:a = "one"
 ```
 
 You can also use a scope modifier with functions. The following function
 definition creates a function in the **global** scope:
 
 ```powershell
-function global:Hello {
+function Global:Hello {
   Write-Host "Hello, World"
 }
 ```
@@ -240,21 +240,21 @@ and then in the global scope:
 
 ```powershell
 $test
-$global:test
+$Global:test
 ```
 
-### The `using:` scope modifier
+### The `Using:` scope modifier
 
 Using is a special scope modifier that identifies a local variable in a remote
 command. Without a modifier, PowerShell expects variables in remote commands to
 be defined in the remote session.
 
-The `using` scope modifier is introduced in PowerShell 3.0.
+The `Using:` scope modifier was introduced in PowerShell 3.0.
 
-For any script or command that executes out of session, you need the `using`
+For any script or command that executes out of session, you need the `Using:`
 scope modifier to embed variable values from the calling session scope, so that
-out of session code can access them. The `using` scope modifier is supported in
-the following contexts:
+out of session code can access them. The `Using:` scope modifier is supported
+in the following contexts:
 
 - Remotely executed commands, started with `Invoke-Command` using the
   **ComputerName**, **HostName**, **SSHConnection** or **Session** parameters
@@ -269,7 +269,7 @@ out-of-process sessions, they're always independent copies.
 
 For more information, see [about_Remote_Variables][08].
 
-A `$using:` reference only expands to a variable's value. If you want to change
+A `$Using:` reference only expands to a variable's value. If you want to change
 the value of a variable in the caller's scope, you must have a reference to the
 variable itself. You can create a reference to a variable by getting the
 **PSVariable** instance of the variable. The following example show how to
@@ -280,7 +280,7 @@ $Count = 1
 $refOfCount = Get-Variable Count
 
 Start-ThreadJob {
-    ($using:refOfCount).Value = 2
+    ($Using:refOfCount).Value = 2
 } | Receive-Job -Wait -AutoRemoveJob
 
 $Count
@@ -311,7 +311,7 @@ It has the type properties and methods. For simple types, such as
 imperfect. For example, rehydrated certificate objects don't include the
 private key.
 
-Instances of all other types are **PSObject** instances. The **PSTypeNames**
+Instances of all other types are **PSObject** instances. The **pstypenames**
 property contains the original type name prefixed with **Deserialized**, for
 example, **Deserialized.System.Data.DataTable**
 
@@ -333,7 +333,7 @@ change) items in a particular scope. Use the following command to find all the
 cmdlets in your session that have a **Scope** parameter:
 
 ```powershell
-Get-Help * -Parameter scope
+Get-Help * -Parameter Scope
 ```
 
 To find the variables that are visible in a particular scope, use the `Scope`
@@ -344,7 +344,7 @@ For example, the following command gets the variables that are visible in the
 local scope:
 
 ```powershell
-Get-Variable -Scope local
+Get-Variable -Scope Local
 ```
 
 To create a variable in a particular scope, use a scope modifier or the
@@ -352,7 +352,7 @@ To create a variable in a particular scope, use a scope modifier or the
 in the global scope:
 
 ```powershell
-New-Variable -Scope global -Name a -Value "One"
+New-Variable -Scope Global -Name a -Value "One"
 ```
 
 You can also use the Scope parameter of the `New-Alias`, `Set-Alias`, or
@@ -360,7 +360,7 @@ You can also use the Scope parameter of the `New-Alias`, `Set-Alias`, or
 alias in the global scope:
 
 ```powershell
-New-Alias -Scope global -Name np -Value Notepad.exe
+New-Alias -Scope Global -Name np -Value Notepad.exe
 ```
 
 To get the functions in a particular scope, use the `Get-Item` cmdlet when you
@@ -390,7 +390,7 @@ the script scope (the default for scripts), just enter the full path to the
 script file on the command line.
 
 ```powershell
-c:\scripts\sample.ps1
+C:\scripts\sample.ps1
 ```
 
 A script file must have a `.ps1` file extension to be executable. Files that
@@ -403,7 +403,7 @@ Using the call operator to run a function or script runs it in script scope.
 Using the call operator is no different than running the script by name.
 
 ```powershell
-& c:\scripts\sample.ps1
+& C:\scripts\sample.ps1
 ```
 
 You can read more about the call operator in [about_Operators][07].
@@ -412,7 +412,7 @@ To run the `Sample.ps1` script in the local scope type a dot and a space (`. `)
 before the path to the script:
 
 ```powershell
-. c:\scripts\sample.ps1
+. C:\scripts\sample.ps1
 ```
 
 Now, any functions, aliases, or variables defined in the script are added to
@@ -460,7 +460,7 @@ $a = "Hello"
 
 function foo {
     "`$a = $a"
-    "`$global:a = $global:a"
+    "`$Global:a = $Global:a"
 }
 ```
 
@@ -477,7 +477,7 @@ The module declares the variable `$a` in the module scope then the function
 
 ```Output
 $a = Hello
-$global:a = Goodbye
+$Global:a = Goodbye
 ```
 
 Modules create parallel scope containers linked to the scope in which they were
@@ -489,10 +489,10 @@ module's scope container.
 
 If you load **Module2** from _within_ **Module1**, **Module2** is loaded into
 the scope container of Module1. Any exports from **Module2** are placed in the
-current module scope of **Module1**. If you use `Import-Module -Scope local`,
+current module scope of **Module1**. If you use `Import-Module -Scope Local`,
 then the exports are placed into the current scope object rather than at the
 top level. If you are _in a module_ and load another module using
-`Import-Module -Scope global` (or `Import-Module -Global`), that module and its
+`Import-Module -Scope Global` (or `Import-Module -Global`), that module and its
 exports are loaded into the global scope instead of the module's local scope.
 The **WindowsCompatibility** feature does this to import proxy modules into the
 global session state.
@@ -515,8 +515,8 @@ that scope.
 
 For example, if you create a variable that has a private option in the global
 scope and then run a script, `Get-Variable` commands in the script don't
-display the private variable. Using the global scope modifier in this instance
-doesn't display the private variable.
+display the private variable. Using the `Global:` scope modifier in this
+instance doesn't display the private variable.
 
 You can use the **Option** parameter of the `New-Variable`, `Set-Variable`,
 `New-Alias`, and `Set-Alias` cmdlets to set the value of the Option property to
@@ -606,7 +606,7 @@ In `Sample.ps1`:
 ```powershell
 $test = "Local"
 "The local value of `$test is $test."
-"The global value of `$test is $global:test."
+"The global value of `$test is $Global:test."
 ```
 
 When you run `Sample.ps1`, the output should resemble the following output:
@@ -642,8 +642,8 @@ the `$test` variable.
 In Sample.ps1:
 
 ```powershell
-$global:test = "Local"
-"The global value of `$test is $global:test."
+$Global:test = "Local"
+"The global value of `$test is $Global:test."
 ```
 
 When the script is complete, the global value of `$test` is changed.
@@ -655,7 +655,7 @@ Local
 
 ### Example 4: Creating a private variable
 
-A variable can be made private by using the `private:` scope modifier or by
+A variable can be made private by using the `Private:` scope modifier or by
 creating the variable with the **Option** property set to `Private`. Private
 variables can only be viewed or changed in the scope in which they were
 created.
@@ -676,7 +676,7 @@ function funcA {
 
 function funcB {
     "In funcB before set -> '$funcAVar1'"
-    $private:funcAVar1 = "Locally overwrite the value - child scopes can't see me!"
+    $Private:funcAVar1 = "Locally overwrite the value - child scopes can't see me!"
     "In funcB after set  -> '$funcAVar1'"
     funcC
 }
@@ -733,14 +733,14 @@ scopes using `Get-Variable` and specifying a scope number.
 
 ### Example 5: Using a local variable in a remote command
 
-For variables in a remote command created in the local session, use the `using`
-scope modifier. PowerShell assumes that the variables in remote commands were
-created in the remote session.
+For variables in a remote command created in the local session, use the
+`Using:` scope modifier. PowerShell assumes that the variables in remote
+commands were created in the remote session.
 
 The syntax is:
 
 ```
-$using:<VariableName>
+$Using:<VariableName>
 ```
 
 For example, the following commands create a `$Cred` variable in the local
@@ -748,10 +748,10 @@ session and then use the `$Cred` variable in a remote command:
 
 ```powershell
 $Cred = Get-Credential
-Invoke-Command $s {Remove-Item .\Test*.ps1 -Credential $using:Cred}
+Invoke-Command $s {Remove-Item .\Test*.ps1 -Credential $Using:Cred}
 ```
 
-The `using` scope modifier was introduced in PowerShell 3.0.
+The `Using:` scope modifier was introduced in PowerShell 3.0.
 
 ## See also
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -36,12 +36,12 @@ keyword doesn't affect or suppress other output returned from your script
 block. However, the `return` keyword exits the script block at that line. For
 more information, see [about_Return][04].
 
-Like functions, a script block can include parameters. Use the Param
+Like functions, a script block can include parameters. Use the `param`
 keyword to assign named parameters, as shown in the following syntax:
 
 ```
 {
-    Param([type]$Parameter1 [,[type]$Parameter2])
+    param ([type]$Parameter1 [,[type]$Parameter2])
     <statement list>
 }
 ```
@@ -50,8 +50,8 @@ keyword to assign named parameters, as shown in the following syntax:
 > In a script block, unlike a function, you can't specify parameters outside
 > the braces.
 
-Like functions, script blocks can include the `DynamicParam`, `Begin`,
-`Process`, and `End` keywords. For more information, see [about_Functions][02]
+Like functions, script blocks can include the `dynamicparam`, `begin`,
+`process`, and `end` keywords. For more information, see [about_Functions][02]
 and [about_Functions_Advanced][01].
 
 ## Using Script Blocks
@@ -174,7 +174,7 @@ Notes on delay-bind script blocks as parameters:
 - You must explicitly specify any parameter names you use with delay-bind
   script blocks.
 - The parameter must not be untyped, and the parameter's type can't be
-  `[scriptblock]` or `[object]`.
+  `[scriptblock]` or `[Object]`.
 - You receive an error if you use a delay-bind script block without providing
   pipeline input.
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -68,7 +68,7 @@ the English-United States (en-US) set of prompt messages for a script. The
 stores them in the `$msgtable` variable.
 
 ```powershell
-$msgTable = Data {
+$msgTable = data {
     #culture="en-US"
     ConvertFrom-StringData @'
     helloWorld = Hello, World.
@@ -186,7 +186,7 @@ are defined in the Data section.
 The remaining commands load the strings into an array and display them.
 
 ```powershell
-$Day = Data {
+$Day = data {
 #culture="en-US"
 ConvertFrom-StringData -StringData @'
     messageDate = Today is

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -133,7 +133,7 @@ Invoke-Command @invokeCommandSplat
 The Get-Help cmdlet gets the help topics for scripts as well as for cmdlets
 and other types of commands. To get the help topic for a script, type
 `Get-Help` followed by the path and filename of the script. If the script
-path is in your `Path` environment variable, you can omit the path.
+path is in your `PATH` environment variable, you can omit the path.
 
 For example, to get help for the ServicesLog.ps1 script, type:
 
@@ -145,7 +145,7 @@ Get-Help C:\admin\scripts\ServicesLog.ps1
 
 A script can contain any valid PowerShell commands, including single commands,
 commands that use the pipeline, functions, and control structures such as If
-statements and For loops.
+statements and `for` loops.
 
 To write a script, open a new file in a text editor, type the commands, and
 save them in a file with a valid filename with the `.ps1` file extension.
@@ -164,9 +164,9 @@ commands, and then save them in a file named `ServiceLog.ps1`.
 
 ### Parameters in scripts
 
-To define parameters in a script, use a Param statement. The `Param` statement
-must be the first statement in a script, except for comments and any
-`#Require` statements.
+To define parameters in a script, use a `param` statement. The `param`
+statement must be the first statement in a script, except for comments and any
+`#Requires` statements.
 
 Script parameters work like function parameters. The parameter values are
 available to all of the commands in the script. All of the features of
@@ -185,7 +185,7 @@ param ($ComputerName = $(throw "ComputerName parameter is required."))
 
 function CanPing {
    $Error.Clear()
-   $tmp = Test-Connection $computername -ErrorAction SilentlyContinue
+   $tmp = Test-Connection $ComputerName -ErrorAction SilentlyContinue
 
    if (!$?)
        {Write-Host "Ping failed: $ComputerName."; return $false}
@@ -194,7 +194,7 @@ function CanPing {
 }
 
 function CanRemote {
-    $s = New-PSSession $computername -ErrorAction SilentlyContinue
+    $s = New-PSSession $ComputerName -ErrorAction SilentlyContinue
 
     if ($s -is [System.Management.Automation.Runspaces.PSSession])
         {Write-Host "Remote test succeeded: $ComputerName."}
@@ -202,7 +202,7 @@ function CanRemote {
         {Write-Host "Remote test failed: $ComputerName."}
 }
 
-if (CanPing $computername) {CanRemote $computername}
+if (CanPing $ComputerName) {CanRemote $ComputerName}
 ```
 
 To run this script, type the parameter name after the script name. For example:
@@ -214,8 +214,8 @@ Ping succeeded: Server01
 Remote test failed: Server01
 ```
 
-For more information about the Param statement and the function parameters, see
-[about_Functions][04] and [about_Functions_Advanced_Parameters][05].
+For more information about the `param` statement and the function parameters,
+see [about_Functions][04] and [about_Functions_Advanced_Parameters][05].
 
 ### Writing help for scripts
 
@@ -235,10 +235,11 @@ methods:
   for cmdlets. XML-based Help is required if you are translating Help topics
   into multiple languages.
 
-To associate the script with the XML-based Help topic, use the .ExternalHelp
-Help comment keyword. For more information about the ExternalHelp keyword, see
-[about_Comment_Based_Help][06]. For more information about XML-based help, see
-[How to Write Cmdlet Help][07].
+To associate the script with the XML-based Help topic, use the `.EXTERNALHELP`
+Help comment keyword. For more information, see:
+
+- [about_Comment_Based_Help][06]
+- [How to Write Cmdlet Help][07]
 
 ### Returning an exit value
 
@@ -310,7 +311,7 @@ function New-Profile
   if (Test-Path $PROFILE)
     {Write-Error "Profile $profileName already exists on this computer."}
   else
-    {New-Item -Type file -Path $PROFILE -Force }
+    {New-Item -Type File -Path $PROFILE -Force }
 }
 ```
 
@@ -323,11 +324,11 @@ removed, as shown in the following example.
 C:\PS> .\UtilityFunctions.ps1
 
 C:\PS> New-Profile
-The term 'new-profile' is not recognized as a cmdlet, function, operable
+The term 'New-Profile' is not recognized as a cmdlet, function, operable
 program, or script file. Verify the term and try again.
 At line:1 char:12
-+ new-profile <<<<
-   + CategoryInfo          : ObjectNotFound: (new-profile:String) [],
++ New-Profile <<<<
+   + CategoryInfo          : ObjectNotFound: (New-Profile:String) [],
    + FullyQualifiedErrorId : CommandNotFoundException
 
 C:\PS> $profileName
@@ -365,7 +366,7 @@ get code from trusted sources.
 
 You can include scripts in your modules, or you can create a script module,
 which is a module that consists entirely or primarily of a script and
-supporting resources. A script module is just a script with a .psm1 file
+supporting resources. A script module is just a script with a `.psm1` file
 extension.
 
 For more information about modules, see [about_Modules][09].

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -18,11 +18,11 @@ sessions that use the session configuration.
 
 > This information only applies to PowerShell running on Windows.
 
-A "session configuration file" is a text file with a .pssc file name extension
-that contains a hash table of session configuration properties and values. You
-can use a session configuration file to set the properties of a session
-configuration. Doing so defines the environment of any PowerShell sessions that
-use that session configuration.
+A "session configuration file" is a text file with a `.pssc` file name
+extension that contains a hash table of session configuration properties and
+values. You can use a session configuration file to set the properties of a
+session configuration. Doing so defines the environment of any PowerShell
+sessions that use that session configuration.
 
 Session configuration files make it easy to create custom session
 configurations without using complex C# assemblies or scripts.
@@ -139,7 +139,7 @@ later time.
 To include a session configuration file when creating a session configuration,
 use the Path parameter of the `Register-PSSessionConfiguration` cmdlet.
 
-For example, the following command uses the NoLanguage.pssc file when it
+For example, the following command uses the `NoLanguage.pssc` file when it
 creates a NoLanguage session configuration.
 
 ```powershell
@@ -156,7 +156,7 @@ new sessions created with the specified session configuration. Note that the
 `Set-PSSessionConfiguration` cmdlet changes the session itself and does not
 modify the session configuration file.
 
-For example, the following command adds the NoLanguage.pssc file to the
+For example, the following command adds the `NoLanguage.pssc` file to the
 LockedDown session configuration.
 
 ```powershell
@@ -225,7 +225,7 @@ C:\WINDOWS\System32\WindowsPowerShell\v1.0\SessionConfig\
 NoLanguage_0c115179-ff2a-4f66-a5eb-e56e5692ba22.pssc
 ```
 
-You can edit the .pssc file in any text editor. After the file is saved it
+You can edit the `.pssc` file in any text editor. After the file is saved it
 will be employed by any new sessions that use the session configuration.
 
 If you need to modify the RunAsVirtualAccount or the RunAsVirtualAccountGroups
@@ -322,7 +322,7 @@ lang                          NoteProperty   System.String lang=e...
 LanguageMode                  NoteProperty   System.String Langua...
 MaxConcurrentCommandsPerShell NoteProperty   System.String MaxCon...
 MaxConcurrentUsers            NoteProperty   System.String MaxCon...
-MaxIdleTimeoutms              NoteProperty   System.String MaxIdl...
+MaxIdleTimeoutMs              NoteProperty   System.String MaxIdl...
 MaxMemoryPerShellMB           NoteProperty   System.String MaxMem...
 MaxProcessesPerShell          NoteProperty   System.String MaxPro...
 MaxShells                     NoteProperty   System.String MaxShells

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -124,9 +124,9 @@ PS C:> Get-PSSessionConfiguration | Format-List -Property *
 ```
 
 You can also use the WSMan provider in PowerShell to view session
-configurations. The WSMan provider creates a WSMAN: drive in your session.
+configurations. The WSMan provider creates a WSMan: drive in your session.
 
-In the WSMAN: drive, session configurations are in the Plugin node. (All
+In the WSMan: drive, session configurations are in the Plugin node. (All
 session configurations are in the Plugin node, but there are items in the
 Plugin node that are not session configurations.)
 
@@ -134,7 +134,7 @@ For example, to view the session configurations on the local computer,
 type:
 
 ```powershell
-PS C:> dir wsman:\localhost\plugin\microsoft*
+PS C:> dir WSMan:\localhost\plugin\microsoft*
 
 WSManConfig: Microsoft.WSMan.Management\WSMan::localhost\Plugin
 
@@ -149,11 +149,11 @@ Container  {Name=microsoft.powershell32}     microsoft.powershell32
 
 To view the session configurations on a remote computer, use the
 `Connect-WSMan` cmdlet to add a note for the remote computer to the
-WSMAN: drive on your local computer, and then use the WSMAN: drive to view the
+WSMan: drive on your local computer, and then use the WSMan: drive to view the
 session configurations.
 
 For example, the following command adds a node for the Server01 remote
-computer to the WSMAN: drive on the local computer.
+computer to the WSMan: drive on the local computer.
 
 ```powershell
 PS C:> Connect-WSMan server01.corp.fabrikam.com
@@ -165,7 +165,7 @@ computer to view the session configurations.
 For example:
 
 ```powershell
-PS C:> cd wsman:
+PS C:> cd WSMan:
 
 PS WSMan:> dir
 
@@ -275,7 +275,7 @@ Register-PSSessionConfiguration @registerPSSessionConfigurationSplat
 ```
 
 When you create a session configuration, you can manage it by using the other
-session configuration cmdlets, and it appears in the WSMAN: drive.
+session configuration cmdlets, and it appears in the WSMan: drive.
 
 For more information, see `Register-PSSessionConfiguration`.
 


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide