### PR TITLE
Fix incorrect case/capitalization in reference documents (23/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-TraceSource.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-TraceSource.md
@@ -33,7 +33,7 @@ The tracing cmdlets were designed for PowerShell developers, but they are availa
 ### Example 1: Get trace sources by name
 
 ```powershell
-Get-TraceSource -Name "*provider*"
+Get-TraceSource -Name "*Provider*"
 ```
 
 This command gets all of the trace sources that have names that include provider.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Unique.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Unique.md
@@ -43,9 +43,9 @@ These commands find the number of unique words in a text file.
 
 ```powershell
 $A = $( foreach ($line in Get-Content C:\Test1\File1.txt) {
-    $line.tolower().split(" ")
+    $line.ToLower().Split(" ")
   }) | Sort-Object | Get-Unique
-$A.count
+$A.Count
 ```
 
 The first command gets the content of the `File.txt` file. It converts each line of text to
@@ -97,7 +97,7 @@ directs `Get-Unique` to return only one object of each type.
 This command gets the names of processes running on the computer with duplicates eliminated.
 
 ```powershell
-Get-Process | Sort-Object | Select-Object processname | Get-Unique -AsString
+Get-Process | Sort-Object | Select-Object ProcessName | Get-Unique -AsString
 ```
 
 The `Get-Process` command gets all of the processes on the computer. The pipeline operator (`|`)

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Variable.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Variable.md
@@ -195,7 +195,7 @@ Windows PowerShell includes the following aliases for `Get-Variable`:
 - `gv`
 
 - This cmdlet does not manage environment variables. To manage environment variables, you can use
-the environment variable provider.
+the Environment provider.
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Group-Object.md
@@ -44,7 +44,7 @@ This example uses the **NoElement** parameter to omit the members of the group.
 ```powershell
 $files = Get-ChildItem -Path $PSHOME -Recurse
 $files |
-    Group-Object -Property extension -NoElement |
+    Group-Object -Property Extension -NoElement |
     Sort-Object -Property Count -Descending
 ```
 
@@ -180,7 +180,7 @@ values are **CmdletInfo** object. The **AsString** parameter doesn't convert the
 groups to strings.
 
 ```powershell
-$A = Get-Command Get-*, Set-* -CommandType cmdlet |
+$A = Get-Command Get-*, Set-* -CommandType Cmdlet |
      Group-Object -Property Verb -AsHashTable -AsString
 $A
 ```

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-Csv.md
@@ -41,7 +41,7 @@ delimiter, or direct `Import-Csv` to use the list separator for the current cult
 delimiter.
 
 You can also use the `ConvertTo-Csv` and `ConvertFrom-Csv` cmdlets to convert objects to CSV
-strings (and back). These cmdlets are the same as the `Export-CSV` and `Import-Csv` cmdlets, except
+strings (and back). These cmdlets are the same as the `Export-Csv` and `Import-Csv` cmdlets, except
 that they work with data from the pipeline instead of from files.
 
 If a header row entry in a CSV file contains an empty or null value, PowerShell inserts a default

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-LocalizedData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-LocalizedData.md
@@ -61,7 +61,7 @@ file in the `C:\test\zh-CN` directory into the `$Messages` variable.
 ### Example 2: Import localized data strings
 
 This example is run at the command line not in a script. It gets localized data strings from the
-Test.psd1 file and displays them at the command line. Because the command isn't used in a script,
+`Test.psd1` file and displays them at the command line. Because the command isn't used in a script,
 the **FileName** parameter is required. The command uses the **UICulture** parameter to specify the
 en-US culture.
 
@@ -154,12 +154,12 @@ Import-LocalizedData -BindingVariable "UserMessages"
 $UserMessages.Msg1...
 ```
 
-In this example, the DATA section of the TestScript.ps1 script contains a `ConvertFrom-StringData`
+In this example, the DATA section of the `TestScript.ps1` script contains a `ConvertFrom-StringData`
 command that converts the contents of the DATA section to a hashtable and stores in the value of the
 `$UserMessages` variable.
 
 The script also includes an `Import-LocalizedData` command, which imports a hashtable of translated
-text strings from the TestScript.psd1 file in the subdirectory specified by the value of the
+text strings from the `TestScript.psd1` file in the subdirectory specified by the value of the
 `$PSUICulture` variable. If the command finds the `.psd1` file, it saves the translated strings from
 the file in the value of the same `$UserMessages` variable, overwriting the hashtable saved by the
 DATA section logic.
@@ -256,7 +256,7 @@ Accept wildcard characters: False
 
 ### -FileName
 
-Specifies the name of the data file (`.psd1)` to be imported. Enter a filename. You can specify a
+Specifies the name of the data file (`.psd1`) to be imported. Enter a filename. You can specify a
 filename that doesn't include its `.psd1` filename extension, or you can specify the filename
 including the `.psd1` filename extension. Data files should be saved as Unicode or UTF-8.
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-PSSession.md
@@ -103,7 +103,7 @@ need to use the `Invoke-Command` cmdlet to run an imported command.
 ```
 $S1 = New-PSSession -ComputerName s1
 $S2 = New-PSSession -ComputerName s2
-Import-PSSession -Session s1 -Type cmdlet -Name New-Test, Get-Test -FormatTypeName *
+Import-PSSession -Session s1 -Type Cmdlet -Name New-Test, Get-Test -FormatTypeName *
 Import-PSSession -Session s2 -Type Cmdlet -Name Set-Test -FormatTypeName *
 New-Test Test1 | Set-Test -RunType Full
 ```
@@ -199,7 +199,7 @@ function into the current session.
 
 The `Import-PSSession` cmdlet returns a **PSModuleInfo** object that represents the temporary
 module. The value of the **Path** property shows that `Import-PSSession` created a script module
-(.psm1) file in a temporary location. The **ExportedFunctions** property shows that the `Get-Date`
+(`.psm1`) file in a temporary location. The **ExportedFunctions** property shows that the `Get-Date`
 cmdlet and the SearchHelp function were both imported as functions.
 
 ### Example 7: Run a command that is hidden by an imported command
@@ -327,7 +327,7 @@ Accept wildcard characters: False
 Specifies an array of commands that results from using the specified arguments (parameter values).
 
 For instance, to import the variant of the `Get-Item` command in the certificate (Cert:) drive in
-the PSSession in `$S`, type `Import-PSSession -Session $S -Command Get-Item -ArgumentList cert:`.
+the PSSession in `$S`, type `Import-PSSession -Session $S -Command Get-Item -ArgumentList Cert:`.
 
 ```yaml
 Type: System.Object[]
@@ -344,7 +344,7 @@ Accept wildcard characters: False
 ### -Certificate
 
 Specifies the client certificate that is used to sign the format files (*.Format.ps1xml) or script
-module files (.psm1) in the temporary module that `Import-PSSession` creates.
+module files (`.psm1`) in the temporary module that `Import-PSSession` creates.
 
 Enter a variable that contains a certificate or a command or expression that gets the certificate.
 
@@ -398,11 +398,11 @@ alias, **Type**. The acceptable values for this parameter are:
 - `Alias`: The Windows PowerShell aliases in the remote session.
 - `All`: The cmdlets and functions in the remote session.
 - `Application`: All the files other than Windows-PowerShell files in the paths that are listed in
-  the Path environment variable (`$env:path`) in the remote session, including .txt, .exe, and .dll
+  the PATH environment variable (`$Env:PATH`) in the remote session, including .txt, .exe, and .dll
   files.
 - `Cmdlet`: The cmdlets in the remote session. "Cmdlet" is the default.
-- `ExternalScript`: The .ps1 files in the paths listed in the Path environment variable
-  (`$env:path`) in the remote session.
+- `ExternalScript`: The `.ps1` files in the paths listed in the PATH environment variable
+  (`$Env:PATH`) in the remote session.
 - `Filter` and `Function`: The Windows PowerShell functions in the remote session.
 - `Script`: The script blocks in the remote session.
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-PowerShellDataFile.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-PowerShellDataFile.md
@@ -11,7 +11,7 @@ title: Import-PowerShellDataFile
 # Import-PowerShellDataFile
 
 ## SYNOPSIS
-Imports values from a `.PSD1` file without invoking its contents.
+Imports values from a `.psd1` file without invoking its contents.
 
 ## SYNTAX
 
@@ -30,7 +30,7 @@ Import-PowerShellDataFile [-LiteralPath <string[]>] [<CommonParameters>]
 ## DESCRIPTION
 
 The `Import-PowerShellDataFile` cmdlet safely imports key-value pairs from hashtables defined in a
-`.PSD1` file. The values could be imported using `Invoke-Expression` on the contents of the file.
+`.psd1` file. The values could be imported using `Invoke-Expression` on the contents of the file.
 However, `Invoke-Expression` runs any code contained in the file. This could produce unwanted
 results or execute unsafe code. `Import-PowerShellDataFile` imports the data without invoking the
 code.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-Expression.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-Expression.md
@@ -79,14 +79,14 @@ Invoke-Expression -Command "C:\ps-test\testscript.ps1"
 "C:\ps-test\testscript.ps1" | Invoke-Expression
 ```
 
-These commands use `Invoke-Expression` to run a script, TestScript.ps1, on the local computer. The
+These commands use `Invoke-Expression` to run a script, `TestScript.ps1`, on the local computer. The
 two commands are equivalent. The first uses the **Command** parameter to specify the command to run.
 The second uses a pipeline operator (`|`) to send the command string to `Invoke-Expression`.
 
 ### Example 3: Run a command in a variable
 
 ```powershell
-$Command = 'Get-Process | where {$_.cpu -gt 1000}'
+$Command = 'Get-Process | where {$_.CPU -gt 1000}'
 Invoke-Expression $Command
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -32,7 +32,7 @@ The `Invoke-RestMethod` cmdlet sends HTTP and HTTPS requests to Representational
 
 PowerShell formats the response based to the data type. For an RSS or ATOM feed, PowerShell returns
 the Item or Entry XML nodes. For JavaScript Object Notation (JSON) or XML, PowerShell converts, or
-deserializes, the content into `[PSCustomObject]` objects. Comments aren't permitted in the JSON
+deserializes, the content into `[pscustomobject]` objects. Comments aren't permitted in the JSON
 data.
 
 > [!NOTE]

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-TraceSource.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-TraceSource.md
@@ -33,7 +33,7 @@ The tracing cmdlets were designed for PowerShell developers, but they are availa
 ### Example 1: Get trace sources by name
 
 ```powershell
-Get-TraceSource -Name "*provider*"
+Get-TraceSource -Name "*Provider*"
 ```
 
 This command gets all of the trace sources that have names that include provider.

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-Unique.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-Unique.md
@@ -43,9 +43,9 @@ These commands find the number of unique words in a text file.
 
 ```powershell
 $A = $( foreach ($line in Get-Content C:\Test1\File1.txt) {
-    $line.tolower().split(" ")
+    $line.ToLower().Split(" ")
   }) | Sort-Object | Get-Unique
-$A.count
+$A.Count
 ```
 
 The first command gets the content of the `File.txt` file. It converts each line of text to
@@ -97,7 +97,7 @@ directs `Get-Unique` to return only one object of each type.
 This command gets the names of processes running on the computer with duplicates eliminated.
 
 ```powershell
-Get-Process | Sort-Object | Select-Object processname | Get-Unique -AsString
+Get-Process | Sort-Object | Select-Object ProcessName | Get-Unique -AsString
 ```
 
 The `Get-Process` command gets all of the processes on the computer. The pipeline operator (`|`)

--- a/reference/7.4/Microsoft.PowerShell.Utility/Get-Variable.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Get-Variable.md
@@ -196,7 +196,7 @@ PowerShell includes the following aliases for `Get-Variable`:
   - `gv`
 
 - This cmdlet does not manage environment variables. To manage environment variables, you can use
-the environment variable provider.
+the Environment provider.
 
 ## RELATED LINKS
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Group-Object.md
@@ -48,7 +48,7 @@ This example uses the **NoElement** parameter to omit the members of the group.
 ```powershell
 $files = Get-ChildItem -Path $PSHOME -Recurse
 $files |
-    Group-Object -Property extension -NoElement |
+    Group-Object -Property Extension -NoElement |
     Sort-Object -Property Count -Descending
 ```
 
@@ -208,7 +208,7 @@ values are **CmdletInfo** object. The **AsString** parameter doesn't convert the
 groups to strings.
 
 ```powershell
-$A = Get-Command Get-*, Set-* -CommandType cmdlet |
+$A = Get-Command Get-*, Set-* -CommandType Cmdlet |
      Group-Object -Property Verb -AsHashTable -AsString
 $A
 ```

--- a/reference/7.4/Microsoft.PowerShell.Utility/Import-Csv.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Import-Csv.md
@@ -55,7 +55,7 @@ delimiter, or direct `Import-Csv` to use the list separator for the current cult
 delimiter.
 
 You can also use the `ConvertTo-Csv` and `ConvertFrom-Csv` cmdlets to convert objects to CSV
-strings (and back). These cmdlets are the same as the `Export-CSV` and `Import-Csv` cmdlets, except
+strings (and back). These cmdlets are the same as the `Export-Csv` and `Import-Csv` cmdlets, except
 that they work with data from the pipeline instead of from files.
 
 If a header row entry in a CSV file contains an empty or null value, PowerShell inserts a default

--- a/reference/7.4/Microsoft.PowerShell.Utility/Import-LocalizedData.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Import-LocalizedData.md
@@ -61,7 +61,7 @@ file in the `C:\test\zh-CN` directory into the `$Messages` variable.
 ### Example 2: Import localized data strings
 
 This example is run at the command line not in a script. It gets localized data strings from the
-Test.psd1 file and displays them at the command line. Because the command isn't used in a script,
+`Test.psd1` file and displays them at the command line. Because the command isn't used in a script,
 the **FileName** parameter is required. The command uses the **UICulture** parameter to specify the
 en-US culture.
 
@@ -154,12 +154,12 @@ Import-LocalizedData -BindingVariable "UserMessages"
 $UserMessages.Msg1...
 ```
 
-In this example, the DATA section of the TestScript.ps1 script contains a `ConvertFrom-StringData`
+In this example, the DATA section of the `TestScript.ps1` script contains a `ConvertFrom-StringData`
 command that converts the contents of the DATA section to a hashtable and stores in the value of the
 `$UserMessages` variable.
 
 The script also includes an `Import-LocalizedData` command, which imports a hashtable of translated
-text strings from the TestScript.psd1 file in the subdirectory specified by the value of the
+text strings from the `TestScript.psd1` file in the subdirectory specified by the value of the
 `$PSUICulture` variable. If the command finds the `.psd1` file, it saves the translated strings from
 the file in the value of the same `$UserMessages` variable, overwriting the hashtable saved by the
 DATA section logic.
@@ -256,7 +256,7 @@ Accept wildcard characters: False
 
 ### -FileName
 
-Specifies the name of the data file (`.psd1)` to be imported. Enter a filename. You can specify a
+Specifies the name of the data file (`.psd1`) to be imported. Enter a filename. You can specify a
 filename that doesn't include its `.psd1` filename extension, or you can specify the filename
 including the `.psd1` filename extension. Data files should be saved as Unicode or UTF-8.
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Import-PSSession.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Import-PSSession.md
@@ -103,7 +103,7 @@ need to use the `Invoke-Command` cmdlet to run an imported command.
 ```
 $S1 = New-PSSession -ComputerName s1
 $S2 = New-PSSession -ComputerName s2
-Import-PSSession -Session s1 -Type cmdlet -Name New-Test, Get-Test -FormatTypeName *
+Import-PSSession -Session s1 -Type Cmdlet -Name New-Test, Get-Test -FormatTypeName *
 Import-PSSession -Session s2 -Type Cmdlet -Name Set-Test -FormatTypeName *
 New-Test Test1 | Set-Test -RunType Full
 ```
@@ -199,7 +199,7 @@ function into the current session.
 
 The `Import-PSSession` cmdlet returns a **PSModuleInfo** object that represents the temporary
 module. The value of the **Path** property shows that `Import-PSSession` created a script module
-(.psm1) file in a temporary location. The **ExportedFunctions** property shows that the `Get-Date`
+(`.psm1`) file in a temporary location. The **ExportedFunctions** property shows that the `Get-Date`
 cmdlet and the SearchHelp function were both imported as functions.
 
 ### Example 7: Run a command that is hidden by an imported command
@@ -327,7 +327,7 @@ Accept wildcard characters: False
 Specifies an array of commands that results from using the specified arguments (parameter values).
 
 For instance, to import the variant of the `Get-Item` command in the certificate (Cert:) drive in
-the PSSession in `$S`, type `Import-PSSession -Session $S -Command Get-Item -ArgumentList cert:`.
+the PSSession in `$S`, type `Import-PSSession -Session $S -Command Get-Item -ArgumentList Cert:`.
 
 ```yaml
 Type: System.Object[]
@@ -344,7 +344,7 @@ Accept wildcard characters: False
 ### -Certificate
 
 Specifies the client certificate that is used to sign the format files (*.Format.ps1xml) or script
-module files (.psm1) in the temporary module that `Import-PSSession` creates.
+module files (`.psm1`) in the temporary module that `Import-PSSession` creates.
 
 Enter a variable that contains a certificate or a command or expression that gets the certificate.
 
@@ -398,11 +398,11 @@ alias, **Type**. The acceptable values for this parameter are:
 - `Alias`: The Windows PowerShell aliases in the remote session.
 - `All`: The cmdlets and functions in the remote session.
 - `Application`: All the files other than Windows-PowerShell files in the paths that are listed in
-  the Path environment variable (`$env:path`) in the remote session, including .txt, .exe, and .dll
+  the PATH environment variable (`$Env:PATH`) in the remote session, including .txt, .exe, and .dll
   files.
 - `Cmdlet`: The cmdlets in the remote session. "Cmdlet" is the default.
-- `ExternalScript`: The .ps1 files in the paths listed in the Path environment variable
-  (`$env:path`) in the remote session.
+- `ExternalScript`: The `.ps1` files in the paths listed in the PATH environment variable
+  (`$Env:PATH`) in the remote session.
 - `Filter` and `Function`: The Windows PowerShell functions in the remote session.
 - `Script`: The script blocks in the remote session.
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Import-PowerShellDataFile.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Import-PowerShellDataFile.md
@@ -11,7 +11,7 @@ title: Import-PowerShellDataFile
 # Import-PowerShellDataFile
 
 ## SYNOPSIS
-Imports values from a `.PSD1` file without invoking its contents.
+Imports values from a `.psd1` file without invoking its contents.
 
 ## SYNTAX
 
@@ -30,7 +30,7 @@ Import-PowerShellDataFile [-LiteralPath] <String[]> [-SkipLimitCheck] [<CommonPa
 ## DESCRIPTION
 
 The `Import-PowerShellDataFile` cmdlet safely imports key-value pairs from hashtables defined in a
-`.PSD1` file. The values could be imported using `Invoke-Expression` on the contents of the file.
+`.psd1` file. The values could be imported using `Invoke-Expression` on the contents of the file.
 However, `Invoke-Expression` runs any code contained in the file. This could produce unwanted
 results or execute unsafe code. `Import-PowerShellDataFile` imports the data without invoking the
 code. By default there is a 500 key limit, but this can be bypassed with the **SkipLimitCheck**

--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-Expression.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-Expression.md
@@ -79,14 +79,14 @@ Invoke-Expression -Command "C:\ps-test\testscript.ps1"
 "C:\ps-test\testscript.ps1" | Invoke-Expression
 ```
 
-These commands use `Invoke-Expression` to run a script, TestScript.ps1, on the local computer. The
+These commands use `Invoke-Expression` to run a script, `TestScript.ps1`, on the local computer. The
 two commands are equivalent. The first uses the **Command** parameter to specify the command to run.
 The second uses a pipeline operator (`|`) to send the command string to `Invoke-Expression`.
 
 ### Example 3: Run a command in a variable
 
 ```powershell
-$Command = 'Get-Process | where {$_.cpu -gt 1000}'
+$Command = 'Get-Process | where {$_.CPU -gt 1000}'
 Invoke-Expression $Command
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -99,7 +99,7 @@ The `Invoke-RestMethod` cmdlet sends HTTP and HTTPS requests to Representational
 
 PowerShell formats the response based to the data type. For an RSS or ATOM feed, PowerShell returns
 the Item or Entry XML nodes. For JavaScript Object Notation (JSON) or XML, PowerShell converts, or
-deserializes, the content into `[PSCustomObject]` objects. Comments are permitted in the JSON data.
+deserializes, the content into `[pscustomobject]` objects. Comments are permitted in the JSON data.
 
 > [!NOTE]
 > When the REST endpoint returns multiple objects, the objects are received as an array. If you pipe
@@ -193,7 +193,7 @@ $Form = @{
     firstName  = 'John'
     lastName   = 'Doe'
     email      = 'john.doe@contoso.com'
-    avatar     = Get-Item -Path 'c:\Pictures\jdoe.png'
+    avatar     = Get-Item -Path 'C:\Pictures\jdoe.png'
     birthday   = '1980-10-15'
     hobbies    = 'Hiking','Fishing','Jogging'
 }
@@ -593,7 +593,7 @@ be used together.
 
 Example:
 
-`Invoke-RestMethod -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
+`Invoke-RestMethod -Uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
 
 This makes a `TEST` HTTP request to the API.
 
@@ -668,7 +668,7 @@ name of the file is submitted as the `filename`. The MIME type is set as `applic
 
 ```powershell
 $Form = @{
-    resume = Get-Item 'c:\Users\jdoe\Documents\John Doe.pdf'
+    resume = Get-Item 'C:\Users\jdoe\Documents\John Doe.pdf'
 }
 ```
 
@@ -680,7 +680,7 @@ aren't supported.
 ```powershell
 $Form = @{
     tags     = 'Vacation', 'Italy', '2017'
-    pictures = Get-ChildItem 'c:\Users\jdoe\Pictures\2017-Italy\'
+    pictures = Get-ChildItem 'C:\Users\jdoe\Pictures\2017-Italy\'
 }
 ```
 
@@ -772,7 +772,7 @@ Accept wildcard characters: False
 
 Specifies how many times to follow relation links if **FollowRelLink** is used. A smaller value may
 be needed if the REST api throttles due to too many requests. The default value is
-`[Int32]::MaxValue`. A value of 0 (zero) prevents following relation links.
+`[int32]::MaxValue`. A value of 0 (zero) prevents following relation links.
 
 ```yaml
 Type: System.Int32

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-TraceSource.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-TraceSource.md
@@ -33,7 +33,7 @@ The tracing cmdlets were designed for PowerShell developers, but they are availa
 ### Example 1: Get trace sources by name
 
 ```powershell
-Get-TraceSource -Name "*provider*"
+Get-TraceSource -Name "*Provider*"
 ```
 
 This command gets all of the trace sources that have names that include provider.

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-Unique.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-Unique.md
@@ -43,9 +43,9 @@ These commands find the number of unique words in a text file.
 
 ```powershell
 $A = $( foreach ($line in Get-Content C:\Test1\File1.txt) {
-    $line.tolower().split(" ")
+    $line.ToLower().Split(" ")
   }) | Sort-Object | Get-Unique
-$A.count
+$A.Count
 ```
 
 The first command gets the content of the `File.txt` file. It converts each line of text to
@@ -97,7 +97,7 @@ directs `Get-Unique` to return only one object of each type.
 This command gets the names of processes running on the computer with duplicates eliminated.
 
 ```powershell
-Get-Process | Sort-Object | Select-Object processname | Get-Unique -AsString
+Get-Process | Sort-Object | Select-Object ProcessName | Get-Unique -AsString
 ```
 
 The `Get-Process` command gets all of the processes on the computer. The pipeline operator (`|`)

--- a/reference/7.5/Microsoft.PowerShell.Utility/Get-Variable.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Get-Variable.md
@@ -196,7 +196,7 @@ PowerShell includes the following aliases for `Get-Variable`:
   - `gv`
 
 - This cmdlet does not manage environment variables. To manage environment variables, you can use
-the environment variable provider.
+the Environment provider.
 
 ## RELATED LINKS
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Group-Object.md
@@ -48,7 +48,7 @@ This example uses the **NoElement** parameter to omit the members of the group.
 ```powershell
 $files = Get-ChildItem -Path $PSHOME -Recurse
 $files |
-    Group-Object -Property extension -NoElement |
+    Group-Object -Property Extension -NoElement |
     Sort-Object -Property Count -Descending
 ```
 
@@ -208,7 +208,7 @@ values are **CmdletInfo** object. The **AsString** parameter doesn't convert the
 groups to strings.
 
 ```powershell
-$A = Get-Command Get-*, Set-* -CommandType cmdlet |
+$A = Get-Command Get-*, Set-* -CommandType Cmdlet |
      Group-Object -Property Verb -AsHashTable -AsString
 $A
 ```

--- a/reference/7.5/Microsoft.PowerShell.Utility/Import-Csv.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Import-Csv.md
@@ -55,7 +55,7 @@ delimiter, or direct `Import-Csv` to use the list separator for the current cult
 delimiter.
 
 You can also use the `ConvertTo-Csv` and `ConvertFrom-Csv` cmdlets to convert objects to CSV
-strings (and back). These cmdlets are the same as the `Export-CSV` and `Import-Csv` cmdlets, except
+strings (and back). These cmdlets are the same as the `Export-Csv` and `Import-Csv` cmdlets, except
 that they work with data from the pipeline instead of from files.
 
 If a header row entry in a CSV file contains an empty or null value, PowerShell inserts a default

--- a/reference/7.5/Microsoft.PowerShell.Utility/Import-LocalizedData.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Import-LocalizedData.md
@@ -61,7 +61,7 @@ file in the `C:\test\zh-CN` directory into the `$Messages` variable.
 ### Example 2: Import localized data strings
 
 This example is run at the command line not in a script. It gets localized data strings from the
-Test.psd1 file and displays them at the command line. Because the command isn't used in a script,
+`Test.psd1` file and displays them at the command line. Because the command isn't used in a script,
 the **FileName** parameter is required. The command uses the **UICulture** parameter to specify the
 en-US culture.
 
@@ -154,12 +154,12 @@ Import-LocalizedData -BindingVariable "UserMessages"
 $UserMessages.Msg1...
 ```
 
-In this example, the DATA section of the TestScript.ps1 script contains a `ConvertFrom-StringData`
+In this example, the DATA section of the `TestScript.ps1` script contains a `ConvertFrom-StringData`
 command that converts the contents of the DATA section to a hashtable and stores in the value of the
 `$UserMessages` variable.
 
 The script also includes an `Import-LocalizedData` command, which imports a hashtable of translated
-text strings from the TestScript.psd1 file in the subdirectory specified by the value of the
+text strings from the `TestScript.psd1` file in the subdirectory specified by the value of the
 `$PSUICulture` variable. If the command finds the `.psd1` file, it saves the translated strings from
 the file in the value of the same `$UserMessages` variable, overwriting the hashtable saved by the
 DATA section logic.
@@ -256,7 +256,7 @@ Accept wildcard characters: False
 
 ### -FileName
 
-Specifies the name of the data file (`.psd1)` to be imported. Enter a filename. You can specify a
+Specifies the name of the data file (`.psd1`) to be imported. Enter a filename. You can specify a
 filename that doesn't include its `.psd1` filename extension, or you can specify the filename
 including the `.psd1` filename extension. Data files should be saved as Unicode or UTF-8.
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Import-PSSession.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Import-PSSession.md
@@ -103,7 +103,7 @@ need to use the `Invoke-Command` cmdlet to run an imported command.
 ```
 $S1 = New-PSSession -ComputerName s1
 $S2 = New-PSSession -ComputerName s2
-Import-PSSession -Session s1 -Type cmdlet -Name New-Test, Get-Test -FormatTypeName *
+Import-PSSession -Session s1 -Type Cmdlet -Name New-Test, Get-Test -FormatTypeName *
 Import-PSSession -Session s2 -Type Cmdlet -Name Set-Test -FormatTypeName *
 New-Test Test1 | Set-Test -RunType Full
 ```
@@ -199,7 +199,7 @@ function into the current session.
 
 The `Import-PSSession` cmdlet returns a **PSModuleInfo** object that represents the temporary
 module. The value of the **Path** property shows that `Import-PSSession` created a script module
-(.psm1) file in a temporary location. The **ExportedFunctions** property shows that the `Get-Date`
+(`.psm1`) file in a temporary location. The **ExportedFunctions** property shows that the `Get-Date`
 cmdlet and the SearchHelp function were both imported as functions.
 
 ### Example 7: Run a command that is hidden by an imported command
@@ -327,7 +327,7 @@ Accept wildcard characters: False
 Specifies an array of commands that results from using the specified arguments (parameter values).
 
 For instance, to import the variant of the `Get-Item` command in the certificate (Cert:) drive in
-the PSSession in `$S`, type `Import-PSSession -Session $S -Command Get-Item -ArgumentList cert:`.
+the PSSession in `$S`, type `Import-PSSession -Session $S -Command Get-Item -ArgumentList Cert:`.
 
 ```yaml
 Type: System.Object[]
@@ -344,7 +344,7 @@ Accept wildcard characters: False
 ### -Certificate
 
 Specifies the client certificate that is used to sign the format files (*.Format.ps1xml) or script
-module files (.psm1) in the temporary module that `Import-PSSession` creates.
+module files (`.psm1`) in the temporary module that `Import-PSSession` creates.
 
 Enter a variable that contains a certificate or a command or expression that gets the certificate.
 
@@ -398,11 +398,11 @@ alias, **Type**. The acceptable values for this parameter are:
 - `Alias`: The Windows PowerShell aliases in the remote session.
 - `All`: The cmdlets and functions in the remote session.
 - `Application`: All the files other than Windows-PowerShell files in the paths that are listed in
-  the Path environment variable (`$env:path`) in the remote session, including .txt, .exe, and .dll
+  the PATH environment variable (`$Env:PATH`) in the remote session, including .txt, .exe, and .dll
   files.
 - `Cmdlet`: The cmdlets in the remote session. "Cmdlet" is the default.
-- `ExternalScript`: The .ps1 files in the paths listed in the Path environment variable
-  (`$env:path`) in the remote session.
+- `ExternalScript`: The `.ps1` files in the paths listed in the PATH environment variable
+  (`$Env:PATH`) in the remote session.
 - `Filter` and `Function`: The Windows PowerShell functions in the remote session.
 - `Script`: The script blocks in the remote session.
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Import-PowerShellDataFile.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Import-PowerShellDataFile.md
@@ -11,7 +11,7 @@ title: Import-PowerShellDataFile
 # Import-PowerShellDataFile
 
 ## SYNOPSIS
-Imports values from a `.PSD1` file without invoking its contents.
+Imports values from a `.psd1` file without invoking its contents.
 
 ## SYNTAX
 
@@ -30,7 +30,7 @@ Import-PowerShellDataFile [-LiteralPath] <String[]> [-SkipLimitCheck] [<CommonPa
 ## DESCRIPTION
 
 The `Import-PowerShellDataFile` cmdlet safely imports key-value pairs from hashtables defined in a
-`.PSD1` file. The values could be imported using `Invoke-Expression` on the contents of the file.
+`.psd1` file. The values could be imported using `Invoke-Expression` on the contents of the file.
 However, `Invoke-Expression` runs any code contained in the file. This could produce unwanted
 results or execute unsafe code. `Import-PowerShellDataFile` imports the data without invoking the
 code. By default there is a 500 key limit, but this can be bypassed with the **SkipLimitCheck**

--- a/reference/7.5/Microsoft.PowerShell.Utility/Invoke-Expression.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Invoke-Expression.md
@@ -79,14 +79,14 @@ Invoke-Expression -Command "C:\ps-test\testscript.ps1"
 "C:\ps-test\testscript.ps1" | Invoke-Expression
 ```
 
-These commands use `Invoke-Expression` to run a script, TestScript.ps1, on the local computer. The
+These commands use `Invoke-Expression` to run a script, `TestScript.ps1`, on the local computer. The
 two commands are equivalent. The first uses the **Command** parameter to specify the command to run.
 The second uses a pipeline operator (`|`) to send the command string to `Invoke-Expression`.
 
 ### Example 3: Run a command in a variable
 
 ```powershell
-$Command = 'Get-Process | where {$_.cpu -gt 1000}'
+$Command = 'Get-Process | where {$_.CPU -gt 1000}'
 Invoke-Expression $Command
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -99,7 +99,7 @@ The `Invoke-RestMethod` cmdlet sends HTTP and HTTPS requests to Representational
 
 PowerShell formats the response based to the data type. For an RSS or ATOM feed, PowerShell returns
 the Item or Entry XML nodes. For JavaScript Object Notation (JSON) or XML, PowerShell converts, or
-deserializes, the content into `[PSCustomObject]` objects. Comments are permitted in the JSON data.
+deserializes, the content into `[pscustomobject]` objects. Comments are permitted in the JSON data.
 
 > [!NOTE]
 > When the REST endpoint returns multiple objects, the objects are received as an array. If you pipe
@@ -193,7 +193,7 @@ $Form = @{
     firstName  = 'John'
     lastName   = 'Doe'
     email      = 'john.doe@contoso.com'
-    avatar     = Get-Item -Path 'c:\Pictures\jdoe.png'
+    avatar     = Get-Item -Path 'C:\Pictures\jdoe.png'
     birthday   = '1980-10-15'
     hobbies    = 'Hiking','Fishing','Jogging'
 }
@@ -593,7 +593,7 @@ be used together.
 
 Example:
 
-`Invoke-RestMethod -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
+`Invoke-RestMethod -Uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
 
 This makes a `TEST` HTTP request to the API.
 
@@ -668,7 +668,7 @@ name of the file is submitted as the `filename`. The MIME type is set as `applic
 
 ```powershell
 $Form = @{
-    resume = Get-Item 'c:\Users\jdoe\Documents\John Doe.pdf'
+    resume = Get-Item 'C:\Users\jdoe\Documents\John Doe.pdf'
 }
 ```
 
@@ -680,7 +680,7 @@ aren't supported.
 ```powershell
 $Form = @{
     tags     = 'Vacation', 'Italy', '2017'
-    pictures = Get-ChildItem 'c:\Users\jdoe\Pictures\2017-Italy\'
+    pictures = Get-ChildItem 'C:\Users\jdoe\Pictures\2017-Italy\'
 }
 ```
 
@@ -772,7 +772,7 @@ Accept wildcard characters: False
 
 Specifies how many times to follow relation links if **FollowRelLink** is used. A smaller value may
 be needed if the REST api throttles due to too many requests. The default value is
-`[Int32]::MaxValue`. A value of 0 (zero) prevents following relation links.
+`[int32]::MaxValue`. A value of 0 (zero) prevents following relation links.
 
 ```yaml
 Type: System.Int32

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-TraceSource.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-TraceSource.md
@@ -33,7 +33,7 @@ The tracing cmdlets were designed for PowerShell developers, but they are availa
 ### Example 1: Get trace sources by name
 
 ```powershell
-Get-TraceSource -Name "*provider*"
+Get-TraceSource -Name "*Provider*"
 ```
 
 This command gets all of the trace sources that have names that include provider.

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-Unique.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-Unique.md
@@ -43,9 +43,9 @@ These commands find the number of unique words in a text file.
 
 ```powershell
 $A = $( foreach ($line in Get-Content C:\Test1\File1.txt) {
-    $line.ToLower().split(" ")
+    $line.ToLower().Split(" ")
   }) | Sort-Object | Get-Unique
-$A.count
+$A.Count
 ```
 
 The first command gets the content of the `File.txt` file. It converts each line of text to
@@ -97,7 +97,7 @@ directs `Get-Unique` to return only one object of each type.
 This command gets the names of processes running on the computer with duplicates eliminated.
 
 ```powershell
-Get-Process | Sort-Object | Select-Object processname | Get-Unique -AsString
+Get-Process | Sort-Object | Select-Object ProcessName | Get-Unique -AsString
 ```
 
 The `Get-Process` command gets all of the processes on the computer. The pipeline operator (`|`)

--- a/reference/7.6/Microsoft.PowerShell.Utility/Get-Variable.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Get-Variable.md
@@ -196,7 +196,7 @@ PowerShell includes the following aliases for `Get-Variable`:
   - `gv`
 
 - This cmdlet does not manage environment variables. To manage environment variables, you can use
-the environment variable provider.
+the Environment provider.
 
 ## RELATED LINKS
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Group-Object.md
@@ -48,7 +48,7 @@ This example uses the **NoElement** parameter to omit the members of the group.
 ```powershell
 $files = Get-ChildItem -Path $PSHOME -Recurse
 $files |
-    Group-Object -Property extension -NoElement |
+    Group-Object -Property Extension -NoElement |
     Sort-Object -Property Count -Descending
 ```
 
@@ -208,7 +208,7 @@ values are **CmdletInfo** object. The **AsString** parameter doesn't convert the
 groups to strings.
 
 ```powershell
-$A = Get-Command Get-*, Set-* -CommandType cmdlet |
+$A = Get-Command Get-*, Set-* -CommandType Cmdlet |
      Group-Object -Property Verb -AsHashTable -AsString
 $A
 ```

--- a/reference/7.6/Microsoft.PowerShell.Utility/Import-Csv.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Import-Csv.md
@@ -55,7 +55,7 @@ delimiter, or direct `Import-Csv` to use the list separator for the current cult
 delimiter.
 
 You can also use the `ConvertTo-Csv` and `ConvertFrom-Csv` cmdlets to convert objects to CSV
-strings (and back). These cmdlets are the same as the `Export-CSV` and `Import-Csv` cmdlets, except
+strings (and back). These cmdlets are the same as the `Export-Csv` and `Import-Csv` cmdlets, except
 that they work with data from the pipeline instead of from files.
 
 If a header row entry in a CSV file contains an empty or null value, PowerShell inserts a default

--- a/reference/7.6/Microsoft.PowerShell.Utility/Import-LocalizedData.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Import-LocalizedData.md
@@ -61,7 +61,7 @@ file in the `C:\test\zh-CN` directory into the `$Messages` variable.
 ### Example 2: Import localized data strings
 
 This example is run at the command line not in a script. It gets localized data strings from the
-Test.psd1 file and displays them at the command line. Because the command isn't used in a script,
+`Test.psd1` file and displays them at the command line. Because the command isn't used in a script,
 the **FileName** parameter is required. The command uses the **UICulture** parameter to specify the
 en-US culture.
 
@@ -154,12 +154,12 @@ Import-LocalizedData -BindingVariable "UserMessages"
 $UserMessages.Msg1...
 ```
 
-In this example, the DATA section of the TestScript.ps1 script contains a `ConvertFrom-StringData`
+In this example, the DATA section of the `TestScript.ps1` script contains a `ConvertFrom-StringData`
 command that converts the contents of the DATA section to a hashtable and stores in the value of the
 `$UserMessages` variable.
 
 The script also includes an `Import-LocalizedData` command, which imports a hashtable of translated
-text strings from the TestScript.psd1 file in the subdirectory specified by the value of the
+text strings from the `TestScript.psd1` file in the subdirectory specified by the value of the
 `$PSUICulture` variable. If the command finds the `.psd1` file, it saves the translated strings from
 the file in the value of the same `$UserMessages` variable, overwriting the hashtable saved by the
 DATA section logic.
@@ -256,7 +256,7 @@ Accept wildcard characters: False
 
 ### -FileName
 
-Specifies the name of the data file (`.psd1)` to be imported. Enter a filename. You can specify a
+Specifies the name of the data file (`.psd1`) to be imported. Enter a filename. You can specify a
 filename that doesn't include its `.psd1` filename extension, or you can specify the filename
 including the `.psd1` filename extension. Data files should be saved as Unicode or UTF-8.
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Import-PSSession.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Import-PSSession.md
@@ -103,7 +103,7 @@ need to use the `Invoke-Command` cmdlet to run an imported command.
 ```
 $S1 = New-PSSession -ComputerName s1
 $S2 = New-PSSession -ComputerName s2
-Import-PSSession -Session s1 -Type cmdlet -Name New-Test, Get-Test -FormatTypeName *
+Import-PSSession -Session s1 -Type Cmdlet -Name New-Test, Get-Test -FormatTypeName *
 Import-PSSession -Session s2 -Type Cmdlet -Name Set-Test -FormatTypeName *
 New-Test Test1 | Set-Test -RunType Full
 ```
@@ -199,7 +199,7 @@ function into the current session.
 
 The `Import-PSSession` cmdlet returns a **PSModuleInfo** object that represents the temporary
 module. The value of the **Path** property shows that `Import-PSSession` created a script module
-(.psm1) file in a temporary location. The **ExportedFunctions** property shows that the `Get-Date`
+(`.psm1`) file in a temporary location. The **ExportedFunctions** property shows that the `Get-Date`
 cmdlet and the SearchHelp function were both imported as functions.
 
 ### Example 7: Run a command that is hidden by an imported command
@@ -327,7 +327,7 @@ Accept wildcard characters: False
 Specifies an array of commands that results from using the specified arguments (parameter values).
 
 For instance, to import the variant of the `Get-Item` command in the certificate (Cert:) drive in
-the PSSession in `$S`, type `Import-PSSession -Session $S -Command Get-Item -ArgumentList cert:`.
+the PSSession in `$S`, type `Import-PSSession -Session $S -Command Get-Item -ArgumentList Cert:`.
 
 ```yaml
 Type: System.Object[]
@@ -344,7 +344,7 @@ Accept wildcard characters: False
 ### -Certificate
 
 Specifies the client certificate that is used to sign the format files (*.Format.ps1xml) or script
-module files (.psm1) in the temporary module that `Import-PSSession` creates.
+module files (`.psm1`) in the temporary module that `Import-PSSession` creates.
 
 Enter a variable that contains a certificate or a command or expression that gets the certificate.
 
@@ -398,11 +398,11 @@ alias, **Type**. The acceptable values for this parameter are:
 - `Alias`: The Windows PowerShell aliases in the remote session.
 - `All`: The cmdlets and functions in the remote session.
 - `Application`: All the files other than Windows-PowerShell files in the paths that are listed in
-  the Path environment variable (`$env:path`) in the remote session, including .txt, .exe, and .dll
+  the PATH environment variable (`$Env:PATH`) in the remote session, including .txt, .exe, and .dll
   files.
 - `Cmdlet`: The cmdlets in the remote session. "Cmdlet" is the default.
-- `ExternalScript`: The .ps1 files in the paths listed in the Path environment variable
-  (`$env:path`) in the remote session.
+- `ExternalScript`: The `.ps1` files in the paths listed in the PATH environment variable
+  (`$Env:PATH`) in the remote session.
 - `Filter` and `Function`: The Windows PowerShell functions in the remote session.
 - `Script`: The script blocks in the remote session.
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Import-PowerShellDataFile.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Import-PowerShellDataFile.md
@@ -11,7 +11,7 @@ title: Import-PowerShellDataFile
 # Import-PowerShellDataFile
 
 ## SYNOPSIS
-Imports values from a `.PSD1` file without invoking its contents.
+Imports values from a `.psd1` file without invoking its contents.
 
 ## SYNTAX
 
@@ -30,7 +30,7 @@ Import-PowerShellDataFile [-LiteralPath] <String[]> [-SkipLimitCheck] [<CommonPa
 ## DESCRIPTION
 
 The `Import-PowerShellDataFile` cmdlet safely imports key-value pairs from hashtables defined in a
-`.PSD1` file. The values could be imported using `Invoke-Expression` on the contents of the file.
+`.psd1` file. The values could be imported using `Invoke-Expression` on the contents of the file.
 However, `Invoke-Expression` runs any code contained in the file. This could produce unwanted
 results or execute unsafe code. `Import-PowerShellDataFile` imports the data without invoking the
 code. By default there is a 500 key limit, but this can be bypassed with the **SkipLimitCheck**

--- a/reference/7.6/Microsoft.PowerShell.Utility/Invoke-Expression.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Invoke-Expression.md
@@ -79,14 +79,14 @@ Invoke-Expression -Command "C:\ps-test\testscript.ps1"
 "C:\ps-test\testscript.ps1" | Invoke-Expression
 ```
 
-These commands use `Invoke-Expression` to run a script, TestScript.ps1, on the local computer. The
+These commands use `Invoke-Expression` to run a script, `TestScript.ps1`, on the local computer. The
 two commands are equivalent. The first uses the **Command** parameter to specify the command to run.
 The second uses a pipeline operator (`|`) to send the command string to `Invoke-Expression`.
 
 ### Example 3: Run a command in a variable
 
 ```powershell
-$Command = 'Get-Process | where {$_.cpu -gt 1000}'
+$Command = 'Get-Process | where {$_.CPU -gt 1000}'
 Invoke-Expression $Command
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -99,7 +99,7 @@ The `Invoke-RestMethod` cmdlet sends HTTP and HTTPS requests to Representational
 
 PowerShell formats the response based to the data type. For an RSS or ATOM feed, PowerShell returns
 the Item or Entry XML nodes. For JavaScript Object Notation (JSON) or XML, PowerShell converts, or
-deserializes, the content into `[PSCustomObject]` objects. Comments are permitted in the JSON data.
+deserializes, the content into `[pscustomobject]` objects. Comments are permitted in the JSON data.
 
 > [!NOTE]
 > When the REST endpoint returns multiple objects, the objects are received as an array. If you pipe
@@ -193,7 +193,7 @@ $Form = @{
     firstName  = 'John'
     lastName   = 'Doe'
     email      = 'john.doe@contoso.com'
-    avatar     = Get-Item -Path 'c:\Pictures\jdoe.png'
+    avatar     = Get-Item -Path 'C:\Pictures\jdoe.png'
     birthday   = '1980-10-15'
     hobbies    = 'Hiking','Fishing','Jogging'
 }
@@ -593,7 +593,7 @@ be used together.
 
 Example:
 
-`Invoke-RestMethod -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
+`Invoke-RestMethod -Uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
 
 This makes a `TEST` HTTP request to the API.
 
@@ -668,7 +668,7 @@ name of the file is submitted as the `filename`. The MIME type is set as `applic
 
 ```powershell
 $Form = @{
-    resume = Get-Item 'c:\Users\jdoe\Documents\John Doe.pdf'
+    resume = Get-Item 'C:\Users\jdoe\Documents\John Doe.pdf'
 }
 ```
 
@@ -680,7 +680,7 @@ aren't supported.
 ```powershell
 $Form = @{
     tags     = 'Vacation', 'Italy', '2017'
-    pictures = Get-ChildItem 'c:\Users\jdoe\Pictures\2017-Italy\'
+    pictures = Get-ChildItem 'C:\Users\jdoe\Pictures\2017-Italy\'
 }
 ```
 
@@ -772,7 +772,7 @@ Accept wildcard characters: False
 
 Specifies how many times to follow relation links if **FollowRelLink** is used. A smaller value may
 be needed if the REST api throttles due to too many requests. The default value is
-`[Int32]::MaxValue`. A value of 0 (zero) prevents following relation links.
+`[int32]::MaxValue`. A value of 0 (zero) prevents following relation links.
 
 ```yaml
 Type: System.Int32


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide