### PR TITLE
Fix incorrect case/capitalization in reference documents (11/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -204,7 +204,7 @@ a certificate file in the file system directory.
 At the PowerShell prompt, type:
 
 ```powershell
-Get-ChildItem cert:\CurrentUser\my -CodeSigning
+Get-ChildItem Cert:\CurrentUser\my -CodeSigning
 ```
 
 This command uses the PowerShell Certificate provider to view information
@@ -241,7 +241,7 @@ To use this script, copy the following text into a text file, and name it
 
 ```powershell
 ## Signs a file
-[cmdletbinding()]
+[CmdletBinding()]
 param(
     [Parameter(Mandatory=$true)]
     [string] $File
@@ -260,7 +260,7 @@ PowerShell command prompt:
 $cert = Get-ChildItem Cert:\CurrentUser\My -CodeSigningCert |
     Select-Object -First 1
 
-Set-AuthenticodeSignature add-signature.ps1 $cert
+Set-AuthenticodeSignature Add-Signature.ps1 $cert
 ```
 
 The `Set-AuthenticodeSignature` cmdlet adds the signature to the script file as

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
@@ -60,7 +60,7 @@ omit them from the command. Using aliases, you can further simplify the
 commands:
 
 ```powershell
-dir Cert:\LocalMachine\Root | Where FriendlyName -EQ 'Verisign'
+dir Cert:\LocalMachine\Root | where FriendlyName -EQ 'Verisign'
 dir Cert:\ -Recurse | foreach GetKeyAlgorithm
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -174,7 +174,7 @@ There is a vertical tab
 between the words.
 ```
 
-On printers or in a unix-based consoles, the vertical tab character advances to
+On printers or in a Unix-based console, the vertical tab character advances to
 the next line and writes the remaining output at that point.
 
 ```Output

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -129,7 +129,7 @@ an array of strings.
 ```powershell
 $array = 'Hello', 'World!'
 Invoke-Command -ScriptBlock {
-  param([string[]]$words) $words -join ' '
+  param([string[]]$Words) $Words -join ' '
   } -ArgumentList $array
 ```
 
@@ -142,7 +142,7 @@ Hello
 ```powershell
 $array = 'Hello', 'World!'
 Invoke-Command -ScriptBlock {
-  param([string[]]$words) $words -join ' '
+  param([string[]]$Words) $Words -join ' '
 } -ArgumentList (,$array)
 ```
 
@@ -276,7 +276,7 @@ When you use the `Get-MyProcess` function, all unassigned parameters and
 parameter values are passed to `@args`, as shown in the following commands.
 
 ```powershell
-Get-MyProcess -Name PowerShell
+Get-MyProcess -Name powershell
 ```
 
 ```Output
@@ -286,7 +286,7 @@ Handles  NPM(K)    PM(K)      WS(K) VM(M)   CPU(s)     Id ProcessName
 ```
 
 ```powershell
-Get-MyProcess -Name PowerShell_Ise -FileVersionInfo
+Get-MyProcess -Name powershell_ise -FileVersionInfo
 ```
 
 ```Output
@@ -302,12 +302,12 @@ passed to all instances of `@args`, as shown in the following example.
 ```powershell
 function Get-MyCommand
 {
-    Param ([switch]$P, [switch]$C)
+    param ([switch]$P, [switch]$C)
     if ($P) { Get-Process @args }
     if ($C) { Get-Command @args }
 }
 
-Get-MyCommand -P -C -Name PowerShell
+Get-MyCommand -P -C -Name powershell
 ```
 
 ```Output

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
@@ -36,15 +36,15 @@ The parameter names do not appear in the command. Include only the parameter
 values. The values must appear in the order specified in the syntax diagram.
 
 ```
--Split <String>
--Split (<String[]>)
-<String> -Split <Delimiter>[,<Max-substrings>[,"<Options>"]]
-<String> -Split {<ScriptBlock>} [,<Max-substrings>]
+-split <String>
+-split (<String[]>)
+<String> -split <Delimiter>[,<Max-substrings>[,"<Options>"]]
+<String> -split {<ScriptBlock>} [,<Max-substrings>]
 ```
 
-You can substitute `-iSplit` or `-cSplit` for `-split` in any binary Split
+You can substitute `-isplit` or `-csplit` for `-split` in any binary Split
 statement (a Split statement that includes a delimiter or script block). The
-`-iSplit` and `-split` operators are case-insensitive. The `-cSplit` operator
+`-isplit` and `-split` operators are case-insensitive. The `-csplit` operator
 is case-sensitive, meaning that case is considered when the delimiter rules
 are applied.
 
@@ -223,7 +223,7 @@ The SimpleMatch options are:
 
 - **SimpleMatch**: Use simple string comparison when evaluating the
   delimiter. Cannot be used with RegexMatch.
-- **IgnoreCase**: Forces case-insensitive matching, even if the -cSplit
+- **IgnoreCase**: Forces case-insensitive matching, even if the -csplit
   operator is specified.
 
 The RegexMatch options are:
@@ -231,7 +231,7 @@ The RegexMatch options are:
 - **RegexMatch**: Use regular expression matching to evaluate the
   delimiter. This is the default behavior. Cannot be used with
   SimpleMatch.
-- **IgnoreCase**: Forces case-insensitive matching, even if the -cSplit
+- **IgnoreCase**: Forces case-insensitive matching, even if the -csplit
   operator is specified.
 - **CultureInvariant**: Ignores cultural differences in language when
   evaluating the delimiter. Valid only with RegexMatch.
@@ -343,7 +343,7 @@ cury,Venus,Earth,Mars,Jupit
 The following statement performs a case-sensitive split at the letter "N".
 
 ```powershell
-"Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -cSplit 'N'
+"Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -csplit 'N'
 ```
 
 ```Output
@@ -441,7 +441,7 @@ $a = @'
 2The second line.
 3The third of three lines.
 '@
-$a -split "^\d", 0, "multiline"
+$a -split "^\d", 0, "Multiline"
 ```
 
 ```Output
@@ -480,7 +480,7 @@ can use options, such as SimpleMatch, only when the Max-substrings value is
 specified.
 
 ```powershell
-"This.is.a.test" -split ".", 0, "simplematch"
+"This.is.a.test" -split ".", 0, "SimpleMatch"
 ```
 
 ```Output

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -342,7 +342,7 @@ statement conditions.
 
 ```powershell
 switch ("Test") {
-    { $_ -is [String] } { "Found a string" }
+    { $_ -is [string] } { "Found a string" }
     "Test"              { "This $_ executes as well" }
 }
 ```
@@ -383,7 +383,7 @@ non-number is encountered, execution is terminated with the `break` keyword.
 ```powershell
 switch (1,4,-1,3,"Hello",2,1) {
     {$_ -lt 0}           { continue }
-    {$_ -isnot [Int32]}  { break }
+    {$_ -isnot [int32]}  { break }
     {$_ % 2}             { "$_ is Odd" }
     {-not ($_ % 2)}      { "$_ is Even" }
 }
@@ -445,7 +445,7 @@ switch -File $fileEscaped { foo { 'Foo' } }
 
 ## See also
 
-- [about_break][03]
+- [about_Break][03]
 - [about_Continue][05]
 - [about_If][06]
 - [about_Script_Blocks][07]

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Tab_Expansion.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Tab_Expansion.md
@@ -5,7 +5,7 @@ ms.date: 06/13/2024
 no-loc: [<kbd>Tab</kbd>, <kbd>Ctrl</kbd>, <kbd>Space</kbd>]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_tab_expansion?view=powershell-5.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
-title: About_tab_expansion
+title: about_Tab_Expansion
 ---
 # about_Tab_Expansion
 
@@ -77,7 +77,7 @@ You can then partially specify the path to the Active Setup log file and use
 tab expansion again:
 
 ```powershell
-PS> Get-Content c:\windows\acts<Tab>
+PS> Get-Content C:\windows\acts<Tab>
 ```
 
 When you press the <kbd>Tab</kbd> key, the command expands to:

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Throw.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Throw.md
@@ -1,5 +1,5 @@
 ---
-description: Describes the Throw keyword, which generates a terminating error.
+description: Describes the `throw` keyword, which generates a terminating error.
 Locale: en-US
 ms.date: 08/24/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_throw?view=powershell-5.1&WT.mc_id=ps-gethelp
@@ -80,7 +80,7 @@ throw (Get-Process pwsh)
 
 ```Output
 At line:1 char:6
-+ throw <<<<  (get-process PowerShell)
++ throw <<<<  (Get-Process powershell)
 + CategoryInfo          : OperationStopped: (System.Diagnostics.Process (Pow
 erShell):Process) [],
 RuntimeException

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
@@ -16,7 +16,7 @@ terminating errors.
 ## Long description
 
 Use `try`, `catch`, and `finally` blocks to respond to or handle terminating
-errors in scripts. The `Trap` statement can also be used to handle terminating
+errors in scripts. The `trap` statement can also be used to handle terminating
 errors in scripts. For more information, see [about_Trap][05].
 
 A terminating error stops a statement from running. If PowerShell does not
@@ -29,8 +29,8 @@ PowerShell to monitor for errors. When an error occurs within the `try` block,
 the error is first saved to the `$Error` automatic variable. PowerShell then
 searches for a `catch` block to handle the error. If the `try` statement does
 not have a matching `catch` block, PowerShell continues to search for an
-appropriate `catch` block or `Trap` statement in the parent scopes. After a
-`catch` block is completed or if no appropriate `catch` block or `Trap`
+appropriate `catch` block or `trap` statement in the parent scopes. After a
+`catch` block is completed or if no appropriate `catch` block or `trap`
 statement is found, the `finally` block is run. If the error cannot be handled,
 the error is written to the error stream.
 
@@ -134,7 +134,7 @@ two `catch` blocks:
 ```powershell
 try {
     $wc = New-Object System.Net.WebClient
-    $wc.DownloadFile("http://www.contoso.com/MyDoc.doc","c:\temp\MyDoc.doc")
+    $wc.DownloadFile("http://www.contoso.com/MyDoc.doc","C:\temp\MyDoc.doc")
 } catch [System.Net.WebException],[System.IO.IOException] {
     "Unable to download MyDoc.doc from http://www.contoso.com."
 } catch {
@@ -179,12 +179,12 @@ block for the derived class before the `catch` block for the general class.
 
 ## Using Traps in a Try Catch
 
-When a terminating error occurs in a `try` block with a `Trap` defined within
-the `try` block, even if there is a matching `catch` block, the `Trap`
+When a terminating error occurs in a `try` block with a `trap` defined within
+the `try` block, even if there is a matching `catch` block, the `trap`
 statement takes control.
 
-If a `Trap` exists at a higher block than the `try`, and there is no matching
-`catch` block within the current scope, the `Trap` will take control, even if
+If a `trap` exists at a higher block than the `try`, and there is no matching
+`catch` block within the current scope, the `trap` will take control, even if
 any parent scope has a matching `catch` block.
 
 ## Accessing exception information
@@ -236,18 +236,18 @@ To free resources used by a script, add a `finally` block after the `try` and
 before the script terminates or before the current block goes out of scope.
 
 A `finally` block runs even if you use <kbd>CTRL</kbd>+<kbd>C</kbd> to stop the
-script. A `finally` block also runs if an Exit keyword stops the script from
+script. A `finally` block also runs if an `exit` keyword stops the script from
 within a `catch` block.
 
 In the following example, the `try` block attempts to download a file to the
-`c:\temp` folder. The `catch` blocks handle errors that occur during the
+`C:\temp` folder. The `catch` blocks handle errors that occur during the
 download. The `finally` block disposes of the `WebClient` object and removes
 the temporary file if it exists.
 
 ```powershell
 try {
     $wc = New-Object System.Net.WebClient
-    $tempFile = "c:\temp\MyDoc.doc"
+    $tempFile = "C:\temp\MyDoc.doc"
     $wc.DownloadFile("http://www.contoso.com/MyDoc.doc",$tempFile)
 } catch [System.Net.WebException],[System.IO.IOException] {
     "Unable to download MyDoc.doc from http://www.contoso.com."

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Type_Conversion.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Type_Conversion.md
@@ -195,7 +195,7 @@ PowerShell also assigns types to literal values automatically.
 
 Numeric literals are implicitly typed by default. Numbers are typed based on
 their size. For example, `42` is small enough to be stored as an **Int32** type
-and `1.2` is stored as a **Double**. Integers larger than `[Int32]::MaxValue`
+and `1.2` is stored as a **Double**. Integers larger than `[int32]::MaxValue`
 are stored as **Int64**. While `42` can be stored as a **Byte** and `1.2` can
 be stored as a **Single** type, the implicit typing uses **Int32** and
 **Double** respectively. For more information, see
@@ -229,7 +229,7 @@ These contexts include:
 PowerShell attempts to convert values passed to parameters to match the
 parameter type. Type conversion of parameter values occurs in cmdlets,
 functions, scripts, scriptblocks, or .NET methods where the parameter is
-declared with a specific type. Declaring a parameter with the type `[object]`
+declared with a specific type. Declaring a parameter with the type `[Object]`
 or not defining a specific type allows any value type to be passed to a
 parameter. Parameters can also have custom conversions defined by decorating
 parameters with [ArgumentTransformationAttribute][17] attribute.
@@ -302,7 +302,7 @@ New-Object: Cannot find an overload for "Guid" and the argument count: "16".
 ```
 
 PowerShell treats the `$bytes` array as a list of individual parameters even
-though `$bytes` is an array of bytes and `System.Guid` has a `Guid(Byte[])`
+though `$bytes` is an array of bytes and `System.Guid` has a `Guid(byte[])`
 constructor.
 
 This common code pattern is an instance of _pseudo method syntax_, which
@@ -314,7 +314,7 @@ PS> New-Object -TypeName System.Guid -ArgumentList $bytes
 New-Object: Cannot find an overload for "Guid" and the argument count: "16".
 ```
 
-Given that the type of **ArgumentList** is `[object[]]`, a single argument that
+Given that the type of **ArgumentList** is `[Object[]]`, a single argument that
 happens to be an array (of any type) binds to it _element by element_. The
 workaround is to wrap `$bytes` in an outer array so that PowerShell looks for a
 constructor with parameters that match the contents of the outer array.
@@ -329,8 +329,8 @@ Guid
 04030201-0605-0807-090a-0b0c0d0e0f10
 ```
 
-The first item of the wrapped array is our original `Byte[]` instance. That
-value matches the `Guid(Byte[]]` constructor.
+The first item of the wrapped array is our original `[byte[]]` instance. That
+value matches the `Guid(byte[])` constructor.
 
 An alternative to the array wrapping workaround is to use the intrinsic static
 `new()` method.
@@ -402,7 +402,7 @@ If you want the result to be an **Int64**, you can cast the result type or
 operands.
 
 ```powershell
-PS> ([Int64]([int]::MaxValue + 1)).GetType().Name
+PS> ([int64]([int]::MaxValue + 1)).GetType().Name
 Int64
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -206,7 +206,7 @@ a certificate file in the file system directory.
 At the PowerShell prompt, type:
 
 ```powershell
-Get-ChildItem cert:\CurrentUser\my -CodeSigning
+Get-ChildItem Cert:\CurrentUser\my -CodeSigning
 ```
 
 This command uses the PowerShell Certificate provider to view information
@@ -243,7 +243,7 @@ To use this script, copy the following text into a text file, and name it
 
 ```powershell
 ## Signs a file
-[cmdletbinding()]
+[CmdletBinding()]
 param(
     [Parameter(Mandatory=$true)]
     [string] $File
@@ -262,7 +262,7 @@ PowerShell command prompt:
 $cert = Get-ChildItem Cert:\CurrentUser\My -CodeSigningCert |
     Select-Object -First 1
 
-Set-AuthenticodeSignature add-signature.ps1 $cert
+Set-AuthenticodeSignature Add-Signature.ps1 $cert
 ```
 
 The `Set-AuthenticodeSignature` cmdlet adds the signature to the script file as

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
@@ -60,7 +60,7 @@ omit them from the command. Using aliases, you can further simplify the
 commands:
 
 ```powershell
-dir Cert:\LocalMachine\Root | Where FriendlyName -EQ 'Verisign'
+dir Cert:\LocalMachine\Root | where FriendlyName -EQ 'Verisign'
 dir Cert:\ -Recurse | foreach GetKeyAlgorithm
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -222,7 +222,7 @@ There is a vertical tab
 between the words.
 ```
 
-On printers or in a unix-based consoles, the vertical tab character advances to
+On printers or in a Unix-based console, the vertical tab character advances to
 the next line and writes the remaining output at that point.
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -132,7 +132,7 @@ an array of strings.
 ```powershell
 $array = 'Hello', 'World!'
 Invoke-Command -ScriptBlock {
-  param([string[]]$words) $words -join ' '
+  param([string[]]$Words) $Words -join ' '
   } -ArgumentList $array
 ```
 
@@ -145,7 +145,7 @@ Hello
 ```powershell
 $array = 'Hello', 'World!'
 Invoke-Command -ScriptBlock {
-  param([string[]]$words) $words -join ' '
+  param([string[]]$Words) $Words -join ' '
 } -ArgumentList (,$array)
 ```
 
@@ -319,7 +319,7 @@ When you use the `Get-MyProcess` function, all unassigned parameters and
 parameter values are passed to `@args`, as shown in the following commands.
 
 ```powershell
-Get-MyProcess -Name PowerShell
+Get-MyProcess -Name powershell
 ```
 
 ```Output
@@ -329,7 +329,7 @@ Handles  NPM(K)    PM(K)      WS(K) VM(M)   CPU(s)     Id ProcessName
 ```
 
 ```powershell
-Get-MyProcess -Name PowerShell_Ise -FileVersionInfo
+Get-MyProcess -Name powershell_ise -FileVersionInfo
 ```
 
 ```Output
@@ -345,12 +345,12 @@ passed to all instances of `@args`, as shown in the following example.
 ```powershell
 function Get-MyCommand
 {
-    Param ([switch]$P, [switch]$C)
+    param ([switch]$P, [switch]$C)
     if ($P) { Get-Process @args }
     if ($C) { Get-Command @args }
 }
 
-Get-MyCommand -P -C -Name PowerShell
+Get-MyCommand -P -C -Name powershell
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Split.md
@@ -36,15 +36,15 @@ The parameter names do not appear in the command. Include only the parameter
 values. The values must appear in the order specified in the syntax diagram.
 
 ```
--Split <String>
--Split (<String[]>)
-<String> -Split <Delimiter>[,<Max-substrings>[,"<Options>"]]
-<String> -Split {<ScriptBlock>} [,<Max-substrings>]
+-split <String>
+-split (<String[]>)
+<String> -split <Delimiter>[,<Max-substrings>[,"<Options>"]]
+<String> -split {<ScriptBlock>} [,<Max-substrings>]
 ```
 
-You can substitute `-iSplit` or `-cSplit` for `-split` in any binary Split
+You can substitute `-isplit` or `-csplit` for `-split` in any binary Split
 statement (a Split statement that includes a delimiter or script block). The
-`-iSplit` and `-split` operators are case-insensitive. The `-cSplit` operator
+`-isplit` and `-split` operators are case-insensitive. The `-csplit` operator
 is case-sensitive, meaning that case is considered when the delimiter rules
 are applied.
 
@@ -223,7 +223,7 @@ The SimpleMatch options are:
 
 - **SimpleMatch**: Use simple string comparison when evaluating the
   delimiter. Cannot be used with RegexMatch.
-- **IgnoreCase**: Forces case-insensitive matching, even if the -cSplit
+- **IgnoreCase**: Forces case-insensitive matching, even if the -csplit
   operator is specified.
 
 The RegexMatch options are:
@@ -231,7 +231,7 @@ The RegexMatch options are:
 - **RegexMatch**: Use regular expression matching to evaluate the
   delimiter. This is the default behavior. Cannot be used with
   SimpleMatch.
-- **IgnoreCase**: Forces case-insensitive matching, even if the -cSplit
+- **IgnoreCase**: Forces case-insensitive matching, even if the -csplit
   operator is specified.
 - **CultureInvariant**: Ignores cultural differences in language when
   evaluating the delimiter. Valid only with RegexMatch.
@@ -343,7 +343,7 @@ cury,Venus,Earth,Mars,Jupit
 The following statement performs a case-sensitive split at the letter "N".
 
 ```powershell
-"Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -cSplit 'N'
+"Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -csplit 'N'
 ```
 
 ```Output
@@ -441,7 +441,7 @@ $a = @'
 2The second line.
 3The third of three lines.
 '@
-$a -split "^\d", 0, "multiline"
+$a -split "^\d", 0, "Multiline"
 ```
 
 ```Output
@@ -480,7 +480,7 @@ can use options, such as SimpleMatch, only when the Max-substrings value is
 specified.
 
 ```powershell
-"This.is.a.test" -split ".", 0, "simplematch"
+"This.is.a.test" -split ".", 0, "SimpleMatch"
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -342,7 +342,7 @@ statement conditions.
 
 ```powershell
 switch ("Test") {
-    { $_ -is [String] } { "Found a string" }
+    { $_ -is [string] } { "Found a string" }
     "Test"              { "This $_ executes as well" }
 }
 ```
@@ -383,7 +383,7 @@ non-number is encountered, execution is terminated with the `break` keyword.
 ```powershell
 switch (1,4,-1,3,"Hello",2,1) {
     {$_ -lt 0}           { continue }
-    {$_ -isnot [Int32]}  { break }
+    {$_ -isnot [int32]}  { break }
     {$_ % 2}             { "$_ is Odd" }
     {-not ($_ % 2)}      { "$_ is Even" }
 }
@@ -445,7 +445,7 @@ switch -File $fileEscaped { foo { 'Foo' } }
 
 ## See also
 
-- [about_break][03]
+- [about_Break][03]
 - [about_Continue][05]
 - [about_If][06]
 - [about_Script_Blocks][07]

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Tab_Expansion.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Tab_Expansion.md
@@ -5,7 +5,7 @@ ms.date: 06/13/2024
 no-loc: [<kbd>Tab</kbd>, <kbd>Ctrl</kbd>, <kbd>Space</kbd>]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_tab_expansion?view=powershell-7.4&WT.mc_id=ps-gethelp
 schema: 2.0.0
-title: About_tab_expansion
+title: about_Tab_Expansion
 ---
 # about_Tab_Expansion
 
@@ -80,7 +80,7 @@ You can then partially specify the path to the Active Setup log file and use
 tab expansion again:
 
 ```powershell
-PS> Get-Content c:\windows\acts<Tab>
+PS> Get-Content C:\windows\acts<Tab>
 ```
 
 When you press the <kbd>Tab</kbd> key, the command expands to:
@@ -173,18 +173,18 @@ $flavor = 'Chocolate'
 ## Tab completions for comment-based keywords
 
 Beginning in PowerShell 7.2, support was added for tab completion of the
-`#requires` parameters and the keywords for comment-based help.
+`#Requires` parameters and the keywords for comment-based help.
 
-### Example for `#requires` statement
+### Example for `#Requires` statement
 
 ```powershell
-#requires -<Ctrl-Space>
+#Requires -<Ctrl-Space>
 ```
 
 Menu expansion shows the following parameter options:
 
 ```powershell
-#requires -<Ctrl-Space>
+#Requires -<Ctrl-Space>
 Modules     PSEdition     RunAsAdministrator    Version
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Throw.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Throw.md
@@ -1,5 +1,5 @@
 ---
-description: Describes the Throw keyword, which generates a terminating error.
+description: Describes the `throw` keyword, which generates a terminating error.
 Locale: en-US
 ms.date: 08/24/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_throw?view=powershell-7.4&WT.mc_id=ps-gethelp

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
@@ -16,7 +16,7 @@ terminating errors.
 ## Long description
 
 Use `try`, `catch`, and `finally` blocks to respond to or handle terminating
-errors in scripts. The `Trap` statement can also be used to handle terminating
+errors in scripts. The `trap` statement can also be used to handle terminating
 errors in scripts. For more information, see [about_Trap][05].
 
 A terminating error stops a statement from running. If PowerShell does not
@@ -29,8 +29,8 @@ PowerShell to monitor for errors. When an error occurs within the `try` block,
 the error is first saved to the `$Error` automatic variable. PowerShell then
 searches for a `catch` block to handle the error. If the `try` statement does
 not have a matching `catch` block, PowerShell continues to search for an
-appropriate `catch` block or `Trap` statement in the parent scopes. After a
-`catch` block is completed or if no appropriate `catch` block or `Trap`
+appropriate `catch` block or `trap` statement in the parent scopes. After a
+`catch` block is completed or if no appropriate `catch` block or `trap`
 statement is found, the `finally` block is run. If the error cannot be handled,
 the error is written to the error stream.
 
@@ -134,7 +134,7 @@ two `catch` blocks:
 ```powershell
 try {
     $wc = New-Object System.Net.WebClient
-    $wc.DownloadFile("http://www.contoso.com/MyDoc.doc","c:\temp\MyDoc.doc")
+    $wc.DownloadFile("http://www.contoso.com/MyDoc.doc","C:\temp\MyDoc.doc")
 } catch [System.Net.WebException],[System.IO.IOException] {
     "Unable to download MyDoc.doc from http://www.contoso.com."
 } catch {
@@ -179,12 +179,12 @@ block for the derived class before the `catch` block for the general class.
 
 ## Using Traps in a Try Catch
 
-When a terminating error occurs in a `try` block with a `Trap` defined within
-the `try` block, even if there is a matching `catch` block, the `Trap`
+When a terminating error occurs in a `try` block with a `trap` defined within
+the `try` block, even if there is a matching `catch` block, the `trap`
 statement takes control.
 
-If a `Trap` exists at a higher block than the `try`, and there is no matching
-`catch` block within the current scope, the `Trap` will take control, even if
+If a `trap` exists at a higher block than the `try`, and there is no matching
+`catch` block within the current scope, the `trap` will take control, even if
 any parent scope has a matching `catch` block.
 
 ## Accessing exception information
@@ -236,18 +236,18 @@ To free resources used by a script, add a `finally` block after the `try` and
 before the script terminates or before the current block goes out of scope.
 
 A `finally` block runs even if you use <kbd>CTRL</kbd>+<kbd>C</kbd> to stop the
-script. A `finally` block also runs if an Exit keyword stops the script from
+script. A `finally` block also runs if an `exit` keyword stops the script from
 within a `catch` block.
 
 In the following example, the `try` block attempts to download a file to the
-`c:\temp` folder. The `catch` blocks handle errors that occur during the
+`C:\temp` folder. The `catch` blocks handle errors that occur during the
 download. The `finally` block disposes of the `WebClient` object and removes
 the temporary file if it exists.
 
 ```powershell
 try {
     $wc = New-Object System.Net.WebClient
-    $tempFile = "c:\temp\MyDoc.doc"
+    $tempFile = "C:\temp\MyDoc.doc"
     $wc.DownloadFile("http://www.contoso.com/MyDoc.doc",$tempFile)
 } catch [System.Net.WebException],[System.IO.IOException] {
     "Unable to download MyDoc.doc from http://www.contoso.com."

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Type_Conversion.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Type_Conversion.md
@@ -195,7 +195,7 @@ PowerShell also assigns types to literal values automatically.
 
 Numeric literals are implicitly typed by default. Numbers are typed based on
 their size. For example, `42` is small enough to be stored as an **Int32** type
-and `1.2` is stored as a **Double**. Integers larger than `[Int32]::MaxValue`
+and `1.2` is stored as a **Double**. Integers larger than `[int32]::MaxValue`
 are stored as **Int64**. While `42` can be stored as a **Byte** and `1.2` can
 be stored as a **Single** type, the implicit typing uses **Int32** and
 **Double** respectively. For more information, see
@@ -229,7 +229,7 @@ These contexts include:
 PowerShell attempts to convert values passed to parameters to match the
 parameter type. Type conversion of parameter values occurs in cmdlets,
 functions, scripts, scriptblocks, or .NET methods where the parameter is
-declared with a specific type. Declaring a parameter with the type `[object]`
+declared with a specific type. Declaring a parameter with the type `[Object]`
 or not defining a specific type allows any value type to be passed to a
 parameter. Parameters can also have custom conversions defined by decorating
 parameters with [ArgumentTransformationAttribute][17] attribute.
@@ -302,7 +302,7 @@ New-Object: Cannot find an overload for "Guid" and the argument count: "16".
 ```
 
 PowerShell treats the `$bytes` array as a list of individual parameters even
-though `$bytes` is an array of bytes and `System.Guid` has a `Guid(Byte[])`
+though `$bytes` is an array of bytes and `System.Guid` has a `Guid(byte[])`
 constructor.
 
 This common code pattern is an instance of _pseudo method syntax_, which
@@ -314,7 +314,7 @@ PS> New-Object -TypeName System.Guid -ArgumentList $bytes
 New-Object: Cannot find an overload for "Guid" and the argument count: "16".
 ```
 
-Given that the type of **ArgumentList** is `[object[]]`, a single argument that
+Given that the type of **ArgumentList** is `[Object[]]`, a single argument that
 happens to be an array (of any type) binds to it _element by element_. The
 workaround is to wrap `$bytes` in an outer array so that PowerShell looks for a
 constructor with parameters that match the contents of the outer array.
@@ -329,8 +329,8 @@ Guid
 04030201-0605-0807-090a-0b0c0d0e0f10
 ```
 
-The first item of the wrapped array is our original `Byte[]` instance. That
-value matches the `Guid(Byte[]]` constructor.
+The first item of the wrapped array is our original `[byte[]]` instance. That
+value matches the `Guid(byte[])` constructor.
 
 An alternative to the array wrapping workaround is to use the intrinsic static
 `new()` method.
@@ -402,7 +402,7 @@ If you want the result to be an **Int64**, you can cast the result type or
 operands.
 
 ```powershell
-PS> ([Int64]([int]::MaxValue + 1)).GetType().Name
+PS> ([int64]([int]::MaxValue + 1)).GetType().Name
 Int64
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -206,7 +206,7 @@ a certificate file in the file system directory.
 At the PowerShell prompt, type:
 
 ```powershell
-Get-ChildItem cert:\CurrentUser\my -CodeSigning
+Get-ChildItem Cert:\CurrentUser\my -CodeSigning
 ```
 
 This command uses the PowerShell Certificate provider to view information
@@ -243,7 +243,7 @@ To use this script, copy the following text into a text file, and name it
 
 ```powershell
 ## Signs a file
-[cmdletbinding()]
+[CmdletBinding()]
 param(
     [Parameter(Mandatory=$true)]
     [string] $File
@@ -262,7 +262,7 @@ PowerShell command prompt:
 $cert = Get-ChildItem Cert:\CurrentUser\My -CodeSigningCert |
     Select-Object -First 1
 
-Set-AuthenticodeSignature add-signature.ps1 $cert
+Set-AuthenticodeSignature Add-Signature.ps1 $cert
 ```
 
 The `Set-AuthenticodeSignature` cmdlet adds the signature to the script file as

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
@@ -60,7 +60,7 @@ omit them from the command. Using aliases, you can further simplify the
 commands:
 
 ```powershell
-dir Cert:\LocalMachine\Root | Where FriendlyName -EQ 'Verisign'
+dir Cert:\LocalMachine\Root | where FriendlyName -EQ 'Verisign'
 dir Cert:\ -Recurse | foreach GetKeyAlgorithm
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -222,7 +222,7 @@ There is a vertical tab
 between the words.
 ```
 
-On printers or in a unix-based consoles, the vertical tab character advances to
+On printers or in a Unix-based console, the vertical tab character advances to
 the next line and writes the remaining output at that point.
 
 ```Output

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -132,7 +132,7 @@ an array of strings.
 ```powershell
 $array = 'Hello', 'World!'
 Invoke-Command -ScriptBlock {
-  param([string[]]$words) $words -join ' '
+  param([string[]]$Words) $Words -join ' '
   } -ArgumentList $array
 ```
 
@@ -145,7 +145,7 @@ Hello
 ```powershell
 $array = 'Hello', 'World!'
 Invoke-Command -ScriptBlock {
-  param([string[]]$words) $words -join ' '
+  param([string[]]$Words) $Words -join ' '
 } -ArgumentList (,$array)
 ```
 
@@ -319,7 +319,7 @@ When you use the `Get-MyProcess` function, all unassigned parameters and
 parameter values are passed to `@args`, as shown in the following commands.
 
 ```powershell
-Get-MyProcess -Name PowerShell
+Get-MyProcess -Name powershell
 ```
 
 ```Output
@@ -329,7 +329,7 @@ Handles  NPM(K)    PM(K)      WS(K) VM(M)   CPU(s)     Id ProcessName
 ```
 
 ```powershell
-Get-MyProcess -Name PowerShell_Ise -FileVersionInfo
+Get-MyProcess -Name powershell_ise -FileVersionInfo
 ```
 
 ```Output
@@ -345,12 +345,12 @@ passed to all instances of `@args`, as shown in the following example.
 ```powershell
 function Get-MyCommand
 {
-    Param ([switch]$P, [switch]$C)
+    param ([switch]$P, [switch]$C)
     if ($P) { Get-Process @args }
     if ($C) { Get-Command @args }
 }
 
-Get-MyCommand -P -C -Name PowerShell
+Get-MyCommand -P -C -Name powershell
 ```
 
 ```Output

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Split.md
@@ -36,15 +36,15 @@ The parameter names do not appear in the command. Include only the parameter
 values. The values must appear in the order specified in the syntax diagram.
 
 ```
--Split <String>
--Split (<String[]>)
-<String> -Split <Delimiter>[,<Max-substrings>[,"<Options>"]]
-<String> -Split {<ScriptBlock>} [,<Max-substrings>]
+-split <String>
+-split (<String[]>)
+<String> -split <Delimiter>[,<Max-substrings>[,"<Options>"]]
+<String> -split {<ScriptBlock>} [,<Max-substrings>]
 ```
 
-You can substitute `-iSplit` or `-cSplit` for `-split` in any binary Split
+You can substitute `-isplit` or `-csplit` for `-split` in any binary Split
 statement (a Split statement that includes a delimiter or script block). The
-`-iSplit` and `-split` operators are case-insensitive. The `-cSplit` operator
+`-isplit` and `-split` operators are case-insensitive. The `-csplit` operator
 is case-sensitive, meaning that case is considered when the delimiter rules
 are applied.
 
@@ -223,7 +223,7 @@ The SimpleMatch options are:
 
 - **SimpleMatch**: Use simple string comparison when evaluating the
   delimiter. Cannot be used with RegexMatch.
-- **IgnoreCase**: Forces case-insensitive matching, even if the -cSplit
+- **IgnoreCase**: Forces case-insensitive matching, even if the -csplit
   operator is specified.
 
 The RegexMatch options are:
@@ -231,7 +231,7 @@ The RegexMatch options are:
 - **RegexMatch**: Use regular expression matching to evaluate the
   delimiter. This is the default behavior. Cannot be used with
   SimpleMatch.
-- **IgnoreCase**: Forces case-insensitive matching, even if the -cSplit
+- **IgnoreCase**: Forces case-insensitive matching, even if the -csplit
   operator is specified.
 - **CultureInvariant**: Ignores cultural differences in language when
   evaluating the delimiter. Valid only with RegexMatch.
@@ -343,7 +343,7 @@ cury,Venus,Earth,Mars,Jupit
 The following statement performs a case-sensitive split at the letter "N".
 
 ```powershell
-"Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -cSplit 'N'
+"Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -csplit 'N'
 ```
 
 ```Output
@@ -441,7 +441,7 @@ $a = @'
 2The second line.
 3The third of three lines.
 '@
-$a -split "^\d", 0, "multiline"
+$a -split "^\d", 0, "Multiline"
 ```
 
 ```Output
@@ -480,7 +480,7 @@ can use options, such as SimpleMatch, only when the Max-substrings value is
 specified.
 
 ```powershell
-"This.is.a.test" -split ".", 0, "simplematch"
+"This.is.a.test" -split ".", 0, "SimpleMatch"
 ```
 
 ```Output

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -342,7 +342,7 @@ statement conditions.
 
 ```powershell
 switch ("Test") {
-    { $_ -is [String] } { "Found a string" }
+    { $_ -is [string] } { "Found a string" }
     "Test"              { "This $_ executes as well" }
 }
 ```
@@ -383,7 +383,7 @@ non-number is encountered, execution is terminated with the `break` keyword.
 ```powershell
 switch (1,4,-1,3,"Hello",2,1) {
     {$_ -lt 0}           { continue }
-    {$_ -isnot [Int32]}  { break }
+    {$_ -isnot [int32]}  { break }
     {$_ % 2}             { "$_ is Odd" }
     {-not ($_ % 2)}      { "$_ is Even" }
 }
@@ -445,7 +445,7 @@ switch -File $fileEscaped { foo { 'Foo' } }
 
 ## See also
 
-- [about_break][03]
+- [about_Break][03]
 - [about_Continue][05]
 - [about_If][06]
 - [about_Script_Blocks][07]

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Tab_Expansion.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Tab_Expansion.md
@@ -5,7 +5,7 @@ ms.date: 06/13/2024
 no-loc: [<kbd>Tab</kbd>, <kbd>Ctrl</kbd>, <kbd>Space</kbd>]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_tab_expansion?view=powershell-7.5&WT.mc_id=ps-gethelp
 schema: 2.0.0
-title: About_tab_expansion
+title: about_Tab_Expansion
 ---
 # about_Tab_Expansion
 
@@ -87,7 +87,7 @@ You can then partially specify the path to the Active Setup log file and use
 tab expansion again:
 
 ```powershell
-PS> Get-Content c:\windows\acts<Tab>
+PS> Get-Content C:\windows\acts<Tab>
 ```
 
 When you press the <kbd>Tab</kbd> key, the command expands to:
@@ -180,18 +180,18 @@ $flavor = 'Chocolate'
 ## Tab completions for comment-based keywords
 
 Beginning in PowerShell 7.2, support was added for tab completion of the
-`#requires` parameters and the keywords for comment-based help.
+`#Requires` parameters and the keywords for comment-based help.
 
-### Example for `#requires` statement
+### Example for `#Requires` statement
 
 ```powershell
-#requires -<Ctrl-Space>
+#Requires -<Ctrl-Space>
 ```
 
 Menu expansion shows the following parameter options:
 
 ```powershell
-#requires -<Ctrl-Space>
+#Requires -<Ctrl-Space>
 Modules     PSEdition     RunAsAdministrator    Version
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Throw.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Throw.md
@@ -1,5 +1,5 @@
 ---
-description: Describes the Throw keyword, which generates a terminating error.
+description: Describes the `throw` keyword, which generates a terminating error.
 Locale: en-US
 ms.date: 08/24/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_throw?view=powershell-7.5&WT.mc_id=ps-gethelp

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
@@ -16,7 +16,7 @@ terminating errors.
 ## Long description
 
 Use `try`, `catch`, and `finally` blocks to respond to or handle terminating
-errors in scripts. The `Trap` statement can also be used to handle terminating
+errors in scripts. The `trap` statement can also be used to handle terminating
 errors in scripts. For more information, see [about_Trap][05].
 
 A terminating error stops a statement from running. If PowerShell does not
@@ -29,8 +29,8 @@ PowerShell to monitor for errors. When an error occurs within the `try` block,
 the error is first saved to the `$Error` automatic variable. PowerShell then
 searches for a `catch` block to handle the error. If the `try` statement does
 not have a matching `catch` block, PowerShell continues to search for an
-appropriate `catch` block or `Trap` statement in the parent scopes. After a
-`catch` block is completed or if no appropriate `catch` block or `Trap`
+appropriate `catch` block or `trap` statement in the parent scopes. After a
+`catch` block is completed or if no appropriate `catch` block or `trap`
 statement is found, the `finally` block is run. If the error cannot be handled,
 the error is written to the error stream.
 
@@ -134,7 +134,7 @@ two `catch` blocks:
 ```powershell
 try {
     $wc = New-Object System.Net.WebClient
-    $wc.DownloadFile("http://www.contoso.com/MyDoc.doc","c:\temp\MyDoc.doc")
+    $wc.DownloadFile("http://www.contoso.com/MyDoc.doc","C:\temp\MyDoc.doc")
 } catch [System.Net.WebException],[System.IO.IOException] {
     "Unable to download MyDoc.doc from http://www.contoso.com."
 } catch {
@@ -179,12 +179,12 @@ block for the derived class before the `catch` block for the general class.
 
 ## Using Traps in a Try Catch
 
-When a terminating error occurs in a `try` block with a `Trap` defined within
-the `try` block, even if there is a matching `catch` block, the `Trap`
+When a terminating error occurs in a `try` block with a `trap` defined within
+the `try` block, even if there is a matching `catch` block, the `trap`
 statement takes control.
 
-If a `Trap` exists at a higher block than the `try`, and there is no matching
-`catch` block within the current scope, the `Trap` will take control, even if
+If a `trap` exists at a higher block than the `try`, and there is no matching
+`catch` block within the current scope, the `trap` will take control, even if
 any parent scope has a matching `catch` block.
 
 ## Accessing exception information
@@ -236,18 +236,18 @@ To free resources used by a script, add a `finally` block after the `try` and
 before the script terminates or before the current block goes out of scope.
 
 A `finally` block runs even if you use <kbd>CTRL</kbd>+<kbd>C</kbd> to stop the
-script. A `finally` block also runs if an Exit keyword stops the script from
+script. A `finally` block also runs if an `exit` keyword stops the script from
 within a `catch` block.
 
 In the following example, the `try` block attempts to download a file to the
-`c:\temp` folder. The `catch` blocks handle errors that occur during the
+`C:\temp` folder. The `catch` blocks handle errors that occur during the
 download. The `finally` block disposes of the `WebClient` object and removes
 the temporary file if it exists.
 
 ```powershell
 try {
     $wc = New-Object System.Net.WebClient
-    $tempFile = "c:\temp\MyDoc.doc"
+    $tempFile = "C:\temp\MyDoc.doc"
     $wc.DownloadFile("http://www.contoso.com/MyDoc.doc",$tempFile)
 } catch [System.Net.WebException],[System.IO.IOException] {
     "Unable to download MyDoc.doc from http://www.contoso.com."

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Type_Conversion.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Type_Conversion.md
@@ -195,7 +195,7 @@ PowerShell also assigns types to literal values automatically.
 
 Numeric literals are implicitly typed by default. Numbers are typed based on
 their size. For example, `42` is small enough to be stored as an **Int32** type
-and `1.2` is stored as a **Double**. Integers larger than `[Int32]::MaxValue`
+and `1.2` is stored as a **Double**. Integers larger than `[int32]::MaxValue`
 are stored as **Int64**. While `42` can be stored as a **Byte** and `1.2` can
 be stored as a **Single** type, the implicit typing uses **Int32** and
 **Double** respectively. For more information, see
@@ -229,7 +229,7 @@ These contexts include:
 PowerShell attempts to convert values passed to parameters to match the
 parameter type. Type conversion of parameter values occurs in cmdlets,
 functions, scripts, scriptblocks, or .NET methods where the parameter is
-declared with a specific type. Declaring a parameter with the type `[object]`
+declared with a specific type. Declaring a parameter with the type `[Object]`
 or not defining a specific type allows any value type to be passed to a
 parameter. Parameters can also have custom conversions defined by decorating
 parameters with [ArgumentTransformationAttribute][17] attribute.
@@ -302,7 +302,7 @@ New-Object: Cannot find an overload for "Guid" and the argument count: "16".
 ```
 
 PowerShell treats the `$bytes` array as a list of individual parameters even
-though `$bytes` is an array of bytes and `System.Guid` has a `Guid(Byte[])`
+though `$bytes` is an array of bytes and `System.Guid` has a `Guid(byte[])`
 constructor.
 
 This common code pattern is an instance of _pseudo method syntax_, which
@@ -314,7 +314,7 @@ PS> New-Object -TypeName System.Guid -ArgumentList $bytes
 New-Object: Cannot find an overload for "Guid" and the argument count: "16".
 ```
 
-Given that the type of **ArgumentList** is `[object[]]`, a single argument that
+Given that the type of **ArgumentList** is `[Object[]]`, a single argument that
 happens to be an array (of any type) binds to it _element by element_. The
 workaround is to wrap `$bytes` in an outer array so that PowerShell looks for a
 constructor with parameters that match the contents of the outer array.
@@ -329,8 +329,8 @@ Guid
 04030201-0605-0807-090a-0b0c0d0e0f10
 ```
 
-The first item of the wrapped array is our original `Byte[]` instance. That
-value matches the `Guid(Byte[]]` constructor.
+The first item of the wrapped array is our original `[byte[]]` instance. That
+value matches the `Guid(byte[])` constructor.
 
 An alternative to the array wrapping workaround is to use the intrinsic static
 `new()` method.
@@ -402,7 +402,7 @@ If you want the result to be an **Int64**, you can cast the result type or
 operands.
 
 ```powershell
-PS> ([Int64]([int]::MaxValue + 1)).GetType().Name
+PS> ([int64]([int]::MaxValue + 1)).GetType().Name
 Int64
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -206,7 +206,7 @@ a certificate file in the file system directory.
 At the PowerShell prompt, type:
 
 ```powershell
-Get-ChildItem cert:\CurrentUser\my -CodeSigning
+Get-ChildItem Cert:\CurrentUser\my -CodeSigning
 ```
 
 This command uses the PowerShell Certificate provider to view information
@@ -243,7 +243,7 @@ To use this script, copy the following text into a text file, and name it
 
 ```powershell
 ## Signs a file
-[cmdletbinding()]
+[CmdletBinding()]
 param(
     [Parameter(Mandatory=$true)]
     [string] $File
@@ -262,7 +262,7 @@ PowerShell command prompt:
 $cert = Get-ChildItem Cert:\CurrentUser\My -CodeSigningCert |
     Select-Object -First 1
 
-Set-AuthenticodeSignature add-signature.ps1 $cert
+Set-AuthenticodeSignature Add-Signature.ps1 $cert
 ```
 
 The `Set-AuthenticodeSignature` cmdlet adds the signature to the script file as

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Simplified_Syntax.md
@@ -60,7 +60,7 @@ omit them from the command. Using aliases, you can further simplify the
 commands:
 
 ```powershell
-dir Cert:\LocalMachine\Root | Where FriendlyName -EQ 'Verisign'
+dir Cert:\LocalMachine\Root | where FriendlyName -EQ 'Verisign'
 dir Cert:\ -Recurse | foreach GetKeyAlgorithm
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -222,7 +222,7 @@ There is a vertical tab
 between the words.
 ```
 
-On printers or in a unix-based consoles, the vertical tab character advances to
+On printers or in a Unix-based console, the vertical tab character advances to
 the next line and writes the remaining output at that point.
 
 ```Output

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -132,7 +132,7 @@ an array of strings.
 ```powershell
 $array = 'Hello', 'World!'
 Invoke-Command -ScriptBlock {
-  param([string[]]$words) $words -join ' '
+  param([string[]]$Words) $Words -join ' '
   } -ArgumentList $array
 ```
 
@@ -145,7 +145,7 @@ Hello
 ```powershell
 $array = 'Hello', 'World!'
 Invoke-Command -ScriptBlock {
-  param([string[]]$words) $words -join ' '
+  param([string[]]$Words) $Words -join ' '
 } -ArgumentList (,$array)
 ```
 
@@ -319,7 +319,7 @@ When you use the `Get-MyProcess` function, all unassigned parameters and
 parameter values are passed to `@args`, as shown in the following commands.
 
 ```powershell
-Get-MyProcess -Name PowerShell
+Get-MyProcess -Name powershell
 ```
 
 ```Output
@@ -329,7 +329,7 @@ Handles  NPM(K)    PM(K)      WS(K) VM(M)   CPU(s)     Id ProcessName
 ```
 
 ```powershell
-Get-MyProcess -Name PowerShell_Ise -FileVersionInfo
+Get-MyProcess -Name powershell_ise -FileVersionInfo
 ```
 
 ```Output
@@ -345,12 +345,12 @@ passed to all instances of `@args`, as shown in the following example.
 ```powershell
 function Get-MyCommand
 {
-    Param ([switch]$P, [switch]$C)
+    param ([switch]$P, [switch]$C)
     if ($P) { Get-Process @args }
     if ($C) { Get-Command @args }
 }
 
-Get-MyCommand -P -C -Name PowerShell
+Get-MyCommand -P -C -Name powershell
 ```
 
 ```Output

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Split.md
@@ -36,15 +36,15 @@ The parameter names do not appear in the command. Include only the parameter
 values. The values must appear in the order specified in the syntax diagram.
 
 ```
--Split <String>
--Split (<String[]>)
-<String> -Split <Delimiter>[,<Max-substrings>[,"<Options>"]]
-<String> -Split {<ScriptBlock>} [,<Max-substrings>]
+-split <String>
+-split (<String[]>)
+<String> -split <Delimiter>[,<Max-substrings>[,"<Options>"]]
+<String> -split {<ScriptBlock>} [,<Max-substrings>]
 ```
 
-You can substitute `-iSplit` or `-cSplit` for `-split` in any binary Split
+You can substitute `-isplit` or `-csplit` for `-split` in any binary Split
 statement (a Split statement that includes a delimiter or script block). The
-`-iSplit` and `-split` operators are case-insensitive. The `-cSplit` operator
+`-isplit` and `-split` operators are case-insensitive. The `-csplit` operator
 is case-sensitive, meaning that case is considered when the delimiter rules
 are applied.
 
@@ -223,7 +223,7 @@ The SimpleMatch options are:
 
 - **SimpleMatch**: Use simple string comparison when evaluating the
   delimiter. Cannot be used with RegexMatch.
-- **IgnoreCase**: Forces case-insensitive matching, even if the -cSplit
+- **IgnoreCase**: Forces case-insensitive matching, even if the -csplit
   operator is specified.
 
 The RegexMatch options are:
@@ -231,7 +231,7 @@ The RegexMatch options are:
 - **RegexMatch**: Use regular expression matching to evaluate the
   delimiter. This is the default behavior. Cannot be used with
   SimpleMatch.
-- **IgnoreCase**: Forces case-insensitive matching, even if the -cSplit
+- **IgnoreCase**: Forces case-insensitive matching, even if the -csplit
   operator is specified.
 - **CultureInvariant**: Ignores cultural differences in language when
   evaluating the delimiter. Valid only with RegexMatch.
@@ -343,7 +343,7 @@ cury,Venus,Earth,Mars,Jupit
 The following statement performs a case-sensitive split at the letter "N".
 
 ```powershell
-"Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -cSplit 'N'
+"Mercury,Venus,Earth,Mars,Jupiter,Saturn,Uranus,Neptune" -csplit 'N'
 ```
 
 ```Output
@@ -441,7 +441,7 @@ $a = @'
 2The second line.
 3The third of three lines.
 '@
-$a -split "^\d", 0, "multiline"
+$a -split "^\d", 0, "Multiline"
 ```
 
 ```Output
@@ -480,7 +480,7 @@ can use options, such as SimpleMatch, only when the Max-substrings value is
 specified.
 
 ```powershell
-"This.is.a.test" -split ".", 0, "simplematch"
+"This.is.a.test" -split ".", 0, "SimpleMatch"
 ```
 
 ```Output

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -342,7 +342,7 @@ statement conditions.
 
 ```powershell
 switch ("Test") {
-    { $_ -is [String] } { "Found a string" }
+    { $_ -is [string] } { "Found a string" }
     "Test"              { "This $_ executes as well" }
 }
 ```
@@ -383,7 +383,7 @@ non-number is encountered, execution is terminated with the `break` keyword.
 ```powershell
 switch (1,4,-1,3,"Hello",2,1) {
     {$_ -lt 0}           { continue }
-    {$_ -isnot [Int32]}  { break }
+    {$_ -isnot [int32]}  { break }
     {$_ % 2}             { "$_ is Odd" }
     {-not ($_ % 2)}      { "$_ is Even" }
 }
@@ -445,7 +445,7 @@ switch -File $fileEscaped { foo { 'Foo' } }
 
 ## See also
 
-- [about_break][03]
+- [about_Break][03]
 - [about_Continue][05]
 - [about_If][06]
 - [about_Script_Blocks][07]

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Tab_Expansion.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Tab_Expansion.md
@@ -5,7 +5,7 @@ ms.date: 06/13/2024
 no-loc: [<kbd>Tab</kbd>, <kbd>Ctrl</kbd>, <kbd>Space</kbd>]
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_tab_expansion?view=powershell-7.6&WT.mc_id=ps-gethelp
 schema: 2.0.0
-title: About_tab_expansion
+title: about_Tab_Expansion
 ---
 # about_Tab_Expansion
 
@@ -87,7 +87,7 @@ You can then partially specify the path to the Active Setup log file and use
 tab expansion again:
 
 ```powershell
-PS> Get-Content c:\windows\acts<Tab>
+PS> Get-Content C:\windows\acts<Tab>
 ```
 
 When you press the <kbd>Tab</kbd> key, the command expands to:
@@ -180,18 +180,18 @@ $flavor = 'Chocolate'
 ## Tab completions for comment-based keywords
 
 Beginning in PowerShell 7.2, support was added for tab completion of the
-`#requires` parameters and the keywords for comment-based help.
+`#Requires` parameters and the keywords for comment-based help.
 
-### Example for `#requires` statement
+### Example for `#Requires` statement
 
 ```powershell
-#requires -<Ctrl-Space>
+#Requires -<Ctrl-Space>
 ```
 
 Menu expansion shows the following parameter options:
 
 ```powershell
-#requires -<Ctrl-Space>
+#Requires -<Ctrl-Space>
 Modules     PSEdition     RunAsAdministrator    Version
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Throw.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Throw.md
@@ -1,5 +1,5 @@
 ---
-description: Describes the Throw keyword, which generates a terminating error.
+description: Describes the `throw` keyword, which generates a terminating error.
 Locale: en-US
 ms.date: 08/24/2022
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_throw?view=powershell-7.6&WT.mc_id=ps-gethelp

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
@@ -16,7 +16,7 @@ terminating errors.
 ## Long description
 
 Use `try`, `catch`, and `finally` blocks to respond to or handle terminating
-errors in scripts. The `Trap` statement can also be used to handle terminating
+errors in scripts. The `trap` statement can also be used to handle terminating
 errors in scripts. For more information, see [about_Trap][05].
 
 A terminating error stops a statement from running. If PowerShell does not
@@ -29,8 +29,8 @@ PowerShell to monitor for errors. When an error occurs within the `try` block,
 the error is first saved to the `$Error` automatic variable. PowerShell then
 searches for a `catch` block to handle the error. If the `try` statement does
 not have a matching `catch` block, PowerShell continues to search for an
-appropriate `catch` block or `Trap` statement in the parent scopes. After a
-`catch` block is completed or if no appropriate `catch` block or `Trap`
+appropriate `catch` block or `trap` statement in the parent scopes. After a
+`catch` block is completed or if no appropriate `catch` block or `trap`
 statement is found, the `finally` block is run. If the error cannot be handled,
 the error is written to the error stream.
 
@@ -134,7 +134,7 @@ two `catch` blocks:
 ```powershell
 try {
     $wc = New-Object System.Net.WebClient
-    $wc.DownloadFile("http://www.contoso.com/MyDoc.doc","c:\temp\MyDoc.doc")
+    $wc.DownloadFile("http://www.contoso.com/MyDoc.doc","C:\temp\MyDoc.doc")
 } catch [System.Net.WebException],[System.IO.IOException] {
     "Unable to download MyDoc.doc from http://www.contoso.com."
 } catch {
@@ -179,12 +179,12 @@ block for the derived class before the `catch` block for the general class.
 
 ## Using Traps in a Try Catch
 
-When a terminating error occurs in a `try` block with a `Trap` defined within
-the `try` block, even if there is a matching `catch` block, the `Trap`
+When a terminating error occurs in a `try` block with a `trap` defined within
+the `try` block, even if there is a matching `catch` block, the `trap`
 statement takes control.
 
-If a `Trap` exists at a higher block than the `try`, and there is no matching
-`catch` block within the current scope, the `Trap` will take control, even if
+If a `trap` exists at a higher block than the `try`, and there is no matching
+`catch` block within the current scope, the `trap` will take control, even if
 any parent scope has a matching `catch` block.
 
 ## Accessing exception information
@@ -236,18 +236,18 @@ To free resources used by a script, add a `finally` block after the `try` and
 before the script terminates or before the current block goes out of scope.
 
 A `finally` block runs even if you use <kbd>CTRL</kbd>+<kbd>C</kbd> to stop the
-script. A `finally` block also runs if an Exit keyword stops the script from
+script. A `finally` block also runs if an `exit` keyword stops the script from
 within a `catch` block.
 
 In the following example, the `try` block attempts to download a file to the
-`c:\temp` folder. The `catch` blocks handle errors that occur during the
+`C:\temp` folder. The `catch` blocks handle errors that occur during the
 download. The `finally` block disposes of the `WebClient` object and removes
 the temporary file if it exists.
 
 ```powershell
 try {
     $wc = New-Object System.Net.WebClient
-    $tempFile = "c:\temp\MyDoc.doc"
+    $tempFile = "C:\temp\MyDoc.doc"
     $wc.DownloadFile("http://www.contoso.com/MyDoc.doc",$tempFile)
 } catch [System.Net.WebException],[System.IO.IOException] {
     "Unable to download MyDoc.doc from http://www.contoso.com."

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Type_Conversion.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Type_Conversion.md
@@ -195,7 +195,7 @@ PowerShell also assigns types to literal values automatically.
 
 Numeric literals are implicitly typed by default. Numbers are typed based on
 their size. For example, `42` is small enough to be stored as an **Int32** type
-and `1.2` is stored as a **Double**. Integers larger than `[Int32]::MaxValue`
+and `1.2` is stored as a **Double**. Integers larger than `[int32]::MaxValue`
 are stored as **Int64**. While `42` can be stored as a **Byte** and `1.2` can
 be stored as a **Single** type, the implicit typing uses **Int32** and
 **Double** respectively. For more information, see
@@ -229,7 +229,7 @@ These contexts include:
 PowerShell attempts to convert values passed to parameters to match the
 parameter type. Type conversion of parameter values occurs in cmdlets,
 functions, scripts, scriptblocks, or .NET methods where the parameter is
-declared with a specific type. Declaring a parameter with the type `[object]`
+declared with a specific type. Declaring a parameter with the type `[Object]`
 or not defining a specific type allows any value type to be passed to a
 parameter. Parameters can also have custom conversions defined by decorating
 parameters with [ArgumentTransformationAttribute][17] attribute.
@@ -302,7 +302,7 @@ New-Object: Cannot find an overload for "Guid" and the argument count: "16".
 ```
 
 PowerShell treats the `$bytes` array as a list of individual parameters even
-though `$bytes` is an array of bytes and `System.Guid` has a `Guid(Byte[])`
+though `$bytes` is an array of bytes and `System.Guid` has a `Guid(byte[])`
 constructor.
 
 This common code pattern is an instance of _pseudo method syntax_, which
@@ -314,7 +314,7 @@ PS> New-Object -TypeName System.Guid -ArgumentList $bytes
 New-Object: Cannot find an overload for "Guid" and the argument count: "16".
 ```
 
-Given that the type of **ArgumentList** is `[object[]]`, a single argument that
+Given that the type of **ArgumentList** is `[Object[]]`, a single argument that
 happens to be an array (of any type) binds to it _element by element_. The
 workaround is to wrap `$bytes` in an outer array so that PowerShell looks for a
 constructor with parameters that match the contents of the outer array.
@@ -329,8 +329,8 @@ Guid
 04030201-0605-0807-090a-0b0c0d0e0f10
 ```
 
-The first item of the wrapped array is our original `Byte[]` instance. That
-value matches the `Guid(Byte[]]` constructor.
+The first item of the wrapped array is our original `[byte[]]` instance. That
+value matches the `Guid(byte[])` constructor.
 
 An alternative to the array wrapping workaround is to use the intrinsic static
 `new()` method.
@@ -402,7 +402,7 @@ If you want the result to be an **Int64**, you can cast the result type or
 operands.
 
 ```powershell
-PS> ([Int64]([int]::MaxValue + 1)).GetType().Name
+PS> ([int64]([int]::MaxValue + 1)).GetType().Name
 Int64
 ```
 


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide