### PR TITLE
Fix incorrect case/capitalization in reference documents (24/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -50,14 +50,14 @@ This cmdlet was introduced in Windows PowerShell 3.0.
 This example uses the `Invoke-WebRequest` cmdlet to send a web request to the Bing.com site.
 
 ```powershell
-$Response = Invoke-WebRequest -UseBasicParsing -URI https://www.bing.com?q=how+many+feet+in+a+mile
+$Response = Invoke-WebRequest -UseBasicParsing -Uri https://www.bing.com?q=how+many+feet+in+a+mile
 $Response.InputFields |
-    Where-Object name -like "* Value" |
-    Select-Object name, value
+    Where-Object Name -Like "* Value" |
+    Select-Object Name, Value
 ```
 
 ```Output
-name       value
+Name       Value
 ----       -----
 From Value 1
 To Value   5280
@@ -65,8 +65,8 @@ To Value   5280
 
 The data returned by `Invoke-WebRequest` is stored in the `$Response` variable. The **InputFields**
 property of the response contains the form fields. `Where-Object` is used to filter the form fields
-to those where the **name** property is like "* Value". The filtered results are piped to
-`Select-Object` to select the **name** and **value** properties.
+to those where the **Name** property is like "* Value". The filtered results are piped to
+`Select-Object` to select the **Name** and **Value** properties.
 
 ### Example 2: Use a stateful web service
 
@@ -77,8 +77,8 @@ Facebook.
 $R = Invoke-WebRequest https://www.facebook.com/login.php -SessionVariable fb
 # This command stores the first form in the Forms property of the $R variable in the $Form variable.
 $Form = $R.Forms[0]
-# This command shows the fields available in the Form.
-$Form.fields
+# This command shows the fields available in the form.
+$Form.Fields
 ```
 
 ```Output
@@ -91,7 +91,7 @@ pass
 ```
 
 ```powershell
-# These commands populate the username and password of the respective Form fields.
+# These commands populate the username and password of the respective form fields.
 $Form.Fields["email"]="User01@Fabrikam.com"
 $Form.Fields["pass"]="P@ssw0rd"
 # This command creates the Uri that will be used to log in to facebook.
@@ -101,7 +101,7 @@ $Uri = "https://www.facebook.com" + $Form.Action
 # The WebRequestSession object in the $FB variable is passed as the value of the WebSession parameter.
 # The value of the Body parameter is the hash table in the Fields property of the form.
 # The value of the *Method* parameter is POST. The command saves the output in the $R variable.
-$R = Invoke-WebRequest -Uri $Uri -WebSession $FB -Method POST -Body $Form.Fields
+$R = Invoke-WebRequest -Uri $Uri -WebSession $FB -Method Post -Body $Form.Fields
 $R.StatusDescription
 ```
 
@@ -181,7 +181,7 @@ $jobs = @()
 
 foreach ($file in $files) {
     $jobs += Start-ThreadJob -Name $file.OutFile -ScriptBlock {
-        $params = $using:file
+        $params = $Using:file
         Invoke-WebRequest @params
     }
 }

--- a/reference/5.1/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -35,7 +35,7 @@ This example measures the time it takes to run a `Get-EventLog` command that get
 Windows PowerShell event log.
 
 ```powershell
-Measure-Command { Get-EventLog "windows powershell" }
+Measure-Command { Get-EventLog "Windows PowerShell" }
 ```
 
 ### Example 2: Compare two outputs from Measure-Command

--- a/reference/5.1/Microsoft.PowerShell.Utility/Measure-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Measure-Object.md
@@ -57,7 +57,7 @@ This command displays the **Minimum**, **Maximum**, and **Sum** of the sizes of 
 current directory, and the average size of a file in the directory.
 
 ```powershell
-Get-ChildItem | Measure-Object -Property length -Minimum -Maximum -Sum -Average
+Get-ChildItem | Measure-Object -Property Length -Minimum -Maximum -Sum -Average
 ```
 
 ### Example 3: Measure text in a text file
@@ -124,7 +124,7 @@ You can use `Measure-Object` to calculate the values of these properties, just l
 property of an object.
 
 ```powershell
-Import-Csv d:\test\serviceyrs.csv | Measure-Object -Property years -Minimum -Maximum -Average
+Import-Csv D:\test\serviceyrs.csv | Measure-Object -Property Years -Minimum -Maximum -Average
 ```
 
 ### Example 6: Measure Boolean values
@@ -134,7 +134,7 @@ In this case, it uses the **PSIsContainer** **Boolean** property to measure the 
 folders (vs. files) in the current directory.
 
 ```powershell
-Get-ChildItem | Measure-Object -Property psiscontainer -Maximum -Sum -Minimum -Average
+Get-ChildItem | Measure-Object -Property PSIsContainer -Maximum -Sum -Minimum -Average
 ```
 
 ```Output

--- a/reference/5.1/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
@@ -181,7 +181,7 @@ Creates table-like custom objects from the items in a character-separated value 
 Imports language-specific data into scripts and functions based on the UI culture that is selected for the operating system.
 
 ### [Import-PowerShellDataFile](Import-PowerShellDataFile.md)
-Imports values from a `.PSD1` file without invoking its contents.
+Imports values from a `.psd1` file without invoking its contents.
 
 ### [Import-PSSession](Import-PSSession.md)
 Imports commands from another session into the current session.

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Alias.md
@@ -40,10 +40,10 @@ This command creates an alias named List to represent the Get-ChildItem cmdlet.
 ### Example 2: Create a read-only alias for a cmdlet
 
 This command creates an alias named `C` to represent the `Get-ChildItem` cmdlet. It creates a
-description of "quick gci alias" for the alias and makes it read-only.
+description of "Quick gci alias" for the alias and makes it read-only.
 
 ```powershell
-New-Alias -Name "C" -Value Get-ChildItem -Description "quick gci alias" -Option ReadOnly
+New-Alias -Name "C" -Value Get-ChildItem -Description "Quick gci alias" -Option ReadOnly
 Get-Alias -Name "C" | Format-List *
 ```
 
@@ -55,7 +55,7 @@ ReferencedCommand   : Get-ChildItem
 ResolvedCommand     : Get-ChildItem
 Definition          : Get-ChildItem
 Options             : ReadOnly
-Description         : quick gci alias
+Description         : Quick gci alias
 OutputType          : {System.IO.FileInfo, System.IO.DirectoryInfo}
 Name                : C
 CommandType         : Alias

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Event.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Event.md
@@ -43,7 +43,7 @@ must change the program conditions or close the PowerShell session.
 ### Example 1: Create a new event in the event queue
 
 ```
-PS C:\> New-Event -SourceIdentifier Timer -Sender windows.timer -MessageData "Test"
+PS C:\> New-Event -SourceIdentifier Timer -Sender Windows.Timer -MessageData "Test"
 ```
 
 This command creates a new event in the PowerShell event queue. It uses a **Windows.Timer** object
@@ -59,7 +59,7 @@ PS C:\> function Enable-ProcessCreationEvent
    $Identifier = "WMI.ProcessCreated"
    Register-ObjectEvent $ProcessWatcher "EventArrived" -SupportEvent $Identifier -Action
    {
-      [void] (New-Event -SourceID "PowerShell.ProcessCreated" -Sender $args[0] -EventArguments $args[1].SourceEventArgs.NewEvent.TargetInstance)
+      [void] (New-Event -SourceId "PowerShell.ProcessCreated" -Sender $args[0] -EventArguments $args[1].SourceEventArgs.NewEvent.TargetInstance)
    }
 }
 ```

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Object.md
@@ -60,10 +60,10 @@ method and set the **Visible** property of the object to `$true` to make the app
 The second instance gets the same results with individual commands.
 
 ```powershell
-$IE1 = New-Object -COMObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $true}
+$IE1 = New-Object -ComObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $true}
 
 # The following command gets the same results as the example above.
-$IE2 = New-Object -COMObject InternetExplorer.Application`
+$IE2 = New-Object -ComObject InternetExplorer.Application`
 $IE2.Navigate2("www.microsoft.com")`
 $IE2.Visible = $true`
 ```
@@ -74,7 +74,7 @@ This example demonstrates that adding the **Strict** parameter causes the `New-O
 generate a non-terminating error when the COM object uses an interop assembly.
 
 ```powershell
-$A = New-Object -COMObject Word.Application -Strict -Property @{Visible = $true}
+$A = New-Object -ComObject Word.Application -Strict -Property @{Visible = $true}
 ```
 
 ```Output
@@ -84,7 +84,7 @@ this type exposes different members than the IDispatch members, scripts written 
 object might not work if the primary interop assembly is not installed.
 
 At line:1 char:14
-+ $A = New-Object  <<<< -COM Word.Application -Strict; $a.visible=$true
++ $A = New-Object  <<<< -ComObject Word.Application -Strict; $a.Visible=$true
 ```
 
 ### Example 4: Create a COM object to manage Windows desktop
@@ -92,16 +92,16 @@ At line:1 char:14
 This example shows how to create and use a COM object to manage your Windows desktop.
 
 The first command uses the **ComObject** parameter of the `New-Object` cmdlet to create a COM object
-with the **Shell.Application** ProgID. It stores the resulting object in the `$ObjShell` variable. The
-second command pipes the `$ObjShell` variable to the `Get-Member` cmdlet, which displays the
+with the **Shell.Application** ProgID. It stores the resulting object in the `$objShell` variable. The
+second command pipes the `$objShell` variable to the `Get-Member` cmdlet, which displays the
 properties and methods of the COM object. Among the methods is the **ToggleDesktop** method. The
 third command calls the **ToggleDesktop** method of the object to minimize the open windows on your
 desktop.
 
 ```powershell
-$Objshell = New-Object -COMObject "Shell.Application"
-$objshell | Get-Member
-$objshell.ToggleDesktop()
+$objShell = New-Object -ComObject "Shell.Application"
+$objShell | Get-Member
+$objShell.ToggleDesktop()
 ```
 
 ```Output
@@ -324,7 +324,7 @@ This cmdlet returns the object that it creates.
 
 - `New-Object` provides the most commonly-used functionality of the VBScript CreateObject
   function. A statement like `Set objShell = CreateObject("Shell.Application")` in VBScript can be
-  translated to `$objShell = New-Object -COMObject "Shell.Application"` in PowerShell.
+  translated to `$objShell = New-Object -ComObject "Shell.Application"` in PowerShell.
 - `New-Object` expands upon the functionality available in the Windows Script Host environment by
   making it easy to work with .NET Framework objects from the command line and within scripts.
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-TimeSpan.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-TimeSpan.md
@@ -84,7 +84,7 @@ These commands return the date that is 90 days after the current date.
 
 ### Example 4: Discover the TimeSpan since a file was updated
 
-This command tells you how long it has been since the [about_remote](../Microsoft.PowerShell.Core/About/about_Remote.md)
+This command tells you how long it has been since the [about_Remote](../Microsoft.PowerShell.Core/About/about_Remote.md)
 help file was last updated.
 You can use this command format on any file, or any other object that has a **LastWriteTime**
 property.
@@ -94,7 +94,7 @@ This command works because the **Start** parameter of `New-TimeSpan` has an alia
 PowerShell uses the value of the **LastWriteTime** property as the value of the **Start** parameter.
 
 ```powershell
-Get-ChildItem $PSHOME\en-us\about_remote.help.txt | New-TimeSpan
+Get-ChildItem $PSHOME\en-US\about_remote.help.txt | New-TimeSpan
 ```
 
 ```Output
@@ -200,13 +200,13 @@ Accept wildcard characters: False
 
 ### -Start
 
-Specifies the start of a time span.
-Enter a string that represents the date and time, such as "3/15/09" or a **DateTime** object, such
-as one from a `Get-Date` command. The default value is the current date and time.
+Specifies the start of a time span. Enter a string that represents the date and time, such as
+"3/15/09" or a **DateTime** object, such as one from a `Get-Date` command. The default value is the
+current date and time.
 
-You can use **Start** or its alias, **LastWriteTime**.
-The **LastWriteTime** alias lets you pipe objects that have a **LastWriteTime** property,
-such as files in the file system `[System.Io.FileIO]`, to the **Start** parameter of `New-TimeSpan`.
+You can use **Start** or its alias, **LastWriteTime**. The **LastWriteTime** alias lets you pipe
+objects that have a **LastWriteTime** property, such as files in the file system (`[IO.FileInfo]`),
+to the **Start** parameter of `New-TimeSpan`.
 
 ```yaml
 Type: System.DateTime

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Variable.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Variable.md
@@ -216,7 +216,7 @@ using a binary-OR operation. Passing values as an array is the simplest option a
 to use tab-completion on the values.
 
 To see the Options property of all variables in the session, type
-`Get-Variable | Format-Table -Property name, options -AutoSize`.
+`Get-Variable | Format-Table -Property Name, Options -AutoSize`.
 
 ```yaml
 Type: System.Management.Automation.ScopedItemOptions

--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-File.md
@@ -91,7 +91,7 @@ This example shows how to encode output with a specific encoding type.
 
 ```powershell
 $Procs = Get-Process
-Out-File -FilePath .\Process.txt -InputObject $Procs -Encoding ASCII -Width 50
+Out-File -FilePath .\Process.txt -InputObject $Procs -Encoding ascii -Width 50
 ```
 
 The `Get-Process` cmdlet gets the list of processes running on the local computer. The **Process**
@@ -145,7 +145,7 @@ of 2000 instead of a line width determined by the PowerShell host's console widt
 ```powershell
 function DemoDefaultOutFileWidth() {
     try {
-        $PSDefaultParameterValues['out-file:width'] = 2000
+        $PSDefaultParameterValues['Out-File:Width'] = 2000
 
         $logFile = "$PWD\logfile.txt"
 
@@ -158,7 +158,7 @@ function DemoDefaultOutFileWidth() {
         Get-Process | Format-Table Id,SI,Name,Path,MainWindowTitle >> $logFile
     }
     finally {
-        $PSDefaultParameterValues.Remove('out-file:width')
+        $PSDefaultParameterValues.Remove('Out-File:Width')
     }
 }
 
@@ -330,7 +330,7 @@ Specifies the maximum number of characters in each line of output. Any additiona
 truncated, not wrapped. If this parameter isn't used, the width is determined by the
 characteristics of the host. The default for the PowerShell console is 80 characters. If you want
 to control the width for all invocations of `Out-File` as well as the redirection operators (`>`
-and `>>`), set `$PSDefaultParameterValues['out-file:width'] = 2000` before using `Out-File`.
+and `>>`), set `$PSDefaultParameterValues['Out-File:Width'] = 2000` before using `Out-File`.
 
 ```yaml
 Type: System.Int32

--- a/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -110,14 +110,14 @@ you need a different encoding, you must set the `charset` attribute in the `Cont
 This example uses the `Invoke-WebRequest` cmdlet to send a web request to the Bing.com site.
 
 ```powershell
-$Response = Invoke-WebRequest -URI https://www.bing.com/search?q=how+many+feet+in+a+mile
+$Response = Invoke-WebRequest -Uri https://www.bing.com/search?q=how+many+feet+in+a+mile
 $Response.InputFields | Where-Object {
-    $_.name -like "* Value*"
+    $_.Name -like "* Value*"
 } | Select-Object Name, Value
 ```
 
 ```Output
-name       value
+Name       Value
 ----       -----
 From Value 1
 To Value   5280
@@ -193,18 +193,18 @@ Note that the **Encoding** property is null if the web request doesn't return te
 ### Example 5: Submit a multipart/form-data file
 
 This example uses the `Invoke-WebRequest` cmdlet upload a file as a `multipart/form-data`
-submission. The file `c:\document.txt` is submitted as the form field `document` with the
+submission. The file `C:\document.txt` is submitted as the form field `document` with the
 `Content-Type` of `text/plain`.
 
 ```powershell
-$FilePath = 'c:\document.txt'
+$FilePath = 'C:\document.txt'
 $FieldName = 'document'
 $ContentType = 'text/plain'
 
 $FileStream = [System.IO.FileStream]::new($filePath, [System.IO.FileMode]::Open)
 $FileHeader = [System.Net.Http.Headers.ContentDispositionHeaderValue]::new('form-data')
 $FileHeader.Name = $FieldName
-$FileHeader.FileName = Split-Path -leaf $FilePath
+$FileHeader.FileName = Split-Path -Leaf $FilePath
 $FileContent = [System.Net.Http.StreamContent]::new($FileStream)
 $FileContent.Headers.ContentDisposition = $FileHeader
 $FileContent.Headers.ContentType = [System.Net.Http.Headers.MediaTypeHeaderValue]::Parse($ContentType)
@@ -226,7 +226,7 @@ $Form = @{
     firstName  = 'John'
     lastName   = 'Doe'
     email      = 'john.doe@contoso.com'
-    avatar     = Get-Item -Path 'c:\Pictures\jdoe.png'
+    avatar     = Get-Item -Path 'C:\Pictures\jdoe.png'
     birthday   = '1980-10-15'
     hobbies    = 'Hiking','Fishing','Jogging'
 }
@@ -303,7 +303,7 @@ $jobs = @()
 
 foreach ($file in $files) {
     $jobs += Start-ThreadJob -Name $file.OutFile -ScriptBlock {
-        $params = $using:file
+        $params = $Using:file
         Invoke-WebRequest @params
     }
 }
@@ -671,7 +671,7 @@ be used together.
 
 This example makes a `TEST` HTTP request to the API:
 
-`Invoke-WebRequest -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
+`Invoke-WebRequest -Uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
 
 This feature was added in PowerShell 6.0.0.
 
@@ -720,7 +720,7 @@ object.
 
 ```powershell
 $Form = @{
-    resume = Get-Item 'c:\Users\jdoe\Documents\John Doe.pdf'
+    resume = Get-Item 'C:\Users\jdoe\Documents\John Doe.pdf'
 }
 ```
 
@@ -731,7 +731,7 @@ object, then the binary file contents are submitted. Nested collections aren't s
 ```powershell
 $Form = @{
     tags     = 'Vacation', 'Italy', '2017'
-    pictures = Get-ChildItem 'c:\Users\jdoe\Pictures\2017-Italy\'
+    pictures = Get-ChildItem 'C:\Users\jdoe\Pictures\2017-Italy\'
 }
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -35,7 +35,7 @@ This example measures the time it takes to run a `Get-EventLog` command that get
 Windows PowerShell event log.
 
 ```powershell
-Measure-Command { Get-EventLog "windows powershell" }
+Measure-Command { Get-EventLog "Windows PowerShell" }
 ```
 
 ### Example 2: Compare two outputs from Measure-Command

--- a/reference/7.4/Microsoft.PowerShell.Utility/Measure-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Measure-Object.md
@@ -57,7 +57,7 @@ This command displays the **Minimum**, **Maximum**, and **Sum** of the sizes of 
 current directory, and the average size of a file in the directory.
 
 ```powershell
-Get-ChildItem | Measure-Object -Property length -Minimum -Maximum -Sum -Average
+Get-ChildItem | Measure-Object -Property Length -Minimum -Maximum -Sum -Average
 ```
 
 ### Example 3: Measure text in a text file
@@ -124,7 +124,7 @@ You can use `Measure-Object` to calculate the values of these properties, just l
 property of an object.
 
 ```powershell
-Import-Csv d:\test\serviceyrs.csv | Measure-Object -Property years -Minimum -Maximum -Average
+Import-Csv D:\test\serviceyrs.csv | Measure-Object -Property Years -Minimum -Maximum -Average
 ```
 
 ### Example 6: Measure Boolean values
@@ -134,7 +134,7 @@ In this case, it uses the **PSIsContainer** **Boolean** property to measure the 
 folders (vs. files) in the current directory.
 
 ```powershell
-Get-ChildItem | Measure-Object -Property psiscontainer -Maximum -Sum -Minimum -Average
+Get-ChildItem | Measure-Object -Property PSIsContainer -Maximum -Sum -Minimum -Average
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
@@ -187,7 +187,7 @@ Creates table-like custom objects from the items in a character-separated value 
 Imports language-specific data into scripts and functions based on the UI culture that is selected for the operating system.
 
 ### [Import-PowerShellDataFile](Import-PowerShellDataFile.md)
-Imports values from a `.PSD1` file without invoking its contents.
+Imports values from a `.psd1` file without invoking its contents.
 
 ### [Import-PSSession](Import-PSSession.md)
 Imports commands from another session into the current session.

--- a/reference/7.4/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/New-Alias.md
@@ -40,10 +40,10 @@ This command creates an alias named List to represent the Get-ChildItem cmdlet.
 ### Example 2: Create a read-only alias for a cmdlet
 
 This command creates an alias named `C` to represent the `Get-ChildItem` cmdlet. It creates a
-description of "quick gci alias" for the alias and makes it read-only.
+description of "Quick gci alias" for the alias and makes it read-only.
 
 ```powershell
-New-Alias -Name "C" -Value Get-ChildItem -Description "quick gci alias" -Option ReadOnly
+New-Alias -Name "C" -Value Get-ChildItem -Description "Quick gci alias" -Option ReadOnly
 Get-Alias -Name "C" | Format-List *
 ```
 
@@ -55,7 +55,7 @@ ReferencedCommand   : Get-ChildItem
 ResolvedCommand     : Get-ChildItem
 Definition          : Get-ChildItem
 Options             : ReadOnly
-Description         : quick gci alias
+Description         : Quick gci alias
 OutputType          : {System.IO.FileInfo, System.IO.DirectoryInfo}
 Name                : C
 CommandType         : Alias

--- a/reference/7.4/Microsoft.PowerShell.Utility/New-Event.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/New-Event.md
@@ -43,7 +43,7 @@ must change the program conditions or close the PowerShell session.
 ### Example 1: Create a new event in the event queue
 
 ```
-PS C:\> New-Event -SourceIdentifier Timer -Sender windows.timer -MessageData "Test"
+PS C:\> New-Event -SourceIdentifier Timer -Sender Windows.Timer -MessageData "Test"
 ```
 
 This command creates a new event in the PowerShell event queue. It uses a **Windows.Timer** object
@@ -59,7 +59,7 @@ PS C:\> function Enable-ProcessCreationEvent
    $Identifier = "WMI.ProcessCreated"
    Register-ObjectEvent $ProcessWatcher "EventArrived" -SupportEvent $Identifier -Action
    {
-      [void] (New-Event -SourceID "PowerShell.ProcessCreated" -Sender $args[0] -EventArguments $args[1].SourceEventArgs.NewEvent.TargetInstance)
+      [void] (New-Event -SourceId "PowerShell.ProcessCreated" -Sender $args[0] -EventArguments $args[1].SourceEventArgs.NewEvent.TargetInstance)
    }
 }
 ```

--- a/reference/7.4/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/New-Object.md
@@ -60,10 +60,10 @@ method and set the **Visible** property of the object to `$true` to make the app
 The second instance gets the same results with individual commands.
 
 ```powershell
-$IE1 = New-Object -COMObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $true}
+$IE1 = New-Object -ComObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $true}
 
 # The following command gets the same results as the example above.
-$IE2 = New-Object -COMObject InternetExplorer.Application`
+$IE2 = New-Object -ComObject InternetExplorer.Application`
 $IE2.Navigate2("www.microsoft.com")`
 $IE2.Visible = $true`
 ```
@@ -74,7 +74,7 @@ This example demonstrates that adding the **Strict** parameter causes the `New-O
 generate a non-terminating error when the COM object uses an interop assembly.
 
 ```powershell
-$A = New-Object -COMObject Word.Application -Strict -Property @{Visible = $true}
+$A = New-Object -ComObject Word.Application -Strict -Property @{Visible = $true}
 ```
 
 ```Output
@@ -84,7 +84,7 @@ this type exposes different members than the IDispatch members, scripts written 
 object might not work if the primary interop assembly is not installed.
 
 At line:1 char:14
-+ $A = New-Object  <<<< -COM Word.Application -Strict; $a.visible=$true
++ $A = New-Object  <<<< -ComObject Word.Application -Strict; $a.Visible=$true
 ```
 
 ### Example 4: Create a COM object to manage Windows desktop
@@ -92,16 +92,16 @@ At line:1 char:14
 This example shows how to create and use a COM object to manage your Windows desktop.
 
 The first command uses the **ComObject** parameter of the `New-Object` cmdlet to create a COM object
-with the **Shell.Application** ProgID. It stores the resulting object in the `$ObjShell` variable. The
-second command pipes the `$ObjShell` variable to the `Get-Member` cmdlet, which displays the
+with the **Shell.Application** ProgID. It stores the resulting object in the `$objShell` variable. The
+second command pipes the `$objShell` variable to the `Get-Member` cmdlet, which displays the
 properties and methods of the COM object. Among the methods is the **ToggleDesktop** method. The
 third command calls the **ToggleDesktop** method of the object to minimize the open windows on your
 desktop.
 
 ```powershell
-$Objshell = New-Object -COMObject "Shell.Application"
-$objshell | Get-Member
-$objshell.ToggleDesktop()
+$objShell = New-Object -ComObject "Shell.Application"
+$objShell | Get-Member
+$objShell.ToggleDesktop()
 ```
 
 ```Output
@@ -324,7 +324,7 @@ This cmdlet returns the object that it creates.
 
 - `New-Object` provides the most commonly-used functionality of the VBScript CreateObject
   function. A statement like `Set objShell = CreateObject("Shell.Application")` in VBScript can be
-  translated to `$objShell = New-Object -COMObject "Shell.Application"` in PowerShell.
+  translated to `$objShell = New-Object -ComObject "Shell.Application"` in PowerShell.
 - `New-Object` expands upon the functionality available in the Windows Script Host environment by
   making it easy to work with .NET Framework objects from the command line and within scripts.
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/New-TimeSpan.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/New-TimeSpan.md
@@ -86,7 +86,7 @@ These commands return the date that is 90 days after the current date.
 ### Example 4: Discover the TimeSpan since a file was updated
 
 This command tells you how long it has been since the
-[about_remote](../Microsoft.PowerShell.Core/About/about_Remote.md) help file was last updated. You
+[about_Remote](../Microsoft.PowerShell.Core/About/about_Remote.md) help file was last updated. You
 can use this command format on any file, or any other object that has a **LastWriteTime** property.
 
 This command works because the **Start** parameter of `New-TimeSpan` has an alias of
@@ -94,7 +94,7 @@ This command works because the **Start** parameter of `New-TimeSpan` has an alia
 PowerShell uses the value of the **LastWriteTime** property as the value of the **Start** parameter.
 
 ```powershell
-Get-ChildItem $PSHOME\en-us\about_remote.help.txt | New-TimeSpan
+Get-ChildItem $PSHOME\en-US\about_remote.help.txt | New-TimeSpan
 ```
 
 ```Output
@@ -217,8 +217,8 @@ Specifies the start of a time span. Enter a string that represents the date and 
 current date and time.
 
 You can use **Start** or its alias, **LastWriteTime**. The **LastWriteTime** alias lets you pipe
-objects that have a **LastWriteTime** property, such as files in the file system
-`[System.Io.FileIO]`, to the **Start** parameter of `New-TimeSpan`.
+objects that have a **LastWriteTime** property, such as files in the file system (`[IO.FileInfo]`),
+to the **Start** parameter of `New-TimeSpan`.
 
 ```yaml
 Type: System.DateTime

--- a/reference/7.4/Microsoft.PowerShell.Utility/New-Variable.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/New-Variable.md
@@ -216,7 +216,7 @@ using a binary-OR operation. Passing values as an array is the simplest option a
 to use tab-completion on the values.
 
 To see the Options property of all variables in the session, type
-`Get-Variable | Format-Table -Property name, options -AutoSize`.
+`Get-Variable | Format-Table -Property Name, Options -AutoSize`.
 
 ```yaml
 Type: System.Management.Automation.ScopedItemOptions

--- a/reference/7.4/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Out-File.md
@@ -94,7 +94,7 @@ This example shows how to encode output with a specific encoding type.
 
 ```powershell
 $Procs = Get-Process
-Out-File -FilePath .\Process.txt -InputObject $Procs -Encoding ASCII -Width 50
+Out-File -FilePath .\Process.txt -InputObject $Procs -Encoding ascii -Width 50
 ```
 
 The `Get-Process` cmdlet gets the list of processes running on the local computer. The **Process**
@@ -148,7 +148,7 @@ of 2000 instead of a line width determined by the PowerShell host's console widt
 ```powershell
 function DemoDefaultOutFileWidth() {
     try {
-        $PSDefaultParameterValues['out-file:width'] = 2000
+        $PSDefaultParameterValues['Out-File:Width'] = 2000
 
         $logFile = "$PWD\logfile.txt"
 
@@ -161,7 +161,7 @@ function DemoDefaultOutFileWidth() {
         Get-Process | Format-Table Id,SI,Name,Path,MainWindowTitle >> $logFile
     }
     finally {
-        $PSDefaultParameterValues.Remove('out-file:width')
+        $PSDefaultParameterValues.Remove('Out-File:Width')
     }
 }
 
@@ -345,7 +345,7 @@ Specifies the maximum number of characters in each line of output. Any additiona
 truncated, not wrapped. If this parameter isn't used, the width is determined by the
 characteristics of the host. The default for the PowerShell console is 80 characters. If you want
 to control the width for all invocations of `Out-File` as well as the redirection operators (`>`
-and `>>`), set `$PSDefaultParameterValues['out-file:width'] = 2000` before using `Out-File`.
+and `>>`), set `$PSDefaultParameterValues['Out-File:Width'] = 2000` before using `Out-File`.
 
 ```yaml
 Type: System.Int32

--- a/reference/7.5/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -110,14 +110,14 @@ you need a different encoding, you must set the `charset` attribute in the `Cont
 This example uses the `Invoke-WebRequest` cmdlet to send a web request to the Bing.com site.
 
 ```powershell
-$Response = Invoke-WebRequest -URI https://www.bing.com/search?q=how+many+feet+in+a+mile
+$Response = Invoke-WebRequest -Uri https://www.bing.com/search?q=how+many+feet+in+a+mile
 $Response.InputFields | Where-Object {
-    $_.name -like "* Value*"
+    $_.Name -like "* Value*"
 } | Select-Object Name, Value
 ```
 
 ```Output
-name       value
+Name       Value
 ----       -----
 From Value 1
 To Value   5280
@@ -193,18 +193,18 @@ Note that the **Encoding** property is null if the web request doesn't return te
 ### Example 5: Submit a multipart/form-data file
 
 This example uses the `Invoke-WebRequest` cmdlet upload a file as a `multipart/form-data`
-submission. The file `c:\document.txt` is submitted as the form field `document` with the
+submission. The file `C:\document.txt` is submitted as the form field `document` with the
 `Content-Type` of `text/plain`.
 
 ```powershell
-$FilePath = 'c:\document.txt'
+$FilePath = 'C:\document.txt'
 $FieldName = 'document'
 $ContentType = 'text/plain'
 
 $FileStream = [System.IO.FileStream]::new($filePath, [System.IO.FileMode]::Open)
 $FileHeader = [System.Net.Http.Headers.ContentDispositionHeaderValue]::new('form-data')
 $FileHeader.Name = $FieldName
-$FileHeader.FileName = Split-Path -leaf $FilePath
+$FileHeader.FileName = Split-Path -Leaf $FilePath
 $FileContent = [System.Net.Http.StreamContent]::new($FileStream)
 $FileContent.Headers.ContentDisposition = $FileHeader
 $FileContent.Headers.ContentType = [System.Net.Http.Headers.MediaTypeHeaderValue]::Parse($ContentType)
@@ -226,7 +226,7 @@ $Form = @{
     firstName  = 'John'
     lastName   = 'Doe'
     email      = 'john.doe@contoso.com'
-    avatar     = Get-Item -Path 'c:\Pictures\jdoe.png'
+    avatar     = Get-Item -Path 'C:\Pictures\jdoe.png'
     birthday   = '1980-10-15'
     hobbies    = 'Hiking','Fishing','Jogging'
 }
@@ -303,7 +303,7 @@ $jobs = @()
 
 foreach ($file in $files) {
     $jobs += Start-ThreadJob -Name $file.OutFile -ScriptBlock {
-        $params = $using:file
+        $params = $Using:file
         Invoke-WebRequest @params
     }
 }
@@ -671,7 +671,7 @@ be used together.
 
 This example makes a `TEST` HTTP request to the API:
 
-`Invoke-WebRequest -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
+`Invoke-WebRequest -Uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
 
 This feature was added in PowerShell 6.0.0.
 
@@ -720,7 +720,7 @@ object.
 
 ```powershell
 $Form = @{
-    resume = Get-Item 'c:\Users\jdoe\Documents\John Doe.pdf'
+    resume = Get-Item 'C:\Users\jdoe\Documents\John Doe.pdf'
 }
 ```
 
@@ -731,7 +731,7 @@ object, then the binary file contents are submitted. Nested collections aren't s
 ```powershell
 $Form = @{
     tags     = 'Vacation', 'Italy', '2017'
-    pictures = Get-ChildItem 'c:\Users\jdoe\Pictures\2017-Italy\'
+    pictures = Get-ChildItem 'C:\Users\jdoe\Pictures\2017-Italy\'
 }
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -35,7 +35,7 @@ This example measures the time it takes to run a `Get-EventLog` command that get
 Windows PowerShell event log.
 
 ```powershell
-Measure-Command { Get-EventLog "windows powershell" }
+Measure-Command { Get-EventLog "Windows PowerShell" }
 ```
 
 ### Example 2: Compare two outputs from Measure-Command

--- a/reference/7.5/Microsoft.PowerShell.Utility/Measure-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Measure-Object.md
@@ -57,7 +57,7 @@ This command displays the **Minimum**, **Maximum**, and **Sum** of the sizes of 
 current directory, and the average size of a file in the directory.
 
 ```powershell
-Get-ChildItem | Measure-Object -Property length -Minimum -Maximum -Sum -Average
+Get-ChildItem | Measure-Object -Property Length -Minimum -Maximum -Sum -Average
 ```
 
 ### Example 3: Measure text in a text file
@@ -124,7 +124,7 @@ You can use `Measure-Object` to calculate the values of these properties, just l
 property of an object.
 
 ```powershell
-Import-Csv d:\test\serviceyrs.csv | Measure-Object -Property years -Minimum -Maximum -Average
+Import-Csv D:\test\serviceyrs.csv | Measure-Object -Property Years -Minimum -Maximum -Average
 ```
 
 ### Example 6: Measure Boolean values
@@ -134,7 +134,7 @@ In this case, it uses the **PSIsContainer** **Boolean** property to measure the 
 folders (vs. files) in the current directory.
 
 ```powershell
-Get-ChildItem | Measure-Object -Property psiscontainer -Maximum -Sum -Minimum -Average
+Get-ChildItem | Measure-Object -Property PSIsContainer -Maximum -Sum -Minimum -Average
 ```
 
 ```Output

--- a/reference/7.5/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
@@ -244,7 +244,7 @@ Imports language-specific data into scripts and functions based on the UI cultur
 
 ### [Import-PowerShellDataFile](Import-PowerShellDataFile.md)
 
-Imports values from a `.PSD1` file without invoking its contents.
+Imports values from a `.psd1` file without invoking its contents.
 
 ### [Import-PSSession](Import-PSSession.md)
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/New-Alias.md
@@ -40,10 +40,10 @@ This command creates an alias named List to represent the Get-ChildItem cmdlet.
 ### Example 2: Create a read-only alias for a cmdlet
 
 This command creates an alias named `C` to represent the `Get-ChildItem` cmdlet. It creates a
-description of "quick gci alias" for the alias and makes it read-only.
+description of "Quick gci alias" for the alias and makes it read-only.
 
 ```powershell
-New-Alias -Name "C" -Value Get-ChildItem -Description "quick gci alias" -Option ReadOnly
+New-Alias -Name "C" -Value Get-ChildItem -Description "Quick gci alias" -Option ReadOnly
 Get-Alias -Name "C" | Format-List *
 ```
 
@@ -55,7 +55,7 @@ ReferencedCommand   : Get-ChildItem
 ResolvedCommand     : Get-ChildItem
 Definition          : Get-ChildItem
 Options             : ReadOnly
-Description         : quick gci alias
+Description         : Quick gci alias
 OutputType          : {System.IO.FileInfo, System.IO.DirectoryInfo}
 Name                : C
 CommandType         : Alias

--- a/reference/7.5/Microsoft.PowerShell.Utility/New-Event.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/New-Event.md
@@ -43,7 +43,7 @@ must change the program conditions or close the PowerShell session.
 ### Example 1: Create a new event in the event queue
 
 ```
-PS C:\> New-Event -SourceIdentifier Timer -Sender windows.timer -MessageData "Test"
+PS C:\> New-Event -SourceIdentifier Timer -Sender Windows.Timer -MessageData "Test"
 ```
 
 This command creates a new event in the PowerShell event queue. It uses a **Windows.Timer** object
@@ -59,7 +59,7 @@ PS C:\> function Enable-ProcessCreationEvent
    $Identifier = "WMI.ProcessCreated"
    Register-ObjectEvent $ProcessWatcher "EventArrived" -SupportEvent $Identifier -Action
    {
-      [void] (New-Event -SourceID "PowerShell.ProcessCreated" -Sender $args[0] -EventArguments $args[1].SourceEventArgs.NewEvent.TargetInstance)
+      [void] (New-Event -SourceId "PowerShell.ProcessCreated" -Sender $args[0] -EventArguments $args[1].SourceEventArgs.NewEvent.TargetInstance)
    }
 }
 ```

--- a/reference/7.5/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/New-Object.md
@@ -60,10 +60,10 @@ method and set the **Visible** property of the object to `$true` to make the app
 The second instance gets the same results with individual commands.
 
 ```powershell
-$IE1 = New-Object -COMObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $true}
+$IE1 = New-Object -ComObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $true}
 
 # The following command gets the same results as the example above.
-$IE2 = New-Object -COMObject InternetExplorer.Application`
+$IE2 = New-Object -ComObject InternetExplorer.Application`
 $IE2.Navigate2("www.microsoft.com")`
 $IE2.Visible = $true`
 ```
@@ -74,7 +74,7 @@ This example demonstrates that adding the **Strict** parameter causes the `New-O
 generate a non-terminating error when the COM object uses an interop assembly.
 
 ```powershell
-$A = New-Object -COMObject Word.Application -Strict -Property @{Visible = $true}
+$A = New-Object -ComObject Word.Application -Strict -Property @{Visible = $true}
 ```
 
 ```Output
@@ -84,7 +84,7 @@ this type exposes different members than the IDispatch members, scripts written 
 object might not work if the primary interop assembly is not installed.
 
 At line:1 char:14
-+ $A = New-Object  <<<< -COM Word.Application -Strict; $a.visible=$true
++ $A = New-Object  <<<< -ComObject Word.Application -Strict; $a.Visible=$true
 ```
 
 ### Example 4: Create a COM object to manage Windows desktop
@@ -92,16 +92,16 @@ At line:1 char:14
 This example shows how to create and use a COM object to manage your Windows desktop.
 
 The first command uses the **ComObject** parameter of the `New-Object` cmdlet to create a COM object
-with the **Shell.Application** ProgID. It stores the resulting object in the `$ObjShell` variable. The
-second command pipes the `$ObjShell` variable to the `Get-Member` cmdlet, which displays the
+with the **Shell.Application** ProgID. It stores the resulting object in the `$objShell` variable. The
+second command pipes the `$objShell` variable to the `Get-Member` cmdlet, which displays the
 properties and methods of the COM object. Among the methods is the **ToggleDesktop** method. The
 third command calls the **ToggleDesktop** method of the object to minimize the open windows on your
 desktop.
 
 ```powershell
-$Objshell = New-Object -COMObject "Shell.Application"
-$objshell | Get-Member
-$objshell.ToggleDesktop()
+$objShell = New-Object -ComObject "Shell.Application"
+$objShell | Get-Member
+$objShell.ToggleDesktop()
 ```
 
 ```Output
@@ -324,7 +324,7 @@ This cmdlet returns the object that it creates.
 
 - `New-Object` provides the most commonly-used functionality of the VBScript CreateObject
   function. A statement like `Set objShell = CreateObject("Shell.Application")` in VBScript can be
-  translated to `$objShell = New-Object -COMObject "Shell.Application"` in PowerShell.
+  translated to `$objShell = New-Object -ComObject "Shell.Application"` in PowerShell.
 - `New-Object` expands upon the functionality available in the Windows Script Host environment by
   making it easy to work with .NET Framework objects from the command line and within scripts.
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/New-TimeSpan.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/New-TimeSpan.md
@@ -86,7 +86,7 @@ These commands return the date that is 90 days after the current date.
 ### Example 4: Discover the TimeSpan since a file was updated
 
 This command tells you how long it has been since the
-[about_remote](../Microsoft.PowerShell.Core/About/about_Remote.md) help file was last updated. You
+[about_Remote](../Microsoft.PowerShell.Core/About/about_Remote.md) help file was last updated. You
 can use this command format on any file, or any other object that has a **LastWriteTime** property.
 
 This command works because the **Start** parameter of `New-TimeSpan` has an alias of
@@ -94,7 +94,7 @@ This command works because the **Start** parameter of `New-TimeSpan` has an alia
 PowerShell uses the value of the **LastWriteTime** property as the value of the **Start** parameter.
 
 ```powershell
-Get-ChildItem $PSHOME\en-us\about_remote.help.txt | New-TimeSpan
+Get-ChildItem $PSHOME\en-US\about_remote.help.txt | New-TimeSpan
 ```
 
 ```Output
@@ -217,8 +217,8 @@ Specifies the start of a time span. Enter a string that represents the date and 
 current date and time.
 
 You can use **Start** or its alias, **LastWriteTime**. The **LastWriteTime** alias lets you pipe
-objects that have a **LastWriteTime** property, such as files in the file system
-`[System.Io.FileIO]`, to the **Start** parameter of `New-TimeSpan`.
+objects that have a **LastWriteTime** property, such as files in the file system (`[IO.FileInfo]`),
+to the **Start** parameter of `New-TimeSpan`.
 
 ```yaml
 Type: System.DateTime

--- a/reference/7.5/Microsoft.PowerShell.Utility/New-Variable.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/New-Variable.md
@@ -216,7 +216,7 @@ using a binary-OR operation. Passing values as an array is the simplest option a
 to use tab-completion on the values.
 
 To see the Options property of all variables in the session, type
-`Get-Variable | Format-Table -Property name, options -AutoSize`.
+`Get-Variable | Format-Table -Property Name, Options -AutoSize`.
 
 ```yaml
 Type: System.Management.Automation.ScopedItemOptions

--- a/reference/7.5/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Out-File.md
@@ -94,7 +94,7 @@ This example shows how to encode output with a specific encoding type.
 
 ```powershell
 $Procs = Get-Process
-Out-File -FilePath .\Process.txt -InputObject $Procs -Encoding ASCII -Width 50
+Out-File -FilePath .\Process.txt -InputObject $Procs -Encoding ascii -Width 50
 ```
 
 The `Get-Process` cmdlet gets the list of processes running on the local computer. The **Process**
@@ -148,7 +148,7 @@ of 2000 instead of a line width determined by the PowerShell host's console widt
 ```powershell
 function DemoDefaultOutFileWidth() {
     try {
-        $PSDefaultParameterValues['out-file:width'] = 2000
+        $PSDefaultParameterValues['Out-File:Width'] = 2000
 
         $logFile = "$PWD\logfile.txt"
 
@@ -161,7 +161,7 @@ function DemoDefaultOutFileWidth() {
         Get-Process | Format-Table Id,SI,Name,Path,MainWindowTitle >> $logFile
     }
     finally {
-        $PSDefaultParameterValues.Remove('out-file:width')
+        $PSDefaultParameterValues.Remove('Out-File:Width')
     }
 }
 
@@ -345,7 +345,7 @@ Specifies the maximum number of characters in each line of output. Any additiona
 truncated, not wrapped. If this parameter isn't used, the width is determined by the
 characteristics of the host. The default for the PowerShell console is 80 characters. If you want
 to control the width for all invocations of `Out-File` as well as the redirection operators (`>`
-and `>>`), set `$PSDefaultParameterValues['out-file:width'] = 2000` before using `Out-File`.
+and `>>`), set `$PSDefaultParameterValues['Out-File:Width'] = 2000` before using `Out-File`.
 
 ```yaml
 Type: System.Int32

--- a/reference/7.6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -110,14 +110,14 @@ you need a different encoding, you must set the `charset` attribute in the `Cont
 This example uses the `Invoke-WebRequest` cmdlet to send a web request to the Bing.com site.
 
 ```powershell
-$Response = Invoke-WebRequest -URI https://www.bing.com/search?q=how+many+feet+in+a+mile
+$Response = Invoke-WebRequest -Uri https://www.bing.com/search?q=how+many+feet+in+a+mile
 $Response.InputFields | Where-Object {
-    $_.name -like "* Value*"
+    $_.Name -like "* Value*"
 } | Select-Object Name, Value
 ```
 
 ```Output
-name       value
+Name       Value
 ----       -----
 From Value 1
 To Value   5280
@@ -193,18 +193,18 @@ Note that the **Encoding** property is null if the web request doesn't return te
 ### Example 5: Submit a multipart/form-data file
 
 This example uses the `Invoke-WebRequest` cmdlet upload a file as a `multipart/form-data`
-submission. The file `c:\document.txt` is submitted as the form field `document` with the
+submission. The file `C:\document.txt` is submitted as the form field `document` with the
 `Content-Type` of `text/plain`.
 
 ```powershell
-$FilePath = 'c:\document.txt'
+$FilePath = 'C:\document.txt'
 $FieldName = 'document'
 $ContentType = 'text/plain'
 
 $FileStream = [System.IO.FileStream]::new($filePath, [System.IO.FileMode]::Open)
 $FileHeader = [System.Net.Http.Headers.ContentDispositionHeaderValue]::new('form-data')
 $FileHeader.Name = $FieldName
-$FileHeader.FileName = Split-Path -leaf $FilePath
+$FileHeader.FileName = Split-Path -Leaf $FilePath
 $FileContent = [System.Net.Http.StreamContent]::new($FileStream)
 $FileContent.Headers.ContentDisposition = $FileHeader
 $FileContent.Headers.ContentType = [System.Net.Http.Headers.MediaTypeHeaderValue]::Parse($ContentType)
@@ -226,7 +226,7 @@ $Form = @{
     firstName  = 'John'
     lastName   = 'Doe'
     email      = 'john.doe@contoso.com'
-    avatar     = Get-Item -Path 'c:\Pictures\jdoe.png'
+    avatar     = Get-Item -Path 'C:\Pictures\jdoe.png'
     birthday   = '1980-10-15'
     hobbies    = 'Hiking','Fishing','Jogging'
 }
@@ -303,7 +303,7 @@ $jobs = @()
 
 foreach ($file in $files) {
     $jobs += Start-ThreadJob -Name $file.OutFile -ScriptBlock {
-        $params = $using:file
+        $params = $Using:file
         Invoke-WebRequest @params
     }
 }
@@ -671,7 +671,7 @@ be used together.
 
 This example makes a `TEST` HTTP request to the API:
 
-`Invoke-WebRequest -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
+`Invoke-WebRequest -Uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'`
 
 This feature was added in PowerShell 6.0.0.
 
@@ -720,7 +720,7 @@ object.
 
 ```powershell
 $Form = @{
-    resume = Get-Item 'c:\Users\jdoe\Documents\John Doe.pdf'
+    resume = Get-Item 'C:\Users\jdoe\Documents\John Doe.pdf'
 }
 ```
 
@@ -731,7 +731,7 @@ object, then the binary file contents are submitted. Nested collections aren't s
 ```powershell
 $Form = @{
     tags     = 'Vacation', 'Italy', '2017'
-    pictures = Get-ChildItem 'c:\Users\jdoe\Pictures\2017-Italy\'
+    pictures = Get-ChildItem 'C:\Users\jdoe\Pictures\2017-Italy\'
 }
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -35,7 +35,7 @@ This example measures the time it takes to run a `Get-EventLog` command that get
 Windows PowerShell event log.
 
 ```powershell
-Measure-Command { Get-EventLog "windows powershell" }
+Measure-Command { Get-EventLog "Windows PowerShell" }
 ```
 
 ### Example 2: Compare two outputs from Measure-Command

--- a/reference/7.6/Microsoft.PowerShell.Utility/Measure-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Measure-Object.md
@@ -57,7 +57,7 @@ This command displays the **Minimum**, **Maximum**, and **Sum** of the sizes of 
 current directory, and the average size of a file in the directory.
 
 ```powershell
-Get-ChildItem | Measure-Object -Property length -Minimum -Maximum -Sum -Average
+Get-ChildItem | Measure-Object -Property Length -Minimum -Maximum -Sum -Average
 ```
 
 ### Example 3: Measure text in a text file
@@ -124,7 +124,7 @@ You can use `Measure-Object` to calculate the values of these properties, just l
 property of an object.
 
 ```powershell
-Import-Csv d:\test\serviceyrs.csv | Measure-Object -Property years -Minimum -Maximum -Average
+Import-Csv D:\test\serviceyrs.csv | Measure-Object -Property Years -Minimum -Maximum -Average
 ```
 
 ### Example 6: Measure Boolean values
@@ -134,7 +134,7 @@ In this case, it uses the **PSIsContainer** **Boolean** property to measure the 
 folders (vs. files) in the current directory.
 
 ```powershell
-Get-ChildItem | Measure-Object -Property psiscontainer -Maximum -Sum -Minimum -Average
+Get-ChildItem | Measure-Object -Property PSIsContainer -Maximum -Sum -Minimum -Average
 ```
 
 ```Output

--- a/reference/7.6/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
@@ -244,7 +244,7 @@ Imports language-specific data into scripts and functions based on the UI cultur
 
 ### [Import-PowerShellDataFile](Import-PowerShellDataFile.md)
 
-Imports values from a `.PSD1` file without invoking its contents.
+Imports values from a `.psd1` file without invoking its contents.
 
 ### [Import-PSSession](Import-PSSession.md)
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/New-Alias.md
@@ -40,10 +40,10 @@ This command creates an alias named List to represent the Get-ChildItem cmdlet.
 ### Example 2: Create a read-only alias for a cmdlet
 
 This command creates an alias named `C` to represent the `Get-ChildItem` cmdlet. It creates a
-description of "quick gci alias" for the alias and makes it read-only.
+description of "Quick gci alias" for the alias and makes it read-only.
 
 ```powershell
-New-Alias -Name "C" -Value Get-ChildItem -Description "quick gci alias" -Option ReadOnly
+New-Alias -Name "C" -Value Get-ChildItem -Description "Quick gci alias" -Option ReadOnly
 Get-Alias -Name "C" | Format-List *
 ```
 
@@ -55,7 +55,7 @@ ReferencedCommand   : Get-ChildItem
 ResolvedCommand     : Get-ChildItem
 Definition          : Get-ChildItem
 Options             : ReadOnly
-Description         : quick gci alias
+Description         : Quick gci alias
 OutputType          : {System.IO.FileInfo, System.IO.DirectoryInfo}
 Name                : C
 CommandType         : Alias

--- a/reference/7.6/Microsoft.PowerShell.Utility/New-Event.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/New-Event.md
@@ -43,7 +43,7 @@ must change the program conditions or close the PowerShell session.
 ### Example 1: Create a new event in the event queue
 
 ```
-PS C:\> New-Event -SourceIdentifier Timer -Sender windows.timer -MessageData "Test"
+PS C:\> New-Event -SourceIdentifier Timer -Sender Windows.Timer -MessageData "Test"
 ```
 
 This command creates a new event in the PowerShell event queue. It uses a **Windows.Timer** object
@@ -59,7 +59,7 @@ PS C:\> function Enable-ProcessCreationEvent
    $Identifier = "WMI.ProcessCreated"
    Register-ObjectEvent $ProcessWatcher "EventArrived" -SupportEvent $Identifier -Action
    {
-      [void] (New-Event -SourceID "PowerShell.ProcessCreated" -Sender $args[0] -EventArguments $args[1].SourceEventArgs.NewEvent.TargetInstance)
+      [void] (New-Event -SourceId "PowerShell.ProcessCreated" -Sender $args[0] -EventArguments $args[1].SourceEventArgs.NewEvent.TargetInstance)
    }
 }
 ```

--- a/reference/7.6/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/New-Object.md
@@ -60,10 +60,10 @@ method and set the **Visible** property of the object to `$true` to make the app
 The second instance gets the same results with individual commands.
 
 ```powershell
-$IE1 = New-Object -COMObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $true}
+$IE1 = New-Object -ComObject InternetExplorer.Application -Property @{Navigate2="www.microsoft.com"; Visible = $true}
 
 # The following command gets the same results as the example above.
-$IE2 = New-Object -COMObject InternetExplorer.Application`
+$IE2 = New-Object -ComObject InternetExplorer.Application`
 $IE2.Navigate2("www.microsoft.com")`
 $IE2.Visible = $true`
 ```
@@ -74,7 +74,7 @@ This example demonstrates that adding the **Strict** parameter causes the `New-O
 generate a non-terminating error when the COM object uses an interop assembly.
 
 ```powershell
-$A = New-Object -COMObject Word.Application -Strict -Property @{Visible = $true}
+$A = New-Object -ComObject Word.Application -Strict -Property @{Visible = $true}
 ```
 
 ```Output
@@ -84,7 +84,7 @@ this type exposes different members than the IDispatch members, scripts written 
 object might not work if the primary interop assembly is not installed.
 
 At line:1 char:14
-+ $A = New-Object  <<<< -COM Word.Application -Strict; $a.visible=$true
++ $A = New-Object  <<<< -ComObject Word.Application -Strict; $a.Visible=$true
 ```
 
 ### Example 4: Create a COM object to manage Windows desktop
@@ -92,16 +92,16 @@ At line:1 char:14
 This example shows how to create and use a COM object to manage your Windows desktop.
 
 The first command uses the **ComObject** parameter of the `New-Object` cmdlet to create a COM object
-with the **Shell.Application** ProgID. It stores the resulting object in the `$ObjShell` variable. The
-second command pipes the `$ObjShell` variable to the `Get-Member` cmdlet, which displays the
+with the **Shell.Application** ProgID. It stores the resulting object in the `$objShell` variable. The
+second command pipes the `$objShell` variable to the `Get-Member` cmdlet, which displays the
 properties and methods of the COM object. Among the methods is the **ToggleDesktop** method. The
 third command calls the **ToggleDesktop** method of the object to minimize the open windows on your
 desktop.
 
 ```powershell
-$Objshell = New-Object -COMObject "Shell.Application"
-$objshell | Get-Member
-$objshell.ToggleDesktop()
+$objShell = New-Object -ComObject "Shell.Application"
+$objShell | Get-Member
+$objShell.ToggleDesktop()
 ```
 
 ```Output
@@ -324,7 +324,7 @@ This cmdlet returns the object that it creates.
 
 - `New-Object` provides the most commonly-used functionality of the VBScript CreateObject
   function. A statement like `Set objShell = CreateObject("Shell.Application")` in VBScript can be
-  translated to `$objShell = New-Object -COMObject "Shell.Application"` in PowerShell.
+  translated to `$objShell = New-Object -ComObject "Shell.Application"` in PowerShell.
 - `New-Object` expands upon the functionality available in the Windows Script Host environment by
   making it easy to work with .NET Framework objects from the command line and within scripts.
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/New-TimeSpan.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/New-TimeSpan.md
@@ -86,7 +86,7 @@ These commands return the date that is 90 days after the current date.
 ### Example 4: Discover the TimeSpan since a file was updated
 
 This command tells you how long it has been since the
-[about_remote](../Microsoft.PowerShell.Core/About/about_Remote.md) help file was last updated. You
+[about_Remote](../Microsoft.PowerShell.Core/About/about_Remote.md) help file was last updated. You
 can use this command format on any file, or any other object that has a **LastWriteTime** property.
 
 This command works because the **Start** parameter of `New-TimeSpan` has an alias of
@@ -94,7 +94,7 @@ This command works because the **Start** parameter of `New-TimeSpan` has an alia
 PowerShell uses the value of the **LastWriteTime** property as the value of the **Start** parameter.
 
 ```powershell
-Get-ChildItem $PSHOME\en-us\about_remote.help.txt | New-TimeSpan
+Get-ChildItem $PSHOME\en-US\about_remote.help.txt | New-TimeSpan
 ```
 
 ```Output
@@ -217,8 +217,8 @@ Specifies the start of a time span. Enter a string that represents the date and 
 current date and time.
 
 You can use **Start** or its alias, **LastWriteTime**. The **LastWriteTime** alias lets you pipe
-objects that have a **LastWriteTime** property, such as files in the file system
-`[System.Io.FileIO]`, to the **Start** parameter of `New-TimeSpan`.
+objects that have a **LastWriteTime** property, such as files in the file system (`[IO.FileInfo]`),
+to the **Start** parameter of `New-TimeSpan`.
 
 ```yaml
 Type: System.DateTime

--- a/reference/7.6/Microsoft.PowerShell.Utility/New-Variable.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/New-Variable.md
@@ -216,7 +216,7 @@ using a binary-OR operation. Passing values as an array is the simplest option a
 to use tab-completion on the values.
 
 To see the Options property of all variables in the session, type
-`Get-Variable | Format-Table -Property name, options -AutoSize`.
+`Get-Variable | Format-Table -Property Name, Options -AutoSize`.
 
 ```yaml
 Type: System.Management.Automation.ScopedItemOptions

--- a/reference/7.6/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Out-File.md
@@ -94,7 +94,7 @@ This example shows how to encode output with a specific encoding type.
 
 ```powershell
 $Procs = Get-Process
-Out-File -FilePath .\Process.txt -InputObject $Procs -Encoding ASCII -Width 50
+Out-File -FilePath .\Process.txt -InputObject $Procs -Encoding ascii -Width 50
 ```
 
 The `Get-Process` cmdlet gets the list of processes running on the local computer. The **Process**
@@ -148,7 +148,7 @@ of 2000 instead of a line width determined by the PowerShell host's console widt
 ```powershell
 function DemoDefaultOutFileWidth() {
     try {
-        $PSDefaultParameterValues['out-file:width'] = 2000
+        $PSDefaultParameterValues['Out-File:Width'] = 2000
 
         $logFile = "$PWD\logfile.txt"
 
@@ -161,7 +161,7 @@ function DemoDefaultOutFileWidth() {
         Get-Process | Format-Table Id,SI,Name,Path,MainWindowTitle >> $logFile
     }
     finally {
-        $PSDefaultParameterValues.Remove('out-file:width')
+        $PSDefaultParameterValues.Remove('Out-File:Width')
     }
 }
 
@@ -345,7 +345,7 @@ Specifies the maximum number of characters in each line of output. Any additiona
 truncated, not wrapped. If this parameter isn't used, the width is determined by the
 characteristics of the host. The default for the PowerShell console is 80 characters. If you want
 to control the width for all invocations of `Out-File` as well as the redirection operators (`>`
-and `>>`), set `$PSDefaultParameterValues['out-file:width'] = 2000` before using `Out-File`.
+and `>>`), set `$PSDefaultParameterValues['Out-File:Width'] = 2000` before using `Out-File`.
 
 ```yaml
 Type: System.Int32


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide