### PR TITLE
Fix incorrect case/capitalization in reference documents (20/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
@@ -52,7 +52,7 @@ cmdlet runs, that signature is removed.
 
 ### Example 1 - Sign a script using a certificate from the local certificate store
 
-These commands retrieve a code-signing certificate from the PowerShell certificate provider and use
+These commands retrieve a code-signing certificate from the PowerShell Certificate provider and use
 it to sign a PowerShell script.
 
 ```powershell
@@ -65,10 +65,10 @@ $signingParameters = @{
 Set-AuthenticodeSignature @signingParameters
 ```
 
-The first command uses the `Get-ChildItem` cmdlet and the PowerShell certificate provider to get the
+The first command uses the `Get-ChildItem` cmdlet and the PowerShell Certificate provider to get the
 certificates in the `Cert:\CurrentUser\My` subdirectory of the certificate store. The `Cert:` drive
-is the drive exposed by the certificate provider. The **CodeSigningCert** parameter, which is
-supported only by the certificate provider, limits the certificates retrieved to those with
+is the drive exposed by the Certificate provider. The **CodeSigningCert** parameter, which is
+supported only by the Certificate provider, limits the certificates retrieved to those with
 code-signing authority. The command stores the result in the `$cert` variable.
 
 The second command defines the `$signingParameters` variable as a **HashTable** with the parameters

--- a/reference/5.1/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -165,7 +165,7 @@ MachinePolicy       Undefined
 ### Example 6: Set the execution policy for the current PowerShell session
 
 The `Process` scope only affects the current PowerShell session. The execution policy is saved in
-the environment variable `$env:PSExecutionPolicyPreference` and is deleted when the session is
+the environment variable `$Env:PSExecutionPolicyPreference` and is deleted when the session is
 closed.
 
 ```powershell
@@ -310,7 +310,7 @@ The effective execution policy is determined by the order of precedence as follo
 - `CurrentUser` - Affects only the current user
 
 The `Process` scope only affects the current PowerShell session. The execution policy is saved in
-the environment variable `$env:PSExecutionPolicyPreference`, rather than the registry. When the
+the environment variable `$Env:PSExecutionPolicyPreference`, rather than the registry. When the
 PowerShell session is closed, the variable and value are deleted.
 
 Execution policies for the `CurrentUser` scope are written to the registry hive `HKEY_LOCAL_USER`.

--- a/reference/5.1/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
@@ -94,7 +94,7 @@ The following example gets an encrypted event from the PowerShell event log and 
 
 ```powershell
 $event = Get-WinEvent Microsoft-Windows-PowerShell/Operational -MaxEvents 1 |
-    Where-Object Id -eq 4104
+    Where-Object Id -EQ 4104
 Unprotect-CmsMessage -EventLogRecord $event
 ```
 
@@ -105,7 +105,7 @@ using `Unprotect-CmsMessage`.
 
 ```powershell
 Get-WinEvent Microsoft-Windows-PowerShell/Operational |
-    Where-Object Id -eq 4104 |
+    Where-Object Id -EQ 4104 |
     Unprotect-CmsMessage
 ```
 
@@ -196,7 +196,7 @@ Accept wildcard characters: False
 
 Specifies one or more CMS message recipients, identified in any of the following formats:
 
-- An actual certificate (as retrieved from the certificate provider).
+- An actual certificate (as retrieved from the Certificate provider).
 - Path to the a file containing the certificate.
 - Path to a directory containing the certificate.
 - Thumbprint of the certificate (used to look in the certificate store).

--- a/reference/5.1/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Add-Member.md
@@ -89,7 +89,7 @@ The third command uses dot notation to get the value of the **Status** property 
 `$a`. As the output shows, the value is `Done`.
 
 ```powershell
-$A = Get-ChildItem c:\ps-test\test.txt
+$A = Get-ChildItem C:\ps-test\test.txt
 $A | Add-Member -NotePropertyName Status -NotePropertyValue Done
 $A.Status
 ```
@@ -142,7 +142,7 @@ Display
 
 This example adds the **SizeInMB** script method to a **FileInfo** object that calculates the file
 size to the nearest MegaByte. The second command creates a **ScriptBlock** that uses the **Round**
-static method from the `[math]` type to round the file size to the second decimal place.
+static method from the `[Math]` type to round the file size to the second decimal place.
 
 The **Value** parameter also uses the `$this` automatic variable, which represents the current
 object. The `$this` variable is valid only in script blocks that define new properties and methods.
@@ -152,7 +152,7 @@ The last command uses dot notation to call the new **SizeInMB** script method on
 
 ```powershell
 $A = Get-ChildItem C:\Temp\test.txt
-$S = {[math]::Round(($this.Length / 1MB), 2)}
+$S = {[Math]::Round(($this.Length / 1MB), 2)}
 $A | Add-Member -MemberType ScriptMethod -Name "SizeInMB" -Value $S
 $A.SizeInMB()
 ```
@@ -173,7 +173,7 @@ Piping `$Asset` to `Add-Member` adds the key-value pairs in the dictionary to th
 in alphabetical order, not in the order that they were added.
 
 ```powershell
-$Asset = New-Object -TypeName PSObject
+$Asset = New-Object -TypeName psobject
 $Asset | Add-Member -NotePropertyMembers @{Name="Server30"} -TypeName Asset
 $Asset | Add-Member -NotePropertyMembers @{System="Server Core"}
 $Asset | Add-Member -NotePropertyMembers @{PSVersion="4.0"}
@@ -191,7 +191,7 @@ System      NoteProperty string System=Server Core
 ```
 
 ```powershell
-$Asset.PSObject.Properties | Format-Table Name, MemberType, TypeNameOfValue, Value
+$Asset.psobject.Properties | Format-Table Name, MemberType, TypeNameOfValue, Value
 ```
 
 ```Output
@@ -216,14 +216,14 @@ PS> $obj = [pscustomobject]@{
       Name = 'Doris'
       Age = '20'
 }
-PS> $obj | Add-Member -MemberType AliasProperty -Name 'intAge' -Value age -SecondValue uint32
+PS> $obj | Add-Member -MemberType AliasProperty -Name 'IntAge' -Value Age -SecondValue uint32
 PS> $obj | Get-Member
 
    TypeName: System.Management.Automation.PSCustomObject
 
 Name        MemberType    Definition
 ----        ----------    ----------
-intAge      AliasProperty intAge = (System.UInt32)age
+IntAge      AliasProperty IntAge = (System.UInt32)Age
 Equals      Method        bool Equals(System.Object obj)
 GetHashCode Method        int GetHashCode()
 GetType     Method        type GetType()
@@ -235,18 +235,18 @@ PS> $obj
 
 Name   : Doris
 Age    : 20
-intAge : 20
+IntAge : 20
 
 PS> $obj.Age + 1
 
 201
 
-PS> $obj.intAge + 1
+PS> $obj.IntAge + 1
 
 21
 ```
 
-The **intAge** property is an **AliasProperty** for the **Age** property, but the type is guaranteed
+The **IntAge** property is an **AliasProperty** for the **Age** property, but the type is guaranteed
 to be **uint32**.
 
 ### Example 7: Add get and set methods to a custom object

--- a/reference/5.1/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -232,7 +232,7 @@ In this example, we are comparing a string to a **TimeSpan** object. In the firs
 is converted to a **TimeSpan** so the objects are equal.
 
 ```powershell
-Compare-Object ([TimeSpan]"0:0:1") "0:0:1" -IncludeEqual
+Compare-Object ([timespan]"0:0:1") "0:0:1" -IncludeEqual
 ```
 
 ```Output
@@ -242,7 +242,7 @@ InputObject SideIndicator
 ```
 
 ```powershell
-Compare-Object "0:0:1" ([TimeSpan]"0:0:1")
+Compare-Object "0:0:1" ([timespan]"0:0:1")
 ```
 
 ```Output
@@ -406,7 +406,7 @@ Accept wildcard characters: False
 
 Specifies the number of adjacent objects that `Compare-Object` inspects while looking for a match in
 a collection of objects. `Compare-Object` examines adjacent objects when it doesn't find the object
-in the same position in a collection. The default value is `[Int32]::MaxValue`, which means that
+in the same position in a collection. The default value is `[int32]::MaxValue`, which means that
 `Compare-Object` examines the entire object collection.
 
 When working with large collections, the default value might not be efficient but is accurate.
@@ -420,7 +420,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: [Int32]::MaxValue
+Default value: [int32]::MaxValue
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -96,7 +96,7 @@ This example shows how to use the `ConvertFrom-Json` cmdlet to convert a JSON fi
 custom object.
 
 ```powershell
-Get-Content -Raw JsonFile.JSON | ConvertFrom-Json
+Get-Content -Raw JsonFile.json | ConvertFrom-Json
 ```
 
 The command uses Get-Content cmdlet to get the strings in a JSON file. The **Raw** parameter

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-SddlString.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-SddlString.md
@@ -65,11 +65,11 @@ It uses the `-Type` parameter to specify that SDDL string represents a registry 
 ```powershell
 $acl = Get-Acl -Path HKLM:\SOFTWARE\Microsoft\
 
-ConvertFrom-SddlString -Sddl $acl.Sddl | Foreach-Object {$_.DiscretionaryAcl[0]}
+ConvertFrom-SddlString -Sddl $acl.Sddl | ForEach-Object {$_.DiscretionaryAcl[0]}
 
 BUILTIN\Administrators: AccessAllowed (ChangePermissions, CreateDirectories, Delete, ExecuteKey, FullControl, GenericExecute, GenericWrite, ListDirectory, ReadExtendedAttributes, ReadPermissions, TakeOwnership, Traverse, WriteData, WriteExtendedAttributes, WriteKey)
 
-ConvertFrom-SddlString -Sddl $acl.Sddl -Type RegistryRights | Foreach-Object {$_.DiscretionaryAcl[0]}
+ConvertFrom-SddlString -Sddl $acl.Sddl -Type RegistryRights | ForEach-Object {$_.DiscretionaryAcl[0]}
 
 BUILTIN\Administrators: AccessAllowed (ChangePermissions, CreateLink, CreateSubKey, Delete, EnumerateSubKeys, ExecuteKey, FullControl, GenericExecute, GenericWrite, Notify, QueryValues, ReadPermissions, SetValue, TakeOwnership, WriteKey)
 ```
@@ -88,7 +88,7 @@ rights returned are for registry.
 ### Example 4: Convert Active Directory access rights SDDL to a PSCustomObject
 
 ```powershell
-$user = [ADSI]"LDAP://CN=username,CN=Users,DC=domain,DC=com"
+$user = [adsi]"LDAP://CN=username,CN=Users,DC=domain,DC=com"
 ConvertFrom-SddlString $user.psbase.ObjectSecurity.Sddl -Type ActiveDirectoryRights
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
@@ -27,8 +27,8 @@ used as the input format. By default, the **key** must be separated from the **v
 sign (`=`) character.
 
 The `ConvertFrom-StringData` cmdlet is considered to be a safe cmdlet that can be used in the
-**DATA** section of a script or function. When used in a **DATA** section, the contents of the
-string must conform to the rules for a **DATA** section. For more information, see
+`data` section of a script or function. When used in a `data` section, the contents of the
+string must conform to the rules for a `data` section. For more information, see
 [about_Data_Sections](../Microsoft.PowerShell.Core/About/about_Data_Sections.md).
 
 `ConvertFrom-StringData` supports escape character sequences that are allowed by conventional
@@ -115,13 +115,13 @@ Top              Red
 To satisfy the condition that each key-value pair must be on a separate line, the string uses the
 PowerShell newline character (`` `n ``) to separate the pairs.
 
-### Example 4: Use in the `DATA` section of a script
+### Example 4: Use in the `data` section of a script
 
-This example shows a `ConvertFrom-StringData` command used in the `DATA` section of a script.
-The statements below the **DATA** section display the text to the user.
+This example shows a `ConvertFrom-StringData` command used in the `data` section of a script.
+The statements below the `data` section display the text to the user.
 
 ```powershell
-$TextMsgs = DATA {
+$TextMsgs = data {
 ConvertFrom-StringData @'
 Text001 = The $Notebook variable contains the name of the user's system notebook.
 Text002 = The $MyNotebook variable contains the name of the user's private notebook.
@@ -138,7 +138,7 @@ Text002          The $MyNotebook variable contains the name of the user's privat
 ```
 
 Because the text includes variable names, it must be enclosed in a single-quoted string so that the
-variables are interpreted literally and not expanded. Variables aren't permitted in the `DATA`
+variables are interpreted literally and not expanded. Variables aren't permitted in the `data`
 section.
 
 ### Example 5: Use the pipeline operator to pass a string
@@ -198,13 +198,13 @@ path to render correctly in the resulting `ConvertFrom-StringData` hash table. T
 ensures that the literal backslash characters render correctly in the hash table output.
 
 ```powershell
-ConvertFrom-StringData "Message=Look in c:\\Windows\\System32"
+ConvertFrom-StringData "Message=Look in C:\\Windows\\System32"
 ```
 
 ```Output
 Name                           Value
 ----                           -----
-Message                        Look in c:\Windows\System32
+Message                        Look in C:\Windows\System32
 ```
 
 ## PARAMETERS

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -30,15 +30,15 @@ ConvertTo-Csv [-InputObject] <psobject> [-UseCulture] [-NoTypeInformation] [<Com
 
 ## DESCRIPTION
 
-The `ConvertTo-CSV` cmdlet returns a series of character-separated value (CSV) strings that
+The `ConvertTo-Csv` cmdlet returns a series of character-separated value (CSV) strings that
 represent the objects that you submit. You can then use the `ConvertFrom-Csv` cmdlet to recreate
 objects from the CSV strings. The objects converted from CSV are string values of the original
 objects that contain property values and no methods.
 
-You can use the `Export-Csv` cmdlet to convert objects to CSV strings. `Export-CSV` is similar to
-`ConvertTo-CSV`, except that it saves the CSV strings to a file.
+You can use the `Export-Csv` cmdlet to convert objects to CSV strings. `Export-Csv` is similar to
+`ConvertTo-Csv`, except that it saves the CSV strings to a file.
 
-The `ConvertTo-CSV` cmdlet has parameters to specify a delimiter other than a comma or use the
+The `ConvertTo-Csv` cmdlet has parameters to specify a delimiter other than a comma or use the
 current culture as the delimiter.
 
 ## EXAMPLES
@@ -57,8 +57,8 @@ Get-Process -Name 'PowerShell' | ConvertTo-Csv -NoTypeInformation
 ```
 
 The `Get-Process` cmdlet gets the **Process** object and uses the **Name** parameter to specify the
-PowerShell process. The process object is sent down the pipeline to the `ConvertTo-CSV` cmdlet. The
-`ConvertTo-CSV` cmdlet converts the object to CSV strings. The **NoTypeInformation** parameter
+PowerShell process. The process object is sent down the pipeline to the `ConvertTo-Csv` cmdlet. The
+`ConvertTo-Csv` cmdlet converts the object to CSV strings. The **NoTypeInformation** parameter
 removes the **#TYPE** information header from the CSV output.
 
 ### Example 2: Convert a DateTime object to CSV
@@ -127,7 +127,7 @@ Accept wildcard characters: False
 ### -InputObject
 
 Specifies the objects that are converted to CSV strings. Enter a variable that contains the objects
-or type a command or expression that gets the objects. You can also pipe objects to `ConvertTo-CSV`.
+or type a command or expression that gets the objects. You can also pipe objects to `ConvertTo-Csv`.
 
 ```yaml
 Type: System.Management.Automation.PSObject
@@ -198,7 +198,7 @@ This cmdlet returns one or more strings representing each converted object.
 
 In CSV format, each object is represented by a character-separated list of its property value. The
 property values are converted to strings using the object's **ToString()** method. The strings are
-represented by the property value name. `ConvertTo-CSV` does not export the object's methods.
+represented by the property value name. `ConvertTo-Csv` does not export the object's methods.
 
 The CSV strings are output as follows:
 
@@ -208,7 +208,7 @@ The CSV strings are output as follows:
   contain the first object's property names as a comma-separated list.
 - The remaining strings contain comma-separated lists of each object's property values.
 
-When you submit multiple objects to `ConvertTo-CSV`, `ConvertTo-CSV` orders the strings based on the
+When you submit multiple objects to `ConvertTo-Csv`, `ConvertTo-Csv` orders the strings based on the
 properties of the first object that you submit. If the remaining objects do not have one of the
 specified properties, the property value of that object is Null, as represented by two consecutive
 commas. If the remaining objects have additional properties, those property values are ignored.

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -132,7 +132,7 @@ attribute in the tag contains the name of the style sheet.
 ### Example 6: Create a web page to display service objects
 
 ```powershell
-Get-Service | ConvertTo-Html -As LIST | Out-File services.htm
+Get-Service | ConvertTo-Html -As List | Out-File services.htm
 ```
 
 This command creates an HTML page of the service objects that the `Get-Service` cmdlet returns. The
@@ -167,7 +167,7 @@ omitted.
 ### Example 8: Create a web page to display PowerShell events
 
 ```powershell
-Get-EventLog -Log "Windows PowerShell" | ConvertTo-Html -Property id, level, task
+Get-EventLog -Log "Windows PowerShell" | ConvertTo-Html -Property Id, Level, Task
 ```
 
 This command uses the `Get-EventLog` cmdlet to get events from the Windows PowerShell event log.
@@ -175,7 +175,7 @@ This command uses the `Get-EventLog` cmdlet to get events from the Windows Power
 It uses a pipeline operator (`|`) to send the events to the `ConvertTo-Html` cmdlet, which converts
 the events to HTML format.
 
-The `ConvertTo-Html` command uses the **Property** parameter to select only the **ID**, **Level**,
+The `ConvertTo-Html` command uses the **Property** parameter to select only the **Id**, **Level**,
 and **Task** properties of the event.
 
 ### Example 9: Create a web page to display specified services

--- a/reference/7.4/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
+++ b/reference/7.4/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
@@ -54,7 +54,7 @@ cmdlet runs, that signature is removed.
 
 ### Example 1 - Sign a script using a certificate from the local certificate store
 
-These commands retrieve a code-signing certificate from the PowerShell certificate provider and use
+These commands retrieve a code-signing certificate from the PowerShell Certificate provider and use
 it to sign a PowerShell script.
 
 ```powershell
@@ -62,10 +62,10 @@ $cert = Get-ChildItem -Path Cert:\CurrentUser\My -CodeSigningCert
 Set-AuthenticodeSignature -FilePath PsTestInternet2.ps1 -Certificate $cert
 ```
 
-The first command uses the `Get-ChildItem` cmdlet and the PowerShell certificate provider to get the
+The first command uses the `Get-ChildItem` cmdlet and the PowerShell Certificate provider to get the
 certificates in the `Cert:\CurrentUser\My` subdirectory of the certificate store. The `Cert:` drive
-is the drive exposed by the certificate provider. The **CodeSigningCert** parameter, which is
-supported only by the certificate provider, limits the certificates retrieved to those with
+is the drive exposed by the Certificate provider. The **CodeSigningCert** parameter, which is
+supported only by the Certificate provider, limits the certificates retrieved to those with
 code-signing authority. The command stores the result in the `$cert` variable.
 
 The second command uses the `Set-AuthenticodeSignature` cmdlet to sign the `PSTestInternet2.ps1`

--- a/reference/7.4/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/7.4/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -169,7 +169,7 @@ MachinePolicy       Undefined
 ### Example 6: Set the execution policy for the current PowerShell session
 
 The `Process` scope only affects the current PowerShell session. The execution policy is saved in
-the environment variable `$env:PSExecutionPolicyPreference` and is deleted when the session is
+the environment variable `$Env:PSExecutionPolicyPreference` and is deleted when the session is
 closed.
 
 ```powershell
@@ -316,7 +316,7 @@ The effective execution policy is determined by the order of precedence as follo
 - `CurrentUser` - Affects only the current user
 
 The `Process` scope only affects the current PowerShell session. The execution policy is saved in
-the environment variable `$env:PSExecutionPolicyPreference`, rather than the registry. When the
+the environment variable `$Env:PSExecutionPolicyPreference`, rather than the registry. When the
 PowerShell session is closed, the variable and value are deleted.
 
 Execution policies for the `CurrentUser` scope are written to the registry hive `HKEY_LOCAL_USER`.

--- a/reference/7.4/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
+++ b/reference/7.4/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
@@ -94,7 +94,7 @@ The following example gets an encrypted event from the PowerShell event log and 
 
 ```powershell
 $event = Get-WinEvent Microsoft-Windows-PowerShell/Operational -MaxEvents 1 |
-    Where-Object Id -eq 4104
+    Where-Object Id -EQ 4104
 Unprotect-CmsMessage -EventLogRecord $event
 ```
 
@@ -105,7 +105,7 @@ using `Unprotect-CmsMessage`.
 
 ```powershell
 Get-WinEvent Microsoft-Windows-PowerShell/Operational |
-    Where-Object Id -eq 4104 |
+    Where-Object Id -EQ 4104 |
     Unprotect-CmsMessage
 ```
 
@@ -196,7 +196,7 @@ Accept wildcard characters: False
 
 Specifies one or more CMS message recipients, identified in any of the following formats:
 
-- An actual certificate (as retrieved from the certificate provider).
+- An actual certificate (as retrieved from the Certificate provider).
 - Path to the a file containing the certificate.
 - Path to a directory containing the certificate.
 - Thumbprint of the certificate (used to look in the certificate store).

--- a/reference/7.4/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Add-Member.md
@@ -89,7 +89,7 @@ The third command uses dot notation to get the value of the **Status** property 
 `$a`. As the output shows, the value is `Done`.
 
 ```powershell
-$A = Get-ChildItem c:\ps-test\test.txt
+$A = Get-ChildItem C:\ps-test\test.txt
 $A | Add-Member -NotePropertyName Status -NotePropertyValue Done
 $A.Status
 ```
@@ -142,7 +142,7 @@ Display
 
 This example adds the **SizeInMB** script method to a **FileInfo** object that calculates the file
 size to the nearest MegaByte. The second command creates a **ScriptBlock** that uses the **Round**
-static method from the `[math]` type to round the file size to the second decimal place.
+static method from the `[Math]` type to round the file size to the second decimal place.
 
 The **Value** parameter also uses the `$this` automatic variable, which represents the current
 object. The `$this` variable is valid only in script blocks that define new properties and methods.
@@ -152,7 +152,7 @@ The last command uses dot notation to call the new **SizeInMB** script method on
 
 ```powershell
 $A = Get-ChildItem C:\Temp\test.txt
-$S = {[math]::Round(($this.Length / 1MB), 2)}
+$S = {[Math]::Round(($this.Length / 1MB), 2)}
 $A | Add-Member -MemberType ScriptMethod -Name "SizeInMB" -Value $S
 $A.SizeInMB()
 ```
@@ -173,7 +173,7 @@ Piping `$Asset` to `Add-Member` adds the key-value pairs in the dictionary to th
 in alphabetical order, not in the order that they were added.
 
 ```powershell
-$Asset = New-Object -TypeName PSObject
+$Asset = New-Object -TypeName psobject
 $d = [ordered]@{Name="Server30"; System="Server Core"; PSVersion="4.0"}
 $Asset | Add-Member -NotePropertyMembers $d -TypeName Asset
 $Asset | Get-Member -MemberType Properties
@@ -190,7 +190,7 @@ System      NoteProperty string System=Server Core
 ```
 
 ```powershell
-$Asset.PSObject.Properties | Format-Table Name, MemberType, TypeNameOfValue, Value
+$Asset.psobject.Properties | Format-Table Name, MemberType, TypeNameOfValue, Value
 ```
 
 ```Output
@@ -215,14 +215,14 @@ PS> $obj = [pscustomobject]@{
       Name = 'Doris'
       Age = '20'
 }
-PS> $obj | Add-Member -MemberType AliasProperty -Name 'intAge' -Value age -SecondValue uint32
+PS> $obj | Add-Member -MemberType AliasProperty -Name 'IntAge' -Value Age -SecondValue uint32
 PS> $obj | Get-Member
 
    TypeName: System.Management.Automation.PSCustomObject
 
 Name        MemberType    Definition
 ----        ----------    ----------
-intAge      AliasProperty intAge = (System.UInt32)age
+IntAge      AliasProperty IntAge = (System.UInt32)Age
 Equals      Method        bool Equals(System.Object obj)
 GetHashCode Method        int GetHashCode()
 GetType     Method        type GetType()
@@ -232,7 +232,7 @@ Name        NoteProperty  string Name=Doris
 
 PS> $obj
 
-Name  Age intAge
+Name  Age IntAge
 ----  --- ------
 Doris 20      20
 
@@ -240,12 +240,12 @@ PS> $obj.Age + 1
 
 201
 
-PS> $obj.intAge + 1
+PS> $obj.IntAge + 1
 
 21
 ```
 
-The **intAge** property is an **AliasProperty** for the **Age** property, but the type is guaranteed
+The **IntAge** property is an **AliasProperty** for the **Age** property, but the type is guaranteed
 to be **uint32**.
 
 ### Example 7: Add get and set methods to a custom object

--- a/reference/7.4/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -233,7 +233,7 @@ In this example, we are comparing a string to a **TimeSpan** object. In the firs
 is converted to a **TimeSpan** so the objects are equal.
 
 ```powershell
-Compare-Object ([TimeSpan]"0:0:1") "0:0:1" -IncludeEqual
+Compare-Object ([timespan]"0:0:1") "0:0:1" -IncludeEqual
 ```
 
 ```Output
@@ -243,7 +243,7 @@ InputObject SideIndicator
 ```
 
 ```powershell
-Compare-Object "0:0:1" ([TimeSpan]"0:0:1")
+Compare-Object "0:0:1" ([timespan]"0:0:1")
 ```
 
 ```Output
@@ -407,7 +407,7 @@ Accept wildcard characters: False
 
 Specifies the number of adjacent objects that `Compare-Object` inspects while looking for a match in
 a collection of objects. `Compare-Object` examines adjacent objects when it doesn't find the object
-in the same position in a collection. The default value is `[Int32]::MaxValue`, which means that
+in the same position in a collection. The default value is `[int32]::MaxValue`, which means that
 `Compare-Object` examines the entire object collection.
 
 When working with large collections, the default value might not be efficient but is accurate.
@@ -421,7 +421,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: [Int32]::MaxValue
+Default value: [int32]::MaxValue
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.4/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -96,7 +96,7 @@ This example shows how to use the `ConvertFrom-Json` cmdlet to convert a JSON fi
 custom object.
 
 ```powershell
-Get-Content -Raw JsonFile.JSON | ConvertFrom-Json
+Get-Content -Raw JsonFile.json | ConvertFrom-Json
 ```
 
 The command uses Get-Content cmdlet to get the strings in a JSON file. The **Raw** parameter

--- a/reference/7.4/Microsoft.PowerShell.Utility/ConvertFrom-SddlString.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/ConvertFrom-SddlString.md
@@ -69,11 +69,11 @@ It uses the `-Type` parameter to specify that SDDL string represents a registry 
 ```powershell
 $acl = Get-Acl -Path HKLM:\SOFTWARE\Microsoft\
 
-ConvertFrom-SddlString -Sddl $acl.Sddl | Foreach-Object {$_.DiscretionaryAcl[0]}
+ConvertFrom-SddlString -Sddl $acl.Sddl | ForEach-Object {$_.DiscretionaryAcl[0]}
 
 BUILTIN\Administrators: AccessAllowed (ChangePermissions, CreateDirectories, Delete, ExecuteKey, FullControl, GenericExecute, GenericWrite, ListDirectory, ReadExtendedAttributes, ReadPermissions, TakeOwnership, Traverse, WriteData, WriteExtendedAttributes, WriteKey)
 
-ConvertFrom-SddlString -Sddl $acl.Sddl -Type RegistryRights | Foreach-Object {$_.DiscretionaryAcl[0]}
+ConvertFrom-SddlString -Sddl $acl.Sddl -Type RegistryRights | ForEach-Object {$_.DiscretionaryAcl[0]}
 
 BUILTIN\Administrators: AccessAllowed (ChangePermissions, CreateLink, CreateSubKey, Delete, EnumerateSubKeys, ExecuteKey, FullControl, GenericExecute, GenericWrite, Notify, QueryValues, ReadPermissions, SetValue, TakeOwnership, WriteKey)
 ```

--- a/reference/7.4/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
@@ -27,8 +27,8 @@ used as the input format. By default, the **key** must be separated from the **v
 sign (`=`) character.
 
 The `ConvertFrom-StringData` cmdlet is considered to be a safe cmdlet that can be used in the
-**DATA** section of a script or function. When used in a **DATA** section, the contents of the
-string must conform to the rules for a **DATA** section. For more information, see
+`data` section of a script or function. When used in a `data` section, the contents of the
+string must conform to the rules for a `data` section. For more information, see
 [about_Data_Sections](../Microsoft.PowerShell.Core/About/about_Data_Sections.md).
 
 `ConvertFrom-StringData` supports escape character sequences that are allowed by conventional
@@ -142,13 +142,13 @@ Top              Red
 To satisfy the condition that each key-value pair must be on a separate line, the string uses the
 PowerShell newline character (`` `n ``) to separate the pairs.
 
-### Example 5: Use in the `DATA` section of a script
+### Example 5: Use in the `data` section of a script
 
-This example shows a `ConvertFrom-StringData` command used in the `DATA` section of a script.
-The statements below the **DATA** section display the text to the user.
+This example shows a `ConvertFrom-StringData` command used in the `data` section of a script.
+The statements below the `data` section display the text to the user.
 
 ```powershell
-$TextMsgs = DATA {
+$TextMsgs = data {
 ConvertFrom-StringData @'
 Text001 = The $Notebook variable contains the name of the user's system notebook.
 Text002 = The $MyNotebook variable contains the name of the user's private notebook.
@@ -165,7 +165,7 @@ Text002          The $MyNotebook variable contains the name of the user's privat
 ```
 
 Because the text includes variable names, it must be enclosed in a single-quoted string so that the
-variables are interpreted literally and not expanded. Variables aren't permitted in the `DATA`
+variables are interpreted literally and not expanded. Variables aren't permitted in the `data`
 section.
 
 ### Example 6: Use the pipeline operator to pass a string
@@ -225,13 +225,13 @@ path to render correctly in the resulting `ConvertFrom-StringData` hash table. T
 ensures that the literal backslash characters render correctly in the hash table output.
 
 ```powershell
-ConvertFrom-StringData "Message=Look in c:\\Windows\\System32"
+ConvertFrom-StringData "Message=Look in C:\\Windows\\System32"
 ```
 
 ```Output
 Name                           Value
 ----                           -----
-Message                        Look in c:\Windows\System32
+Message                        Look in C:\Windows\System32
 ```
 
 ## PARAMETERS

--- a/reference/7.4/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -32,15 +32,15 @@ ConvertTo-Csv [-InputObject] <PSObject> [-UseCulture] [-IncludeTypeInformation] 
 
 ## DESCRIPTION
 
-The `ConvertTo-CSV` cmdlet returns a series of character-separated value (CSV) strings that
+The `ConvertTo-Csv` cmdlet returns a series of character-separated value (CSV) strings that
 represent the objects that you submit. You can then use the `ConvertFrom-Csv` cmdlet to recreate
 objects from the CSV strings. The objects converted from CSV are string values of the original
 objects that contain property values and no methods.
 
-You can use the `Export-Csv` cmdlet to convert objects to CSV strings. `Export-CSV` is similar to
-`ConvertTo-CSV`, except that it saves the CSV strings to a file.
+You can use the `Export-Csv` cmdlet to convert objects to CSV strings. `Export-Csv` is similar to
+`ConvertTo-Csv`, except that it saves the CSV strings to a file.
 
-The `ConvertTo-CSV` cmdlet has parameters to specify a delimiter other than a comma or use the
+The `ConvertTo-Csv` cmdlet has parameters to specify a delimiter other than a comma or use the
 current culture as the delimiter.
 
 ## EXAMPLES
@@ -59,8 +59,8 @@ Get-Process -Name pwsh | ConvertTo-Csv -NoTypeInformation
 ```
 
 The `Get-Process` cmdlet gets the **Process** object and uses the **Name** parameter to specify the
-PowerShell process. The process object is sent down the pipeline to the `ConvertTo-CSV` cmdlet. The
-`ConvertTo-CSV` cmdlet converts the object to CSV strings. The **NoTypeInformation** parameter
+PowerShell process. The process object is sent down the pipeline to the `ConvertTo-Csv` cmdlet. The
+`ConvertTo-Csv` cmdlet converts the object to CSV strings. The **NoTypeInformation** parameter
 removes the **#TYPE** information header from the CSV output and is not required in PowerShell 6.
 
 ### Example 2: Convert a DateTime object to CSV
@@ -223,7 +223,7 @@ Accept wildcard characters: False
 ### -InputObject
 
 Specifies the objects that are converted to CSV strings. Enter a variable that contains the objects
-or type a command or expression that gets the objects. You can also pipe objects to `ConvertTo-CSV`.
+or type a command or expression that gets the objects. You can also pipe objects to `ConvertTo-Csv`.
 
 ```yaml
 Type: System.Management.Automation.PSObject
@@ -353,7 +353,7 @@ This cmdlet returns one or more strings representing each converted object.
 
 In CSV format, each object is represented by a character-separated list of its property value. The
 property values are converted to strings using the object's **ToString()** method. The strings are
-represented by the property value name. `ConvertTo-CSV` does not export the object's methods.
+represented by the property value name. `ConvertTo-Csv` does not export the object's methods.
 
 The CSV strings are output as follows:
 
@@ -363,12 +363,12 @@ The CSV strings are output as follows:
   headers contain the first object's property names as a character-separated list.
 - The remaining strings contain character-separated lists of each object's property values.
 
-Beginning with PowerShell 6.0 the default behavior of `ConvertTo-CSV` is to not include the
+Beginning with PowerShell 6.0 the default behavior of `ConvertTo-Csv` is to not include the
 **#TYPE** information in the CSV and **NoTypeInformation** is implied. **IncludeTypeInformation**
-can be used to include the **#TYPE** information and emulate the default behavior of `ConvertTo-CSV`
+can be used to include the **#TYPE** information and emulate the default behavior of `ConvertTo-Csv`
 prior to PowerShell 6.0.
 
-When you submit multiple objects to `ConvertTo-CSV`, `ConvertTo-CSV` orders the strings based on the
+When you submit multiple objects to `ConvertTo-Csv`, `ConvertTo-Csv` orders the strings based on the
 properties of the first object that you submit. If the remaining objects do not have one of the
 specified properties, the property value of that object is Null, as represented by two consecutive
 commas. If the remaining objects have additional properties, those property values are ignored.

--- a/reference/7.4/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -133,7 +133,7 @@ attribute in the tag contains the name of the style sheet.
 ### Example 6: Create a web page to display service objects
 
 ```powershell
-Get-Service | ConvertTo-Html -As LIST | Out-File services.htm
+Get-Service | ConvertTo-Html -As List | Out-File services.htm
 ```
 
 This command creates an HTML page of the service objects that the `Get-Service` cmdlet returns. The
@@ -168,7 +168,7 @@ omitted.
 ### Example 8: Create a web page to display PowerShell events
 
 ```powershell
-Get-EventLog -Log "Windows PowerShell" | ConvertTo-Html -Property id, level, task
+Get-EventLog -Log "Windows PowerShell" | ConvertTo-Html -Property Id, Level, Task
 ```
 
 This command uses the `Get-EventLog` cmdlet to get events from the Windows PowerShell event log.
@@ -176,7 +176,7 @@ This command uses the `Get-EventLog` cmdlet to get events from the Windows Power
 It uses a pipeline operator (`|`) to send the events to the `ConvertTo-Html` cmdlet, which converts
 the events to HTML format.
 
-The `ConvertTo-Html` command uses the **Property** parameter to select only the **ID**, **Level**,
+The `ConvertTo-Html` command uses the **Property** parameter to select only the **Id**, **Level**,
 and **Task** properties of the event.
 
 ### Example 9: Create a web page to display specified services
@@ -209,10 +209,10 @@ cmdlet to open the `Services.htm` file in the default browser.
 ### Example 10: Set the Meta properties and Charset of the HTML
 
 ```powershell
-Get-Service | ConvertTo-HTML -Meta @{
+Get-Service | ConvertTo-Html -Meta @{
   refresh=10
   author="Author's Name"
-  keywords="PowerShell, HTML, ConvertTo-HTML"
+  keywords="PowerShell, HTML, ConvertTo-Html"
 } -Charset "UTF-8"
 ```
 
@@ -222,7 +222,7 @@ The charset for the page is set to UTF-8
 ### Example 11: Set the HTML to XHTML Transitional DTD
 
 ```powershell
-Get-Service | ConvertTo-HTML -Transitional
+Get-Service | ConvertTo-Html -Transitional
 ```
 
 This command sets the `DOCTYPE` of the returned HTML to **XHTML Transitional DTD**

--- a/reference/7.5/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
+++ b/reference/7.5/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
@@ -54,7 +54,7 @@ cmdlet runs, that signature is removed.
 
 ### Example 1 - Sign a script using a certificate from the local certificate store
 
-These commands retrieve a code-signing certificate from the PowerShell certificate provider and use
+These commands retrieve a code-signing certificate from the PowerShell Certificate provider and use
 it to sign a PowerShell script.
 
 ```powershell
@@ -62,10 +62,10 @@ $cert = Get-ChildItem -Path Cert:\CurrentUser\My -CodeSigningCert
 Set-AuthenticodeSignature -FilePath PsTestInternet2.ps1 -Certificate $cert
 ```
 
-The first command uses the `Get-ChildItem` cmdlet and the PowerShell certificate provider to get the
+The first command uses the `Get-ChildItem` cmdlet and the PowerShell Certificate provider to get the
 certificates in the `Cert:\CurrentUser\My` subdirectory of the certificate store. The `Cert:` drive
-is the drive exposed by the certificate provider. The **CodeSigningCert** parameter, which is
-supported only by the certificate provider, limits the certificates retrieved to those with
+is the drive exposed by the Certificate provider. The **CodeSigningCert** parameter, which is
+supported only by the Certificate provider, limits the certificates retrieved to those with
 code-signing authority. The command stores the result in the `$cert` variable.
 
 The second command uses the `Set-AuthenticodeSignature` cmdlet to sign the `PSTestInternet2.ps1`

--- a/reference/7.5/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/7.5/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -170,7 +170,7 @@ MachinePolicy       Undefined
 ### Example 6: Set the execution policy for the current PowerShell session
 
 The `Process` scope only affects the current PowerShell session. The execution policy is saved in
-the environment variable `$env:PSExecutionPolicyPreference` and is deleted when the session is
+the environment variable `$Env:PSExecutionPolicyPreference` and is deleted when the session is
 closed.
 
 ```powershell
@@ -317,7 +317,7 @@ The effective execution policy is determined by the order of precedence as follo
 - `CurrentUser` - Affects only the current user
 
 The `Process` scope only affects the current PowerShell session. The execution policy is saved in
-the environment variable `$env:PSExecutionPolicyPreference`, rather than the registry. When the
+the environment variable `$Env:PSExecutionPolicyPreference`, rather than the registry. When the
 PowerShell session is closed, the variable and value are deleted.
 
 Execution policies for the `CurrentUser` scope are written to the registry hive `HKEY_LOCAL_USER`.

--- a/reference/7.5/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
+++ b/reference/7.5/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
@@ -94,7 +94,7 @@ The following example gets an encrypted event from the PowerShell event log and 
 
 ```powershell
 $event = Get-WinEvent Microsoft-Windows-PowerShell/Operational -MaxEvents 1 |
-    Where-Object Id -eq 4104
+    Where-Object Id -EQ 4104
 Unprotect-CmsMessage -EventLogRecord $event
 ```
 
@@ -105,7 +105,7 @@ using `Unprotect-CmsMessage`.
 
 ```powershell
 Get-WinEvent Microsoft-Windows-PowerShell/Operational |
-    Where-Object Id -eq 4104 |
+    Where-Object Id -EQ 4104 |
     Unprotect-CmsMessage
 ```
 
@@ -196,7 +196,7 @@ Accept wildcard characters: False
 
 Specifies one or more CMS message recipients, identified in any of the following formats:
 
-- An actual certificate (as retrieved from the certificate provider).
+- An actual certificate (as retrieved from the Certificate provider).
 - Path to the a file containing the certificate.
 - Path to a directory containing the certificate.
 - Thumbprint of the certificate (used to look in the certificate store).

--- a/reference/7.5/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Add-Member.md
@@ -142,7 +142,7 @@ Display
 
 This example adds the **SizeInMB** script method to a **FileInfo** object that calculates the file
 size to the nearest MegaByte. The second command creates a **ScriptBlock** that uses the **Round**
-static method from the `[math]` type to round the file size to the second decimal place.
+static method from the `[Math]` type to round the file size to the second decimal place.
 
 The **Value** parameter also uses the `$this` automatic variable, which represents the current
 object. The `$this` variable is valid only in script blocks that define new properties and methods.
@@ -152,7 +152,7 @@ The last command uses dot notation to call the new **SizeInMB** script method on
 
 ```powershell
 $A = Get-ChildItem C:\Temp\test.txt
-$S = {[math]::Round(($this.Length / 1MB), 2)}
+$S = {[Math]::Round(($this.Length / 1MB), 2)}
 $A | Add-Member -MemberType ScriptMethod -Name "SizeInMB" -Value $S
 $A.SizeInMB()
 ```
@@ -173,7 +173,7 @@ Piping `$Asset` to `Add-Member` adds the key-value pairs in the dictionary to th
 in alphabetical order, not in the order that they were added.
 
 ```powershell
-$Asset = New-Object -TypeName PSObject
+$Asset = New-Object -TypeName psobject
 $d = [ordered]@{Name="Server30"; System="Server Core"; PSVersion="4.0"}
 $Asset | Add-Member -NotePropertyMembers $d -TypeName Asset
 $Asset | Get-Member -MemberType Properties
@@ -190,7 +190,7 @@ System      NoteProperty string System=Server Core
 ```
 
 ```powershell
-$Asset.PSObject.Properties | Format-Table Name, MemberType, TypeNameOfValue, Value
+$Asset.psobject.Properties | Format-Table Name, MemberType, TypeNameOfValue, Value
 ```
 
 ```Output
@@ -217,7 +217,7 @@ $user = [pscustomobject]@{
 }
 $addMemberSplat = @{
     MemberType = 'AliasProperty'
-    Name = 'intAge'
+    Name = 'IntAge'
     Value = 'Age'
     SecondValue = 'UInt32'
 }
@@ -230,7 +230,7 @@ $user | Get-Member
 
 Name        MemberType    Definition
 ----        ----------    ----------
-intAge      AliasProperty intAge = (System.UInt32)Age
+IntAge      AliasProperty IntAge = (System.UInt32)Age
 Equals      Method        bool Equals(System.Object obj)
 GetHashCode Method        int GetHashCode()
 GetType     Method        type GetType()
@@ -242,7 +242,7 @@ Name        NoteProperty  string Name=Doris
 ```powershell
 PS> $obj
 
-Name  Age intAge
+Name  Age IntAge
 ----  --- ------
 Doris 20      20
 
@@ -250,12 +250,12 @@ PS> $obj.Age + 1
 
 201
 
-PS> $obj.intAge + 1
+PS> $obj.IntAge + 1
 
 21
 ```
 
-The **intAge** property is an **AliasProperty** for the **Age** property, but the type is guaranteed
+The **IntAge** property is an **AliasProperty** for the **Age** property, but the type is guaranteed
 to be **uint32**.
 
 ### Example 7: Add get and set methods to a custom object

--- a/reference/7.5/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -242,7 +242,7 @@ In this example, we are comparing a string to a **TimeSpan** object. In the firs
 is converted to a **TimeSpan** so the objects are equal.
 
 ```powershell
-Compare-Object ([TimeSpan]"0:0:1") "0:0:1" -IncludeEqual
+Compare-Object ([timespan]"0:0:1") "0:0:1" -IncludeEqual
 ```
 
 ```Output
@@ -252,7 +252,7 @@ InputObject SideIndicator
 ```
 
 ```powershell
-Compare-Object "0:0:1" ([TimeSpan]"0:0:1")
+Compare-Object "0:0:1" ([timespan]"0:0:1")
 ```
 
 ```Output
@@ -416,7 +416,7 @@ Accept wildcard characters: False
 
 Specifies the number of adjacent objects that `Compare-Object` inspects while looking for a match in
 a collection of objects. `Compare-Object` examines adjacent objects when it doesn't find the object
-in the same position in a collection. The default value is `[Int32]::MaxValue`, which means that
+in the same position in a collection. The default value is `[int32]::MaxValue`, which means that
 `Compare-Object` examines the entire object collection.
 
 When working with large collections, the default value might not be efficient but is accurate.
@@ -430,7 +430,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: [Int32]::MaxValue
+Default value: [int32]::MaxValue
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.5/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -104,7 +104,7 @@ This example shows how to use the `ConvertFrom-Json` cmdlet to convert a JSON fi
 custom object.
 
 ```powershell
-Get-Content -Raw JsonFile.JSON | ConvertFrom-Json
+Get-Content -Raw JsonFile.json | ConvertFrom-Json
 ```
 
 The command uses Get-Content cmdlet to get the strings in a JSON file. The **Raw** parameter
@@ -323,6 +323,6 @@ preserves that order.
 
 [Invoke-RestMethod](Invoke-RestMethod.md)
 
-[DateTime](xref:System.DateTime)
+[datetime](xref:System.DateTime)
 
 [DateTimeOffset](xref:System.DateTimeOffset)

--- a/reference/7.5/Microsoft.PowerShell.Utility/ConvertFrom-SddlString.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/ConvertFrom-SddlString.md
@@ -70,7 +70,7 @@ It uses the `-Type` parameter to specify that SDDL string represents a registry 
 ```powershell
 $acl = Get-Acl -Path HKLM:\SOFTWARE\Microsoft\
 
-ConvertFrom-SddlString -Sddl $acl.Sddl | Foreach-Object {$_.DiscretionaryAcl[0]}
+ConvertFrom-SddlString -Sddl $acl.Sddl | ForEach-Object {$_.DiscretionaryAcl[0]}
 ```
 
 ```Output
@@ -78,7 +78,7 @@ BUILTIN\Administrators: AccessAllowed (ChangePermissions, CreateDirectories, Del
 ```
 
 ```powershell
-ConvertFrom-SddlString -Sddl $acl.Sddl -Type RegistryRights | Foreach-Object {$_.DiscretionaryAcl[0]}
+ConvertFrom-SddlString -Sddl $acl.Sddl -Type RegistryRights | ForEach-Object {$_.DiscretionaryAcl[0]}
 ```
 
 ```Output

--- a/reference/7.5/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
@@ -27,8 +27,8 @@ used as the input format. By default, the **key** must be separated from the **v
 sign (`=`) character.
 
 The `ConvertFrom-StringData` cmdlet is considered to be a safe cmdlet that can be used in the
-**DATA** section of a script or function. When used in a **DATA** section, the contents of the
-string must conform to the rules for a **DATA** section. For more information, see
+`data` section of a script or function. When used in a `data` section, the contents of the
+string must conform to the rules for a `data` section. For more information, see
 [about_Data_Sections](../Microsoft.PowerShell.Core/About/about_Data_Sections.md).
 
 `ConvertFrom-StringData` supports escape character sequences that are allowed by conventional
@@ -142,13 +142,13 @@ Top              Red
 To satisfy the condition that each key-value pair must be on a separate line, the string uses the
 PowerShell newline character (`` `n ``) to separate the pairs.
 
-### Example 5: Use in the `DATA` section of a script
+### Example 5: Use in the `data` section of a script
 
-This example shows a `ConvertFrom-StringData` command used in the `DATA` section of a script.
-The statements below the **DATA** section display the text to the user.
+This example shows a `ConvertFrom-StringData` command used in the `data` section of a script.
+The statements below the `data` section display the text to the user.
 
 ```powershell
-$TextMsgs = DATA {
+$TextMsgs = data {
 ConvertFrom-StringData @'
 Text001 = The $Notebook variable contains the name of the user's system notebook.
 Text002 = The $MyNotebook variable contains the name of the user's private notebook.
@@ -165,7 +165,7 @@ Text002          The $MyNotebook variable contains the name of the user's privat
 ```
 
 Because the text includes variable names, it must be enclosed in a single-quoted string so that the
-variables are interpreted literally and not expanded. Variables aren't permitted in the `DATA`
+variables are interpreted literally and not expanded. Variables aren't permitted in the `data`
 section.
 
 ### Example 6: Use the pipeline operator to pass a string
@@ -225,13 +225,13 @@ path to render correctly in the resulting `ConvertFrom-StringData` hash table. T
 ensures that the literal backslash characters render correctly in the hash table output.
 
 ```powershell
-ConvertFrom-StringData "Message=Look in c:\\Windows\\System32"
+ConvertFrom-StringData "Message=Look in C:\\Windows\\System32"
 ```
 
 ```Output
 Name                           Value
 ----                           -----
-Message                        Look in c:\Windows\System32
+Message                        Look in C:\Windows\System32
 ```
 
 ## PARAMETERS

--- a/reference/7.5/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -33,15 +33,15 @@ ConvertTo-Csv [-InputObject] <PSObject> [-UseCulture] [-IncludeTypeInformation]
 
 ## DESCRIPTION
 
-The `ConvertTo-CSV` cmdlet returns a series of character-separated value (CSV) strings that
+The `ConvertTo-Csv` cmdlet returns a series of character-separated value (CSV) strings that
 represent the objects that you submit. You can then use the `ConvertFrom-Csv` cmdlet to recreate
 objects from the CSV strings. The objects converted from CSV are string values of the original
 objects that contain property values and no methods.
 
-You can use the `Export-Csv` cmdlet to convert objects to CSV strings. `Export-CSV` is similar to
-`ConvertTo-CSV`, except that it saves the CSV strings to a file.
+You can use the `Export-Csv` cmdlet to convert objects to CSV strings. `Export-Csv` is similar to
+`ConvertTo-Csv`, except that it saves the CSV strings to a file.
 
-The `ConvertTo-CSV` cmdlet has parameters to specify a delimiter other than a comma or use the
+The `ConvertTo-Csv` cmdlet has parameters to specify a delimiter other than a comma or use the
 current culture as the delimiter.
 
 ## EXAMPLES
@@ -60,8 +60,8 @@ Get-Process -Name pwsh | ConvertTo-Csv -NoTypeInformation
 ```
 
 The `Get-Process` cmdlet gets the **Process** object and uses the **Name** parameter to specify the
-PowerShell process. The process object is sent down the pipeline to the `ConvertTo-CSV` cmdlet. The
-`ConvertTo-CSV` cmdlet converts the object to CSV strings. The **NoTypeInformation** parameter
+PowerShell process. The process object is sent down the pipeline to the `ConvertTo-Csv` cmdlet. The
+`ConvertTo-Csv` cmdlet converts the object to CSV strings. The **NoTypeInformation** parameter
 removes the **#TYPE** information header from the CSV output and is not required in PowerShell 6.
 
 ### Example 2: Convert a DateTime object to CSV
@@ -225,7 +225,7 @@ Accept wildcard characters: False
 ### -InputObject
 
 Specifies the objects that are converted to CSV strings. Enter a variable that contains the objects
-or type a command or expression that gets the objects. You can also pipe objects to `ConvertTo-CSV`.
+or type a command or expression that gets the objects. You can also pipe objects to `ConvertTo-Csv`.
 
 ```yaml
 Type: System.Management.Automation.PSObject
@@ -355,7 +355,7 @@ This cmdlet returns one or more strings representing each converted object.
 
 In CSV format, each object is represented by a character-separated list of its property value. The
 property values are converted to strings using the object's **ToString()** method. The strings are
-represented by the property value name. `ConvertTo-CSV` does not export the object's methods.
+represented by the property value name. `ConvertTo-Csv` does not export the object's methods.
 
 The CSV strings are output as follows:
 
@@ -365,12 +365,12 @@ The CSV strings are output as follows:
   headers contain the first object's property names as a character-separated list.
 - The remaining strings contain character-separated lists of each object's property values.
 
-Beginning with PowerShell 6.0 the default behavior of `ConvertTo-CSV` is to not include the
+Beginning with PowerShell 6.0 the default behavior of `ConvertTo-Csv` is to not include the
 **#TYPE** information in the CSV and **NoTypeInformation** is implied. **IncludeTypeInformation**
-can be used to include the **#TYPE** information and emulate the default behavior of `ConvertTo-CSV`
+can be used to include the **#TYPE** information and emulate the default behavior of `ConvertTo-Csv`
 prior to PowerShell 6.0.
 
-When you submit multiple objects to `ConvertTo-CSV`, `ConvertTo-CSV` orders the strings based on the
+When you submit multiple objects to `ConvertTo-Csv`, `ConvertTo-Csv` orders the strings based on the
 properties of the first object that you submit. If the remaining objects do not have one of the
 specified properties, the property value of that object is Null, as represented by two consecutive
 commas. If the remaining objects have additional properties, those property values are ignored.

--- a/reference/7.5/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -176,7 +176,7 @@ This command uses the `Get-EventLog` cmdlet to get events from the Windows Power
 It uses a pipeline operator (`|`) to send the events to the `ConvertTo-Html` cmdlet, which converts
 the events to HTML format.
 
-The `ConvertTo-Html` command uses the **Property** parameter to select only the **ID**, **Level**,
+The `ConvertTo-Html` command uses the **Property** parameter to select only the **Id**, **Level**,
 and **Task** properties of the event.
 
 ### Example 9: Create a web page to display specified services
@@ -209,10 +209,10 @@ cmdlet to open the `Services.htm` file in the default browser.
 ### Example 10: Set the Meta properties and Charset of the HTML
 
 ```powershell
-Get-Service | ConvertTo-HTML -Meta @{
+Get-Service | ConvertTo-Html -Meta @{
   refresh=10
   author="Author's Name"
-  keywords="PowerShell, HTML, ConvertTo-HTML"
+  keywords="PowerShell, HTML, ConvertTo-Html"
 } -Charset "UTF-8"
 ```
 
@@ -222,7 +222,7 @@ The charset for the page is set to UTF-8
 ### Example 11: Set the HTML to XHTML Transitional DTD
 
 ```powershell
-Get-Service | ConvertTo-HTML -Transitional
+Get-Service | ConvertTo-Html -Transitional
 ```
 
 This command sets the `DOCTYPE` of the returned HTML to **XHTML Transitional DTD**

--- a/reference/7.6/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
+++ b/reference/7.6/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
@@ -54,7 +54,7 @@ cmdlet runs, that signature is removed.
 
 ### Example 1 - Sign a script using a certificate from the local certificate store
 
-These commands retrieve a code-signing certificate from the PowerShell certificate provider and use
+These commands retrieve a code-signing certificate from the PowerShell Certificate provider and use
 it to sign a PowerShell script.
 
 ```powershell
@@ -62,10 +62,10 @@ $cert = Get-ChildItem -Path Cert:\CurrentUser\My -CodeSigningCert
 Set-AuthenticodeSignature -FilePath PsTestInternet2.ps1 -Certificate $cert
 ```
 
-The first command uses the `Get-ChildItem` cmdlet and the PowerShell certificate provider to get the
+The first command uses the `Get-ChildItem` cmdlet and the PowerShell Certificate provider to get the
 certificates in the `Cert:\CurrentUser\My` subdirectory of the certificate store. The `Cert:` drive
-is the drive exposed by the certificate provider. The **CodeSigningCert** parameter, which is
-supported only by the certificate provider, limits the certificates retrieved to those with
+is the drive exposed by the Certificate provider. The **CodeSigningCert** parameter, which is
+supported only by the Certificate provider, limits the certificates retrieved to those with
 code-signing authority. The command stores the result in the `$cert` variable.
 
 The second command uses the `Set-AuthenticodeSignature` cmdlet to sign the `PSTestInternet2.ps1`

--- a/reference/7.6/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/7.6/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -169,7 +169,7 @@ MachinePolicy       Undefined
 ### Example 6: Set the execution policy for the current PowerShell session
 
 The `Process` scope only affects the current PowerShell session. The execution policy is saved in
-the environment variable `$env:PSExecutionPolicyPreference` and is deleted when the session is
+the environment variable `$Env:PSExecutionPolicyPreference` and is deleted when the session is
 closed.
 
 ```powershell
@@ -316,7 +316,7 @@ The effective execution policy is determined by the order of precedence as follo
 - `CurrentUser` - Affects only the current user
 
 The `Process` scope only affects the current PowerShell session. The execution policy is saved in
-the environment variable `$env:PSExecutionPolicyPreference`, rather than the registry. When the
+the environment variable `$Env:PSExecutionPolicyPreference`, rather than the registry. When the
 PowerShell session is closed, the variable and value are deleted.
 
 Execution policies for the `CurrentUser` scope are written to the registry hive `HKEY_LOCAL_USER`.

--- a/reference/7.6/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
+++ b/reference/7.6/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
@@ -94,7 +94,7 @@ The following example gets an encrypted event from the PowerShell event log and 
 
 ```powershell
 $event = Get-WinEvent Microsoft-Windows-PowerShell/Operational -MaxEvents 1 |
-    Where-Object Id -eq 4104
+    Where-Object Id -EQ 4104
 Unprotect-CmsMessage -EventLogRecord $event
 ```
 
@@ -105,7 +105,7 @@ using `Unprotect-CmsMessage`.
 
 ```powershell
 Get-WinEvent Microsoft-Windows-PowerShell/Operational |
-    Where-Object Id -eq 4104 |
+    Where-Object Id -EQ 4104 |
     Unprotect-CmsMessage
 ```
 
@@ -196,7 +196,7 @@ Accept wildcard characters: False
 
 Specifies one or more CMS message recipients, identified in any of the following formats:
 
-- An actual certificate (as retrieved from the certificate provider).
+- An actual certificate (as retrieved from the Certificate provider).
 - Path to the a file containing the certificate.
 - Path to a directory containing the certificate.
 - Thumbprint of the certificate (used to look in the certificate store).

--- a/reference/7.6/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Add-Member.md
@@ -89,7 +89,7 @@ The third command uses dot notation to get the value of the **Status** property 
 `$a`. As the output shows, the value is `Done`.
 
 ```powershell
-$A = Get-ChildItem c:\ps-test\test.txt
+$A = Get-ChildItem C:\ps-test\test.txt
 $A | Add-Member -NotePropertyName Status -NotePropertyValue Done
 $A.Status
 ```
@@ -142,7 +142,7 @@ Display
 
 This example adds the **SizeInMB** script method to a **FileInfo** object that calculates the file
 size to the nearest MegaByte. The second command creates a **ScriptBlock** that uses the **Round**
-static method from the `[math]` type to round the file size to the second decimal place.
+static method from the `[Math]` type to round the file size to the second decimal place.
 
 The **Value** parameter also uses the `$this` automatic variable, which represents the current
 object. The `$this` variable is valid only in script blocks that define new properties and methods.
@@ -152,7 +152,7 @@ The last command uses dot notation to call the new **SizeInMB** script method on
 
 ```powershell
 $A = Get-ChildItem C:\Temp\test.txt
-$S = {[math]::Round(($this.Length / 1MB), 2)}
+$S = {[Math]::Round(($this.Length / 1MB), 2)}
 $A | Add-Member -MemberType ScriptMethod -Name "SizeInMB" -Value $S
 $A.SizeInMB()
 ```
@@ -173,7 +173,7 @@ Piping `$Asset` to `Add-Member` adds the key-value pairs in the dictionary to th
 in alphabetical order, not in the order that they were added.
 
 ```powershell
-$Asset = New-Object -TypeName PSObject
+$Asset = New-Object -TypeName psobject
 $d = [ordered]@{Name="Server30"; System="Server Core"; PSVersion="4.0"}
 $Asset | Add-Member -NotePropertyMembers $d -TypeName Asset
 $Asset | Get-Member -MemberType Properties
@@ -190,7 +190,7 @@ System      NoteProperty string System=Server Core
 ```
 
 ```powershell
-$Asset.PSObject.Properties | Format-Table Name, MemberType, TypeNameOfValue, Value
+$Asset.psobject.Properties | Format-Table Name, MemberType, TypeNameOfValue, Value
 ```
 
 ```Output
@@ -215,14 +215,14 @@ PS> $obj = [pscustomobject]@{
       Name = 'Doris'
       Age = '20'
 }
-PS> $obj | Add-Member -MemberType AliasProperty -Name 'intAge' -Value age -SecondValue uint32
+PS> $obj | Add-Member -MemberType AliasProperty -Name 'IntAge' -Value Age -SecondValue uint32
 PS> $obj | Get-Member
 
    TypeName: System.Management.Automation.PSCustomObject
 
 Name        MemberType    Definition
 ----        ----------    ----------
-intAge      AliasProperty intAge = (System.UInt32)age
+IntAge      AliasProperty IntAge = (System.UInt32)Age
 Equals      Method        bool Equals(System.Object obj)
 GetHashCode Method        int GetHashCode()
 GetType     Method        type GetType()
@@ -232,7 +232,7 @@ Name        NoteProperty  string Name=Doris
 
 PS> $obj
 
-Name  Age intAge
+Name  Age IntAge
 ----  --- ------
 Doris 20      20
 
@@ -240,12 +240,12 @@ PS> $obj.Age + 1
 
 201
 
-PS> $obj.intAge + 1
+PS> $obj.IntAge + 1
 
 21
 ```
 
-The **intAge** property is an **AliasProperty** for the **Age** property, but the type is guaranteed
+The **IntAge** property is an **AliasProperty** for the **Age** property, but the type is guaranteed
 to be **uint32**.
 
 ### Example 7: Add get and set methods to a custom object

--- a/reference/7.6/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -233,7 +233,7 @@ In this example, we are comparing a string to a **TimeSpan** object. In the firs
 is converted to a **TimeSpan** so the objects are equal.
 
 ```powershell
-Compare-Object ([TimeSpan]"0:0:1") "0:0:1" -IncludeEqual
+Compare-Object ([timespan]"0:0:1") "0:0:1" -IncludeEqual
 ```
 
 ```Output
@@ -243,7 +243,7 @@ InputObject SideIndicator
 ```
 
 ```powershell
-Compare-Object "0:0:1" ([TimeSpan]"0:0:1")
+Compare-Object "0:0:1" ([timespan]"0:0:1")
 ```
 
 ```Output
@@ -407,7 +407,7 @@ Accept wildcard characters: False
 
 Specifies the number of adjacent objects that `Compare-Object` inspects while looking for a match in
 a collection of objects. `Compare-Object` examines adjacent objects when it doesn't find the object
-in the same position in a collection. The default value is `[Int32]::MaxValue`, which means that
+in the same position in a collection. The default value is `[int32]::MaxValue`, which means that
 `Compare-Object` examines the entire object collection.
 
 When working with large collections, the default value might not be efficient but is accurate.
@@ -421,7 +421,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: [Int32]::MaxValue
+Default value: [int32]::MaxValue
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/7.6/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -103,7 +103,7 @@ This example shows how to use the `ConvertFrom-Json` cmdlet to convert a JSON fi
 custom object.
 
 ```powershell
-Get-Content -Raw JsonFile.JSON | ConvertFrom-Json
+Get-Content -Raw JsonFile.json | ConvertFrom-Json
 ```
 
 The command uses Get-Content cmdlet to get the strings in a JSON file. The **Raw** parameter
@@ -320,6 +320,6 @@ preserves that order.
 
 [Invoke-RestMethod](Invoke-RestMethod.md)
 
-[DateTime](xref:System.DateTime)
+[datetime](xref:System.DateTime)
 
 [DateTimeOffset](xref:System.DateTimeOffset)

--- a/reference/7.6/Microsoft.PowerShell.Utility/ConvertFrom-SddlString.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/ConvertFrom-SddlString.md
@@ -69,11 +69,11 @@ It uses the `-Type` parameter to specify that SDDL string represents a registry 
 ```powershell
 $acl = Get-Acl -Path HKLM:\SOFTWARE\Microsoft\
 
-ConvertFrom-SddlString -Sddl $acl.Sddl | Foreach-Object {$_.DiscretionaryAcl[0]}
+ConvertFrom-SddlString -Sddl $acl.Sddl | ForEach-Object {$_.DiscretionaryAcl[0]}
 
 BUILTIN\Administrators: AccessAllowed (ChangePermissions, CreateDirectories, Delete, ExecuteKey, FullControl, GenericExecute, GenericWrite, ListDirectory, ReadExtendedAttributes, ReadPermissions, TakeOwnership, Traverse, WriteData, WriteExtendedAttributes, WriteKey)
 
-ConvertFrom-SddlString -Sddl $acl.Sddl -Type RegistryRights | Foreach-Object {$_.DiscretionaryAcl[0]}
+ConvertFrom-SddlString -Sddl $acl.Sddl -Type RegistryRights | ForEach-Object {$_.DiscretionaryAcl[0]}
 
 BUILTIN\Administrators: AccessAllowed (ChangePermissions, CreateLink, CreateSubKey, Delete, EnumerateSubKeys, ExecuteKey, FullControl, GenericExecute, GenericWrite, Notify, QueryValues, ReadPermissions, SetValue, TakeOwnership, WriteKey)
 ```

--- a/reference/7.6/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
@@ -27,8 +27,8 @@ used as the input format. By default, the **key** must be separated from the **v
 sign (`=`) character.
 
 The `ConvertFrom-StringData` cmdlet is considered to be a safe cmdlet that can be used in the
-**DATA** section of a script or function. When used in a **DATA** section, the contents of the
-string must conform to the rules for a **DATA** section. For more information, see
+`data` section of a script or function. When used in a `data` section, the contents of the
+string must conform to the rules for a `data` section. For more information, see
 [about_Data_Sections](../Microsoft.PowerShell.Core/About/about_Data_Sections.md).
 
 `ConvertFrom-StringData` supports escape character sequences that are allowed by conventional
@@ -142,13 +142,13 @@ Top              Red
 To satisfy the condition that each key-value pair must be on a separate line, the string uses the
 PowerShell newline character (`` `n ``) to separate the pairs.
 
-### Example 5: Use in the `DATA` section of a script
+### Example 5: Use in the `data` section of a script
 
-This example shows a `ConvertFrom-StringData` command used in the `DATA` section of a script.
-The statements below the **DATA** section display the text to the user.
+This example shows a `ConvertFrom-StringData` command used in the `data` section of a script.
+The statements below the `data` section display the text to the user.
 
 ```powershell
-$TextMsgs = DATA {
+$TextMsgs = data {
 ConvertFrom-StringData @'
 Text001 = The $Notebook variable contains the name of the user's system notebook.
 Text002 = The $MyNotebook variable contains the name of the user's private notebook.
@@ -165,7 +165,7 @@ Text002          The $MyNotebook variable contains the name of the user's privat
 ```
 
 Because the text includes variable names, it must be enclosed in a single-quoted string so that the
-variables are interpreted literally and not expanded. Variables aren't permitted in the `DATA`
+variables are interpreted literally and not expanded. Variables aren't permitted in the `data`
 section.
 
 ### Example 6: Use the pipeline operator to pass a string
@@ -225,13 +225,13 @@ path to render correctly in the resulting `ConvertFrom-StringData` hash table. T
 ensures that the literal backslash characters render correctly in the hash table output.
 
 ```powershell
-ConvertFrom-StringData "Message=Look in c:\\Windows\\System32"
+ConvertFrom-StringData "Message=Look in C:\\Windows\\System32"
 ```
 
 ```Output
 Name                           Value
 ----                           -----
-Message                        Look in c:\Windows\System32
+Message                        Look in C:\Windows\System32
 ```
 
 ## PARAMETERS

--- a/reference/7.6/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -32,15 +32,15 @@ ConvertTo-Csv [-InputObject] <PSObject> [-UseCulture] [-IncludeTypeInformation] 
 
 ## DESCRIPTION
 
-The `ConvertTo-CSV` cmdlet returns a series of character-separated value (CSV) strings that
+The `ConvertTo-Csv` cmdlet returns a series of character-separated value (CSV) strings that
 represent the objects that you submit. You can then use the `ConvertFrom-Csv` cmdlet to recreate
 objects from the CSV strings. The objects converted from CSV are string values of the original
 objects that contain property values and no methods.
 
-You can use the `Export-Csv` cmdlet to convert objects to CSV strings. `Export-CSV` is similar to
-`ConvertTo-CSV`, except that it saves the CSV strings to a file.
+You can use the `Export-Csv` cmdlet to convert objects to CSV strings. `Export-Csv` is similar to
+`ConvertTo-Csv`, except that it saves the CSV strings to a file.
 
-The `ConvertTo-CSV` cmdlet has parameters to specify a delimiter other than a comma or use the
+The `ConvertTo-Csv` cmdlet has parameters to specify a delimiter other than a comma or use the
 current culture as the delimiter.
 
 ## EXAMPLES
@@ -59,8 +59,8 @@ Get-Process -Name pwsh | ConvertTo-Csv -NoTypeInformation
 ```
 
 The `Get-Process` cmdlet gets the **Process** object and uses the **Name** parameter to specify the
-PowerShell process. The process object is sent down the pipeline to the `ConvertTo-CSV` cmdlet. The
-`ConvertTo-CSV` cmdlet converts the object to CSV strings. The **NoTypeInformation** parameter
+PowerShell process. The process object is sent down the pipeline to the `ConvertTo-Csv` cmdlet. The
+`ConvertTo-Csv` cmdlet converts the object to CSV strings. The **NoTypeInformation** parameter
 removes the **#TYPE** information header from the CSV output and is not required in PowerShell 6.
 
 ### Example 2: Convert a DateTime object to CSV
@@ -223,7 +223,7 @@ Accept wildcard characters: False
 ### -InputObject
 
 Specifies the objects that are converted to CSV strings. Enter a variable that contains the objects
-or type a command or expression that gets the objects. You can also pipe objects to `ConvertTo-CSV`.
+or type a command or expression that gets the objects. You can also pipe objects to `ConvertTo-Csv`.
 
 ```yaml
 Type: System.Management.Automation.PSObject
@@ -353,7 +353,7 @@ This cmdlet returns one or more strings representing each converted object.
 
 In CSV format, each object is represented by a character-separated list of its property value. The
 property values are converted to strings using the object's **ToString()** method. The strings are
-represented by the property value name. `ConvertTo-CSV` does not export the object's methods.
+represented by the property value name. `ConvertTo-Csv` does not export the object's methods.
 
 The CSV strings are output as follows:
 
@@ -363,12 +363,12 @@ The CSV strings are output as follows:
   headers contain the first object's property names as a character-separated list.
 - The remaining strings contain character-separated lists of each object's property values.
 
-Beginning with PowerShell 6.0 the default behavior of `ConvertTo-CSV` is to not include the
+Beginning with PowerShell 6.0 the default behavior of `ConvertTo-Csv` is to not include the
 **#TYPE** information in the CSV and **NoTypeInformation** is implied. **IncludeTypeInformation**
-can be used to include the **#TYPE** information and emulate the default behavior of `ConvertTo-CSV`
+can be used to include the **#TYPE** information and emulate the default behavior of `ConvertTo-Csv`
 prior to PowerShell 6.0.
 
-When you submit multiple objects to `ConvertTo-CSV`, `ConvertTo-CSV` orders the strings based on the
+When you submit multiple objects to `ConvertTo-Csv`, `ConvertTo-Csv` orders the strings based on the
 properties of the first object that you submit. If the remaining objects do not have one of the
 specified properties, the property value of that object is Null, as represented by two consecutive
 commas. If the remaining objects have additional properties, those property values are ignored.

--- a/reference/7.6/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -133,7 +133,7 @@ attribute in the tag contains the name of the style sheet.
 ### Example 6: Create a web page to display service objects
 
 ```powershell
-Get-Service | ConvertTo-Html -As LIST | Out-File services.htm
+Get-Service | ConvertTo-Html -As List | Out-File services.htm
 ```
 
 This command creates an HTML page of the service objects that the `Get-Service` cmdlet returns. The
@@ -168,7 +168,7 @@ omitted.
 ### Example 8: Create a web page to display PowerShell events
 
 ```powershell
-Get-EventLog -Log "Windows PowerShell" | ConvertTo-Html -Property id, level, task
+Get-EventLog -Log "Windows PowerShell" | ConvertTo-Html -Property Id, Level, Task
 ```
 
 This command uses the `Get-EventLog` cmdlet to get events from the Windows PowerShell event log.
@@ -176,7 +176,7 @@ This command uses the `Get-EventLog` cmdlet to get events from the Windows Power
 It uses a pipeline operator (`|`) to send the events to the `ConvertTo-Html` cmdlet, which converts
 the events to HTML format.
 
-The `ConvertTo-Html` command uses the **Property** parameter to select only the **ID**, **Level**,
+The `ConvertTo-Html` command uses the **Property** parameter to select only the **Id**, **Level**,
 and **Task** properties of the event.
 
 ### Example 9: Create a web page to display specified services
@@ -209,10 +209,10 @@ cmdlet to open the `Services.htm` file in the default browser.
 ### Example 10: Set the Meta properties and Charset of the HTML
 
 ```powershell
-Get-Service | ConvertTo-HTML -Meta @{
+Get-Service | ConvertTo-Html -Meta @{
   refresh=10
   author="Author's Name"
-  keywords="PowerShell, HTML, ConvertTo-HTML"
+  keywords="PowerShell, HTML, ConvertTo-Html"
 } -Charset "UTF-8"
 ```
 
@@ -222,7 +222,7 @@ The charset for the page is set to UTF-8
 ### Example 11: Set the HTML to XHTML Transitional DTD
 
 ```powershell
-Get-Service | ConvertTo-HTML -Transitional
+Get-Service | ConvertTo-Html -Transitional
 ```
 
 This command sets the `DOCTYPE` of the returned HTML to **XHTML Transitional DTD**


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide