### PR TITLE
Fix incorrect case/capitalization in reference documents (22/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -90,7 +90,7 @@ parameter gets the alias when you know the item name.
 ### Example 4: Get aliases by property
 
 ```powershell
-Get-Alias | Where-Object {$_.Options -Match "ReadOnly"}
+Get-Alias | Where-Object {$_.Options -match "ReadOnly"}
 ```
 
 This command gets all aliases in which the value of the **Options** property is **ReadOnly**. This
@@ -98,7 +98,7 @@ command provides a quick way to find the aliases that are built into PowerShell,
 the **ReadOnly** option.
 
 **Options** is just one property of the **AliasInfo** objects that `Get-Alias` gets. To find all
-properties and methods of **AliasInfo** objects, type `Get-Alias | get-member`.
+properties and methods of **AliasInfo** objects, type `Get-Alias | Get-Member`.
 
 ### Example 5: Get aliases by name and filter by beginning letter
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -34,7 +34,7 @@ Get-Date [[-Date] <DateTime>] [-Year <Int32>] [-Month <Int32>] [-Day <Int32>] [-
 ## DESCRIPTION
 
 The `Get-Date` cmdlet gets a **DateTime** object that represents the current date or a date that you
-specify. `Get-Date` can format the date and time in several .NET and UNIX formats. You can use
+specify. `Get-Date` can format the date and time in several .NET and Unix formats. You can use
 `Get-Date` to generate a date or time character string, and then send the string to other cmdlets or
 programs.
 
@@ -144,7 +144,7 @@ The Gregorian calendar has 365 days, except for leap years that have 366 days. F
 ```
 
 `Get-Date` uses three parameters to specify the date: **Year**, **Month**, and **Day**. The command
-is wrapped with parentheses so that the result is evaluated by the **DayofYear** property.
+is wrapped with parentheses so that the result is evaluated by the **DayOfYear** property.
 
 ### Example 6: Check if a date is adjusted for daylight saving time
 
@@ -436,7 +436,7 @@ Accept wildcard characters: False
 
 ### -UFormat
 
-Displays the date and time in UNIX format. The **UFormat** parameter outputs a string object.
+Displays the date and time in Unix format. The **UFormat** parameter outputs a string object.
 
 **UFormat** specifiers are preceded by a percent sign (`%`), for example, `%m`, `%d`, and `%Y`. The
 [Notes](#notes) section contains a table of valid **UFormat specifiers**.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Event.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Event.md
@@ -72,7 +72,7 @@ SourceEventArgs  : System.Management.EventArrivedEventArgs
 SourceArgs       : {System.Management.ManagementEventWatcher, System.Management.EventArrivedEventArgs}
 SourceIdentifier : ProcessStarted
 TimeGenerated    : 11/13/2008 12:09:32 PM
-MessageData      : PS C:\> Get-Event | Where {$_.TimeGenerated -ge "11/13/2008 12:15:00 PM"}
+MessageData      : PS C:\> Get-Event | where {$_.TimeGenerated -ge "11/13/2008 12:15:00 PM"}
 ComputerName     :
 RunspaceId       : c2153740-256d-46c0-a57c-b8059325d1a0
 EventIdentifier  : 1

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -113,7 +113,7 @@ Id  Name           State      HasMoreData  Location  Command
 ```powershell
 $Timer.Enabled = $true
 $Subscriber = Get-EventSubscriber -SourceIdentifier Timer.Random
-($Subscriber.action).gettype().fullname
+($Subscriber.Action).GetType().FullName
 ```
 
 ```Output
@@ -121,7 +121,7 @@ System.Management.Automation.PSEventJob
 ```
 
 ```powershell
-$Subscriber.action | Format-List -Property *
+$Subscriber.Action | Format-List -Property *
 ```
 
 ```Output
@@ -141,7 +141,7 @@ ChildJobs     : {}
 ```
 
 ```powershell
-& $Subscriber.action.module {$Random}
+& $Subscriber.Action.Module {$Random}
 ```
 
 The third command uses the `Register-ObjectEvent` cmdlet to register the Elapsed event of the timer
@@ -183,7 +183,7 @@ subscribers, including hidden subscribers.
 
 ```powershell
 Register-EngineEvent -SourceIdentifier PowerShell.Exiting -SupportEvent -Action {
-    Get-History | Export-Clixml d:\temp\history.clixml
+    Get-History | Export-Clixml D:\temp\history.clixml
 }
 Get-EventSubscriber  # No output - must use -Force
 Get-EventSubscriber -Force

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-FileHash.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-FileHash.md
@@ -58,7 +58,7 @@ is supported by the target operating system can be used.
 
 ### Example 1: Compute the hash value for a file
 
-This example uses the `Get-FileHash` cmdlet to compute the hash value for the `Powershell.exe` file.
+This example uses the `Get-FileHash` cmdlet to compute the hash value for the `powershell.exe` file.
 The hash algorithm used is the default, SHA256. The output is piped to the `Format-List` cmdlet to
 format the output as a list.
 
@@ -115,7 +115,7 @@ string to a stream and use the **InputStream** parameter of `Get-FileHash` to ge
 ```powershell
 $stringAsStream = [System.IO.MemoryStream]::new()
 $writer = [System.IO.StreamWriter]::new($stringAsStream)
-$writer.write("Hello world")
+$writer.Write("Hello world")
 $writer.Flush()
 $stringAsStream.Position = 0
 Get-FileHash -InputStream $stringAsStream | Select-Object Hash

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -69,7 +69,7 @@ HelpInfoShort   {help , TableControl}
 ```
 
 ```powershell
-$F.FormatViewDefinition[0].control
+$F.FormatViewDefinition[0].Control
 ```
 
 ```Output
@@ -85,7 +85,7 @@ OutOfBand        : False
 ```
 
 ```powershell
-$F.FormatViewDefinition[0].control.Headers
+$F.FormatViewDefinition[0].Control.Headers
 ```
 
 ```Output
@@ -104,7 +104,7 @@ data that is added by a module.
 
 ```powershell
 $A = Get-FormatData
-Import-Module bitstransfer
+Import-Module BitsTransfer
 $B = Get-FormatData
 Compare-Object $A $B
 ```
@@ -116,8 +116,8 @@ Microsoft.BackgroundIntelligentTransfer.Management.BitsJob =>
 ```
 
 ```powershell
-Get-FormatData *bits* | Export-FormatData -FilePath c:\test\bits.format.ps1xml
-Get-Content c:\test\bits.format.ps1xml
+Get-FormatData *bits* | Export-FormatData -FilePath C:\test\Bits.format.ps1xml
+Get-Content C:\test\Bits.format.ps1xml
 ```
 
 ```Output
@@ -132,7 +132,7 @@ identify the format type that the **BitsTransfer** module adds to the session.
 The fifth command uses the `Get-FormatData` cmdlet to get the format type that the **BitsTransfer**
 module adds. It uses a pipeline operator (`|`) to send the format type object to the
 `Export-FormatData` cmdlet, which converts it back to XML and saves it in the specified
-`format.ps1xml` file.
+`Bits.format.ps1xml` file.
 
 The final command shows an excerpt of the `format.ps1xml` file content.
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Host.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Host.md
@@ -84,7 +84,7 @@ Major  Minor  Build  Revision
 This command gets detailed information about the version of Windows PowerShell running in the host.
 You can view, but not change, these values.
 
-The Version property of `Get-Host` contains a **System.Version** object. This command uses a
+The **Version** property of `Get-Host` contains a **System.Version** object. This command uses a
 pipeline operator (`|`) to send the version object to the `Format-List` cmdlet. The `Format-List`
 command uses the **Property** parameter with a value of all (`*`) to display all of the properties
 and property values of the version object.
@@ -225,7 +225,7 @@ interchangeably.
 
 This command uses the **PrivateData** property of `$Host` as its ErrorBackgroundColor property. To
 see all of the properties of the object in the `$Host`.PrivateData property, type
-`$Host.PrivateData | format-list *`.
+`$Host.PrivateData | Format-List *`.
 
 ## PARAMETERS
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
@@ -89,18 +89,18 @@ ToString                  ScriptMethod  System.Object ToString();
 ### Example 2: Get members of service objects
 
 This example gets all the members (properties and methods) of service objects retrieved by the
-`Get-Service` cmdlet, including the intrinsic members, such as **PSBase**, **PSObject**, and the
+`Get-Service` cmdlet, including the intrinsic members, such as **psbase**, **psobject**, and the
 **get_** and **set_** methods.
 
 ```powershell
 Get-Service | Get-Member -Force
-(Get-Service Schedule).PSBase
+(Get-Service Schedule).psbase
 ```
 
 The `Get-Member` command uses the **Force** parameter to add the intrinsic members and
 compiler-generated members of the objects to the display. You can use these properties and methods
 in the same way that you would use an adapted method of the object. The second command shows how to
-display the value of the **PSBase** property of the Schedule service. For more information on
+display the value of the **psbase** property of the Schedule service. For more information on
 intrinsic members, see
 [about_Intrinsic_Members](../Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md)
 
@@ -244,8 +244,8 @@ returns the members of the **Object[]** type.
 This example shows how to determine which properties of an object can be changed.
 
 ```powershell
-$File = Get-Item c:\test\textFile.txt
-$File.PSObject.Properties | Where-Object isSettable | Select-Object -Property Name
+$File = Get-Item C:\test\textFile.txt
+$File.psobject.Properties | Where-Object IsSettable | Select-Object -Property Name
 ```
 
 ```Output
@@ -271,13 +271,13 @@ Attributes
 
 This example creates a new **PSObject** and adds properties to it. `Get-Member` lists the properties
 in alphabetic order. To see the properties in the order they were added to the object you must use
-the **PSObject** intrinsic member.
+the **psobject** intrinsic member.
 
 ```powershell
-$Asset = New-Object -TypeName PSObject
+$Asset = New-Object -TypeName psobject
 $d = [ordered]@{Name="Server30";System="Server Core";PSVersion="4.0"}
 $Asset | Add-Member -NotePropertyMembers $d -TypeName Asset
-$Asset.PSObject.Properties | Select-Object Name, Value
+$Asset.psobject.Properties | Select-Object Name, Value
 ```
 
 ```Output
@@ -295,13 +295,13 @@ PSVersion 4.0
 Adds the intrinsic members and the compiler-generated **get_** and **set_** methods to the display.
 The following list describes the properties that are added when you use the **Force** parameter:
 
-- `PSBase`: The original properties of the .NET object without extension or adaptation. These are
+- `psbase`: The original properties of the .NET object without extension or adaptation. These are
   the properties defined for the object class.
-- `PSAdapted`: The properties and methods defined in the PowerShell extended type system.
-- `PSExtended`: The properties and methods that were added in the `Types.ps1xml` files or using the
+- `psadapted`: The properties and methods defined in the PowerShell extended type system.
+- `psextended`: The properties and methods that were added in the `Types.ps1xml` files or using the
   `Add-Member` cmdlet.
-- `PSObject`: The adapter that converts the base object to a PowerShell **PSObject** object.
-- `PSTypeNames`: A list of object types that describe the object, in order of specificity. When
+- `psobject`: The adapter that converts the base object to a PowerShell **PSObject** object.
+- `pstypenames`: A list of object types that describe the object, in order of specificity. When
   formatting the object, PowerShell searches for the types in the `Format.ps1xml` files in the
   PowerShell installation directory (`$PSHOME`). It uses the formatting definition for the first
   type that it finds.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
@@ -47,7 +47,7 @@ Get-PSBreakpoint [-Id] <Int32[]> [<CommonParameters>]
 
 ## DESCRIPTION
 
-The `Get-PSBreakPoint` cmdlet gets the breakpoints that are set in the current session. You can use
+The `Get-PSBreakpoint` cmdlet gets the breakpoints that are set in the current session. You can use
 the cmdlet parameters to get particular breakpoints.
 
 A breakpoint is a point in a command or script where execution stops temporarily so that you can
@@ -204,7 +204,7 @@ acceptable values for this parameter are:
 - Command
 - Variable
 
-You can also pipe breakpoint types to `Get-PSBreakPoint`.
+You can also pipe breakpoint types to `Get-PSBreakpoint`.
 
 ```yaml
 Type: Microsoft.PowerShell.Commands.BreakpointType[]

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-PSCallStack.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-PSCallStack.md
@@ -33,32 +33,32 @@ To run a `Get-PSCallStack` command while in the debugger, type `k` or `Get-PSCal
 ### Example 1: Get the call stack for a function
 
 ```powershell
-PS C:\> function my-alias {
+PS C:\> function My-Alias {
 $p = $args[0]
-Get-Alias | where {$_.definition -like "*$p"} | format-table definition, name -auto
+Get-Alias | where {$_.Definition -like "*$p"} | Format-Table Definition, Name -Auto
 }
-PS C:\ps-test> Set-PSBreakpoint -Command my-alias
-Command    : my-alias
+PS C:\ps-test> Set-PSBreakpoint -Command My-Alias
+Command    : My-Alias
 Action     :
 Enabled    : True
 HitCount   : 0
 Id         : 0
-Script     : prompt PS C:\> my-alias Get-Content
+Script     : prompt PS C:\> My-Alias Get-Content
 
 Entering debug mode. Use h or ? for help.
-Hit Command breakpoint on 'prompt:my-alias'
-my-alias get-content
+Hit Command breakpoint on 'prompt:My-Alias'
+My-Alias Get-Content
 [DBG]: PS C:\ps-test> s
 $p = $args[0]
 DEBUG: Stepped to ':    $p = $args[0]    '
 [DBG]: PS C:\ps-test> s
-get-alias | Where {$_.Definition -like "*$p*"} | format-table Definition,
-[DBG]: PS C:\ps-test>get-pscallstack
+Get-Alias | where {$_.Definition -like "*$p*"} | Format-Table Definition,
+[DBG]: PS C:\ps-test>Get-PSCallStack
 
 Name        CommandLineParameters         UnboundArguments              Location
 ----        ---------------------         ----------------              --------
 prompt      {}                            {}                            prompt
-my-alias    {}                            {get-content}                 prompt
+My-Alias    {}                            {Get-Content}                 prompt
 prompt      {}                            {}                            prompt
 
 PS C:\> [DBG]: PS C:\ps-test> o

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -90,7 +90,7 @@ parameter gets the alias when you know the item name.
 ### Example 4: Get aliases by property
 
 ```powershell
-Get-Alias | Where-Object {$_.Options -Match "ReadOnly"}
+Get-Alias | Where-Object {$_.Options -match "ReadOnly"}
 ```
 
 This command gets all aliases in which the value of the **Options** property is **ReadOnly**. This
@@ -98,7 +98,7 @@ command provides a quick way to find the aliases that are built into PowerShell,
 the **ReadOnly** option.
 
 **Options** is just one property of the **AliasInfo** objects that `Get-Alias` gets. To find all
-properties and methods of **AliasInfo** objects, type `Get-Alias | get-member`.
+properties and methods of **AliasInfo** objects, type `Get-Alias | Get-Member`.
 
 ### Example 5: Get aliases by name and filter by beginning letter
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-Date.md
@@ -50,7 +50,7 @@ Get-Date -UnixTimeSeconds <Int64> [-Year <Int32>] [-Month <Int32>] [-Day <Int32>
 ## DESCRIPTION
 
 The `Get-Date` cmdlet gets a **DateTime** object that represents the current date or a date that you
-specify. `Get-Date` can format the date and time in several .NET and UNIX formats. You can use
+specify. `Get-Date` can format the date and time in several .NET and Unix formats. You can use
 `Get-Date` to generate a date or time character string, and then send the string to other cmdlets or
 programs.
 
@@ -160,7 +160,7 @@ The Gregorian calendar has 365 days, except for leap years that have 366 days. F
 ```
 
 `Get-Date` uses three parameters to specify the date: **Year**, **Month**, and **Day**. The command
-is wrapped with parentheses so that the result is evaluated by the **DayofYear** property.
+is wrapped with parentheses so that the result is evaluated by the **DayOfYear** property.
 
 ### Example 6: Check if a date is adjusted for daylight saving time
 
@@ -514,7 +514,7 @@ Accept wildcard characters: False
 
 ### -UFormat
 
-Displays the date and time in UNIX format. The **UFormat** parameter outputs a string object.
+Displays the date and time in Unix format. The **UFormat** parameter outputs a string object.
 
 **UFormat** specifiers are preceded by a percent sign (`%`), for example, `%m`, `%d`, and `%Y`. The
 [Notes](#notes) section contains a table of valid **UFormat specifiers**.

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-Event.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-Event.md
@@ -72,7 +72,7 @@ SourceEventArgs  : System.Management.EventArrivedEventArgs
 SourceArgs       : {System.Management.ManagementEventWatcher, System.Management.EventArrivedEventArgs}
 SourceIdentifier : ProcessStarted
 TimeGenerated    : 11/13/2008 12:09:32 PM
-MessageData      : PS C:\> Get-Event | Where {$_.TimeGenerated -ge "11/13/2008 12:15:00 PM"}
+MessageData      : PS C:\> Get-Event | where {$_.TimeGenerated -ge "11/13/2008 12:15:00 PM"}
 ComputerName     :
 RunspaceId       : c2153740-256d-46c0-a57c-b8059325d1a0
 EventIdentifier  : 1

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -113,7 +113,7 @@ Id  Name           State      HasMoreData  Location  Command
 ```powershell
 $Timer.Enabled = $true
 $Subscriber = Get-EventSubscriber -SourceIdentifier Timer.Random
-($Subscriber.action).gettype().fullname
+($Subscriber.Action).GetType().FullName
 ```
 
 ```Output
@@ -121,7 +121,7 @@ System.Management.Automation.PSEventJob
 ```
 
 ```powershell
-$Subscriber.action | Format-List -Property *
+$Subscriber.Action | Format-List -Property *
 ```
 
 ```Output
@@ -141,7 +141,7 @@ ChildJobs     : {}
 ```
 
 ```powershell
-& $Subscriber.action.module {$Random}
+& $Subscriber.Action.Module {$Random}
 ```
 
 The third command uses the `Register-ObjectEvent` cmdlet to register the Elapsed event of the timer
@@ -183,7 +183,7 @@ subscribers, including hidden subscribers.
 
 ```powershell
 Register-EngineEvent -SourceIdentifier PowerShell.Exiting -SupportEvent -Action {
-    Get-History | Export-Clixml d:\temp\history.clixml
+    Get-History | Export-Clixml D:\temp\history.clixml
 }
 Get-EventSubscriber  # No output - must use -Force
 Get-EventSubscriber -Force

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-FileHash.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-FileHash.md
@@ -115,7 +115,7 @@ string to a stream and use the **InputStream** parameter of `Get-FileHash` to ge
 ```powershell
 $stringAsStream = [System.IO.MemoryStream]::new()
 $writer = [System.IO.StreamWriter]::new($stringAsStream)
-$writer.write("Hello world")
+$writer.Write("Hello world")
 $writer.Flush()
 $stringAsStream.Position = 0
 Get-FileHash -InputStream $stringAsStream | Select-Object Hash

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -69,7 +69,7 @@ HelpInfoShort   {help , TableControl}
 ```
 
 ```powershell
-$F.FormatViewDefinition[0].control
+$F.FormatViewDefinition[0].Control
 ```
 
 ```Output
@@ -85,7 +85,7 @@ OutOfBand        : False
 ```
 
 ```powershell
-$F.FormatViewDefinition[0].control.Headers
+$F.FormatViewDefinition[0].Control.Headers
 ```
 
 ```Output
@@ -104,7 +104,7 @@ data that is added by a module.
 
 ```powershell
 $A = Get-FormatData
-Import-Module bitstransfer
+Import-Module BitsTransfer
 $B = Get-FormatData
 Compare-Object $A $B
 ```
@@ -116,8 +116,8 @@ Microsoft.BackgroundIntelligentTransfer.Management.BitsJob =>
 ```
 
 ```powershell
-Get-FormatData *bits* | Export-FormatData -FilePath c:\test\bits.format.ps1xml
-Get-Content c:\test\bits.format.ps1xml
+Get-FormatData *bits* | Export-FormatData -FilePath C:\test\Bits.format.ps1xml
+Get-Content C:\test\Bits.format.ps1xml
 ```
 
 ```Output
@@ -132,7 +132,7 @@ identify the format type that the **BitsTransfer** module adds to the session.
 The fifth command uses the `Get-FormatData` cmdlet to get the format type that the **BitsTransfer**
 module adds. It uses a pipeline operator (`|`) to send the format type object to the
 `Export-FormatData` cmdlet, which converts it back to XML and saves it in the specified
-`format.ps1xml` file.
+`Bits.format.ps1xml` file.
 
 The final command shows an excerpt of the `format.ps1xml` file content.
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-Host.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-Host.md
@@ -84,7 +84,7 @@ Major  Minor  Build  Revision PSSemVerPreReleaseLabel    PSSemVerBuildLabel
 This command gets detailed information about the version of Windows PowerShell running in the host.
 You can view, but not change, these values.
 
-The Version property of `Get-Host` contains a **System.Version** object. This command uses a
+The **Version** property of `Get-Host` contains a **System.Version** object. This command uses a
 pipeline operator (`|`) to send the version object to the `Format-List` cmdlet. The `Format-List`
 command uses the **Property** parameter with a value of all (`*`) to display all of the properties
 and property values of the version object.

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-Member.md
@@ -93,18 +93,18 @@ ToString                  ScriptMethod  System.Object ToString();
 ### Example 2: Get members of service objects
 
 This example gets all the members (properties and methods) of service objects retrieved by the
-`Get-Service` cmdlet, including the intrinsic members, such as **PSBase**, **PSObject**, and the
+`Get-Service` cmdlet, including the intrinsic members, such as **psbase**, **psobject**, and the
 **get_** and **set_** methods.
 
 ```powershell
 Get-Service | Get-Member -Force
-(Get-Service Schedule).PSBase
+(Get-Service Schedule).psbase
 ```
 
 The `Get-Member` command uses the **Force** parameter to add the intrinsic members and
 compiler-generated members of the objects to the display. You can use these properties and methods
 in the same way that you would use an adapted method of the object. The second command shows how to
-display the value of the **PSBase** property of the Schedule service. For more information on
+display the value of the **psbase** property of the Schedule service. For more information on
 intrinsic members, see
 [about_Intrinsic_Members](../Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md)
 
@@ -248,8 +248,8 @@ returns the members of the **Object[]** type.
 This example shows how to determine which properties of an object can be changed.
 
 ```powershell
-$File = Get-Item c:\test\textFile.txt
-$File.PSObject.Properties | Where-Object isSettable | Select-Object -Property Name
+$File = Get-Item C:\test\textFile.txt
+$File.psobject.Properties | Where-Object IsSettable | Select-Object -Property Name
 ```
 
 ```Output
@@ -275,13 +275,13 @@ Attributes
 
 This example creates a new **PSObject** and adds properties to it. `Get-Member` lists the properties
 in alphabetic order. To see the properties in the order they were added to the object you must use
-the **PSObject** intrinsic member.
+the **psobject** intrinsic member.
 
 ```powershell
-$Asset = New-Object -TypeName PSObject
+$Asset = New-Object -TypeName psobject
 $d = [ordered]@{Name="Server30";System="Server Core";PSVersion="4.0"}
 $Asset | Add-Member -NotePropertyMembers $d -TypeName Asset
-$Asset.PSObject.Properties | Select-Object Name, Value
+$Asset.psobject.Properties | Select-Object Name, Value
 ```
 
 ```Output
@@ -299,13 +299,13 @@ PSVersion 4.0
 Adds the intrinsic members and the compiler-generated **get_** and **set_** methods to the display.
 The following list describes the properties that are added when you use the **Force** parameter:
 
-- `PSBase`: The original properties of the .NET object without extension or adaptation. These are
+- `psbase`: The original properties of the .NET object without extension or adaptation. These are
   the properties defined for the object class.
-- `PSAdapted`: The properties and methods defined in the PowerShell extended type system.
-- `PSExtended`: The properties and methods that were added in the `Types.ps1xml` files or using the
+- `psadapted`: The properties and methods defined in the PowerShell extended type system.
+- `psextended`: The properties and methods that were added in the `Types.ps1xml` files or using the
   `Add-Member` cmdlet.
-- `PSObject`: The adapter that converts the base object to a PowerShell **PSObject** object.
-- `PSTypeNames`: A list of object types that describe the object, in order of specificity. When
+- `psobject`: The adapter that converts the base object to a PowerShell **PSObject** object.
+- `pstypenames`: A list of object types that describe the object, in order of specificity. When
   formatting the object, PowerShell searches for the types in the `Format.ps1xml` files in the
   PowerShell installation directory (`$PSHOME`). It uses the formatting definition for the first
   type that it finds.

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
@@ -47,7 +47,7 @@ Get-PSBreakpoint [-Id] <Int32[]> [-Runspace <Runspace>] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The `Get-PSBreakPoint` cmdlet gets the breakpoints that are set in the current session. You can use
+The `Get-PSBreakpoint` cmdlet gets the breakpoints that are set in the current session. You can use
 the cmdlet parameters to get particular breakpoints.
 
 A breakpoint is a point in a command or script where execution stops temporarily so that you can
@@ -144,8 +144,8 @@ Get-PSBreakpoint -Type Line, Variable -Script "Sample.ps1"
 
 ### Example 9: Get the breakpoints set in a specific runspace
 
-In this example, a job is started and a breakpoint is set to break when the `Set-PSBreakPoint` is
-run. The runspace is stored in a variable and passed to the `Get-PSBreakPoint` command with the
+In this example, a job is started and a breakpoint is set to break when the `Set-PSBreakpoint` is
+run. The runspace is stored in a variable and passed to the `Get-PSBreakpoint` command with the
 **Runspace** parameter. You can then inspect the breakpoint in the `$breakpoint` variable.
 
 ```powershell
@@ -156,7 +156,7 @@ Start-Job -ScriptBlock {
 
 $runspace = Get-Runspace -Id 1
 
-$breakpoint = Get-PSBreakPoint -Runspace $runspace
+$breakpoint = Get-PSBreakpoint -Runspace $runspace
 ```
 
 ## PARAMETERS
@@ -240,7 +240,7 @@ acceptable values for this parameter are:
 - Command
 - Variable
 
-You can also pipe breakpoint types to `Get-PSBreakPoint`.
+You can also pipe breakpoint types to `Get-PSBreakpoint`.
 
 ```yaml
 Type: Microsoft.PowerShell.Commands.BreakpointType[]

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-PSCallStack.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-PSCallStack.md
@@ -33,32 +33,32 @@ To run a `Get-PSCallStack` command while in the debugger, type `k` or `Get-PSCal
 ### Example 1: Get the call stack for a function
 
 ```powershell
-PS C:\> function my-alias {
+PS C:\> function My-Alias {
 $p = $args[0]
-Get-Alias | where {$_.definition -like "*$p"} | format-table definition, name -auto
+Get-Alias | where {$_.Definition -like "*$p"} | Format-Table Definition, Name -Auto
 }
-PS C:\ps-test> Set-PSBreakpoint -Command my-alias
-Command    : my-alias
+PS C:\ps-test> Set-PSBreakpoint -Command My-Alias
+Command    : My-Alias
 Action     :
 Enabled    : True
 HitCount   : 0
 Id         : 0
-Script     : prompt PS C:\> my-alias Get-Content
+Script     : prompt PS C:\> My-Alias Get-Content
 
 Entering debug mode. Use h or ? for help.
-Hit Command breakpoint on 'prompt:my-alias'
-my-alias get-content
+Hit Command breakpoint on 'prompt:My-Alias'
+My-Alias Get-Content
 [DBG]: PS C:\ps-test> s
 $p = $args[0]
 DEBUG: Stepped to ':    $p = $args[0]    '
 [DBG]: PS C:\ps-test> s
-get-alias | Where {$_.Definition -like "*$p*"} | format-table Definition,
-[DBG]: PS C:\ps-test>get-pscallstack
+Get-Alias | where {$_.Definition -like "*$p*"} | Format-Table Definition,
+[DBG]: PS C:\ps-test>Get-PSCallStack
 
 Name        CommandLineParameters         UnboundArguments              Location
 ----        ---------------------         ----------------              --------
 prompt      {}                            {}                            prompt
-my-alias    {}                            {get-content}                 prompt
+My-Alias    {}                            {Get-Content}                 prompt
 prompt      {}                            {}                            prompt
 
 PS C:\> [DBG]: PS C:\ps-test> o

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -92,7 +92,7 @@ parameter gets the alias when you know the item name.
 ### Example 4: Get aliases by property
 
 ```powershell
-Get-Alias | Where-Object {$_.Options -Match "ReadOnly"}
+Get-Alias | Where-Object {$_.Options -match "ReadOnly"}
 ```
 
 This command gets all aliases in which the value of the **Options** property is **ReadOnly**. This

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-Date.md
@@ -50,7 +50,7 @@ Get-Date -UnixTimeSeconds <Int64> [-Year <Int32>] [-Month <Int32>] [-Day <Int32>
 ## DESCRIPTION
 
 The `Get-Date` cmdlet gets a **DateTime** object that represents the current date or a date that you
-specify. `Get-Date` can format the date and time in several .NET and UNIX formats. You can use
+specify. `Get-Date` can format the date and time in several .NET and Unix formats. You can use
 `Get-Date` to generate a date or time character string, and then send the string to other cmdlets or
 programs.
 
@@ -160,7 +160,7 @@ The Gregorian calendar has 365 days, except for leap years that have 366 days. F
 ```
 
 `Get-Date` uses three parameters to specify the date: **Year**, **Month**, and **Day**. The command
-is wrapped with parentheses so that the result is evaluated by the **DayofYear** property.
+is wrapped with parentheses so that the result is evaluated by the **DayOfYear** property.
 
 ### Example 6: Check if a date is adjusted for daylight saving time
 
@@ -514,7 +514,7 @@ Accept wildcard characters: False
 
 ### -UFormat
 
-Displays the date and time in UNIX format. The **UFormat** parameter outputs a string object.
+Displays the date and time in Unix format. The **UFormat** parameter outputs a string object.
 
 **UFormat** specifiers are preceded by a percent sign (`%`), for example, `%m`, `%d`, and `%Y`. The
 [Notes](#notes) section contains a table of valid **UFormat specifiers**.

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-Event.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-Event.md
@@ -72,7 +72,7 @@ SourceEventArgs  : System.Management.EventArrivedEventArgs
 SourceArgs       : {System.Management.ManagementEventWatcher, System.Management.EventArrivedEventArgs}
 SourceIdentifier : ProcessStarted
 TimeGenerated    : 11/13/2008 12:09:32 PM
-MessageData      : PS C:\> Get-Event | Where {$_.TimeGenerated -ge "11/13/2008 12:15:00 PM"}
+MessageData      : PS C:\> Get-Event | where {$_.TimeGenerated -ge "11/13/2008 12:15:00 PM"}
 ComputerName     :
 RunspaceId       : c2153740-256d-46c0-a57c-b8059325d1a0
 EventIdentifier  : 1

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -188,7 +188,7 @@ subscribers, including hidden subscribers.
 
 ```powershell
 Register-EngineEvent -SourceIdentifier PowerShell.Exiting -SupportEvent -Action {
-    Get-History | Export-Clixml d:\temp\history.clixml
+    Get-History | Export-Clixml D:\temp\history.clixml
 }
 Get-EventSubscriber  # No output - must use -Force
 Get-EventSubscriber -Force

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-FileHash.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-FileHash.md
@@ -119,7 +119,7 @@ string to a stream and use the **InputStream** parameter of `Get-FileHash` to ge
 ```powershell
 $stringAsStream = [System.IO.MemoryStream]::new()
 $writer = [System.IO.StreamWriter]::new($stringAsStream)
-$writer.write("Hello world")
+$writer.Write("Hello world")
 $writer.Flush()
 $stringAsStream.Position = 0
 Get-FileHash -InputStream $stringAsStream | Select-Object Hash

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -117,8 +117,8 @@ Microsoft.BackgroundIntelligentTransfer.Management.BitsJob =>
 ```
 
 ```powershell
-Get-FormatData *bits* | Export-FormatData -FilePath c:\test\bits.format.ps1xml
-Get-Content c:\test\bits.format.ps1xml
+Get-FormatData *bits* | Export-FormatData -FilePath C:\test\Bits.format.ps1xml
+Get-Content C:\test\Bits.format.ps1xml
 ```
 
 ```Output
@@ -133,7 +133,7 @@ identify the format type that the **BitsTransfer** module adds to the session.
 The fifth command uses the `Get-FormatData` cmdlet to get the format type that the **BitsTransfer**
 module adds. It uses a pipeline operator (`|`) to send the format type object to the
 `Export-FormatData` cmdlet, which converts it back to XML and saves it in the specified
-`bits.format.ps1xml` file.
+`Bits.format.ps1xml` file.
 
 The final command shows an excerpt of the `format.ps1xml` file content.
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-Host.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-Host.md
@@ -84,7 +84,7 @@ Major  Minor  Build  Revision PSSemVerPreReleaseLabel    PSSemVerBuildLabel
 This command gets detailed information about the version of Windows PowerShell running in the host.
 You can view, but not change, these values.
 
-The Version property of `Get-Host` contains a **System.Version** object. This command uses a
+The **Version** property of `Get-Host` contains a **System.Version** object. This command uses a
 pipeline operator (`|`) to send the version object to the `Format-List` cmdlet. The `Format-List`
 command uses the **Property** parameter with a value of all (`*`) to display all of the properties
 and property values of the version object.

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-Member.md
@@ -93,18 +93,18 @@ ToString                  ScriptMethod  System.Object ToString();
 ### Example 2: Get members of service objects
 
 This example gets all the members (properties and methods) of service objects retrieved by the
-`Get-Service` cmdlet, including the intrinsic members, such as **PSBase**, **PSObject**, and the
+`Get-Service` cmdlet, including the intrinsic members, such as **psbase**, **psobject**, and the
 **get_** and **set_** methods.
 
 ```powershell
 Get-Service | Get-Member -Force
-(Get-Service Schedule).PSBase
+(Get-Service Schedule).psbase
 ```
 
 The `Get-Member` command uses the **Force** parameter to add the intrinsic members and
 compiler-generated members of the objects to the display. You can use these properties and methods
 in the same way that you would use an adapted method of the object. The second command shows how to
-display the value of the **PSBase** property of the Schedule service. For more information on
+display the value of the **psbase** property of the Schedule service. For more information on
 intrinsic members, see
 [about_Intrinsic_Members](../Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md)
 
@@ -248,8 +248,8 @@ returns the members of the **Object[]** type.
 This example shows how to determine which properties of an object can be changed.
 
 ```powershell
-$File = Get-Item c:\test\textFile.txt
-$File.PSObject.Properties | Where-Object isSettable | Select-Object -Property Name
+$File = Get-Item C:\test\textFile.txt
+$File.psobject.Properties | Where-Object IsSettable | Select-Object -Property Name
 ```
 
 ```Output
@@ -275,13 +275,13 @@ Attributes
 
 This example creates a new **PSObject** and adds properties to it. `Get-Member` lists the properties
 in alphabetic order. To see the properties in the order they were added to the object you must use
-the **PSObject** intrinsic member.
+the **psobject** intrinsic member.
 
 ```powershell
-$Asset = New-Object -TypeName PSObject
+$Asset = New-Object -TypeName psobject
 $d = [ordered]@{Name="Server30";System="Server Core";PSVersion="4.0"}
 $Asset | Add-Member -NotePropertyMembers $d -TypeName Asset
-$Asset.PSObject.Properties | Select-Object Name, Value
+$Asset.psobject.Properties | Select-Object Name, Value
 ```
 
 ```Output
@@ -299,13 +299,13 @@ PSVersion 4.0
 Adds the intrinsic members and the compiler-generated **get_** and **set_** methods to the display.
 The following list describes the properties that are added when you use the **Force** parameter:
 
-- `PSBase`: The original properties of the .NET object without extension or adaptation. These are
+- `psbase`: The original properties of the .NET object without extension or adaptation. These are
   the properties defined for the object class.
-- `PSAdapted`: The properties and methods defined in the PowerShell extended type system.
-- `PSExtended`: The properties and methods that were added in the `Types.ps1xml` files or using the
+- `psadapted`: The properties and methods defined in the PowerShell extended type system.
+- `psextended`: The properties and methods that were added in the `Types.ps1xml` files or using the
   `Add-Member` cmdlet.
-- `PSObject`: The adapter that converts the base object to a PowerShell **PSObject** object.
-- `PSTypeNames`: A list of object types that describe the object, in order of specificity. When
+- `psobject`: The adapter that converts the base object to a PowerShell **PSObject** object.
+- `pstypenames`: A list of object types that describe the object, in order of specificity. When
   formatting the object, PowerShell searches for the types in the `Format.ps1xml` files in the
   PowerShell installation directory (`$PSHOME`). It uses the formatting definition for the first
   type that it finds.

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
@@ -50,7 +50,7 @@ Get-PSBreakpoint [-Id] <Int32[]> [-Runspace <Runspace>] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The `Get-PSBreakPoint` cmdlet gets the breakpoints that are set in the current session. You can use
+The `Get-PSBreakpoint` cmdlet gets the breakpoints that are set in the current session. You can use
 the cmdlet parameters to get particular breakpoints.
 
 A breakpoint is a point in a command or script where execution stops temporarily so that you can
@@ -147,8 +147,8 @@ Get-PSBreakpoint -Type Line, Variable -Script "Sample.ps1"
 
 ### Example 9: Get the breakpoints set in a specific runspace
 
-In this example, a job is started and a breakpoint is set to break when the `Set-PSBreakPoint` is
-run. The runspace is stored in a variable and passed to the `Get-PSBreakPoint` command with the
+In this example, a job is started and a breakpoint is set to break when the `Set-PSBreakpoint` is
+run. The runspace is stored in a variable and passed to the `Get-PSBreakpoint` command with the
 **Runspace** parameter. You can then inspect the breakpoint in the `$breakpoint` variable.
 
 ```powershell
@@ -159,7 +159,7 @@ Start-Job -ScriptBlock {
 
 $runspace = Get-Runspace -Id 1
 
-$breakpoint = Get-PSBreakPoint -Runspace $runspace
+$breakpoint = Get-PSBreakpoint -Runspace $runspace
 ```
 
 ## PARAMETERS
@@ -243,7 +243,7 @@ acceptable values for this parameter are:
 - Command
 - Variable
 
-You can also pipe breakpoint types to `Get-PSBreakPoint`.
+You can also pipe breakpoint types to `Get-PSBreakpoint`.
 
 ```yaml
 Type: Microsoft.PowerShell.Commands.BreakpointType[]

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-PSCallStack.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-PSCallStack.md
@@ -33,32 +33,32 @@ To run a `Get-PSCallStack` command while in the debugger, type `k` or `Get-PSCal
 ### Example 1: Get the call stack for a function
 
 ```powershell
-PS C:\> function my-alias {
+PS C:\> function My-Alias {
 $p = $args[0]
 Get-Alias | where {$_.Definition -like "*$p"} | Format-Table Definition, Name -Auto
 }
-PS C:\ps-test> Set-PSBreakpoint -Command my-alias
-Command    : my-alias
+PS C:\ps-test> Set-PSBreakpoint -Command My-Alias
+Command    : My-Alias
 Action     :
 Enabled    : True
 HitCount   : 0
 Id         : 0
-Script     : prompt PS C:\> my-alias Get-Content
+Script     : prompt PS C:\> My-Alias Get-Content
 
 Entering debug mode. Use h or ? for help.
-Hit Command breakpoint on 'prompt:my-alias'
-my-alias Get-Content
+Hit Command breakpoint on 'prompt:My-Alias'
+My-Alias Get-Content
 [DBG]: PS C:\ps-test> s
 $p = $args[0]
 DEBUG: Stepped to ':    $p = $args[0]    '
 [DBG]: PS C:\ps-test> s
-Get-Alias | Where {$_.Definition -like "*$p*"} | Format-Table Definition,
+Get-Alias | where {$_.Definition -like "*$p*"} | Format-Table Definition,
 [DBG]: PS C:\ps-test>Get-PSCallStack
 
 Name        CommandLineParameters         UnboundArguments              Location
 ----        ---------------------         ----------------              --------
 prompt      {}                            {}                            prompt
-my-alias    {}                            {Get-Content}                 prompt
+My-Alias    {}                            {Get-Content}                 prompt
 prompt      {}                            {}                            prompt
 
 PS C:\> [DBG]: PS C:\ps-test> o

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -90,7 +90,7 @@ parameter gets the alias when you know the item name.
 ### Example 4: Get aliases by property
 
 ```powershell
-Get-Alias | Where-Object {$_.Options -Match "ReadOnly"}
+Get-Alias | Where-Object {$_.Options -match "ReadOnly"}
 ```
 
 This command gets all aliases in which the value of the **Options** property is **ReadOnly**. This
@@ -98,7 +98,7 @@ command provides a quick way to find the aliases that are built into PowerShell,
 the **ReadOnly** option.
 
 **Options** is just one property of the **AliasInfo** objects that `Get-Alias` gets. To find all
-properties and methods of **AliasInfo** objects, type `Get-Alias | get-member`.
+properties and methods of **AliasInfo** objects, type `Get-Alias | Get-Member`.
 
 ### Example 5: Get aliases by name and filter by beginning letter
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-Date.md
@@ -50,7 +50,7 @@ Get-Date -UnixTimeSeconds <Int64> [-Year <Int32>] [-Month <Int32>] [-Day <Int32>
 ## DESCRIPTION
 
 The `Get-Date` cmdlet gets a **DateTime** object that represents the current date or a date that you
-specify. `Get-Date` can format the date and time in several .NET and UNIX formats. You can use
+specify. `Get-Date` can format the date and time in several .NET and Unix formats. You can use
 `Get-Date` to generate a date or time character string, and then send the string to other cmdlets or
 programs.
 
@@ -160,7 +160,7 @@ The Gregorian calendar has 365 days, except for leap years that have 366 days. F
 ```
 
 `Get-Date` uses three parameters to specify the date: **Year**, **Month**, and **Day**. The command
-is wrapped with parentheses so that the result is evaluated by the **DayofYear** property.
+is wrapped with parentheses so that the result is evaluated by the **DayOfYear** property.
 
 ### Example 6: Check if a date is adjusted for daylight saving time
 
@@ -514,7 +514,7 @@ Accept wildcard characters: False
 
 ### -UFormat
 
-Displays the date and time in UNIX format. The **UFormat** parameter outputs a string object.
+Displays the date and time in Unix format. The **UFormat** parameter outputs a string object.
 
 **UFormat** specifiers are preceded by a percent sign (`%`), for example, `%m`, `%d`, and `%Y`. The
 [Notes](#notes) section contains a table of valid **UFormat specifiers**.

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-Event.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-Event.md
@@ -72,7 +72,7 @@ SourceEventArgs  : System.Management.EventArrivedEventArgs
 SourceArgs       : {System.Management.ManagementEventWatcher, System.Management.EventArrivedEventArgs}
 SourceIdentifier : ProcessStarted
 TimeGenerated    : 11/13/2008 12:09:32 PM
-MessageData      : PS C:\> Get-Event | Where {$_.TimeGenerated -ge "11/13/2008 12:15:00 PM"}
+MessageData      : PS C:\> Get-Event | where {$_.TimeGenerated -ge "11/13/2008 12:15:00 PM"}
 ComputerName     :
 RunspaceId       : c2153740-256d-46c0-a57c-b8059325d1a0
 EventIdentifier  : 1

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -113,7 +113,7 @@ Id  Name           State      HasMoreData  Location  Command
 ```powershell
 $Timer.Enabled = $true
 $Subscriber = Get-EventSubscriber -SourceIdentifier Timer.Random
-($Subscriber.action).GetType().fullname
+($Subscriber.Action).GetType().FullName
 ```
 
 ```Output
@@ -121,7 +121,7 @@ System.Management.Automation.PSEventJob
 ```
 
 ```powershell
-$Subscriber.action | Format-List -Property *
+$Subscriber.Action | Format-List -Property *
 ```
 
 ```Output
@@ -141,7 +141,7 @@ ChildJobs     : {}
 ```
 
 ```powershell
-& $Subscriber.action.module {$Random}
+& $Subscriber.Action.Module {$Random}
 ```
 
 The third command uses the `Register-ObjectEvent` cmdlet to register the Elapsed event of the timer
@@ -183,7 +183,7 @@ subscribers, including hidden subscribers.
 
 ```powershell
 Register-EngineEvent -SourceIdentifier PowerShell.Exiting -SupportEvent -Action {
-    Get-History | Export-Clixml d:\temp\history.clixml
+    Get-History | Export-Clixml D:\temp\history.clixml
 }
 Get-EventSubscriber  # No output - must use -Force
 Get-EventSubscriber -Force

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-FileHash.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-FileHash.md
@@ -115,7 +115,7 @@ string to a stream and use the **InputStream** parameter of `Get-FileHash` to ge
 ```powershell
 $stringAsStream = [System.IO.MemoryStream]::new()
 $writer = [System.IO.StreamWriter]::new($stringAsStream)
-$writer.write("Hello world")
+$writer.Write("Hello world")
 $writer.Flush()
 $stringAsStream.Position = 0
 Get-FileHash -InputStream $stringAsStream | Select-Object Hash

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -69,7 +69,7 @@ HelpInfoShort   {help , TableControl}
 ```
 
 ```powershell
-$F.FormatViewDefinition[0].control
+$F.FormatViewDefinition[0].Control
 ```
 
 ```Output
@@ -85,7 +85,7 @@ OutOfBand        : False
 ```
 
 ```powershell
-$F.FormatViewDefinition[0].control.Headers
+$F.FormatViewDefinition[0].Control.Headers
 ```
 
 ```Output
@@ -104,7 +104,7 @@ data that is added by a module.
 
 ```powershell
 $A = Get-FormatData
-Import-Module bitstransfer
+Import-Module BitsTransfer
 $B = Get-FormatData
 Compare-Object $A $B
 ```
@@ -116,8 +116,8 @@ Microsoft.BackgroundIntelligentTransfer.Management.BitsJob =>
 ```
 
 ```powershell
-Get-FormatData *bits* | Export-FormatData -FilePath c:\test\bits.format.ps1xml
-Get-Content c:\test\bits.format.ps1xml
+Get-FormatData *bits* | Export-FormatData -FilePath C:\test\Bits.format.ps1xml
+Get-Content C:\test\Bits.format.ps1xml
 ```
 
 ```Output
@@ -132,7 +132,7 @@ identify the format type that the **BitsTransfer** module adds to the session.
 The fifth command uses the `Get-FormatData` cmdlet to get the format type that the **BitsTransfer**
 module adds. It uses a pipeline operator (`|`) to send the format type object to the
 `Export-FormatData` cmdlet, which converts it back to XML and saves it in the specified
-`format.ps1xml` file.
+`Bits.format.ps1xml` file.
 
 The final command shows an excerpt of the `format.ps1xml` file content.
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-Host.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-Host.md
@@ -84,7 +84,7 @@ Major  Minor  Build  Revision PSSemVerPreReleaseLabel    PSSemVerBuildLabel
 This command gets detailed information about the version of Windows PowerShell running in the host.
 You can view, but not change, these values.
 
-The Version property of `Get-Host` contains a **System.Version** object. This command uses a
+The **Version** property of `Get-Host` contains a **System.Version** object. This command uses a
 pipeline operator (`|`) to send the version object to the `Format-List` cmdlet. The `Format-List`
 command uses the **Property** parameter with a value of all (`*`) to display all of the properties
 and property values of the version object.

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-Member.md
@@ -93,18 +93,18 @@ ToString                  ScriptMethod  System.Object ToString();
 ### Example 2: Get members of service objects
 
 This example gets all the members (properties and methods) of service objects retrieved by the
-`Get-Service` cmdlet, including the intrinsic members, such as **PSBase**, **PSObject**, and the
+`Get-Service` cmdlet, including the intrinsic members, such as **psbase**, **psobject**, and the
 **get_** and **set_** methods.
 
 ```powershell
 Get-Service | Get-Member -Force
-(Get-Service Schedule).PSBase
+(Get-Service Schedule).psbase
 ```
 
 The `Get-Member` command uses the **Force** parameter to add the intrinsic members and
 compiler-generated members of the objects to the display. You can use these properties and methods
 in the same way that you would use an adapted method of the object. The second command shows how to
-display the value of the **PSBase** property of the Schedule service. For more information on
+display the value of the **psbase** property of the Schedule service. For more information on
 intrinsic members, see
 [about_Intrinsic_Members](../Microsoft.PowerShell.Core/About/about_Intrinsic_Members.md)
 
@@ -248,8 +248,8 @@ returns the members of the **Object[]** type.
 This example shows how to determine which properties of an object can be changed.
 
 ```powershell
-$File = Get-Item c:\test\textFile.txt
-$File.PSObject.Properties | Where-Object isSettable | Select-Object -Property Name
+$File = Get-Item C:\test\textFile.txt
+$File.psobject.Properties | Where-Object IsSettable | Select-Object -Property Name
 ```
 
 ```Output
@@ -275,13 +275,13 @@ Attributes
 
 This example creates a new **PSObject** and adds properties to it. `Get-Member` lists the properties
 in alphabetic order. To see the properties in the order they were added to the object you must use
-the **PSObject** intrinsic member.
+the **psobject** intrinsic member.
 
 ```powershell
-$Asset = New-Object -TypeName PSObject
+$Asset = New-Object -TypeName psobject
 $d = [ordered]@{Name="Server30";System="Server Core";PSVersion="4.0"}
 $Asset | Add-Member -NotePropertyMembers $d -TypeName Asset
-$Asset.PSObject.Properties | Select-Object Name, Value
+$Asset.psobject.Properties | Select-Object Name, Value
 ```
 
 ```Output
@@ -299,13 +299,13 @@ PSVersion 4.0
 Adds the intrinsic members and the compiler-generated **get_** and **set_** methods to the display.
 The following list describes the properties that are added when you use the **Force** parameter:
 
-- `PSBase`: The original properties of the .NET object without extension or adaptation. These are
+- `psbase`: The original properties of the .NET object without extension or adaptation. These are
   the properties defined for the object class.
-- `PSAdapted`: The properties and methods defined in the PowerShell extended type system.
-- `PSExtended`: The properties and methods that were added in the `Types.ps1xml` files or using the
+- `psadapted`: The properties and methods defined in the PowerShell extended type system.
+- `psextended`: The properties and methods that were added in the `Types.ps1xml` files or using the
   `Add-Member` cmdlet.
-- `PSObject`: The adapter that converts the base object to a PowerShell **PSObject** object.
-- `PSTypeNames`: A list of object types that describe the object, in order of specificity. When
+- `psobject`: The adapter that converts the base object to a PowerShell **PSObject** object.
+- `pstypenames`: A list of object types that describe the object, in order of specificity. When
   formatting the object, PowerShell searches for the types in the `Format.ps1xml` files in the
   PowerShell installation directory (`$PSHOME`). It uses the formatting definition for the first
   type that it finds.

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
@@ -47,7 +47,7 @@ Get-PSBreakpoint [-Id] <Int32[]> [-Runspace <Runspace>] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The `Get-PSBreakPoint` cmdlet gets the breakpoints that are set in the current session. You can use
+The `Get-PSBreakpoint` cmdlet gets the breakpoints that are set in the current session. You can use
 the cmdlet parameters to get particular breakpoints.
 
 A breakpoint is a point in a command or script where execution stops temporarily so that you can
@@ -144,8 +144,8 @@ Get-PSBreakpoint -Type Line, Variable -Script "Sample.ps1"
 
 ### Example 9: Get the breakpoints set in a specific runspace
 
-In this example, a job is started and a breakpoint is set to break when the `Set-PSBreakPoint` is
-run. The runspace is stored in a variable and passed to the `Get-PSBreakPoint` command with the
+In this example, a job is started and a breakpoint is set to break when the `Set-PSBreakpoint` is
+run. The runspace is stored in a variable and passed to the `Get-PSBreakpoint` command with the
 **Runspace** parameter. You can then inspect the breakpoint in the `$breakpoint` variable.
 
 ```powershell
@@ -156,7 +156,7 @@ Start-Job -ScriptBlock {
 
 $runspace = Get-Runspace -Id 1
 
-$breakpoint = Get-PSBreakPoint -Runspace $runspace
+$breakpoint = Get-PSBreakpoint -Runspace $runspace
 ```
 
 ## PARAMETERS
@@ -240,7 +240,7 @@ acceptable values for this parameter are:
 - Command
 - Variable
 
-You can also pipe breakpoint types to `Get-PSBreakPoint`.
+You can also pipe breakpoint types to `Get-PSBreakpoint`.
 
 ```yaml
 Type: Microsoft.PowerShell.Commands.BreakpointType[]

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-PSCallStack.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-PSCallStack.md
@@ -33,32 +33,32 @@ To run a `Get-PSCallStack` command while in the debugger, type `k` or `Get-PSCal
 ### Example 1: Get the call stack for a function
 
 ```powershell
-PS C:\> function my-alias {
+PS C:\> function My-Alias {
 $p = $args[0]
-Get-Alias | where {$_.Definition -like "*$p"} | Format-Table definition, name -auto
+Get-Alias | where {$_.Definition -like "*$p"} | Format-Table Definition, Name -Auto
 }
-PS C:\ps-test> Set-PSBreakpoint -Command my-alias
-Command    : my-alias
+PS C:\ps-test> Set-PSBreakpoint -Command My-Alias
+Command    : My-Alias
 Action     :
 Enabled    : True
 HitCount   : 0
 Id         : 0
-Script     : prompt PS C:\> my-alias Get-Content
+Script     : prompt PS C:\> My-Alias Get-Content
 
 Entering debug mode. Use h or ? for help.
-Hit Command breakpoint on 'prompt:my-alias'
-my-alias Get-Content
+Hit Command breakpoint on 'prompt:My-Alias'
+My-Alias Get-Content
 [DBG]: PS C:\ps-test> s
 $p = $args[0]
 DEBUG: Stepped to ':    $p = $args[0]    '
 [DBG]: PS C:\ps-test> s
-Get-Alias | Where {$_.Definition -like "*$p*"} | Format-Table Definition,
-[DBG]: PS C:\ps-test>Get-PSCallstack
+Get-Alias | where {$_.Definition -like "*$p*"} | Format-Table Definition,
+[DBG]: PS C:\ps-test>Get-PSCallStack
 
 Name        CommandLineParameters         UnboundArguments              Location
 ----        ---------------------         ----------------              --------
 prompt      {}                            {}                            prompt
-my-alias    {}                            {Get-Content}                 prompt
+My-Alias    {}                            {Get-Content}                 prompt
 prompt      {}                            {}                            prompt
 
 PS C:\> [DBG]: PS C:\ps-test> o


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide