### PR TITLE
Fix incorrect case/capitalization in reference documents (17/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -88,7 +88,7 @@ as follows:
 - `s` (system)
 
 For more information about the mode flags, see
-[about_Filesystem_Provider](../Microsoft.PowerShell.Core/About/about_Filesystem_Provider.md#attributes-flagsexpression).
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_Filesystem_Provider.md#attributes-flagsexpression).
 
 ### Example 2: Get child item names in a directory
 
@@ -357,8 +357,8 @@ point. In PowerShell, this information is available from the **Target** property
 object returned by `Get-ChildItem`.
 
 ```powershell
-PS D:\> New-Item -ItemType Junction -Name tmp -Target $env:TEMP
-PS D:\> Get-ChildItem | Select-Object name,*target
+PS D:\> New-Item -ItemType Junction -Name tmp -Target $Env:TEMP
+PS D:\> Get-ChildItem | Select-Object Name, *Target
 
 Name     Target
 ----     ------
@@ -979,7 +979,7 @@ The cmdlet outputs this type when accessing the `Env:` drive.
 
 ### System.IO.FileInfo
 
-The cmdlet outputs these types when accessing the Filesystem drives.
+The cmdlet outputs these types when accessing the FileSystem drives.
 
 ### System.Management.Automation.FunctionInfo
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-HotFix.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-HotFix.md
@@ -33,14 +33,14 @@ Get-HotFix [-Description <String[]>] [-ComputerName <String[]>] [-Credential <PS
 
 > **This cmdlet is only available on the Windows platform.**
 
-The `Get-Hotfix` cmdlet uses the **Win32_QuickFixEngineering** WMI class to list hotfixes that are
+The `Get-HotFix` cmdlet uses the **Win32_QuickFixEngineering** WMI class to list hotfixes that are
 installed on the local computer or specified remote computers.
 
 ## EXAMPLES
 
 ### Example 1: Get all hotfixes on the local computer
 
-The `Get-Hotfix` cmdlet gets all hotfixes installed on the local computer.
+The `Get-HotFix` cmdlet gets all hotfixes installed on the local computer.
 
 ```powershell
 Get-HotFix
@@ -56,14 +56,14 @@ Server01       Update           KB4480056     NT AUTHORITY\SYSTEM  1/24/2019 00:
 
 ### Example 2: Get hotfixes from multiple computers filtered by a string
 
-The `Get-Hotfix` command uses parameters to get hotfixes installed on remote computers. The results
+The `Get-HotFix` command uses parameters to get hotfixes installed on remote computers. The results
 are filtered by a specified description string.
 
 ```powershell
 Get-HotFix -Description Security* -ComputerName Server01, Server02 -Credential Domain01\admin01
 ```
 
-`Get-Hotfix` filters the output with the **Description** parameter and the string **Security** that
+`Get-HotFix` filters the output with the **Description** parameter and the string **Security** that
 includes the asterisk (`*`) wildcard. The **ComputerName** parameter includes a comma-separated
 string of remote computer names. The **Credential** parameter specifies a user account that has
 permission to access the remote computers and run commands.
@@ -81,7 +81,7 @@ $A | ForEach-Object { if (!(Get-HotFix -Id KB957095 -ComputerName $_))
 
 The `$A` variable contains computer names that were obtained by `Get-Content` from a text file. The
 objects in `$A` are sent down the pipeline to `ForEach-Object`. An `if` statement uses the
-`Get-Hotfix` cmdlet with the **Id** parameter and a specific Id number for each computer name. If a
+`Get-HotFix` cmdlet with the **Id** parameter and a specific Id number for each computer name. If a
 computer doesn't have the specified hotfix Id installed, the `Add-Content` cmdlet writes the
 computer name to a file.
 
@@ -93,7 +93,7 @@ This example gets the most recent hotfix installed on a computer.
 (Get-HotFix | Sort-Object -Property InstalledOn)[-1]
 ```
 
-`Get-Hotfix` sends the objects down the pipeline to the `Sort-Object` cmdlet. `Sort-Object` sorts
+`Get-HotFix` sends the objects down the pipeline to the `Sort-Object` cmdlet. `Sort-Object` sorts
 objects by ascending order and uses the **Property** parameter to evaluate each **InstalledOn**
 date. The array notation `[-1]` selects the most recent installed hotfix.
 
@@ -104,7 +104,7 @@ date. The array notation `[-1]` selects the most recent installed hotfix.
 Specifies a remote computer. Type the NetBIOS name, an Internet Protocol (IP) address, or a fully
 qualified domain name (FQDN) of a remote computer.
 
-When the **ComputerName** parameter isn't specified, `Get-Hotfix` runs on the local computer.
+When the **ComputerName** parameter isn't specified, `Get-HotFix` runs on the local computer.
 
 The **ComputerName** parameter doesn't rely on Windows PowerShell remoting. If your computer isn't
 configured to run remote commands, use the **ComputerName** parameter.
@@ -196,7 +196,7 @@ You can pipe a string containing a computer name to this cmdlet.
 
 ## OUTPUTS
 
-### System.Management.ManagementObject#root\CIMV2\Win32_QuickFixEngineering
+### System.Management.ManagementObject#root\cimv2\Win32_QuickFixEngineering
 
 This cmdlet returns objects representing the hotfixes on the computer.
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Item.md
@@ -155,7 +155,7 @@ cmdlet with the PowerShell Registry provider to get registry keys and subkeys, b
 `Get-ItemProperty` cmdlet to get the registry values and data.
 
 ```powershell
-Get-Item HKLM:\Software\Microsoft\Powershell\1\Shellids\Microsoft.Powershell\
+Get-Item HKLM:\Software\Microsoft\PowerShell\1\Shellids\Microsoft.PowerShell\
 ```
 
 ### Example 7: Get items in a directory that have an exclusion
@@ -527,7 +527,7 @@ The cmdlet outputs this type when accessing the `Env:` drive.
 
 ### System.IO.FileInfo
 
-The cmdlet outputs these types when accessing the Filesystem drives.
+The cmdlet outputs these types when accessing the FileSystem drives.
 
 ### System.Management.Automation.FunctionInfo
 
@@ -563,7 +563,7 @@ to get registry values and data. The registry values are considered to be proper
 registry key.
 
 This cmdlet is designed to work with the data exposed by any provider. To list the providers
-available in your session, type `Get-PsProvider`. For more information, see
+available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -89,7 +89,7 @@ D                1211.06     123642.32 FileSystem    D:\
 This command gets the D: drive on the computer. Note that the drive letter in the command is not
 followed by a colon.
 
-### Example 3: Get all the drives that are supported by the Windows PowerShell file system provider
+### Example 3: Get all the drives that are supported by the Windows PowerShell FileSystem provider
 
 ```
 PS C:\> Get-PSDrive -PSProvider FileSystem

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-PSProvider.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-PSProvider.md
@@ -41,11 +41,11 @@ This command displays a list of all available PowerShell providers.
 ### Example 2: Display a list of all PowerShell providers that begin with specified letters
 
 ```powershell
-Get-PSProvider f*, r* | Format-List
+Get-PSProvider F*, R* | Format-List
 ```
 
-This command displays a list of all PowerShell providers with names that begin with the letter `f`
-or `r`.
+This command displays a list of all PowerShell providers with names that begin with the letter `F`
+or `R`.
 
 ### Example 3: Find snap-ins or module that added providers to your session
 
@@ -67,7 +67,7 @@ WSMan       Microsoft.WSMan.Management
 ```
 
 ```powershell
-Get-PSProvider | Where {$_.ModuleName -eq "Microsoft.PowerShell.Security"}
+Get-PSProvider | where {$_.ModuleName -eq "Microsoft.PowerShell.Security"}
 ```
 
 ```Output
@@ -89,7 +89,7 @@ values of their Name, Module, and PSSnapin properties.
 The second command uses the `Where-Object` cmdlet to get the providers that come from the
 **Microsoft.PowerShell.Security** snap-in.
 
-### Example 4: Resolve the path of the Home property of the file system provider
+### Example 4: Resolve the path of the Home property of the FileSystem provider
 
 ```powershell
 C:\> Resolve-Path ~
@@ -102,7 +102,7 @@ C:\Users\User01
 ```
 
 ```powershell
-PS C:\> (get-psprovider FileSystem).home
+PS C:\> (Get-PSProvider FileSystem).Home
 ```
 
 ```Output
@@ -111,7 +111,7 @@ C:\Users\User01
 
 This example shows that the tilde symbol (`~`) represents the value of the **Home** property of the
 FileSystem provider. The **Home** property value is optional, but for the **FileSystem** provider,
-it is defined as `$env:HOMEDRIVE\$env:HOMEPATH` or `$HOME`.
+it is defined as `$Env:HOMEDRIVE\$Env:HOMEPATH` or `$HOME`.
 
 ## PARAMETERS
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
@@ -110,7 +110,7 @@ though the default display lists them in kilobytes and megabytes.
 
 ```powershell
 $A = Get-Process
-$A | Get-Process | Format-Table -View priority
+$A | Get-Process | Format-Table -View Priority
 ```
 
 These commands list the processes on the computer in groups based on their priority class. The first
@@ -257,13 +257,13 @@ The second command gets the PowerShell process that is hosting the current sessi
 ### Example 10: Get all processes that have a main window title and display them in a table
 
 ```powershell
-Get-Process | Where-Object {$_.mainWindowTitle} | Format-Table Id, Name, mainWindowtitle -AutoSize
+Get-Process | Where-Object {$_.MainWindowTitle} | Format-Table Id, Name, MainWindowTitle -AutoSize
 ```
 
 This command gets all the processes that have a main window title, and it displays them in a table
 with the process ID and the process name.
 
-The **mainWindowTitle** property is just one of many useful properties of the **Process** object
+The **MainWindowTitle** property is just one of many useful properties of the **Process** object
 that `Get-Process` returns. To view all of the properties, pipe the results of a `Get-Process`
 command to the `Get-Member` cmdlet `Get-Process | Get-Member`.
 
@@ -476,7 +476,7 @@ of all of the properties of process objects, see
 - **VM(M)**: The amount of virtual memory that the process is using, in megabytes. Virtual memory
   includes storage in the paging files on disk.
 - **CPU(s)**: The amount of processor time that the process has used on all processors, in seconds.
-- **ID**: The process ID (PID) of the process.
+- **Id**: The process ID (PID) of the process.
 - **ProcessName**: The name of the process. For explanations of the concepts related to processes,
   see the Glossary in Help and Support Center and the Help for Task Manager.
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Service.md
@@ -73,7 +73,7 @@ display name finds network-related services even when the service name doesn't i
 xmlprov, the Network Provisioning Service.
 
 ```powershell
-Get-Service -Displayname "*network*"
+Get-Service -DisplayName "*network*"
 ```
 
 ### Example 4: Get services that begin with a search string and an exclusion
@@ -119,7 +119,7 @@ This example gets services that have dependent services.
 Get-Service |
   Where-Object {$_.DependentServices} |
     Format-List -Property Name, DependentServices, @{
-      Label="NoOfDependentServices"; Expression={$_.dependentservices.count}
+      Label="NoOfDependentServices"; Expression={$_.DependentServices.Count}
     }
 ```
 
@@ -153,7 +153,7 @@ property, stopped services appear before running services. This happens because 
 To list running services first, use the **Descending** parameter of the `Sort-Object` cmdlet.
 
 ```powershell
-Get-Service "s*" | Sort-Object status
+Get-Service "s*" | Sort-Object Status
 ```
 
 ```Output
@@ -178,7 +178,7 @@ Running  seclogon           Secondary Logon
 
 ```powershell
 Get-Service -Name "WinRM" -ComputerName "localhost", "Server01", "Server02" |
- Format-Table -Property MachineName, Status, Name, DisplayName -auto
+ Format-Table -Property MachineName, Status, Name, DisplayName -Auto
 ```
 
 ```Output

--- a/reference/5.1/Microsoft.PowerShell.Management/Join-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Join-Path.md
@@ -65,7 +65,7 @@ the `System\*` child path. It displays the same files and folders as `Get-ChildI
 displays the fully qualified path to each item. In this command, the `Path` and `ChildPath` optional
 parameter names are omitted.
 
-### Example 4: Use Join-Path with the PowerShell registry provider
+### Example 4: Use Join-Path with the PowerShell Registry provider
 
 ```powershell
 PS HKLM:\> Join-Path -Path System -ChildPath *ControlSet* -Resolve
@@ -103,7 +103,7 @@ This command uses `Join-Path` to combine multiple path roots with a child path.
 ### Example 6: Combine the roots of a file system drive with a child path
 
 ```powershell
-Get-PSDrive -PSProvider filesystem | ForEach-Object {$_.root} | Join-Path -ChildPath "Subdir"
+Get-PSDrive -PSProvider FileSystem | ForEach-Object {$_.Root} | Join-Path -ChildPath "Subdir"
 ```
 
 ```output

--- a/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
@@ -81,7 +81,7 @@ This command creates a text file that is named "testfile1.txt" in the current di
 follows the **Value** parameter is added to the file as content.
 
 ```powershell
-New-Item -Path . -Name "testfile1.txt" -ItemType "file" -Value "This is a text string."
+New-Item -Path . -Name "testfile1.txt" -ItemType "File" -Value "This is a text string."
 ```
 
 ### Example 2: Create a directory
@@ -90,7 +90,7 @@ This command creates a directory named "Logfiles" in the `C:` drive. The **ItemT
 specifies that the new item is a directory, not a file or other file system object.
 
 ```powershell
-New-Item -Path "c:\" -Name "logfiles" -ItemType "directory"
+New-Item -Path "C:\" -Name "logfiles" -ItemType "Directory"
 ```
 
 ### Example 3: Create a profile
@@ -112,7 +112,7 @@ For more information, see [about_Automatic_Variables](../Microsoft.PowerShell.Co
 and [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
 
 ```powershell
-New-Item -Path $PROFILE -ItemType "file" -Force
+New-Item -Path $PROFILE -ItemType "File" -Force
 ```
 
 > [!NOTE]
@@ -128,7 +128,7 @@ instead of being specified in the value of **Name**. As indicated by the syntax,
 is valid.
 
 ```powershell
-New-Item -ItemType "directory" -Path "c:\ps-test\scripts"
+New-Item -ItemType "Directory" -Path "C:\ps-test\scripts"
 ```
 
 ### Example 5: Create multiple files
@@ -137,7 +137,7 @@ This example creates files in two different directories. Because **Path** takes 
 you can use it to create multiple items.
 
 ```powershell
-New-Item -ItemType "file" -Path "c:\ps-test\test.txt", "c:\ps-test\Logs\test.log"
+New-Item -ItemType "File" -Path "C:\ps-test\test.txt", "C:\ps-test\Logs\test.log"
 ```
 
 ### Example 6: Use wildcards to create files in multiple directories
@@ -221,7 +221,7 @@ Mode                LastWriteTime         Length Name
 ### Example 9: Use the -Force parameter to overwrite existing files
 
 This example creates a file with a value and then recreates the file using `-Force`. This overwrites
-the existing file, as you can see by the length property.
+the existing file, as you can see by the **Length** property.
 
 ```powershell
 PS> New-Item ./TestFile.txt -ItemType File -Value 'This is just a test file'
@@ -676,7 +676,7 @@ Windows PowerShell includes the following aliases for `New-Item`:
 - `ni`
 
 `New-Item` is designed to work with the data exposed by any provider. To list the providers
-available in your session, type `Get-PsProvider`. For more information, see
+available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/5.1/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -97,7 +97,7 @@ $newValue = New-ItemProperty -Path "HKLM:\SOFTWARE\ContosoCompany\" -Name 'HereS
 This is text which contains newlines
 It can also contain "quoted" strings
 "@
-$newValue.multistring
+$newValue.HereString
 ```
 
 ```output
@@ -111,7 +111,7 @@ The example shows how to use an array of values to create the `MultiString` valu
 
 ```powershell
 $newValue = New-ItemProperty -Path "HKLM:\SOFTWARE\ContosoCompany\" -Name 'MultiString' -PropertyType MultiString -Value ('a','b','c')
-$newValue.multistring[0]
+$newValue.MultiString[0]
 ```
 
 ```output

--- a/reference/7.4/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -86,7 +86,7 @@ as follows:
 - `s` (system)
 
 For more information about the mode flags, see
-[about_Filesystem_Provider](../Microsoft.PowerShell.Core/About/about_Filesystem_Provider.md#attributes-flagsexpression).
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_Filesystem_Provider.md#attributes-flagsexpression).
 
 ### Example 2: Get child item names in a directory
 
@@ -398,8 +398,8 @@ point. In PowerShell, this information is available from the **LinkTarget** prop
 filesystem object returned by `Get-ChildItem` and is displayed in the default output.
 
 ```powershell
-PS D:\> New-Item -ItemType Junction -Name tmp -Target $env:TEMP
-PS D:\> Get-ChildItem | Select-Object name, LinkTarget
+PS D:\> New-Item -ItemType Junction -Name tmp -Target $Env:TEMP
+PS D:\> Get-ChildItem | Select-Object Name, LinkTarget
 
 Name     LinkTarget
 ----     ----------
@@ -991,7 +991,7 @@ The cmdlet outputs this type when accessing the `Env:` drive.
 
 ### System.IO.FileInfo
 
-The cmdlet outputs these types when accessing the Filesystem drives.
+The cmdlet outputs these types when accessing the FileSystem drives.
 
 ### System.Management.Automation.FunctionInfo
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Get-HotFix.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Get-HotFix.md
@@ -33,14 +33,14 @@ Get-HotFix [-Description <String[]>] [-ComputerName <String[]>] [-Credential <PS
 
 > **This cmdlet is only available on the Windows platform.**
 
-The `Get-Hotfix` cmdlet uses the **Win32_QuickFixEngineering** WMI class to list hotfixes that are
+The `Get-HotFix` cmdlet uses the **Win32_QuickFixEngineering** WMI class to list hotfixes that are
 installed on the local computer or specified remote computers.
 
 ## EXAMPLES
 
 ### Example 1: Get all hotfixes on the local computer
 
-The `Get-Hotfix` cmdlet gets all hotfixes installed on the local computer.
+The `Get-HotFix` cmdlet gets all hotfixes installed on the local computer.
 
 ```powershell
 Get-HotFix
@@ -56,14 +56,14 @@ Server01       Update           KB4480056     NT AUTHORITY\SYSTEM  1/24/2019 00:
 
 ### Example 2: Get hotfixes from multiple computers filtered by a string
 
-The `Get-Hotfix` command uses parameters to get hotfixes installed on remote computers. The results
+The `Get-HotFix` command uses parameters to get hotfixes installed on remote computers. The results
 are filtered by a specified description string.
 
 ```powershell
 Get-HotFix -Description Security* -ComputerName Server01, Server02 -Credential Domain01\admin01
 ```
 
-`Get-Hotfix` filters the output with the **Description** parameter and the string **Security** that
+`Get-HotFix` filters the output with the **Description** parameter and the string **Security** that
 includes the asterisk (`*`) wildcard. The **ComputerName** parameter includes a comma-separated
 string of remote computer names. The **Credential** parameter specifies a user account that has
 permission to access the remote computers and run commands.
@@ -81,7 +81,7 @@ $A | ForEach-Object { if (!(Get-HotFix -Id KB957095 -ComputerName $_))
 
 The `$A` variable contains computer names that were obtained by `Get-Content` from a text file. The
 objects in `$A` are sent down the pipeline to `ForEach-Object`. An `if` statement uses the
-`Get-Hotfix` cmdlet with the **Id** parameter and a specific Id number for each computer name. If a
+`Get-HotFix` cmdlet with the **Id** parameter and a specific Id number for each computer name. If a
 computer doesn't have the specified hotfix Id installed, the `Add-Content` cmdlet writes the
 computer name to a file.
 
@@ -93,7 +93,7 @@ This example gets the most recent hotfix installed on a computer.
 (Get-HotFix | Sort-Object -Property InstalledOn)[-1]
 ```
 
-`Get-Hotfix` sends the objects down the pipeline to the `Sort-Object` cmdlet. `Sort-Object` sorts
+`Get-HotFix` sends the objects down the pipeline to the `Sort-Object` cmdlet. `Sort-Object` sorts
 objects by ascending order and uses the **Property** parameter to evaluate each **InstalledOn**
 date. The array notation `[-1]` selects the most recent installed hotfix.
 
@@ -104,7 +104,7 @@ date. The array notation `[-1]` selects the most recent installed hotfix.
 Specifies a remote computer. Type the NetBIOS name, an Internet Protocol (IP) address, or a fully
 qualified domain name (FQDN) of a remote computer.
 
-When the **ComputerName** parameter isn't specified, `Get-Hotfix` runs on the local computer.
+When the **ComputerName** parameter isn't specified, `Get-HotFix` runs on the local computer.
 
 The **ComputerName** parameter doesn't rely on Windows PowerShell remoting. If your computer isn't
 configured to run remote commands, use the **ComputerName** parameter.
@@ -196,7 +196,7 @@ You can pipe a string containing a computer name to this cmdlet.
 
 ## OUTPUTS
 
-### System.Management.ManagementObject#root\CIMV2\Win32_QuickFixEngineering
+### System.Management.ManagementObject#root\cimv2\Win32_QuickFixEngineering
 
 This cmdlet returns objects representing the hotfixes on the computer.
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Get-Item.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Get-Item.md
@@ -151,7 +151,7 @@ cmdlet with the PowerShell Registry provider to get registry keys and subkeys, b
 `Get-ItemProperty` cmdlet to get the registry values and data.
 
 ```powershell
-Get-Item HKLM:\Software\Microsoft\Powershell\1\Shellids\Microsoft.Powershell\
+Get-Item HKLM:\Software\Microsoft\PowerShell\1\Shellids\Microsoft.PowerShell\
 ```
 
 ### Example 7: Get items in a directory that have an exclusion
@@ -560,7 +560,7 @@ The cmdlet outputs this type when accessing the `Env:` drive.
 
 ### System.IO.FileInfo
 
-The cmdlet outputs these types when accessing the Filesystem drives.
+The cmdlet outputs these types when accessing the FileSystem drives.
 
 ### System.Management.Automation.FunctionInfo
 
@@ -597,7 +597,7 @@ to get registry values and data. The registry values are considered to be proper
 registry key.
 
 This cmdlet is designed to work with the data exposed by any provider. To list the providers
-available in your session, type `Get-PsProvider`. For more information, see
+available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/7.4/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -89,7 +89,7 @@ D                1211.06     123642.32 FileSystem    D:\
 This command gets the D: drive on the computer. Note that the drive letter in the command is not
 followed by a colon.
 
-### Example 3: Get all the drives that are supported by the Windows PowerShell file system provider
+### Example 3: Get all the drives that are supported by the Windows PowerShell FileSystem provider
 
 ```
 PS C:\> Get-PSDrive -PSProvider FileSystem

--- a/reference/7.4/Microsoft.PowerShell.Management/Get-PSProvider.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Get-PSProvider.md
@@ -41,11 +41,11 @@ This command displays a list of all available PowerShell providers.
 ### Example 2: Display a list of all PowerShell providers that begin with specified letters
 
 ```powershell
-Get-PSProvider f*, r* | Format-List
+Get-PSProvider F*, R* | Format-List
 ```
 
-This command displays a list of all PowerShell providers with names that begin with the letter `f`
-or `r`.
+This command displays a list of all PowerShell providers with names that begin with the letter `F`
+or `R`.
 
 ### Example 3: Find snap-ins or module that added providers to your session
 
@@ -67,7 +67,7 @@ WSMan       Microsoft.WSMan.Management
 ```
 
 ```powershell
-Get-PSProvider | Where {$_.ModuleName -eq "Microsoft.PowerShell.Security"}
+Get-PSProvider | where {$_.ModuleName -eq "Microsoft.PowerShell.Security"}
 ```
 
 ```Output
@@ -89,7 +89,7 @@ values of their Name, Module, and PSSnapin properties.
 The second command uses the `Where-Object` cmdlet to get the providers that come from the
 **Microsoft.PowerShell.Security** snap-in.
 
-### Example 4: Resolve the path of the Home property of the file system provider
+### Example 4: Resolve the path of the Home property of the FileSystem provider
 
 ```powershell
 C:\> Resolve-Path ~
@@ -102,7 +102,7 @@ C:\Users\User01
 ```
 
 ```powershell
-PS C:\> (get-psprovider FileSystem).home
+PS C:\> (Get-PSProvider FileSystem).Home
 ```
 
 ```Output
@@ -111,7 +111,7 @@ C:\Users\User01
 
 This example shows that the tilde symbol (`~`) represents the value of the **Home** property of the
 FileSystem provider. The **Home** property value is optional, but for the **FileSystem** provider,
-it is defined as `$env:HOMEDRIVE\$env:HOMEPATH` or `$HOME`.
+it is defined as `$Env:HOMEDRIVE\$Env:HOMEPATH` or `$HOME`.
 
 ## PARAMETERS
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Get-Process.md
@@ -107,7 +107,7 @@ though the default display lists them in kilobytes and megabytes.
 
 ```powershell
 $A = Get-Process
-$A | Get-Process | Format-Table -View priority
+$A | Get-Process | Format-Table -View Priority
 ```
 
 These commands list the processes on the computer in groups based on their priority class. The first
@@ -226,13 +226,13 @@ The second command gets the PowerShell process that is hosting the current sessi
 ### Example 10: Get all processes that have a main window title and display them in a table
 
 ```powershell
-Get-Process | Where-Object {$_.mainWindowTitle} | Format-Table Id, Name, mainWindowtitle -AutoSize
+Get-Process | Where-Object {$_.MainWindowTitle} | Format-Table Id, Name, MainWindowTitle -AutoSize
 ```
 
 This command gets all the processes that have a main window title, and it displays them in a table
 with the process ID and the process name.
 
-The **mainWindowTitle** property is just one of many useful properties of the **Process** object
+The **MainWindowTitle** property is just one of many useful properties of the **Process** object
 that `Get-Process` returns. To view all of the properties, pipe the results of a `Get-Process`
 command to the `Get-Member` cmdlet `Get-Process | Get-Member`.
 
@@ -416,7 +416,7 @@ of all of the properties of process objects, see
 - **VM(M)**: The amount of virtual memory that the process is using, in megabytes. Virtual memory
   includes storage in the paging files on disk.
 - **CPU(s)**: The amount of processor time that the process has used on all processors, in seconds.
-- **ID**: The process ID (PID) of the process.
+- **Id**: The process ID (PID) of the process.
 - **ProcessName**: The name of the process. For explanations of the concepts related to processes,
   see the Glossary in Help and Support Center and the Help for Task Manager.
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Get-Service.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Get-Service.md
@@ -75,7 +75,7 @@ display name finds network-related services even when the service name doesn't i
 xmlprov, the Network Provisioning Service.
 
 ```powershell
-Get-Service -Displayname "*network*"
+Get-Service -DisplayName "*network*"
 ```
 
 ### Example 4: Get services that begin with a search string and an exclusion
@@ -109,7 +109,7 @@ This example gets services that have dependent services.
 Get-Service |
   Where-Object {$_.DependentServices} |
     Format-List -Property Name, DependentServices, @{
-      Label="NoOfDependentServices"; Expression={$_.dependentservices.count}
+      Label="NoOfDependentServices"; Expression={$_.DependentServices.Count}
     }
 ```
 
@@ -143,7 +143,7 @@ property, stopped services appear before running services. This happens because 
 To list running services first, use the **Descending** parameter of the `Sort-Object` cmdlet.
 
 ```powershell
-Get-Service "s*" | Sort-Object status
+Get-Service "s*" | Sort-Object Status
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Management/Join-Path.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Join-Path.md
@@ -65,7 +65,7 @@ the `System\*` child path. It displays the same files and folders as `Get-ChildI
 displays the fully qualified path to each item. In this command, the `Path` and `ChildPath` optional
 parameter names are omitted.
 
-### Example 4: Use Join-Path with the PowerShell registry provider
+### Example 4: Use Join-Path with the PowerShell Registry provider
 
 ```powershell
 PS HKLM:\> Join-Path -Path System -ChildPath *ControlSet* -Resolve
@@ -103,7 +103,7 @@ This command uses `Join-Path` to combine multiple path roots with a child path.
 ### Example 6: Combine the roots of a file system drive with a child path
 
 ```powershell
-Get-PSDrive -PSProvider filesystem | ForEach-Object {$_.root} | Join-Path -ChildPath "Subdir"
+Get-PSDrive -PSProvider FileSystem | ForEach-Object {$_.Root} | Join-Path -ChildPath "Subdir"
 ```
 
 ```output

--- a/reference/7.4/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/New-Item.md
@@ -81,7 +81,7 @@ This command creates a text file that is named "testfile1.txt" in the current di
 follows the **Value** parameter is added to the file as content.
 
 ```powershell
-New-Item -Path . -Name "testfile1.txt" -ItemType "file" -Value "This is a text string."
+New-Item -Path . -Name "testfile1.txt" -ItemType "File" -Value "This is a text string."
 ```
 
 ### Example 2: Create a directory
@@ -90,7 +90,7 @@ This command creates a directory named "Logfiles" in the `C:` drive. The **ItemT
 specifies that the new item is a directory, not a file or other file system object.
 
 ```powershell
-New-Item -Path "c:\" -Name "logfiles" -ItemType "directory"
+New-Item -Path "C:\" -Name "logfiles" -ItemType "Directory"
 ```
 
 ### Example 3: Create a profile
@@ -112,7 +112,7 @@ For more information, see [about_Automatic_Variables](../Microsoft.PowerShell.Co
 and [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
 
 ```powershell
-New-Item -Path $PROFILE -ItemType "file" -Force
+New-Item -Path $PROFILE -ItemType "File" -Force
 ```
 
 ### Example 4: Create a directory in a different directory
@@ -124,7 +124,7 @@ instead of being specified in the value of **Name**. As indicated by the syntax,
 is valid.
 
 ```powershell
-New-Item -ItemType "directory" -Path "c:\ps-test\scripts"
+New-Item -ItemType "Directory" -Path "C:\ps-test\scripts"
 ```
 
 ### Example 5: Create multiple files
@@ -133,7 +133,7 @@ This example creates files in two different directories. Because **Path** takes 
 you can use it to create multiple items.
 
 ```powershell
-New-Item -ItemType "file" -Path "c:\ps-test\test.txt", "c:\ps-test\Logs\test.log"
+New-Item -ItemType "File" -Path "C:\ps-test\test.txt", "C:\ps-test\Logs\test.log"
 ```
 
 ### Example 6: Use wildcards to create files in multiple directories
@@ -221,7 +221,7 @@ Mode                LastWriteTime         Length Name
 ### Example 9: Use the -Force parameter to overwrite existing files
 
 This example creates a file with a value and then recreates the file using `-Force`. This overwrites
-the existing file, as you can see by the length property.
+the existing file, as you can see by the **Length** property.
 
 ```powershell
 PS> New-Item ./TestFile.txt -ItemType File -Value 'This is just a test file'
@@ -661,7 +661,7 @@ PowerShell includes the following aliases for `New-Item`:
   - `ni`
 
 `New-Item` is designed to work with the data exposed by any provider. To list the providers
-available in your session, type `Get-PsProvider`. For more information, see
+available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/7.4/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -97,7 +97,7 @@ $newValue = New-ItemProperty -Path "HKLM:\SOFTWARE\ContosoCompany\" -Name 'HereS
 This is text which contains newlines
 It can also contain "quoted" strings
 "@
-$newValue.multistring
+$newValue.HereString
 ```
 
 ```output
@@ -111,7 +111,7 @@ The example shows how to use an array of values to create the `MultiString` valu
 
 ```powershell
 $newValue = New-ItemProperty -Path "HKLM:\SOFTWARE\ContosoCompany\" -Name 'MultiString' -PropertyType MultiString -Value ('a','b','c')
-$newValue.multistring[0]
+$newValue.MultiString[0]
 ```
 
 ```output

--- a/reference/7.5/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -86,7 +86,7 @@ as follows:
 - `s` (system)
 
 For more information about the mode flags, see
-[about_Filesystem_Provider](../Microsoft.PowerShell.Core/About/about_Filesystem_Provider.md#attributes-flagsexpression).
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md#attributes-flagsexpression).
 
 ### Example 2: Get child item names in a directory
 
@@ -398,8 +398,8 @@ point. In PowerShell, this information is available from the **LinkTarget** prop
 filesystem object returned by `Get-ChildItem` and is displayed in the default output.
 
 ```powershell
-PS D:\> New-Item -ItemType Junction -Name tmp -Target $env:TEMP
-PS D:\> Get-ChildItem | Select-Object name, LinkTarget
+PS D:\> New-Item -ItemType Junction -Name tmp -Target $Env:TEMP
+PS D:\> Get-ChildItem | Select-Object Name, LinkTarget
 
 Name     LinkTarget
 ----     ----------
@@ -991,7 +991,7 @@ The cmdlet outputs this type when accessing the `Env:` drive.
 
 ### System.IO.FileInfo
 
-The cmdlet outputs these types when accessing the Filesystem drives.
+The cmdlet outputs these types when accessing the FileSystem drives.
 
 ### System.Management.Automation.FunctionInfo
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Get-HotFix.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Get-HotFix.md
@@ -33,14 +33,14 @@ Get-HotFix [-Description <String[]>] [-ComputerName <String[]>] [-Credential <PS
 
 > **This cmdlet is only available on the Windows platform.**
 
-The `Get-Hotfix` cmdlet uses the **Win32_QuickFixEngineering** WMI class to list hotfixes that are
+The `Get-HotFix` cmdlet uses the **Win32_QuickFixEngineering** WMI class to list hotfixes that are
 installed on the local computer or specified remote computers.
 
 ## EXAMPLES
 
 ### Example 1: Get all hotfixes on the local computer
 
-The `Get-Hotfix` cmdlet gets all hotfixes installed on the local computer.
+The `Get-HotFix` cmdlet gets all hotfixes installed on the local computer.
 
 ```powershell
 Get-HotFix
@@ -56,7 +56,7 @@ Server01       Update           KB4480056     NT AUTHORITY\SYSTEM  1/24/2019 00:
 
 ### Example 2: Get hotfixes from multiple computers filtered by a string
 
-The `Get-Hotfix` command uses parameters to get hotfixes installed on remote computers. The results
+The `Get-HotFix` command uses parameters to get hotfixes installed on remote computers. The results
 are filtered by a specified description string.
 
 ```powershell
@@ -68,7 +68,7 @@ $hotFixParams = @{
 Get-HotFix @hotFixParams
 ```
 
-`Get-Hotfix` filters the output with the **Description** parameter and the string **Security** that
+`Get-HotFix` filters the output with the **Description** parameter and the string **Security** that
 includes the asterisk (`*`) wildcard. The **ComputerName** parameter includes a comma-separated
 string of remote computer names. The **Credential** parameter specifies a user account that has
 permission to access the remote computers and run commands.
@@ -86,7 +86,7 @@ $A | ForEach-Object { if (!(Get-HotFix -Id KB957095 -ComputerName $_))
 
 The `$A` variable contains computer names that were obtained by `Get-Content` from a text file. The
 objects in `$A` are sent down the pipeline to `ForEach-Object`. An `if` statement uses the
-`Get-Hotfix` cmdlet with the **Id** parameter and a specific Id number for each computer name. If a
+`Get-HotFix` cmdlet with the **Id** parameter and a specific Id number for each computer name. If a
 computer doesn't have the specified hotfix Id installed, the `Add-Content` cmdlet writes the
 computer name to a file.
 
@@ -98,7 +98,7 @@ This example gets the most recent hotfix installed on a computer.
 (Get-HotFix | Sort-Object -Property InstalledOn)[-1]
 ```
 
-`Get-Hotfix` sends the objects down the pipeline to the `Sort-Object` cmdlet. `Sort-Object` sorts
+`Get-HotFix` sends the objects down the pipeline to the `Sort-Object` cmdlet. `Sort-Object` sorts
 objects by ascending order and uses the **Property** parameter to evaluate each **InstalledOn**
 date. The array notation `[-1]` selects the most recent installed hotfix.
 
@@ -109,7 +109,7 @@ date. The array notation `[-1]` selects the most recent installed hotfix.
 Specifies a remote computer. Type the NetBIOS name, an Internet Protocol (IP) address, or a fully
 qualified domain name (FQDN) of a remote computer.
 
-When the **ComputerName** parameter isn't specified, `Get-Hotfix` runs on the local computer.
+When the **ComputerName** parameter isn't specified, `Get-HotFix` runs on the local computer.
 
 The **ComputerName** parameter doesn't rely on Windows PowerShell remoting. If your computer isn't
 configured to run remote commands, use the **ComputerName** parameter.
@@ -201,7 +201,7 @@ You can pipe a string containing a computer name to this cmdlet.
 
 ## OUTPUTS
 
-### System.Management.ManagementObject#root\CIMV2\Win32_QuickFixEngineering
+### System.Management.ManagementObject#root\cimv2\Win32_QuickFixEngineering
 
 This cmdlet returns objects representing the hotfixes on the computer.
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Get-Item.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Get-Item.md
@@ -151,7 +151,7 @@ cmdlet with the PowerShell Registry provider to get registry keys and subkeys, b
 `Get-ItemProperty` cmdlet to get the registry values and data.
 
 ```powershell
-Get-Item HKLM:\Software\Microsoft\Powershell\1\Shellids\Microsoft.Powershell\
+Get-Item HKLM:\Software\Microsoft\PowerShell\1\Shellids\Microsoft.PowerShell\
 ```
 
 ### Example 7: Get items in a directory that have an exclusion
@@ -562,7 +562,7 @@ The cmdlet outputs this type when accessing the `Env:` drive.
 
 ### System.IO.FileInfo
 
-The cmdlet outputs these types when accessing the Filesystem drives.
+The cmdlet outputs these types when accessing the FileSystem drives.
 
 ### System.Management.Automation.FunctionInfo
 
@@ -599,7 +599,7 @@ to get registry values and data. The registry values are considered to be proper
 registry key.
 
 This cmdlet is designed to work with the data exposed by any provider. To list the providers
-available in your session, type `Get-PsProvider`. For more information, see
+available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/7.5/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -89,7 +89,7 @@ D                1211.06     123642.32 FileSystem    D:\
 This command gets the D: drive on the computer. Note that the drive letter in the command is not
 followed by a colon.
 
-### Example 3: Get all the drives that are supported by the Windows PowerShell file system provider
+### Example 3: Get all the drives that are supported by the Windows PowerShell FileSystem provider
 
 ```
 PS C:\> Get-PSDrive -PSProvider FileSystem

--- a/reference/7.5/Microsoft.PowerShell.Management/Get-PSProvider.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Get-PSProvider.md
@@ -41,11 +41,11 @@ This command displays a list of all available PowerShell providers.
 ### Example 2: Display a list of all PowerShell providers that begin with specified letters
 
 ```powershell
-Get-PSProvider f*, r* | Format-List
+Get-PSProvider F*, R* | Format-List
 ```
 
-This command displays a list of all PowerShell providers with names that begin with the letter `f`
-or `r`.
+This command displays a list of all PowerShell providers with names that begin with the letter `F`
+or `R`.
 
 ### Example 3: Find snap-ins or module that added providers to your session
 
@@ -67,7 +67,7 @@ WSMan       Microsoft.WSMan.Management
 ```
 
 ```powershell
-Get-PSProvider | Where {$_.ModuleName -eq "Microsoft.PowerShell.Security"}
+Get-PSProvider | where {$_.ModuleName -eq "Microsoft.PowerShell.Security"}
 ```
 
 ```Output
@@ -89,7 +89,7 @@ values of their Name, Module, and PSSnapin properties.
 The second command uses the `Where-Object` cmdlet to get the providers that come from the
 **Microsoft.PowerShell.Security** snap-in.
 
-### Example 4: Resolve the path of the Home property of the file system provider
+### Example 4: Resolve the path of the Home property of the FileSystem provider
 
 ```powershell
 C:\> Resolve-Path ~
@@ -111,7 +111,7 @@ C:\Users\User01
 
 This example shows that the tilde symbol (`~`) represents the value of the **Home** property of the
 FileSystem provider. The **Home** property value is optional, but for the **FileSystem** provider,
-it is defined as `$env:HOMEDRIVE\$env:HOMEPATH` or `$HOME`.
+it is defined as `$Env:HOMEDRIVE\$Env:HOMEPATH` or `$HOME`.
 
 ## PARAMETERS
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Get-Process.md
@@ -107,7 +107,7 @@ though the default display lists them in kilobytes and megabytes.
 
 ```powershell
 $A = Get-Process
-$A | Get-Process | Format-Table -View priority
+$A | Get-Process | Format-Table -View Priority
 ```
 
 These commands list the processes on the computer in groups based on their priority class. The first
@@ -227,13 +227,13 @@ The second command gets the PowerShell process that's hosting the current sessio
 ### Example 10: Get all processes that have a main window title and display them in a table
 
 ```powershell
-Get-Process | Where-Object {$_.mainWindowTitle} | Format-Table Id, Name, mainWindowTitle -AutoSize
+Get-Process | Where-Object {$_.MainWindowTitle} | Format-Table Id, Name, MainWindowTitle -AutoSize
 ```
 
 This command gets all the processes that have a main window title, and it displays them in a table
 with the process ID and the process name.
 
-The **mainWindowTitle** property is just one of many useful properties of the **Process** object
+The **MainWindowTitle** property is just one of many useful properties of the **Process** object
 that `Get-Process` returns. To view all the properties, pipe the results of a `Get-Process`
 command to the `Get-Member` cmdlet `Get-Process | Get-Member`.
 
@@ -417,7 +417,7 @@ of all the properties of process objects, see
 - **VM(M)**: The amount of virtual memory that the process is using, in megabytes. Virtual memory
   includes storage in the paging files on disk.
 - **CPU(s)**: The amount of processor time that the process has used on all processors, in seconds.
-- **ID**: The process ID (PID) of the process.
+- **Id**: The process ID (PID) of the process.
 - **ProcessName**: The name of the process. For explanations of the concepts related to processes,
   see the Glossary in Help and Support Center and the Help for Task Manager.
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Get-Service.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Get-Service.md
@@ -143,7 +143,7 @@ property, stopped services appear before running services. This happens because 
 To list running services first, use the **Descending** parameter of the `Sort-Object` cmdlet.
 
 ```powershell
-Get-Service "s*" | Sort-Object status
+Get-Service "s*" | Sort-Object Status
 ```
 
 ```Output

--- a/reference/7.5/Microsoft.PowerShell.Management/Join-Path.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Join-Path.md
@@ -65,7 +65,7 @@ the `System\*` child path. It displays the same files and folders as `Get-ChildI
 displays the fully qualified path to each item. In this command, the `Path` and `ChildPath` optional
 parameter names are omitted.
 
-### Example 4: Use Join-Path with the PowerShell registry provider
+### Example 4: Use Join-Path with the PowerShell Registry provider
 
 ```powershell
 PS HKLM:\> Join-Path -Path System -ChildPath *ControlSet* -Resolve
@@ -103,7 +103,7 @@ This command uses `Join-Path` to combine multiple path roots with a child path.
 ### Example 6: Combine the roots of a file system drive with a child path
 
 ```powershell
-Get-PSDrive -PSProvider filesystem | ForEach-Object {$_.Root} | Join-Path -ChildPath "Subdir"
+Get-PSDrive -PSProvider FileSystem | ForEach-Object {$_.Root} | Join-Path -ChildPath "Subdir"
 ```
 
 ```output

--- a/reference/7.5/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/New-Item.md
@@ -81,7 +81,7 @@ This command creates a text file that is named "testfile1.txt" in the current di
 follows the **Value** parameter is added to the file as content.
 
 ```powershell
-New-Item -Path . -Name "testfile1.txt" -ItemType "file" -Value "This is a text string."
+New-Item -Path . -Name "testfile1.txt" -ItemType "File" -Value "This is a text string."
 ```
 
 ### Example 2: Create a directory
@@ -90,7 +90,7 @@ This command creates a directory named "Logfiles" in the `C:` drive. The **ItemT
 specifies that the new item is a directory, not a file or other file system object.
 
 ```powershell
-New-Item -Path "c:\" -Name "Logfiles" -ItemType "directory"
+New-Item -Path "C:\" -Name "Logfiles" -ItemType "Directory"
 ```
 
 ### Example 3: Create a profile
@@ -113,7 +113,7 @@ For more information, see
 and [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
 
 ```powershell
-New-Item -Path $PROFILE -ItemType "file" -Force
+New-Item -Path $PROFILE -ItemType "File" -Force
 ```
 
 ### Example 4: Create a directory in a different directory
@@ -125,7 +125,7 @@ instead of being specified in the value of **Name**. As indicated by the syntax,
 is valid.
 
 ```powershell
-New-Item -ItemType "directory" -Path "c:\ps-test\scripts"
+New-Item -ItemType "Directory" -Path "C:\ps-test\scripts"
 ```
 
 ### Example 5: Create multiple files
@@ -134,7 +134,7 @@ This example creates files in two different directories. Because **Path** takes 
 you can use it to create multiple items.
 
 ```powershell
-New-Item -ItemType "file" -Path "c:\ps-test\test.txt", "c:\ps-test\Logs\test.log"
+New-Item -ItemType "File" -Path "C:\ps-test\test.txt", "C:\ps-test\Logs\test.log"
 ```
 
 ### Example 6: Use wildcards to create files in multiple directories
@@ -222,7 +222,7 @@ Mode                LastWriteTime         Length Name
 ### Example 9: Use the Force parameter to overwrite existing files
 
 This example creates a file with a value and then recreates the file using the **Force** parameter.
-This overwrites the existing file, as you can see by the length property.
+This overwrites the existing file, as you can see by the **Length** property.
 
 ```powershell
 PS> New-Item ./TestFile.txt -ItemType File -Value 'This is just a test file'
@@ -662,7 +662,7 @@ PowerShell includes the following aliases for `New-Item`:
   - `ni`
 
 `New-Item` is designed to work with the data exposed by any provider. To list the providers
-available in your session, type `Get-PsProvider`. For more information, see
+available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/7.5/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -97,7 +97,7 @@ $newValue = New-ItemProperty -Path "HKLM:\SOFTWARE\ContosoCompany\" -Name 'HereS
 This is text which contains newlines
 It can also contain "quoted" strings
 "@
-$newValue.MultiString
+$newValue.HereString
 ```
 
 ```output

--- a/reference/7.6/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -86,7 +86,7 @@ as follows:
 - `s` (system)
 
 For more information about the mode flags, see
-[about_Filesystem_Provider](../Microsoft.PowerShell.Core/About/about_Filesystem_Provider.md#attributes-flagsexpression).
+[about_FileSystem_Provider](../Microsoft.PowerShell.Core/About/about_Filesystem_Provider.md#attributes-flagsexpression).
 
 ### Example 2: Get child item names in a directory
 
@@ -398,8 +398,8 @@ point. In PowerShell, this information is available from the **LinkTarget** prop
 filesystem object returned by `Get-ChildItem` and is displayed in the default output.
 
 ```powershell
-PS D:\> New-Item -ItemType Junction -Name tmp -Target $env:TEMP
-PS D:\> Get-ChildItem | Select-Object name, LinkTarget
+PS D:\> New-Item -ItemType Junction -Name tmp -Target $Env:TEMP
+PS D:\> Get-ChildItem | Select-Object Name, LinkTarget
 
 Name     LinkTarget
 ----     ----------

--- a/reference/7.6/Microsoft.PowerShell.Management/Get-HotFix.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Get-HotFix.md
@@ -33,14 +33,14 @@ Get-HotFix [-Description <String[]>] [-ComputerName <String[]>] [-Credential <PS
 
 > **This cmdlet is only available on the Windows platform.**
 
-The `Get-Hotfix` cmdlet uses the **Win32_QuickFixEngineering** WMI class to list hotfixes that are
+The `Get-HotFix` cmdlet uses the **Win32_QuickFixEngineering** WMI class to list hotfixes that are
 installed on the local computer or specified remote computers.
 
 ## EXAMPLES
 
 ### Example 1: Get all hotfixes on the local computer
 
-The `Get-Hotfix` cmdlet gets all hotfixes installed on the local computer.
+The `Get-HotFix` cmdlet gets all hotfixes installed on the local computer.
 
 ```powershell
 Get-HotFix
@@ -56,14 +56,14 @@ Server01       Update           KB4480056     NT AUTHORITY\SYSTEM  1/24/2019 00:
 
 ### Example 2: Get hotfixes from multiple computers filtered by a string
 
-The `Get-Hotfix` command uses parameters to get hotfixes installed on remote computers. The results
+The `Get-HotFix` command uses parameters to get hotfixes installed on remote computers. The results
 are filtered by a specified description string.
 
 ```powershell
 Get-HotFix -Description Security* -ComputerName Server01, Server02 -Credential Domain01\admin01
 ```
 
-`Get-Hotfix` filters the output with the **Description** parameter and the string **Security** that
+`Get-HotFix` filters the output with the **Description** parameter and the string **Security** that
 includes the asterisk (`*`) wildcard. The **ComputerName** parameter includes a comma-separated
 string of remote computer names. The **Credential** parameter specifies a user account that has
 permission to access the remote computers and run commands.
@@ -81,7 +81,7 @@ $A | ForEach-Object { if (!(Get-HotFix -Id KB957095 -ComputerName $_))
 
 The `$A` variable contains computer names that were obtained by `Get-Content` from a text file. The
 objects in `$A` are sent down the pipeline to `ForEach-Object`. An `if` statement uses the
-`Get-Hotfix` cmdlet with the **Id** parameter and a specific Id number for each computer name. If a
+`Get-HotFix` cmdlet with the **Id** parameter and a specific Id number for each computer name. If a
 computer doesn't have the specified hotfix Id installed, the `Add-Content` cmdlet writes the
 computer name to a file.
 
@@ -93,7 +93,7 @@ This example gets the most recent hotfix installed on a computer.
 (Get-HotFix | Sort-Object -Property InstalledOn)[-1]
 ```
 
-`Get-Hotfix` sends the objects down the pipeline to the `Sort-Object` cmdlet. `Sort-Object` sorts
+`Get-HotFix` sends the objects down the pipeline to the `Sort-Object` cmdlet. `Sort-Object` sorts
 objects by ascending order and uses the **Property** parameter to evaluate each **InstalledOn**
 date. The array notation `[-1]` selects the most recent installed hotfix.
 
@@ -104,7 +104,7 @@ date. The array notation `[-1]` selects the most recent installed hotfix.
 Specifies a remote computer. Type the NetBIOS name, an Internet Protocol (IP) address, or a fully
 qualified domain name (FQDN) of a remote computer.
 
-When the **ComputerName** parameter isn't specified, `Get-Hotfix` runs on the local computer.
+When the **ComputerName** parameter isn't specified, `Get-HotFix` runs on the local computer.
 
 The **ComputerName** parameter doesn't rely on Windows PowerShell remoting. If your computer isn't
 configured to run remote commands, use the **ComputerName** parameter.
@@ -196,7 +196,7 @@ You can pipe a string containing a computer name to this cmdlet.
 
 ## OUTPUTS
 
-### System.Management.ManagementObject#root\CIMV2\Win32_QuickFixEngineering
+### System.Management.ManagementObject#root\cimv2\Win32_QuickFixEngineering
 
 This cmdlet returns objects representing the hotfixes on the computer.
 

--- a/reference/7.6/Microsoft.PowerShell.Management/Get-Item.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Get-Item.md
@@ -151,7 +151,7 @@ cmdlet with the PowerShell Registry provider to get registry keys and subkeys, b
 `Get-ItemProperty` cmdlet to get the registry values and data.
 
 ```powershell
-Get-Item HKLM:\Software\Microsoft\Powershell\1\Shellids\Microsoft.Powershell\
+Get-Item HKLM:\Software\Microsoft\PowerShell\1\Shellids\Microsoft.PowerShell\
 ```
 
 ### Example 7: Get items in a directory that have an exclusion
@@ -560,7 +560,7 @@ The cmdlet outputs this type when accessing the `Env:` drive.
 
 ### System.IO.FileInfo
 
-The cmdlet outputs these types when accessing the Filesystem drives.
+The cmdlet outputs these types when accessing the FileSystem drives.
 
 ### System.Management.Automation.FunctionInfo
 
@@ -597,7 +597,7 @@ to get registry values and data. The registry values are considered to be proper
 registry key.
 
 This cmdlet is designed to work with the data exposed by any provider. To list the providers
-available in your session, type `Get-PsProvider`. For more information, see
+available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/7.6/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -89,7 +89,7 @@ D                1211.06     123642.32 FileSystem    D:\
 This command gets the D: drive on the computer. Note that the drive letter in the command is not
 followed by a colon.
 
-### Example 3: Get all the drives that are supported by the Windows PowerShell file system provider
+### Example 3: Get all the drives that are supported by the Windows PowerShell FileSystem provider
 
 ```
 PS C:\> Get-PSDrive -PSProvider FileSystem

--- a/reference/7.6/Microsoft.PowerShell.Management/Get-PSProvider.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Get-PSProvider.md
@@ -41,11 +41,11 @@ This command displays a list of all available PowerShell providers.
 ### Example 2: Display a list of all PowerShell providers that begin with specified letters
 
 ```powershell
-Get-PSProvider f*, r* | Format-List
+Get-PSProvider F*, R* | Format-List
 ```
 
-This command displays a list of all PowerShell providers with names that begin with the letter `f`
-or `r`.
+This command displays a list of all PowerShell providers with names that begin with the letter `F`
+or `R`.
 
 ### Example 3: Find snap-ins or module that added providers to your session
 
@@ -67,7 +67,7 @@ WSMan       Microsoft.WSMan.Management
 ```
 
 ```powershell
-Get-PSProvider | Where {$_.ModuleName -eq "Microsoft.PowerShell.Security"}
+Get-PSProvider | where {$_.ModuleName -eq "Microsoft.PowerShell.Security"}
 ```
 
 ```Output
@@ -89,7 +89,7 @@ values of their Name, Module, and PSSnapin properties.
 The second command uses the `Where-Object` cmdlet to get the providers that come from the
 **Microsoft.PowerShell.Security** snap-in.
 
-### Example 4: Resolve the path of the Home property of the file system provider
+### Example 4: Resolve the path of the Home property of the FileSystem provider
 
 ```powershell
 C:\> Resolve-Path ~
@@ -111,7 +111,7 @@ C:\Users\User01
 
 This example shows that the tilde symbol (`~`) represents the value of the **Home** property of the
 FileSystem provider. The **Home** property value is optional, but for the **FileSystem** provider,
-it is defined as `$env:HOMEDRIVE\$env:HOMEPATH` or `$HOME`.
+it is defined as `$Env:HOMEDRIVE\$Env:HOMEPATH` or `$HOME`.
 
 ## PARAMETERS
 

--- a/reference/7.6/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Get-Process.md
@@ -107,7 +107,7 @@ though the default display lists them in kilobytes and megabytes.
 
 ```powershell
 $A = Get-Process
-$A | Get-Process | Format-Table -View priority
+$A | Get-Process | Format-Table -View Priority
 ```
 
 These commands list the processes on the computer in groups based on their priority class. The first
@@ -227,13 +227,13 @@ The second command gets the PowerShell process that's hosting the current sessio
 ### Example 10: Get all processes that have a main window title and display them in a table
 
 ```powershell
-Get-Process | Where-Object {$_.mainWindowTitle} | Format-Table Id, Name, mainWindowTitle -AutoSize
+Get-Process | Where-Object {$_.MainWindowTitle} | Format-Table Id, Name, MainWindowTitle -AutoSize
 ```
 
 This command gets all the processes that have a main window title, and it displays them in a table
 with the process ID and the process name.
 
-The **mainWindowTitle** property is just one of many useful properties of the **Process** object
+The **MainWindowTitle** property is just one of many useful properties of the **Process** object
 that `Get-Process` returns. To view all the properties, pipe the results of a `Get-Process`
 command to the `Get-Member` cmdlet `Get-Process | Get-Member`.
 
@@ -417,7 +417,7 @@ of all the properties of process objects, see
 - **VM(M)**: The amount of virtual memory that the process is using, in megabytes. Virtual memory
   includes storage in the paging files on disk.
 - **CPU(s)**: The amount of processor time that the process has used on all processors, in seconds.
-- **ID**: The process ID (PID) of the process.
+- **Id**: The process ID (PID) of the process.
 - **ProcessName**: The name of the process. For explanations of the concepts related to processes,
   see the Glossary in Help and Support Center and the Help for Task Manager.
 

--- a/reference/7.6/Microsoft.PowerShell.Management/Get-Service.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Get-Service.md
@@ -143,7 +143,7 @@ property, stopped services appear before running services. This happens because 
 To list running services first, use the **Descending** parameter of the `Sort-Object` cmdlet.
 
 ```powershell
-Get-Service "s*" | Sort-Object status
+Get-Service "s*" | Sort-Object Status
 ```
 
 ```Output

--- a/reference/7.6/Microsoft.PowerShell.Management/Join-Path.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Join-Path.md
@@ -65,7 +65,7 @@ the `System\*` child path. It displays the same files and folders as `Get-ChildI
 displays the fully qualified path to each item. In this command, the `Path` and `ChildPath` optional
 parameter names are omitted.
 
-### Example 4: Use Join-Path with the PowerShell registry provider
+### Example 4: Use Join-Path with the PowerShell Registry provider
 
 ```powershell
 PS HKLM:\> Join-Path -Path System -ChildPath *ControlSet* -Resolve
@@ -103,7 +103,7 @@ This command uses `Join-Path` to combine multiple path roots with a child path.
 ### Example 6: Combine the roots of a file system drive with a child path
 
 ```powershell
-Get-PSDrive -PSProvider filesystem | ForEach-Object {$_.root} | Join-Path -ChildPath "Subdir"
+Get-PSDrive -PSProvider FileSystem | ForEach-Object {$_.Root} | Join-Path -ChildPath "Subdir"
 ```
 
 ```output

--- a/reference/7.6/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/New-Item.md
@@ -81,7 +81,7 @@ This command creates a text file that is named "testfile1.txt" in the current di
 follows the **Value** parameter is added to the file as content.
 
 ```powershell
-New-Item -Path . -Name "testfile1.txt" -ItemType "file" -Value "This is a text string."
+New-Item -Path . -Name "testfile1.txt" -ItemType "File" -Value "This is a text string."
 ```
 
 ### Example 2: Create a directory
@@ -90,7 +90,7 @@ This command creates a directory named "Logfiles" in the `C:` drive. The **ItemT
 specifies that the new item is a directory, not a file or other file system object.
 
 ```powershell
-New-Item -Path "c:\" -Name "Logfiles" -ItemType "directory"
+New-Item -Path "C:\" -Name "Logfiles" -ItemType "Directory"
 ```
 
 ### Example 3: Create a profile
@@ -112,7 +112,7 @@ For more information, see [about_Automatic_Variables](../Microsoft.PowerShell.Co
 and [about_Profiles](../Microsoft.PowerShell.Core/About/about_Profiles.md).
 
 ```powershell
-New-Item -Path $PROFILE -ItemType "file" -Force
+New-Item -Path $PROFILE -ItemType "File" -Force
 ```
 
 ### Example 4: Create a directory in a different directory
@@ -124,7 +124,7 @@ instead of being specified in the value of **Name**. As indicated by the syntax,
 is valid.
 
 ```powershell
-New-Item -ItemType "directory" -Path "c:\ps-test\scripts"
+New-Item -ItemType "Directory" -Path "C:\ps-test\scripts"
 ```
 
 ### Example 5: Create multiple files
@@ -133,7 +133,7 @@ This example creates files in two different directories. Because **Path** takes 
 you can use it to create multiple items.
 
 ```powershell
-New-Item -ItemType "file" -Path "c:\ps-test\test.txt", "c:\ps-test\Logs\test.log"
+New-Item -ItemType "File" -Path "C:\ps-test\test.txt", "C:\ps-test\Logs\test.log"
 ```
 
 ### Example 6: Use wildcards to create files in multiple directories
@@ -221,7 +221,7 @@ Mode                LastWriteTime         Length Name
 ### Example 9: Use the -Force parameter to overwrite existing files
 
 This example creates a file with a value and then recreates the file using `-Force`. This overwrites
-the existing file, as you can see by the length property.
+the existing file, as you can see by the **Length** property.
 
 ```powershell
 PS> New-Item ./TestFile.txt -ItemType File -Value 'This is just a test file'
@@ -661,7 +661,7 @@ PowerShell includes the following aliases for `New-Item`:
   - `ni`
 
 `New-Item` is designed to work with the data exposed by any provider. To list the providers
-available in your session, type `Get-PsProvider`. For more information, see
+available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/7.6/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -97,7 +97,7 @@ $newValue = New-ItemProperty -Path "HKLM:\SOFTWARE\ContosoCompany\" -Name 'HereS
 This is text which contains newlines
 It can also contain "quoted" strings
 "@
-$newValue.MultiString
+$newValue.HereString
 ```
 
 ```output


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide