### PR TITLE
Fix incorrect case/capitalization in reference documents (25/38)

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
@@ -29,7 +29,7 @@ parameter to direct `Out-String` to return one line at a time or create an array
 cmdlet lets you search and manipulate string output as you would in traditional shells when object
 manipulation is less convenient.
 
-PowerShell also adds the `OSS` function that calls `Out-String -Stream` as a shorthand way to use
+PowerShell also adds the `oss` function that calls `Out-String -Stream` as a shorthand way to use
 `Out-String` in a pipeline.
 
 ## EXAMPLES

--- a/reference/5.1/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -47,7 +47,7 @@ This example registers for a PowerShell engine event on two remote computers.
 ```powershell
 $S = New-PSSession -ComputerName "Server01, Server02"
 Invoke-Command -Session $S {
-  Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PsEngineEvent]::Exiting) -Forward
+  Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PSEngineEvent]::Exiting) -Forward
 }
 ```
 
@@ -81,13 +81,13 @@ data to a text file.
 
 ```powershell
 Register-EngineEvent -SourceIdentifier MyEventSource -Action {
-    "Event: {0}" -f $Event.MessageData | Out-File c:\temp\MyEvents.txt -Append
+    "Event: {0}" -f $Event.MessageData | Out-File C:\temp\MyEvents.txt -Append
 }
 
 Start-Job -Name TestJob -ScriptBlock {
-    While ($true) {
+    while ($true) {
         Register-EngineEvent -SourceIdentifier MyEventSource -Forward
-        Start-Sleep -seconds 2
+        Start-Sleep -Seconds 2
         "Doing some work..."
         $newEventSplat = @{
             SourceIdentifier = 'MyEventSource'
@@ -96,7 +96,7 @@ Start-Job -Name TestJob -ScriptBlock {
         New-Event @newEventSplat
     }
 }
-Start-Sleep -seconds 4
+Start-Sleep -Seconds 4
 Get-EventSubscriber
 Get-Job
 ```
@@ -126,7 +126,7 @@ This is a continuation of Example 3. In this example we wait for 10 seconds to l
 occur. Then we unregister the event subscription.
 
 ```powershell
-PS> Start-Sleep -seconds 10
+PS> Start-Sleep -Seconds 10
 PS> Get-EventSubscriber | Unregister-Event
 PS> Get-Job
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -150,8 +150,8 @@ $objectEventArgs = @{
 }
 $Job = Register-ObjectEvent @objectEventArgs
 $Job | Format-List -Property *
-& $Job.module {$Random}
-& $Job.module {$Random}
+& $Job.Module {$Random}
+& $Job.Module {$Random}
 ```
 
 ```Output

--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-Object.md
@@ -57,7 +57,7 @@ reached. To turn off this optimizing behavior, use the **Wait** parameter.
 
 ### Example 1: Select objects by property
 
-This example creates objects that have the **Name**, **ID**, and working set (**WS**) properties of
+This example creates objects that have the **Name**, **Id**, and working set (**WS**) properties of
 process objects.
 
 ```powershell
@@ -170,7 +170,7 @@ event is 0. The index of the last event is the number of items in `$a` minus 1.
 
 ```powershell
 $a = Get-EventLog -LogName "Windows PowerShell"
-$a | Select-Object -Index 0, ($A.count - 1)
+$a | Select-Object -Index 0, ($A.Count - 1)
 ```
 
 ### Example 7: Select all but the first object
@@ -310,7 +310,7 @@ ati2evxx                   Thursday
 # Add a custom property to calculate the size in KiloBytes of each FileInfo
 # object you pass in. Use the pipeline variable to divide each file's length by
 # 1 KiloBytes
-$size = @{label="Size(KB)";expression={$_.length/1KB}}
+$size = @{Label="Size(KB)";Expression={$_.Length/1KB}}
 # Create an additional calculated property with the number of Days since the
 # file was last accessed. You can also shorten the key names to be 'l', and 'e',
 # or use Name instead of Label.
@@ -337,8 +337,8 @@ value for that key.
 
 ```powershell
 @{ name = 'a' ; weight = 7 } | Select-Object -Property @(
-    @{ label = 'Name' ; expression = { $_.name } }
-    @{ label = 'Weight' ; expression = { $_.weight } }
+    @{ Label = 'Name' ; Expression = { $_.name } }
+    @{ Label = 'Weight' ; Expression = { $_.weight } }
 )
 ```
 
@@ -355,9 +355,9 @@ This example demonstrates the side-effect of using the **ExpandProperty** parame
 **NoteProperty** members.
 
 ```powershell
-PS> $object = [PSCustomObject]@{
+PS> $object = [pscustomobject]@{
     name = 'USA'
-    children = [PSCustomObject]@{
+    children = [pscustomobject]@{
         name = 'Southwest'
     }
 }
@@ -391,9 +391,9 @@ You can avoid the side-effect of using the **ExpandProperty** parameter by creat
 copying the properties from the input object.
 
 ```powershell
-PS> $object = [PSCustomObject]@{
+PS> $object = [pscustomobject]@{
     name = 'USA'
-    children = [PSCustomObject]@{
+    children = [pscustomobject]@{
         name = 'Southwest'
     }
 }
@@ -404,12 +404,12 @@ name children
 USA  @{name=Southwest}
 
 # Create a new object with selected properties
-PS> $newobject = [PSCustomObject]@{
+PS> $newObject = [pscustomobject]@{
     country = $object.name
     children = $object.children
 }
 
-PS> $newobject
+PS> $newObject
 
 country children
 ------- --------

--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-String.md
@@ -42,7 +42,7 @@ Select-String [-Pattern] <String[]> -LiteralPath <String[]> [-SimpleMatch] [-Cas
 ## DESCRIPTION
 
 The `Select-String` cmdlet uses regular expression matching to search for text patterns in input
-strings and files. You can use `Select-String` similar to `grep` in UNIX or `findstr.exe` in
+strings and files. You can use `Select-String` similar to `grep` in Unix or `findstr.exe` in
 Windows.
 
 `Select-String` is based on lines of text. By default, `Select-String` finds the first match in each
@@ -148,7 +148,7 @@ C:\Windows\System32\WindowsPowerShell\v1.0\en-US\about_ActivityCommonParameters.
 C:\Windows\System32\WindowsPowerShell\v1.0\en-US\about_ActivityCommonParameters.help.txt:33:  about_CommonParameters.
 ```
 
-The function is created on the PowerShell command line. The `Function` command uses the name
+The function is created on the PowerShell command line. The `function` keyword uses the name
 `Search-Help`. Press **Enter** to begin adding statements to the function. From the `>>` prompt,
 add each statement and press **Enter** as shown in the example. After the closing bracket is added,
 you're returned to a PowerShell prompt.
@@ -171,7 +171,7 @@ object in the pipeline. For more information, see [about_Automatic_Variables](..
 
 ```powershell
 $Events = Get-WinEvent -LogName Application -MaxEvents 50
-$Events | Select-String -InputObject {$_.message} -Pattern 'Failed'
+$Events | Select-String -InputObject {$_.Message} -Pattern 'Failed'
 ```
 
 The `Get-WinEvent` cmdlet uses the **LogName** parameter to specify the Application log. The
@@ -179,9 +179,9 @@ The `Get-WinEvent` cmdlet uses the **LogName** parameter to specify the Applicat
 the variable named `$Events`.
 
 The `$Events` variable is sent down the pipeline to the `Select-String` cmdlet. `Select-String` uses
-the **InputObject** parameter. The `$_` variable represents the current object and `message` is a
+the **InputObject** parameter. The `$_` variable represents the current object and `Message` is a
 property of the event. The **Pattern** parameter specifies the string **Failed** and searches for
-matches in `$_.message`. `Select-String` displays the output in the PowerShell console.
+matches in `$_.Message`. `Select-String` displays the output in the PowerShell console.
 
 ### Example 6: Find a string in subdirectories
 
@@ -685,7 +685,7 @@ Windows PowerShell includes the following aliases for `Select-String`:
 
 - `sls`
 
-`Select-String` is similar to `grep` in UNIX or `findstr.exe` in Windows.
+`Select-String` is similar to `grep` in Unix or `findstr.exe` in Windows.
 
 > [!NOTE]
 > According to

--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -92,7 +92,7 @@ file. For example, there is a **Count** property that is an alias of the **Lengt
 
 ### Example 2: Input an XML document
 
-This example shows how to use the **XML** parameter to provide an XML document to the `Select-Xml`
+This example shows how to use the **Xml** parameter to provide an XML document to the `Select-Xml`
 cmdlet.
 
 The `Get-Content` cmdlet gets the content of the `Types.ps1xml` file and saves it in the `$Types`
@@ -124,10 +124,10 @@ information about Updatable Help, see
 The `Select-Xml` cmdlet searches the XML files for cmdlet names by finding `Command:Name` element
 anywhere in the files. The results are stored in the `$Xml` variable. `Select-Xml` returns a
 **SelectXmlInfo** object that has a **Node** property, which is a **System.Xml.XmlElement** object.
-The **Node** property has an **InnerXML** property that contains the actual XML that is retrieved.
+The **Node** property has an **InnerXml** property that contains the actual XML that is retrieved.
 
 The `$Xml` variable is piped to the `Format-Table` cmdlet. The `Format-Table` command uses a
-calculated property to get the **Node.InnerXML** property of each object in the `$Xml` variable,
+calculated property to get the **Node.InnerXml** property of each object in the `$Xml` variable,
 trim the white space before and after the text, and display it in the table, along with the **Path**
 to the source file.
 
@@ -138,21 +138,21 @@ $Namespace = @{
     dev = "http://schemas.microsoft.com/maml/dev/2004/10"
 }
 
-$Path = "$PSHOME\en-us\*dll-Help.xml"
+$Path = "$PSHOME\en-US\*dll-Help.xml"
 $Xml = Select-Xml -Path $Path -Namespace $Namespace -XPath "//command:name"
-$Xml | Format-Table @{Label="Name"; Expression= {($_.node.innerxml).trim()}}, Path -AutoSize
+$Xml | Format-Table @{Label="Name"; Expression= {($_.Node.InnerXml).Trim()}}, Path -AutoSize
 ```
 
 ```Output
 Name                    Path
 ----                    ----
-Export-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Get-Counter             C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Get-WinEvent            C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Import-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Add-Computer            C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Management.dll-Help.xml
-Add-Content             C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Management.dll-Help.xml
-Checkpoint-Computer     C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Management.dll-Help.xml
+Export-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Get-Counter             C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Get-WinEvent            C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Import-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Add-Computer            C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Management.dll-Help.xml
+Add-Content             C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Management.dll-Help.xml
+Checkpoint-Computer     C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Management.dll-Help.xml
 ...
 ```
 
@@ -187,14 +187,14 @@ $Xml = @"
 </Book>
 "@
 
-Select-Xml -Content $Xml -XPath "//edition" | foreach {$_.node.InnerXML}
+Select-Xml -Content $Xml -XPath "//edition" | foreach {$_.Node.InnerXml}
 
 En.Book1.com
 Ge.Book1.Com
 Fr.Book1.com
 Pl.Book1.com
 
-$Xml | Select-Xml -XPath "//edition" | foreach {$_.node.InnerXML}
+$Xml | Select-Xml -XPath "//edition" | foreach {$_.Node.InnerXml}
 
 En.Book1.com
 Ge.Book1.Com

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -172,7 +172,7 @@ function. For more information, see
 [about_Functions](../Microsoft.PowerShell.Core/about/about_Functions.md).
 
 ```
-Function CD32 {Set-Location -Path C:\Windows\System32}
+function CD32 {Set-Location -Path C:\Windows\System32}
 
 Set-Alias -Name Go -Value CD32
 ```
@@ -260,7 +260,7 @@ Accept wildcard characters: False
 
 Sets the **Option** property value of the alias. Values such as `ReadOnly` and `Constant`
 protect an alias from unintended changes. To see the **Option** property of all aliases in the
-session, type `Get-Alias | Format-Table -Property Name, Options -Autosize`.
+session, type `Get-Alias | Format-Table -Property Name, Options -AutoSize`.
 
 The acceptable values for this parameter are as follows:
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -160,7 +160,7 @@ Action   :
 
 function CheckLog {
 >> Get-EventLog -Log Application |
->> where {($_.Source -like "TestApp") -and ($_.Message -like "*failed*")}
+>> Where-Object {($_.Source -like "TestApp") -and ($_.Message -like "*failed*")}
 >>}
 >>
 PS> Checklog

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -159,8 +159,8 @@ HitCount : 0
 Action   :
 
 function CheckLog {
->> get-eventlog -log Application |
->> where {($_.source -like "TestApp") -and ($_.Message -like "*failed*")}
+>> Get-EventLog -Log Application |
+>> where {($_.Source -like "TestApp") -and ($_.Message -like "*failed*")}
 >>}
 >>
 PS> Checklog
@@ -220,9 +220,9 @@ tasks, such as testing or logging.
 If this parameter is omitted, or no action is specified, execution stops at the breakpoint, and the
 debugger starts.
 
-When the **Action** parameter is used, the Action script block runs at each breakpoint. Execution does
-not stop unless the script block includes the Break keyword. If you use the Continue keyword in the
-script block, execution resumes until the next breakpoint.
+When the **Action** parameter is used, the Action script block runs at each breakpoint. Execution
+does not stop unless the script block includes the `break` keyword. If you use the `continue`
+keyword in the script block, execution resumes until the next breakpoint.
 
 For more information, see [about_Script_Blocks](../Microsoft.PowerShell.Core/About/about_Script_Blocks.md),
 [about_Break](../Microsoft.PowerShell.Core/About/about_Break.md), and
@@ -272,7 +272,7 @@ Sets a command breakpoint. Enter cmdlet names, such as `Get-Process`, or functio
 are permitted.
 
 Execution stops just before each instance of each command is executed. If the command is a function,
-execution stops each time the function is called and at each BEGIN, PROCESS, and END section.
+execution stops each time the function is called and at each `begin`, `process`, and `end` block.
 
 ```yaml
 Type: System.String[]

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -50,7 +50,7 @@ Set-TraceSource -Name "ParameterBinding" -Option ExecutionFlow -PSHost -Listener
 This command starts tracing for the ParameterBinding component of PowerShell. It uses the **Name**
 parameter to specify the trace source, the **Option** parameter to select the `ExecutionFlow` trace
 events, and the **PSHost** parameter to select the PowerShell host listener, which sends the output
-to the console. The **ListenerOption** parameter adds the `ProcessID` and `TimeStamp` values to the
+to the console. The **ListenerOption** parameter adds the `ProcessId` and `TimeStamp` values to the
 trace message prefix.
 
 ### Example 2: Stop a trace

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -50,7 +50,7 @@ This example creates a global, read-only variable that contains all processes on
 then it displays all properties of the variable.
 
 ```powershell
-Set-Variable -Name "processes" -Value (Get-Process) -Option constant -Scope global -Description "All processes" -PassThru |
+Set-Variable -Name "processes" -Value (Get-Process) -Option Constant -Scope Global -Description "All processes" -PassThru |
     Format-List -Property *
 ```
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Out-String.md
@@ -35,7 +35,7 @@ parameter to direct `Out-String` to return one line at a time or create an array
 cmdlet lets you search and manipulate string output as you would in traditional shells when object
 manipulation is less convenient.
 
-PowerShell also adds the `OSS` function that calls `Out-String -Stream` as a shorthand way to use
+PowerShell also adds the `oss` function that calls `Out-String -Stream` as a shorthand way to use
 `Out-String` in a pipeline.
 
 ## EXAMPLES

--- a/reference/7.4/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -47,7 +47,7 @@ This example registers for a PowerShell engine event on two remote computers.
 ```powershell
 $S = New-PSSession -ComputerName "Server01, Server02"
 Invoke-Command -Session $S {
-  Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PsEngineEvent]::Exiting) -Forward
+  Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PSEngineEvent]::Exiting) -Forward
 }
 ```
 
@@ -81,13 +81,13 @@ data to a text file.
 
 ```powershell
 Register-EngineEvent -SourceIdentifier MyEventSource -Action {
-    "Event: {0}" -f $Event.MessageData | Out-File c:\temp\MyEvents.txt -Append
+    "Event: {0}" -f $Event.MessageData | Out-File C:\temp\MyEvents.txt -Append
 }
 
 Start-Job -Name TestJob -ScriptBlock {
-    While ($true) {
+    while ($true) {
         Register-EngineEvent -SourceIdentifier MyEventSource -Forward
-        Start-Sleep -seconds 2
+        Start-Sleep -Seconds 2
         "Doing some work..."
         $newEventSplat = @{
             SourceIdentifier = 'MyEventSource'
@@ -96,7 +96,7 @@ Start-Job -Name TestJob -ScriptBlock {
         New-Event @newEventSplat
     }
 }
-Start-Sleep -seconds 4
+Start-Sleep -Seconds 4
 Get-EventSubscriber
 Get-Job
 ```
@@ -126,7 +126,7 @@ This is a continuation of Example 3. In this example we wait for 10 seconds to l
 occur. Then we unregister the event subscription.
 
 ```powershell
-PS> Start-Sleep -seconds 10
+PS> Start-Sleep -Seconds 10
 PS> Get-EventSubscriber | Unregister-Event
 PS> Get-Job
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -150,8 +150,8 @@ $objectEventArgs = @{
 }
 $Job = Register-ObjectEvent @objectEventArgs
 $Job | Format-List -Property *
-& $Job.module {$Random}
-& $Job.module {$Random}
+& $Job.Module {$Random}
+& $Job.Module {$Random}
 ```
 
 ```Output

--- a/reference/7.4/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Select-Object.md
@@ -66,7 +66,7 @@ reached. To turn off this optimizing behavior, use the **Wait** parameter.
 
 ### Example 1: Select objects by property
 
-This example creates objects that have the **Name**, **ID**, and working set (**WS**) properties of
+This example creates objects that have the **Name**, **Id**, and working set (**WS**) properties of
 process objects.
 
 ```powershell
@@ -193,7 +193,7 @@ event is 0. The index of the last event is the number of items in `$a` minus 1.
 
 ```powershell
 $a = Get-WinEvent -LogName "Windows PowerShell"
-$a | Select-Object -Index 0, ($a.count - 1)
+$a | Select-Object -Index 0, ($a.Count - 1)
 ```
 
 ### Example 8: Select all but the first object
@@ -333,7 +333,7 @@ ati2evxx                   Thursday
 # Add a custom property to calculate the size in KiloBytes of each FileInfo
 # object you pass in. Use the pipeline variable to divide each file's length by
 # 1 KiloBytes
-$size = @{label="Size(KB)";expression={$_.length/1KB}}
+$size = @{Label="Size(KB)";Expression={$_.Length/1KB}}
 # Create an additional calculated property with the number of Days since the
 # file was last accessed. You can also shorten the key names to be 'l', and 'e',
 # or use Name instead of Label.
@@ -374,9 +374,9 @@ This example demonstrates the side-effect of using the **ExpandProperty** parame
 **NoteProperty** members.
 
 ```powershell
-PS> $object = [PSCustomObject]@{
+PS> $object = [pscustomobject]@{
     name = 'USA'
-    children = [PSCustomObject]@{
+    children = [pscustomobject]@{
         name = 'Southwest'
     }
 }
@@ -410,9 +410,9 @@ You can avoid the side-effect of using the **ExpandProperty** parameter by creat
 copying the properties from the input object.
 
 ```powershell
-PS> $object = [PSCustomObject]@{
+PS> $object = [pscustomobject]@{
     name = 'USA'
-    children = [PSCustomObject]@{
+    children = [pscustomobject]@{
         name = 'Southwest'
     }
 }
@@ -423,12 +423,12 @@ name children
 USA  @{name=Southwest}
 
 # Create a new object with selected properties
-PS> $newobject = [PSCustomObject]@{
+PS> $newObject = [pscustomobject]@{
     country = $object.name
     children = $object.children
 }
 
-PS> $newobject
+PS> $newObject
 
 country children
 ------- --------

--- a/reference/7.4/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Select-String.md
@@ -66,7 +66,7 @@ Select-String [-Culture <String>] [-Pattern] <String[]> -LiteralPath <String[]> 
 ## DESCRIPTION
 
 The `Select-String` cmdlet uses regular expression matching to search for text patterns in input
-strings and files. You can use `Select-String` similar to `grep` in UNIX or `findstr.exe` in
+strings and files. You can use `Select-String` similar to `grep` in Unix or `findstr.exe` in
 Windows.
 
 `Select-String` is based on lines of text. By default, `Select-String` finds the first match in each
@@ -173,7 +173,7 @@ C:\Program Files\PowerShell\7\en-US\default.help.txt:93:    Get-Help About_Modul
 C:\Program Files\PowerShell\7\en-US\default.help.txt:97:    about_Updatable_Help
 ```
 
-The function is created on the PowerShell command line. The `Function` command uses the name
+The function is created on the PowerShell command line. The `function` keyword uses the name
 `Search-Help`. Press **Enter** to begin adding statements to the function. From the `>>` prompt,
 add each statement and press **Enter** as shown in the example. After the closing bracket is added,
 you're returned to a PowerShell prompt.
@@ -197,7 +197,7 @@ object in the pipeline. For more information, see
 
 ```powershell
 $Events = Get-WinEvent -LogName Application -MaxEvents 50
-$Events | Select-String -InputObject {$_.message} -Pattern 'Failed'
+$Events | Select-String -InputObject {$_.Message} -Pattern 'Failed'
 ```
 
 The `Get-WinEvent` cmdlet uses the **LogName** parameter to specify the Application log. The
@@ -205,9 +205,9 @@ The `Get-WinEvent` cmdlet uses the **LogName** parameter to specify the Applicat
 the variable named `$Events`.
 
 The `$Events` variable is sent down the pipeline to the `Select-String` cmdlet. `Select-String` uses
-the **InputObject** parameter. The `$_` variable represents the current object and `message` is a
+the **InputObject** parameter. The `$_` variable represents the current object and `Message` is a
 property of the event. The **Pattern** parameter specifies the string **Failed** and searches for
-matches in `$_.message`. `Select-String` displays the output in the PowerShell console.
+matches in `$_.Message`. `Select-String` displays the output in the PowerShell console.
 
 ### Example 6: Find a string in subdirectories
 
@@ -819,7 +819,7 @@ PowerShell includes the following aliases for `Select-String`:
 - All platforms:
   - `sls`
 
-`Select-String` is similar to `grep` in UNIX or `findstr.exe` in Windows.
+`Select-String` is similar to `grep` in Unix or `findstr.exe` in Windows.
 
 The `sls` alias for the `Select-String` cmdlet was introduced in PowerShell 3.0.
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -124,10 +124,10 @@ information about Updatable Help, see
 The `Select-Xml` cmdlet searches the XML files for cmdlet names by finding `Command:Name` element
 anywhere in the files. The results are stored in the `$Xml` variable. `Select-Xml` returns a
 **SelectXmlInfo** object that has a **Node** property, which is a **System.Xml.XmlElement** object.
-The **Node** property has an **InnerXML** property that contains the actual XML that is retrieved.
+The **Node** property has an **InnerXml** property that contains the actual XML that is retrieved.
 
 The `$Xml` variable is piped to the `Format-Table` cmdlet. The `Format-Table` command uses a
-calculated property to get the **Node.InnerXML** property of each object in the `$Xml` variable,
+calculated property to get the **Node.InnerXml** property of each object in the `$Xml` variable,
 trim the white space before and after the text, and display it in the table, along with the **Path**
 to the source file.
 
@@ -138,21 +138,21 @@ $Namespace = @{
     dev = "http://schemas.microsoft.com/maml/dev/2004/10"
 }
 
-$Path = "$PSHOME\en-us\*dll-Help.xml"
+$Path = "$PSHOME\en-US\*dll-Help.xml"
 $Xml = Select-Xml -Path $Path -Namespace $Namespace -XPath "//command:name"
-$Xml | Format-Table @{Label="Name"; Expression= {($_.node.innerxml).trim()}}, Path -AutoSize
+$Xml | Format-Table @{Label="Name"; Expression= {($_.Node.InnerXml).Trim()}}, Path -AutoSize
 ```
 
 ```Output
 Name                    Path
 ----                    ----
-Export-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Get-Counter             C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Get-WinEvent            C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Import-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Add-Computer            C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Management.dll-Help.xml
-Add-Content             C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Management.dll-Help.xml
-Checkpoint-Computer     C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Management.dll-Help.xml
+Export-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Get-Counter             C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Get-WinEvent            C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Import-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Add-Computer            C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Management.dll-Help.xml
+Add-Content             C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Management.dll-Help.xml
+Checkpoint-Computer     C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Management.dll-Help.xml
 ...
 ```
 
@@ -187,14 +187,14 @@ $Xml = @"
 </Book>
 "@
 
-Select-Xml -Content $Xml -XPath "//edition" | foreach {$_.node.InnerXML}
+Select-Xml -Content $Xml -XPath "//edition" | foreach {$_.Node.InnerXml}
 
 En.Book1.com
 Ge.Book1.Com
 Fr.Book1.com
 Pl.Book1.com
 
-$Xml | Select-Xml -XPath "//edition" | foreach {$_.node.InnerXML}
+$Xml | Select-Xml -XPath "//edition" | foreach {$_.Node.InnerXml}
 
 En.Book1.com
 Ge.Book1.Com

--- a/reference/7.4/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -172,7 +172,7 @@ function. For more information, see
 [about_Functions](../Microsoft.PowerShell.Core/about/about_Functions.md).
 
 ```
-Function CD32 {Set-Location -Path C:\Windows\System32}
+function CD32 {Set-Location -Path C:\Windows\System32}
 
 Set-Alias -Name Go -Value CD32
 ```
@@ -260,7 +260,7 @@ Accept wildcard characters: False
 
 Sets the **Option** property value of the alias. Values such as `ReadOnly` and `Constant`
 protect an alias from unintended changes. To see the **Option** property of all aliases in the
-session, type `Get-Alias | Format-Table -Property Name, Options -Autosize`.
+session, type `Get-Alias | Format-Table -Property Name, Options -AutoSize`.
 
 The acceptable values for this parameter are as follows:
 

--- a/reference/7.4/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -160,8 +160,8 @@ HitCount : 0
 Action   :
 
 function CheckLog {
->> get-eventlog -log Application |
->> where {($_.source -like "TestApp") -and ($_.Message -like "*failed*")}
+>> Get-EventLog -Log Application |
+>> where {($_.Source -like "TestApp") -and ($_.Message -like "*failed*")}
 >>}
 >>
 PS> Checklog
@@ -213,7 +213,7 @@ ScriptName : C:\ps-test\sample.ps1
 ### Example 8: Set a breakpoint in a runspace
 
 In this example, a job is started. The runspace is stored in a variable and passed to the
-`Set-PSBreakPoint` command with the **Runspace** parameter.
+`Set-PSBreakpoint` command with the **Runspace** parameter.
 
 ```powershell
 Start-Job -ScriptBlock {
@@ -236,9 +236,9 @@ tasks, such as testing or logging.
 If this parameter is omitted, or no action is specified, execution stops at the breakpoint, and the
 debugger starts.
 
-When the **Action** parameter is used, the Action script block runs at each breakpoint. Execution does
-not stop unless the script block includes the Break keyword. If you use the Continue keyword in the
-script block, execution resumes until the next breakpoint.
+When the **Action** parameter is used, the Action script block runs at each breakpoint. Execution
+does not stop unless the script block includes the `break` keyword. If you use the `continue`
+keyword in the script block, execution resumes until the next breakpoint.
 
 For more information, see [about_Script_Blocks](../Microsoft.PowerShell.Core/About/about_Script_Blocks.md),
 [about_Break](../Microsoft.PowerShell.Core/About/about_Break.md), and
@@ -288,7 +288,7 @@ Sets a command breakpoint. Enter cmdlet names, such as `Get-Process`, or functio
 are permitted.
 
 Execution stops just before each instance of each command is executed. If the command is a function,
-execution stops each time the function is called and at each BEGIN, PROCESS, and END section.
+execution stops each time the function is called and at each `begin`, `process`, and `end` block.
 
 ```yaml
 Type: System.String[]

--- a/reference/7.4/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -161,7 +161,7 @@ Action   :
 
 function CheckLog {
 >> Get-EventLog -Log Application |
->> where {($_.Source -like "TestApp") -and ($_.Message -like "*failed*")}
+>> Where-Object {($_.Source -like "TestApp") -and ($_.Message -like "*failed*")}
 >>}
 >>
 PS> Checklog

--- a/reference/7.4/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -50,7 +50,7 @@ Set-TraceSource -Name "ParameterBinding" -Option ExecutionFlow -PSHost -Listener
 This command starts tracing for the ParameterBinding component of PowerShell. It uses the **Name**
 parameter to specify the trace source, the **Option** parameter to select the `ExecutionFlow` trace
 events, and the **PSHost** parameter to select the PowerShell host listener, which sends the output
-to the console. The **ListenerOption** parameter adds the `ProcessID` and `TimeStamp` values to the
+to the console. The **ListenerOption** parameter adds the `ProcessId` and `TimeStamp` values to the
 trace message prefix.
 
 ### Example 2: Stop a trace

--- a/reference/7.4/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/7.4/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -50,7 +50,7 @@ This example creates a global, read-only variable that contains all processes on
 then it displays all properties of the variable.
 
 ```powershell
-Set-Variable -Name "processes" -Value (Get-Process) -Option constant -Scope global -Description "All processes" -PassThru |
+Set-Variable -Name "processes" -Value (Get-Process) -Option Constant -Scope Global -Description "All processes" -PassThru |
     Format-List -Property *
 ```
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Out-String.md
@@ -35,7 +35,7 @@ parameter to direct `Out-String` to return one line at a time or create an array
 cmdlet lets you search and manipulate string output as you would in traditional shells when object
 manipulation is less convenient.
 
-PowerShell also adds the `OSS` function that calls `Out-String -Stream` as a shorthand way to use
+PowerShell also adds the `oss` function that calls `Out-String -Stream` as a shorthand way to use
 `Out-String` in a pipeline.
 
 ## EXAMPLES

--- a/reference/7.5/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -47,7 +47,7 @@ This example registers for a PowerShell engine event on two remote computers.
 ```powershell
 $S = New-PSSession -ComputerName "Server01, Server02"
 Invoke-Command -Session $S {
-  Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PsEngineEvent]::Exiting) -Forward
+  Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PSEngineEvent]::Exiting) -Forward
 }
 ```
 
@@ -81,13 +81,13 @@ data to a text file.
 
 ```powershell
 Register-EngineEvent -SourceIdentifier MyEventSource -Action {
-    "Event: {0}" -f $Event.MessageData | Out-File c:\temp\MyEvents.txt -Append
+    "Event: {0}" -f $Event.MessageData | Out-File C:\temp\MyEvents.txt -Append
 }
 
 Start-Job -Name TestJob -ScriptBlock {
-    While ($true) {
+    while ($true) {
         Register-EngineEvent -SourceIdentifier MyEventSource -Forward
-        Start-Sleep -seconds 2
+        Start-Sleep -Seconds 2
         "Doing some work..."
         $newEventSplat = @{
             SourceIdentifier = 'MyEventSource'
@@ -96,7 +96,7 @@ Start-Job -Name TestJob -ScriptBlock {
         New-Event @newEventSplat
     }
 }
-Start-Sleep -seconds 4
+Start-Sleep -Seconds 4
 Get-EventSubscriber
 Get-Job
 ```
@@ -126,7 +126,7 @@ This is a continuation of Example 3. In this example we wait for 10 seconds to l
 occur. Then we unregister the event subscription.
 
 ```powershell
-PS> Start-Sleep -seconds 10
+PS> Start-Sleep -Seconds 10
 PS> Get-EventSubscriber | Unregister-Event
 PS> Get-Job
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -150,8 +150,8 @@ $objectEventArgs = @{
 }
 $Job = Register-ObjectEvent @objectEventArgs
 $Job | Format-List -Property *
-& $Job.module {$Random}
-& $Job.module {$Random}
+& $Job.Module {$Random}
+& $Job.Module {$Random}
 ```
 
 ```Output

--- a/reference/7.5/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Select-Object.md
@@ -66,7 +66,7 @@ reached. To turn off this optimizing behavior, use the **Wait** parameter.
 
 ### Example 1: Select objects by property
 
-This example creates objects that have the **Name**, **ID**, and working set (**WS**) properties of
+This example creates objects that have the **Name**, **Id**, and working set (**WS**) properties of
 process objects.
 
 ```powershell
@@ -193,7 +193,7 @@ event is 0. The index of the last event is the number of items in `$a` minus 1.
 
 ```powershell
 $a = Get-WinEvent -LogName "Windows PowerShell"
-$a | Select-Object -Index 0, ($a.count - 1)
+$a | Select-Object -Index 0, ($a.Count - 1)
 ```
 
 ### Example 8: Select all but the first object
@@ -333,7 +333,7 @@ ati2evxx                   Thursday
 # Add a custom property to calculate the size in KiloBytes of each FileInfo
 # object you pass in. Use the pipeline variable to divide each file's length by
 # 1 KiloBytes
-$size = @{label="Size(KB)";expression={$_.length/1KB}}
+$size = @{Label="Size(KB)";Expression={$_.Length/1KB}}
 # Create an additional calculated property with the number of Days since the
 # file was last accessed. You can also shorten the key names to be 'l', and 'e',
 # or use Name instead of Label.
@@ -374,9 +374,9 @@ This example demonstrates the side-effect of using the **ExpandProperty** parame
 **NoteProperty** members.
 
 ```powershell
-PS> $object = [PSCustomObject]@{
+PS> $object = [pscustomobject]@{
     name = 'USA'
-    children = [PSCustomObject]@{
+    children = [pscustomobject]@{
         name = 'Southwest'
     }
 }
@@ -410,9 +410,9 @@ You can avoid the side-effect of using the **ExpandProperty** parameter by creat
 copying the properties from the input object.
 
 ```powershell
-PS> $object = [PSCustomObject]@{
+PS> $object = [pscustomobject]@{
     name = 'USA'
-    children = [PSCustomObject]@{
+    children = [pscustomobject]@{
         name = 'Southwest'
     }
 }
@@ -423,12 +423,12 @@ name children
 USA  @{name=Southwest}
 
 # Create a new object with selected properties
-PS> $newobject = [PSCustomObject]@{
+PS> $newObject = [pscustomobject]@{
     country = $object.name
     children = $object.children
 }
 
-PS> $newobject
+PS> $newObject
 
 country children
 ------- --------

--- a/reference/7.5/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Select-String.md
@@ -66,7 +66,7 @@ Select-String [-Culture <String>] [-Pattern] <String[]> -LiteralPath <String[]> 
 ## DESCRIPTION
 
 The `Select-String` cmdlet uses regular expression matching to search for text patterns in input
-strings and files. You can use `Select-String` similar to `grep` in UNIX or `findstr.exe` in
+strings and files. You can use `Select-String` similar to `grep` in Unix or `findstr.exe` in
 Windows.
 
 `Select-String` is based on lines of text. By default, `Select-String` finds the first match in each
@@ -173,7 +173,7 @@ C:\Program Files\PowerShell\7\en-US\default.help.txt:93:    Get-Help About_Modul
 C:\Program Files\PowerShell\7\en-US\default.help.txt:97:    about_Updatable_Help
 ```
 
-The function is created on the PowerShell command line. The `Function` command uses the name
+The function is created on the PowerShell command line. The `function` keyword uses the name
 `Search-Help`. Press **Enter** to begin adding statements to the function. From the `>>` prompt,
 add each statement and press **Enter** as shown in the example. After the closing bracket is added,
 you're returned to a PowerShell prompt.
@@ -197,7 +197,7 @@ object in the pipeline. For more information, see
 
 ```powershell
 $Events = Get-WinEvent -LogName Application -MaxEvents 50
-$Events | Select-String -InputObject {$_.message} -Pattern 'Failed'
+$Events | Select-String -InputObject {$_.Message} -Pattern 'Failed'
 ```
 
 The `Get-WinEvent` cmdlet uses the **LogName** parameter to specify the Application log. The
@@ -205,9 +205,9 @@ The `Get-WinEvent` cmdlet uses the **LogName** parameter to specify the Applicat
 the variable named `$Events`.
 
 The `$Events` variable is sent down the pipeline to the `Select-String` cmdlet. `Select-String` uses
-the **InputObject** parameter. The `$_` variable represents the current object and `message` is a
+the **InputObject** parameter. The `$_` variable represents the current object and `Message` is a
 property of the event. The **Pattern** parameter specifies the string **Failed** and searches for
-matches in `$_.message`. `Select-String` displays the output in the PowerShell console.
+matches in `$_.Message`. `Select-String` displays the output in the PowerShell console.
 
 ### Example 6: Find a string in subdirectories
 
@@ -819,7 +819,7 @@ PowerShell includes the following aliases for `Select-String`:
 - All platforms:
   - `sls`
 
-`Select-String` is similar to `grep` in UNIX or `findstr.exe` in Windows.
+`Select-String` is similar to `grep` in Unix or `findstr.exe` in Windows.
 
 The `sls` alias for the `Select-String` cmdlet was introduced in PowerShell 3.0.
 

--- a/reference/7.5/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -124,10 +124,10 @@ information about Updatable Help, see
 The `Select-Xml` cmdlet searches the XML files for cmdlet names by finding `Command:Name` element
 anywhere in the files. The results are stored in the `$Xml` variable. `Select-Xml` returns a
 **SelectXmlInfo** object that has a **Node** property, which is a **System.Xml.XmlElement** object.
-The **Node** property has an **InnerXML** property that contains the actual XML that is retrieved.
+The **Node** property has an **InnerXml** property that contains the actual XML that is retrieved.
 
 The `$Xml` variable is piped to the `Format-Table` cmdlet. The `Format-Table` command uses a
-calculated property to get the **Node.InnerXML** property of each object in the `$Xml` variable,
+calculated property to get the **Node.InnerXml** property of each object in the `$Xml` variable,
 trim the white space before and after the text, and display it in the table, along with the **Path**
 to the source file.
 
@@ -138,21 +138,21 @@ $Namespace = @{
     dev = "http://schemas.microsoft.com/maml/dev/2004/10"
 }
 
-$Path = "$PSHOME\en-us\*dll-Help.xml"
+$Path = "$PSHOME\en-US\*dll-Help.xml"
 $Xml = Select-Xml -Path $Path -Namespace $Namespace -XPath "//command:name"
-$Xml | Format-Table @{Label="Name"; Expression= {($_.Node.InnerXml).trim()}}, Path -AutoSize
+$Xml | Format-Table @{Label="Name"; Expression= {($_.Node.InnerXml).Trim()}}, Path -AutoSize
 ```
 
 ```Output
 Name                    Path
 ----                    ----
-Export-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Get-Counter             C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Get-WinEvent            C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Import-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Add-Computer            C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Management.dll-Help.xml
-Add-Content             C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Management.dll-Help.xml
-Checkpoint-Computer     C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Management.dll-Help.xml
+Export-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Get-Counter             C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Get-WinEvent            C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Import-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Add-Computer            C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Management.dll-Help.xml
+Add-Content             C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Management.dll-Help.xml
+Checkpoint-Computer     C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Management.dll-Help.xml
 ...
 ```
 
@@ -186,14 +186,14 @@ $Xml = @"
 </Book>
 "@
 
-Select-Xml -Content $Xml -XPath "//edition" | foreach {$_.node.InnerXML}
+Select-Xml -Content $Xml -XPath "//edition" | foreach {$_.Node.InnerXml}
 
 En.Book1.com
 Ge.Book1.Com
 Fr.Book1.com
 Pl.Book1.com
 
-$Xml | Select-Xml -XPath "//edition" | foreach {$_.node.InnerXML}
+$Xml | Select-Xml -XPath "//edition" | foreach {$_.Node.InnerXml}
 
 En.Book1.com
 Ge.Book1.Com

--- a/reference/7.5/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -172,7 +172,7 @@ function. For more information, see
 [about_Functions](../Microsoft.PowerShell.Core/about/about_Functions.md).
 
 ```
-Function CD32 {Set-Location -Path C:\Windows\System32}
+function CD32 {Set-Location -Path C:\Windows\System32}
 
 Set-Alias -Name Go -Value CD32
 ```

--- a/reference/7.5/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -161,7 +161,7 @@ Action   :
 
 function CheckLog {
 >> Get-EventLog -Log Application |
->> where {($_.Source -like "TestApp") -and ($_.Message -like "*failed*")}
+>> Where-Object {($_.Source -like "TestApp") -and ($_.Message -like "*failed*")}
 >>}
 >>
 PS> CheckLog

--- a/reference/7.5/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -160,8 +160,8 @@ HitCount : 0
 Action   :
 
 function CheckLog {
->> get-eventlog -log Application |
->> where {($_.source -like "TestApp") -and ($_.Message -like "*failed*")}
+>> Get-EventLog -Log Application |
+>> where {($_.Source -like "TestApp") -and ($_.Message -like "*failed*")}
 >>}
 >>
 PS> CheckLog
@@ -213,7 +213,7 @@ ScriptName : C:\ps-test\sample.ps1
 ### Example 8: Set a breakpoint in a runspace
 
 In this example, a job is started. The runspace is stored in a variable and passed to the
-`Set-PSBreakPoint` command with the **Runspace** parameter.
+`Set-PSBreakpoint` command with the **Runspace** parameter.
 
 ```powershell
 Start-Job -ScriptBlock {
@@ -236,9 +236,9 @@ tasks, such as testing or logging.
 If this parameter is omitted, or no action is specified, execution stops at the breakpoint, and the
 debugger starts.
 
-When the **Action** parameter is used, the Action script block runs at each breakpoint. Execution does
-not stop unless the script block includes the Break keyword. If you use the Continue keyword in the
-script block, execution resumes until the next breakpoint.
+When the **Action** parameter is used, the Action script block runs at each breakpoint. Execution
+does not stop unless the script block includes the `break` keyword. If you use the `continue`
+keyword in the script block, execution resumes until the next breakpoint.
 
 For more information, see [about_Script_Blocks](../Microsoft.PowerShell.Core/About/about_Script_Blocks.md),
 [about_Break](../Microsoft.PowerShell.Core/About/about_Break.md), and
@@ -288,7 +288,7 @@ Sets a command breakpoint. Enter cmdlet names, such as `Get-Process`, or functio
 are permitted.
 
 Execution stops just before each instance of each command is executed. If the command is a function,
-execution stops each time the function is called and at each BEGIN, PROCESS, and END section.
+execution stops each time the function is called and at each `begin`, `process`, and `end` block.
 
 ```yaml
 Type: System.String[]

--- a/reference/7.5/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -50,7 +50,7 @@ Set-TraceSource -Name "ParameterBinding" -Option ExecutionFlow -PSHost -Listener
 This command starts tracing for the ParameterBinding component of PowerShell. It uses the **Name**
 parameter to specify the trace source, the **Option** parameter to select the `ExecutionFlow` trace
 events, and the **PSHost** parameter to select the PowerShell host listener, which sends the output
-to the console. The **ListenerOption** parameter adds the `ProcessID` and `TimeStamp` values to the
+to the console. The **ListenerOption** parameter adds the `ProcessId` and `TimeStamp` values to the
 trace message prefix.
 
 ### Example 2: Stop a trace

--- a/reference/7.5/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/7.5/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -50,7 +50,7 @@ This example creates a global, read-only variable that contains all processes on
 then it displays all properties of the variable.
 
 ```powershell
-Set-Variable -Name "processes" -Value (Get-Process) -Option constant -Scope global -Description "All processes" -PassThru |
+Set-Variable -Name "processes" -Value (Get-Process) -Option Constant -Scope Global -Description "All processes" -PassThru |
     Format-List -Property *
 ```
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Out-String.md
@@ -35,7 +35,7 @@ parameter to direct `Out-String` to return one line at a time or create an array
 cmdlet lets you search and manipulate string output as you would in traditional shells when object
 manipulation is less convenient.
 
-PowerShell also adds the `OSS` function that calls `Out-String -Stream` as a shorthand way to use
+PowerShell also adds the `oss` function that calls `Out-String -Stream` as a shorthand way to use
 `Out-String` in a pipeline.
 
 ## EXAMPLES

--- a/reference/7.6/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -47,7 +47,7 @@ This example registers for a PowerShell engine event on two remote computers.
 ```powershell
 $S = New-PSSession -ComputerName "Server01, Server02"
 Invoke-Command -Session $S {
-  Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PsEngineEvent]::Exiting) -Forward
+  Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PSEngineEvent]::Exiting) -Forward
 }
 ```
 
@@ -81,13 +81,13 @@ data to a text file.
 
 ```powershell
 Register-EngineEvent -SourceIdentifier MyEventSource -Action {
-    "Event: {0}" -f $Event.MessageData | Out-File c:\temp\MyEvents.txt -Append
+    "Event: {0}" -f $Event.MessageData | Out-File C:\temp\MyEvents.txt -Append
 }
 
 Start-Job -Name TestJob -ScriptBlock {
-    While ($true) {
+    while ($true) {
         Register-EngineEvent -SourceIdentifier MyEventSource -Forward
-        Start-Sleep -seconds 2
+        Start-Sleep -Seconds 2
         "Doing some work..."
         $newEventSplat = @{
             SourceIdentifier = 'MyEventSource'
@@ -96,7 +96,7 @@ Start-Job -Name TestJob -ScriptBlock {
         New-Event @newEventSplat
     }
 }
-Start-Sleep -seconds 4
+Start-Sleep -Seconds 4
 Get-EventSubscriber
 Get-Job
 ```
@@ -126,7 +126,7 @@ This is a continuation of Example 3. In this example we wait for 10 seconds to l
 occur. Then we unregister the event subscription.
 
 ```powershell
-PS> Start-Sleep -seconds 10
+PS> Start-Sleep -Seconds 10
 PS> Get-EventSubscriber | Unregister-Event
 PS> Get-Job
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -150,8 +150,8 @@ $objectEventArgs = @{
 }
 $Job = Register-ObjectEvent @objectEventArgs
 $Job | Format-List -Property *
-& $Job.module {$Random}
-& $Job.module {$Random}
+& $Job.Module {$Random}
+& $Job.Module {$Random}
 ```
 
 ```Output

--- a/reference/7.6/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Select-Object.md
@@ -66,7 +66,7 @@ reached. To turn off this optimizing behavior, use the **Wait** parameter.
 
 ### Example 1: Select objects by property
 
-This example creates objects that have the **Name**, **ID**, and working set (**WS**) properties of
+This example creates objects that have the **Name**, **Id**, and working set (**WS**) properties of
 process objects.
 
 ```powershell
@@ -193,7 +193,7 @@ event is 0. The index of the last event is the number of items in `$a` minus 1.
 
 ```powershell
 $a = Get-WinEvent -LogName "Windows PowerShell"
-$a | Select-Object -Index 0, ($a.count - 1)
+$a | Select-Object -Index 0, ($a.Count - 1)
 ```
 
 ### Example 8: Select all but the first object
@@ -333,7 +333,7 @@ ati2evxx                   Thursday
 # Add a custom property to calculate the size in KiloBytes of each FileInfo
 # object you pass in. Use the pipeline variable to divide each file's length by
 # 1 KiloBytes
-$size = @{label="Size(KB)";expression={$_.length/1KB}}
+$size = @{Label="Size(KB)";Expression={$_.Length/1KB}}
 # Create an additional calculated property with the number of Days since the
 # file was last accessed. You can also shorten the key names to be 'l', and 'e',
 # or use Name instead of Label.
@@ -374,9 +374,9 @@ This example demonstrates the side-effect of using the **ExpandProperty** parame
 **NoteProperty** members.
 
 ```powershell
-PS> $object = [PSCustomObject]@{
+PS> $object = [pscustomobject]@{
     name = 'USA'
-    children = [PSCustomObject]@{
+    children = [pscustomobject]@{
         name = 'Southwest'
     }
 }
@@ -410,9 +410,9 @@ You can avoid the side-effect of using the **ExpandProperty** parameter by creat
 copying the properties from the input object.
 
 ```powershell
-PS> $object = [PSCustomObject]@{
+PS> $object = [pscustomobject]@{
     name = 'USA'
-    children = [PSCustomObject]@{
+    children = [pscustomobject]@{
         name = 'Southwest'
     }
 }
@@ -423,12 +423,12 @@ name children
 USA  @{name=Southwest}
 
 # Create a new object with selected properties
-PS> $newobject = [PSCustomObject]@{
+PS> $newObject = [pscustomobject]@{
     country = $object.name
     children = $object.children
 }
 
-PS> $newobject
+PS> $newObject
 
 country children
 ------- --------

--- a/reference/7.6/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Select-String.md
@@ -66,7 +66,7 @@ Select-String [-Culture <String>] [-Pattern] <String[]> -LiteralPath <String[]> 
 ## DESCRIPTION
 
 The `Select-String` cmdlet uses regular expression matching to search for text patterns in input
-strings and files. You can use `Select-String` similar to `grep` in UNIX or `findstr.exe` in
+strings and files. You can use `Select-String` similar to `grep` in Unix or `findstr.exe` in
 Windows.
 
 `Select-String` is based on lines of text. By default, `Select-String` finds the first match in each
@@ -173,7 +173,7 @@ C:\Program Files\PowerShell\7\en-US\default.help.txt:93:    Get-Help About_Modul
 C:\Program Files\PowerShell\7\en-US\default.help.txt:97:    about_Updatable_Help
 ```
 
-The function is created on the PowerShell command line. The `Function` command uses the name
+The function is created on the PowerShell command line. The `function` keyword uses the name
 `Search-Help`. Press **Enter** to begin adding statements to the function. From the `>>` prompt,
 add each statement and press **Enter** as shown in the example. After the closing bracket is added,
 you're returned to a PowerShell prompt.
@@ -197,7 +197,7 @@ object in the pipeline. For more information, see
 
 ```powershell
 $Events = Get-WinEvent -LogName Application -MaxEvents 50
-$Events | Select-String -InputObject {$_.message} -Pattern 'Failed'
+$Events | Select-String -InputObject {$_.Message} -Pattern 'Failed'
 ```
 
 The `Get-WinEvent` cmdlet uses the **LogName** parameter to specify the Application log. The
@@ -205,9 +205,9 @@ The `Get-WinEvent` cmdlet uses the **LogName** parameter to specify the Applicat
 the variable named `$Events`.
 
 The `$Events` variable is sent down the pipeline to the `Select-String` cmdlet. `Select-String` uses
-the **InputObject** parameter. The `$_` variable represents the current object and `message` is a
+the **InputObject** parameter. The `$_` variable represents the current object and `Message` is a
 property of the event. The **Pattern** parameter specifies the string **Failed** and searches for
-matches in `$_.message`. `Select-String` displays the output in the PowerShell console.
+matches in `$_.Message`. `Select-String` displays the output in the PowerShell console.
 
 ### Example 6: Find a string in subdirectories
 
@@ -819,7 +819,7 @@ PowerShell includes the following aliases for `Select-String`:
 - All platforms:
   - `sls`
 
-`Select-String` is similar to `grep` in UNIX or `findstr.exe` in Windows.
+`Select-String` is similar to `grep` in Unix or `findstr.exe` in Windows.
 
 The `sls` alias for the `Select-String` cmdlet was introduced in PowerShell 3.0.
 

--- a/reference/7.6/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -124,10 +124,10 @@ information about Updatable Help, see
 The `Select-Xml` cmdlet searches the XML files for cmdlet names by finding `Command:Name` element
 anywhere in the files. The results are stored in the `$Xml` variable. `Select-Xml` returns a
 **SelectXmlInfo** object that has a **Node** property, which is a **System.Xml.XmlElement** object.
-The **Node** property has an **InnerXML** property that contains the actual XML that is retrieved.
+The **Node** property has an **InnerXml** property that contains the actual XML that is retrieved.
 
 The `$Xml` variable is piped to the `Format-Table` cmdlet. The `Format-Table` command uses a
-calculated property to get the **Node.InnerXML** property of each object in the `$Xml` variable,
+calculated property to get the **Node.InnerXml** property of each object in the `$Xml` variable,
 trim the white space before and after the text, and display it in the table, along with the **Path**
 to the source file.
 
@@ -138,21 +138,21 @@ $Namespace = @{
     dev = "http://schemas.microsoft.com/maml/dev/2004/10"
 }
 
-$Path = "$PSHOME\en-us\*dll-Help.xml"
+$Path = "$PSHOME\en-US\*dll-Help.xml"
 $Xml = Select-Xml -Path $Path -Namespace $Namespace -XPath "//command:name"
-$Xml | Format-Table @{Label="Name"; Expression= {($_.Node.InnerXml).trim()}}, Path -AutoSize
+$Xml | Format-Table @{Label="Name"; Expression= {($_.Node.InnerXml).Trim()}}, Path -AutoSize
 ```
 
 ```Output
 Name                    Path
 ----                    ----
-Export-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Get-Counter             C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Get-WinEvent            C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Import-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
-Add-Computer            C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Management.dll-Help.xml
-Add-Content             C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Management.dll-Help.xml
-Checkpoint-Computer     C:\Windows\system32\WindowsPowerShell\v1.0\en-us\Microsoft.PowerShell.Commands.Management.dll-Help.xml
+Export-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Get-Counter             C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Get-WinEvent            C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Import-Counter          C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml
+Add-Computer            C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Management.dll-Help.xml
+Add-Content             C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Management.dll-Help.xml
+Checkpoint-Computer     C:\Windows\system32\WindowsPowerShell\v1.0\en-US\Microsoft.PowerShell.Commands.Management.dll-Help.xml
 ...
 ```
 
@@ -186,14 +186,14 @@ $Xml = @"
 </Book>
 "@
 
-Select-Xml -Content $Xml -XPath "//edition" | foreach {$_.node.InnerXML}
+Select-Xml -Content $Xml -XPath "//edition" | foreach {$_.Node.InnerXml}
 
 En.Book1.com
 Ge.Book1.Com
 Fr.Book1.com
 Pl.Book1.com
 
-$Xml | Select-Xml -XPath "//edition" | foreach {$_.node.InnerXML}
+$Xml | Select-Xml -XPath "//edition" | foreach {$_.Node.InnerXml}
 
 En.Book1.com
 Ge.Book1.Com

--- a/reference/7.6/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -172,7 +172,7 @@ function. For more information, see
 [about_Functions](../Microsoft.PowerShell.Core/about/about_Functions.md).
 
 ```
-Function CD32 {Set-Location -Path C:\Windows\System32}
+function CD32 {Set-Location -Path C:\Windows\System32}
 
 Set-Alias -Name Go -Value CD32
 ```

--- a/reference/7.6/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -161,7 +161,7 @@ Action   :
 
 function CheckLog {
 >> Get-EventLog -Log Application |
->> where {($_.Source -like "TestApp") -and ($_.Message -like "*failed*")}
+>> Where-Object {($_.Source -like "TestApp") -and ($_.Message -like "*failed*")}
 >>}
 >>
 PS> CheckLog

--- a/reference/7.6/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -160,8 +160,8 @@ HitCount : 0
 Action   :
 
 function CheckLog {
->> get-eventlog -log Application |
->> where {($_.source -like "TestApp") -and ($_.Message -like "*failed*")}
+>> Get-EventLog -Log Application |
+>> where {($_.Source -like "TestApp") -and ($_.Message -like "*failed*")}
 >>}
 >>
 PS> CheckLog
@@ -213,7 +213,7 @@ ScriptName : C:\ps-test\sample.ps1
 ### Example 8: Set a breakpoint in a runspace
 
 In this example, a job is started. The runspace is stored in a variable and passed to the
-`Set-PSBreakPoint` command with the **Runspace** parameter.
+`Set-PSBreakpoint` command with the **Runspace** parameter.
 
 ```powershell
 Start-Job -ScriptBlock {
@@ -236,9 +236,9 @@ tasks, such as testing or logging.
 If this parameter is omitted, or no action is specified, execution stops at the breakpoint, and the
 debugger starts.
 
-When the **Action** parameter is used, the Action script block runs at each breakpoint. Execution does
-not stop unless the script block includes the Break keyword. If you use the Continue keyword in the
-script block, execution resumes until the next breakpoint.
+When the **Action** parameter is used, the Action script block runs at each breakpoint. Execution
+does not stop unless the script block includes the `break` keyword. If you use the `continue`
+keyword in the script block, execution resumes until the next breakpoint.
 
 For more information, see [about_Script_Blocks](../Microsoft.PowerShell.Core/About/about_Script_Blocks.md),
 [about_Break](../Microsoft.PowerShell.Core/About/about_Break.md), and
@@ -288,7 +288,7 @@ Sets a command breakpoint. Enter cmdlet names, such as `Get-Process`, or functio
 are permitted.
 
 Execution stops just before each instance of each command is executed. If the command is a function,
-execution stops each time the function is called and at each BEGIN, PROCESS, and END section.
+execution stops each time the function is called and at each `begin`, `process`, and `end` block.
 
 ```yaml
 Type: System.String[]

--- a/reference/7.6/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -50,7 +50,7 @@ Set-TraceSource -Name "ParameterBinding" -Option ExecutionFlow -PSHost -Listener
 This command starts tracing for the ParameterBinding component of PowerShell. It uses the **Name**
 parameter to specify the trace source, the **Option** parameter to select the `ExecutionFlow` trace
 events, and the **PSHost** parameter to select the PowerShell host listener, which sends the output
-to the console. The **ListenerOption** parameter adds the `ProcessID` and `TimeStamp` values to the
+to the console. The **ListenerOption** parameter adds the `ProcessId` and `TimeStamp` values to the
 trace message prefix.
 
 ### Example 2: Stop a trace

--- a/reference/7.6/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/7.6/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -50,7 +50,7 @@ This example creates a global, read-only variable that contains all processes on
 then it displays all properties of the variable.
 
 ```powershell
-Set-Variable -Name "processes" -Value (Get-Process) -Option constant -Scope global -Description "All processes" -PassThru |
+Set-Variable -Name "processes" -Value (Get-Process) -Option Constant -Scope Global -Description "All processes" -PassThru |
     Format-List -Property *
 ```
 


### PR DESCRIPTION
# PR Summary

This is a series of PRs that fixes incorrect case/capitalization of the PowerShell-related components listed below. This is intended for documentation-wide consistency and to promote best practices.

This PR series targets the [reference](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/main/reference) documentation systematically. Each PR is split into ~40 files, with versioned-files grouped together.

Components:

- Preference variable
- PS environment variable
- PS drive
- PS provider
- PS command name
- PS command argument
- PS module
- PS file extension
- PS host name/application
- Parameter name
- `#Requires` statement
- `about_*` topic
- Member name
- Scope modifier
- Keyword
- Operator
- Calculated property key/value
- Attribute
- Type literal/name (including accelerator)
- WMI namespace/class
- Variable name
- Special character
- Comment-based help keyword
- Product/company name
- Windows drive letter/directory
- Windows/Unix environment variable

Changes also include fixes to incorrect terminology (e.g., referring to a keyword as a command) and some formatting of PowerShell syntax elements, but note the latter is non-exhaustive. 

## Additional Information

Source of truth:

- PowerShell tab completion
- External definition
- Best practices from this documentation

For example:

- Scope modifiers start with an upper-case letter because that matches tab completion behavior.
- Type accelerators match their definition (lowercase, excluding attributes and anomalies).
- Custom function parameters follow the official best practice (PascalCase).

<details>
<summary>Not included in this PR series:</summary>

- `C:\Windows\System32` directory
- Certain common terminology (e.g., `null`/`Null`/`NULL` value)
- Numeric literal suffixes
- Non-PS application names
- Single-letter parameter names
- Custom dictionary key names
- Placeholder names (e.g., `server01`/`Server01`)
- URLs

</details>

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide