### PR TITLE
Fix incorrect case/capitalization in reference documents (21/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 ### -InputObject
 
 Specifies the object to be converted. Enter a variable that contains the objects, or type a command
-or expression that gets the objects. You can also pipe objects to `ConvertTo-XML`.
+or expression that gets the objects. You can also pipe objects to `ConvertTo-Xml`.
 
 ```yaml
 Type: System.Management.Automation.PSObject

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -128,7 +128,7 @@ The acceptable values for this parameter are:
 
 - CSV. Comma-separated value (CSV) format.
 - Script. Creates a `Set-Alias` command for each exported alias. If you name the output file with a
-  .ps1 file name extension, you can run it as a script to add the aliases to any session.
+  `.ps1` file name extension, you can run it as a script to add the aliases to any session.
 
 ```yaml
 Type: Microsoft.PowerShell.Commands.ExportAliasFormat

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -37,7 +37,7 @@ recreate the saved object based on the contents of that file. For more informati
 [Language independence](/dotnet/standard/language-independence).
 
 This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
-file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+file. `ConvertTo-Xml` returns the XML, so you can continue to process it in PowerShell.
 
 A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
 securely as XML. For an example, see Example 3.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -34,11 +34,11 @@ Export-Csv [[-Path] <string>] -InputObject <psobject> [-LiteralPath <string>] [-
 
 ## DESCRIPTION
 
-The `Export-CSV` cmdlet creates a CSV file of the objects that you submit. Each object is a row that
-includes a character-separated list of the object's property values. You can use the `Export-CSV`
+The `Export-Csv` cmdlet creates a CSV file of the objects that you submit. Each object is a row that
+includes a character-separated list of the object's property values. You can use the `Export-Csv`
 cmdlet to create spreadsheets and share data with programs that accept CSV files as input.
 
-Do not format objects before sending them to the `Export-CSV` cmdlet. If `Export-CSV` receives
+Do not format objects before sending them to the `Export-Csv` cmdlet. If `Export-Csv` receives
 formatted objects the CSV file contains the format properties rather than the object properties. To
 export only selected properties of an object, use the `Select-Object` cmdlet.
 
@@ -301,9 +301,9 @@ This example shows how to use the **Force** and **Append** parameters. When thes
 combined, mismatched object properties can be written to a CSV file.
 
 ```powershell
-$Content = [PSCustomObject]@{Name = 'PowerShell'; Version = '7.0'}
+$Content = [pscustomobject]@{Name = 'PowerShell'; Version = '7.0'}
 $Content | Export-Csv -Path .\ParmFile.csv -NoTypeInformation
-$AdditionalContent = [PSCustomObject]@{Name = 'Windows PowerShell'; Edition = 'Desktop'}
+$AdditionalContent = [pscustomobject]@{Name = 'Windows PowerShell'; Edition = 'Desktop'}
 $AdditionalContent | Export-Csv -Path .\ParmFile.csv -NoTypeInformation -Append
 ```
 
@@ -351,8 +351,8 @@ the file located in the current directory.
 
 ### -Append
 
-Use this parameter so that `Export-CSV` adds CSV output to the end of the specified file. Without
-this parameter, `Export-CSV` replaces the file contents without warning.
+Use this parameter so that `Export-Csv` adds CSV output to the end of the specified file. Without
+this parameter, `Export-Csv` replaces the file contents without warning.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -436,7 +436,7 @@ Accept wildcard characters: False
 ### -InputObject
 
 Specifies the objects to export as CSV strings. Enter a variable that contains the objects or type a
-command or expression that gets the objects. You can also pipe objects to `Export-CSV`.
+command or expression that gets the objects. You can also pipe objects to `Export-Csv`.
 
 ```yaml
 Type: System.Management.Automation.PSObject
@@ -471,8 +471,8 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Use this parameter so that `Export-CSV` does not overwrite an existing file. By default, if the file
-exists in the specified path, `Export-CSV` overwrites the file without warning.
+Use this parameter so that `Export-Csv` does not overwrite an existing file. By default, if the file
+exists in the specified path, `Export-Csv` overwrites the file without warning.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -594,13 +594,13 @@ Windows PowerShell includes the following aliases for `Export-Csv`:
 
 - `epcsv`
 
-The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV strings and saves
-them in the specified text file. You can use `Export-CSV` to save objects in a CSV file and then use
+The `Export-Csv` cmdlet converts the objects that you submit into a series of CSV strings and saves
+them in the specified text file. You can use `Export-Csv` to save objects in a CSV file and then use
 the `Import-Csv` cmdlet to create objects from the CSV file.
 
 In the CSV file, each object is represented by a character-separated list of the property values of
 the object. The property values are converted to strings using the **ToString()** method. The
-strings are represented by the property value name. `Export-CSV does not export the methods of the
+strings are represented by the property value name. `Export-Csv does not export the methods of the
 object.
 
 The CSV strings are output as follows:
@@ -611,7 +611,7 @@ The CSV strings are output as follows:
   contain the first object's property names as a character-separated list.
 - The remaining strings contain character-separated lists of each object's property values.
 
-When you submit multiple objects to `Export-CSV`, `Export-CSV` organizes the file based on the
+When you submit multiple objects to `Export-Csv`, `Export-Csv` organizes the file based on the
 properties of the first object that you submit. If the remaining objects do not have one of the
 specified properties, the property value of that object is null, as represented by two consecutive
 commas. If the remaining objects have additional properties, those property values are not included
@@ -622,7 +622,7 @@ resulting objects are CSV versions of the original objects that consist of strin
 the property values and no methods.
 
 The `ConvertTo-Csv` and `ConvertFrom-Csv` cmdlets convert objects to CSV strings and from CSV
-strings. `Export-CSV` is the same as `ConvertTo-CSV`, except that it saves the CSV strings in a
+strings. `Export-Csv` is the same as `ConvertTo-Csv`, except that it saves the CSV strings in a
 file.
 
 ## RELATED LINKS

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -31,13 +31,13 @@ Export-FormatData -InputObject <ExtendedTypeDefinition[]> -LiteralPath <String> 
 
 ## DESCRIPTION
 
-The `Export-FormatData` cmdlet creates Windows PowerShell formatting files (format.ps1xml) from
+The `Export-FormatData` cmdlet creates Windows PowerShell formatting files (`format.ps1xml`) from
 the formatting objects in the current session. It takes the **ExtendedTypeDefinition** objects that
 `Get-FormatData` returns and saves them in a file in XML format.
 
-Windows PowerShell uses the data in formatting files (format.ps1xml) to generate the default display
-of Microsoft .NET Framework objects in the session. You can view and edit the formatting files and
-use the Update-FormatData cmdlet to add the formatting data to a session.
+Windows PowerShell uses the data in formatting files (`format.ps1xml`) to generate the default
+display of Microsoft .NET Framework objects in the session. You can view and edit the formatting
+files and use the Update-FormatData cmdlet to add the formatting data to a session.
 
 For more information about formatting files in Windows PowerShell, see [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
 
@@ -46,16 +46,16 @@ For more information about formatting files in Windows PowerShell, see [about_Fo
 ### Example 1: Export session format data
 
 ```powershell
-Get-FormatData -TypeName "*" | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
+Get-FormatData -TypeName "*" | Export-FormatData -Path "AllFormat.ps1xml" -IncludeScriptBlock
 ```
 
-This command exports all of the format data in the session to the AllFormat.ps1xml file.
+This command exports all of the format data in the session to the `AllFormat.ps1xml` file.
 
 The command uses the `Get-FormatData` cmdlet to get the format data in the session. A value of `*`
 (all) for the **TypeName** parameter directs the cmdlet to get all of the data in the session.
 
 The command uses a pipeline operator (`|`) to send the format data from the `Get-FormatData` command
-to the `Export-FormatData` cmdlet, which exports the format data to the AllFormat.ps1 file.
+to the `Export-FormatData` cmdlet, which exports the format data to the `AllFormat.ps1xml` file.
 
 The `Export-FormatData` command uses the **IncludeScriptBlock** parameter to include script blocks
 in the format data in the file.
@@ -64,10 +64,11 @@ in the format data in the file.
 
 ```powershell
 $F = Get-FormatData -TypeName "helpinfoshort"
-Export-FormatData -InputObject $F -Path "c:\test\help.format.ps1xml" -IncludeScriptBlock
+Export-FormatData -InputObject $F -Path "C:\test\Help.format.ps1xml" -IncludeScriptBlock
 ```
 
-These commands export the format data for the **HelpInfoShort** type to the Help.format.ps1xml file.
+These commands export the format data for the **HelpInfoShort** type to the `Help.format.ps1xml`
+file.
 
 The first command uses the `Get-FormatData` cmdlet to get the format data for the **HelpInfoShort**
 type, and it saves it in the `$F` variable.
@@ -79,8 +80,8 @@ script blocks in the output.
 ### Example 3: Export format data without a script block
 
 ```powershell
-Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path process.format.ps1xml
-Update-FormatData -PrependPath ".\process.format.ps1xml"
+Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path Process.format.ps1xml
+Update-FormatData -PrependPath ".\Process.format.ps1xml"
 Get-Process p*
 ```
 
@@ -98,14 +99,14 @@ This example shows the effect of omitting the **IncludeScriptBlock** parameter f
 The first command uses the `Get-FormatData` cmdlet to get the format data for the
 **System.Diagnostics.Process** object that the Get-Process cmdlet returns. The command uses a
 pipeline operator (`|`) to send the formatting data to the `Export-FormatData` cmdlet, which exports
-it to the Process.format.ps1xml file in the current directory.
+it to the `Process.format.ps1xml` file in the current directory.
 
 In this case, the `Export-FormatData` command does not use the **IncludeScriptBlock** parameter.
 
-The second command uses the `Update-FormatData` cmdlet to add the Process.format.ps1xml file to the
-current session. The command uses the **PrependPath** parameter to ensure that the formatting data for
-process objects in the Process.format.ps1xml file is found before the standard formatting data for
-process objects.
+The second command uses the `Update-FormatData` cmdlet to add the `Process.format.ps1xml` file to
+the current session. The command uses the **PrependPath** parameter to ensure that the formatting
+data for process objects in the Process.format.ps1xml file is found before the standard formatting
+data for process objects.
 
 The third command shows the effects of this change. The command uses the `Get-Process` cmdlet to
 get processes that have names that begin with P. The output shows that property values that are
@@ -206,10 +207,10 @@ Accept wildcard characters: False
 ### -Path
 
 Specifies a location for the output file.
-Enter a path (optional) and file name with a format.ps1xml file name extension.
+Enter a path (optional) and file name with a `format.ps1xml` file name extension.
 If you omit the path, `Export-FormatData` creates the file in the current directory.
 
-If you use a file name extension other than .ps1xml, the `Update-FormatData` cmdlet will not
+If you use a file name extension other than `.ps1xml`, the `Update-FormatData` cmdlet will not
 recognize the file.
 
 If you specify an existing file, `Export-FormatData` overwrites the file without warning, unless

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -183,7 +183,7 @@ Exports the variant of the command that results from using the specified argumen
 values).
 
 For example, to export the variant of the `Get-Item` command in the certificate (Cert:) drive in
-the PSSession in `$S`, type `Export-PSSession -Session $S -Command Get-Item -ArgumentList cert:`.
+the PSSession in `$S`, type `Export-PSSession -Session $S -Command Get-Item -ArgumentList Cert:`.
 
 ```yaml
 Type: System.Object[]
@@ -200,7 +200,7 @@ Accept wildcard characters: False
 ### -Certificate
 
 Specifies the client certificate that is used to sign the format files (*.Format.ps1xml) or script
-module files (.psm1) in the module that `Export-PSSession` creates. Enter a variable that contains
+module files (`.psm1`) in the module that `Export-PSSession` creates. Enter a variable that contains
 a certificate or a command or expression that gets the certificate.
 
 To find a certificate, use the `Get-PfxCertificate` cmdlet or use the `Get-ChildItem` cmdlet in the
@@ -253,13 +253,13 @@ The acceptable values for this parameter are as follows:
 
 - `Alias`: All PowerShell aliases in the current session.
 - `All`: All command types. It is the equivalent of `Get-Command -Name *`.
-- `Application`: All files other than PowerShell files in paths listed in the Path environment
-  variable (`$env:path`), including .txt, .exe, and .dll files.
+- `Application`: All files other than PowerShell files in paths listed in the PATH environment
+  variable (`$Env:PATH`), including .txt, .exe, and .dll files.
 - `Cmdlet`: The cmdlets in the current session. Cmdlet is the default.
 - `Configuration`: A PowerShell configuration. For more information, see
   [about_Session_Configurations](../Microsoft.PowerShell.Core/About/about_Session_Configurations.md).
-- `ExternalScript`: All .ps1 files in the paths listed in the Path environment variable
-  (`$env:path`).
+- `ExternalScript`: All `.ps1` files in the paths listed in the PATH environment variable
+  (`$Env:PATH`).
 - `Filter` and `Function`: All PowerShell functions.
 - `Script` Script blocks in the current session.
 - `Workflow` A PowerShell workflow. For more information, see [about_Workflows](../PSWorkflow/About/about_Workflows.md).

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -157,7 +157,7 @@ Specifies the objects to be formatted. Enter a variable that contains the object
 or expression that gets the objects.
 
 Only certain [scalar](/powershell/scripting/learn/glossary#scalar-value) types and
-`[system.io.fileinfo]` are supported.
+`[System.IO.FileInfo]` are supported.
 
 The supported scalar types are:
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-List.md
@@ -316,7 +316,7 @@ If you do not use a format cmdlet, PowerShell applies that default format for ea
 displays.
 
 The **View** parameter lets you specify an alternate format for the table. You can use the views
-defined in the `*.format.PS1XML` files in the PowerShell directory, or you can create your own views
+defined in the `*.format.ps1xml` files in the PowerShell directory, or you can create your own views
 in new PS1XML files and use the `Update-FormatData` cmdlet to include them in PowerShell.
 
 The alternate view for the **View** parameter must use the list format, otherwise, the command

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Table.md
@@ -103,7 +103,7 @@ more information about views and the code used to create this example's view, se
 [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md#sample-xml-for-a-format-table-custom-view).
 
 ```powershell
-Get-ChildItem  -Path C:\Test | Format-Table -View mygciview
+Get-ChildItem  -Path C:\Test | Format-Table -View MyGciView
 ```
 
 ```Output
@@ -121,7 +121,7 @@ d-----       10/23/2019     09:38       2/25/2019     09:38                Files
 
 `Get-ChildItem` gets the contents of the current directory, `C:\Test`. The
 **System.IO.DirectoryInfo** and **System.IO.FileInfo** objects are sent down the pipeline.
-`Format-Table` uses the **View** parameter to specify the custom view **mygciview** that includes
+`Format-Table` uses the **View** parameter to specify the custom view **MyGciView** that includes
 the **CreationTime** column.
 
 The default `Format-Table` output for `Get-ChildItem` doesn't include the **CreationTime** column.
@@ -177,7 +177,7 @@ local computer. You can use `Get-CimInstance` with the **ComputerName** paramete
 from remote computers.
 
 ```powershell
-$Processes = Get-CimInstance -Class win32_process -Filter "name='notepad.exe'"
+$Processes = Get-CimInstance -Class Win32_Process -Filter "name='notepad.exe'"
 $Processes | Format-Table ProcessName, @{
     Label = "Total Running Time"
     Expression={(Get-Date) - $_.CreationDate}

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -46,7 +46,7 @@ output. The **Column** parameter specifies the number of columns.
 This command displays the names of registry keys in the `HKEY_CURRENT_USER\Software\Microsoft` key.
 
 ```powershell
-Get-ChildItem HKCU:\software\microsoft | Format-Wide -Property pschildname -AutoSize
+Get-ChildItem HKCU:\software\Microsoft | Format-Wide -Property PSChildName -AutoSize
 ```
 
 The `Get-ChildItem` cmdlet gets objects representing the keys. The path is specified as `HKCU:`, one
@@ -309,7 +309,7 @@ Windows PowerShell includes the following aliases for `Format-Wide`:
 - `fw`
 
 The **View** parameter lets you specify an alternate format for the table. You can use the views
-defined in the `*.format.PS1XML` files in the PowerShell directory or you can create your own views
+defined in the `*.format.ps1xml` files in the PowerShell directory or you can create your own views
 in new PS1XML files and use the `Update-FormatData` cmdlet to include them in PowerShell.
 
 The alternate view for the **View** parameter must use table format; if it does not, the command

--- a/reference/7.4/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 ### -InputObject
 
 Specifies the object to be converted. Enter a variable that contains the objects, or type a command
-or expression that gets the objects. You can also pipe objects to `ConvertTo-XML`.
+or expression that gets the objects. You can also pipe objects to `ConvertTo-Xml`.
 
 ```yaml
 Type: System.Management.Automation.PSObject

--- a/reference/7.4/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -128,7 +128,7 @@ The acceptable values for this parameter are:
 
 - CSV. Comma-separated value (CSV) format.
 - Script. Creates a `Set-Alias` command for each exported alias. If you name the output file with a
-  .ps1 file name extension, you can run it as a script to add the aliases to any session.
+  `.ps1` file name extension, you can run it as a script to add the aliases to any session.
 
 ```yaml
 Type: Microsoft.PowerShell.Commands.ExportAliasFormat

--- a/reference/7.4/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -37,7 +37,7 @@ recreate the saved object based on the contents of that file. For more informati
 [Language independence](/dotnet/standard/language-independence).
 
 This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
-file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+file. `ConvertTo-Xml` returns the XML, so you can continue to process it in PowerShell.
 
 A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
 securely as XML. For an example, see Example 3.

--- a/reference/7.4/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -36,11 +36,11 @@ Export-Csv -InputObject <PSObject> [[-Path] <String>] [-LiteralPath <String>] [-
 
 ## DESCRIPTION
 
-The `Export-CSV` cmdlet creates a CSV file of the objects that you submit. Each object is a row that
-includes a character-separated list of the object's property values. You can use the `Export-CSV`
+The `Export-Csv` cmdlet creates a CSV file of the objects that you submit. Each object is a row that
+includes a character-separated list of the object's property values. You can use the `Export-Csv`
 cmdlet to create spreadsheets and share data with programs that accept CSV files as input.
 
-Do not format objects before sending them to the `Export-CSV` cmdlet. If `Export-CSV` receives
+Do not format objects before sending them to the `Export-Csv` cmdlet. If `Export-Csv` receives
 formatted objects the CSV file contains the format properties rather than the object properties. To
 export only selected properties of an object, use the `Select-Object` cmdlet.
 
@@ -304,9 +304,9 @@ This example shows how to use the **Force** and **Append** parameters. When thes
 combined, mismatched object properties can be written to a CSV file.
 
 ```powershell
-$Content = [PSCustomObject]@{Name = 'PowerShell'; Version = '7.0'}
+$Content = [pscustomobject]@{Name = 'PowerShell'; Version = '7.0'}
 $Content | Export-Csv -Path .\ParmFile.csv -NoTypeInformation
-$AdditionalContent = [PSCustomObject]@{Name = 'Windows PowerShell'; Edition = 'Desktop'}
+$AdditionalContent = [pscustomobject]@{Name = 'Windows PowerShell'; Edition = 'Desktop'}
 $AdditionalContent | Export-Csv -Path .\ParmFile.csv -NoTypeInformation -Append
 ```
 
@@ -435,8 +435,8 @@ only the key is exported to CSV.
 
 ### -Append
 
-Use this parameter so that `Export-CSV` adds CSV output to the end of the specified file. Without
-this parameter, `Export-CSV` replaces the file contents without warning.
+Use this parameter so that `Export-Csv` adds CSV output to the end of the specified file. Without
+this parameter, `Export-Csv` replaces the file contents without warning.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -554,7 +554,7 @@ Accept wildcard characters: False
 ### -InputObject
 
 Specifies the objects to export as CSV strings. Enter a variable that contains the objects or type a
-command or expression that gets the objects. You can also pipe objects to `Export-CSV`.
+command or expression that gets the objects. You can also pipe objects to `Export-Csv`.
 
 ```yaml
 Type: System.Management.Automation.PSObject
@@ -589,8 +589,8 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Use this parameter so that `Export-CSV` does not overwrite an existing file. By default, if the file
-exists in the specified path, `Export-CSV` overwrites the file without warning.
+Use this parameter so that `Export-Csv` does not overwrite an existing file. By default, if the file
+exists in the specified path, `Export-Csv` overwrites the file without warning.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -772,13 +772,13 @@ PowerShell includes the following aliases for `Export-Csv`:
 - All platforms:
   - `epcsv`
 
-The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV strings and saves
-them in the specified text file. You can use `Export-CSV -IncludeTypeInformation` to save objects in
+The `Export-Csv` cmdlet converts the objects that you submit into a series of CSV strings and saves
+them in the specified text file. You can use `Export-Csv -IncludeTypeInformation` to save objects in
 a CSV file and then use the `Import-Csv` cmdlet to create objects from the text in the CSV file.
 
 In the CSV file, each object is represented by a character-separated list of the property values of
 the object. The property values are converted to strings using the **ToString()** method. The
-strings are represented by the property value name. `Export-CSV -IncludeTypeInformation` does not
+strings are represented by the property value name. `Export-Csv -IncludeTypeInformation` does not
 export the methods of the object.
 
 The CSV strings are output as follows:
@@ -790,12 +790,12 @@ The CSV strings are output as follows:
   headers contain the first object's property names as a character-separated list.
 - The remaining strings contain character-separated lists of each object's property values.
 
-Beginning with PowerShell 6.0 the default behavior of `Export-CSV` is to not include the **#TYPE**
+Beginning with PowerShell 6.0 the default behavior of `Export-Csv` is to not include the **#TYPE**
 information in the CSV and **NoTypeInformation** is implied. **IncludeTypeInformation** can be used
-to include the **#TYPE** Information and emulate the default behavior of `Export-CSV` prior to
+to include the **#TYPE** Information and emulate the default behavior of `Export-Csv` prior to
 PowerShell 6.0.
 
-When you submit multiple objects to `Export-CSV`, `Export-CSV` organizes the file based on the
+When you submit multiple objects to `Export-Csv`, `Export-Csv` organizes the file based on the
 properties of the first object that you submit. If the remaining objects do not have one of the
 specified properties, the property value of that object is null, as represented by two consecutive
 commas. If the remaining objects have additional properties, those property values are not included
@@ -806,7 +806,7 @@ resulting objects are CSV versions of the original objects that consist of strin
 the property values and no methods.
 
 The `ConvertTo-Csv` and `ConvertFrom-Csv` cmdlets convert objects to CSV strings and from CSV
-strings. `Export-CSV` is the same as `ConvertTo-CSV`, except that it saves the CSV strings in a
+strings. `Export-Csv` is the same as `ConvertTo-Csv`, except that it saves the CSV strings in a
 file.
 
 ## RELATED LINKS

--- a/reference/7.4/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -31,12 +31,12 @@ Export-FormatData -InputObject <ExtendedTypeDefinition[]> -LiteralPath <String> 
 
 ## DESCRIPTION
 
-The `Export-FormatData` cmdlet creates PowerShell formatting files (format.ps1xml) from
-the formatting objects in the current session. It takes the **ExtendedTypeDefinition** objects that
+The `Export-FormatData` cmdlet creates PowerShell formatting files (`format.ps1xml`) from the
+formatting objects in the current session. It takes the **ExtendedTypeDefinition** objects that
 `Get-FormatData` returns and saves them in a file in XML format.
 
-PowerShell uses the data in formatting files (format.ps1xml) to generate the default display
-of Microsoft .NET Framework objects in the session. You can view and edit the formatting files and
+PowerShell uses the data in formatting files (`format.ps1xml`) to generate the default display of
+Microsoft .NET Framework objects in the session. You can view and edit the formatting files and
 use the Update-FormatData cmdlet to add the formatting data to a session.
 
 For more information about formatting files in PowerShell, see [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
@@ -46,16 +46,16 @@ For more information about formatting files in PowerShell, see [about_Format.ps1
 ### Example 1: Export session format data
 
 ```powershell
-Get-FormatData -TypeName "*" | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
+Get-FormatData -TypeName "*" | Export-FormatData -Path "AllFormat.ps1xml" -IncludeScriptBlock
 ```
 
-This command exports all of the format data in the session to the AllFormat.ps1xml file.
+This command exports all of the format data in the session to the `AllFormat.ps1xml` file.
 
 The command uses the `Get-FormatData` cmdlet to get the format data in the session. A value of `*`
 (all) for the **TypeName** parameter directs the cmdlet to get all of the data in the session.
 
 The command uses a pipeline operator (`|`) to send the format data from the `Get-FormatData` command
-to the `Export-FormatData` cmdlet, which exports the format data to the AllFormat.ps1 file.
+to the `Export-FormatData` cmdlet, which exports the format data to the `AllFormat.ps1xml` file.
 
 The `Export-FormatData` command uses the **IncludeScriptBlock** parameter to include script blocks
 in the format data in the file.
@@ -64,10 +64,11 @@ in the format data in the file.
 
 ```powershell
 $F = Get-FormatData -TypeName "helpinfoshort"
-Export-FormatData -InputObject $F -Path "c:\test\help.format.ps1xml" -IncludeScriptBlock
+Export-FormatData -InputObject $F -Path "C:\test\Help.format.ps1xml" -IncludeScriptBlock
 ```
 
-These commands export the format data for the **HelpInfoShort** type to the Help.format.ps1xml file.
+These commands export the format data for the **HelpInfoShort** type to the `Help.format.ps1xml`
+file.
 
 The first command uses the `Get-FormatData` cmdlet to get the format data for the **HelpInfoShort**
 type, and it saves it in the `$F` variable.
@@ -79,8 +80,8 @@ script blocks in the output.
 ### Example 3: Export format data without a script block
 
 ```powershell
-Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path process.format.ps1xml
-Update-FormatData -PrependPath ".\process.format.ps1xml"
+Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path Process.format.ps1xml
+Update-FormatData -PrependPath ".\Process.format.ps1xml"
 Get-Process p*
 ```
 
@@ -98,14 +99,14 @@ This example shows the effect of omitting the **IncludeScriptBlock** parameter f
 The first command uses the `Get-FormatData` cmdlet to get the format data for the
 **System.Diagnostics.Process** object that the Get-Process cmdlet returns. The command uses a
 pipeline operator (`|`) to send the formatting data to the `Export-FormatData` cmdlet, which exports
-it to the Process.format.ps1xml file in the current directory.
+it to the `Process.format.ps1xml` file in the current directory.
 
 In this case, the `Export-FormatData` command does not use the **IncludeScriptBlock** parameter.
 
-The second command uses the `Update-FormatData` cmdlet to add the Process.format.ps1xml file to the
-current session. The command uses the **PrependPath** parameter to ensure that the formatting data for
-process objects in the Process.format.ps1xml file is found before the standard formatting data for
-process objects.
+The second command uses the `Update-FormatData` cmdlet to add the `Process.format.ps1xml` file to
+the current session. The command uses the **PrependPath** parameter to ensure that the formatting
+data for process objects in the Process.format.ps1xml file is found before the standard formatting
+data for process objects.
 
 The third command shows the effects of this change. The command uses the `Get-Process` cmdlet to
 get processes that have names that begin with P. The output shows that property values that are
@@ -206,10 +207,10 @@ Accept wildcard characters: False
 ### -Path
 
 Specifies a location for the output file.
-Enter a path (optional) and file name with a format.ps1xml file name extension.
+Enter a path (optional) and file name with a `format.ps1xml` file name extension.
 If you omit the path, `Export-FormatData` creates the file in the current directory.
 
-If you use a file name extension other than .ps1xml, the `Update-FormatData` cmdlet will not
+If you use a file name extension other than `.ps1xml`, the `Update-FormatData` cmdlet will not
 recognize the file.
 
 If you specify an existing file, `Export-FormatData` overwrites the file without warning, unless

--- a/reference/7.4/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -70,7 +70,7 @@ This example exports all of the `Get` and `Set` commands from a server.
 
 ```powershell
 $S = New-PSSession -ConnectionUri https://exchange.microsoft.com/mailbox -Credential exchangeadmin01@hotmail.com -Authentication Negotiate
-Export-PSSession -Session $S -Module exch* -CommandName Get-*, Set-* -FormatTypeName * -OutputModule $PSHOME\Modules\Exchange -Encoding ASCII
+Export-PSSession -Session $S -Module exch* -CommandName Get-*, Set-* -FormatTypeName * -OutputModule $PSHOME\Modules\Exchange -Encoding ascii
 ```
 
 These commands export the `Get` and `Set` commands from a Microsoft Exchange Server snap-in on a
@@ -185,7 +185,7 @@ Exports the variant of the command that results from using the specified argumen
 values).
 
 For example, to export the variant of the `Get-Item` command in the certificate (Cert:) drive in
-the PSSession in `$S`, type `Export-PSSession -Session $S -Command Get-Item -ArgumentList cert:`.
+the PSSession in `$S`, type `Export-PSSession -Session $S -Command Get-Item -ArgumentList Cert:`.
 
 ```yaml
 Type: System.Object[]
@@ -202,7 +202,7 @@ Accept wildcard characters: False
 ### -Certificate
 
 Specifies the client certificate that is used to sign the format files (*.Format.ps1xml) or script
-module files (.psm1) in the module that `Export-PSSession` creates. Enter a variable that contains
+module files (`.psm1`) in the module that `Export-PSSession` creates. Enter a variable that contains
 a certificate or a command or expression that gets the certificate.
 
 To find a certificate, use the `Get-PfxCertificate` cmdlet or use the `Get-ChildItem` cmdlet in the
@@ -255,13 +255,13 @@ The acceptable values for this parameter are as follows:
 
 - `Alias`: All PowerShell aliases in the current session.
 - `All`: All command types. It is the equivalent of `Get-Command -Name *`.
-- `Application`: All files other than PowerShell files in paths listed in the Path environment
-  variable (`$env:path`), including .txt, .exe, and .dll files.
+- `Application`: All files other than PowerShell files in paths listed in the PATH environment
+  variable (`$Env:PATH`), including .txt, .exe, and .dll files.
 - `Cmdlet`: The cmdlets in the current session. Cmdlet is the default.
 - `Configuration`: A PowerShell configuration. For more information, see
   [about_Session_Configurations](../Microsoft.PowerShell.Core/About/about_Session_Configurations.md).
-- `ExternalScript`: All .ps1 files in the paths listed in the Path environment variable
-  (`$env:path`).
+- `ExternalScript`: All `.ps1` files in the paths listed in the PATH environment variable
+  (`$Env:PATH`).
 - `Filter` and `Function`: All PowerShell functions.
 - `Script` Script blocks in the current session.
 - `Workflow` A PowerShell workflow. For more information, see [about_Workflows](/powershell/module/PSWorkflow/About/about_Workflows).

--- a/reference/7.4/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -225,7 +225,7 @@ Specifies the objects to be formatted. Enter a variable that contains the object
 or expression that gets the objects.
 
 Only certain [scalar](/powershell/scripting/learn/glossary#scalar-value) types and
-`[system.io.fileinfo]` are supported.
+`[System.IO.FileInfo]` are supported.
 
 The supported scalar types are:
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Format-List.md
@@ -317,7 +317,7 @@ If you do not use a format cmdlet, PowerShell applies that default format for ea
 displays.
 
 The **View** parameter lets you specify an alternate format for the table. You can use the views
-defined in the `*.format.PS1XML` files in the PowerShell directory, or you can create your own views
+defined in the `*.format.ps1xml` files in the PowerShell directory, or you can create your own views
 in new PS1XML files and use the `Update-FormatData` cmdlet to include them in PowerShell.
 
 The alternate view for the **View** parameter must use the list format, otherwise, the command

--- a/reference/7.4/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Format-Table.md
@@ -103,7 +103,7 @@ more information about views and the code used to create this example's view, se
 [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md#sample-xml-for-a-format-table-custom-view).
 
 ```powershell
-Get-ChildItem  -Path C:\Test | Format-Table -View mygciview
+Get-ChildItem  -Path C:\Test | Format-Table -View MyGciView
 ```
 
 ```Output
@@ -121,7 +121,7 @@ d-----       10/23/2019     09:38       2/25/2019     09:38                Files
 
 `Get-ChildItem` gets the contents of the current directory, `C:\Test`. The
 **System.IO.DirectoryInfo** and **System.IO.FileInfo** objects are sent down the pipeline.
-`Format-Table` uses the **View** parameter to specify the custom view **mygciview** that includes
+`Format-Table` uses the **View** parameter to specify the custom view **MyGciView** that includes
 the **CreationTime** column.
 
 The default `Format-Table` output for `Get-ChildItem` doesn't include the **CreationTime** column.
@@ -177,7 +177,7 @@ local computer. You can use `Get-CimInstance` with the **ComputerName** paramete
 from remote computers.
 
 ```powershell
-$Processes = Get-CimInstance -Class win32_process -Filter "name='notepad.exe'"
+$Processes = Get-CimInstance -Class Win32_Process -Filter "name='notepad.exe'"
 $Processes | Format-Table ProcessName, @{
     Label = "Total Running Time"
     Expression={(Get-Date) - $_.CreationDate}

--- a/reference/7.4/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -46,7 +46,7 @@ output. The **Column** parameter specifies the number of columns.
 This command displays the names of registry keys in the `HKEY_CURRENT_USER\Software\Microsoft` key.
 
 ```powershell
-Get-ChildItem HKCU:\software\microsoft | Format-Wide -Property pschildname -AutoSize
+Get-ChildItem HKCU:\software\Microsoft | Format-Wide -Property PSChildName -AutoSize
 ```
 
 The `Get-ChildItem` cmdlet gets objects representing the keys. The path is specified as `HKCU:`, one
@@ -310,7 +310,7 @@ PowerShell includes the following aliases for `Format-Wide`:
   - `fw`
 
 The **View** parameter lets you specify an alternate format for the table. You can use the views
-defined in the `*.format.PS1XML` files in the PowerShell directory or you can create your own views
+defined in the `*.format.ps1xml` files in the PowerShell directory or you can create your own views
 in new PS1XML files and use the `Update-FormatData` cmdlet to include them in PowerShell.
 
 The alternate view for the **View** parameter must use table format; if it does not, the command

--- a/reference/7.5/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 ### -InputObject
 
 Specifies the object to be converted. Enter a variable that contains the objects, or type a command
-or expression that gets the objects. You can also pipe objects to `ConvertTo-XML`.
+or expression that gets the objects. You can also pipe objects to `ConvertTo-Xml`.
 
 ```yaml
 Type: System.Management.Automation.PSObject

--- a/reference/7.5/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -128,7 +128,7 @@ The acceptable values for this parameter are:
 
 - CSV. Comma-separated value (CSV) format.
 - Script. Creates a `Set-Alias` command for each exported alias. If you name the output file with a
-  .ps1 file name extension, you can run it as a script to add the aliases to any session.
+  `.ps1` file name extension, you can run it as a script to add the aliases to any session.
 
 ```yaml
 Type: Microsoft.PowerShell.Commands.ExportAliasFormat

--- a/reference/7.5/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -37,7 +37,7 @@ recreate the saved object based on the contents of that file. For more informati
 [Language independence](/dotnet/standard/language-independence).
 
 This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
-file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+file. `ConvertTo-Xml` returns the XML, so you can continue to process it in PowerShell.
 
 A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
 securely as XML. For an example, see Example 3.

--- a/reference/7.5/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -36,11 +36,11 @@ Export-Csv -InputObject <PSObject> [[-Path] <String>] [-LiteralPath <String>] [-
 
 ## DESCRIPTION
 
-The `Export-CSV` cmdlet creates a CSV file of the objects that you submit. Each object is a row that
-includes a character-separated list of the object's property values. You can use the `Export-CSV`
+The `Export-Csv` cmdlet creates a CSV file of the objects that you submit. Each object is a row that
+includes a character-separated list of the object's property values. You can use the `Export-Csv`
 cmdlet to create spreadsheets and share data with programs that accept CSV files as input.
 
-Do not format objects before sending them to the `Export-CSV` cmdlet. If `Export-CSV` receives
+Do not format objects before sending them to the `Export-Csv` cmdlet. If `Export-Csv` receives
 formatted objects the CSV file contains the format properties rather than the object properties. To
 export only selected properties of an object, use the `Select-Object` cmdlet.
 
@@ -308,9 +308,9 @@ This example shows how to use the **Force** and **Append** parameters. When thes
 combined, mismatched object properties can be written to a CSV file.
 
 ```powershell
-$Content = [PSCustomObject]@{Name = 'PowerShell'; Version = '7.0'}
+$Content = [pscustomobject]@{Name = 'PowerShell'; Version = '7.0'}
 $Content | Export-Csv -Path .\ParmFile.csv -NoTypeInformation
-$AdditionalContent = [PSCustomObject]@{Name = 'Windows PowerShell'; Edition = 'Desktop'}
+$AdditionalContent = [pscustomobject]@{Name = 'Windows PowerShell'; Edition = 'Desktop'}
 $AdditionalContent | Export-Csv -Path .\ParmFile.csv -NoTypeInformation -Append
 ```
 
@@ -439,8 +439,8 @@ only the key is exported to CSV.
 
 ### -Append
 
-Use this parameter so that `Export-CSV` adds CSV output to the end of the specified file. Without
-this parameter, `Export-CSV` replaces the file contents without warning.
+Use this parameter so that `Export-Csv` adds CSV output to the end of the specified file. Without
+this parameter, `Export-Csv` replaces the file contents without warning.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -558,7 +558,7 @@ Accept wildcard characters: False
 ### -InputObject
 
 Specifies the objects to export as CSV strings. Enter a variable that contains the objects or type a
-command or expression that gets the objects. You can also pipe objects to `Export-CSV`.
+command or expression that gets the objects. You can also pipe objects to `Export-Csv`.
 
 ```yaml
 Type: System.Management.Automation.PSObject
@@ -593,8 +593,8 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Use this parameter so that `Export-CSV` does not overwrite an existing file. By default, if the file
-exists in the specified path, `Export-CSV` overwrites the file without warning.
+Use this parameter so that `Export-Csv` does not overwrite an existing file. By default, if the file
+exists in the specified path, `Export-Csv` overwrites the file without warning.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -776,13 +776,13 @@ PowerShell includes the following aliases for `Export-Csv`:
 - All platforms:
   - `epcsv`
 
-The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV strings and saves
-them in the specified text file. You can use `Export-CSV -IncludeTypeInformation` to save objects in
+The `Export-Csv` cmdlet converts the objects that you submit into a series of CSV strings and saves
+them in the specified text file. You can use `Export-Csv -IncludeTypeInformation` to save objects in
 a CSV file and then use the `Import-Csv` cmdlet to create objects from the text in the CSV file.
 
 In the CSV file, each object is represented by a character-separated list of the property values of
 the object. The property values are converted to strings using the **ToString()** method. The
-strings are represented by the property value name. `Export-CSV -IncludeTypeInformation` does not
+strings are represented by the property value name. `Export-Csv -IncludeTypeInformation` does not
 export the methods of the object.
 
 The CSV strings are output as follows:
@@ -794,12 +794,12 @@ The CSV strings are output as follows:
   headers contain the first object's property names as a character-separated list.
 - The remaining strings contain character-separated lists of each object's property values.
 
-Beginning with PowerShell 6.0 the default behavior of `Export-CSV` is to not include the **#TYPE**
+Beginning with PowerShell 6.0 the default behavior of `Export-Csv` is to not include the **#TYPE**
 information in the CSV and **NoTypeInformation** is implied. **IncludeTypeInformation** can be used
-to include the **#TYPE** Information and emulate the default behavior of `Export-CSV` prior to
+to include the **#TYPE** Information and emulate the default behavior of `Export-Csv` prior to
 PowerShell 6.0.
 
-When you submit multiple objects to `Export-CSV`, `Export-CSV` organizes the file based on the
+When you submit multiple objects to `Export-Csv`, `Export-Csv` organizes the file based on the
 properties of the first object that you submit. If the remaining objects do not have one of the
 specified properties, the property value of that object is null, as represented by two consecutive
 commas. If the remaining objects have additional properties, those property values are not included
@@ -810,7 +810,7 @@ resulting objects are CSV versions of the original objects that consist of strin
 the property values and no methods.
 
 The `ConvertTo-Csv` and `ConvertFrom-Csv` cmdlets convert objects to CSV strings and from CSV
-strings. `Export-CSV` is the same as `ConvertTo-CSV`, except that it saves the CSV strings in a
+strings. `Export-Csv` is the same as `ConvertTo-Csv`, except that it saves the CSV strings in a
 file.
 
 ## RELATED LINKS

--- a/reference/7.5/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -31,11 +31,11 @@ Export-FormatData -InputObject <ExtendedTypeDefinition[]> -LiteralPath <String> 
 
 ## DESCRIPTION
 
-The `Export-FormatData` cmdlet creates PowerShell formatting files (format.ps1xml) from the
+The `Export-FormatData` cmdlet creates PowerShell formatting files (`format.ps1xml`) from the
 formatting objects in the current session. It takes the **ExtendedTypeDefinition** objects that
 `Get-FormatData` returns and saves them in a file in XML format.
 
-PowerShell uses the data in formatting files (format.ps1xml) to generate the default display of
+PowerShell uses the data in formatting files (`format.ps1xml`) to generate the default display of
 Microsoft .NET Framework objects in the session. You can view and edit the formatting files and
 use the Update-FormatData cmdlet to add the formatting data to a session.
 
@@ -51,13 +51,13 @@ Get-FormatData -TypeName "*" |
     Export-FormatData -Path "AllFormat.ps1xml" -IncludeScriptBlock
 ```
 
-This command exports all of the format data in the session to the AllFormat.ps1xml file.
+This command exports all of the format data in the session to the `AllFormat.ps1xml` file.
 
 The command uses the `Get-FormatData` cmdlet to get the format data in the session. A value of `*`
 (all) for the **TypeName** parameter directs the cmdlet to get all of the data in the session.
 
 The command uses a pipeline operator (`|`) to send the format data from the `Get-FormatData` command
-to the `Export-FormatData` cmdlet, which exports the format data to the AllFormat.ps1xml file.
+to the `Export-FormatData` cmdlet, which exports the format data to the `AllFormat.ps1xml` file.
 
 The `Export-FormatData` command uses the **IncludeScriptBlock** parameter to include script blocks
 in the format data in the file.
@@ -66,10 +66,11 @@ in the format data in the file.
 
 ```powershell
 $F = Get-FormatData -TypeName "HelpInfoShort"
-Export-FormatData -InputObject $F -Path "c:\test\Help.format.ps1xml" -IncludeScriptBlock
+Export-FormatData -InputObject $F -Path "C:\test\Help.format.ps1xml" -IncludeScriptBlock
 ```
 
-These commands export the format data for the **HelpInfoShort** type to the Help.format.ps1xml file.
+These commands export the format data for the **HelpInfoShort** type to the `Help.format.ps1xml`
+file.
 
 The first command uses the `Get-FormatData` cmdlet to get the format data for the **HelpInfoShort**
 type, and it saves it in the `$F` variable.
@@ -82,7 +83,7 @@ script blocks in the output.
 
 ```powershell
 Get-FormatData -TypeName "System.Diagnostics.Process" |
-    Export-FormatData -Path process.format.ps1xml
+    Export-FormatData -Path Process.format.ps1xml
 Update-FormatData -PrependPath ".\Process.format.ps1xml"
 Get-Process p*
 ```
@@ -101,14 +102,14 @@ This example shows the effect of omitting the **IncludeScriptBlock** parameter f
 The first command uses the `Get-FormatData` cmdlet to get the format data for the
 **System.Diagnostics.Process** object that the Get-Process cmdlet returns. The command uses a
 pipeline operator (`|`) to send the formatting data to the `Export-FormatData` cmdlet, which exports
-it to the Process.format.ps1xml file in the current directory.
+it to the `Process.format.ps1xml` file in the current directory.
 
 In this case, the `Export-FormatData` command does not use the **IncludeScriptBlock** parameter.
 
-The second command uses the `Update-FormatData` cmdlet to add the Process.format.ps1xml file to the
-current session. The command uses the **PrependPath** parameter to ensure that the formatting data
-for process objects in the Process.format.ps1xml file is found before the standard formatting data
-for process objects.
+The second command uses the `Update-FormatData` cmdlet to add the `Process.format.ps1xml` file to
+the current session. The command uses the **PrependPath** parameter to ensure that the formatting
+data for process objects in the Process.format.ps1xml file is found before the standard formatting
+data for process objects.
 
 The third command shows the effects of this change. The command uses the `Get-Process` cmdlet to
 get processes that have names that begin with P. The output shows that property values that are
@@ -209,10 +210,10 @@ Accept wildcard characters: False
 ### -Path
 
 Specifies a location for the output file. Enter a path (optional) and file name with a
-format.ps1xml file name extension. If you omit the path, `Export-FormatData` creates the file in
+`format.ps1xml` file name extension. If you omit the path, `Export-FormatData` creates the file in
 the current directory.
 
-If you use a file name extension other than .ps1xml, the `Update-FormatData` cmdlet will not
+If you use a file name extension other than `.ps1xml`, the `Update-FormatData` cmdlet will not
 recognize the file.
 
 If you specify an existing file, `Export-FormatData` overwrites the file without warning, unless

--- a/reference/7.5/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -81,7 +81,7 @@ $exportSession = @{
     CommandName = 'Get-*', 'Set-*'
     FormatTypeName = '*'
     OutputModule = "$PSHOME\Modules\Exchange"
-    Encoding = 'ASCII'
+    Encoding = 'ascii'
 }
 
 Export-PSSession @exportSession
@@ -212,7 +212,7 @@ Exports the variant of the command that results from using the specified argumen
 values).
 
 For example, to export the variant of the `Get-Item` command in the certificate (Cert:) drive in
-the PSSession in `$S`, type `Export-PSSession -Session $S -Command Get-Item -ArgumentList cert:`.
+the PSSession in `$S`, type `Export-PSSession -Session $S -Command Get-Item -ArgumentList Cert:`.
 
 ```yaml
 Type: System.Object[]
@@ -229,7 +229,7 @@ Accept wildcard characters: False
 ### -Certificate
 
 Specifies the client certificate that is used to sign the format files (*.Format.ps1xml) or script
-module files (.psm1) in the module that `Export-PSSession` creates. Enter a variable that contains
+module files (`.psm1`) in the module that `Export-PSSession` creates. Enter a variable that contains
 a certificate or a command or expression that gets the certificate.
 
 To find a certificate, use the `Get-PfxCertificate` cmdlet or use the `Get-ChildItem` cmdlet in the
@@ -282,13 +282,13 @@ The acceptable values for this parameter are as follows:
 
 - `Alias`: All PowerShell aliases in the current session.
 - `All`: All command types. It is the equivalent of `Get-Command -Name *`.
-- `Application`: All files other than PowerShell files in paths listed in the Path environment
-  variable (`$env:path`), including .txt, .exe, and .dll files.
+- `Application`: All files other than PowerShell files in paths listed in the PATH environment
+  variable (`$Env:PATH`), including .txt, .exe, and .dll files.
 - `Cmdlet`: The cmdlets in the current session. Cmdlet is the default.
 - `Configuration`: A PowerShell configuration. For more information, see
   [about_Session_Configurations](../Microsoft.PowerShell.Core/About/about_Session_Configurations.md).
-- `ExternalScript`: All .ps1 files in the paths listed in the Path environment variable
-  (`$env:path`).
+- `ExternalScript`: All `.ps1` files in the paths listed in the PATH environment variable
+  (`$Env:PATH`).
 - `Filter` and `Function`: All PowerShell functions.
 - `Script` Script blocks in the current session.
 - `Workflow` A PowerShell workflow. For more information, see

--- a/reference/7.5/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -225,7 +225,7 @@ Specifies the objects to be formatted. Enter a variable that contains the object
 or expression that gets the objects.
 
 Only certain [scalar](/powershell/scripting/learn/glossary#scalar-value) types and
-`[system.io.fileinfo]` are supported.
+`[System.IO.FileInfo]` are supported.
 
 The supported scalar types are:
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Format-List.md
@@ -318,7 +318,7 @@ If you do not use a format cmdlet, PowerShell applies that default format for ea
 displays.
 
 The **View** parameter lets you specify an alternate format for the table. You can use the views
-defined in the `*.format.PS1XML` files in the PowerShell directory, or you can create your own views
+defined in the `*.format.ps1xml` files in the PowerShell directory, or you can create your own views
 in new PS1XML files and use the `Update-FormatData` cmdlet to include them in PowerShell.
 
 The alternate view for the **View** parameter must use the list format, otherwise, the command

--- a/reference/7.5/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Format-Table.md
@@ -104,7 +104,7 @@ more information about views and the code used to create this example's view, se
 [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md#sample-xml-for-a-format-table-custom-view).
 
 ```powershell
-Get-ChildItem  -Path C:\Test | Format-Table -View mygciview
+Get-ChildItem  -Path C:\Test | Format-Table -View MyGciView
 ```
 
 ```Output
@@ -122,7 +122,7 @@ d-----       10/23/2019     09:38       2/25/2019     09:38                Files
 
 `Get-ChildItem` gets the contents of the current directory, `C:\Test`. The
 **System.IO.DirectoryInfo** and **System.IO.FileInfo** objects are sent down the pipeline.
-`Format-Table` uses the **View** parameter to specify the custom view **mygciview** that includes
+`Format-Table` uses the **View** parameter to specify the custom view **MyGciView** that includes
 the **CreationTime** column.
 
 The default `Format-Table` output for `Get-ChildItem` doesn't include the **CreationTime** column.
@@ -181,7 +181,7 @@ local computer. You can use `Get-CimInstance` with the **ComputerName** paramete
 from remote computers.
 
 ```powershell
-$Processes = Get-CimInstance -Class win32_process -Filter "name='notepad.exe'"
+$Processes = Get-CimInstance -Class Win32_Process -Filter "name='notepad.exe'"
 $Processes | Format-Table ProcessName, @{
     Label = "Total Running Time"
     Expression = {(Get-Date) - $_.CreationDate}

--- a/reference/7.5/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -46,7 +46,7 @@ output. The **Column** parameter specifies the number of columns.
 This command displays the names of registry keys in the `HKEY_CURRENT_USER\Software\Microsoft` key.
 
 ```powershell
-Get-ChildItem HKCU:\software\microsoft | Format-Wide -Property PSChildName -AutoSize
+Get-ChildItem HKCU:\software\Microsoft | Format-Wide -Property PSChildName -AutoSize
 ```
 
 The `Get-ChildItem` cmdlet gets objects representing the keys. The path is specified as `HKCU:`, one
@@ -310,7 +310,7 @@ PowerShell includes the following aliases for `Format-Wide`:
   - `fw`
 
 The **View** parameter lets you specify an alternate format for the table. You can use the views
-defined in the `*.format.PS1XML` files in the PowerShell directory or you can create your own views
+defined in the `*.format.ps1xml` files in the PowerShell directory or you can create your own views
 in new PS1XML files and use the `Update-FormatData` cmdlet to include them in PowerShell.
 
 The alternate view for the **View** parameter must use table format; if it does not, the command

--- a/reference/7.6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 ### -InputObject
 
 Specifies the object to be converted. Enter a variable that contains the objects, or type a command
-or expression that gets the objects. You can also pipe objects to `ConvertTo-XML`.
+or expression that gets the objects. You can also pipe objects to `ConvertTo-Xml`.
 
 ```yaml
 Type: System.Management.Automation.PSObject

--- a/reference/7.6/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -128,7 +128,7 @@ The acceptable values for this parameter are:
 
 - CSV. Comma-separated value (CSV) format.
 - Script. Creates a `Set-Alias` command for each exported alias. If you name the output file with a
-  .ps1 file name extension, you can run it as a script to add the aliases to any session.
+  `.ps1` file name extension, you can run it as a script to add the aliases to any session.
 
 ```yaml
 Type: Microsoft.PowerShell.Commands.ExportAliasFormat

--- a/reference/7.6/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -37,7 +37,7 @@ recreate the saved object based on the contents of that file. For more informati
 [Language independence](/dotnet/standard/language-independence).
 
 This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in a
-file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+file. `ConvertTo-Xml` returns the XML, so you can continue to process it in PowerShell.
 
 A valuable use of `Export-Clixml` on Windows computers is to export credentials and secure strings
 securely as XML. For an example, see Example 3.

--- a/reference/7.6/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -36,11 +36,11 @@ Export-Csv -InputObject <PSObject> [[-Path] <String>] [-LiteralPath <String>] [-
 
 ## DESCRIPTION
 
-The `Export-CSV` cmdlet creates a CSV file of the objects that you submit. Each object is a row that
-includes a character-separated list of the object's property values. You can use the `Export-CSV`
+The `Export-Csv` cmdlet creates a CSV file of the objects that you submit. Each object is a row that
+includes a character-separated list of the object's property values. You can use the `Export-Csv`
 cmdlet to create spreadsheets and share data with programs that accept CSV files as input.
 
-Do not format objects before sending them to the `Export-CSV` cmdlet. If `Export-CSV` receives
+Do not format objects before sending them to the `Export-Csv` cmdlet. If `Export-Csv` receives
 formatted objects the CSV file contains the format properties rather than the object properties. To
 export only selected properties of an object, use the `Select-Object` cmdlet.
 
@@ -304,9 +304,9 @@ This example shows how to use the **Force** and **Append** parameters. When thes
 combined, mismatched object properties can be written to a CSV file.
 
 ```powershell
-$Content = [PSCustomObject]@{Name = 'PowerShell'; Version = '7.0'}
+$Content = [pscustomobject]@{Name = 'PowerShell'; Version = '7.0'}
 $Content | Export-Csv -Path .\ParmFile.csv -NoTypeInformation
-$AdditionalContent = [PSCustomObject]@{Name = 'Windows PowerShell'; Edition = 'Desktop'}
+$AdditionalContent = [pscustomobject]@{Name = 'Windows PowerShell'; Edition = 'Desktop'}
 $AdditionalContent | Export-Csv -Path .\ParmFile.csv -NoTypeInformation -Append
 ```
 
@@ -435,8 +435,8 @@ only the key is exported to CSV.
 
 ### -Append
 
-Use this parameter so that `Export-CSV` adds CSV output to the end of the specified file. Without
-this parameter, `Export-CSV` replaces the file contents without warning.
+Use this parameter so that `Export-Csv` adds CSV output to the end of the specified file. Without
+this parameter, `Export-Csv` replaces the file contents without warning.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -554,7 +554,7 @@ Accept wildcard characters: False
 ### -InputObject
 
 Specifies the objects to export as CSV strings. Enter a variable that contains the objects or type a
-command or expression that gets the objects. You can also pipe objects to `Export-CSV`.
+command or expression that gets the objects. You can also pipe objects to `Export-Csv`.
 
 ```yaml
 Type: System.Management.Automation.PSObject
@@ -589,8 +589,8 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Use this parameter so that `Export-CSV` does not overwrite an existing file. By default, if the file
-exists in the specified path, `Export-CSV` overwrites the file without warning.
+Use this parameter so that `Export-Csv` does not overwrite an existing file. By default, if the file
+exists in the specified path, `Export-Csv` overwrites the file without warning.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -772,13 +772,13 @@ PowerShell includes the following aliases for `Export-Csv`:
 - All platforms:
   - `epcsv`
 
-The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV strings and saves
-them in the specified text file. You can use `Export-CSV -IncludeTypeInformation` to save objects in
+The `Export-Csv` cmdlet converts the objects that you submit into a series of CSV strings and saves
+them in the specified text file. You can use `Export-Csv -IncludeTypeInformation` to save objects in
 a CSV file and then use the `Import-Csv` cmdlet to create objects from the text in the CSV file.
 
 In the CSV file, each object is represented by a character-separated list of the property values of
 the object. The property values are converted to strings using the **ToString()** method. The
-strings are represented by the property value name. `Export-CSV -IncludeTypeInformation` does not
+strings are represented by the property value name. `Export-Csv -IncludeTypeInformation` does not
 export the methods of the object.
 
 The CSV strings are output as follows:
@@ -790,12 +790,12 @@ The CSV strings are output as follows:
   headers contain the first object's property names as a character-separated list.
 - The remaining strings contain character-separated lists of each object's property values.
 
-Beginning with PowerShell 6.0 the default behavior of `Export-CSV` is to not include the **#TYPE**
+Beginning with PowerShell 6.0 the default behavior of `Export-Csv` is to not include the **#TYPE**
 information in the CSV and **NoTypeInformation** is implied. **IncludeTypeInformation** can be used
-to include the **#TYPE** Information and emulate the default behavior of `Export-CSV` prior to
+to include the **#TYPE** Information and emulate the default behavior of `Export-Csv` prior to
 PowerShell 6.0.
 
-When you submit multiple objects to `Export-CSV`, `Export-CSV` organizes the file based on the
+When you submit multiple objects to `Export-Csv`, `Export-Csv` organizes the file based on the
 properties of the first object that you submit. If the remaining objects do not have one of the
 specified properties, the property value of that object is null, as represented by two consecutive
 commas. If the remaining objects have additional properties, those property values are not included
@@ -806,7 +806,7 @@ resulting objects are CSV versions of the original objects that consist of strin
 the property values and no methods.
 
 The `ConvertTo-Csv` and `ConvertFrom-Csv` cmdlets convert objects to CSV strings and from CSV
-strings. `Export-CSV` is the same as `ConvertTo-CSV`, except that it saves the CSV strings in a
+strings. `Export-Csv` is the same as `ConvertTo-Csv`, except that it saves the CSV strings in a
 file.
 
 ## RELATED LINKS

--- a/reference/7.6/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -31,12 +31,12 @@ Export-FormatData -InputObject <ExtendedTypeDefinition[]> -LiteralPath <String> 
 
 ## DESCRIPTION
 
-The `Export-FormatData` cmdlet creates PowerShell formatting files (format.ps1xml) from
-the formatting objects in the current session. It takes the **ExtendedTypeDefinition** objects that
+The `Export-FormatData` cmdlet creates PowerShell formatting files (`format.ps1xml`) from the
+formatting objects in the current session. It takes the **ExtendedTypeDefinition** objects that
 `Get-FormatData` returns and saves them in a file in XML format.
 
-PowerShell uses the data in formatting files (format.ps1xml) to generate the default display
-of Microsoft .NET Framework objects in the session. You can view and edit the formatting files and
+PowerShell uses the data in formatting files (`format.ps1xml`) to generate the default display of
+Microsoft .NET Framework objects in the session. You can view and edit the formatting files and
 use the Update-FormatData cmdlet to add the formatting data to a session.
 
 For more information about formatting files in PowerShell, see [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md).
@@ -46,16 +46,16 @@ For more information about formatting files in PowerShell, see [about_Format.ps1
 ### Example 1: Export session format data
 
 ```powershell
-Get-FormatData -TypeName "*" | Export-FormatData -Path "allformat.ps1xml" -IncludeScriptBlock
+Get-FormatData -TypeName "*" | Export-FormatData -Path "AllFormat.ps1xml" -IncludeScriptBlock
 ```
 
-This command exports all of the format data in the session to the AllFormat.ps1xml file.
+This command exports all of the format data in the session to the `AllFormat.ps1xml` file.
 
 The command uses the `Get-FormatData` cmdlet to get the format data in the session. A value of `*`
 (all) for the **TypeName** parameter directs the cmdlet to get all of the data in the session.
 
 The command uses a pipeline operator (`|`) to send the format data from the `Get-FormatData` command
-to the `Export-FormatData` cmdlet, which exports the format data to the AllFormat.ps1 file.
+to the `Export-FormatData` cmdlet, which exports the format data to the `AllFormat.ps1xml` file.
 
 The `Export-FormatData` command uses the **IncludeScriptBlock** parameter to include script blocks
 in the format data in the file.
@@ -64,10 +64,11 @@ in the format data in the file.
 
 ```powershell
 $F = Get-FormatData -TypeName "helpinfoshort"
-Export-FormatData -InputObject $F -Path "c:\test\help.format.ps1xml" -IncludeScriptBlock
+Export-FormatData -InputObject $F -Path "C:\test\Help.format.ps1xml" -IncludeScriptBlock
 ```
 
-These commands export the format data for the **HelpInfoShort** type to the Help.format.ps1xml file.
+These commands export the format data for the **HelpInfoShort** type to the `Help.format.ps1xml`
+file.
 
 The first command uses the `Get-FormatData` cmdlet to get the format data for the **HelpInfoShort**
 type, and it saves it in the `$F` variable.
@@ -79,8 +80,8 @@ script blocks in the output.
 ### Example 3: Export format data without a script block
 
 ```powershell
-Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path process.format.ps1xml
-Update-FormatData -PrependPath ".\process.format.ps1xml"
+Get-FormatData -TypeName "System.Diagnostics.Process" | Export-FormatData -Path Process.format.ps1xml
+Update-FormatData -PrependPath ".\Process.format.ps1xml"
 Get-Process p*
 ```
 
@@ -98,14 +99,14 @@ This example shows the effect of omitting the **IncludeScriptBlock** parameter f
 The first command uses the `Get-FormatData` cmdlet to get the format data for the
 **System.Diagnostics.Process** object that the Get-Process cmdlet returns. The command uses a
 pipeline operator (`|`) to send the formatting data to the `Export-FormatData` cmdlet, which exports
-it to the Process.format.ps1xml file in the current directory.
+it to the `Process.format.ps1xml` file in the current directory.
 
 In this case, the `Export-FormatData` command does not use the **IncludeScriptBlock** parameter.
 
-The second command uses the `Update-FormatData` cmdlet to add the Process.format.ps1xml file to the
-current session. The command uses the **PrependPath** parameter to ensure that the formatting data for
-process objects in the Process.format.ps1xml file is found before the standard formatting data for
-process objects.
+The second command uses the `Update-FormatData` cmdlet to add the `Process.format.ps1xml` file to
+the current session. The command uses the **PrependPath** parameter to ensure that the formatting
+data for process objects in the Process.format.ps1xml file is found before the standard formatting
+data for process objects.
 
 The third command shows the effects of this change. The command uses the `Get-Process` cmdlet to
 get processes that have names that begin with P. The output shows that property values that are
@@ -206,10 +207,10 @@ Accept wildcard characters: False
 ### -Path
 
 Specifies a location for the output file.
-Enter a path (optional) and file name with a format.ps1xml file name extension.
+Enter a path (optional) and file name with a `format.ps1xml` file name extension.
 If you omit the path, `Export-FormatData` creates the file in the current directory.
 
-If you use a file name extension other than .ps1xml, the `Update-FormatData` cmdlet will not
+If you use a file name extension other than `.ps1xml`, the `Update-FormatData` cmdlet will not
 recognize the file.
 
 If you specify an existing file, `Export-FormatData` overwrites the file without warning, unless

--- a/reference/7.6/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -70,7 +70,7 @@ This example exports all of the `Get` and `Set` commands from a server.
 
 ```powershell
 $S = New-PSSession -ConnectionUri https://exchange.microsoft.com/mailbox -Credential exchangeadmin01@hotmail.com -Authentication Negotiate
-Export-PSSession -Session $S -Module exch* -CommandName Get-*, Set-* -FormatTypeName * -OutputModule $PSHOME\Modules\Exchange -Encoding ASCII
+Export-PSSession -Session $S -Module exch* -CommandName Get-*, Set-* -FormatTypeName * -OutputModule $PSHOME\Modules\Exchange -Encoding ascii
 ```
 
 These commands export the `Get` and `Set` commands from a Microsoft Exchange Server snap-in on a
@@ -185,7 +185,7 @@ Exports the variant of the command that results from using the specified argumen
 values).
 
 For example, to export the variant of the `Get-Item` command in the certificate (Cert:) drive in
-the PSSession in `$S`, type `Export-PSSession -Session $S -Command Get-Item -ArgumentList cert:`.
+the PSSession in `$S`, type `Export-PSSession -Session $S -Command Get-Item -ArgumentList Cert:`.
 
 ```yaml
 Type: System.Object[]
@@ -202,7 +202,7 @@ Accept wildcard characters: False
 ### -Certificate
 
 Specifies the client certificate that is used to sign the format files (*.Format.ps1xml) or script
-module files (.psm1) in the module that `Export-PSSession` creates. Enter a variable that contains
+module files (`.psm1`) in the module that `Export-PSSession` creates. Enter a variable that contains
 a certificate or a command or expression that gets the certificate.
 
 To find a certificate, use the `Get-PfxCertificate` cmdlet or use the `Get-ChildItem` cmdlet in the
@@ -255,13 +255,13 @@ The acceptable values for this parameter are as follows:
 
 - `Alias`: All PowerShell aliases in the current session.
 - `All`: All command types. It is the equivalent of `Get-Command -Name *`.
-- `Application`: All files other than PowerShell files in paths listed in the Path environment
-  variable (`$env:path`), including .txt, .exe, and .dll files.
+- `Application`: All files other than PowerShell files in paths listed in the PATH environment
+  variable (`$Env:PATH`), including .txt, .exe, and .dll files.
 - `Cmdlet`: The cmdlets in the current session. Cmdlet is the default.
 - `Configuration`: A PowerShell configuration. For more information, see
   [about_Session_Configurations](../Microsoft.PowerShell.Core/About/about_Session_Configurations.md).
-- `ExternalScript`: All .ps1 files in the paths listed in the Path environment variable
-  (`$env:path`).
+- `ExternalScript`: All `.ps1` files in the paths listed in the PATH environment variable
+  (`$Env:PATH`).
 - `Filter` and `Function`: All PowerShell functions.
 - `Script` Script blocks in the current session.
 - `Workflow` A PowerShell workflow. For more information, see [about_Workflows](/powershell/module/PSWorkflow/About/about_Workflows).

--- a/reference/7.6/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -225,7 +225,7 @@ Specifies the objects to be formatted. Enter a variable that contains the object
 or expression that gets the objects.
 
 Only certain [scalar](/powershell/scripting/learn/glossary#scalar-value) types and
-`[system.io.fileinfo]` are supported.
+`[System.IO.FileInfo]` are supported.
 
 The supported scalar types are:
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Format-List.md
@@ -317,7 +317,7 @@ If you do not use a format cmdlet, PowerShell applies that default format for ea
 displays.
 
 The **View** parameter lets you specify an alternate format for the table. You can use the views
-defined in the `*.format.PS1XML` files in the PowerShell directory, or you can create your own views
+defined in the `*.format.ps1xml` files in the PowerShell directory, or you can create your own views
 in new PS1XML files and use the `Update-FormatData` cmdlet to include them in PowerShell.
 
 The alternate view for the **View** parameter must use the list format, otherwise, the command

--- a/reference/7.6/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Format-Table.md
@@ -103,7 +103,7 @@ more information about views and the code used to create this example's view, se
 [about_Format.ps1xml](../Microsoft.PowerShell.Core/About/about_Format.ps1xml.md#sample-xml-for-a-format-table-custom-view).
 
 ```powershell
-Get-ChildItem  -Path C:\Test | Format-Table -View mygciview
+Get-ChildItem  -Path C:\Test | Format-Table -View MyGciView
 ```
 
 ```Output
@@ -121,7 +121,7 @@ d-----       10/23/2019     09:38       2/25/2019     09:38                Files
 
 `Get-ChildItem` gets the contents of the current directory, `C:\Test`. The
 **System.IO.DirectoryInfo** and **System.IO.FileInfo** objects are sent down the pipeline.
-`Format-Table` uses the **View** parameter to specify the custom view **mygciview** that includes
+`Format-Table` uses the **View** parameter to specify the custom view **MyGciView** that includes
 the **CreationTime** column.
 
 The default `Format-Table` output for `Get-ChildItem` doesn't include the **CreationTime** column.
@@ -177,7 +177,7 @@ local computer. You can use `Get-CimInstance` with the **ComputerName** paramete
 from remote computers.
 
 ```powershell
-$Processes = Get-CimInstance -Class win32_process -Filter "name='notepad.exe'"
+$Processes = Get-CimInstance -Class Win32_Process -Filter "name='notepad.exe'"
 $Processes | Format-Table ProcessName, @{
     Label = "Total Running Time"
     Expression={(Get-Date) - $_.CreationDate}

--- a/reference/7.6/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -46,7 +46,7 @@ output. The **Column** parameter specifies the number of columns.
 This command displays the names of registry keys in the `HKEY_CURRENT_USER\Software\Microsoft` key.
 
 ```powershell
-Get-ChildItem HKCU:\software\microsoft | Format-Wide -Property pschildname -AutoSize
+Get-ChildItem HKCU:\software\Microsoft | Format-Wide -Property PSChildName -AutoSize
 ```
 
 The `Get-ChildItem` cmdlet gets objects representing the keys. The path is specified as `HKCU:`, one
@@ -310,7 +310,7 @@ PowerShell includes the following aliases for `Format-Wide`:
   - `fw`
 
 The **View** parameter lets you specify an alternate format for the table. You can use the views
-defined in the `*.format.PS1XML` files in the PowerShell directory or you can create your own views
+defined in the `*.format.ps1xml` files in the PowerShell directory or you can create your own views
 in new PS1XML files and use the `Update-FormatData` cmdlet to include them in PowerShell.
 
 The alternate view for the **View** parameter must use table format; if it does not, the command


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide