### PR TITLE
Fix incorrect case/capitalization in reference documents (12/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -29,19 +29,19 @@ PowerShell has the  following type operators:
 - `-is`   |Returns TRUE when the input is an instance of the specified .NET type.
 
   ```powershell
-  (get-date) -is [DateTime]     # Result is True
+  (Get-Date) -is [datetime]     # Result is True
   ```
 
 - `-isnot`|Returns TRUE when the input not an instance of the specified.NET type.
 
   ```powershell
-  (get-date) -isnot [DateTime]  # Result is False
+  (Get-Date) -isnot [datetime]  # Result is False
   ```
 
 - `-as`   |Converts the input to the   specified .NET type.
 
   ```powershell
-  "5/7/07" -as [DateTime]       # Result is Monday, May 7, 2007 12:00:00 AM
+  "5/7/07" -as [datetime]       # Result is Monday, May 7, 2007 12:00:00 AM
   ```
 
 The syntax of the type operators is as follows:
@@ -57,7 +57,7 @@ You can also use the following syntax:
 ```
 
 The .NET type can be written as a type name in brackets or a string, such as
-`[DateTime]` or `"DateTime"` for **System.DateTime**. If the type is not at the
+`[datetime]` or `"DateTime"` for **System.DateTime**. If the type is not at the
 root of the system namespace, specify the full name of the object type. You can
 omit "System.". For example, to specify **System.Diagnostics.Process**, enter
 `[System.Diagnostics.Process]`, `[Diagnostics.Process]`, or
@@ -113,7 +113,7 @@ System.IO.DirectoryInfo
 
 #### Converting the DateTime type is culture-sensitive
 
-Unlike type casting, converting to `[DateTime]` type using the `-as` operator
+Unlike type casting, converting to `[datetime]` type using the `-as` operator
 only works with strings that are formatted according to the rules of the
 current culture.
 
@@ -148,25 +148,25 @@ System.Globalization.CultureInfo
 The following examples show some uses of the Type operators:
 
 ```powershell
-PS> 32 -is [Float]
+PS> 32 -is [float]
 False
 
 PS> 32 -is "int"
 True
 
-PS> (get-date) -is [DateTime]
+PS> (Get-Date) -is [datetime]
 True
 
-PS> "12/31/2007" -is [DateTime]
+PS> "12/31/2007" -is [datetime]
 False
 
-PS> "12/31/2007" -is [String]
+PS> "12/31/2007" -is [string]
 True
 
-PS> (get-process PowerShell)[0] -is [System.Diagnostics.Process]
+PS> (Get-Process powershell)[0] -is [System.Diagnostics.Process]
 True
 
-PS> (get-command get-member) -is [System.Management.Automation.CmdletInfo]
+PS> (Get-Command Get-Member) -is [System.Management.Automation.CmdletInfo]
 True
 ```
 
@@ -179,40 +179,40 @@ return **System.Globalization.CultureInfo** objects, a collection of these
 objects is a System.Object array.
 
 ```powershell
-PS> (get-culture) -is [System.Globalization.CultureInfo]
+PS> (Get-Culture) -is [System.Globalization.CultureInfo]
 True
 
-PS> (get-uiculture) -is [System.Globalization.CultureInfo]
+PS> (Get-UICulture) -is [System.Globalization.CultureInfo]
 True
 
-PS> (get-culture), (get-uiculture) -is [System.Globalization.CultureInfo]
+PS> (Get-Culture), (Get-UICulture) -is [System.Globalization.CultureInfo]
 False
 
-PS> (get-culture), (get-uiculture) -is [Array]
+PS> (Get-Culture), (Get-UICulture) -is [array]
 True
 
-PS> (get-culture), (get-uiculture) | foreach {
+PS> (Get-Culture), (Get-UICulture) | foreach {
   $_ -is [System.Globalization.CultureInfo])
 }
 True
 True
 
-PS> (get-culture), (get-uiculture) -is [Object]
+PS> (Get-Culture), (Get-UICulture) -is [Object]
 True
 ```
 
 The following examples show how to use the `-as` operator.
 
 ```powershell
-PS> "12/31/07" -is [DateTime]
+PS> "12/31/07" -is [datetime]
 False
 
-PS> "12/31/07" -as [DateTime]
+PS> "12/31/07" -as [datetime]
 Monday, December 31, 2007 12:00:00 AM
 
-PS> $date = "12/31/07" -as [DateTime]
+PS> $date = "12/31/07" -as [datetime]
 
-C:\PS>$a -is [DateTime]
+C:\PS>$a -is [datetime]
 True
 
 PS> 1031 -as [System.Globalization.CultureInfo]

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -215,7 +215,7 @@ information about `Update-TypeData`, see [Update-TypeData][01].
 Update-TypeData -PrependPath $PSHOME\MyTypes.ps1xml
 ```
 
-To test the change, run a `Get-ChildItem` command to get the PowerShell.exe
+To test the change, run a `Get-ChildItem` command to get the `powershell.exe`
 file in the `$PSHOME` directory, and then pipe the file to the `Format-List`
 cmdlet to list all of the properties of the file. As a result of the change,
 the **Age** property appears in the list.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -313,7 +313,7 @@ Update-Help -Module DhcpServer -SourcePath E:\UsbDrive\SavedHelp
 Without parameters, `Save-Help` downloads help for all modules in the session
 and for all installed modules that support Updatable Help. To be included,
 modules must be installed in directories that are listed in the value of the
-`$env:PSModulePath` environment variable, on either the local computer or on a
+`$Env:PSModulePath` environment variable, on either the local computer or on a
 remote computer for which you want to save help. These are also modules that
 are returned by running a `Get-Help -ListAvailable` command.
 
@@ -330,10 +330,10 @@ However, you can use the **UICulture** parameters of the `Update-Help` and
 which they're available.
 
 For example, to save the newest help files for all modules on the session in
-Japanese (ja-Jp) and French (fr-FR), type:
+Japanese (ja-JP) and French (fr-FR), type:
 
 ```powershell
-Save-Help -Path \Server\Share -UICulture ja-jp, fr-fr
+Save-Help -Path \Server\Share -UICulture ja-JP, fr-FR
 ```
 
 If help files for the modules aren't available in the languages that you
@@ -411,7 +411,7 @@ only a module name. They don't accept the path to a module file.
 
 Use this technique to update or save help for any module that's not returned by
 the **ListAvailable** parameter of the `Get-Module` cmdlet, such as a module
-that's installed in a location that's not listed in the `$env:PSModulePath`
+that's installed in a location that's not listed in the `$Env:PSModulePath`
 environment variable, or a module that's not well-formed (the module directory
 doesn't contain at least one file whose basename is the same as the directory
 name).

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Using.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Using.md
@@ -23,7 +23,7 @@ module. No uncommented statement can precede it, including parameters.
 
 The `using` statement must not contain any variables.
 
-The `using` statement isn't the same as the `using:` scope modifier for
+The `using` statement isn't the same as the `Using:` scope modifier for
 variables. For more information, see
 [about_Remote_Variables](about_Remote_Variables.md).
 
@@ -91,7 +91,7 @@ A module specification is a hashtable that has the following keys.
   - `RequiredVersion` - Specifies an exact, required version of the module.
     This can't be used with the other Version keys.
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes and enumerations
 aren't imported.
 
@@ -120,7 +120,7 @@ following classes:
 - **Deck**
 - **Card**
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes aren't imported. The
 `using module` command imports the module and also loads the class definitions.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
@@ -159,10 +159,12 @@ This command gets the variables that have the values of `ReadOnly` or
 `Constant` for their **Options** property.
 
 ```powershell
-Get-ChildItem -Path Variable: | Where-Object {
-   $_.Options -match "Constant" `
-   -or $_.Options -match "ReadOnly"
- } | Format-List -Property Name, Value, Options
+Get-ChildItem -Path Variable: |
+    Where-Object {
+        $_.Options -match 'Constant' -or 
+        $_.Options -match 'ReadOnly'
+    } | 
+    Format-List -Property Name, Value, Options
 ```
 
 ## Creating variables

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
@@ -130,16 +130,16 @@ the dollar sign (`$`). This has the same effect as prefixing the variables name
 with the dollar sign (`$`).
 
 ```powershell
-$variable:HOME
+$Variable:HOME
 ```
 
 ### Get variables using wildcards
 
-This command gets the variables with names that begin with "max". You can use
+This command gets the variables with names that begin with "Max". You can use
 this command from any PowerShell drive.
 
 ```powershell
-Get-ChildItem -Path Variable:max*
+Get-ChildItem -Path Variable:Max*
 ```
 
 ### Get the value of the ? variable
@@ -160,9 +160,9 @@ This command gets the variables that have the values of `ReadOnly` or
 
 ```powershell
 Get-ChildItem -Path Variable: | Where-Object {
-   $_.options -match "Constant" `
-   -or $_.options -match "ReadOnly"
- } | Format-List -Property name, value, options
+   $_.Options -match "Constant" `
+   -or $_.Options -match "ReadOnly"
+ } | Format-List -Property Name, Value, Options
 ```
 
 ## Creating variables
@@ -273,7 +273,7 @@ Get-Help Get-ChildItem
 ```
 
 ```powershell
-Get-Help Get-ChildItem -Path variable:
+Get-Help Get-ChildItem -Path Variable:
 ```
 
 ## See also

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Variables.md
@@ -163,7 +163,7 @@ The next example assigns multiple values to multiple variables.
 
 ```powershell
 $i,$j,$k = 10, "red", $true    # $i is 10, $j is "red", $k is True
-$i,$j = 10, "red", $true       # $i is 10, $j is [object[]], Length 2
+$i,$j = 10, "red", $true       # $i is 10, $j is [Object[]], Length 2
 ```
 
 For more detailed information, see the **Assigning multiple variables** section
@@ -367,7 +367,7 @@ The following command gets the child items in the directory that is represented
 by the `ProgramFiles(x86)` environment variable.
 
 ```powershell
-Get-ChildItem ${env:ProgramFiles(x86)}
+Get-ChildItem ${Env:ProgramFiles(x86)}
 ```
 
 To reference a variable name that includes braces, enclose the variable name in
@@ -400,7 +400,7 @@ global scope, even when it's created in a script or function.
 $Global:Computers = "Server01"
 ```
 
-For any script or command that executes out of session, you need the `Using`
+For any script or command that executes out of session, you need the `Using:`
 scope modifier to embed variable values from the calling session scope, so that
 out of session code can access them.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_While.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_While.md
@@ -17,12 +17,12 @@ the results of a conditional test.
 The `while` statement (also known as a `while` loop) is a language construct
 for creating a loop that runs commands in a command block as long as a
 conditional test evaluates to true. The `while` statement is easier to
-construct than a For statement because its syntax is less complicated. In
-addition, it is more flexible than the Foreach statement because you specify a
-conditional test in the `while` statement to control how many times the loop
+construct than a `for` statement because its syntax is less complicated. In
+addition, it is more flexible than the `foreach` statement because you specify
+a conditional test in the `while` statement to control how many times the loop
 runs.
 
-The following shows the While statement syntax:
+The following shows the `while` statement syntax:
 
 ```powershell
 while (<condition>){<statement list>}

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -85,7 +85,7 @@ includes **Interactive**.
 Get-Service | Where-Object {$_.ServiceType -like "*Interactive*"}
 ```
 
-In the following example, the `If` statement includes a condition that uses
+In the following example, the `if` statement includes a condition that uses
 wildcard characters to find property values. If the restore point's
 **Description** includes **PowerShell**, the command adds the value of the
 restore point's **CreationTime** property to a log file.
@@ -93,7 +93,7 @@ restore point's **CreationTime** property to a log file.
 ```powershell
 $p = Get-ComputerRestorePoint
 foreach ($point in $p) {
-  if ($point.description -like "*PowerShell*") {
+  if ($point.Description -like "*PowerShell*") {
     Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
   }
 }

--- a/reference/5.1/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -518,7 +518,7 @@ Specifies the instance IDs of the disconnected sessions.
 
 The instance ID is a GUID that uniquely identifies a **PSSession** on a local or remote computer.
 
-The instance ID is stored in the **InstanceID** property of the **PSSession**.
+The instance ID is stored in the **InstanceId** property of the **PSSession**.
 
 ```yaml
 Type: System.Guid[]

--- a/reference/5.1/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Debug-Job.md
@@ -54,7 +54,7 @@ command detaches the debugger, and allows the job to continue to run.
 This command breaks into a running job with an ID of 3.
 
 ```powershell
-Debug-Job -ID 3
+Debug-Job -Id 3
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -29,19 +29,19 @@ PowerShell has the  following type operators:
 - `-is`   |Returns TRUE when the input is an instance of the specified .NET type.
 
   ```powershell
-  (get-date) -is [DateTime]     # Result is True
+  (Get-Date) -is [datetime]     # Result is True
   ```
 
 - `-isnot`|Returns TRUE when the input not an instance of the specified.NET type.
 
   ```powershell
-  (get-date) -isnot [DateTime]  # Result is False
+  (Get-Date) -isnot [datetime]  # Result is False
   ```
 
 - `-as`   |Converts the input to the   specified .NET type.
 
   ```powershell
-  "5/7/07" -as [DateTime]       # Result is Monday, May 7, 2007 12:00:00 AM
+  "5/7/07" -as [datetime]       # Result is Monday, May 7, 2007 12:00:00 AM
   ```
 
 The syntax of the type operators is as follows:
@@ -57,7 +57,7 @@ You can also use the following syntax:
 ```
 
 The .NET type can be written as a type name in brackets or a string, such as
-`[DateTime]` or `"DateTime"` for **System.DateTime**. If the type is not at the
+`[datetime]` or `"DateTime"` for **System.DateTime**. If the type is not at the
 root of the system namespace, specify the full name of the object type. You can
 omit "System.". For example, to specify **System.Diagnostics.Process**, enter
 `[System.Diagnostics.Process]`, `[Diagnostics.Process]`, or
@@ -113,7 +113,7 @@ System.IO.DirectoryInfo
 
 #### Converting the DateTime type is culture-sensitive
 
-Unlike type casting, converting to `[DateTime]` type using the `-as` operator
+Unlike type casting, converting to `[datetime]` type using the `-as` operator
 only works with strings that are formatted according to the rules of the
 current culture.
 
@@ -148,25 +148,25 @@ System.Globalization.CultureInfo
 The following examples show some uses of the Type operators:
 
 ```powershell
-PS> 32 -is [Float]
+PS> 32 -is [float]
 False
 
 PS> 32 -is "int"
 True
 
-PS> (get-date) -is [DateTime]
+PS> (Get-Date) -is [datetime]
 True
 
-PS> "12/31/2007" -is [DateTime]
+PS> "12/31/2007" -is [datetime]
 False
 
-PS> "12/31/2007" -is [String]
+PS> "12/31/2007" -is [string]
 True
 
-PS> (get-process PowerShell)[0] -is [System.Diagnostics.Process]
+PS> (Get-Process powershell)[0] -is [System.Diagnostics.Process]
 True
 
-PS> (get-command get-member) -is [System.Management.Automation.CmdletInfo]
+PS> (Get-Command Get-Member) -is [System.Management.Automation.CmdletInfo]
 True
 ```
 
@@ -179,40 +179,40 @@ return **System.Globalization.CultureInfo** objects, a collection of these
 objects is a System.Object array.
 
 ```powershell
-PS> (get-culture) -is [System.Globalization.CultureInfo]
+PS> (Get-Culture) -is [System.Globalization.CultureInfo]
 True
 
-PS> (get-uiculture) -is [System.Globalization.CultureInfo]
+PS> (Get-UICulture) -is [System.Globalization.CultureInfo]
 True
 
-PS> (get-culture), (get-uiculture) -is [System.Globalization.CultureInfo]
+PS> (Get-Culture), (Get-UICulture) -is [System.Globalization.CultureInfo]
 False
 
-PS> (get-culture), (get-uiculture) -is [Array]
+PS> (Get-Culture), (Get-UICulture) -is [array]
 True
 
-PS> (get-culture), (get-uiculture) | foreach {
+PS> (Get-Culture), (Get-UICulture) | foreach {
   $_ -is [System.Globalization.CultureInfo])
 }
 True
 True
 
-PS> (get-culture), (get-uiculture) -is [Object]
+PS> (Get-Culture), (Get-UICulture) -is [Object]
 True
 ```
 
 The following examples show how to use the `-as` operator.
 
 ```powershell
-PS> "12/31/07" -is [DateTime]
+PS> "12/31/07" -is [datetime]
 False
 
-PS> "12/31/07" -as [DateTime]
+PS> "12/31/07" -as [datetime]
 Monday, December 31, 2007 12:00:00 AM
 
-PS> $date = "12/31/07" -as [DateTime]
+PS> $date = "12/31/07" -as [datetime]
 
-C:\PS>$a -is [DateTime]
+C:\PS>$a -is [datetime]
 True
 
 PS> 1031 -as [System.Globalization.CultureInfo]

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -215,7 +215,7 @@ information about `Update-TypeData`, see [Update-TypeData][01].
 Update-TypeData -PrependPath $PSHOME\MyTypes.ps1xml
 ```
 
-To test the change, run a `Get-ChildItem` command to get the PowerShell.exe
+To test the change, run a `Get-ChildItem` command to get the `powershell.exe`
 file in the `$PSHOME` directory, and then pipe the file to the `Format-List`
 cmdlet to list all of the properties of the file. As a result of the change,
 the **Age** property appears in the list.

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -305,7 +305,7 @@ Update-Help -Module DhcpServer -SourcePath E:\UsbDrive\SavedHelp
 Without parameters, `Save-Help` downloads help for all modules in the session
 and for all installed modules that support Updatable Help. To be included,
 modules must be installed in directories that are listed in the value of the
-`$env:PSModulePath` environment variable, on either the local computer or on a
+`$Env:PSModulePath` environment variable, on either the local computer or on a
 remote computer for which you want to save help. These are also modules that
 are returned by running a `Get-Help -ListAvailable` command.
 
@@ -322,10 +322,10 @@ However, you can use the **UICulture** parameters of the `Update-Help` and
 which they're available.
 
 For example, to save the newest help files for all modules on the session in
-Japanese (ja-Jp) and French (fr-FR), type:
+Japanese (ja-JP) and French (fr-FR), type:
 
 ```powershell
-Save-Help -Path \Server\Share -UICulture ja-jp, fr-fr
+Save-Help -Path \Server\Share -UICulture ja-JP, fr-FR
 ```
 
 If help files for the modules aren't available in the languages that you
@@ -403,7 +403,7 @@ only a module name. They don't accept the path to a module file.
 
 Use this technique to update or save help for any module that's not returned by
 the **ListAvailable** parameter of the `Get-Module` cmdlet, such as a module
-that's installed in a location that's not listed in the `$env:PSModulePath`
+that's installed in a location that's not listed in the `$Env:PSModulePath`
 environment variable, or a module that's not well-formed (the module directory
 doesn't contain at least one file whose basename is the same as the directory
 name).

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Using.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Using.md
@@ -23,7 +23,7 @@ module. No uncommented statement can precede it, including parameters.
 
 The `using` statement must not contain any variables.
 
-The `using` statement isn't the same as the `using:` scope modifier for
+The `using` statement isn't the same as the `Using:` scope modifier for
 variables. For more information, see
 [about_Remote_Variables](about_Remote_Variables.md).
 
@@ -91,7 +91,7 @@ A module specification is a hashtable that has the following keys.
   - `RequiredVersion` - Specifies an exact, required version of the module.
     This can't be used with the other Version keys.
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes and enumerations
 aren't imported.
 
@@ -120,7 +120,7 @@ following classes:
 - **Deck**
 - **Card**
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes aren't imported. The
 `using module` command imports the module and also loads the class definitions.
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
@@ -159,10 +159,12 @@ This command gets the variables that have the values of `ReadOnly` or
 `Constant` for their **Options** property.
 
 ```powershell
-Get-ChildItem -Path Variable: | Where-Object {
-   $_.Options -match "Constant" `
-   -or $_.Options -match "ReadOnly"
- } | Format-List -Property Name, Value, Options
+Get-ChildItem -Path Variable: |
+    Where-Object {
+        $_.Options -match 'Constant' -or 
+        $_.Options -match 'ReadOnly'
+    } | 
+    Format-List -Property Name, Value, Options
 ```
 
 ## Creating variables

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
@@ -130,16 +130,16 @@ the dollar sign (`$`). This has the same effect as prefixing the variables name
 with the dollar sign (`$`).
 
 ```powershell
-$variable:HOME
+$Variable:HOME
 ```
 
 ### Get variables using wildcards
 
-This command gets the variables with names that begin with "max". You can use
+This command gets the variables with names that begin with "Max". You can use
 this command from any PowerShell drive.
 
 ```powershell
-Get-ChildItem -Path Variable:max*
+Get-ChildItem -Path Variable:Max*
 ```
 
 ### Get the value of the ? variable
@@ -160,9 +160,9 @@ This command gets the variables that have the values of `ReadOnly` or
 
 ```powershell
 Get-ChildItem -Path Variable: | Where-Object {
-   $_.options -match "Constant" `
-   -or $_.options -match "ReadOnly"
- } | Format-List -Property name, value, options
+   $_.Options -match "Constant" `
+   -or $_.Options -match "ReadOnly"
+ } | Format-List -Property Name, Value, Options
 ```
 
 ## Creating variables
@@ -273,7 +273,7 @@ Get-Help Get-ChildItem
 ```
 
 ```powershell
-Get-Help Get-ChildItem -Path variable:
+Get-Help Get-ChildItem -Path Variable:
 ```
 
 ## See also

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Variables.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Variables.md
@@ -163,7 +163,7 @@ The next example assigns multiple values to multiple variables.
 
 ```powershell
 $i,$j,$k = 10, "red", $true    # $i is 10, $j is "red", $k is True
-$i,$j = 10, "red", $true       # $i is 10, $j is [object[]], Length 2
+$i,$j = 10, "red", $true       # $i is 10, $j is [Object[]], Length 2
 ```
 
 For more detailed information, see the **Assigning multiple variables** section
@@ -367,7 +367,7 @@ The following command gets the child items in the directory that is represented
 by the `ProgramFiles(x86)` environment variable.
 
 ```powershell
-Get-ChildItem ${env:ProgramFiles(x86)}
+Get-ChildItem ${Env:ProgramFiles(x86)}
 ```
 
 To reference a variable name that includes braces, enclose the variable name in
@@ -400,7 +400,7 @@ global scope, even when it's created in a script or function.
 $Global:Computers = "Server01"
 ```
 
-For any script or command that executes out of session, you need the `Using`
+For any script or command that executes out of session, you need the `Using:`
 scope modifier to embed variable values from the calling session scope, so that
 out of session code can access them.
 

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_While.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_While.md
@@ -18,12 +18,12 @@ the results of a conditional test.
 The `while` statement (also known as a `while` loop) is a language construct
 for creating a loop that runs commands in a command block as long as a
 conditional test evaluates to true. The `while` statement is easier to
-construct than a For statement because its syntax is less complicated. In
-addition, it is more flexible than the Foreach statement because you specify a
-conditional test in the `while` statement to control how many times the loop
+construct than a `for` statement because its syntax is less complicated. In
+addition, it is more flexible than the `foreach` statement because you specify
+a conditional test in the `while` statement to control how many times the loop
 runs.
 
-The following shows the While statement syntax:
+The following shows the `while` statement syntax:
 
 ```powershell
 while (<condition>){<statement list>}

--- a/reference/7.4/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -85,7 +85,7 @@ includes **Interactive**.
 Get-Service | Where-Object {$_.ServiceType -like "*Interactive*"}
 ```
 
-In the following example, the `If` statement includes a condition that uses
+In the following example, the `if` statement includes a condition that uses
 wildcard characters to find property values. If the restore point's
 **Description** includes **PowerShell**, the command adds the value of the
 restore point's **CreationTime** property to a log file.
@@ -93,7 +93,7 @@ restore point's **CreationTime** property to a log file.
 ```powershell
 $p = Get-ComputerRestorePoint
 foreach ($point in $p) {
-  if ($point.description -like "*PowerShell*") {
+  if ($point.Description -like "*PowerShell*") {
     Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
   }
 }

--- a/reference/7.4/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -523,7 +523,7 @@ Specifies the instance IDs of the disconnected sessions.
 
 The instance ID is a GUID that uniquely identifies a **PSSession** on a local or remote computer.
 
-The instance ID is stored in the **InstanceID** property of the **PSSession**.
+The instance ID is stored in the **InstanceId** property of the **PSSession**.
 
 ```yaml
 Type: System.Guid[]

--- a/reference/7.4/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/7.4/Microsoft.PowerShell.Core/Debug-Job.md
@@ -54,7 +54,7 @@ command detaches the debugger, and allows the job to continue to run.
 This command breaks into a running job with an ID of 3.
 
 ```powershell
-Debug-Job -ID 3
+Debug-Job -Id 3
 ```
 
 ```Output

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -30,19 +30,19 @@ PowerShell has the  following type operators:
 - `-is`   |Returns TRUE when the input is an instance of the specified .NET type.
 
   ```powershell
-  (Get-Date) -is [DateTime]     # Result is True
+  (Get-Date) -is [datetime]     # Result is True
   ```
 
 - `-isnot`|Returns TRUE when the input not an instance of the specified.NET type.
 
   ```powershell
-  (Get-Date) -isnot [DateTime]  # Result is False
+  (Get-Date) -isnot [datetime]  # Result is False
   ```
 
 - `-as`   |Converts the input to the   specified .NET type.
 
   ```powershell
-  "5/7/07" -as [DateTime]       # Result is Monday, May 7, 2007 12:00:00 AM
+  "5/7/07" -as [datetime]       # Result is Monday, May 7, 2007 12:00:00 AM
   ```
 
 The syntax of the type operators is as follows:
@@ -58,7 +58,7 @@ You can also use the following syntax:
 ```
 
 The .NET type can be written as a type name in brackets or a string, such as
-`[DateTime]` or `"DateTime"` for **System.DateTime**. If the type is not at the
+`[datetime]` or `"DateTime"` for **System.DateTime**. If the type is not at the
 root of the system namespace, specify the full name of the object type. You can
 omit "System.". For example, to specify **System.Diagnostics.Process**, enter
 `[System.Diagnostics.Process]`, `[Diagnostics.Process]`, or
@@ -114,7 +114,7 @@ System.IO.DirectoryInfo
 
 #### Converting the DateTime type is culture-sensitive
 
-Unlike type casting, converting to `[DateTime]` type using the `-as` operator
+Unlike type casting, converting to `[datetime]` type using the `-as` operator
 only works with strings that are formatted according to the rules of the
 current culture.
 
@@ -149,25 +149,25 @@ System.Globalization.CultureInfo
 The following examples show some uses of the Type operators:
 
 ```powershell
-PS> 32 -is [Float]
+PS> 32 -is [float]
 False
 
 PS> 32 -is "int"
 True
 
-PS> (Get-Date) -is [DateTime]
+PS> (Get-Date) -is [datetime]
 True
 
-PS> "12/31/2007" -is [DateTime]
+PS> "12/31/2007" -is [datetime]
 False
 
-PS> "12/31/2007" -is [String]
+PS> "12/31/2007" -is [string]
 True
 
-PS> (get-process PowerShell)[0] -is [System.Diagnostics.Process]
+PS> (Get-Process powershell)[0] -is [System.Diagnostics.Process]
 True
 
-PS> (get-command get-member) -is [System.Management.Automation.CmdletInfo]
+PS> (Get-Command Get-Member) -is [System.Management.Automation.CmdletInfo]
 True
 ```
 
@@ -189,7 +189,7 @@ True
 PS> (Get-Culture), (Get-UICulture) -is [System.Globalization.CultureInfo]
 False
 
-PS> (Get-Culture), (Get-UICulture) -is [Array]
+PS> (Get-Culture), (Get-UICulture) -is [array]
 True
 
 PS> (Get-Culture), (Get-UICulture) | foreach {
@@ -205,15 +205,15 @@ True
 The following examples show how to use the `-as` operator.
 
 ```powershell
-PS> "12/31/07" -is [DateTime]
+PS> "12/31/07" -is [datetime]
 False
 
-PS> "12/31/07" -as [DateTime]
+PS> "12/31/07" -as [datetime]
 Monday, December 31, 2007 12:00:00 AM
 
-PS> $date = "12/31/07" -as [DateTime]
+PS> $date = "12/31/07" -as [datetime]
 
-C:\PS>$a -is [DateTime]
+C:\PS>$a -is [datetime]
 True
 
 PS> 1031 -as [System.Globalization.CultureInfo]

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -215,7 +215,7 @@ information about `Update-TypeData`, see [Update-TypeData][01].
 Update-TypeData -PrependPath $PSHOME\MyTypes.ps1xml
 ```
 
-To test the change, run a `Get-ChildItem` command to get the PowerShell.exe
+To test the change, run a `Get-ChildItem` command to get the `powershell.exe`
 file in the `$PSHOME` directory, and then pipe the file to the `Format-List`
 cmdlet to list all of the properties of the file. As a result of the change,
 the **Age** property appears in the list.

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -305,7 +305,7 @@ Update-Help -Module DhcpServer -SourcePath E:\UsbDrive\SavedHelp
 Without parameters, `Save-Help` downloads help for all modules in the session
 and for all installed modules that support Updatable Help. To be included,
 modules must be installed in directories that are listed in the value of the
-`$env:PSModulePath` environment variable, on either the local computer or on a
+`$Env:PSModulePath` environment variable, on either the local computer or on a
 remote computer for which you want to save help. These are also modules that
 are returned by running a `Get-Help -ListAvailable` command.
 
@@ -322,10 +322,10 @@ However, you can use the **UICulture** parameters of the `Update-Help` and
 which they're available.
 
 For example, to save the newest help files for all modules on the session in
-Japanese (ja-Jp) and French (fr-FR), type:
+Japanese (ja-JP) and French (fr-FR), type:
 
 ```powershell
-Save-Help -Path \Server\Share -UICulture ja-jp, fr-fr
+Save-Help -Path \Server\Share -UICulture ja-JP, fr-FR
 ```
 
 If help files for the modules aren't available in the languages that you
@@ -403,7 +403,7 @@ only a module name. They don't accept the path to a module file.
 
 Use this technique to update or save help for any module that's not returned by
 the **ListAvailable** parameter of the `Get-Module` cmdlet, such as a module
-that's installed in a location that's not listed in the `$env:PSModulePath`
+that's installed in a location that's not listed in the `$Env:PSModulePath`
 environment variable, or a module that's not well-formed (the module directory
 doesn't contain at least one file whose basename is the same as the directory
 name).

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Using.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Using.md
@@ -23,7 +23,7 @@ module. No uncommented statement can precede it, including parameters.
 
 The `using` statement must not contain any variables.
 
-The `using` statement isn't the same as the `using:` scope modifier for
+The `using` statement isn't the same as the `Using:` scope modifier for
 variables. For more information, see
 [about_Remote_Variables](about_Remote_Variables.md).
 
@@ -91,7 +91,7 @@ A module specification is a hashtable that has the following keys.
   - `RequiredVersion` - Specifies an exact, required version of the module.
     This can't be used with the other Version keys.
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes and enumerations
 aren't imported.
 
@@ -120,7 +120,7 @@ following classes:
 - **Deck**
 - **Card**
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes aren't imported. The
 `using module` command imports the module and also loads the class definitions.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
@@ -159,10 +159,12 @@ This command gets the variables that have the values of `ReadOnly` or
 `Constant` for their **Options** property.
 
 ```powershell
-Get-ChildItem -Path Variable: | Where-Object {
-   $_.Options -match "Constant" `
-   -or $_.Options -match "ReadOnly"
- } | Format-List -Property Name, Value, Options
+Get-ChildItem -Path Variable: |
+    Where-Object {
+        $_.Options -match 'Constant' -or 
+        $_.Options -match 'ReadOnly'
+    } | 
+    Format-List -Property Name, Value, Options
 ```
 
 ## Creating variables

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
@@ -130,16 +130,16 @@ the dollar sign (`$`). This has the same effect as prefixing the variables name
 with the dollar sign (`$`).
 
 ```powershell
-$variable:HOME
+$Variable:HOME
 ```
 
 ### Get variables using wildcards
 
-This command gets the variables with names that begin with "max". You can use
+This command gets the variables with names that begin with "Max". You can use
 this command from any PowerShell drive.
 
 ```powershell
-Get-ChildItem -Path Variable:max*
+Get-ChildItem -Path Variable:Max*
 ```
 
 ### Get the value of the ? variable
@@ -160,9 +160,9 @@ This command gets the variables that have the values of `ReadOnly` or
 
 ```powershell
 Get-ChildItem -Path Variable: | Where-Object {
-   $_.options -match "Constant" `
-   -or $_.options -match "ReadOnly"
- } | Format-List -Property name, value, options
+   $_.Options -match "Constant" `
+   -or $_.Options -match "ReadOnly"
+ } | Format-List -Property Name, Value, Options
 ```
 
 ## Creating variables
@@ -273,7 +273,7 @@ Get-Help Get-ChildItem
 ```
 
 ```powershell
-Get-Help Get-ChildItem -Path variable:
+Get-Help Get-ChildItem -Path Variable:
 ```
 
 ## See also

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Variables.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Variables.md
@@ -163,7 +163,7 @@ The next example assigns multiple values to multiple variables.
 
 ```powershell
 $i,$j,$k = 10, "red", $true    # $i is 10, $j is "red", $k is True
-$i,$j = 10, "red", $true       # $i is 10, $j is [object[]], Length 2
+$i,$j = 10, "red", $true       # $i is 10, $j is [Object[]], Length 2
 ```
 
 For more detailed information, see the **Assigning multiple variables** section
@@ -367,7 +367,7 @@ The following command gets the child items in the directory that is represented
 by the `ProgramFiles(x86)` environment variable.
 
 ```powershell
-Get-ChildItem ${env:ProgramFiles(x86)}
+Get-ChildItem ${Env:ProgramFiles(x86)}
 ```
 
 To reference a variable name that includes braces, enclose the variable name in
@@ -400,7 +400,7 @@ global scope, even when it's created in a script or function.
 $Global:Computers = "Server01"
 ```
 
-For any script or command that executes out of session, you need the `Using`
+For any script or command that executes out of session, you need the `Using:`
 scope modifier to embed variable values from the calling session scope, so that
 out of session code can access them.
 

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_While.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_While.md
@@ -18,12 +18,12 @@ the results of a conditional test.
 The `while` statement (also known as a `while` loop) is a language construct
 for creating a loop that runs commands in a command block as long as a
 conditional test evaluates to true. The `while` statement is easier to
-construct than a For statement because its syntax is less complicated. In
-addition, it is more flexible than the Foreach statement because you specify a
-conditional test in the `while` statement to control how many times the loop
+construct than a `for` statement because its syntax is less complicated. In
+addition, it is more flexible than the `foreach` statement because you specify
+a conditional test in the `while` statement to control how many times the loop
 runs.
 
-The following shows the While statement syntax:
+The following shows the `while` statement syntax:
 
 ```powershell
 while (<condition>){<statement list>}

--- a/reference/7.5/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -85,7 +85,7 @@ includes **Interactive**.
 Get-Service | Where-Object {$_.ServiceType -like "*Interactive*"}
 ```
 
-In the following example, the `If` statement includes a condition that uses
+In the following example, the `if` statement includes a condition that uses
 wildcard characters to find property values. If the restore point's
 **Description** includes **PowerShell**, the command adds the value of the
 restore point's **CreationTime** property to a log file.
@@ -93,7 +93,7 @@ restore point's **CreationTime** property to a log file.
 ```powershell
 $p = Get-ComputerRestorePoint
 foreach ($point in $p) {
-  if ($point.description -like "*PowerShell*") {
+  if ($point.Description -like "*PowerShell*") {
     Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
   }
 }

--- a/reference/7.5/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -523,7 +523,7 @@ Specifies the instance IDs of the disconnected sessions.
 
 The instance ID is a GUID that uniquely identifies a **PSSession** on a local or remote computer.
 
-The instance ID is stored in the **InstanceID** property of the **PSSession**.
+The instance ID is stored in the **InstanceId** property of the **PSSession**.
 
 ```yaml
 Type: System.Guid[]

--- a/reference/7.5/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/7.5/Microsoft.PowerShell.Core/Debug-Job.md
@@ -54,7 +54,7 @@ command detaches the debugger, and allows the job to continue to run.
 This command breaks into a running job with an ID of 3.
 
 ```powershell
-Debug-Job -ID 3
+Debug-Job -Id 3
 ```
 
 ```Output

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -30,19 +30,19 @@ PowerShell has the  following type operators:
 - `-is`   |Returns TRUE when the input is an instance of the specified .NET type.
 
   ```powershell
-  (Get-Date) -is [DateTime]     # Result is True
+  (Get-Date) -is [datetime]     # Result is True
   ```
 
 - `-isnot`|Returns TRUE when the input not an instance of the specified.NET type.
 
   ```powershell
-  (Get-Date) -isnot [DateTime]  # Result is False
+  (Get-Date) -isnot [datetime]  # Result is False
   ```
 
 - `-as`   |Converts the input to the   specified .NET type.
 
   ```powershell
-  "5/7/07" -as [DateTime]       # Result is Monday, May 7, 2007 12:00:00 AM
+  "5/7/07" -as [datetime]       # Result is Monday, May 7, 2007 12:00:00 AM
   ```
 
 The syntax of the type operators is as follows:
@@ -58,7 +58,7 @@ You can also use the following syntax:
 ```
 
 The .NET type can be written as a type name in brackets or a string, such as
-`[DateTime]` or `"DateTime"` for **System.DateTime**. If the type is not at the
+`[datetime]` or `"DateTime"` for **System.DateTime**. If the type is not at the
 root of the system namespace, specify the full name of the object type. You can
 omit "System.". For example, to specify **System.Diagnostics.Process**, enter
 `[System.Diagnostics.Process]`, `[Diagnostics.Process]`, or
@@ -114,7 +114,7 @@ System.IO.DirectoryInfo
 
 #### Converting the DateTime type is culture-sensitive
 
-Unlike type casting, converting to `[DateTime]` type using the `-as` operator
+Unlike type casting, converting to `[datetime]` type using the `-as` operator
 only works with strings that are formatted according to the rules of the
 current culture.
 
@@ -149,25 +149,25 @@ System.Globalization.CultureInfo
 The following examples show some uses of the Type operators:
 
 ```powershell
-PS> 32 -is [Float]
+PS> 32 -is [float]
 False
 
 PS> 32 -is "int"
 True
 
-PS> (Get-Date) -is [DateTime]
+PS> (Get-Date) -is [datetime]
 True
 
-PS> "12/31/2007" -is [DateTime]
+PS> "12/31/2007" -is [datetime]
 False
 
-PS> "12/31/2007" -is [String]
+PS> "12/31/2007" -is [string]
 True
 
-PS> (get-process PowerShell)[0] -is [System.Diagnostics.Process]
+PS> (Get-Process powershell)[0] -is [System.Diagnostics.Process]
 True
 
-PS> (get-command get-member) -is [System.Management.Automation.CmdletInfo]
+PS> (Get-Command Get-Member) -is [System.Management.Automation.CmdletInfo]
 True
 ```
 
@@ -189,7 +189,7 @@ True
 PS> (Get-Culture), (Get-UICulture) -is [System.Globalization.CultureInfo]
 False
 
-PS> (Get-Culture), (Get-UICulture) -is [Array]
+PS> (Get-Culture), (Get-UICulture) -is [array]
 True
 
 PS> (Get-Culture), (Get-UICulture) | foreach {
@@ -205,15 +205,15 @@ True
 The following examples show how to use the `-as` operator.
 
 ```powershell
-PS> "12/31/07" -is [DateTime]
+PS> "12/31/07" -is [datetime]
 False
 
-PS> "12/31/07" -as [DateTime]
+PS> "12/31/07" -as [datetime]
 Monday, December 31, 2007 12:00:00 AM
 
-PS> $date = "12/31/07" -as [DateTime]
+PS> $date = "12/31/07" -as [datetime]
 
-C:\PS>$a -is [DateTime]
+C:\PS>$a -is [datetime]
 True
 
 PS> 1031 -as [System.Globalization.CultureInfo]

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -215,7 +215,7 @@ information about `Update-TypeData`, see [Update-TypeData][01].
 Update-TypeData -PrependPath $PSHOME\MyTypes.ps1xml
 ```
 
-To test the change, run a `Get-ChildItem` command to get the PowerShell.exe
+To test the change, run a `Get-ChildItem` command to get the `powershell.exe`
 file in the `$PSHOME` directory, and then pipe the file to the `Format-List`
 cmdlet to list all of the properties of the file. As a result of the change,
 the **Age** property appears in the list.

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -305,7 +305,7 @@ Update-Help -Module DhcpServer -SourcePath E:\UsbDrive\SavedHelp
 Without parameters, `Save-Help` downloads help for all modules in the session
 and for all installed modules that support Updatable Help. To be included,
 modules must be installed in directories that are listed in the value of the
-`$env:PSModulePath` environment variable, on either the local computer or on a
+`$Env:PSModulePath` environment variable, on either the local computer or on a
 remote computer for which you want to save help. These are also modules that
 are returned by running a `Get-Help -ListAvailable` command.
 
@@ -322,10 +322,10 @@ However, you can use the **UICulture** parameters of the `Update-Help` and
 which they're available.
 
 For example, to save the newest help files for all modules on the session in
-Japanese (ja-Jp) and French (fr-FR), type:
+Japanese (ja-JP) and French (fr-FR), type:
 
 ```powershell
-Save-Help -Path \Server\Share -UICulture ja-jp, fr-fr
+Save-Help -Path \Server\Share -UICulture ja-JP, fr-FR
 ```
 
 If help files for the modules aren't available in the languages that you
@@ -403,7 +403,7 @@ only a module name. They don't accept the path to a module file.
 
 Use this technique to update or save help for any module that's not returned by
 the **ListAvailable** parameter of the `Get-Module` cmdlet, such as a module
-that's installed in a location that's not listed in the `$env:PSModulePath`
+that's installed in a location that's not listed in the `$Env:PSModulePath`
 environment variable, or a module that's not well-formed (the module directory
 doesn't contain at least one file whose basename is the same as the directory
 name).

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Using.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Using.md
@@ -23,7 +23,7 @@ module. No uncommented statement can precede it, including parameters.
 
 The `using` statement must not contain any variables.
 
-The `using` statement isn't the same as the `using:` scope modifier for
+The `using` statement isn't the same as the `Using:` scope modifier for
 variables. For more information, see
 [about_Remote_Variables](about_Remote_Variables.md).
 
@@ -91,7 +91,7 @@ A module specification is a hashtable that has the following keys.
   - `RequiredVersion` - Specifies an exact, required version of the module.
     This can't be used with the other Version keys.
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes and enumerations
 aren't imported.
 
@@ -120,7 +120,7 @@ following classes:
 - **Deck**
 - **Card**
 
-`Import-Module` and the `#requires` statement only import the module functions,
+`Import-Module` and the `#Requires` statement only import the module functions,
 aliases, and variables, as defined by the module. Classes aren't imported. The
 `using module` command imports the module and also loads the class definitions.
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
@@ -159,10 +159,12 @@ This command gets the variables that have the values of `ReadOnly` or
 `Constant` for their **Options** property.
 
 ```powershell
-Get-ChildItem -Path Variable: | Where-Object {
-   $_.Options -match "Constant" `
-   -or $_.Options -match "ReadOnly"
- } | Format-List -Property Name, Value, Options
+Get-ChildItem -Path Variable: |
+    Where-Object {
+        $_.Options -match 'Constant' -or 
+        $_.Options -match 'ReadOnly'
+    } | 
+    Format-List -Property Name, Value, Options
 ```
 
 ## Creating variables

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Variable_Provider.md
@@ -130,16 +130,16 @@ the dollar sign (`$`). This has the same effect as prefixing the variables name
 with the dollar sign (`$`).
 
 ```powershell
-$variable:HOME
+$Variable:HOME
 ```
 
 ### Get variables using wildcards
 
-This command gets the variables with names that begin with "max". You can use
+This command gets the variables with names that begin with "Max". You can use
 this command from any PowerShell drive.
 
 ```powershell
-Get-ChildItem -Path Variable:max*
+Get-ChildItem -Path Variable:Max*
 ```
 
 ### Get the value of the ? variable
@@ -160,9 +160,9 @@ This command gets the variables that have the values of `ReadOnly` or
 
 ```powershell
 Get-ChildItem -Path Variable: | Where-Object {
-   $_.options -match "Constant" `
-   -or $_.options -match "ReadOnly"
- } | Format-List -Property name, value, options
+   $_.Options -match "Constant" `
+   -or $_.Options -match "ReadOnly"
+ } | Format-List -Property Name, Value, Options
 ```
 
 ## Creating variables
@@ -273,7 +273,7 @@ Get-Help Get-ChildItem
 ```
 
 ```powershell
-Get-Help Get-ChildItem -Path variable:
+Get-Help Get-ChildItem -Path Variable:
 ```
 
 ## See also

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Variables.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Variables.md
@@ -163,7 +163,7 @@ The next example assigns multiple values to multiple variables.
 
 ```powershell
 $i,$j,$k = 10, "red", $true    # $i is 10, $j is "red", $k is True
-$i,$j = 10, "red", $true       # $i is 10, $j is [object[]], Length 2
+$i,$j = 10, "red", $true       # $i is 10, $j is [Object[]], Length 2
 ```
 
 For more detailed information, see the **Assigning multiple variables** section
@@ -367,7 +367,7 @@ The following command gets the child items in the directory that is represented
 by the `ProgramFiles(x86)` environment variable.
 
 ```powershell
-Get-ChildItem ${env:ProgramFiles(x86)}
+Get-ChildItem ${Env:ProgramFiles(x86)}
 ```
 
 To reference a variable name that includes braces, enclose the variable name in
@@ -400,7 +400,7 @@ global scope, even when it's created in a script or function.
 $Global:Computers = "Server01"
 ```
 
-For any script or command that executes out of session, you need the `Using`
+For any script or command that executes out of session, you need the `Using:`
 scope modifier to embed variable values from the calling session scope, so that
 out of session code can access them.
 

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_While.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_While.md
@@ -18,12 +18,12 @@ the results of a conditional test.
 The `while` statement (also known as a `while` loop) is a language construct
 for creating a loop that runs commands in a command block as long as a
 conditional test evaluates to true. The `while` statement is easier to
-construct than a For statement because its syntax is less complicated. In
-addition, it is more flexible than the Foreach statement because you specify a
-conditional test in the `while` statement to control how many times the loop
+construct than a `for` statement because its syntax is less complicated. In
+addition, it is more flexible than the `foreach` statement because you specify
+a conditional test in the `while` statement to control how many times the loop
 runs.
 
-The following shows the While statement syntax:
+The following shows the `while` statement syntax:
 
 ```powershell
 while (<condition>){<statement list>}

--- a/reference/7.6/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -85,7 +85,7 @@ includes **Interactive**.
 Get-Service | Where-Object {$_.ServiceType -like "*Interactive*"}
 ```
 
-In the following example, the `If` statement includes a condition that uses
+In the following example, the `if` statement includes a condition that uses
 wildcard characters to find property values. If the restore point's
 **Description** includes **PowerShell**, the command adds the value of the
 restore point's **CreationTime** property to a log file.
@@ -93,7 +93,7 @@ restore point's **CreationTime** property to a log file.
 ```powershell
 $p = Get-ComputerRestorePoint
 foreach ($point in $p) {
-  if ($point.description -like "*PowerShell*") {
+  if ($point.Description -like "*PowerShell*") {
     Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
   }
 }

--- a/reference/7.6/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -523,7 +523,7 @@ Specifies the instance IDs of the disconnected sessions.
 
 The instance ID is a GUID that uniquely identifies a **PSSession** on a local or remote computer.
 
-The instance ID is stored in the **InstanceID** property of the **PSSession**.
+The instance ID is stored in the **InstanceId** property of the **PSSession**.
 
 ```yaml
 Type: System.Guid[]

--- a/reference/7.6/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/7.6/Microsoft.PowerShell.Core/Debug-Job.md
@@ -54,7 +54,7 @@ command detaches the debugger, and allows the job to continue to run.
 This command breaks into a running job with an ID of 3.
 
 ```powershell
-Debug-Job -ID 3
+Debug-Job -Id 3
 ```
 
 ```Output


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide