### PR TITLE
Fix incorrect case/capitalization in reference documents (18/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -205,7 +205,7 @@ Get-PSDrive -Name "PSDrive", "X"
 Name       Provider      Root
 ----       --------      ----
 
-PsDrive    FileSystem    \\Server01\public
+PSDrive    FileSystem    \\Server01\public
 X          FileSystem    X:\
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-Service.md
@@ -79,7 +79,7 @@ object includes the start mode and the service description.
 ```powershell
 sc.exe delete TestService
 # - or -
-(Get-CimInstance -Class Win32_Service -Filter "name='TestService'").delete()
+(Get-CimInstance -Class Win32_Service -Filter "name='TestService'").Delete()
 ```
 
 This example shows two ways to delete the TestService service. The first command uses the delete
@@ -93,11 +93,11 @@ that `Get-CimInstance` returns.
 Specifies the path of the executable file for the service. This parameter is required.
 
 The fully qualified path to the service binary file. If the path contains a space, it must be quoted
-so that it is correctly interpreted. For example, `d:\my share\myservice.exe` should be specified as
-`'"d:\my share\myservice.exe"'`.
+so that it is correctly interpreted. For example, `D:\my share\myservice.exe` should be specified as
+`'"D:\my share\myservice.exe"'`.
 
 The path can also include arguments for an auto-start service. For example,
-`'"d:\my share\myservice.exe" arg1 arg2'`. These arguments are passed to the service entry point.
+`'"D:\my share\myservice.exe" arg1 arg2'`. These arguments are passed to the service entry point.
 
 For more information, see the **lpBinaryPathName** parameter of
 [CreateServiceW](/windows/win32/api/winsvc/nf-winsvc-createservicew) API.

--- a/reference/5.1/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Pop-Location.md
@@ -50,7 +50,7 @@ For more information about location stacks, see the [Notes](#notes).
 ```
 PS C:\> pushd HKLM:\Software\Microsoft\PowerShell
 PS HKLM:\Software\Microsoft\PowerShell> pushd Cert:\LocalMachine\TrustedPublisher
-PS cert:\LocalMachine\TrustedPublisher> popd
+PS Cert:\LocalMachine\TrustedPublisher> popd
 PS HKLM:\Software\Microsoft\PowerShell> popd
 PS C:\>
 ```
@@ -63,7 +63,7 @@ The first command pushes the current file system location onto the stack and mov
 supported by the PowerShell Registry provider.
 
 The second command pushes the registry location onto the stack and moves to a location supported by
-the PowerShell certificate provider.
+the PowerShell Certificate provider.
 
 The last two commands pop those locations off the stack. The first `popd` command returns to the
 Registry drive, and the second command returns to the file system drive.

--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-Item.md
@@ -526,7 +526,7 @@ Windows PowerShell includes the following aliases for `Remove-Item`:
 - `rmdir`
 
 The `Remove-Item` cmdlet is designed to work with the data exposed by any provider. To list the
-providers available in your session, type `Get-PsProvider`. For more information, see
+providers available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 When you try to delete a folder that contains items without using the **Recurse** parameter, the

--- a/reference/5.1/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Rename-Item.md
@@ -44,7 +44,7 @@ name. To move and rename an item, use the `Move-Item` cmdlet.
 This command renames the file `daily_file.txt` to `monday_file.txt`.
 
 ```powershell
-Rename-Item -Path "c:\logfiles\daily_file.txt" -NewName "monday_file.txt"
+Rename-Item -Path "C:\logfiles\daily_file.txt" -NewName "monday_file.txt"
 ```
 
 ### Example 2: Rename and move an item
@@ -54,15 +54,15 @@ for the value of the **NewName** parameter, unless the path is identical to the 
 the **Path** parameter. Otherwise, only a new name is permitted.
 
 ```powershell
-Rename-Item -Path "project.txt" -NewName "d:\archive\old-project.txt"
+Rename-Item -Path "project.txt" -NewName "D:\archive\old-project.txt"
 ```
 
 ```Output
 Rename-Item : can't rename because the target specified represents a path or device name.
 At line:1 char:12
-+ Rename-Item <<<<  -path project.txt -NewName d:\archive\old-project.txt
++ Rename-Item <<<<  -Path project.txt -NewName D:\archive\old-project.txt
 + CategoryInfo          : InvalidArgument: (:) [Rename-Item], PS>  Move-Item -Path "project.txt" -De
-stination "d:\archive\old-project.txt"
+stination "D:\archive\old-project.txt"
 ```
 
 This example attempts to rename the `project.txt` file in the current directory to `old-project.txt`
@@ -189,8 +189,8 @@ differs from the path that is specified in the **Path** parameter, `Rename-Item`
 To rename and move an item, use `Move-Item`.
 
 You can't use wildcard characters in the value of the **NewName** parameter. To specify a name for
-multiple files, use the **Replace** operator in a regular expression. For more information about the
-Replace operator, see [about_Comparison_Operators](../Microsoft.PowerShell.Core/About/about_Comparison_Operators.md).
+multiple files, use the `-replace` operator in a regular expression. For more information about the
+`-replace` operator, see [about_Comparison_Operators](../Microsoft.PowerShell.Core/About/about_Comparison_Operators.md).
 
 ```yaml
 Type: System.String
@@ -319,7 +319,7 @@ Windows PowerShell includes the following aliases for `Rename-Item`:
 - `rni`
 
 `Rename-Item` is designed to work with the data exposed by any provider. To list the providers
-available in your session, type `Get-PsProvider`. For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
+available in your session, type `Get-PSProvider`. For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Resolve-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Resolve-Path.md
@@ -87,7 +87,7 @@ This command resolves a Universal Naming Convention (UNC) path and returns the s
 ### Example 5: Get relative paths
 
 ```powershell
-Resolve-Path -Path "c:\prog*" -Relative
+Resolve-Path -Path "C:\prog*" -Relative
 ```
 
 ```Output
@@ -188,7 +188,7 @@ Accept wildcard characters: False
 ### -UseTransaction
 Includes the command in the active transaction.
 This parameter is valid only when a transaction is in progress.
-For more information, see [about_transactions](../Microsoft.PowerShell.Core/About/about_Transactions.md).
+For more information, see [about_Transactions](../Microsoft.PowerShell.Core/About/about_Transactions.md).
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -235,7 +235,7 @@ The `*-Path` cmdlets work with the **FileSystem**, **Registry**, and **Certifica
 
 `Resolve-Path` is designed to work with any provider. To list the providers available in your
 session, type `Get-PSProvider`. For more information, see
-[about_providers](../microsoft.powershell.core/about/about_providers.md).
+[about_Providers](../microsoft.powershell.core/about/about_providers.md).
 
 `Resolve-Path` only resolves existing paths. It cannot be used to resolve a location that does not
 exist yet.

--- a/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -298,7 +298,7 @@ The acceptable values for this parameter are:
 
 - **Default**: Waits for PowerShell to restart.
 - **PowerShell**: Can run commands in a PowerShell remote session on the computer.
-- **WMI**: Receives a reply to a Win32_ComputerSystem query for the computer.
+- **WMI**: Receives a reply to a **Win32_ComputerSystem** query for the computer.
 - **WinRM**: Can establish a remote session to the computer by using WS-Management.
 
 This parameter was introduced in Windows PowerShell 3.0.

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Content.md
@@ -125,7 +125,7 @@ The word Warning was replaced.
 
 ```powershell
 (Get-Content -Path .\Notice.txt) |
-    ForEach-Object {$_ -Replace 'Warning', 'Caution'} |
+    ForEach-Object {$_ -replace 'Warning', 'Caution'} |
         Set-Content -Path .\Notice.txt
 Get-Content -Path .\Notice.txt
 ```
@@ -506,7 +506,7 @@ Windows PowerShell includes the following aliases for `Set-Content`:
 - `Set-Content` is designed for string processing. If you pipe non-string objects to `Set-Content`,
   it converts the object to a string before writing it. To write objects to files, use `Out-File`.
 - The `Set-Content` cmdlet is designed to work with the data exposed by any provider. To list the
-  providers available in your session, type `Get-PsProvider`. For more information, see
+  providers available in your session, type `Get-PSProvider`. For more information, see
   [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Item.md
@@ -74,7 +74,7 @@ specified in the command.
 This command creates an alias of np for Notepad.
 
 ```powershell
-Set-Item -Path alias:np -Value "c:\windows\notepad.exe"
+Set-Item -Path Alias:np -Value "C:\windows\notepad.exe"
 ```
 
 ### Example 2: Change the value of an environment variable
@@ -82,7 +82,7 @@ Set-Item -Path alias:np -Value "c:\windows\notepad.exe"
 This command changes the value of the UserRole environment variable to Administrator.
 
 ```powershell
-Set-Item -Path env:UserRole -Value "Administrator"
+Set-Item -Path Env:UserRole -Value "Administrator"
 ```
 
 ### Example 3: Modify your prompt function
@@ -90,7 +90,7 @@ Set-Item -Path env:UserRole -Value "Administrator"
 This command changes the prompt function so that it displays the time before the path.
 
 ```powershell
-Set-Item -Path function:prompt -Value {'PS '+ (Get-Date -Format t) + " " + (Get-Location) + '> '}
+Set-Item -Path Function:prompt -Value {'PS '+ (Get-Date -Format t) + " " + (Get-Location) + '> '}
 ```
 
 ### Example 4: Set options for your prompt function
@@ -101,7 +101,7 @@ The **Options** parameter is available in `Set-Item` only when you use it with t
 **Function** provider.
 
 ```powershell
-Set-Item -Path function:prompt -Options "AllScope,ReadOnly"
+Set-Item -Path Function:prompt -Options "AllScope,ReadOnly"
 ```
 
 ## PARAMETERS
@@ -423,7 +423,7 @@ Windows PowerShell includes the following aliases for `Set-Item`:
   - To change the names and data in registry values, use the `New-ItemProperty`, `Set-ItemProperty`, and
     `Rename-ItemProperty` cmdlets.
 - `Set-Item` is designed to work with the data exposed by any provider.
-  To list the providers available in your session, type `Get-PsProvider`.
+  To list the providers available in your session, type `Get-PSProvider`.
   For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/5.1/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Split-Path.md
@@ -299,7 +299,7 @@ Accept wildcard characters: True
 ### -Qualifier
 
 Indicates that this cmdlet returns only the qualifier of the specified path. For the FileSystem or
-registry providers, the qualifier is the drive of the provider path, such as `C:` or `HKCU:`.
+Registry providers, the qualifier is the drive of the provider path, such as `C:` or `HKCU:`.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.4/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -205,7 +205,7 @@ Get-PSDrive -Name "PSDrive", "X"
 Name       Provider      Root
 ----       --------      ----
 
-PsDrive    FileSystem    \\Server01\public
+PSDrive    FileSystem    \\Server01\public
 X          FileSystem    X:\
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/New-Service.md
@@ -103,11 +103,11 @@ parameter uses `$SDDL` to set the **SecurityDescriptor** of the new service.
 Specifies the path of the executable file for the service. This parameter is required.
 
 The fully qualified path to the service binary file. If the path contains a space, it must be quoted
-so that it is correctly interpreted. For example, `d:\my share\myservice.exe` should be specified as
-`'"d:\my share\myservice.exe"'`.
+so that it is correctly interpreted. For example, `D:\my share\myservice.exe` should be specified as
+`'"D:\my share\myservice.exe"'`.
 
 The path can also include arguments for an auto-start service. For example,
-`'"d:\my share\myservice.exe" arg1 arg2'`. These arguments are passed to the service entry point.
+`'"D:\my share\myservice.exe" arg1 arg2'`. These arguments are passed to the service entry point.
 
 For more information, see the **lpBinaryPathName** parameter of
 [CreateServiceW](/windows/win32/api/winsvc/nf-winsvc-createservicew) API.

--- a/reference/7.4/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Pop-Location.md
@@ -50,7 +50,7 @@ For more information about location stacks, see the [Notes](#notes).
 ```
 PS C:\> pushd HKLM:\Software\Microsoft\PowerShell
 PS HKLM:\Software\Microsoft\PowerShell> pushd Cert:\LocalMachine\TrustedPublisher
-PS cert:\LocalMachine\TrustedPublisher> popd
+PS Cert:\LocalMachine\TrustedPublisher> popd
 PS HKLM:\Software\Microsoft\PowerShell> popd
 PS C:\>
 ```
@@ -63,7 +63,7 @@ The first command pushes the current file system location onto the stack and mov
 supported by the PowerShell Registry provider.
 
 The second command pushes the registry location onto the stack and moves to a location supported by
-the PowerShell certificate provider.
+the PowerShell Certificate provider.
 
 The last two commands pop those locations off the stack. The first `popd` command returns to the
 Registry drive, and the second command returns to the file system drive.

--- a/reference/7.4/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Remove-Item.md
@@ -504,7 +504,7 @@ PowerShell includes the following aliases for `Remove-Item`:
   - `rmdir`
 
 The `Remove-Item` cmdlet is designed to work with the data exposed by any provider. To list the
-providers available in your session, type `Get-PsProvider`. For more information, see
+providers available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 When you try to delete a folder that contains items without using the **Recurse** parameter, the

--- a/reference/7.4/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Rename-Item.md
@@ -44,7 +44,7 @@ name. To move and rename an item, use the `Move-Item` cmdlet.
 This command renames the file `daily_file.txt` to `monday_file.txt`.
 
 ```powershell
-Rename-Item -Path "c:\logfiles\daily_file.txt" -NewName "monday_file.txt"
+Rename-Item -Path "C:\logfiles\daily_file.txt" -NewName "monday_file.txt"
 ```
 
 ### Example 2: Rename and move an item
@@ -54,15 +54,15 @@ for the value of the **NewName** parameter, unless the path is identical to the 
 the **Path** parameter. Otherwise, only a new name is permitted.
 
 ```powershell
-Rename-Item -Path "project.txt" -NewName "d:\archive\old-project.txt"
+Rename-Item -Path "project.txt" -NewName "D:\archive\old-project.txt"
 ```
 
 ```Output
 Rename-Item : can't rename because the target specified represents a path or device name.
 At line:1 char:12
-+ Rename-Item <<<<  -path project.txt -NewName d:\archive\old-project.txt
++ Rename-Item <<<<  -Path project.txt -NewName D:\archive\old-project.txt
 + CategoryInfo          : InvalidArgument: (:) [Rename-Item], PS>  Move-Item -Path "project.txt" -De
-stination "d:\archive\old-project.txt"
+stination "D:\archive\old-project.txt"
 ```
 
 This example attempts to rename the `project.txt` file in the current directory to `old-project.txt`
@@ -189,8 +189,8 @@ differs from the path that is specified in the **Path** parameter, `Rename-Item`
 To rename and move an item, use `Move-Item`.
 
 You can't use wildcard characters in the value of the **NewName** parameter. To specify a name for
-multiple files, use the **Replace** operator in a regular expression. For more information about the
-Replace operator, see [about_Comparison_Operators](../Microsoft.PowerShell.Core/About/about_Comparison_Operators.md).
+multiple files, use the `-replace` operator in a regular expression. For more information about the
+`-replace` operator, see [about_Comparison_Operators](../Microsoft.PowerShell.Core/About/about_Comparison_Operators.md).
 
 ```yaml
 Type: System.String
@@ -302,7 +302,7 @@ PowerShell includes the following aliases for `Rename-Item`:
   - `rni`
 
 `Rename-Item` is designed to work with the data exposed by any provider. To list the providers
-available in your session, type `Get-PsProvider`. For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
+available in your session, type `Get-PSProvider`. For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS
 

--- a/reference/7.4/Microsoft.PowerShell.Management/Resolve-Path.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Resolve-Path.md
@@ -87,7 +87,7 @@ This command resolves a Universal Naming Convention (UNC) path and returns the s
 ### Example 5: Get relative paths
 
 ```powershell
-Resolve-Path -Path "c:\prog*" -Relative
+Resolve-Path -Path "C:\prog*" -Relative
 ```
 
 ```Output
@@ -111,12 +111,12 @@ Resolve-Path -LiteralPath 'test[xml]'
 ### Example 7: Resolve a path relative to another folder
 
 This example uses the **RelativeBasePath** parameter to resolve the path of the `pwsh` executable
-relative to `$env:TEMP`. When the command includes the **Relative** switch parameter, it returns a
-**String** representing the relative path from `$env:TEMP` to the `pwsh` executable.
+relative to `$Env:TEMP`. When the command includes the **Relative** switch parameter, it returns a
+**String** representing the relative path from `$Env:TEMP` to the `pwsh` executable.
 
 ```powershell
 $ExecutablePath = Get-Command -Name pwsh | Select-Object -ExpandProperty Source
-Resolve-Path -Path $ExecutablePath -RelativeBasePath $env:TEMP -Relative
+Resolve-Path -Path $ExecutablePath -RelativeBasePath $Env:TEMP -Relative
 ```
 
 ```Output
@@ -261,7 +261,7 @@ The `*-Path` cmdlets work with the **FileSystem**, **Registry**, and **Certifica
 
 `Resolve-Path` is designed to work with any provider. To list the providers available in your
 session, type `Get-PSProvider`. For more information, see
-[about_providers](../microsoft.powershell.core/about/about_providers.md).
+[about_Providers](../microsoft.powershell.core/about/about_providers.md).
 
 `Resolve-Path` only resolves existing paths. It cannot be used to resolve a location that does not
 exist yet.

--- a/reference/7.4/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -203,7 +203,7 @@ The acceptable values for this parameter are:
 
 - **Default**: Waits for PowerShell to restart.
 - **PowerShell**: Can run commands in a PowerShell remote session on the computer.
-- **WMI**: Receives a reply to a Win32_ComputerSystem query for the computer.
+- **WMI**: Receives a reply to a **Win32_ComputerSystem** query for the computer.
 - **WinRM**: Can establish a remote session to the computer by using WS-Management.
 
 This parameter was introduced in Windows PowerShell 3.0.

--- a/reference/7.4/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Set-Content.md
@@ -125,7 +125,7 @@ The word Warning was replaced.
 
 ```powershell
 (Get-Content -Path .\Notice.txt) |
-    ForEach-Object {$_ -Replace 'Warning', 'Caution'} |
+    ForEach-Object {$_ -replace 'Warning', 'Caution'} |
         Set-Content -Path .\Notice.txt
 Get-Content -Path .\Notice.txt
 ```
@@ -519,7 +519,7 @@ When you use the **PassThru** parameter, this cmdlet returns a string representi
 - `Set-Content` is designed for string processing. If you pipe non-string objects to `Set-Content`,
   it converts the object to a string before writing it. To write objects to files, use `Out-File`.
 - The `Set-Content` cmdlet is designed to work with the data exposed by any provider. To list the
-  providers available in your session, type `Get-PsProvider`. For more information, see
+  providers available in your session, type `Get-PSProvider`. For more information, see
   [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/7.4/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Set-Item.md
@@ -74,7 +74,7 @@ specified in the command.
 This command creates an alias of np for Notepad.
 
 ```powershell
-Set-Item -Path alias:np -Value "c:\windows\notepad.exe"
+Set-Item -Path Alias:np -Value "C:\windows\notepad.exe"
 ```
 
 ### Example 2: Change the value of an environment variable
@@ -82,7 +82,7 @@ Set-Item -Path alias:np -Value "c:\windows\notepad.exe"
 This command changes the value of the UserRole environment variable to Administrator.
 
 ```powershell
-Set-Item -Path env:UserRole -Value "Administrator"
+Set-Item -Path Env:UserRole -Value "Administrator"
 ```
 
 ### Example 3: Modify your prompt function
@@ -90,7 +90,7 @@ Set-Item -Path env:UserRole -Value "Administrator"
 This command changes the prompt function so that it displays the time before the path.
 
 ```powershell
-Set-Item -Path function:prompt -Value {'PS '+ (Get-Date -Format t) + " " + (Get-Location) + '> '}
+Set-Item -Path Function:prompt -Value {'PS '+ (Get-Date -Format t) + " " + (Get-Location) + '> '}
 ```
 
 ### Example 4: Set options for your prompt function
@@ -101,7 +101,7 @@ The **Options** parameter is available in `Set-Item` only when you use it with t
 **Function** provider.
 
 ```powershell
-Set-Item -Path function:prompt -Options "AllScope,ReadOnly"
+Set-Item -Path Function:prompt -Options "AllScope,ReadOnly"
 ```
 
 ## PARAMETERS
@@ -406,7 +406,7 @@ PowerShell includes the following aliases for `Set-Item`:
   - To change the names and data in registry values, use the `New-ItemProperty`, `Set-ItemProperty`, and
     `Rename-ItemProperty` cmdlets.
 - `Set-Item` is designed to work with the data exposed by any provider.
-  To list the providers available in your session, type `Get-PsProvider`.
+  To list the providers available in your session, type `Get-PSProvider`.
   For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/7.4/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/7.4/Microsoft.PowerShell.Management/Split-Path.md
@@ -351,7 +351,7 @@ Accept wildcard characters: True
 ### -Qualifier
 
 Indicates that this cmdlet returns only the qualifier of the specified path. For the FileSystem or
-registry providers, the qualifier is the drive of the provider path, such as `C:` or `HKCU:`.
+Registry providers, the qualifier is the drive of the provider path, such as `C:` or `HKCU:`.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.5/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -205,7 +205,7 @@ Get-PSDrive -Name "PSDrive", "X"
 Name       Provider      Root
 ----       --------      ----
 
-PsDrive    FileSystem    \\Server01\public
+PSDrive    FileSystem    \\Server01\public
 X          FileSystem    X:\
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/New-Service.md
@@ -103,11 +103,11 @@ parameter uses `$SDDL` to set the **SecurityDescriptor** of the new service.
 Specifies the path of the executable file for the service. This parameter is required.
 
 The fully qualified path to the service binary file. If the path contains a space, it must be quoted
-so that it is correctly interpreted. For example, `d:\my share\myservice.exe` should be specified as
-`'"d:\my share\myservice.exe"'`.
+so that it is correctly interpreted. For example, `D:\my share\myservice.exe` should be specified as
+`'"D:\my share\myservice.exe"'`.
 
 The path can also include arguments for an auto-start service. For example,
-`'"d:\my share\myservice.exe" arg1 arg2'`. These arguments are passed to the service entry point.
+`'"D:\my share\myservice.exe" arg1 arg2'`. These arguments are passed to the service entry point.
 
 For more information, see the **lpBinaryPathName** parameter of
 [CreateServiceW](/windows/win32/api/winsvc/nf-winsvc-createservicew) API.

--- a/reference/7.5/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Pop-Location.md
@@ -50,7 +50,7 @@ For more information about location stacks, see the [Notes](#notes).
 ```
 PS C:\> pushd HKLM:\Software\Microsoft\PowerShell
 PS HKLM:\Software\Microsoft\PowerShell> pushd Cert:\LocalMachine\TrustedPublisher
-PS cert:\LocalMachine\TrustedPublisher> popd
+PS Cert:\LocalMachine\TrustedPublisher> popd
 PS HKLM:\Software\Microsoft\PowerShell> popd
 PS C:\>
 ```
@@ -63,7 +63,7 @@ The first command pushes the current file system location onto the stack and mov
 supported by the PowerShell Registry provider.
 
 The second command pushes the registry location onto the stack and moves to a location supported by
-the PowerShell certificate provider.
+the PowerShell Certificate provider.
 
 The last two commands pop those locations off the stack. The first `popd` command returns to the
 Registry drive, and the second command returns to the file system drive.

--- a/reference/7.5/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Remove-Item.md
@@ -504,7 +504,7 @@ PowerShell includes the following aliases for `Remove-Item`:
   - `rmdir`
 
 The `Remove-Item` cmdlet is designed to work with the data exposed by any provider. To list the
-providers available in your session, type `Get-PsProvider`. For more information, see
+providers available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 When you try to delete a folder that contains items without using the **Recurse** parameter, the

--- a/reference/7.5/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Rename-Item.md
@@ -44,7 +44,7 @@ name. To move and rename an item, use the `Move-Item` cmdlet.
 This command renames the file `daily_file.txt` to `monday_file.txt`.
 
 ```powershell
-Rename-Item -Path "c:\logfiles\daily_file.txt" -NewName "monday_file.txt"
+Rename-Item -Path "C:\logfiles\daily_file.txt" -NewName "monday_file.txt"
 ```
 
 ### Example 2: Rename and move an item
@@ -54,15 +54,15 @@ for the value of the **NewName** parameter, unless the path is identical to the 
 the **Path** parameter. Otherwise, only a new name is permitted.
 
 ```powershell
-Rename-Item -Path "project.txt" -NewName "d:\archive\old-project.txt"
+Rename-Item -Path "project.txt" -NewName "D:\archive\old-project.txt"
 ```
 
 ```Output
 Rename-Item : can't rename because the target specified represents a path or device name.
 At line:1 char:12
-+ Rename-Item <<<<  -path project.txt -NewName d:\archive\old-project.txt
++ Rename-Item <<<<  -Path project.txt -NewName D:\archive\old-project.txt
 + CategoryInfo          : InvalidArgument: (:) [Rename-Item], PS>  Move-Item -Path "project.txt" -De
-stination "d:\archive\old-project.txt"
+stination "D:\archive\old-project.txt"
 ```
 
 This example attempts to rename the `project.txt` file in the current directory to `old-project.txt`
@@ -192,8 +192,8 @@ differs from the path that is specified in the **Path** parameter, `Rename-Item`
 To rename and move an item, use `Move-Item`.
 
 You can't use wildcard characters in the value of the **NewName** parameter. To specify a name for
-multiple files, use the **Replace** operator in a regular expression. For more information about the
-Replace operator, see
+multiple files, use the `-replace` operator in a regular expression. For more information about the
+`-replace` operator, see
 [about_Comparison_Operators](../Microsoft.PowerShell.Core/About/about_Comparison_Operators.md).
 
 ```yaml
@@ -307,7 +307,7 @@ PowerShell includes the following aliases for `Rename-Item`:
   - `rni`
 
 `Rename-Item` is designed to work with the data exposed by any provider. To list the providers
-available in your session, type `Get-PsProvider`. For more information, see
+available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/7.5/Microsoft.PowerShell.Management/Resolve-Path.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Resolve-Path.md
@@ -87,7 +87,7 @@ This command resolves a Universal Naming Convention (UNC) path and returns the s
 ### Example 5: Get relative paths
 
 ```powershell
-Resolve-Path -Path "c:\prog*" -Relative
+Resolve-Path -Path "C:\prog*" -Relative
 ```
 
 ```Output
@@ -111,12 +111,12 @@ Resolve-Path -LiteralPath 'test[xml]'
 ### Example 7: Resolve a path relative to another folder
 
 This example uses the **RelativeBasePath** parameter to resolve the path of the `pwsh` executable
-relative to `$env:TEMP`. When the command includes the **Relative** switch parameter, it returns a
-**String** representing the relative path from `$env:TEMP` to the `pwsh` executable.
+relative to `$Env:TEMP`. When the command includes the **Relative** switch parameter, it returns a
+**String** representing the relative path from `$Env:TEMP` to the `pwsh` executable.
 
 ```powershell
 $ExecutablePath = Get-Command -Name pwsh | Select-Object -ExpandProperty Source
-Resolve-Path -Path $ExecutablePath -RelativeBasePath $env:TEMP -Relative
+Resolve-Path -Path $ExecutablePath -RelativeBasePath $Env:TEMP -Relative
 ```
 
 ```Output

--- a/reference/7.5/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -203,7 +203,7 @@ The acceptable values for this parameter are:
 
 - **Default**: Waits for PowerShell to restart.
 - **PowerShell**: Can run commands in a PowerShell remote session on the computer.
-- **WMI**: Receives a reply to a Win32_ComputerSystem query for the computer.
+- **WMI**: Receives a reply to a **Win32_ComputerSystem** query for the computer.
 - **WinRM**: Can establish a remote session to the computer by using WS-Management.
 
 This parameter was introduced in Windows PowerShell 3.0.

--- a/reference/7.5/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Set-Content.md
@@ -125,7 +125,7 @@ The word Warning was replaced.
 
 ```powershell
 (Get-Content -Path .\Notice.txt) |
-    ForEach-Object {$_ -Replace 'Warning', 'Caution'} |
+    ForEach-Object {$_ -replace 'Warning', 'Caution'} |
         Set-Content -Path .\Notice.txt
 Get-Content -Path .\Notice.txt
 ```
@@ -519,7 +519,7 @@ When you use the **PassThru** parameter, this cmdlet returns a string representi
 - `Set-Content` is designed for string processing. If you pipe non-string objects to `Set-Content`,
   it converts the object to a string before writing it. To write objects to files, use `Out-File`.
 - The `Set-Content` cmdlet is designed to work with the data exposed by any provider. To list the
-  providers available in your session, type `Get-PsProvider`. For more information, see
+  providers available in your session, type `Get-PSProvider`. For more information, see
   [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/7.5/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Set-Item.md
@@ -75,7 +75,7 @@ specified in the command.
 This command creates an alias of np for Notepad.
 
 ```powershell
-Set-Item -Path alias:np -Value "c:\windows\notepad.exe"
+Set-Item -Path Alias:np -Value "C:\windows\notepad.exe"
 ```
 
 ### Example 2: Change the value of an environment variable
@@ -83,7 +83,7 @@ Set-Item -Path alias:np -Value "c:\windows\notepad.exe"
 This command changes the value of the UserRole environment variable to Administrator.
 
 ```powershell
-Set-Item -Path env:UserRole -Value "Administrator"
+Set-Item -Path Env:UserRole -Value "Administrator"
 ```
 
 ### Example 3: Modify your prompt function
@@ -91,7 +91,7 @@ Set-Item -Path env:UserRole -Value "Administrator"
 This command changes the prompt function so that it displays the time before the path.
 
 ```powershell
-Set-Item -Path function:prompt -Value {
+Set-Item -Path Function:prompt -Value {
     'PS '+ (Get-Date -Format t) + " " + (Get-Location) + '> '
 }
 ```
@@ -104,7 +104,7 @@ The **Options** parameter is available in `Set-Item` only when you use it with t
 **Function** provider.
 
 ```powershell
-Set-Item -Path function:prompt -Options "AllScope,ReadOnly"
+Set-Item -Path Function:prompt -Options "AllScope,ReadOnly"
 ```
 
 ## PARAMETERS
@@ -412,7 +412,7 @@ PowerShell includes the following aliases for `Set-Item`:
   - To change the names and data in registry values, use the `New-ItemProperty`, `Set-ItemProperty`,
     and `Rename-ItemProperty` cmdlets.
 - `Set-Item` is designed to work with the data exposed by any provider.
-  To list the providers available in your session, type `Get-PsProvider`.
+  To list the providers available in your session, type `Get-PSProvider`.
   For more information, see
   [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 

--- a/reference/7.5/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/7.5/Microsoft.PowerShell.Management/Split-Path.md
@@ -351,7 +351,7 @@ Accept wildcard characters: True
 ### -Qualifier
 
 Indicates that this cmdlet returns only the qualifier of the specified path. For the FileSystem or
-registry providers, the qualifier is the drive of the provider path, such as `C:` or `HKCU:`.
+Registry providers, the qualifier is the drive of the provider path, such as `C:` or `HKCU:`.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter

--- a/reference/7.6/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -205,7 +205,7 @@ Get-PSDrive -Name "PSDrive", "X"
 Name       Provider      Root
 ----       --------      ----
 
-PsDrive    FileSystem    \\Server01\public
+PSDrive    FileSystem    \\Server01\public
 X          FileSystem    X:\
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/New-Service.md
@@ -103,11 +103,11 @@ parameter uses `$SDDL` to set the **SecurityDescriptor** of the new service.
 Specifies the path of the executable file for the service. This parameter is required.
 
 The fully qualified path to the service binary file. If the path contains a space, it must be quoted
-so that it is correctly interpreted. For example, `d:\my share\myservice.exe` should be specified as
-`'"d:\my share\myservice.exe"'`.
+so that it is correctly interpreted. For example, `D:\my share\myservice.exe` should be specified as
+`'"D:\my share\myservice.exe"'`.
 
 The path can also include arguments for an auto-start service. For example,
-`'"d:\my share\myservice.exe" arg1 arg2'`. These arguments are passed to the service entry point.
+`'"D:\my share\myservice.exe" arg1 arg2'`. These arguments are passed to the service entry point.
 
 For more information, see the **lpBinaryPathName** parameter of
 [CreateServiceW](/windows/win32/api/winsvc/nf-winsvc-createservicew) API.

--- a/reference/7.6/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Pop-Location.md
@@ -50,7 +50,7 @@ For more information about location stacks, see the [Notes](#notes).
 ```
 PS C:\> pushd HKLM:\Software\Microsoft\PowerShell
 PS HKLM:\Software\Microsoft\PowerShell> pushd Cert:\LocalMachine\TrustedPublisher
-PS cert:\LocalMachine\TrustedPublisher> popd
+PS Cert:\LocalMachine\TrustedPublisher> popd
 PS HKLM:\Software\Microsoft\PowerShell> popd
 PS C:\>
 ```
@@ -63,7 +63,7 @@ The first command pushes the current file system location onto the stack and mov
 supported by the PowerShell Registry provider.
 
 The second command pushes the registry location onto the stack and moves to a location supported by
-the PowerShell certificate provider.
+the PowerShell Certificate provider.
 
 The last two commands pop those locations off the stack. The first `popd` command returns to the
 Registry drive, and the second command returns to the file system drive.

--- a/reference/7.6/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Remove-Item.md
@@ -504,7 +504,7 @@ PowerShell includes the following aliases for `Remove-Item`:
   - `rmdir`
 
 The `Remove-Item` cmdlet is designed to work with the data exposed by any provider. To list the
-providers available in your session, type `Get-PsProvider`. For more information, see
+providers available in your session, type `Get-PSProvider`. For more information, see
 [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 When you try to delete a folder that contains items without using the **Recurse** parameter, the

--- a/reference/7.6/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Rename-Item.md
@@ -44,7 +44,7 @@ name. To move and rename an item, use the `Move-Item` cmdlet.
 This command renames the file `daily_file.txt` to `monday_file.txt`.
 
 ```powershell
-Rename-Item -Path "c:\logfiles\daily_file.txt" -NewName "monday_file.txt"
+Rename-Item -Path "C:\logfiles\daily_file.txt" -NewName "monday_file.txt"
 ```
 
 ### Example 2: Rename and move an item
@@ -54,15 +54,15 @@ for the value of the **NewName** parameter, unless the path is identical to the 
 the **Path** parameter. Otherwise, only a new name is permitted.
 
 ```powershell
-Rename-Item -Path "project.txt" -NewName "d:\archive\old-project.txt"
+Rename-Item -Path "project.txt" -NewName "D:\archive\old-project.txt"
 ```
 
 ```Output
 Rename-Item : can't rename because the target specified represents a path or device name.
 At line:1 char:12
-+ Rename-Item <<<<  -path project.txt -NewName d:\archive\old-project.txt
++ Rename-Item <<<<  -Path project.txt -NewName D:\archive\old-project.txt
 + CategoryInfo          : InvalidArgument: (:) [Rename-Item], PS>  Move-Item -Path "project.txt" -De
-stination "d:\archive\old-project.txt"
+stination "D:\archive\old-project.txt"
 ```
 
 This example attempts to rename the `project.txt` file in the current directory to `old-project.txt`
@@ -189,8 +189,8 @@ differs from the path that is specified in the **Path** parameter, `Rename-Item`
 To rename and move an item, use `Move-Item`.
 
 You can't use wildcard characters in the value of the **NewName** parameter. To specify a name for
-multiple files, use the **Replace** operator in a regular expression. For more information about the
-Replace operator, see [about_Comparison_Operators](../Microsoft.PowerShell.Core/About/about_Comparison_Operators.md).
+multiple files, use the `-replace` operator in a regular expression. For more information about the
+`-replace` operator, see [about_Comparison_Operators](../Microsoft.PowerShell.Core/About/about_Comparison_Operators.md).
 
 ```yaml
 Type: System.String
@@ -302,7 +302,7 @@ PowerShell includes the following aliases for `Rename-Item`:
   - `rni`
 
 `Rename-Item` is designed to work with the data exposed by any provider. To list the providers
-available in your session, type `Get-PsProvider`. For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
+available in your session, type `Get-PSProvider`. For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS
 

--- a/reference/7.6/Microsoft.PowerShell.Management/Resolve-Path.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Resolve-Path.md
@@ -87,7 +87,7 @@ This command resolves a Universal Naming Convention (UNC) path and returns the s
 ### Example 5: Get relative paths
 
 ```powershell
-Resolve-Path -Path "c:\prog*" -Relative
+Resolve-Path -Path "C:\prog*" -Relative
 ```
 
 ```Output
@@ -111,12 +111,12 @@ Resolve-Path -LiteralPath 'test[xml]'
 ### Example 7: Resolve a path relative to another folder
 
 This example uses the **RelativeBasePath** parameter to resolve the path of the `pwsh` executable
-relative to `$env:TEMP`. When the command includes the **Relative** switch parameter, it returns a
-**String** representing the relative path from `$env:TEMP` to the `pwsh` executable.
+relative to `$Env:TEMP`. When the command includes the **Relative** switch parameter, it returns a
+**String** representing the relative path from `$Env:TEMP` to the `pwsh` executable.
 
 ```powershell
 $ExecutablePath = Get-Command -Name pwsh | Select-Object -ExpandProperty Source
-Resolve-Path -Path $ExecutablePath -RelativeBasePath $env:TEMP -Relative
+Resolve-Path -Path $ExecutablePath -RelativeBasePath $Env:TEMP -Relative
 ```
 
 ```Output
@@ -316,7 +316,7 @@ The `*-Path` cmdlets work with the **FileSystem**, **Registry**, and **Certifica
 
 `Resolve-Path` is designed to work with any provider. To list the providers available in your
 session, type `Get-PSProvider`. For more information, see
-[about_providers](../microsoft.powershell.core/about/about_providers.md).
+[about_Providers](../microsoft.powershell.core/about/about_providers.md).
 
 `Resolve-Path` only resolves existing paths. It cannot be used to resolve a location that does not
 exist yet.

--- a/reference/7.6/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -203,7 +203,7 @@ The acceptable values for this parameter are:
 
 - **Default**: Waits for PowerShell to restart.
 - **PowerShell**: Can run commands in a PowerShell remote session on the computer.
-- **WMI**: Receives a reply to a Win32_ComputerSystem query for the computer.
+- **WMI**: Receives a reply to a **Win32_ComputerSystem** query for the computer.
 - **WinRM**: Can establish a remote session to the computer by using WS-Management.
 
 This parameter was introduced in Windows PowerShell 3.0.

--- a/reference/7.6/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Set-Content.md
@@ -125,7 +125,7 @@ The word Warning was replaced.
 
 ```powershell
 (Get-Content -Path .\Notice.txt) |
-    ForEach-Object {$_ -Replace 'Warning', 'Caution'} |
+    ForEach-Object {$_ -replace 'Warning', 'Caution'} |
         Set-Content -Path .\Notice.txt
 Get-Content -Path .\Notice.txt
 ```
@@ -519,7 +519,7 @@ When you use the **PassThru** parameter, this cmdlet returns a string representi
 - `Set-Content` is designed for string processing. If you pipe non-string objects to `Set-Content`,
   it converts the object to a string before writing it. To write objects to files, use `Out-File`.
 - The `Set-Content` cmdlet is designed to work with the data exposed by any provider. To list the
-  providers available in your session, type `Get-PsProvider`. For more information, see
+  providers available in your session, type `Get-PSProvider`. For more information, see
   [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/7.6/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Set-Item.md
@@ -74,7 +74,7 @@ specified in the command.
 This command creates an alias of np for Notepad.
 
 ```powershell
-Set-Item -Path alias:np -Value "c:\windows\notepad.exe"
+Set-Item -Path Alias:np -Value "C:\windows\notepad.exe"
 ```
 
 ### Example 2: Change the value of an environment variable
@@ -82,7 +82,7 @@ Set-Item -Path alias:np -Value "c:\windows\notepad.exe"
 This command changes the value of the UserRole environment variable to Administrator.
 
 ```powershell
-Set-Item -Path env:UserRole -Value "Administrator"
+Set-Item -Path Env:UserRole -Value "Administrator"
 ```
 
 ### Example 3: Modify your prompt function
@@ -90,7 +90,7 @@ Set-Item -Path env:UserRole -Value "Administrator"
 This command changes the prompt function so that it displays the time before the path.
 
 ```powershell
-Set-Item -Path function:prompt -Value {'PS '+ (Get-Date -Format t) + " " + (Get-Location) + '> '}
+Set-Item -Path Function:prompt -Value {'PS '+ (Get-Date -Format t) + " " + (Get-Location) + '> '}
 ```
 
 ### Example 4: Set options for your prompt function
@@ -101,7 +101,7 @@ The **Options** parameter is available in `Set-Item` only when you use it with t
 **Function** provider.
 
 ```powershell
-Set-Item -Path function:prompt -Options "AllScope,ReadOnly"
+Set-Item -Path Function:prompt -Options "AllScope,ReadOnly"
 ```
 
 ## PARAMETERS
@@ -406,7 +406,7 @@ PowerShell includes the following aliases for `Set-Item`:
   - To change the names and data in registry values, use the `New-ItemProperty`, `Set-ItemProperty`, and
     `Rename-ItemProperty` cmdlets.
 - `Set-Item` is designed to work with the data exposed by any provider.
-  To list the providers available in your session, type `Get-PsProvider`.
+  To list the providers available in your session, type `Get-PSProvider`.
   For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS

--- a/reference/7.6/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/7.6/Microsoft.PowerShell.Management/Split-Path.md
@@ -351,7 +351,7 @@ Accept wildcard characters: True
 ### -Qualifier
 
 Indicates that this cmdlet returns only the qualifier of the specified path. For the FileSystem or
-registry providers, the qualifier is the drive of the provider path, such as `C:` or `HKCU:`.
+Registry providers, the qualifier is the drive of the provider path, such as `C:` or `HKCU:`.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide